### PR TITLE
Catch illegal state exception on RESTHandler exception when calling g…

### DIFF
--- a/dev/com.ibm.ws.rest.handler/src/com/ibm/ws/rest/handler/internal/service/RESTHandlerContainerImpl.java
+++ b/dev/com.ibm.ws.rest.handler/src/com/ibm/ws/rest/handler/internal/service/RESTHandlerContainerImpl.java
@@ -478,13 +478,25 @@ public class RESTHandlerContainerImpl implements RESTHandlerContainer {
                         response.setResponseHeader("Allow", e.getAllowedMethods());
                         response.sendError(e.getStatusCode());
                     } catch (RESTHandlerJsonException e) {
-                        if (e.isMessageContentJSON()) {
-                            response.setStatus(e.getStatusCode());
-                            response.setContentType("application/json");
-                            response.setCharacterEncoding("UTF-8");
-                            response.getWriter().write(e.getMessage());
-                        } else {
-                            response.sendError(e.getStatusCode(), e.getMessage());
+                        // If getOutputStream has been called we cannot use getWriter
+                        try {
+                            if (e.isMessageContentJSON()) {
+                                response.setStatus(e.getStatusCode());
+                                response.setContentType("application/json");
+                                response.setCharacterEncoding("UTF-8");
+                                response.getWriter().write(e.getMessage());
+                            } else {
+                                response.sendError(e.getStatusCode(), e.getMessage());
+                            }
+                        } catch (IllegalStateException stateException) {
+                            if (e.isMessageContentJSON()) {
+                                response.setStatus(e.getStatusCode());
+                                response.setContentType("application/json");
+                                response.setCharacterEncoding("UTF-8");
+                                response.getOutputStream().write(e.getMessage().getBytes());
+                            } else {
+                                response.sendError(e.getStatusCode(), e.getMessage());
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
…etWriter.
- Catch IllegalStateExceptions thrown by the call to getWriter, and use getOutputStream instead.
- Fixes #9380 
- Test by running corresponding FAT test 30 times as a pre-req before opening PR.

