### PR TITLE
update cxf 2.6.2 bundle license

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.api.2.6.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.api.2.6.2/bnd.overrides
@@ -1,9 +1,20 @@
+#*******************************************************************************
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
 -include= ~../cnf/resources/bnd/rejar.props
 bVersion=1.0
 
-Bundle-Name: Apache CXF API
-Bundle-Description: Apache CXF API, version 2.6.2
 Bundle-SymbolicName: com.ibm.ws.org.apache.cxf.cxf.api.2.6.2
+Bundle-Copyright: Copyright (c) 1999, 2019 IBM Corporation and others. All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at http://www.eclipse.org/legal/epl-v10.html.
+Bundle-Vendor: IBM
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.2.6.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.2.6.2/bnd.overrides
@@ -11,10 +11,12 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-Bundle-Name: Apache CXF Runtime SOAP Binding
-Bundle-Description: Apache CXF Runtime SOAP Binding, version 2.6.2
 Bundle-SymbolicName: com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.2.6.2
 Bundle-Activator: com.ibm.ws.cxf.rt.bindings.soap.NoOpActivator
+Bundle-Copyright: Copyright (c) 1999, 2019 IBM Corporation and others. All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at http://www.eclipse.org/legal/epl-v10.html.
+Bundle-Description: Apache CXF Runtime HTTP Transport, version 2.6.2
+Bundle-Vendor: IBM
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.xml.2.6.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.xml.2.6.2/bnd.overrides
@@ -1,8 +1,22 @@
+#*******************************************************************************
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
 -include= ~../cnf/resources/bnd/rejar.props
 bVersion=1.0
 
 Bundle-SymbolicName: com.ibm.ws.org.apache.cxf.cxf.rt.bindings.xml.2.6.2
 Bundle-Activator: com.ibm.ws.cxf.rt.bindings.xml.NoOpActivator
+Bundle-Copyright: Copyright (c) 1999, 2019 IBM Corporation and others. All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at http://www.eclipse.org/legal/epl-v10.html.
+Bundle-Description: Apache CXF Runtime HTTP Transport, version 2.6.2
+Bundle-Vendor: IBM
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.core.2.6.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.core.2.6.2/bnd.overrides
@@ -1,9 +1,20 @@
+#*******************************************************************************
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
 -include= ~../cnf/resources/bnd/rejar.props
 bVersion=1.0
 
-Bundle-Name: Apache CXF Runtime Core
-Bundle-Description: Apache CXF Runtime Core, version 2.6.2
 Bundle-SymbolicName: com.ibm.ws.org.apache.cxf.cxf.rt.core.2.6.2
+Bundle-Copyright: Copyright (c) 1999, 2019 IBM Corporation and others. All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at http://www.eclipse.org/legal/epl-v10.html.
+Bundle-Vendor: IBM
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
  

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.2.6.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.2.6.2/bnd.overrides
@@ -1,9 +1,20 @@
+#*******************************************************************************
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
 -include= ~../cnf/resources/bnd/rejar.props
 bVersion=1.0
 
-Bundle-Name: Apache CXF Runtime Data Binding JAX-B
-Bundle-Description: Apache CXF Runtime Data Binding JAX-B, version 2.6.2
 Bundle-SymbolicName: com.ibm.ws.org.apache.cxf.cxf.rt.databinding.jaxb.2.6.2
+Bundle-Copyright: Copyright (c) 1999, 2019 IBM Corporation and others. All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at http://www.eclipse.org/legal/epl-v10.html.
+Bundle-Vendor: IBM
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
  

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.2.6.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.2.6.2/bnd.overrides
@@ -1,11 +1,22 @@
+#*******************************************************************************
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
 -include= ~../cnf/resources/bnd/rejar.props
 bVersion=1.0
 cxfVersion=2.6.2
 
-Bundle-Name: Apache CXF Runtime JAX-WS Frontend
-Bundle-Description: Apache CXF Runtime JAX-WS Frontend, version 2.6.2
 Bundle-SymbolicName: com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.2.6.2
 Bundle-Activator: com.ibm.ws.cxf.rt.frontend.jaxws.NoOpActivator
+Bundle-Copyright: Copyright (c) 1999, 2019 IBM Corporation and others. All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at http://www.eclipse.org/legal/epl-v10.html.
+Bundle-Vendor: IBM
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.simple.2.6.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.simple.2.6.2/bnd.overrides
@@ -1,10 +1,21 @@
+#*******************************************************************************
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
 -include= ~../cnf/resources/bnd/rejar.props
 bVersion=1.0
 
-Bundle-Name: Apache CXF Runtime Simple Frontend
-Bundle-Description: Apache CXF Runtime Simple Frontend, version 2.6.2
 Bundle-SymbolicName: com.ibm.ws.org.apache.cxf.cxf.rt.frontend.simple.2.6.2
 Bundle-Activator: com.ibm.ws.cxf.rt.frontend.simple.NoOpActivator
+Bundle-Copyright: Copyright (c) 1999, 2019 IBM Corporation and others. All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at http://www.eclipse.org/legal/epl-v10.html.
+Bundle-Vendor: IBM
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.management.2.6.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.management.2.6.2/bnd.overrides
@@ -1,8 +1,21 @@
+#*******************************************************************************
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
 -include= ~../cnf/resources/bnd/rejar.props
 bVersion=1.0
 
 Bundle-SymbolicName: com.ibm.ws.org.apache.cxf.cxf.rt.management.2.6.2
 Bundle-Activator: com.ibm.ws.cxf.rt.management.NoOpActivator
+Bundle-Copyright: Copyright (c) 1999, 2019 IBM Corporation and others. All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at http://www.eclipse.org/legal/epl-v10.html.
+Bundle-Vendor: IBM
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.2.6.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.2.6.2/bnd.overrides
@@ -11,10 +11,11 @@
 -include= ~../cnf/resources/bnd/rejar.props
 bVersion=1.0
 
-Bundle-Name: Apache CXF Runtime HTTP Transport
-Bundle-Description: Apache CXF Runtime HTTP Transport, version 2.6.2
 Bundle-SymbolicName: com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.2.6.2
 Bundle-Activator: org.apache.cxf.transport.http.osgi.HTTPTransportActivator
+Bundle-Copyright: Copyright (c) 1999, 2019 IBM Corporation and others. All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at http://www.eclipse.org/legal/epl-v10.html.
+Bundle-Vendor: IBM
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.addr.2.6.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.addr.2.6.2/bnd.overrides
@@ -13,6 +13,9 @@ bVersion=1.0
 
 Bundle-SymbolicName: com.ibm.ws.org.apache.cxf.cxf.rt.ws.addr.2.6.2
 Bundle-Activator: com.ibm.ws.cxf.rt.ws.addr.NoOpActivator
+Bundle-Copyright: Copyright (c) 1999, 2019 IBM Corporation and others. All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at http://www.eclipse.org/legal/epl-v10.html.
+Bundle-Vendor: IBM
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.2.6.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.2.6.2/bnd.overrides
@@ -13,6 +13,9 @@ bVersion=1.0
 
 Bundle-SymbolicName: com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.2.6.2
 Bundle-Activator: com.ibm.ws.cxf.rt.ws.policy.NoOpActivator
+Bundle-Copyright: Copyright (c) 1999, 2019 IBM Corporation and others. All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at http://www.eclipse.org/legal/epl-v10.html.
+Bundle-Vendor: IBM
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 


### PR DESCRIPTION
update the manifest.mf license for our CXF 2.6.2 bundles