### PR TITLE
allow a hiccup during the config file parse

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/MessageConstants.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/MessageConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,4 +18,5 @@ public class MessageConstants {
     public static final String CWWKO0219I_SSL_CHANNEL_READY = ".*CWWKO0219I.*defaultHttpEndpoint-ssl.*";
     public static final String CWWKS0008I_SECURITY_SERVICE_READY = "CWWKS0008I" ;
     public static final String CWWKS4105I_LTPA_CONFIG_READY = "CWWKS4105I" ;
+    public static final String CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR = "CWWKG0014E";
 }

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/servers/ServerTracker.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/servers/ServerTracker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,11 +11,13 @@
 package com.ibm.ws.security.fat.common.servers;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import com.ibm.ws.security.fat.common.Constants;
+import com.ibm.ws.security.fat.common.MessageConstants;
 import com.ibm.ws.security.fat.common.exceptions.FatExceptionUtils;
 
 import componenttest.topology.impl.LibertyServer;
@@ -33,8 +35,23 @@ public class ServerTracker {
         }
         // Every server should have the testMarker app in dropins (make sure it starts)
         server.addInstalledAppForValidation(Constants.APP_TESTMARKER);
+        addServerIgnoreErrorMessages(server)   ;    
+ 
     }
 
+    /**
+     * Add Warning/Error messages that should be ignored in all server logs
+     * Additional errors can be added for specific server types by overriding/extending this method
+     * @param server - the server to add the message(s) to ignore to...
+     */
+    public void addServerIgnoreErrorMessages(LibertyServer server) {
+ 
+        // The code reading the server config sometimes starts before the file is written (it happens rarely)
+        // that code will retry and succeed, but the error has already been logged
+        // The test framework will still see the error and fail the tests - tell the framework to ignore this error 
+        server.addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
+    }
+    
     public Set<LibertyServer> getServers() {
         return new HashSet<LibertyServer>(libertyServers);
     }

--- a/dev/com.ibm.ws.security.fat.common/test/com/ibm/ws/security/fat/common/servers/ServerTrackerTest.java
+++ b/dev/com.ibm.ws.security.fat.common/test/com/ibm/ws/security/fat/common/servers/ServerTrackerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.Arrays;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -26,6 +27,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.ibm.ws.security.fat.common.Constants;
+import com.ibm.ws.security.fat.common.MessageConstants;
 import com.ibm.ws.security.test.common.CommonTestClass;
 
 import componenttest.topology.impl.LibertyServer;
@@ -102,6 +104,7 @@ public class ServerTrackerTest extends CommonTestClass {
             mockery.checking(new Expectations() {
                 {
                     one(server1).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                 }
             });
 
@@ -127,6 +130,7 @@ public class ServerTrackerTest extends CommonTestClass {
             mockery.checking(new Expectations() {
                 {
                     exactly(2).of(server1).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    exactly(2).of(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                 }
             });
 
@@ -153,8 +157,11 @@ public class ServerTrackerTest extends CommonTestClass {
             mockery.checking(new Expectations() {
                 {
                     one(server1).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server2).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server3).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                 }
             });
 
@@ -218,7 +225,8 @@ public class ServerTrackerTest extends CommonTestClass {
             mockery.checking(new Expectations() {
                 {
                     one(server1).addInstalledAppForValidation(Constants.APP_TESTMARKER);
-                }
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
+               }
             });
 
             tracker.addServer(server1);
@@ -248,7 +256,8 @@ public class ServerTrackerTest extends CommonTestClass {
             mockery.checking(new Expectations() {
                 {
                     one(server1).addInstalledAppForValidation(Constants.APP_TESTMARKER);
-                }
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
+               }
             });
 
             tracker.addServer(server1);
@@ -283,8 +292,11 @@ public class ServerTrackerTest extends CommonTestClass {
             mockery.checking(new Expectations() {
                 {
                     one(server1).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server2).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server3).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                 }
             });
 
@@ -319,8 +331,11 @@ public class ServerTrackerTest extends CommonTestClass {
             mockery.checking(new Expectations() {
                 {
                     one(server1).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server2).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server3).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                 }
             });
 


### PR DESCRIPTION
Add code to ignore error messages for issues where retrys are attempted.  The error message is logged when a failure occurs, but, then a retry is attempted and subsequently works.  The FAT framework still sees the original error and fails the test.
The code added will allow for error message "CWWKG0014E" to occur anytime the server.xml file is updated and may be read too soon.
The update is being done in the serverTracker code and will be used by all SSO FAT tests.

