### PR TITLE
Revert "default server file updates"

### DIFF
--- a/dev/com.ibm.ws.kernel.boot/publish/templates/servers/defaultServer/server.xml
+++ b/dev/com.ibm.ws.kernel.boot/publish/templates/servers/defaultServer/server.xml
@@ -13,7 +13,4 @@
 
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
-
-    <!-- Default SSL configuration enables trust for default certificates from the Java runtime --> 
-    <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
 </server>

--- a/dev/com.ibm.ws.kernel.boot/publish/templates/servers/javaee7/server.xml
+++ b/dev/com.ibm.ws.kernel.boot/publish/templates/servers/javaee7/server.xml
@@ -31,7 +31,4 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
 
-    <!-- Default SSL configuration enables trust for default certificates from the Java runtime --> 
-    <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
-
 </server>

--- a/dev/com.ibm.ws.kernel.boot/publish/templates/servers/javaee8/server.xml
+++ b/dev/com.ibm.ws.kernel.boot/publish/templates/servers/javaee8/server.xml
@@ -31,7 +31,4 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
 
-    <!-- Default SSL configuration enables trust for default certificates from the Java runtime --> 
-    <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
-
 </server>

--- a/dev/com.ibm.ws.kernel.boot/publish/templates/servers/microProfile1/server.xml
+++ b/dev/com.ibm.ws.kernel.boot/publish/templates/servers/microProfile1/server.xml
@@ -14,7 +14,4 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
 
-    <!-- Default SSL configuration enables trusting default certificates -->
-    <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
-
 </server>

--- a/dev/com.ibm.ws.kernel.boot/publish/templates/servers/microProfile2/server.xml
+++ b/dev/com.ibm.ws.kernel.boot/publish/templates/servers/microProfile2/server.xml
@@ -14,7 +14,4 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
 
-    <!-- Default SSL configuration enables trust for default certificates from the Java runtime --> 
-    <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
-
 </server>

--- a/dev/com.ibm.ws.kernel.boot/publish/templates/servers/microProfile3/server.xml
+++ b/dev/com.ibm.ws.kernel.boot/publish/templates/servers/microProfile3/server.xml
@@ -14,7 +14,4 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
 
-    <!-- Default SSL configuration enables trust for default certificates from the Java runtime --> 
-    <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
-
 </server>

--- a/dev/com.ibm.ws.kernel.boot/publish/templates/servers/springBoot1/server.xml
+++ b/dev/com.ibm.ws.kernel.boot/publish/templates/servers/springBoot1/server.xml
@@ -15,7 +15,4 @@
                   httpPort="9080"
                   httpsPort="9443" />
 
-    <!-- Default SSL configuration enables trust for default certificates from the Java runtime --> 
-    <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
-
 </server>

--- a/dev/com.ibm.ws.kernel.boot/publish/templates/servers/springBoot2/server.xml
+++ b/dev/com.ibm.ws.kernel.boot/publish/templates/servers/springBoot2/server.xml
@@ -15,7 +15,4 @@
                   httpPort="9080"
                   httpsPort="9443" />
 
-    <!-- Default SSL configuration enables trust for default certificates from the Java runtime --> 
-    <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
-
 </server>

--- a/dev/com.ibm.ws.kernel.boot/publish/templates/servers/webProfile7/server.xml
+++ b/dev/com.ibm.ws.kernel.boot/publish/templates/servers/webProfile7/server.xml
@@ -14,7 +14,4 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
 
-    <!-- Default SSL configuration enables trust for default certificates from the Java runtime --> 
-    <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
-
 </server>

--- a/dev/com.ibm.ws.kernel.boot/publish/templates/servers/webProfile8/server.xml
+++ b/dev/com.ibm.ws.kernel.boot/publish/templates/servers/webProfile8/server.xml
@@ -14,7 +14,4 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
 
-    <!-- Default SSL configuration enables trust for default certificates from the Java runtime --> 
-    <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
-
 </server>


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#9359

The parent feature is not being included in the next release and these changes are not beta guarded (may not be technically possible). Reverting until the following release.