### PR TITLE
Replace file.renameTo() method to Files.move() for platform compatibilty

### DIFF
--- a/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/NonZipExtensionFilesInBootInfLibTests20.java
+++ b/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/NonZipExtensionFilesInBootInfLibTests20.java
@@ -18,6 +18,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -80,7 +81,7 @@ public class NonZipExtensionFilesInBootInfLibTests20 extends AbstractSpringTests
                 }
                 putANonZipEntry(appFile, tempFile);
                 appFile.delete();
-                tempFile.renameTo(appFile);
+                Files.move(tempFile.toPath(), appFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
             }
         }
 
@@ -109,7 +110,7 @@ public class NonZipExtensionFilesInBootInfLibTests20 extends AbstractSpringTests
                 }
                 putAZipEntryWithNonZipExtension(appFile, tempFile);
                 appFile.delete();
-                tempFile.renameTo(appFile);
+                Files.move(tempFile.toPath(), appFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
             }
         }
 


### PR DESCRIPTION
The changes are done in reference to the Defect 262720 caused due to `file.renameTo()` method not working on platforms like windows, CENTOS, etc. So replacing the method with `File.move() `