### PR TITLE
Remove `@Deprecated` references and tests

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -114,7 +114,7 @@ org.apache.felix:org.osgi.service.obr:1.0.2
 org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0
 org.apache.santuario:xmlsec:1.5.2-ibm
 org.apache.ws.security:wss4j:1.6.7-ibm-s20130913-2015
-org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.0-20191001
+org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.0-20191003
 org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.4-ad5b7c6
 org.eclipse.persistence:org.eclipse.persistence.asm:2.7.4-ad5b7c6
 org.eclipse.persistence:org.eclipse.persistence.core:2.7.4-ad5b7c6

--- a/dev/com.ibm.websphere.org.eclipse.microprofile.graphql.1.0/bnd.bnd
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.graphql.1.0/bnd.bnd
@@ -20,7 +20,7 @@ Export-Package: \
   org.eclipse.microprofile.graphql;version=1.0
 
 Include-Resource: \
-  @${repo;org.eclipse.microprofile.graphql:microprofile-graphql-api;1.0.0.20191001;EXACT}
+  @${repo;org.eclipse.microprofile.graphql:microprofile-graphql-api;1.0.0.20191003;EXACT}
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version>=1.8))"
 

--- a/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/generator/mapping/common/EnumMapper.java
+++ b/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/generator/mapping/common/EnumMapper.java
@@ -73,10 +73,6 @@ public class EnumMapper extends CachingMapper<GraphQLEnumType, GraphQLEnumType> 
 
     @SuppressWarnings("WeakerAccess")
     protected String getValueDeprecationReason(Enum<?> value, MessageBundle messageBundle) {
-        org.eclipse.microprofile.graphql.Deprecated mpAnnotation = ClassUtils.getEnumConstantField(value).getAnnotation(org.eclipse.microprofile.graphql.Deprecated.class);
-        if (mpAnnotation != null) {
-            return ReservedStrings.decode(messageBundle.interpolate(mpAnnotation.value()));
-        }
         io.leangen.graphql.annotations.Deprecated annotation = ClassUtils.getEnumConstantField(value).getAnnotation(io.leangen.graphql.annotations.Deprecated.class);
         if (annotation != null) {
             return ReservedStrings.decode(messageBundle.interpolate(annotation.value()));

--- a/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/query/AnnotatedResolverBuilder.java
+++ b/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/query/AnnotatedResolverBuilder.java
@@ -107,10 +107,6 @@ public class AnnotatedResolverBuilder extends FilteredResolverBuilder {
     }
 
     private String deprecationReason(AnnotatedElement element, MessageBundle messageBundle) {
-        if (element.isAnnotationPresent(org.eclipse.microprofile.graphql.Deprecated.class)) {
-            return messageBundle.interpolate(ReservedStrings.decode(
-                element.getAnnotation(org.eclipse.microprofile.graphql.Deprecated.class).value()));
-        }
         if (element.isAnnotationPresent(Deprecated.class)) {
             return messageBundle.interpolate(ReservedStrings.decode(element.getAnnotation(Deprecated.class).value()));
         }

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/deprecationApp/src/mpGraphQL10/deprecation/MyGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/deprecationApp/src/mpGraphQL10/deprecation/MyGraphQLEndpoint.java
@@ -43,7 +43,7 @@ public class MyGraphQLEndpoint {
         return allWidgets;
     }
 
-    @org.eclipse.microprofile.graphql.Deprecated("Deprecated mutation, please use \"createWidget\" instead.")
+    //@org.eclipse.microprofile.graphql.Deprecated("Deprecated mutation, please use \"createWidget\" instead.")
     @Deprecated
     @Mutation("createWidgetByHand")
     public Widget createNewWidgetByHand(@Argument("widgetString") String widgetString) {

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/deprecationApp/src/mpGraphQL10/deprecation/Widget.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/deprecationApp/src/mpGraphQL10/deprecation/Widget.java
@@ -12,7 +12,7 @@ package mpGraphQL10.deprecation;
 
 import java.text.DecimalFormat;
 
-import org.eclipse.microprofile.graphql.Deprecated;
+//import org.eclipse.microprofile.graphql.Deprecated;
 /**
  * This is an implementation class of the interface entity, Widget.
  */
@@ -22,7 +22,7 @@ public class Widget {
     private int quantity = -1;
     private double weight = -1.0;
     
-    @Deprecated("Deprecated, use length, height, and depth instead.")
+    //@Deprecated("Deprecated, use length, height, and depth instead.")
     private String dimensions;
     private double length;
     private double height;

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/ignoreApp/src/mpGraphQL10/ignore/MyGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/ignoreApp/src/mpGraphQL10/ignore/MyGraphQLEndpoint.java
@@ -43,8 +43,6 @@ public class MyGraphQLEndpoint {
         return allWidgets;
     }
 
-    @org.eclipse.microprofile.graphql.Deprecated("Deprecated mutation, please use \"createWidget\" instead.")
-    @Deprecated
     @Mutation("createWidgetByHand")
     public Widget createNewWidgetByHand(@Argument("widgetString") String widgetString) {
         Widget w = Widget.fromString(widgetString);

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/MyGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/MyGraphQLEndpoint.java
@@ -43,8 +43,6 @@ public class MyGraphQLEndpoint {
         return allWidgets;
     }
 
-    @org.eclipse.microprofile.graphql.Deprecated("Deprecated mutation, please use \"createWidget\" instead.")
-    @Deprecated
     @Mutation("createWidgetByHand")
     public Widget createNewWidgetByHand(@Argument("widgetString") String widgetString) {
         Widget w = Widget.fromString(widgetString);

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/outputFieldsApp/src/mpGraphQL10/outputFields/MyGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/outputFieldsApp/src/mpGraphQL10/outputFields/MyGraphQLEndpoint.java
@@ -43,8 +43,6 @@ public class MyGraphQLEndpoint {
         return allWidgets;
     }
 
-    @org.eclipse.microprofile.graphql.Deprecated("Deprecated mutation, please use \"createWidget\" instead.")
-    @Deprecated
     @Mutation("createWidgetByHand")
     public Widget createNewWidgetByHand(@Argument("widgetString") String widgetString) {
         Widget w = Widget.fromString(widgetString);


### PR DESCRIPTION
The `@Deprecated` support in MP GraphQL has been pushed back to a later release.  It's still possible that it will be added back in to the 1.0 release, but unlikely at this point.  This change removes that support, and can be reverted if deprecation support is part of 1.0.
