### PR TITLE
unnecessary failover attempt results in too much locking

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskStore.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskStore.java
@@ -353,6 +353,11 @@ public interface TaskStore {
 
     /**
      * Assigns a task to the specified partition.
+     * The implementation should aim to return as quickly as possible with a false value if the entry is already locked
+     * by another member, rather than waiting to make the update.  A locked task entry indicates that failover is not needed
+     * - a false positive occurred because the task was taking too long to run.  This could be caused by a lengthy timer/task
+     * that is otherwise behaving properly, in which case the customer ought to be using a larger value for missedTaskThreshold
+     * so as to avoid triggering failover logic/overhead when there is no outage.
      *
      * @param taskId         id of the task to reassign.
      * @param version        version number of the task entry which must match in order for the task to be transferred.
@@ -360,7 +365,7 @@ public interface TaskStore {
      * @return true if the task was assigned. Otherwise false.
      * @throws Exception if an error occurs when attempting to update the persistent task store.
      */
-    boolean setPartition(long taskId, int version, long newPartitionId) throws Exception;
+    boolean setPartitionIfNotLocked(long taskId, int version, long newPartitionId) throws Exception;
 
     /**
      * Assigns the value of the property if it exists in the persistent store.

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/ejb/stateless/StatelessProgrammaticTimersBean.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/ejb/stateless/StatelessProgrammaticTimersBean.java
@@ -14,6 +14,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Resource;
 import javax.ejb.SessionContext;
@@ -82,6 +83,15 @@ public class StatelessProgrammaticTimersBean {
             System.out.println("Timer " + timerName + " can only roll back on " + serverName);
             sessionContext.setRollbackOnly();
         }
+
+        if (timerName.startsWith("Long_Running_Timer_"))
+            try {
+                long delay = 8;
+                System.out.println("Timer " + timerName + " about to wait " + delay + " seconds before ending.");
+                TimeUnit.SECONDS.sleep(delay);
+            } catch (InterruptedException x) {
+                throw new CompletionException(x);
+            }
     }
 
     public Timer scheduleTimer(long initialDelayMS, long intervalMS, String name) {

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/web/FailoverTimersTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/test-applications/failoverTimersApp/src/failovertimers/web/FailoverTimersTestServlet.java
@@ -135,6 +135,14 @@ public class FailoverTimersTestServlet extends FATServlet {
     }
 
     /**
+     * Cancel all timers that were scheduled by the StatelessProgrammaticTimersBean.
+     */
+    public void testCancelStatelessProgrammaticTimers(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        StatelessProgrammaticTimersBean bean = InitialContext.doLookup("java:global/failoverTimersApp/StatelessProgrammaticTimersBean!failovertimers.ejb.stateless.StatelessProgrammaticTimersBean");
+        bean.cancelTimers();
+    }
+
+    /**
      * Cancel all timers that were scheduled by the StatelessTxSuspendedBean.
      */
     public void testCancelStatelessTxSuspendedTimers(HttpServletRequest request, HttpServletResponse response) throws Exception {


### PR DESCRIPTION
If a timer takes too long to run (longer than the missedTaskThreshold, which ought to be increased to accommodate), Liberty makes an attempt to fail over, which it doesn't realize is unnecessary.  This attempt ends up with a lock collision on the task entry, which is still running (validly) on the original server.  This pull makes some updates to reduce the waiting for locks and avoid some of the impact when it happens.  The proper solution here is for the end user to increase the missedTaskThreshold, or otherwise debug why their timer has taken too long, but we would like Liberty to behave as gracefully as possible when this happens.