### PR TITLE
initial tests of failover when app stops

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/db/DatabaseTaskStore.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/db/DatabaseTaskStore.java
@@ -751,6 +751,38 @@ public class DatabaseTaskStore implements TaskStore {
         return taskRecord;
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public Long getPartition(long taskId) throws Exception {
+        String find = "SELECT t.PARTN FROM Task t WHERE t.ID=:i";
+
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+        if (trace && tc.isEntryEnabled())
+            Tr.entry(this, tc, "getPartition", taskId, find);
+
+        List<Object[]> resultList;
+        EntityManager em = getPersistenceServiceUnit().createEntityManager();
+        try {
+            TypedQuery<Object[]> query = em.createQuery(find.toString(), Object[].class);
+            query.setParameter("i", taskId);
+            resultList = query.getResultList();
+        } finally {
+            em.close();
+        }
+
+        Long partitionId;
+        if (resultList.isEmpty())
+            partitionId = null;
+        else {
+            Object[] result = resultList.get(0);
+            partitionId = (Long) result[0];
+        }
+
+        if (trace && tc.isEntryEnabled())
+            Tr.exit(this, tc, "getPartition", partitionId);
+        return partitionId;
+    }
+
     /**
      * Returns the persistence service unit, lazily initializing if necessary.
      *

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskStore.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskStore.java
@@ -208,6 +208,16 @@ public interface TaskStore {
     TaskRecord getNextExecutionTime(long taskId, String owner) throws Exception;
 
     /**
+     * Returns the identifier of the partition to which the task is assigned.
+     *
+     * @param taskId unique identifier for the task.
+     * @return the identifier of the partition to which the task is assigned.
+     *         If the task is not found then <code>null</code> is returned.
+     * @throws Exception if an error occurs accessing the persistent store.
+     */
+    Long getPartition(long taskId) throws Exception;
+
+    /**
      * Returns name/value pairs for all persisted properties that match the specified name pattern.
      * For example, to find property names that start with "MY_PROP_NAME_",
      * taskStore.getProperties("MY\\_PROP\\_NAME\\_%", '\\');

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/fat/src/com/ibm/ws/concurrent/persistent/fat/failovertimers/FailoverTimersTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/fat/src/com/ibm/ws/concurrent/persistent/fat/failovertimers/FailoverTimersTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -105,13 +106,59 @@ public class FailoverTimersTest extends FATServletClient {
     }
 
     /**
+     * Determine which server an automatic persistent timer, which is a Singleton EJB, is running on.
+     * Stop the application on that server (but not the server itself)
+     * and verify that the timer starts running on the same application on a different server.
+     */
+    @Test
+    public void testSingletonTimerFailsOverWhenAppStops() throws Exception {
+        StringBuilder sb = runTestWithResponse(serverA, APP_NAME + "/FailoverTimersTestServlet",
+                "findServerWhereTimerRuns&timer=AutomaticCountingSingletonTimer&test=testSingletonTimerFailsOverWhenAppStops[1]");
+        assertEquals(sb.toString(), 0, sb.indexOf(TIMER_LAST_RAN_ON));
+        String serverName = sb.substring(TIMER_LAST_RAN_ON.length(), sb.lastIndexOf("."));
+        assertTrue(serverName, SERVER_A_NAME.equals(serverName) || SERVER_B_NAME.equals(serverName));
+
+        LibertyServer serverOnWhichToStopApp = SERVER_A_NAME.equals(serverName) ? serverA : serverB;
+        ServerConfiguration originalConfig = serverOnWhichToStopApp == serverA ? originalConfigA : originalConfigB;
+        try {
+            ServerConfiguration newConfig = originalConfig.clone();
+            newConfig.getApplications().removeBy("location", "failoverTimersApp.war");
+            serverOnWhichToStopApp.setMarkToEndOfLog();
+            serverOnWhichToStopApp.updateServerConfiguration(newConfig);
+
+            String nameOfServerForFailover = serverOnWhichToStopApp == serverA ? SERVER_B_NAME : SERVER_A_NAME;
+            LibertyServer serverForFailover = serverOnWhichToStopApp == serverA ? serverB : serverA;
+
+            runTest(serverForFailover, APP_NAME + "/FailoverTimersTestServlet",
+                    "testTimerFailover&timer=AutomaticCountingSingletonTimer&server=" + nameOfServerForFailover + "&test=testSingletonTimerFailsOverWhenAppStops[2]");
+
+            Set<String> remainingApps = APP_NAMES.stream().filter(s -> !s.equals(APP_NAME)).collect(Collectors.toSet());
+            serverOnWhichToStopApp.waitForConfigUpdateInLogUsingMark(remainingApps);
+        } finally {
+            serverOnWhichToStopApp.setMarkToEndOfLog();
+            serverOnWhichToStopApp.updateServerConfiguration(originalConfig);
+            serverOnWhichToStopApp.waitForConfigUpdateInLogUsingMark(APP_NAMES);
+
+            // The server upon which the application was stopped will try to run the task again
+            // upon seeing that the application has become available.
+            // However, the task now belongs to a different member (paritionId). It should be skipped silently without errors.
+            Thread.sleep(2000);
+
+            // Also restart the server. This allows us to process any expected warning messages that are logged in response
+            // to the application going away while its scheduled tasks remain.
+            serverOnWhichToStopApp.stopServer("CWWKC1556W"); // Execution of tasks from application failoverTimersApp is deferred until the application and modules that scheduled the tasks are available.
+            serverOnWhichToStopApp.startServer("after-testSingletonTimerFailsOverWhenAppStops");
+        }
+    }
+
+    /**
      * Determine which server an automatic persistent timer is running on.
      * Stop that server and verify that the timer starts running on a different server.
      */
     @Test
     public void testTimerFailsOverWhenServerStops() throws Exception {
         StringBuilder sb = runTestWithResponse(serverA, APP_NAME + "/FailoverTimersTestServlet",
-                "findServerWhereTimerRuns&timer=AutomaticCountingTimer&test=testTimerFailsOverWhenServerStops[1]");
+                "findServerWhereTimerRuns&timer=AutomaticCountingSingletonTimer&test=testTimerFailsOverWhenServerStops[1]");
         assertEquals(sb.toString(), 0, sb.indexOf(TIMER_LAST_RAN_ON));
         String serverName = sb.substring(TIMER_LAST_RAN_ON.length(), sb.lastIndexOf("."));
         assertTrue(serverName, SERVER_A_NAME.equals(serverName) || SERVER_B_NAME.equals(serverName));
@@ -124,7 +171,7 @@ public class FailoverTimersTest extends FATServletClient {
             LibertyServer serverForFailover = serverToStop == serverA ? serverB : serverA;
 
             runTest(serverForFailover, APP_NAME + "/FailoverTimersTestServlet",
-                    "testTimerFailover&timer=AutomaticCountingTimer&server=" + nameOfServerForFailover + "&test=testTimerFailsOverWhenServerStops[2]");
+                    "testTimerFailover&timer=AutomaticCountingSingletonTimer&server=" + nameOfServerForFailover + "&test=testTimerFailsOverWhenServerStops[2]");
         } finally {
             serverToStop.startServer();
         }

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/publish/servers/com.ibm.ws.concurrent.persistent.fat.failovertimers.serverA/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/publish/servers/com.ibm.ws.concurrent.persistent.fat.failovertimers.serverA/server.xml
@@ -21,7 +21,7 @@
 
   <application location="failoverTimersApp.war"/>
 
-  <persistentExecutor id="DefaultPersistentExecutor" pollInterval="1s400ms" missedTaskThreshold="3s"/>
+  <persistentExecutor id="defaultEJBPersistentTimerExecutor" pollInterval="1s400ms" missedTaskThreshold="3s"/>
 
   <!-- database for persistent EJB timerss -->
   <dataSource id="DefaultDataSource">

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/publish/servers/com.ibm.ws.concurrent.persistent.fat.failovertimers.serverB/configDropins/overrides/fatSecondaryPorts.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/publish/servers/com.ibm.ws.concurrent.persistent.fat.failovertimers.serverB/configDropins/overrides/fatSecondaryPorts.xml
@@ -1,0 +1,17 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+  <!-- override the values in fatTestPorts.xml file which use the primary ports which are already used by the other server -->
+  <httpEndpoint id="defaultHttpEndpoint"
+                host="*"
+                httpPort="${bvt.prop.HTTP_secondary}"
+                httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+</server>

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/publish/servers/com.ibm.ws.concurrent.persistent.fat.failovertimers.serverB/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/publish/servers/com.ibm.ws.concurrent.persistent.fat.failovertimers.serverB/server.xml
@@ -17,16 +17,11 @@
     <feature>servlet-4.0</feature>
   </featureManager>
 
-  <include location="../fatTestPorts.xml"/>
-
-  <httpEndpoint id="defaultHttpEndpoint"
-                host="*"
-                httpPort="${bvt.prop.HTTP_secondary}"
-                httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+  <include location="../fatTestPorts.xml"/> <!-- see overrides under configDropins/overrides/fatSecondaryPorts.xml -->
 
   <application location="failoverTimersApp.war"/>
 
-  <persistentExecutor id="DefaultPersistentExecutor" pollInterval="1s500ms" missedTaskThreshold="3s"/>
+  <persistentExecutor id="defaultEJBPersistentTimerExecutor" pollInterval="1s500ms" missedTaskThreshold="3s"/>
 
   <!-- database for persistent EJB timerss -->
   <dataSource id="DefaultDataSource">

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/ejb/autotimer/AutoCountingSingletonTimer.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/ejb/autotimer/AutoCountingSingletonTimer.java
@@ -24,22 +24,15 @@ import javax.sql.DataSource;
 import failovertimers.web.FailoverTimersTestServlet;
 
 @Singleton
-public class AutoCountingTimer {
-    private int count;
-
+public class AutoCountingSingletonTimer {
     @Resource
     private DataSource ds;
 
     @Resource
     private SessionContext sessionContext;
 
-    public void cancel() {
-        for (Timer timer : sessionContext.getTimerService().getTimers())
-            timer.cancel();
-    }
-
     // Timer runs every other other second
-    @Schedule(info = "AutomaticCountingTimer", hour = "*", minute = "*", second = "*/2")
+    @Schedule(info = "AutomaticCountingSingletonTimer", hour = "*", minute = "*", second = "*/2")
     public void run(Timer timer) {
         String serverConfigDir = System.getProperty("server.config.dir");
         String wlpUserDir = System.getProperty("wlp.user.dir");

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/ejb/stateless/StatelessTxSuspendedBean.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/ejb/stateless/StatelessTxSuspendedBean.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package failovertimers.ejb.stateless;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import javax.annotation.Resource;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+import javax.ejb.Timeout;
+import javax.ejb.Timer;
+import javax.ejb.TimerConfig;
+import javax.ejb.TimerService;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.sql.DataSource;
+
+import failovertimers.web.FailoverTimersTestServlet;
+
+@Stateless
+@TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+public class StatelessTxSuspendedBean {
+    @Resource
+    private DataSource ds;
+
+    @Resource
+    private SessionContext sessionContext;
+
+    public void cancelTimers() {
+        TimerService timerService = sessionContext.getTimerService();
+        for (Timer t : timerService.getTimers())
+            t.cancel();
+    }
+
+    @Timeout
+    public void runTimer(Timer timer) {
+        String serverConfigDir = System.getProperty("server.config.dir");
+        String wlpUserDir = System.getProperty("wlp.user.dir");
+        String serverName = serverConfigDir.substring(wlpUserDir.length() + "servers/".length(), serverConfigDir.length() - 1);
+
+        System.out.println("Running timer " + timer.getInfo() + " on " + serverName);
+
+        try (Connection con = ds.getConnection()) {
+            boolean found;
+            try {
+                PreparedStatement stmt = con.prepareStatement("UPDATE TIMERLOG SET SERVERNAME=?, COUNT=COUNT+1 WHERE TIMERNAME=?");
+                stmt.setString(1, serverName);
+                stmt.setString(2, (String) timer.getInfo());
+                found = stmt.executeUpdate() == 1;
+            } catch (SQLException x) {
+                found = false;
+                FailoverTimersTestServlet.createTables(ds);
+            }
+            if (!found) { // insert new entry
+                PreparedStatement stmt = con.prepareStatement("INSERT INTO TIMERLOG VALUES (?,?,?)");
+                stmt.setString(1, (String) timer.getInfo());
+                stmt.setInt(2, 1);
+                stmt.setString(3, serverName);
+                stmt.executeUpdate();
+            }
+        } catch (SQLException x) {
+            System.out.println("Timer " + timer.getInfo() + " failed.");
+            x.printStackTrace(System.out);
+            throw new RuntimeException(x);
+        }
+    }
+
+    public Timer scheduleTimer(long initialDelayMS, long intervalMS, String name) {
+        TimerService timerService = sessionContext.getTimerService();
+        return timerService.createIntervalTimer(initialDelayMS, intervalMS, new TimerConfig(name, true));
+    }
+}


### PR DESCRIPTION
Create the first few tests of scenarios where EJB persistent timers are expected to fail over when the application (but not the server) on which they are running stops.
Under this pull, coverage is added for scenarios with a singleton automatic timer and programmatic timer that runs outside of a global transaction.