### PR TITLE
add heart beats per the heartbeatInterval

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/metatype/metatype.xml
@@ -24,6 +24,7 @@
   <AD id="contextServiceRef"                 type="String"  default="DefaultContextService" ibm:type="pid" ibm:reference="com.ibm.ws.context.service" name="%contextService" description="%contextService.desc" required="false"/>  
   <AD id="ContextService.target"             type="String"  default="(|(service.pid=${contextServiceRef})(&amp;(service.pid=com.ibm.ws.context.manager)(|(service.pid&gt;=${contextServiceRef})(default.for&lt;=${contextServiceRef}))))" ibm:final="true" name="internal" description="internal use only"/>
   <AD id="enableTaskExecution"               type="Boolean" default="true" name="%enableTaskExecution" description="%enableTaskExecution.desc"/>
+  <AD id="heartbeatInterval"                 type="String"  default="-1" ibm:type="duration(s)" max="6" name="internal" description="internal use only"/> <!-- max applies to string length and will limit to 99999h -->
   <AD id="initialPollDelay"                  type="String"  default="0" ibm:type="duration" name="%initialPollDelay" description="%initialPollDelay.desc"/>
   <AD id="jndiName"                          type="String"  required="false" ibm:unique="jndiName" name="internal" description="internal use only"/>
   <AD id="missedTaskThreshold"               type="String"  default="-1" ibm:type="duration(s)" name="internal" description="internal use only"/>

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
@@ -160,6 +160,11 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
     };
 
     /**
+     * Multiple of the heartbeatInterval after which, absent any heart beats, the partition is eligible for removal.
+     */
+    private static final short HEARTBEAT_EXPIRY_FACTOR = 10;
+
+    /**
      * Names of applications using this ResourceFactory
      */
     private final Set<String> applications = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
@@ -204,6 +209,11 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
      * Common Liberty thread pool.
      */
     ExecutorService executor;
+
+    /**
+     * Reference to the future (if any) for the periodic heart beat task.
+     */
+    private final AtomicReference<Future<?>> heartbeatFutureRef = new AtomicReference<Future<?>>();
 
     /**
      * Set of task ids that are scheduled in memory. When polling for tasks, we can ignore these because they are already scheduled.
@@ -350,6 +360,12 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
         if (readyForPollingTask.addAndCheckIfReady(PollingManager.DS_READY))
             startPollingTask(config);
 
+        if (config.heartbeatInterval > 0)
+            heartbeatFutureRef.set(scheduledExecutor.scheduleWithFixedDelay(new HeartbeatTask(config),
+                                                                            config.heartbeatInterval,
+                                                                            config.heartbeatInterval,
+                                                                            TimeUnit.SECONDS));
+
         mbean = new PersistentExecutorMBeanImpl(this);
         mbean.register(InvokerTask.priv.getBundleContext(context));
 
@@ -434,6 +450,10 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
         deactivated = true;
         if (mbean != null)
             mbean.unregister();
+
+        Future<?> future = heartbeatFutureRef.get();
+        if (future != null)
+            future.cancel(false);
 
         try {
             Config config = configRef.get();
@@ -786,7 +806,9 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
         partitionEntry.setLibertyServer(locationAdmin.getServerName());
         partitionEntry.setUserDir(variableRegistry.resolveString(VariableRegistry.USER_DIR));
         partitionEntry.setHostName(AccessController.doPrivileged(getHostName));
-        // TODO partitionEntry.setExpiry if heartbeatInterval enabled
+        partitionEntry.setExpiry(config.heartbeatInterval > 0 //
+                        ? (System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(config.heartbeatInterval * HEARTBEAT_EXPIRY_FACTOR)) //
+                        : Long.MAX_VALUE);
         if (config.missedTaskThreshold > 0) // TODO unconditionally supply this information once we are done experimenting and determine how much of it we really need.
             partitionEntry.setStates((config.missedTaskThreshold > 0 ? PartitionRecord.States.MISSED_TASK_THRESHOLD_ENABLED.bit : 0) +
                                      (config.pollInterval >= 0 ? PartitionRecord.States.POLLS_PERIODICALLY.bit : 0));
@@ -1085,6 +1107,12 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
         if (previousFuture != null)
             previousFuture.cancel(false);
 
+        if (oldConfig.heartbeatInterval != newConfig.heartbeatInterval) {
+            previousFuture = heartbeatFutureRef.getAndSet(null);
+            if (previousFuture != null)
+                previousFuture.cancel(false);
+        }
+
         if (oldConfig.enableTaskExecution != newConfig.enableTaskExecution)
             if (newConfig.enableTaskExecution)
                 readyForPollingTask.add(PollingManager.EXECUTION_ENABLED);
@@ -1122,6 +1150,13 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
 
         if (readyForPollingTask.addAndCheckIfReady(PollingManager.DS_READY))
             startPollingTask(newConfig);
+
+        if (oldConfig.heartbeatInterval != newConfig.heartbeatInterval && newConfig.heartbeatInterval > 0) {
+            heartbeatFutureRef.set(scheduledExecutor.scheduleWithFixedDelay(new HeartbeatTask(newConfig),
+                                                                            newConfig.heartbeatInterval,
+                                                                            newConfig.heartbeatInterval,
+                                                                            TimeUnit.SECONDS));
+        }
 
         if (trace && tc.isEntryEnabled())
             Tr.exit(this, tc, "modified");
@@ -2258,6 +2293,69 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
     };
 
     /**
+     * Periodically updates the persistent store to indicate that this instance is still running.
+     */
+    @Trivial
+    private class HeartbeatTask implements Runnable {
+        /**
+         * Config instance from when this HeartbeatTask was initially scheduled. We should stop running if we find that it changes.
+         */
+        private final Config initialConfig;
+
+        private HeartbeatTask(Config config) {
+            initialConfig = config;
+        }
+
+        @Override
+        public void run() {
+            final boolean trace = TraceComponent.isAnyTracingEnabled();
+            if (trace && tc.isEntryEnabled())
+                Tr.entry(PersistentExecutorImpl.this, tc, "run[heartbeat]");
+
+            Config config = configRef.get();
+
+            if (deactivated || config.heartbeatInterval < 1 || config.heartbeatInterval != initialConfig.heartbeatInterval) {
+                if (trace && tc.isEntryEnabled())
+                    Tr.exit(PersistentExecutorImpl.this, tc, "run[heartbeat]", deactivated ? "deactivated" : config);
+                return;
+            }
+
+            Object result;
+            try {
+                EmbeddableWebSphereTransactionManager tranMgr = tranMgrRef.getServiceWithException();
+
+                PartitionRecord expected = new PartitionRecord(false);
+                expected.setId(getPartitionId());
+
+                PartitionRecord updates = new PartitionRecord(false);
+                updates.setExpiry(System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(config.heartbeatInterval * HEARTBEAT_EXPIRY_FACTOR));
+
+                tranMgr.begin();
+                try {
+                    result = taskStore.persist(updates, expected);
+                } finally {
+                    if (tranMgr.getStatus() == Status.STATUS_ACTIVE)
+                        tranMgr.commit();
+                    else
+                        tranMgr.rollback();
+                }
+
+                // If the update isn't successful, it means we didn't renew our partition entry in time and another instance removed it.
+                // TODO Try to re-acquire it or just get a new one and reassign tasks?
+
+                // TODO look for expired partitions (expiry < current time).
+                // If found, asynchronously reassign their tasks and finally remove the partition if still expired.
+
+            } catch (Throwable x) {
+                result = x;
+            }
+
+            if (trace && tc.isEntryEnabled())
+                Tr.exit(PersistentExecutorImpl.this, tc, "run[heartbeat]", result);
+        }
+    }
+
+    /**
      * Polls the persistent task store for tasks that ought to run in the near future and then schedules them.
      *
      * For scenarios where tasks a transferred to a persistent executor where repeated polling is disabled (pollInterval < 0),
@@ -2364,7 +2462,7 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
 
             if (deactivated || !config.enableTaskExecution || config != initialConfig) {
                 if (trace && tc.isEntryEnabled())
-                    Tr.exit(PersistentExecutorImpl.this, tc, "run[poll]", deactivated ? deactivated : config);
+                    Tr.exit(PersistentExecutorImpl.this, tc, "run[poll]", deactivated ? "deactivated" : config);
                 return;
             }
 
@@ -2374,12 +2472,13 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
                 try {
                     EmbeddableWebSphereTransactionManager tranMgr = tranMgrRef.getServiceWithException();
 
+                    long partitionId = getPartitionId();
                     long now = new Date().getTime();
                     long maxNextExecTime = config.pollInterval >= 0 ? (config.pollInterval + now) : Long.MAX_VALUE;
                     List<Object[]> results;
                     tranMgr.begin();
                     try {
-                        results = taskStore.findUpcomingTasks(getPartitionId(), maxNextExecTime, config.pollSize);
+                        results = taskStore.findUpcomingTasks(partitionId, maxNextExecTime, config.pollSize);
                     } catch (Throwable x) {
                         throw failure = x;
                     } finally {
@@ -2409,7 +2508,7 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
                         long lateTaskThresholdMS = TimeUnit.SECONDS.toMillis(config.missedTaskThreshold);
                         tranMgr.begin();
                         try {
-                            results = taskStore.findLateTasks(now - lateTaskThresholdMS, getPartitionId(), config.pollSize);
+                            results = taskStore.findLateTasks(now - lateTaskThresholdMS, partitionId, config.pollSize);
                         } catch (Throwable x) {
                             throw failure = x;
                         } finally {
@@ -2650,7 +2749,9 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
             Config config = configRef.get();
 
             PartitionRecord updates = new PartitionRecord(false);
-            // TODO updates.setExpiry if heartbeatInterval enabled
+            updates.setExpiry(config.heartbeatInterval > 0 //
+                            ? (System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(config.heartbeatInterval * HEARTBEAT_EXPIRY_FACTOR)) //
+                            : Long.MAX_VALUE);
             updates.setStates((config.missedTaskThreshold > 0 ? PartitionRecord.States.MISSED_TASK_THRESHOLD_ENABLED.bit : 0) +
                               (config.pollInterval >= 0 ? PartitionRecord.States.POLLS_PERIODICALLY.bit : 0));
 

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskStore.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskStore.java
@@ -135,7 +135,8 @@ public interface TaskStore {
      * The invoker is expected to handle this by rolling back and retrying.
      * 
      * @param record partition entry with executor/host/server/userdir to locate, or if not found, add to the persistent store.
-     *            The record must contain the following attributes (Executor, Expiry, Host, Server, State, UserDir).
+     *            If an entry is found, it is updated to match the Expiry and States if either of those is supplied.
+     *            The record must contain the following attributes (Executor, Host, Server, UserDir) and can optionally contain (Expiry, States).
      * @return unique identifier for the partition record which either already exists or was newly created.
      * @throws Exception if an error occurs when attempting to access the persistent task store.
      */

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskStore.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskStore.java
@@ -110,6 +110,14 @@ public interface TaskStore {
     TaskRecord findById(long taskId, String owner, boolean includeTrigger) throws Exception;
 
     /**
+     * Returns information about all partition entries with expired heart beats.
+     *
+     * @return List of expired partition records.
+     * @throws Exception if an error occurs when attempting to access the persistent task store.
+     */
+    List<PartitionRecord> findExpired() throws Exception;
+
+    /**
      * Find all pending tasks which are late beyond the specified expected execution time without a
      * successful execution of the task.
      *

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/fat/src/com/ibm/ws/concurrent/persistent/fat/failover1serv/Failover1ServerTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/fat/src/com/ibm/ws/concurrent/persistent/fat/failover1serv/Failover1ServerTest.java
@@ -70,7 +70,7 @@ public class Failover1ServerTest extends FATServletClient {
      * testFailoverFromMissedHeartbeats - verify that a task fails over due to missed heartbeats alone,
      * even if the missed task threshold has not yet been reached.
      */
-    //@Test TODO enable once feature code (8406) is written
+    @Test
     public void testFailoverFromMissedHeartbeats() throws Exception {
         StringBuilder result = runTestWithResponse(server, APP_NAME + "/Failover1ServerTestServlet",
                 "testScheduleRepeatingTask&jndiName=persistent/exec2&initialDelayMS=2468&delayMS=600&test=testFailoverFromMissedHeartbeats[1]");

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/publish/servers/com.ibm.ws.concurrent.persistent.fat.failover1serv/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/publish/servers/com.ibm.ws.concurrent.persistent.fat.failover1serv/server.xml
@@ -21,10 +21,10 @@
   <include location="../fatTestPorts.xml"/>
 
   <!-- cannot run tasks -->
-  <persistentExecutor id="persistentExec1" jndiName="persistent/exec1" enableTaskExecution="false"/>
+  <persistentExecutor id="persistentExec1" jndiName="persistent/exec1" enableTaskExecution="false" heartbeatInterval="15s"/>
 
   <!-- runs its own tasks and takes late tasks from others -->
-  <persistentExecutor id="persistentExec2" jndiName="persistent/exec2" pollInterval="2s" missedTaskThreshold="3s"/>
+  <persistentExecutor id="persistentExec2" jndiName="persistent/exec2" pollInterval="2s" missedTaskThreshold="3s" heartbeatInterval="1s"/>
 
   <!-- database for scheduled tasks -->
   <dataSource id="DefaultDataSource">


### PR DESCRIPTION
This pull adds period heart beats per the heartbeatInterval, along with checking for expired heartbeats and removal of the expired entry and transfer of its tasks. Having done this, a test case is enabled which now passes.