### PR TITLE
Change baseAuthz for security service from OPTIONAL to MANDATORY

### DIFF
--- a/dev/com.ibm.ws.security.authorization.builtin/src/com/ibm/ws/security/authorization/builtin/BaseAuthorizationTableService.java
+++ b/dev/com.ibm.ws.security.authorization.builtin/src/com/ibm/ws/security/authorization/builtin/BaseAuthorizationTableService.java
@@ -59,7 +59,7 @@ public abstract class BaseAuthorizationTableService implements UserRegistryChang
     protected String bundleLocation;
 
     @Reference(service = SecurityService.class, name = KEY_SECURITY_SERVICE,
-               cardinality = ReferenceCardinality.OPTIONAL,
+               cardinality = ReferenceCardinality.MANDATORY,
                policy = ReferencePolicy.DYNAMIC)
     protected void setSecurityService(ServiceReference<SecurityService> reference) {
         securityServiceRef.setReference(reference);


### PR DESCRIPTION
Enable parallel bundle activation in the security features cause base authz null point exception since security service is optional; change it from optional to mandatory. 
