### PR TITLE
Add senderConfig to reporterConfig

### DIFF
--- a/dev/com.ibm.ws.microprofile.opentracing.jaeger/src/com/ibm/ws/microprofile/opentracing/jaeger/JaegerTracerFactory.java
+++ b/dev/com.ibm.ws.microprofile.opentracing.jaeger/src/com/ibm/ws/microprofile/opentracing/jaeger/JaegerTracerFactory.java
@@ -154,6 +154,9 @@ public class JaegerTracerFactory implements OpentracingTracerFactory {
             if (reporterFlushInterval != null) {
                 reporterConfiguration.withFlushInterval(reporterFlushInterval);
             }
+            if (senderConfiguration != null) {
+                reporterConfiguration.withSender(senderConfiguration);
+            }
 
             //CodecConfiguration
             String propagation = getProperty(ENV_JAEGER_PROPAGATION);


### PR DESCRIPTION
SenderConfig was not added to ReporterConfig so its values were lost.

Fixes #9210 