### PR TITLE
add heartbeatInterval as nonship

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/metatype/metatype.xml
@@ -24,6 +24,7 @@
   <AD id="contextServiceRef"                 type="String"  default="DefaultContextService" ibm:type="pid" ibm:reference="com.ibm.ws.context.service" name="%contextService" description="%contextService.desc" required="false"/>  
   <AD id="ContextService.target"             type="String"  default="(|(service.pid=${contextServiceRef})(&amp;(service.pid=com.ibm.ws.context.manager)(|(service.pid&gt;=${contextServiceRef})(default.for&lt;=${contextServiceRef}))))" ibm:final="true" name="internal" description="internal use only"/>
   <AD id="enableTaskExecution"               type="Boolean" default="true" name="%enableTaskExecution" description="%enableTaskExecution.desc"/>
+  <AD id="heartbeatInterval"                 type="String"  default="-1" ibm:type="duration(s)" name="internal" description="internal use only"/>
   <AD id="initialPollDelay"                  type="String"  default="0" ibm:type="duration" name="%initialPollDelay" description="%initialPollDelay.desc"/>
   <AD id="jndiName"                          type="String"  required="false" ibm:unique="jndiName" name="internal" description="internal use only"/>
   <AD id="missedTaskThreshold"               type="String"  default="-1" ibm:type="duration(s)" name="internal" description="internal use only"/>


### PR DESCRIPTION
Add a configurable heartbeatInterval, initially as nonship/internal, so that we can experiment with its implementation.