### PR TITLE
internal attribute to gate experimentation with infinispan config

### DIFF
--- a/dev/com.ibm.ws.session.cache/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.session.cache/resources/OSGI-INF/metatype/metatype.xml
@@ -19,6 +19,7 @@
  </Designate>
 
  <OCD id="com.ibm.ws.session.cache" ibm:alias="httpSessionCache" name="%httpSessionCache" description="%httpSessionCache.desc" ibmui:localization="OSGI-INF/l10n/metatype">
+  <AD id="enableBetaSupportForInfinispan" type="Boolean" default="false" name="internal" description="internal use only"/> <!-- Add ibm:beta="true" when ready to beta -->
   <AD id="libraryRef"                     type="String"  required="false" ibm:type="pid" ibm:reference="com.ibm.ws.classloading.sharedlibrary" cardinality="1" name="%libraryRef" description="%libraryRef.desc"/>
   <AD id="library.target"                 type="String"  default="(|(service.pid=${libraryRef})(&amp;(zero=${count(libraryRef)})(id=com.ibm.ws.session.cache.defaultprovider.library)))" ibm:final="true" name="internal" description="internal use only"/>
   <AD id="monitor.target"                 type="String"  default="(|(!(filter>=!))(filter=*Session*))" ibm:final="true" name="internal" description="internal use only"/>


### PR DESCRIPTION
Some experimentation will be done with augmenting/generating config for Infinsipan when used by HTTP session persistence.  In order to keep the experimentation on nonship (and later beta) codepath so that no one starts to depend on partially completed function, we need a configuration attribute to gate its enablement.