### PR TITLE
ignore ssl errors

### DIFF
--- a/dev/com.ibm.ws.cloudant_fat/fat/src/com/ibm/ws/cloudant/fat/CloudantTestOutboundSSL.java
+++ b/dev/com.ibm.ws.cloudant_fat/fat/src/com/ibm/ws/cloudant/fat/CloudantTestOutboundSSL.java
@@ -41,7 +41,8 @@ public class CloudantTestOutboundSSL extends FATServletClient {
     private static final String DB_NAME = "outboundssldb";
     public static final String JEE_APP = "cloudantfat";
     public static final String SERVLET_NAME = "CloudantTestServlet";
-    public static String[] expectedFailures = { "CWWKG0033W.*does_not_exist" };
+    // CWWKO0801E (SSLHandshakeErrorTracker - no cipher suites in common) : See defect 260787
+    public static String[] expectedFailures = { "CWWKG0033W.*does_not_exist", "CWWKO0801E" };
 
     @BeforeClass
     public static void setUp() throws Exception {


### PR DESCRIPTION
Ignore the "CWWKO0801E: Unable to initialize SSL connection. Unauthorized access was denied or security settings have expired. Exception is javax.net.ssl.SSLHandshakeException: no cipher suites in common" error in the com.ibm.ws.cloudant.fat.CloudantTestOutboundSSL bucket. 

fixe #9424 