### PR TITLE
test where a failing timer fails over with retries remaining

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/publish/servers/com.ibm.ws.concurrent.persistent.fat.failovertimers.serverA/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/publish/servers/com.ibm.ws.concurrent.persistent.fat.failovertimers.serverA/server.xml
@@ -21,7 +21,7 @@
 
   <application location="failoverTimersApp.war"/>
 
-  <persistentExecutor id="defaultEJBPersistentTimerExecutor" pollInterval="1s400ms" missedTaskThreshold="3s"/>
+  <persistentExecutor id="defaultEJBPersistentTimerExecutor" pollInterval="1s400ms" retryInterval="600ms" missedTaskThreshold="3s"/>
 
   <!-- database for persistent EJB timerss -->
   <dataSource id="DefaultDataSource">

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/ejb/autotimer/AutoCountingSingletonTimer.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/ejb/autotimer/AutoCountingSingletonTimer.java
@@ -20,6 +20,7 @@ import javax.ejb.Schedule;
 import javax.ejb.SessionContext;
 import javax.ejb.Singleton;
 import javax.ejb.Timer;
+import javax.naming.InitialContext;
 import javax.sql.DataSource;
 
 import failovertimers.web.FailoverTimersTestServlet;
@@ -69,6 +70,11 @@ public class AutoCountingSingletonTimer {
             System.out.println("Timer " + timerName + " failed.");
             x.printStackTrace(System.out);
             throw new RuntimeException(x);
+        }
+
+        if (FailoverTimersTestServlet.TIMERS_TO_ROLL_BACK.contains(timerName)) {
+            System.out.println("Timer " + timerName + " can only roll back on " + serverName);
+            sessionContext.setRollbackOnly();
         }
     }
 }

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/ejb/stateless/StatelessProgrammaticTimersBean.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/ejb/stateless/StatelessProgrammaticTimersBean.java
@@ -77,6 +77,11 @@ public class StatelessProgrammaticTimersBean {
             x.printStackTrace(System.out);
             throw new RuntimeException(x);
         }
+
+        if (FailoverTimersTestServlet.TIMERS_TO_ROLL_BACK.contains(timerName)) {
+            System.out.println("Timer " + timerName + " can only roll back on " + serverName);
+            sessionContext.setRollbackOnly();
+        }
     }
 
     public Timer scheduleTimer(long initialDelayMS, long intervalMS, String name) {

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/ejb/stateless/StatelessProgrammaticTimersBean.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/ejb/stateless/StatelessProgrammaticTimersBean.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package failovertimers.ejb.autotimer;
+package failovertimers.ejb.stateless;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -16,25 +16,32 @@ import java.sql.SQLException;
 import java.util.concurrent.CompletionException;
 
 import javax.annotation.Resource;
-import javax.ejb.Schedule;
 import javax.ejb.SessionContext;
-import javax.ejb.Singleton;
+import javax.ejb.Stateless;
+import javax.ejb.Timeout;
 import javax.ejb.Timer;
+import javax.ejb.TimerConfig;
+import javax.ejb.TimerService;
 import javax.sql.DataSource;
 
 import failovertimers.web.FailoverTimersTestServlet;
 
-@Singleton
-public class AutoCountingSingletonTimer {
+@Stateless
+public class StatelessProgrammaticTimersBean {
     @Resource
     private DataSource ds;
 
     @Resource
     private SessionContext sessionContext;
 
-    // Timer runs every other other second
-    @Schedule(info = "AutomaticCountingSingletonTimer", hour = "*", minute = "*", second = "*/2")
-    public void run(Timer timer) {
+    public void cancelTimers() {
+        TimerService timerService = sessionContext.getTimerService();
+        for (Timer t : timerService.getTimers())
+            t.cancel();
+    }
+
+    @Timeout
+    public void execTimer(Timer timer) {
         String serverConfigDir = System.getProperty("server.config.dir");
         String wlpUserDir = System.getProperty("wlp.user.dir");
         String serverName = serverConfigDir.substring(wlpUserDir.length() + "servers/".length(), serverConfigDir.length() - 1);
@@ -70,5 +77,10 @@ public class AutoCountingSingletonTimer {
             x.printStackTrace(System.out);
             throw new RuntimeException(x);
         }
+    }
+
+    public Timer scheduleTimer(long initialDelayMS, long intervalMS, String name) {
+        TimerService timerService = sessionContext.getTimerService();
+        return timerService.createIntervalTimer(initialDelayMS, intervalMS, new TimerConfig(name, true));
     }
 }

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/ejb/stateless/StatelessTxSuspendedBean.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/ejb/stateless/StatelessTxSuspendedBean.java
@@ -55,6 +55,10 @@ public class StatelessTxSuspendedBean {
             throw new CompletionException("Intentionally failing timer " + timerName + " for testing purposes", null);
         }
 
+        if (FailoverTimersTestServlet.TIMERS_TO_ROLL_BACK.contains(timerName)) {
+            throw new AssertionError("Auto rollback option is not supported for the TransactionAttributeType.NOT_SUPPORTED EJB");
+        }
+
         System.out.println("Running timer " + timerName + " on " + serverName);
 
         try (Connection con = ds.getConnection()) {

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/web/FailoverTimersTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/web/FailoverTimersTestServlet.java
@@ -51,6 +51,11 @@ public class FailoverTimersTestServlet extends FATServlet {
      */
     public static final Set<String> TIMERS_TO_FAIL = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
 
+    /**
+     * List of timers that will roll back their own execution when run on this server.
+     */
+    public static final Set<String> TIMERS_TO_ROLL_BACK = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+
     @Resource
     private DataSource ds;
 
@@ -63,6 +68,14 @@ public class FailoverTimersTestServlet extends FATServlet {
     public void allowTimer(HttpServletRequest request, HttpServletResponse response) throws Exception {
         String timerName = request.getParameter("timer");
         TIMERS_TO_FAIL.remove(timerName);
+    }
+
+    /**
+     * Allow executions of the specified timer to commit on this server.
+     */
+    public void allowTimerCommit(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        String timerName = request.getParameter("timer");
+        TIMERS_TO_ROLL_BACK.remove(timerName);
     }
 
     /**
@@ -106,6 +119,14 @@ public class FailoverTimersTestServlet extends FATServlet {
         }
 
         response.getWriter().println("Timer did not run within allotted interval.");
+    }
+
+    /**
+     * Force executions of the specified timer to roll back on this server.
+     */
+    public void forceRollbackForTimer(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        String timerName = request.getParameter("timer");
+        TIMERS_TO_ROLL_BACK.add(timerName);
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/web/FailoverTimersTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/web/FailoverTimersTestServlet.java
@@ -17,6 +17,9 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Resource;
@@ -30,6 +33,7 @@ import javax.sql.DataSource;
 import javax.transaction.UserTransaction;
 
 import componenttest.app.FATServlet;
+import failovertimers.ejb.stateless.StatelessProgrammaticTimersBean;
 import failovertimers.ejb.stateless.StatelessTxSuspendedBean;
 
 @SuppressWarnings("serial")
@@ -42,11 +46,24 @@ public class FailoverTimersTestServlet extends FATServlet {
      */
     private static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(2);
 
+    /**
+     * List of timers that will intentionally fail on this server.
+     */
+    public static final Set<String> TIMERS_TO_FAIL = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+
     @Resource
     private DataSource ds;
 
     @Resource
     private UserTransaction tx;
+
+    /**
+     * Allow executions of the specified timer to succeed on this server.
+     */
+    public void allowTimer(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        String timerName = request.getParameter("timer");
+        TIMERS_TO_FAIL.remove(timerName);
+    }
 
     /**
      * Create (if not already created) a table where EJB timers can write data when they run indicating which
@@ -59,6 +76,14 @@ public class FailoverTimersTestServlet extends FATServlet {
         } catch (SQLException x) {
             System.out.println("Table might have already been created: " + x.getMessage());
         }
+    }
+
+    /**
+     * Force executions of the specified timer to fail on this server.
+     */
+    public void disallowTimer(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        String timerName = request.getParameter("timer");
+        TIMERS_TO_FAIL.add(timerName);
     }
 
     /**
@@ -94,6 +119,19 @@ public class FailoverTimersTestServlet extends FATServlet {
     public void testCancelStatelessTxSuspendedTimers(HttpServletRequest request, HttpServletResponse response) throws Exception {
         StatelessTxSuspendedBean bean = InitialContext.doLookup("java:global/failoverTimersApp/StatelessTxSuspendedBean!failovertimers.ejb.stateless.StatelessTxSuspendedBean");
         bean.cancelTimers();
+    }
+
+    /**
+     * Programmatically schedule an EJB persistent timer that runs
+     * at the specified interval and with the specific initial delay.
+     */
+    public void testScheduleStatelessTimer(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        String timerName = request.getParameter("timer");
+        long initialDelayMS = Long.parseLong((String) request.getParameter("initialDelayMS"));
+        long intervalMS = Long.parseLong(request.getParameter("intervalMS"));
+
+        StatelessProgrammaticTimersBean bean = InitialContext.doLookup("java:global/failoverTimersApp/StatelessProgrammaticTimersBean!failovertimers.ejb.stateless.StatelessProgrammaticTimersBean");
+        bean.scheduleTimer(initialDelayMS, intervalMS, timerName);
     }
 
     /**


### PR DESCRIPTION
Adds a test case where a timer that is failing on one server fails over to another server while there are still retries remaining.  It is not necessary to use up all of the retries before the failover occurs. It can happen as soon as the missedTaskThreshold is reached.