### PR TITLE
Ensure name in `@InputField` is honored

### DIFF
--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/AllWidgetData.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/AllWidgetData.java
@@ -14,30 +14,30 @@ import java.util.List;
 
 public class AllWidgetData {
 
-    private List<Widget> allWidgets;
-    private Widget createdWidget;
+    private List<WidgetClientObject> allWidgets;
+    private WidgetClientObject createdWidget;
 
-    public List<Widget> getAllWidgets() {
+    public List<WidgetClientObject> getAllWidgets() {
         return allWidgets;
     }
 
-    public void setAllWidgets(List<Widget> allWidgets) {
+    public void setAllWidgets(List<WidgetClientObject> allWidgets) {
         this.allWidgets = allWidgets;
     }
     
-    public Widget getCreateWidget() {
+    public WidgetClientObject getCreateWidget() {
         return createdWidget;
     }
     
-    public void setCreateWidget(Widget widget) {
+    public void setCreateWidget(WidgetClientObject widget) {
         createdWidget = widget;
     }
 
-    public Widget getCreateWidgetByHand() {
+    public WidgetClientObject getCreateWidgetByHand() {
         return createdWidget;
     }
     
-    public void setCreateWidgetByHand(Widget widget) {
+    public void setCreateWidgetByHand(WidgetClientObject widget) {
         createdWidget = widget;
     }
 }

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/WidgetClientObject.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/WidgetClientObject.java
@@ -19,7 +19,7 @@ import org.eclipse.microprofile.graphql.InputField;
 /**
  * This is an implementation class of the interface entity, Widget.
  */
-public class Widget {
+public class WidgetClientObject {
 
     private String name;
     @InputField("qty")
@@ -32,21 +32,21 @@ public class Widget {
     private double weight2 = -1.0;
 
 
-    static Widget fromWidgetInput(Widget input) {
-        return new Widget(input.getName(),
+    static WidgetClientObject fromWidgetInput(WidgetClientObject input) {
+        return new WidgetClientObject(input.getName(),
                           input.getQuantity(),
                           input.getWeight(),
                           input.getQuantity2(),
                           input.getWeight2());
     }
 
-    static Widget fromString(String s) {
+    static WidgetClientObject fromString(String s) {
         if (!s.startsWith("Widget(") || !s.endsWith(")")) {
             throw new IllegalArgumentException();
         }
         s = s.substring("Widget(".length(), s.length()-1);
         String[] fields = s.split(",");
-        Widget w = new Widget();
+        WidgetClientObject w = new WidgetClientObject();
         w.setName(fields[0]);
         w.setQuantity(Integer.parseInt(fields[1]));
         w.setWeight(Double.parseDouble(fields[2]));
@@ -55,9 +55,9 @@ public class Widget {
         return w;
     }
 
-    public Widget() {}
+    public WidgetClientObject() {}
 
-    public Widget(String name, int quantity, double weight, int quantity2, double weight2) {
+    public WidgetClientObject(String name, int quantity, double weight, int quantity2, double weight2) {
         this.name = name;
         this.quantity = quantity;
         this.weight = weight;
@@ -102,7 +102,7 @@ public class Widget {
         return weight2;
     }
 
-    @JsonbProperty("shippingWeight2")
+    //@JsonbProperty("shippingWeight2") // cannot use JsonbProperty here since we're getting "weight2" back
     public void setWeight2(double weight2) {
         this.weight2 = weight2;
     }

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/WidgetQueryResponse.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/WidgetQueryResponse.java
@@ -31,7 +31,7 @@ public class WidgetQueryResponse {
         if (data == null) {
             sb.append("null");
         } else {
-            List<Widget> widgets = data.getAllWidgets();
+            List<WidgetClientObject> widgets = data.getAllWidgets();
             if (widgets == null) {
                 if (data.getCreateWidget() != null) {
                     sb.append("created widget:" + data.getCreateWidget());
@@ -39,7 +39,7 @@ public class WidgetQueryResponse {
                     sb.append("nullList");
                 }
             } else {
-                for (Widget w : widgets) {
+                for (WidgetClientObject w : widgets) {
                     sb.append(" ").append(w);
                 }
             }


### PR DESCRIPTION
The `@InputField("someOtherName")` annotation is used to specify a different field name for input type fields in the schema.  Prior to this change, it worked just fine for schema generation but failed when deserializing the input JSON (from a mutation) into the actual object, because the JSON would include a field name (i.e. "someOtherName") that doesn't exist in the Java POJO being deserialized.  This change fixes that by using a custom JSON-B `PropertyNamingStrategy` that maps the user-specified input field name back into the POJO field name.

This change also includes a FAT test case showing that this works.