### PR TITLE
Re-apply performance improvement for local builds

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -10,6 +10,8 @@
  *******************************************************************************/
 
 import org.apache.tools.ant.filters.ReplaceTokens
+import groovy.json.*
+import org.gradle.internal.os.OperatingSystem
 
 apply plugin: 'maven'
 
@@ -56,11 +58,6 @@ assemble {
     dependsOn copyLicenseToBuildImage
     dependsOn copySwidTagToBuildImage
 }
-
-import groovy.json.*
-import org.gradle.internal.os.OperatingSystem
-
-
 
 File packageDir = new File(project.buildDir, 'openliberty')
 File mavenDir = new File(project.buildDir, 'maven')
@@ -163,22 +160,6 @@ def microProfile3Features() {
     features
 }
 
-task packageOpenLiberty(type: PackageLibertyWithFeatures) {
-    enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
-    dependsOn parent.subprojects.assemble
-    dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
-    withFeatures this.&gaPublicFeatures
-    outputTo packageDir
-}
-
-task packageOpenLibertyKernel(type: PackageLibertyWithFeatures) {
-    enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
-    dependsOn parent.subprojects.assemble
-    dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
-    withFeatures { '' }
-    outputTo packageDir
-}
-
 def removeFeature(feature) {
     def file = new File("$projectDir/wlp/lib/features/com.ibm.websphere.appserver." + feature + ".mf")
     file.renameTo(new File("$projectDir/wlp/lib/features/com.ibm.websphere.appserver." + feature + ".mf.bak"))
@@ -197,78 +178,96 @@ def excludedFeatures = ['cdi-1.2',
                         'jaxrsClient-2.0',
                         'servlet-3.1']
 
-task packageOpenLibertyWebProfile8(type: PackageLibertyWithFeatures) {
-    doFirst {
-        excludedFeatures.each {
-            this.&removeFeature("${it}")
-        }
-    }
-    enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
-    dependsOn parent.subprojects.assemble
-    dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
-    withFeatures this.&webProfile8Features
-    outputTo packageDir
-    doLast {
-        copy {
-            from "$packageDir/wlp/templates/servers/webProfile8/server.xml" 
-            into "$packageDir/wlp/templates/servers/defaultServer" 
-        }
-        copy {
-            from "$packageDir/wlp/templates/clients/javaeeClient8/client.xml"
-            into "$packageDir/wlp/templates/clients/defaultClient" 
-        }
-        excludedFeatures.each {
-            this.&restoreFeature("${it}")
-        }
-    }
-}
-
-task packageOpenLibertyJavaee8(type: PackageLibertyWithFeatures) {
-    doFirst {
-        excludedFeatures.each {
-            this.&removeFeature("${it}")
-        }
+if (isAutomatedBuild) {
+    task packageOpenLiberty(type: PackageLibertyWithFeatures) {
+        enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
+        dependsOn parent.subprojects.assemble
+        dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
+        withFeatures this.&gaPublicFeatures
+        outputTo packageDir
     }
 
-    enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
-    dependsOn parent.subprojects.assemble
-    dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
-    withFeatures this.&javaee8Features
-    outputTo packageDir
-    doLast {
-        copy {
-            from "$packageDir/wlp/templates/servers/javaee8/server.xml" 
-            into "$packageDir/wlp/templates/servers/defaultServer" 
-        }
-        copy {
-            from "$packageDir/wlp/templates/clients/javaeeClient8/client.xml"
-            into "$packageDir/wlp/templates/clients/defaultClient" 
-        }
-        excludedFeatures.each {
-            this.&restoreFeature("${it}")
-        }
+    task packageOpenLibertyKernel(type: PackageLibertyWithFeatures) {
+        enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
+        dependsOn parent.subprojects.assemble
+        dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
+        withFeatures { '' }
+        outputTo packageDir
     }
-}
 
-task packageOpenLibertyMicroProfile3(type: PackageLibertyWithFeatures) {
-    doFirst {
-        excludedFeatures.each {
-            this.&removeFeature("${it}")
+    task packageOpenLibertyWebProfile8(type: PackageLibertyWithFeatures) {
+        doFirst {
+            excludedFeatures.each {
+                this.&removeFeature("${it}")
+            }
+        }
+        enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
+        dependsOn parent.subprojects.assemble
+        dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
+        withFeatures this.&webProfile8Features
+        outputTo packageDir
+        doLast {
+            copy {
+                from "$packageDir/wlp/templates/servers/webProfile8/server.xml"
+                into "$packageDir/wlp/templates/servers/defaultServer"
+            }
+            copy {
+                from "$packageDir/wlp/templates/clients/javaeeClient8/client.xml"
+                into "$packageDir/wlp/templates/clients/defaultClient"
+            }
+            excludedFeatures.each {
+                this.&restoreFeature("${it}")
+            }
         }
     }
 
-    enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
-    dependsOn parent.subprojects.assemble
-    dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
-    withFeatures this.&microProfile3Features
-    outputTo packageDir
-    doLast {
-        copy {
-            from "$packageDir/wlp/templates/servers/microProfile3/server.xml" 
-            into "$packageDir/wlp/templates/servers/defaultServer" 
+    task packageOpenLibertyJavaee8(type: PackageLibertyWithFeatures) {
+        doFirst {
+            excludedFeatures.each {
+                this.&removeFeature("${it}")
+            }
         }
-        excludedFeatures.each {
-            this.&restoreFeature("${it}")
+
+        enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
+        dependsOn parent.subprojects.assemble
+        dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
+        withFeatures this.&javaee8Features
+        outputTo packageDir
+        doLast {
+            copy {
+                from "$packageDir/wlp/templates/servers/javaee8/server.xml"
+                into "$packageDir/wlp/templates/servers/defaultServer"
+            }
+            copy {
+                from "$packageDir/wlp/templates/clients/javaeeClient8/client.xml"
+                into "$packageDir/wlp/templates/clients/defaultClient"
+            }
+            excludedFeatures.each {
+                this.&restoreFeature("${it}")
+            }
+        }
+    }
+
+    task packageOpenLibertyMicroProfile3(type: PackageLibertyWithFeatures) {
+        doFirst {
+            excludedFeatures.each {
+                this.&removeFeature("${it}")
+            }
+        }
+
+        enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
+        dependsOn parent.subprojects.assemble
+        dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
+        withFeatures this.&microProfile3Features
+        outputTo packageDir
+        doLast {
+            copy {
+                from "$packageDir/wlp/templates/servers/microProfile3/server.xml"
+                into "$packageDir/wlp/templates/servers/defaultServer"
+            }
+            excludedFeatures.each {
+                this.&restoreFeature("${it}")
+            }
         }
     }
 }
@@ -290,74 +289,76 @@ task zipOpenLibertyAll(type: Zip) {
 }
 publish.dependsOn zipOpenLibertyAll
 
-// Includes only kind=ga features.
-task zipOpenLiberty(type: Zip) {
-    dependsOn packageOpenLiberty
-    baseName 'openliberty'
-    from packageDir
-    destinationDir distsDir
-    version releaseVersion
-    doLast{
-        rootProject.userProps.setProperty('zipopenliberty.runtime.archivename', archivePath.toString())
-        rootProject.storeProps()
+if (isAutomatedBuild) {
+    // Includes only kind=ga features.
+    task zipOpenLiberty(type: Zip) {
+        dependsOn packageOpenLiberty
+        baseName 'openliberty'
+        from packageDir
+        destinationDir distsDir
+        version releaseVersion
+        doLast {
+            rootProject.userProps.setProperty('zipopenliberty.runtime.archivename', archivePath.toString())
+            rootProject.storeProps()
+        }
     }
-}
-publish.dependsOn zipOpenLiberty
+    publish.dependsOn zipOpenLiberty
 
-// Includes only kind=ga features.
-task zipOpenLibertyKernel(type: Zip) {
-    dependsOn packageOpenLibertyKernel
-    baseName 'openliberty-kernel'
-    from packageDir
-    destinationDir distsDir
-    version releaseVersion
-    doLast{
-        rootProject.userProps.setProperty('zipopenliberty.kernel.archivename', archivePath.toString())
-        rootProject.storeProps()
+    // Includes only kind=ga features.
+    task zipOpenLibertyKernel(type: Zip) {
+        dependsOn packageOpenLibertyKernel
+        baseName 'openliberty-kernel'
+        from packageDir
+        destinationDir distsDir
+        version releaseVersion
+        doLast {
+            rootProject.userProps.setProperty('zipopenliberty.kernel.archivename', archivePath.toString())
+            rootProject.storeProps()
+        }
     }
-}
-publish.dependsOn zipOpenLibertyKernel
+    publish.dependsOn zipOpenLibertyKernel
 
-// Includes only kind=ga features.
-task zipOpenLibertyWebProfile8(type: Zip) {
-    dependsOn packageOpenLibertyWebProfile8
-    baseName 'openliberty-webProfile8'
-    from packageDir
-    destinationDir distsDir
-    version releaseVersion
-    doLast{
-        rootProject.userProps.setProperty('zipopenliberty.webprofile8.archivename', archivePath.toString())
-        rootProject.storeProps()
+    // Includes only kind=ga features.
+    task zipOpenLibertyWebProfile8(type: Zip) {
+        dependsOn packageOpenLibertyWebProfile8
+        baseName 'openliberty-webProfile8'
+        from packageDir
+        destinationDir distsDir
+        version releaseVersion
+        doLast {
+            rootProject.userProps.setProperty('zipopenliberty.webprofile8.archivename', archivePath.toString())
+            rootProject.storeProps()
+        }
     }
-}
-publish.dependsOn zipOpenLibertyWebProfile8
+    publish.dependsOn zipOpenLibertyWebProfile8
 
-// Includes only kind=ga features.
-task zipOpenLibertyJavaee8(type: Zip) {
-    dependsOn packageOpenLibertyJavaee8
-    baseName 'openliberty-javaee8'
-    from packageDir
-    destinationDir distsDir
-    version releaseVersion
-    doLast{
-        rootProject.userProps.setProperty('zipopenliberty.javaee8.archivename', archivePath.toString())
-        rootProject.storeProps()
+    // Includes only kind=ga features.
+    task zipOpenLibertyJavaee8(type: Zip) {
+        dependsOn packageOpenLibertyJavaee8
+        baseName 'openliberty-javaee8'
+        from packageDir
+        destinationDir distsDir
+        version releaseVersion
+        doLast {
+            rootProject.userProps.setProperty('zipopenliberty.javaee8.archivename', archivePath.toString())
+            rootProject.storeProps()
+        }
     }
-}
-publish.dependsOn zipOpenLibertyJavaee8
+    publish.dependsOn zipOpenLibertyJavaee8
 
-task zipOpenLibertyMicroProfile3(type: Zip) {
-    dependsOn packageOpenLibertyMicroProfile3
-    baseName 'openliberty-microProfile3'
-    from packageDir
-    destinationDir distsDir
-    version releaseVersion
-    doLast {
-        rootProject.userProps.setProperty('zipopenliberty.microprofile3.archivename', archivePath.toString())
-        rootProject.storeProps()
+    task zipOpenLibertyMicroProfile3(type: Zip) {
+        dependsOn packageOpenLibertyMicroProfile3
+        baseName 'openliberty-microProfile3'
+        from packageDir
+        destinationDir distsDir
+        version releaseVersion
+        doLast {
+            rootProject.userProps.setProperty('zipopenliberty.microprofile3.archivename', archivePath.toString())
+            rootProject.storeProps()
+        }
     }
+    publish.dependsOn zipOpenLibertyMicroProfile3
 }
-publish.dependsOn zipOpenLibertyMicroProfile3
 
 clean.doLast {
     file('wlp').deleteDir()
@@ -371,344 +372,345 @@ publishing {
             version project.version
             artifact zipOpenLibertyAll
         }
-        openLiberty(MavenPublication) {
-            groupId 'io.openliberty'
-            artifactId 'openliberty-runtime'
-            version project.version
-            artifact zipOpenLiberty
-        }
-        openLibertyKernel(MavenPublication) {
-            groupId 'io.openliberty'
-            artifactId 'openliberty-kernel'
-            version project.version
-            artifact zipOpenLibertyKernel
-        }
-        openLibertyWebProfile8(MavenPublication) {
-            groupId 'io.openliberty'
-            artifactId 'openliberty-webProfile8'
-            version project.version
-            artifact zipOpenLibertyWebProfile8
-        }
-        openLibertyJavaee8(MavenPublication) {
-            groupId 'io.openliberty'
-            artifactId 'openliberty-javaee8'
-            version project.version
-            artifact zipOpenLibertyJavaee8
+        if (isAutomatedBuild) {
+            openLiberty(MavenPublication) {
+                groupId 'io.openliberty'
+                artifactId 'openliberty-runtime'
+                version project.version
+                artifact zipOpenLiberty
+            }
+            openLibertyKernel(MavenPublication) {
+                groupId 'io.openliberty'
+                artifactId 'openliberty-kernel'
+                version project.version
+                artifact zipOpenLibertyKernel
+            }
+            openLibertyWebProfile8(MavenPublication) {
+                groupId 'io.openliberty'
+                artifactId 'openliberty-webProfile8'
+                version project.version
+                artifact zipOpenLibertyWebProfile8
+            }
+            openLibertyJavaee8(MavenPublication) {
+                groupId 'io.openliberty'
+                artifactId 'openliberty-javaee8'
+                version project.version
+                artifact zipOpenLibertyJavaee8
+            }
         }
     }
 }
 
-task createOLRuntimePoms {
-    dependsOn packageOpenLiberty
-    pom {
-        project {
-            groupId 'io.openliberty'
-            artifactId 'openliberty-runtime'
-            version bnd.libertyRelease
-            packaging 'zip'
-            name 'Open Liberty Runtime Package'
-            description 'Open Liberty Runtime Package'
-            url 'https://openliberty.io/'
-            licenses {
-                license {
-                    name 'Eclipse Public License v1.0'
-                    url 'http://www.eclipse.org/legal/epl-v10.html'
-                    distribution 'repo'
+if (isAutomatedBuild) {
+    task createOLRuntimePoms {
+        dependsOn packageOpenLiberty
+        pom {
+            project {
+                groupId 'io.openliberty'
+                artifactId 'openliberty-runtime'
+                version bnd.libertyRelease
+                packaging 'zip'
+                name 'Open Liberty Runtime Package'
+                description 'Open Liberty Runtime Package'
+                url 'https://openliberty.io/'
+                licenses {
+                    license {
+                        name 'Eclipse Public License v1.0'
+                        url 'http://www.eclipse.org/legal/epl-v10.html'
+                        distribution 'repo'
+                    }
+                }
+                scm {
+                    connection 'scm:git:git@github.com:OpenLiberty/open-liberty.git'
+                    developerConnection 'scm:git:git@github.com:OpenLiberty/open-liberty.git'
+                    url 'git@github.com:OpenLiberty/open-liberty.git'
+                    tag 'HEAD'
+                }
+                developers {
+                    developer {
+                        id 'cbridgha'
+                        name 'Chuck Bridgham'
+                        email 'cbridgha@us.ibm.com'
+                    }
                 }
             }
-            scm {
-                connection 'scm:git:git@github.com:OpenLiberty/open-liberty.git'
-                developerConnection 'scm:git:git@github.com:OpenLiberty/open-liberty.git'
-                url 'git@github.com:OpenLiberty/open-liberty.git'
-                tag 'HEAD'
-            }
-            developers {
-                developer {
-                    id 'cbridgha'
-                    name 'Chuck Bridgham'
-                    email 'cbridgha@us.ibm.com'
+        }.writeTo("${mavenDir}/openliberty-runtime-${bnd.libertyRelease}.pom")
+        pom {
+            project {
+                groupId 'io.openliberty'
+                artifactId 'openliberty-webProfile8'
+                version bnd.libertyRelease
+                packaging 'zip'
+                name 'Open Liberty JavaEE 8 Web Profile Package'
+                description 'Open Liberty JavaEE 8 Web Profile Package'
+                url 'https://openliberty.io/'
+                licenses {
+                    license {
+                        name 'Eclipse Public License v1.0'
+                        url 'http://www.eclipse.org/legal/epl-v10.html'
+                        distribution 'repo'
+                    }
+                }
+                scm {
+                    connection 'scm:git:git@github.com:OpenLiberty/open-liberty.git'
+                    developerConnection 'scm:git:git@github.com:OpenLiberty/open-liberty.git'
+                    url 'git@github.com:OpenLiberty/open-liberty.git'
+                    tag 'HEAD'
+                }
+                developers {
+                    developer {
+                        id 'cbridgha'
+                        name 'Chuck Bridgham'
+                        email 'cbridgha@us.ibm.com'
+                    }
                 }
             }
-        }
-    }.writeTo("${mavenDir}/openliberty-runtime-${bnd.libertyRelease}.pom")
-    pom {
-        project {
-            groupId 'io.openliberty'
-            artifactId 'openliberty-webProfile8'
-            version bnd.libertyRelease
-            packaging 'zip'
-            name 'Open Liberty JavaEE 8 Web Profile Package'
-            description 'Open Liberty JavaEE 8 Web Profile Package'
-            url 'https://openliberty.io/'
-            licenses {
-                license {
-                    name 'Eclipse Public License v1.0'
-                    url 'http://www.eclipse.org/legal/epl-v10.html'
-                    distribution 'repo'
+        }.writeTo("${mavenDir}/openliberty-webProfile8-${bnd.libertyRelease}.pom")
+        pom {
+            project {
+                groupId 'io.openliberty'
+                artifactId 'openliberty-kernel'
+                version bnd.libertyRelease
+                packaging 'zip'
+                name 'Open Liberty Kernel Package'
+                description 'Open Liberty Kernel Package'
+                url 'https://openliberty.io/'
+                licenses {
+                    license {
+                        name 'Eclipse Public License v1.0'
+                        url 'http://www.eclipse.org/legal/epl-v10.html'
+                        distribution 'repo'
+                    }
+                }
+                scm {
+                    connection 'scm:git:git@github.com:OpenLiberty/open-liberty.git'
+                    developerConnection 'scm:git:git@github.com:OpenLiberty/open-liberty.git'
+                    url 'git@github.com:OpenLiberty/open-liberty.git'
+                    tag 'HEAD'
+                }
+                developers {
+                    developer {
+                        id 'cbridgha'
+                        name 'Chuck Bridgham'
+                        email 'cbridgha@us.ibm.com'
+                    }
                 }
             }
-            scm {
-                connection 'scm:git:git@github.com:OpenLiberty/open-liberty.git'
-                developerConnection 'scm:git:git@github.com:OpenLiberty/open-liberty.git'
-                url 'git@github.com:OpenLiberty/open-liberty.git'
-                tag 'HEAD'
-            }
-            developers {
-                developer {
-                    id 'cbridgha'
-                    name 'Chuck Bridgham'
-                    email 'cbridgha@us.ibm.com'
+        }.writeTo("${mavenDir}/openliberty-kernel-${bnd.libertyRelease}.pom")
+        pom {
+            project {
+                groupId 'io.openliberty'
+                artifactId 'openliberty-javaee8'
+                version bnd.libertyRelease
+                packaging 'zip'
+                name 'Open Liberty JavaEE8 Package'
+                description 'Open Liberty JavaEE8 Package'
+                url 'https://openliberty.io/'
+                licenses {
+                    license {
+                        name 'Eclipse Public License v1.0'
+                        url 'http://www.eclipse.org/legal/epl-v10.html'
+                        distribution 'repo'
+                    }
+                }
+                scm {
+                    connection 'scm:git:git@github.com:OpenLiberty/open-liberty.git'
+                    developerConnection 'scm:git:git@github.com:OpenLiberty/open-liberty.git'
+                    url 'git@github.com:OpenLiberty/open-liberty.git'
+                    tag 'HEAD'
+                }
+                developers {
+                    developer {
+                        id 'cbridgha'
+                        name 'Chuck Bridgham'
+                        email 'cbridgha@us.ibm.com'
+                    }
                 }
             }
+        }.writeTo("${mavenDir}/openliberty-javaee8-${bnd.libertyRelease}.pom")
+    }
+
+    if (isRelease) {
+        task zipOpenLibertyMaven(type: Zip) {
+            dependsOn createOLRuntimePoms
+            archiveName "openliberty-runtimes-maven-${releaseVersion}.zip"
+            from mavenDir
+            from distsDir
+            include '*.zip'
+            include '*.pom'
+            exclude 'openliberty-all*.zip'
+            destinationDir project.file('build/temp/mavenArtifact')
         }
-    }.writeTo("${mavenDir}/openliberty-webProfile8-${bnd.libertyRelease}.pom")
-    pom {
-        project {
-            groupId 'io.openliberty'
-            artifactId 'openliberty-kernel'
-            version bnd.libertyRelease
-            packaging 'zip'
-            name 'Open Liberty Kernel Package'
-            description 'Open Liberty Kernel Package'
-            url 'https://openliberty.io/'
-            licenses {
-                license {
-                    name 'Eclipse Public License v1.0'
-                    url 'http://www.eclipse.org/legal/epl-v10.html'
-                    distribution 'repo'
-                }
-            }
-            scm {
-                connection 'scm:git:git@github.com:OpenLiberty/open-liberty.git'
-                developerConnection 'scm:git:git@github.com:OpenLiberty/open-liberty.git'
-                url 'git@github.com:OpenLiberty/open-liberty.git'
-                tag 'HEAD'
-            }
-            developers {
-                developer {
-                    id 'cbridgha'
-                    name 'Chuck Bridgham'
-                    email 'cbridgha@us.ibm.com'
-                }
-            }
-        }
-    }.writeTo("${mavenDir}/openliberty-kernel-${bnd.libertyRelease}.pom")
-    pom {
-        project {
-            groupId 'io.openliberty'
-            artifactId 'openliberty-javaee8'
-            version bnd.libertyRelease
-            packaging 'zip'
-            name 'Open Liberty JavaEE8 Package'
-            description 'Open Liberty JavaEE8 Package'
-            url 'https://openliberty.io/'
-            licenses {
-                license {
-                    name 'Eclipse Public License v1.0'
-                    url 'http://www.eclipse.org/legal/epl-v10.html'
-                    distribution 'repo'
-                }
-            }
-            scm {
-                connection 'scm:git:git@github.com:OpenLiberty/open-liberty.git'
-                developerConnection 'scm:git:git@github.com:OpenLiberty/open-liberty.git'
-                url 'git@github.com:OpenLiberty/open-liberty.git'
-                tag 'HEAD'
-            }
-            developers {
-                developer {
-                    id 'cbridgha'
-                    name 'Chuck Bridgham'
-                    email 'cbridgha@us.ibm.com'
-                }
-            }
-        }
-    }.writeTo("${mavenDir}/openliberty-javaee8-${bnd.libertyRelease}.pom")
-}
+        publish.dependsOn zipOpenLibertyMaven
+    }
 
-
-task zipOpenLibertyMaven(type: Zip) {
-    dependsOn createOLRuntimePoms
-    archiveName "openliberty-runtimes-maven-${releaseVersion}.zip"
-    from mavenDir
-    from distsDir
-    include '*.zip'
-    include '*.pom'
-    exclude 'openliberty-all*.zip'
-    destinationDir project.file('build/temp/mavenArtifact')
-}
-if (isRelease) {
-    publish.dependsOn zipOpenLibertyMaven
-}
-
-task zipTestReport(type: Zip) {
-    baseName 'openliberty_test_report'
-    from cnf.file('generated/testReports/allUnitTests')
-    destinationDir cnf.file('generated/testReports')
-    rootProject.userProps.setProperty('gradle.test.report.zip', archivePath.toString())
-    rootProject.storeProps()
-}
-
-
-
-task createJSONForPublicArtifacts {
-    enabled isAutomatedBuild
-    dependsOn zipTestReport
-
-    doLast {
-        println "running createJSONForPublicArtifacts"
-        delete "${buildDir}/info.json"
-        File json = new File("${buildDir}/info.json")
-        json.createNewFile()
-
-        String testsPassed = "0"
-        if (rootProject.userProps.getProperty("tests.total.successful") != null) {
-            testsPassed = rootProject.userProps.getProperty("tests.total.successful")
-	    println "testsPassed is ${testsPassed}"
-        }
-        String testsTotal = "0"
-        if ((rootProject.userProps.getProperty("tests.total.successful") != null) &&
-                (rootProject.userProps.getProperty("tests.total.failed") != null)) {
-            def sum = Integer.valueOf(rootProject.userProps.getProperty("tests.total.successful")) + Integer.valueOf(rootProject.userProps.getProperty("tests.total.failed"))
-            testsTotal = sum.toString()
-	    println "testsTotal is ${testsTotal}"
-        }
-
-        String junitPath = rootProject.userProps.getProperty("junit.report.zip")
-        String testReportPath = rootProject.userProps.getProperty("gradle.test.report.zip");
-        String logPath = rootProject.userProps.getProperty("published.gradle.log")
-        String driverLocation = rootProject.userProps.getProperty("zipopenliberty.archivename")
-        println "junitPath is ${junitPath}"
-        println "testReportPath is ${testReportPath}"
-        println "logPath is ${logPath}"
-        println "driverLocation is ${driverLocation}"
-
-        if (junitPath == null) {
-            raise InvalidUserDataException("Could not find property named 'junit.report.zip'")
-        }
-
-        if (isPersonal && (testReportPath == null)) {
-            raise InvalidUserDataException("Could not find property named 'gradle.test.report.zip'")
-        }
-
-        if (logPath == null) {
-            raise InvalidUserDataException("Could not find property named 'published.gradle.log'")
-        }
-
-        if (driverLocation == null) {
-            raise InvalidUserDataException("Could not find property named 'zipopenliberty.archivename'")
-        }
-
-        String testResultName = null
-        if (isPersonal) {
-            testResultName = new File(testReportPath).getName()
-        } else {
-            testResultName = new File(junitPath).getName()
-        }
-	    println "testResultName is ${testResultName}"
-        String logName = new File(logPath).getName()
-        String driverLocationName = new File(driverLocation).getName()
-
-        def object = [test_passed: "${testsPassed}",
-                      total_tests: "${testsTotal}",
-                      tests_log: "${testResultName}",
-                      build_log: "${logName}"]
-
-        if (isPersonal || isRelease || isContinuousBuild) {
-            object.driver_location = "${driverLocationName}"
-            object.version = "${project.version}"
-        }
-
-        json.text = JsonOutput.prettyPrint(JsonOutput.toJson(object))
-
-        rootProject.userProps.setProperty('published.json', json.toString())
-        println "json output is:"
-        println json.toString()
-
+    task zipTestReport(type: Zip) {
+        baseName 'openliberty_test_report'
+        from cnf.file('generated/testReports/allUnitTests')
+        destinationDir cnf.file('generated/testReports')
+        rootProject.userProps.setProperty('gradle.test.report.zip', archivePath.toString())
         rootProject.storeProps()
     }
-}
 
-task gatherTestResults {
-    dependsOn zipTestReport,createJSONForPublicArtifacts
-}
-
-if (isBuildOsNativePackages){
-    task copyOpenLiberty(type: Sync) {
-       dependsOn zipOpenLiberty
-
-       mkdir("packaging/tempPackagingDir")
-
-       from zipOpenLiberty
-       into 'packaging/tempPackagingDir'
-    }
-
-    task updateSpecTemplate(type: Copy) {
-        from 'packaging'
-        include 'openliberty.spec.template'
-        into 'packaging/rpmbuild/SPECS'
-        filter { line -> line.replaceAll('@SPEC_VERSION@', bnd('libertyServiceVersion', 'Unknown')) }
-        rename { it.replace(".template", "") }
-    }
-
-    task updateChangelogTemplate(type: Copy) {
-        from 'packaging'
-        include 'changelog.template'
-        into 'packaging/debuild/openliberty/debian'
-        filter { line -> line.replaceAll('@CHANGELOG_VERSION@', bnd('libertyServiceVersion', 'Unknown')) }
-        rename { it.replace(".template", "") }
-    }
-
-    task updateBuildPackageScriptTemplate(type: Copy) {
-        from 'packaging'
-        include 'buildOsNativePackages.sh.template'
-        into 'packaging'
-        filter { line -> line.replaceAll('@DRIVER_VERSION@', bnd('libertyServiceVersion', 'Unknown')) }
-        rename { it.replace(".template", "") }
-    }
-
-    task updateRulesTemplate(type: Copy) {
-        from 'packaging'
-        include 'rules.template'
-        into 'packaging/debuild/openliberty/debian'
-        filter { line -> line.replaceAll('@VERSION@', bnd('libertyServiceVersion', 'Unknown')) }
-        rename { it.replace(".template", "") }
-    }
-
-    task buildOsNativePackages(type:Exec) {
-        dependsOn copyOpenLiberty
-        dependsOn updateChangelogTemplate
-        dependsOn updateSpecTemplate
-        dependsOn updateBuildPackageScriptTemplate
-        dependsOn updateRulesTemplate
-
-        workingDir 'packaging'
-        mkdir("packaging/tempPackagingDir/tempTar")
-        
-        def rpms = file("./packaging/rpmbuild/RPMS/noarch/openliberty-" + bnd('libertyServiceVersion') + "-1.noarch.rpm")
-        def debs = file("./packaging/debuild/openliberty_" + bnd('libertyServiceVersion') + "-1ubuntu1_all.deb")
-        
-        inputs.dir('packaging/tempPackagingDir')
-        outputs.file(rpms)
-        outputs.file(debs)
-
-        errorOutput = new ByteArrayOutputStream()
-
-        commandLine 'sh', './buildOsNativePackages.sh'
-
-        ignoreExitValue true
+    task createJSONForPublicArtifacts {
+        enabled isAutomatedBuild
+        dependsOn zipTestReport
 
         doLast {
-            file('packaging/tempPackagingDir').deleteDir()
-            file('packaging/rpmbuild/SPECS/openliberty.spec').delete()
-            file('packaging/debuild/openliberty/debian/changelog').delete()
-            file('packaging/buildOsNativePackages.sh').delete()
-            file('packaging/debuild/openliberty/debian/rules').delete()
-            if (execResult.getExitValue() != 0) {
-                throw new GradleException("Script buildOsNativePackages.sh failed to run rpmbuild and debuild: " + errorOutput.toString())
+            println "running createJSONForPublicArtifacts"
+            delete "${buildDir}/info.json"
+            File json = new File("${buildDir}/info.json")
+            json.createNewFile()
+
+            String testsPassed = "0"
+            if (rootProject.userProps.getProperty("tests.total.successful") != null) {
+                testsPassed = rootProject.userProps.getProperty("tests.total.successful")
+                println "testsPassed is ${testsPassed}"
             }
+            String testsTotal = "0"
+            if ((rootProject.userProps.getProperty("tests.total.successful") != null) &&
+                    (rootProject.userProps.getProperty("tests.total.failed") != null)) {
+                def sum = Integer.valueOf(rootProject.userProps.getProperty("tests.total.successful")) + Integer.valueOf(rootProject.userProps.getProperty("tests.total.failed"))
+                testsTotal = sum.toString()
+                println "testsTotal is ${testsTotal}"
+            }
+
+            String junitPath = rootProject.userProps.getProperty("junit.report.zip")
+            String testReportPath = rootProject.userProps.getProperty("gradle.test.report.zip");
+            String logPath = rootProject.userProps.getProperty("published.gradle.log")
+            String driverLocation = rootProject.userProps.getProperty("zipopenliberty.archivename")
+            println "junitPath is ${junitPath}"
+            println "testReportPath is ${testReportPath}"
+            println "logPath is ${logPath}"
+            println "driverLocation is ${driverLocation}"
+
+            if (junitPath == null) {
+                raise InvalidUserDataException("Could not find property named 'junit.report.zip'")
+            }
+
+            if (isPersonal && (testReportPath == null)) {
+                raise InvalidUserDataException("Could not find property named 'gradle.test.report.zip'")
+            }
+
+            if (logPath == null) {
+                raise InvalidUserDataException("Could not find property named 'published.gradle.log'")
+            }
+
+            if (driverLocation == null) {
+                raise InvalidUserDataException("Could not find property named 'zipopenliberty.archivename'")
+            }
+
+            String testResultName = null
+            if (isPersonal) {
+                testResultName = new File(testReportPath).getName()
+            } else {
+                testResultName = new File(junitPath).getName()
+            }
+            println "testResultName is ${testResultName}"
+            String logName = new File(logPath).getName()
+            String driverLocationName = new File(driverLocation).getName()
+
+            def object = [test_passed: "${testsPassed}",
+                          total_tests: "${testsTotal}",
+                          tests_log  : "${testResultName}",
+                          build_log  : "${logName}"]
+
+            if (isPersonal || isRelease || isContinuousBuild) {
+                object.driver_location = "${driverLocationName}"
+                object.version = "${project.version}"
+            }
+
+            json.text = JsonOutput.prettyPrint(JsonOutput.toJson(object))
+
+            rootProject.userProps.setProperty('published.json', json.toString())
+            println "json output is:"
+            println json.toString()
+
+            rootProject.storeProps()
         }
-        
     }
-    publish.dependsOn buildOsNativePackages
+
+    task gatherTestResults {
+        dependsOn zipTestReport, createJSONForPublicArtifacts
+    }
+
+    if (isBuildOsNativePackages) {
+        task copyOpenLiberty(type: Sync) {
+            dependsOn zipOpenLiberty
+
+            mkdir("packaging/tempPackagingDir")
+
+            from zipOpenLiberty
+            into 'packaging/tempPackagingDir'
+        }
+
+        task updateSpecTemplate(type: Copy) {
+            from 'packaging'
+            include 'openliberty.spec.template'
+            into 'packaging/rpmbuild/SPECS'
+            filter { line -> line.replaceAll('@SPEC_VERSION@', bnd('libertyServiceVersion', 'Unknown')) }
+            rename { it.replace(".template", "") }
+        }
+
+        task updateChangelogTemplate(type: Copy) {
+            from 'packaging'
+            include 'changelog.template'
+            into 'packaging/debuild/openliberty/debian'
+            filter { line -> line.replaceAll('@CHANGELOG_VERSION@', bnd('libertyServiceVersion', 'Unknown')) }
+            rename { it.replace(".template", "") }
+        }
+
+        task updateBuildPackageScriptTemplate(type: Copy) {
+            from 'packaging'
+            include 'buildOsNativePackages.sh.template'
+            into 'packaging'
+            filter { line -> line.replaceAll('@DRIVER_VERSION@', bnd('libertyServiceVersion', 'Unknown')) }
+            rename { it.replace(".template", "") }
+        }
+
+        task updateRulesTemplate(type: Copy) {
+            from 'packaging'
+            include 'rules.template'
+            into 'packaging/debuild/openliberty/debian'
+            filter { line -> line.replaceAll('@VERSION@', bnd('libertyServiceVersion', 'Unknown')) }
+            rename { it.replace(".template", "") }
+        }
+
+        task buildOsNativePackages(type: Exec) {
+            dependsOn copyOpenLiberty
+            dependsOn updateChangelogTemplate
+            dependsOn updateSpecTemplate
+            dependsOn updateBuildPackageScriptTemplate
+            dependsOn updateRulesTemplate
+
+            workingDir 'packaging'
+            mkdir("packaging/tempPackagingDir/tempTar")
+
+            def rpms = file("./packaging/rpmbuild/RPMS/noarch/openliberty-" + bnd('libertyServiceVersion') + "-1.noarch.rpm")
+            def debs = file("./packaging/debuild/openliberty_" + bnd('libertyServiceVersion') + "-1ubuntu1_all.deb")
+
+            inputs.dir('packaging/tempPackagingDir')
+            outputs.file(rpms)
+            outputs.file(debs)
+
+            errorOutput = new ByteArrayOutputStream()
+
+            commandLine 'sh', './buildOsNativePackages.sh'
+
+            ignoreExitValue true
+
+            doLast {
+                file('packaging/tempPackagingDir').deleteDir()
+                file('packaging/rpmbuild/SPECS/openliberty.spec').delete()
+                file('packaging/debuild/openliberty/debian/changelog').delete()
+                file('packaging/buildOsNativePackages.sh').delete()
+                file('packaging/debuild/openliberty/debian/rules').delete()
+                if (execResult.getExitValue() != 0) {
+                    throw new GradleException("Script buildOsNativePackages.sh failed to run rpmbuild and debuild: " + errorOutput.toString())
+                }
+            }
+
+        }
+        publish.dependsOn buildOsNativePackages
+    }
 }

--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -159,8 +159,10 @@ task createGradleBootstrap {
             }
         }
 
-        depsList.add('    compile \'' + org + ':openliberty-MavenArtifact:' + getVersionFromReleaseRepo('dev', 'openliberty-MavenArtifact') + '@zip\'')
-        depsList.add('    compile \'' + org + ':openliberty-singleJson:' + getVersionFromReleaseRepo('dev', 'openliberty-singleJson') + '@json\'')
+        if (isAutomatedBuild) {
+            depsList.add('    compile \'' + org + ':openliberty-MavenArtifact:' + getVersionFromReleaseRepo('dev', 'openliberty-MavenArtifact') + '@zip\'')
+            depsList.add('    compile \'' + org + ':openliberty-singleJson:' + getVersionFromReleaseRepo('dev', 'openliberty-singleJson') + '@json\'')
+        }
         depsList.add('    compile \'' + org + ':openliberty-modifiedgaFeatureList:' + getVersionFromReleaseRepo('dev', 'openliberty-modifiedgaFeatureList') + '@txt\'')
 
         File dependenciesFile = new File(project.buildDir, 'dependencies.gradle')

--- a/dev/com.ibm.websphere.appserver.features/build.gradle
+++ b/dev/com.ibm.websphere.appserver.features/build.gradle
@@ -9,13 +9,6 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-  // Start building feature resources after all other assemble artifacts are done being published
-  //dependsOn {
-  //  bndWorkspace.getProject(project.name)?.getDependson()*.getName().collect {
-  //    rootProject.project(it).tasks.getByName 'prereqFeatureResources'
-  //  }
-  //}
-
 def featurePropertiesMap
 def gaFeatures
 def betaFeatures
@@ -315,81 +308,96 @@ publishing {
   }
 }
 
-def singleOpenLibertyJsonRepo = project.file('build/temp/SingleJson.json')
 def modifiedgaFeatureList = project.file('build/temp/gaFeaturesList.txt')
-task generateSingleJsonRepo {
+task generateModifiedGAFeatureList {
     dependsOn publishFeatureResources
     inputs.dir new File(project.buildDir, 'repo')
-    outputs.file singleOpenLibertyJsonRepo
     outputs.file modifiedgaFeatureList
     doLast {
-        project.delete('build/temp')
         project.mkdir('build/temp')
-
-        repositoryGeneratorTaskdef(ant)
-		
-	String features = ""     
+        String features = ""
         getGaFeatures().each { gaFeature ->
-        	features += gaFeature + "*.esa\n"
-            ant.singleJsonRepo(assetFile: project.file("build/libs/repo/${gaFeature}.esa"),
-                assetType: 'FEATURE',
-                metadataFile: project.file("build/libs/repo/${gaFeature}.esa.metadata.zip"),
-                jsonFile: singleOpenLibertyJsonRepo)
-            
+            features += gaFeature + "*.esa\n"
+
         }
         modifiedgaFeatureList.text = features
     }
 }
 
 publishing {
-  publications {
-    newJsonArtifact(MavenPublication) {
-      artifactId 'openliberty-singleJson'
-      version project.version
-      artifact(singleOpenLibertyJsonRepo) {
-        extension 'json'
-        builtBy generateSingleJsonRepo
-      }
-    }
-    
-   modifiedFeatureList(MavenPublication){
-   	artifactId 'openliberty-modifiedgaFeatureList'
-   	version project.version
-   	artifact(modifiedgaFeatureList){
-   		extension 'txt'
-   		builtBy generateSingleJsonRepo
-   	}
-   }
-  }
-}
-
-task generateMavenArtifact {
-    dependsOn generateSingleJsonRepo
-    doLast {
-        mavenRepoTaskdef(ant)
-
-        project.delete('build/temp/mavenArtifact')
-        project.mkdir('build/temp/mavenArtifact')
-        ant.libertyFeaturesToMavenRepo(inputDirPath: project.file('build/libs/repo'),
-                   outputDirPath: project.file('build/temp/mavenArtifact'),
-                   openLibertyJson: singleOpenLibertyJsonRepo)
+    publications {
+        modifiedFeatureList(MavenPublication) {
+            artifactId 'openliberty-modifiedgaFeatureList'
+            version project.version
+            artifact(modifiedgaFeatureList) {
+                extension 'txt'
+                builtBy generateModifiedGAFeatureList
+            }
+        }
     }
 }
 
-task zipOpenLibertyMavenRepo(type: Zip) {
-     dependsOn generateMavenArtifact
-     from project.file('build/temp/mavenArtifact')
-     include "io/**"
-     archiveName 'openliberty-mavenArtifact.zip'
-     destinationDir distsDir
- }
+if (isAutomatedBuild) {
+    def singleOpenLibertyJsonRepo = project.file('build/temp/SingleJson.json')
+    task generateSingleJsonRepo {
+        dependsOn publishFeatureResources
+        inputs.dir new File(project.buildDir, 'repo')
+        outputs.file singleOpenLibertyJsonRepo
+        doLast {
+            project.mkdir('build/temp')
 
-publishing {
-  publications {
-    newMavenArtifact(MavenPublication) {
-      artifactId 'openliberty-MavenArtifact'
-      version project.version
-      artifact zipOpenLibertyMavenRepo
+            repositoryGeneratorTaskdef(ant)
+
+            getGaFeatures().each { gaFeature ->
+                ant.singleJsonRepo(assetFile: project.file("build/libs/repo/${gaFeature}.esa"),
+                        assetType: 'FEATURE',
+                        metadataFile: project.file("build/libs/repo/${gaFeature}.esa.metadata.zip"),
+                        jsonFile: singleOpenLibertyJsonRepo)
+            }
+        }
     }
-  }
+
+    publishing {
+        publications {
+            newJsonArtifact(MavenPublication) {
+                artifactId 'openliberty-singleJson'
+                version project.version
+                artifact(singleOpenLibertyJsonRepo) {
+                    extension 'json'
+                    builtBy generateSingleJsonRepo
+                }
+            }
+        }
+    }
+
+    task generateMavenArtifact {
+        dependsOn generateSingleJsonRepo
+        doLast {
+            mavenRepoTaskdef(ant)
+
+            project.delete('build/temp/mavenArtifact')
+            project.mkdir('build/temp/mavenArtifact')
+            ant.libertyFeaturesToMavenRepo(inputDirPath: project.file('build/libs/repo'),
+                    outputDirPath: project.file('build/temp/mavenArtifact'),
+                    openLibertyJson: singleOpenLibertyJsonRepo)
+        }
+    }
+
+    task zipOpenLibertyMavenRepo(type: Zip) {
+        dependsOn generateMavenArtifact
+        from project.file('build/temp/mavenArtifact')
+        include "io/**"
+        archiveName 'openliberty-mavenArtifact.zip'
+        destinationDir distsDir
+    }
+
+    publishing {
+        publications {
+            newMavenArtifact(MavenPublication) {
+                artifactId 'openliberty-MavenArtifact'
+                version project.version
+                artifact zipOpenLibertyMavenRepo
+            }
+        }
+    }
 }

--- a/dev/wlp-gradle/bndSettings.gradle
+++ b/dev/wlp-gradle/bndSettings.gradle
@@ -192,5 +192,6 @@ gradle.projectsLoaded { gradle ->
     gradle.rootProject.ext.bndPlugin = BndPlugin.class
     gradle.rootProject.ext.bndWorkspace = workspace
     gradle.rootProject.ext.gradleBndProjects = allBndProjects
+    gradle.rootProject.ext.projectNames = projectNames
     gradle.rootProject.ext.parseBoolean = { value -> parseBoolean(value) }
 }

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -293,13 +293,15 @@ task zipProjectFVT(type: Zip) {
   into project.name, {from 'build-test.xml'}
 }
 
-publishing {
-  publications {
-    maven(MavenPublication) {
-      artifactId project.name + '_autoFVT'
-      groupId 'test'
-      version project.version
-      artifact zipProjectFVT
+if (isAutomatedBuild || rootProject.projectNames.contains(project.name)) {
+  publishing {
+    publications {
+      maven(MavenPublication) {
+        artifactId project.name + '_autoFVT'
+        groupId 'test'
+        version project.version
+        artifact zipProjectFVT
+      }
     }
   }
 }


### PR DESCRIPTION
This reverts commit 6106240cc919b686f27d39742700182bd032ad58.

- Only build the openliberty-all.zip which contains everything assembled into `build.image/wlp`. Automated builds will generate the additional artifacts.
- Skip autoFVT tasks unless it is an automated build or the autoFVT project is specifically requested on CLI.