### PR TITLE
Enable discovery of PKCE code challenge methods

### DIFF
--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/OIDCConstants.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/util/OIDCConstants.java
@@ -131,6 +131,7 @@ public interface OIDCConstants extends OAuth20Constants {
     public static final String OIDC_DISC_PERSONAL_TOKEN_MGMT_EP = "personal_token_mgmt_endpoint";
     public static final String OIDC_DISC_USERS_TOKEN_MGMT_EP = "users_token_mgmt_endpoint";
     public static final String OIDC_DISC_CLIENT_MGMT_EP = "client_mgmt_endpoint";
+    public static final String OIDC_DISC_PKCE_CODE_CHALLENGE_METHODS_SUPP = "code_challenge_methods_supported";
 
     /* parameters for oidc discovery response with origins from session management */
     public static final String OIDC_SESS_CHECK_SESSION_IFRAME = "check_session_iframe";
@@ -206,6 +207,11 @@ public interface OIDCConstants extends OAuth20Constants {
     public static final String OIDC_DISC_CLAIM_TYPES_SUPP_AGGREGATED = "aggregated";
     public static final String OIDC_DISC_CLAIM_TYPES_SUPP_DISTRIBUTED = "distributed";
 
+    public static final String OIDC_DISC_PKCE_CODE_CHALLENGE_METHODS_SUPP_PLAIN = "plain";
+    public static final String OIDC_DISC_PKCE_CODE_CHALLENGE_METHODS_SUPP_S256 = "S256";
+
+    public static final String[] OIDC_DISC_PKCE_CODE_CHALLENGE_METHODS_SUPPORTED = { OIDC_DISC_PKCE_CODE_CHALLENGE_METHODS_SUPP_PLAIN, OIDC_DISC_PKCE_CODE_CHALLENGE_METHODS_SUPP_S256 };
+
     // OIDC Discovery Properties for use in OAuth20Parameter
     public static final String KEY_OIDC_ISSUER_ID = "issuerIdentifier";
     public static final String KEY_OIDC_AUTHORIZATION_EP = "authorizationEndpoint";
@@ -239,6 +245,7 @@ public interface OIDCConstants extends OAuth20Constants {
     public static final String KEY_OIDC_PERSONAL_TOKEN_MGMT_EP = "personalTokenMgmtEndpoint";
     public static final String KEY_OIDC_USERS_TOKEN_MGMT_EP = "usersTokenMgmtEndpoint";
     public static final String KEY_OIDC_CLIENT_MGMT_EP = "clientMgmtEndpoint";
+    public static final String KEY_OIDC_PKCE_CODE_CHALLENGE_METHODS_SUPP = "codeChallengeMethodsSupported";
 
     // Server config property for coverageMap
     static final String JSA_QUAL = "jsa.provider.";
@@ -279,6 +286,7 @@ public interface OIDCConstants extends OAuth20Constants {
     public static final String KEY_OIDC_PERSONAL_TOKEN_MGMT_EP_QUAL = OIDC_QUAL + KEY_OIDC_PERSONAL_TOKEN_MGMT_EP;
     public static final String KEY_OIDC_USERS_TOKEN_MGMT_EP_QUAL = OIDC_QUAL + KEY_OIDC_USERS_TOKEN_MGMT_EP;
     public static final String KEY_OIDC_CLIENT_MGMT_EP_QUAL = OIDC_QUAL + KEY_OIDC_CLIENT_MGMT_EP;
+    public static final String KEY_OIDC_PKCE_CODE_CHALLENGE_METHODS_SUPP_QUAL = OIDC_QUAL + KEY_OIDC_PKCE_CODE_CHALLENGE_METHODS_SUPP;
 
     /**
      * Supported OIDC client registration parameter names

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/OIDCAbstractDiscoveryModel.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/server/plugins/OIDCAbstractDiscoveryModel.java
@@ -51,6 +51,7 @@ public abstract class OIDCAbstractDiscoveryModel {
     private String personal_token_mgmt_endpoint;
     private String users_token_mgmt_endpoint;
     private String client_mgmt_endpoint;
+    private String[] code_challenge_methods_supported;
 
     /**
      * OIDC Properties not utilized in implementation
@@ -464,6 +465,20 @@ public abstract class OIDCAbstractDiscoveryModel {
      */
     public void setClientMgmtEndpoint(String clientMgmtEndpoint) {
         this.client_mgmt_endpoint = clientMgmtEndpoint;
+    }
+
+    /**
+     * @return the pkceCodeChallengeMethodsSupported
+     */
+    public String[] getPkceCodeChallengeMethodsSupported() {
+        return defensiveCopy(code_challenge_methods_supported);
+    }
+
+    /**
+     * @param pkceCodeChallengeMethodsSupported the pkceCodeChallengeMethodsSupported to set
+     */
+    public void setPkceCodeChallengeMethodsSupported(String[] pkceCodeChallengeMethodsSupported) {
+        this.code_challenge_methods_supported = defensiveCopy(pkceCodeChallengeMethodsSupported);
     }
 
     private String[] defensiveCopy(String[] strArr) {

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/Discovery.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/Discovery.java
@@ -97,6 +97,8 @@ public class Discovery {
 
         discoveryObj.setClientMgmtEndpoint(discoverConfig.getEndpoint(OIDCConstants.KEY_OIDC_CLIENT_MGMT_EP_QUAL));
 
+        discoveryObj.setPkceCodeChallengeMethodsSupported(OIDCConstants.OIDC_DISC_PKCE_CODE_CHALLENGE_METHODS_SUPPORTED);
+
         String discoverJSONString = discoveryObj.toJSONString();
 
         if (tc.isDebugEnabled()) {

--- a/dev/com.ibm.ws.security.openidconnect.server/test/com/ibm/ws/security/openidconnect/web/DiscoveryTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/test/com/ibm/ws/security/openidconnect/web/DiscoveryTest.java
@@ -63,6 +63,7 @@ public class DiscoveryTest {
     private final static String[] supportedDisplayVals = { "page" };
     private final static String[] supportedClaimTypes = { "normal" };
     private final static String[] supportedSubjectTypes = { "public" };
+    private final static String[] supportedPkceCodeChallengeMethods = { "plain", "S256" };
     private final static String SIGNING_ALG_VALUE = "HS256";
     private final static String ISSUER_URI = "https://localhost:8020/oidc/endpoint/TestProvider";
     private final static String AUTHORIZE_URI = ISSUER_URI + "/authorize";
@@ -190,6 +191,7 @@ public class DiscoveryTest {
             assertEquals("Discovery model property should have matched.", expectedDiscoveryModel.getClientMgmtEndpoint(), CLIENT_MGMT_URI);
             assertEquals("Discovery model property should have matched.", expectedDiscoveryModel.getPersonalTokenMgmtEndpoint(), PERSONAL_TOKEN_MGMT_URI);
             assertEquals("Discovery model property should have matched.", expectedDiscoveryModel.getUsersTokenMgmtEndpoint(), USERS_TOKEN_MGMT_URI);
+            assertArrayEquals(expectedDiscoveryModel.getPkceCodeChallengeMethodsSupported(), supportedPkceCodeChallengeMethods);
 
         } catch (Throwable t) {
             outputMgr.failWithThrowable(methodName, t);
@@ -310,6 +312,7 @@ public class DiscoveryTest {
         model.setClientMgmtEndpoint(CLIENT_MGMT_URI);
         model.setPersonalTokenMgmtEndpoint(PERSONAL_TOKEN_MGMT_URI);
         model.setUsersTokenMgmtEndpoint(USERS_TOKEN_MGMT_URI);
+        model.setPkceCodeChallengeMethodsSupported(supportedPkceCodeChallengeMethods);
 
         return model;
     }


### PR DESCRIPTION
This PR enables OpenID Connect Discovery of PKCE supported code challenge methods but returning the information -- "code_challenge_methods_supported":["plain","S256"]}


