### PR TITLE
experiment with temporary files for infinispan config

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.serverA/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.serverA/server.xml
@@ -11,9 +11,10 @@
     
     <httpSession maxInMemorySessionCount="1" allowOverflow="false" hideSessionValues="false" invalidationTimeout="10m"/>
 
-    <httpSessionCache libraryRef="InfinispanLib" writeContents="GET_AND_SET_ATTRIBUTES" uri="file:${shared.resource.dir}/infinispan/infinispan.xml">
+    <httpSessionCache libraryRef="InfinispanLib" writeContents="GET_AND_SET_ATTRIBUTES">
         <properties/>
     </httpSessionCache>
+    <httpSessionCache enableBetaSupportForInfinispan="true"/> <!-- TODO remove once no longer gated -->
 
     <library id="InfinispanLib">
         <fileset dir="${shared.resource.dir}/infinispan" includes="*.jar"/>

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.serverB/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.serverB/server.xml
@@ -18,7 +18,7 @@
     
     <httpSession maxInMemorySessionCount="1" allowOverflow="false" hideSessionValues="false" invalidationTimeout="10m"/>
     
-    <httpSessionCache uri="file:${shared.resource.dir}/infinispan/infinispan.xml" />
+    <httpSessionCache enableBetaSupportForInfinispan="true"/> <!-- TODO remove once no longer gated -->
 
     <bell libraryRef="InfinispanLib" service="javax.cache.spi.CachingProvider"/>
 

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
@@ -244,6 +244,10 @@ public class SessionCacheTestServlet extends FATServlet {
     public void testMXBeansEnabled(HttpServletRequest request, HttpServletResponse response) throws Exception {
         MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
 
+        // Useful to see when the provider changes the value that is used for CacheManager
+        ObjectName name = mbs.queryNames(new ObjectName("javax.cache:type=CacheConfiguration,CacheManager=*,Cache=com.ibm.ws.session.meta.default_host%2FsessionCacheApp"), null).iterator().next();
+        System.out.println("Found with name " + name.toString());
+
         // CacheMXBean for session meta info cache
         CacheMXBean metaInfoCacheMXBean = //
                         JMX.newMBeanProxy(mbs,


### PR DESCRIPTION
Experiment with writing a temporary file when Infinispan config is absent, gated by the property that was added for this purpose.  Findings thus far shown that doing this alters the MBean object names, which are based on the URI.  We will need to consider whether/how to cope with this later, as well as any changes to intelligently generate/modify the infinispan config.