### PR TITLE
moved testDataFrameAfterContinuationFrame to Http2FullModeTests.java

### DIFF
--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2FullModeTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2FullModeTests.java
@@ -759,10 +759,11 @@ public class Http2FullModeTests extends FATServletClient {
      *
      * @throws Exception
      */
-    @Test
-    public void testDataFrameAfterContinuationFrame() throws Exception {
-        runTest(defaultServletPath, testName.getMethodName());
-    }
+    // Moved to tracing, build break 268375
+    // @Test
+    // public void testDataFrameAfterContinuationFrame() throws Exception {
+    //     runTest(defaultServletPath, testName.getMethodName());
+    // }
 
     /**
      * Test Coverage: Send a CONTINUATION frame on stream 0

--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2FullTracingTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2FullTracingTests.java
@@ -121,4 +121,10 @@ public class Http2FullTracingTests extends FATServletClient {
     public void testHeaderFrameAfterHeaderFrameWithEndOfStream() throws Exception {
         runTest(defaultServletPath, testName.getMethodName());
     }
+
+    // Moved to tracing, build break 268375
+    @Test
+    public void testDataFrameAfterContinuationFrame() throws Exception {
+        runTest(defaultServletPath, testName.getMethodName());
+    }
 }


### PR DESCRIPTION
fixes #7296 

Move another test over to the tracing bucket. 