### PR TITLE
Support for OPENJ9_JAVA_OPTIONS

### DIFF
--- a/dev/cnf/resources/bin/tool
+++ b/dev/cnf/resources/bin/tool
@@ -236,7 +236,7 @@ fi
 
 # Set a default file encoding if needed
 if [ -n "$defaultFileEncoding" ]; then
-  if ! expr "${JVM_ARGS} ${IBM_JAVA_OPTIONS}" : '.*\(-Dfile\.encoding\=[^[:space:]]\)' > /dev/null; then
+  if ! expr "${JVM_ARGS} ${OPENJ9_JAVA_OPTIONS}" : '.*\(-Dfile\.encoding\=[^[:space:]]\)' > /dev/null; then
     JVM_ARGS="${JVM_ARGS} -Dfile.encoding=$defaultFileEncoding"
   fi
 fi

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -577,26 +577,28 @@ serverEnvDefaults()
   # Command-line parsing of -Xshareclasses does not allow "," in cacheDir.
   case ${WLP_OUTPUT_DIR} in
   *,*)
-    SERVER_IBM_JAVA_OPTIONS=${IBM_JAVA_OPTIONS}
+    SERVER_IBM_JAVA_OPTIONS=${OPENJ9_JAVA_OPTIONS}
     ;;
   *)
     if $shareclassesCacheDirPerm
     then
-      SERVER_IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty-%u,nonfatal,cacheDir=\"${WLP_OUTPUT_DIR}/.classCache\",cacheDirPerm=1000 -XX:ShareClassesEnableBCI -Xscmx80m ${IBM_JAVA_OPTIONS}"
+      SERVER_IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty-%u,nonfatal,cacheDir=\"${WLP_OUTPUT_DIR}/.classCache\",cacheDirPerm=1000 -XX:ShareClassesEnableBCI -Xscmx80m ${OPENJ9_JAVA_OPTIONS}"
     else
-      SERVER_IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty-%u,nonfatal,cacheDir=\"${WLP_OUTPUT_DIR}/.classCache\" -XX:ShareClassesEnableBCI -Xscmx80m ${IBM_JAVA_OPTIONS}"
+      SERVER_IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty-%u,nonfatal,cacheDir=\"${WLP_OUTPUT_DIR}/.classCache\" -XX:ShareClassesEnableBCI -Xscmx80m ${OPENJ9_JAVA_OPTIONS}"
     fi
   esac
 
   # Add -Xquickstart -Xnoaot for client JVMs only.  AOT is ineffective if JVMs have conflicting
   # options, and it's more important that the server JVMs be able to use AOT.
   # Add -Dcom.ibm.tools.attach.enable=yes to allow self-attach on z/OS
-  IBM_JAVA_OPTIONS="-Xquickstart -Xnoaot -Dcom.ibm.tools.attach.enable=yes ${IBM_JAVA_OPTIONS}"
+  IBM_JAVA_OPTIONS="-Xquickstart -Xnoaot -Dcom.ibm.tools.attach.enable=yes ${OPENJ9_JAVA_OPTIONS}"
   export IBM_JAVA_OPTIONS
+  OPENJ9_JAVA_OPTIONS="-Xquickstart -Xnoaot -Dcom.ibm.tools.attach.enable=yes ${OPENJ9_JAVA_OPTIONS}"
+  export OPENJ9_JAVA_OPTIONS
 
   # Set a default file encoding if needed
   if [ -n "$defaultFileEncoding" ]; then
-    if ! expr "${JVM_OPTIONS_QUOTED} ${JVM_ARGS} ${IBM_JAVA_OPTIONS}" : '.*\(-Dfile\.encoding\=[^[:space:]]\)' > /dev/null; then
+    if ! expr "${JVM_OPTIONS_QUOTED} ${JVM_ARGS} ${OPENJ9_JAVA_OPTIONS}" : '.*\(-Dfile\.encoding\=[^[:space:]]\)' > /dev/null; then
       JVM_ARGS="${JVM_ARGS} -Dfile.encoding=$defaultFileEncoding"
     fi
   fi
@@ -927,8 +929,9 @@ serverCmd()
 
   SAVE_JVM_OPTIONS_QUOTED=${JVM_OPTIONS_QUOTED}
   JVM_OPTIONS_QUOTED=${SERVER_JVM_OPTIONS_QUOTED}
-  SAVE_IBM_JAVA_OPTIONS=${IBM_JAVA_OPTIONS}
+  SAVE_IBM_JAVA_OPTIONS=${OPENJ9_JAVA_OPTIONS}
   IBM_JAVA_OPTIONS=${SERVER_IBM_JAVA_OPTIONS}
+  OPENJ9_JAVA_OPTIONS=${SERVER_IBM_JAVA_OPTIONS}
 
   if $os400lib; then
     serverCmdOS400 "${SERVER_CMD_BACKGROUND_LOG}" "${SERVER_NAME}" "$@"
@@ -936,6 +939,7 @@ serverCmd()
 
     JVM_OPTIONS_QUOTED=${SAVE_JVM_OPTIONS_QUOTED}
     IBM_JAVA_OPTIONS=${SAVE_IBM_JAVA_OPTIONS}
+    OPENJ9_JAVA_OPTIONS=${SAVE_IBM_JAVA_OPTIONS}
 
     if [ -n "${SERVER_CMD_BACKGROUND_LOG}" ]; then
       PID=`cat "${X_PID_FILE}"`
@@ -957,6 +961,7 @@ serverCmd()
 
       JVM_OPTIONS_QUOTED=${SAVE_JVM_OPTIONS_QUOTED}
       IBM_JAVA_OPTIONS=${SAVE_IBM_JAVA_OPTIONS}
+      OPENJ9_JAVA_OPTIONS=${SAVE_IBM_JAVA_OPTIONS}
 
       if [ $rc = 0 ]; then
         # Verify/wait for the process to start
@@ -1017,6 +1022,7 @@ serverCmd()
 
     JVM_OPTIONS_QUOTED=${SAVE_JVM_OPTIONS_QUOTED}
     IBM_JAVA_OPTIONS=${SAVE_IBM_JAVA_OPTIONS}
+    OPENJ9_JAVA_OPTIONS=${SAVE_IBM_JAVA_OPTIONS}
 
     if [ -n "${SERVER_CMD_BACKGROUND_LOG}" ]; then
       # Verify/wait for the process to start

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
@@ -247,11 +247,13 @@ goto:eof
   if %RC% == 2 goto:eof
 
   call:serverWorkingDirectory
-  set SAVE_IBM_JAVA_OPTIONS=!IBM_JAVA_OPTIONS!
+  set SAVE_IBM_JAVA_OPTIONS=!OPENJ9_JAVA_OPTIONS!
   set IBM_JAVA_OPTIONS=!SERVER_IBM_JAVA_OPTIONS!
+  set OPENJ9_JAVA_OPTIONS=!SERVER_IBM_JAVA_OPTIONS!
   !JAVA_CMD_QUOTED! !JAVA_AGENT_QUOTED! !JVM_OPTIONS! !JAVA_PARAMS_QUOTED! --batch-file !PARAMS_QUOTED!
   set RC=%errorlevel%
   set IBM_JAVA_OPTIONS=!SAVE_IBM_JAVA_OPTIONS!
+  set OPENJ9_JAVA_OPTIONS=!SAVE_IBM_JAVA_OPTIONS!
   call:javaCmdResult
 goto:eof
 
@@ -262,11 +264,13 @@ goto:eof
   if %RC% == 2 goto:eof
 
   call:serverWorkingDirectory
-  set SAVE_IBM_JAVA_OPTIONS=!IBM_JAVA_OPTIONS!
+  set SAVE_IBM_JAVA_OPTIONS=!OPENJ9_JAVA_OPTIONS!
   set IBM_JAVA_OPTIONS=!SERVER_IBM_JAVA_OPTIONS!
+  set OPENJ9_JAVA_OPTIONS=!SERVER_IBM_JAVA_OPTIONS!
   !JAVA_CMD_QUOTED! !JAVA_AGENT_QUOTED! !JVM_OPTIONS! !JAVA_PARAMS_QUOTED! --batch-file !PARAMS_QUOTED!
   set RC=%errorlevel%
   set IBM_JAVA_OPTIONS=!SAVE_IBM_JAVA_OPTIONS!
+  set OPENJ9_JAVA_OPTIONS=!SAVE_IBM_JAVA_OPTIONS!
   call:javaCmdResult
 goto:eof
 
@@ -306,13 +310,15 @@ goto:eof
     )
 
     set X_CMD=!JAVA_CMD_QUOTED! !JAVA_AGENT_QUOTED! !JVM_OPTIONS! !JAVA_PARAMS_QUOTED! --batch-file !PARAMS_QUOTED!
-    set SAVE_IBM_JAVA_OPTIONS=!IBM_JAVA_OPTIONS!
+    set SAVE_IBM_JAVA_OPTIONS=!OPENJ9_JAVA_OPTIONS!
     set IBM_JAVA_OPTIONS=!SERVER_IBM_JAVA_OPTIONS!
+    set OPENJ9_JAVA_OPTIONS=!SERVER_IBM_JAVA_OPTIONS!
 
     @REM Use javaw so command windows can be closed.
     start /min /b "" !JAVA_CMD_QUOTED!w !JAVA_AGENT_QUOTED! !JVM_OPTIONS! !JAVA_PARAMS_QUOTED! --batch-file !PARAMS_QUOTED! >> "%X_LOG_DIR%\%X_LOG_FILE%" 2>&1
 
     set IBM_JAVA_OPTIONS=!SAVE_IBM_JAVA_OPTIONS!
+    set OPENJ9_JAVA_OPTIONS=!SAVE_IBM_JAVA_OPTIONS!
 
     !JAVA_CMD_QUOTED! !JAVA_PARAMS_QUOTED! "!SERVER_NAME!" --status:start
     set RC=!errorlevel!
@@ -501,15 +507,16 @@ goto:eof
 
   @REM Command-line parsing of -Xshareclasses does not allow "," in cacheDir.
   if "!WLP_OUTPUT_DIR:,=!" == "!WLP_OUTPUT_DIR!" (
-    set SERVER_IBM_JAVA_OPTIONS=-Xshareclasses:name=liberty-%%u,nonfatal,cacheDir="%WLP_OUTPUT_DIR%\.classCache" -XX:ShareClassesEnableBCI -Xscmx80m !IBM_JAVA_OPTIONS!
+    set SERVER_IBM_JAVA_OPTIONS=-Xshareclasses:name=liberty-%%u,nonfatal,cacheDir="%WLP_OUTPUT_DIR%\.classCache" -XX:ShareClassesEnableBCI -Xscmx80m !OPENJ9_JAVA_OPTIONS!
   ) else (
-    set SERVER_IBM_JAVA_OPTIONS=!IBM_JAVA_OPTIONS!
+    set SERVER_IBM_JAVA_OPTIONS=!OPENJ9_JAVA_OPTIONS!
   )
 
   @REM Add -Xquickstart -Xnoaot for client JVMs only.  AOT is ineffective if
   @REM JVMs have conflicting options, and it's more important that server JVMs
   @REM be able to use AOT.
-  set IBM_JAVA_OPTIONS=-Xquickstart -Xnoaot !IBM_JAVA_OPTIONS!
+  set IBM_JAVA_OPTIONS=-Xquickstart -Xnoaot !OPENJ9_JAVA_OPTIONS!
+  set OPENJ9_JAVA_OPTIONS=-Xquickstart -Xnoaot !OPENJ9_JAVA_OPTIONS!
 goto:eof
 
 @REM

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/FATSuite.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/FATSuite.java
@@ -56,9 +56,11 @@ import com.ibm.wsspi.kernel.embeddable.EmbeddedServerTest;
                 StartCommandTest.class,
                 ServerClasspathTest.class,
                 ServerStartJVMOptionsTest.class,
+                ServerStartJavaEnvironmentVariablesTest.class,
                 PauseResumeCommandTest.class,
                 EmbeddedServerMergeProductExtensionTest.class,
                 ServerEndpointControlMBeanTest.class,
                 OSGiEmbedManagerTest.class
 })
-public class FATSuite {}
+public class FATSuite {
+}

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerStartJavaEnvironmentVariablesTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/ServerStartJavaEnvironmentVariablesTest.java
@@ -1,0 +1,138 @@
+package com.ibm.ws.kernel.boot;
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Enumeration;
+import java.util.Properties;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.OperatingSystem;
+import com.ibm.websphere.simplicity.ProgramOutput;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
+
+@RunWith(FATRunner.class)
+public class ServerStartJavaEnvironmentVariablesTest {
+    private static final Class<?> c = ServerStartJavaEnvironmentVariablesTest.class;
+
+    private static final String SERVER_NAME = "com.ibm.ws.kernel.boot.serverstart.fat";
+    static String executionDir;
+    static String serverCommand;
+
+    @Rule
+    public TestName testName = new TestName();
+
+    private static LibertyServer server;
+
+    @BeforeClass
+    public static void before() throws Exception {
+        server = LibertyServerFactory.getLibertyServer(SERVER_NAME);
+        executionDir = server.getInstallRoot();
+        if (server.getMachine().getOperatingSystem() == OperatingSystem.WINDOWS)
+            serverCommand = "bin\\server.bat";
+        else
+            serverCommand = "bin/server";
+    }
+
+    @AfterClass
+    public static void after() throws Exception {
+        if (server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+    /**
+     * Ensures that OPENJ9_JAVA_OPTIONS and IBM_JAVA_OPTIONS enviroment variables 
+     * are both set and are equal to eachother
+     */
+    @Test
+    public void testServerStartJavaOptionsSet() throws Exception {
+        Log.entering(c, testName.getMethodName());
+
+        String[] parms = new String[] { "start", SERVER_NAME };
+
+        Properties envVars = new Properties();
+        envVars.put("CDPATH", ".");
+
+        ProgramOutput po = server.getMachine().execute(serverCommand, parms, executionDir, envVars);
+        Log.info(c, testName.getMethodName(), "server start stdout = " + po.getStdout());
+        Log.info(c, testName.getMethodName(), "server start stderr = " + po.getStderr());
+
+        server.waitForStringInLog("CWWKF0011I");
+        server.resetStarted();
+
+        ProgramOutput dumpOut = server.serverDump();
+
+        File[] filesAfterDump = new File(executionDir + "/usr/servers/" + SERVER_NAME).listFiles();
+
+        File dumpFile = new File("");
+        for (File f : filesAfterDump) {
+            String fileName = f.getName();
+            if (fileName.startsWith(SERVER_NAME + ".dump") && fileName.endsWith(".zip")) {
+                dumpFile = f;
+                break;
+            }
+        }
+        assertTrue("The Dump File was not found", dumpFile.getPath().compareTo("") != 0);
+
+        ZipFile zipFile = new ZipFile(dumpFile);
+        for (Enumeration<? extends ZipEntry> en = zipFile.entries(); en.hasMoreElements();) {
+            ZipEntry entry = en.nextElement();
+            if (entry.getName().endsWith("EnvironmentVariables.txt")) {
+                InputStream entryInputStream = zipFile.getInputStream(entry);
+                BufferedReader entryReader = new BufferedReader(new InputStreamReader(entryInputStream));
+
+                String[] firstLine = new String[2], secondLine = new String[2];
+                while ((firstLine = entryReader.readLine().split("=", 2)) != null) {
+                    if (firstLine[0].startsWith("IBM_JAVA_OPTIONS")) {
+                        while ((secondLine = entryReader.readLine().split("=", 2)) != null) {
+                            if (secondLine[0].equals("OPENJ9_JAVA_OPTIONS")) {
+                                Log.info(c, testName.getMethodName(), String.format("%-20s=%s", firstLine[0], firstLine[1]));
+                                Log.info(c, testName.getMethodName(), String.format("%-20s=%s", secondLine[0], secondLine[1]));
+                                assertTrue("IBM_JAVA_OPTIONS did not equal OPENJ9_JAVA OPTIONS", firstLine[1].equals(secondLine[1]));
+                                break;
+                            }
+                        }
+                        assertTrue("OPENJ9_JAVA_OPTIONS was not found", secondLine[0].equals("OPENJ9_JAVA_OPTIONS"));
+                        break;
+                    }
+                }
+                assertTrue("IBM_JAVA_OPTIONS was not found", firstLine[0].equals("IBM_JAVA_OPTIONS"));
+
+                entryReader.close();
+                entryInputStream.close();
+            }
+        }
+
+        zipFile.close();
+        dumpFile.delete();
+
+        server.stopServer();
+    }
+
+}


### PR DESCRIPTION
fixes #9096 

- IBM_JAVA_OPTIONS is still being set with the same Java options but all references to it in the server scripts now use OPENJ9_JAVA_OPTIONS.
- The added test checks that they are both set correctly and are equal to each other