### PR TITLE
persist information about which instances repeatedly poll and detect missed tasks

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/db/DatabaseTaskStore.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/db/DatabaseTaskStore.java
@@ -846,9 +846,8 @@ public class DatabaseTaskStore implements TaskStore {
             query.setParameter("r", stateBits);
             query.setParameter("t", System.currentTimeMillis());
             query.setMaxResults(1);
-            query.getSingleResult();
             List<Object[]> results = query.getResultList();
-            partitionInfo = results == null ? null : results.get(0);
+            partitionInfo = results == null || results.isEmpty() ? null : results.get(0);
         } finally {
             em.close();
         }

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/db/Partition.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/db/Partition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -58,18 +58,20 @@ public class Partition {
     public String USERDIR;
 
     /**
-     * Currently unused. Reserved for possible future use.
+     * Stores the expiration timestamp for this partition record.
+     * Long.MAX_VALUE indicates that it never expires.
      */
     @Column(nullable = false)
     public long EXPIRY = Long.MAX_VALUE;
 
     /**
-     * Currently unused. Reserved for possible future use.
+     * Bits that represent configured state.
      */
     @Column(nullable = false)
     public long STATES = 0l;
 
-    public Partition() {}
+    public Partition() {
+    }
 
     Partition(PartitionRecord record) {
         if (record.hasExecutor())
@@ -82,5 +84,9 @@ public class Partition {
             LSERVER = record.getLibertyServer();
         if (record.hasUserDir())
             USERDIR = record.getUserDir();
+        if (record.hasExpiry())
+            EXPIRY = record.getExpiry();
+        if (record.hasStates())
+            STATES = record.getStates();
     }
 }

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
@@ -743,11 +743,16 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
             partitionIdLock.readLock().unlock();
         }
 
+        Config config = configRef.get();
+
         PartitionRecord partitionEntry = new PartitionRecord(false);
         partitionEntry.setExecutor(name);
         partitionEntry.setLibertyServer(locationAdmin.getServerName());
         partitionEntry.setUserDir(variableRegistry.resolveString(VariableRegistry.USER_DIR));
         partitionEntry.setHostName(AccessController.doPrivileged(getHostName));
+        // TODO partitionEntry.setExpiry if heartbeatInterval enabled
+        if (config.missedTaskThreshold > 0) // TODO unconditionally supply this information once we are done experimenting and determine how much of it we really need.
+            partitionEntry.setStates((config.missedTaskThreshold > 0 ? 2 : 0) + (config.pollInterval >= 0 ? 1 : 0));
 
         // Run under a new transaction and commit right away
         EmbeddableWebSphereTransactionManager tranMgr = tranMgrRef.getServiceWithException();
@@ -1894,61 +1899,6 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
     protected synchronized void unsetServerStarted(ServiceReference<ServerStarted> ref) {
         // server is shutting down
         deactivated = true;
-    }
-
-    /**
-     * Updates partition information in the persistent store. The parameters are optional, except at least one new value
-     * must be specified.
-     *
-     * This method is for the mbean only.
-     *
-     * @param oldHostName           the host name to update.
-     * @param oldUserDir            wlp.user.dir to update.
-     * @param oldLibertyServerName  name of the Liberty server to update.
-     * @param oldExecutorIdentifier config.displayId of the persistent executor to update.
-     * @param newHostName           the new host name.
-     * @param newUserDir            the new wlp.user.dir.
-     * @param newLibertyServerName  the new name of the Liberty server.
-     * @param newExecutorIdentifier config.displayId of the new persistent executor.
-     * @return the number of entries removed from the persistent store.
-     * @throws Exception if an error occurs.
-     */
-    int updatePartitionInfo(String oldHostName, String oldUserDir, String oldLibertyServerName, String oldExecutorIdentifier,
-                            String newHostName, String newUserDir, String newLibertyServerName, String newExecutorIdentifier) throws Exception {
-        PartitionRecord updates = new PartitionRecord(false);
-        if (newHostName != null)
-            updates.setHostName(newHostName);
-        if (newUserDir != null)
-            updates.setUserDir(newUserDir);
-        if (newLibertyServerName != null)
-            updates.setLibertyServer(newLibertyServerName);
-        if (newExecutorIdentifier != null)
-            updates.setExecutor(newExecutorIdentifier);
-
-        PartitionRecord expected = new PartitionRecord(false);
-        if (oldHostName != null)
-            expected.setHostName(oldHostName);
-        if (oldUserDir != null)
-            expected.setUserDir(oldUserDir);
-        if (oldLibertyServerName != null)
-            expected.setLibertyServer(oldLibertyServerName);
-        if (oldExecutorIdentifier != null)
-            expected.setExecutor(oldExecutorIdentifier);
-
-        int numUpdated = 0;
-        TransactionController tranController = new TransactionController();
-        try {
-            tranController.preInvoke();
-            numUpdated = taskStore.persist(updates, expected);
-        } catch (Throwable x) {
-            tranController.setFailure(x);
-        } finally {
-            Exception x = tranController.postInvoke(Exception.class);
-            if (x != null)
-                throw x;
-        }
-
-        return numUpdated;
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/PartitionRecord.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/PartitionRecord.java
@@ -18,6 +18,28 @@ import com.ibm.websphere.ras.annotation.Trivial;
 @Trivial
 public class PartitionRecord {
     /**
+     * Queryable bits that are stored in the States field
+     */
+    @Trivial
+    public enum States {
+        /**
+         * Indicates that the instance performs polling of the persistent store on a periodic basis.
+         */
+        POLLS_PERIODICALLY((short) 0x1),
+
+        /**
+         * Indicates that the instance is configured with a positive value for missedTaskThreshold.
+         */
+        MISSED_TASK_THRESHOLD_ENABLED((short) 0x2);
+
+        public final short bit;
+
+        private States(short bit) {
+            this.bit = bit;
+        }
+    }
+
+    /**
      * End of line character.
      */
     private static final String EOLN = String.format("%n");

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/PartitionRecord.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/PartitionRecord.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,12 +25,13 @@ public class PartitionRecord {
     /**
      * Bits corresponding to each specified attribute.
      */
-    private static final int
-                    ID = 0x1,
+    private static final int ID = 0x1,
                     EXECUTOR = 0x2,
                     HOSTNAME = 0x4,
                     LSERVER = 0x8,
-                    USERDIR = 0x10;
+                    USERDIR = 0x10,
+                    EXPIRY = 0x20,
+                    STATES = 0x40;
 
     /**
      * Bits indicating which attributes are set.
@@ -41,6 +42,11 @@ public class PartitionRecord {
      * Id, JNDI name, or config.displayId of the persistent executor.
      */
     private String executor;
+
+    /**
+     * Expiry timestamp for the partition entry.
+     */
+    private long expiry;
 
     /**
      * Host name.
@@ -58,13 +64,18 @@ public class PartitionRecord {
     private String libertyServer;
 
     /**
+     * Bits that represent configured state.
+     */
+    private long states;
+
+    /**
      * Value of ${wlp.user.dir}
      */
     private String userDir;
 
     /**
      * Construct an empty partition record.
-     * 
+     *
      * @param allAttributesAreSpecified indicates whether all attributes should be considered specified or unspecified.
      */
     public PartitionRecord(boolean allAttributesAreSpecified) {
@@ -74,7 +85,7 @@ public class PartitionRecord {
     /**
      * Deep comparison of attributes for equality. Only specified attributes are compared.
      * Both instances must specify the same sets of attributes.
-     * 
+     *
      * @param obj instance with which to compare.
      * @return true if equal, otherwise false.
      */
@@ -89,14 +100,16 @@ public class PartitionRecord {
                    && ((attrs & EXECUTOR) == 0 || match(executor, other.executor))
                    && ((attrs & HOSTNAME) == 0 || match(hostName, other.hostName))
                    && ((attrs & LSERVER) == 0 || match(libertyServer, other.libertyServer))
-                   && ((attrs & USERDIR) == 0 || match(userDir, other.userDir));
+                   && ((attrs & USERDIR) == 0 || match(userDir, other.userDir))
+                   && ((attrs & EXPIRY) == 0 || expiry == other.expiry)
+                   && ((attrs & STATES) == 0 || states == other.states);
         }
         return false;
     }
 
     /**
      * Returns the name (Id, JNDI name, or config.displayId) of the persistent executor.
-     * 
+     *
      * @return the name (Id, JNDI name, or config.displayId) of the persistent executor.
      */
     public String getExecutor() {
@@ -107,8 +120,20 @@ public class PartitionRecord {
     }
 
     /**
+     * Returns the expiry timestamp for the partition entry.
+     *
+     * @return the expiry timestamp for the partition entry.
+     */
+    public long getExpiry() {
+        if ((attrs & EXPIRY) == 0)
+            throw new IllegalStateException();
+        else
+            return expiry;
+    }
+
+    /**
      * Returns the host name.
-     * 
+     *
      * @return the host name.
      */
     public String getHostName() {
@@ -120,7 +145,7 @@ public class PartitionRecord {
 
     /**
      * Returns the unique identifier for the partition.
-     * 
+     *
      * @return the unique identifier for the partition.
      */
     public final long getId() {
@@ -132,7 +157,7 @@ public class PartitionRecord {
 
     /**
      * Returns the Liberty server name.
-     * 
+     *
      * @return the Liberty server name.
      */
     public String getLibertyServer() {
@@ -143,8 +168,20 @@ public class PartitionRecord {
     }
 
     /**
+     * Returns bits that represent the configured state of the executor.
+     *
+     * @return bits that represent the configured state of the executor.
+     */
+    public long getStates() {
+        if ((attrs & STATES) == 0)
+            throw new IllegalStateException();
+        else
+            return states;
+    }
+
+    /**
      * Returns the value of ${wlp.user.dir}.
-     * 
+     *
      * @return the value of ${wlp.user.dir}.
      */
     public String getUserDir() {
@@ -156,7 +193,7 @@ public class PartitionRecord {
 
     /**
      * Hash code for the partition record is computed from the id.
-     * 
+     *
      * @return the hash code.
      */
     @Override
@@ -166,7 +203,7 @@ public class PartitionRecord {
 
     /**
      * Returns true if the Executor attribute is set. Otherwise false.
-     * 
+     *
      * @return true if the attribute is set. Otherwise false.
      */
     public final boolean hasExecutor() {
@@ -174,8 +211,17 @@ public class PartitionRecord {
     }
 
     /**
+     * Returns true if the Expiry attribute is set. Otherwise false.
+     *
+     * @return true if the attribute is set. Otherwise false.
+     */
+    public final boolean hasExpiry() {
+        return (attrs & EXPIRY) != 0;
+    }
+
+    /**
      * Returns true if the Host attribute is set. Otherwise false.
-     * 
+     *
      * @return true if the attribute is set. Otherwise false.
      */
     public final boolean hasHostName() {
@@ -184,7 +230,7 @@ public class PartitionRecord {
 
     /**
      * Returns true if the Id attribute is set. Otherwise false.
-     * 
+     *
      * @return true if the attribute is set. Otherwise false.
      */
     public final boolean hasId() {
@@ -193,7 +239,7 @@ public class PartitionRecord {
 
     /**
      * Returns true if the Server attribute is set. Otherwise false.
-     * 
+     *
      * @return true if the attribute is set. Otherwise false.
      */
     public final boolean hasLibertyServer() {
@@ -201,8 +247,17 @@ public class PartitionRecord {
     }
 
     /**
+     * Returns true if the States attribute is set. Otherwise false.
+     *
+     * @return true if the attribute is set. Otherwise false.
+     */
+    public final boolean hasStates() {
+        return (attrs & STATES) != 0;
+    }
+
+    /**
      * Returns true if the UserDir attribute is set. Otherwise false.
-     * 
+     *
      * @return true if the attribute is set. Otherwise false.
      */
     public final boolean hasUserDir() {
@@ -211,7 +266,7 @@ public class PartitionRecord {
 
     /**
      * Utility method to compare for equality.
-     * 
+     *
      * @param obj1 first object.
      * @param obj2 second object.
      * @return true if equal or both null. False otherwise.
@@ -222,7 +277,7 @@ public class PartitionRecord {
 
     /**
      * Sets the name (Id, JNDI name, or config.displayId) of the persistent executor.
-     * 
+     *
      * @param executor the name of the persistent executor.
      */
     public final void setExecutor(String executor) {
@@ -231,8 +286,18 @@ public class PartitionRecord {
     }
 
     /**
+     * Sets the expiry timestamp for the partition entry.
+     *
+     * @param expiry the expiry timestamp for the partition entry.
+     */
+    public final void setExpiry(long expiry) {
+        this.expiry = expiry;
+        attrs |= EXPIRY;
+    }
+
+    /**
      * Sets the host name.
-     * 
+     *
      * @param host the host name.
      */
     public final void setHostName(String host) {
@@ -242,7 +307,7 @@ public class PartitionRecord {
 
     /**
      * Sets the unique identifier for the partition.
-     * 
+     *
      * @param id unique identifier for the partition.
      */
     public final void setId(long id) {
@@ -252,7 +317,7 @@ public class PartitionRecord {
 
     /**
      * Sets the server name.
-     * 
+     *
      * @param server the server name.
      */
     public final void setLibertyServer(String server) {
@@ -261,8 +326,18 @@ public class PartitionRecord {
     }
 
     /**
+     * Sets the bits that represent configured state.
+     *
+     * @param expiry the expiry timestamp for the partition entry.
+     */
+    public final void setStates(long states) {
+        this.states = states;
+        attrs |= STATES;
+    }
+
+    /**
      * Sets the value obtained from ${wlp.user.dir}.
-     * 
+     *
      * @param userDir value obtained from ${wlp.user.dir}.
      */
     public final void setUserDir(String userDir) {
@@ -272,7 +347,7 @@ public class PartitionRecord {
 
     /**
      * Returns a textual representation of this instance.
-     * 
+     *
      * @return a textual representation of this instance.
      */
     @Override
@@ -289,6 +364,10 @@ public class PartitionRecord {
             output.append(EOLN).append("LSERVER=").append(libertyServer);
         if ((attrs & USERDIR) != 0)
             output.append(EOLN).append("USERDIR=").append(userDir);
+        if ((attrs & EXPIRY) != 0)
+            output.append(EOLN).append("EXPIRY=").append(expiry);
+        if ((attrs & STATES) != 0)
+            output.append(EOLN).append("STATES=").append(states);
 
         return output.toString();
     }
@@ -298,6 +377,13 @@ public class PartitionRecord {
      */
     public final void unsetExecutor() {
         attrs &= ~EXECUTOR;
+    }
+
+    /**
+     * Unsets the Expiry attribute.
+     */
+    public final void unsetExpiry() {
+        attrs &= ~EXPIRY;
     }
 
     /**
@@ -319,6 +405,13 @@ public class PartitionRecord {
      */
     public final void unsetLibertyServer() {
         attrs &= ~LSERVER;
+    }
+
+    /**
+     * Unsets the States attribute.
+     */
+    public final void unsetStates() {
+        attrs &= ~STATES;
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskStore.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskStore.java
@@ -218,6 +218,17 @@ public interface TaskStore {
     Long getPartition(long taskId) throws Exception;
 
     /**
+     * Returns the identifier of a partition whose STATE field's rightmost bits matches the specified value.
+     * This method assumes that the sign bit of the persisted STATES field is always positive (0),
+     * so as to be able to compute the remainder when dividing by the next highest power of 2.
+     *
+     * @param stateBits desired state bits to match.
+     * @return a matching partition identifier, otherwise null.
+     * @throws Exception if an error occurs accessing the persistent store.
+     */
+    Long getPartitionWithState(long stateBits) throws Exception;
+
+    /**
      * Returns name/value pairs for all persisted properties that match the specified name pattern.
      * For example, to find property names that start with "MY_PROP_NAME_",
      * taskStore.getProperties("MY\\_PROP\\_NAME\\_%", '\\');

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/fat/src/com/ibm/ws/concurrent/persistent/fat/failover1serv/Failover1ServerTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/fat/src/com/ibm/ws/concurrent/persistent/fat/failover1serv/Failover1ServerTest.java
@@ -398,7 +398,7 @@ public class Failover1ServerTest extends FATServletClient {
 
     /**
      * testScheduleToRunOnDifferentServer - Schedule a task using an instance that cannot run tasks.
-     * If it sees another instance that can run tasks polls for missed tasks, then it should schedule
+     * If it sees another instance that can run tasks and polls for missed tasks, then it should schedule
      * the task to run on that server instead.
      */
     @Test
@@ -429,10 +429,9 @@ public class Failover1ServerTest extends FATServletClient {
 
             boolean completed = false;
             try {
-                // TODO enable once the feature code (8406) is written
-                //runTest(server, APP_NAME + "/Failover1ServerTestServlet",
-                //        "testTaskCompleted&taskId=" + taskId + "&expectedResult=1&jndiName=persistent/exec1&test=testScheduleToRunOnDifferentServer[2]");
-                //completed = true;
+                runTest(server, APP_NAME + "/Failover1ServerTestServlet",
+                        "testTaskCompleted&taskId=" + taskId + "&expectedResult=1&jndiName=persistent/exec1&test=testScheduleToRunOnDifferentServer[2]");
+                completed = true;
             } finally {
                 if (!completed)
                     runTest(server, APP_NAME + "/Failover1ServerTestServlet",


### PR DESCRIPTION
Include information in the persistent store, within an existing table, about whether an instance polls periodically and has the missedTaskThreshold setting enabled.  This will be useful when an instance that is not able to run tasks itself needs to select where to assign them.