### PR TITLE
[9412] Ensure mpGraphQL-1.0 works with mpMetrics-1.1 and 2.0

### DIFF
--- a/dev/com.ibm.ws.microprofile.graphql.1.0/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0/bnd.bnd
@@ -31,10 +31,15 @@ Private-Package: \
 Export-Package: \
   com.ibm.ws.microprofile.graphql.component;thread-context=true
 
+DynamicImport-Package: \
+  com.ibm.ws.microprofile.metrics.cdi.producer; version="[1.0.0,2.0.0)",\
+  org.eclipse.microprofile.config,\
+  org.eclipse.microprofile.metrics
+
 Import-Package: \
-  com.ibm.ws.microprofile.metrics.cdi.producer; version="[1.0.0,2.0.0)";resolution:=optional,\
-  org.eclipse.microprofile.config;resolution:=optional,\
-  org.eclipse.microprofile.metrics;resolution:=optional,\
+  !com.ibm.ws.microprofile.metrics.cdi.producer,\
+  !org.eclipse.microprofile.config,\
+  !org.eclipse.microprofile.metrics,\
   *
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"

--- a/dev/com.ibm.ws.microprofile.graphql.1.0/src/com/ibm/ws/microprofile/graphql/component/MetricsInterceptor.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0/src/com/ibm/ws/microprofile/graphql/component/MetricsInterceptor.java
@@ -40,13 +40,14 @@ import com.ibm.ws.microprofile.metrics.cdi.producer.MetricRegistryFactory;
 @Priority(Interceptor.Priority.PLATFORM_AFTER)
 public class MetricsInterceptor {
 
+    private final static String PREFIX = "mp_graphql_";
     private final static TraceComponent tc = Tr.register(MetricsInterceptor.class);
     private final static MetricRegistry metrics = MetricRegistryFactory.getVendorRegistry();
 
     @AroundInvoke
     public Object captureMetrics(InvocationContext ctx) throws Exception {
         Method m = ctx.getMethod();
-        String fqMethodName = m.getDeclaringClass().getName() + "." + m.getName();
+        String fqMethodName = PREFIX + m.getDeclaringClass().getName() + "." + m.getName();
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "invoking " + fqMethodName );
         }

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/.classpath
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/.classpath
@@ -9,6 +9,7 @@
 	<classpathentry kind="src" path="test-applications/ifaceApp/src"/>
 	<classpathentry kind="src" path="test-applications/ignoreApp/src"/>
 	<classpathentry kind="src" path="test-applications/inputFieldsApp/src"/>
+	<classpathentry kind="src" path="test-applications/metricsApp/src"/>
 	<classpathentry kind="src" path="test-applications/outputFieldsApp/src"/>
 	<classpathentry kind="src" path="test-applications/typesApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/bnd.bnd
@@ -20,6 +20,7 @@ src: \
   test-applications/graphQLInterfaceApp/src,\
   test-applications/ifaceApp/src,\
   test-applications/ignoreApp/src,\
+  test-applications/metricsApp/src,\
   test-applications/inputFieldsApp/src,\
   test-applications/outputFieldsApp/src,\
   test-applications/typesApp/src,\
@@ -28,6 +29,8 @@ fat.project: true
 
 javac.source: 1.8
 javac.target: 1.8
+
+tested.features: mpMetrics-2.0
 
 -buildpath: \
   com.ibm.websphere.javaee.annotation.1.2;version=latest,\

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/FATSuite.java
@@ -25,6 +25,7 @@ import org.junit.runners.Suite.SuiteClasses;
                 IfaceTest.class,
                 IgnoreTest.class,
                 InputFieldsTest.class,
+                MetricsTest.class,
                 OutputFieldsTest.class,
                 TypesTest.class
 })

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/MetricsTest.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/MetricsTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.graphql.fat;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import mpGraphQL10.metrics.MetricsTestServlet;
+
+@RunWith(FATRunner.class)
+public class MetricsTest extends FATServletClient {
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.withoutModification()
+        .andWith(new FeatureReplacementAction("mpMetrics-1.1", "mpMetrics-2.0"));
+
+    private static final String SERVER = "mpGraphQL10.metrics";
+    private static final String APP_NAME = "metricsApp";
+
+    @Server(SERVER)
+    @TestServlet(servlet = MetricsTestServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultDropinApp(server, APP_NAME, "mpGraphQL10.metrics");
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        server.stopServer();
+    }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.metrics/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.metrics/bootstrap.properties
@@ -1,0 +1,4 @@
+com.ibm.ws.logging.trace.specification=*=info:LogService=all:com.ibm.ws.microprofile.*=all
+com.ibm.ws.logging.max.file.size=0
+osgi.console=5678
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.metrics/jvm.options
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.metrics/jvm.options
@@ -1,0 +1,1 @@
+-Dmicroprofile.rest.client.disable.default.mapper=true

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.metrics/server.xml
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.metrics/server.xml
@@ -3,12 +3,15 @@
     <feature>componenttest-1.0</feature>
     <feature>mpRestClient-1.2</feature>
     <feature>mpGraphQL-1.0</feature>
+    <feature>mpMetrics-1.1</feature>
     <feature>jaxrsClient-2.1</feature>
     <feature>jsonp-1.1</feature>
     <feature>jsonb-1.0</feature>
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>
+
+  <mpMetrics authentication="false"/>
 
   <!--  Required to read the server's port system property -->
   <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.types/server.xml
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.types/server.xml
@@ -10,13 +10,6 @@
 
   <include location="../fatTestPorts.xml"/>
 
-  <keyStore id="defaultKeyStore" password="passw0rd" />
-
-  <!--  the self-signed cert from the server should only be available in the client keystore -->
-  <ssl id="mySSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" />
-  <keyStore id="clientKeyStore" location="key.jks" type="JKS" password="passw0rd" />
-  <keyStore id="clientTrustStore" location="trust.jks" type="JKS" password="passw0rd" />
-
   <!--  Required to read the server's port system property -->
   <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
 

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/resources/graphiql.html
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/resources/graphiql.html
@@ -1,0 +1,142 @@
+<!--
+ *  Copyright (c) Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the license found in the
+ *  LICENSE file in the root directory of this source tree.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            height: 100%;
+            margin: 0;
+            width: 100%;
+            overflow: hidden;
+        }
+        #graphiql {
+            height: 100vh;
+        }
+    </style>
+
+    <!--
+      This GraphiQL example depends on Promise and fetch, which are available in
+      modern browsers, but can be "polyfilled" for older browsers.
+      GraphiQL itself depends on React DOM.
+      If you do not want to rely on a CDN, you can host these files locally or
+      include them directly in your favored resource bunder.
+    -->
+    <script src="//cdn.jsdelivr.net/es6-promise/4.0.5/es6-promise.auto.min.js"></script>
+    <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
+    <script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
+    <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
+
+    <!--
+      These two files can be found in the npm module, however you may wish to
+      copy them directly into your environment, or perhaps include them in your
+      favored resource bundler.
+     -->
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphiql@0.11.2/graphiql.css" />
+    <script src="//cdn.jsdelivr.net/npm/graphiql@0.11.2/graphiql.js"></script>
+
+</head>
+<body>
+<div id="graphiql">Loading...</div>
+<script>
+    /**
+     * This GraphiQL example illustrates how to use some of GraphiQL's props
+     * in order to enable reading and updating the URL parameters, making
+     * link sharing of queries a little bit easier.
+     *
+     * This is only one example of this kind of feature, GraphiQL exposes
+     * various React params to enable interesting integrations.
+     */
+        // Parse the search string to get url parameters.
+    var search = window.location.search;
+    var parameters = {};
+    search.substr(1).split('&').forEach(function (entry) {
+        var eq = entry.indexOf('=');
+        if (eq >= 0) {
+            parameters[decodeURIComponent(entry.slice(0, eq))] =
+                decodeURIComponent(entry.slice(eq + 1));
+        }
+    });
+    // if variables was provided, try to format it.
+    if (parameters.variables) {
+        try {
+            parameters.variables =
+                JSON.stringify(JSON.parse(parameters.variables), null, 2);
+        } catch (e) {
+            // Do nothing, we want to display the invalid JSON as a string, rather
+            // than present an error.
+        }
+    }
+    // When the query and variables string is edited, update the URL bar so
+    // that it can be easily shared
+    function onEditQuery(newQuery) {
+        parameters.query = newQuery;
+        updateURL();
+    }
+    function onEditVariables(newVariables) {
+        parameters.variables = newVariables;
+        updateURL();
+    }
+    function onEditOperationName(newOperationName) {
+        parameters.operationName = newOperationName;
+        updateURL();
+    }
+    function updateURL() {
+        var newSearch = '?' + Object.keys(parameters).filter(function (key) {
+                return Boolean(parameters[key]);
+            }).map(function (key) {
+                return encodeURIComponent(key) + '=' +
+                       encodeURIComponent(parameters[key]);
+            }).join('&');
+        history.replaceState(null, null, newSearch);
+    }
+    // Defines a GraphQL fetcher using the fetch API. You're not required to
+    // use fetch, and could instead implement graphQLFetcher however you like,
+    // as long as it returns a Promise or Observable.
+    function graphQLFetcher(graphQLParams) {
+        // This example expects a GraphQL server at the path /graphql.
+        // Change this to point wherever you host your GraphQL server.
+        // Changes by JJS to run on Payara
+        return fetch('graphql', {
+            method: 'post',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+                'Authorization': '5c54174535fc171980956533',
+            },
+            body: JSON.stringify(graphQLParams),
+            credentials: 'include',
+        }).then(function (response) {
+            return response.text();
+        }).then(function (responseBody) {
+            try {
+                return JSON.parse(responseBody);
+            } catch (error) {
+                return responseBody;
+            }
+        });
+    }
+    // Render <GraphiQL /> into the body.
+    // See the README in the top level of this module to learn more about
+    // how you can customize GraphiQL by providing different values or
+    // additional child elements.
+    ReactDOM.render(
+        React.createElement(GraphiQL, {
+            fetcher: graphQLFetcher,
+            query: parameters.query,
+            variables: parameters.variables,
+            operationName: parameters.operationName,
+            onEditQuery: onEditQuery,
+            onEditVariables: onEditVariables,
+            onEditOperationName: onEditOperationName
+        }),
+        document.getElementById('graphiql')
+    );
+</script>
+</body>
+</html>

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/AllWidgetData.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/AllWidgetData.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.metrics;
+
+import java.util.List;
+
+public class AllWidgetData {
+
+    private List<Widget> allWidgets;
+
+    public List<Widget> getAllWidgets() {
+        return allWidgets;
+    }
+
+    public void setGetCountWidget(List<Widget> allWidgets) {
+        this.allWidgets = allWidgets;
+    }
+
+    public void setGetTimeWidget(List<Widget> allWidgets) {
+        this.allWidgets = allWidgets;
+    }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/LoggingFilter.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/LoggingFilter.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.metrics;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
+
+public class LoggingFilter implements ClientResponseFilter, ClientRequestFilter {
+
+
+    private final static Logger LOG = Logger.getLogger(LoggingFilter.class.getName());
+
+    @Override
+    public void filter(ClientRequestContext reqCtx) throws IOException {
+        Object entity = reqCtx.getEntity();
+        LOG.log(Level.INFO, "Request entity={0}", new Object[]{entity});
+
+    }
+
+    @Override
+    public void filter(ClientRequestContext reqCtx, ClientResponseContext resCtx) throws IOException {
+        int status = resCtx.getStatus();
+        String entity;
+        byte[] buf = new byte[1024];
+        BufferedReader br = new BufferedReader(new InputStreamReader(resCtx.getEntityStream()));
+        StringBuilder entityBuilder = new StringBuilder();
+        String line = br.readLine();
+        while (line != null) {
+            entityBuilder.append(line).append(System.lineSeparator());
+            line = br.readLine();
+        }
+        entity = entityBuilder.toString();
+        ByteArrayInputStream bais = new ByteArrayInputStream(entity.getBytes());
+        resCtx.setEntityStream(bais);
+
+        LOG.log(Level.INFO, "Response status={0} entity={1}", new Object[]{status, entity});
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/MetricsTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/MetricsTestServlet.java
@@ -1,0 +1,168 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.metrics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/MetricsTestServlet")
+public class MetricsTestServlet extends FATServlet {
+    private static final Logger LOG = Logger.getLogger(MetricsTestServlet.class.getName());
+    private static final long PADDING_TIME = 5000; //milliseconds
+
+    private RestClientBuilder builder;
+    private RestClientBuilder statsBuilder;
+
+    private static String getSysProp(String key, String defaultValue) {
+        return AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty(key, defaultValue));
+    }
+
+    @Override
+    public void init() throws ServletException {
+        String contextPath = getSysProp("com.ibm.ws.microprofile.graphql.fat.contextpath", "graphql");
+        String baseUriStr = "http://localhost:" + getSysProp("bvt.prop.HTTP_default", "8010");
+        String graphQLURI = baseUriStr + "/metricsApp/" + contextPath;
+        LOG.info("graphQLURI = " + graphQLURI);
+        URI baseUri = URI.create(graphQLURI);
+        builder = RestClientBuilder.newBuilder()
+                        .property("com.ibm.ws.jaxrs.client.receive.timeout", "120000")
+                        .property("com.ibm.ws.jaxrs.client.connection.timeout", "120000")
+                        .baseUri(baseUri);
+        
+        URI metricsUri = URI.create(baseUriStr);
+        statsBuilder = RestClientBuilder.newBuilder()
+                        .property("com.ibm.ws.jaxrs.client.receive.timeout", "120000")
+                        .property("com.ibm.ws.jaxrs.client.connection.timeout", "120000")
+                        .baseUri(metricsUri);
+    }
+
+    @Test
+    public void testCount(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        QueryClient client = builder.register(LoggingFilter.class).build(QueryClient.class);
+        Query query = new Query();
+        query.setOperationName("getCountWidget");
+        query.setQuery("query getCountWidget {" + System.lineSeparator() +
+                       "  getCountWidget {" + System.lineSeparator() +
+                       "    name," + System.lineSeparator() +
+                       "    count" + System.lineSeparator() +
+                       "  }" + System.lineSeparator() +
+                       "}");
+
+        WidgetQueryResponse response = client.count(query);
+        LOG.info("Response: " + response);
+        List<Widget> widgets = response.getData().getAllWidgets();
+        assertEquals(1, widgets.size());
+        Widget widget = widgets.get(0);
+        assertEquals("Count", widget.getName());
+        assertEquals(1, widget.getCount());
+
+        response = client.count(query);
+        LOG.info("Response: " + response);
+        widgets = response.getData().getAllWidgets();
+        assertEquals(1, widgets.size());
+        widget = widgets.get(0);
+        assertEquals("Count", widget.getName());
+        assertEquals(2, widget.getCount());
+        
+        response = client.count(query);
+        LOG.info("Response: " + response);
+        widgets = response.getData().getAllWidgets();
+        assertEquals(1, widgets.size());
+        widget = widgets.get(0);
+        assertEquals("Count", widget.getName());
+        assertEquals(3, widget.getCount());
+        
+        Stats stats = statsBuilder.build(StatsClient.class).getVendorStats();
+        assertNotNull(stats);
+        assertEquals(3, stats.getCount());
+    }
+
+    @Test
+    public void testTime(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        Duration HALF_SECOND = Duration.ofMillis(500);
+        QueryClient client = builder.register(LoggingFilter.class).build(QueryClient.class);
+        Query query = new Query();
+        query.setOperationName("getTimeWidget");
+        query.setQuery("query getTimeWidget {" + System.lineSeparator() +
+                       "  getTimeWidget {" + System.lineSeparator() +
+                       "    name," + System.lineSeparator() +
+                       "    time" + System.lineSeparator() +
+                       "  }" + System.lineSeparator() +
+                       "}");
+
+        WidgetQueryResponse response = client.time(query);
+        LOG.info("Response: " + response);
+        List<Widget> widgets = response.getData().getAllWidgets();
+        assertEquals(1, widgets.size());
+        Widget widget = widgets.get(0);
+        assertEquals("Time", widget.getName());
+        Duration duration = Duration.ofNanos(widget.getTime());
+        assertTrue(duration.compareTo(HALF_SECOND) >=0 );
+
+        response = client.time(query);
+        LOG.info("Response: " + response);
+        widgets = response.getData().getAllWidgets();
+        assertEquals(1, widgets.size());
+        widget = widgets.get(0);
+        assertEquals("Time", widget.getName());
+        duration = Duration.ofNanos(widget.getTime());
+        assertTrue(duration.compareTo(HALF_SECOND.multipliedBy(2)) >=0 );
+
+        response = client.time(query);
+        LOG.info("Response: " + response);
+        widgets = response.getData().getAllWidgets();
+        assertEquals(1, widgets.size());
+        widget = widgets.get(0);
+        assertEquals("Time", widget.getName());
+        duration = Duration.ofNanos(widget.getTime());
+        assertTrue( duration.compareTo(HALF_SECOND.multipliedBy(3)) >=0 );
+        
+        //TODO: check mpMetrics shows that (1.5s + someBuffer) >= time_from_mpMetrics >= time_from_widget 
+        Stats stats = statsBuilder.build(StatsClient.class).getVendorStats();
+        assertNotNull(stats);
+        assertNotNull(stats.getTime());
+        assertEquals(3, stats.getTime().getCount());
+        Duration metricsDuration = Duration.ofNanos((long)stats.getTime().getMean());
+        Duration maxTimeDuration = Duration.ofMillis(1500 + PADDING_TIME);
+        assertTrue( maxTimeDuration.compareTo(metricsDuration) >= 0 );
+        assertTrue( metricsDuration.compareTo(duration.dividedBy(3)) >= 0 );
+    }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/MyGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/MyGraphQLEndpoint.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.metrics;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.GraphQLApi;
+
+@GraphQLApi
+public class MyGraphQLEndpoint {
+    private static Logger LOG = Logger.getLogger(MyGraphQLEndpoint.class.getName());
+
+    private final Widget countWidget = new Widget("Count", 0, 0);
+    private final Widget timeWidget = new Widget("Time", -1, 0);
+
+
+    @Query("getCountWidget")
+    public List<Widget> getCountWidget() {
+        countWidget.setCount(countWidget.getCount() + 1);
+        LOG.info("getCountWidget " + countWidget.getCount());
+        return Collections.singletonList(countWidget);
+    }
+
+    @Query("getTimeWidget")
+    public List<Widget> getTimeWidget() {
+        long startTime = System.nanoTime();
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException iex) {
+            iex.printStackTrace();
+        }
+        long elapsed = System.nanoTime() - startTime;
+        timeWidget.setTime(timeWidget.getTime() + elapsed);
+        LOG.info("getTimeWidget " + timeWidget.getTime());
+        return Collections.singletonList(timeWidget);
+    }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/Query.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/Query.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.metrics;
+
+public class Query {
+
+    private String query;
+    private String variables;
+    private String operationName;
+
+    public String getQuery() {
+        return query;
+    }
+    public void setQuery(String query) {
+        this.query = query;
+    }
+    public String getVariables() {
+        return variables;
+    }
+    public void setVariables(String variables) {
+        this.variables = variables;
+    }
+    public String getOperationName() {
+        return operationName;
+    }
+    public void setOperationName(String operationName) {
+        this.operationName = operationName;
+    }
+    
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/QueryClient.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/QueryClient.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.metrics;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public interface QueryClient {
+
+    @POST
+    WidgetQueryResponse count(Query query);
+
+    @POST
+    WidgetQueryResponse time(Query query);
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/Stats.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/Stats.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.metrics;
+
+import javax.json.bind.annotation.JsonbProperty;
+
+public class Stats {
+
+    public static class Time {
+        private int count;
+        private double mean;
+        private double max;
+        private double min;
+
+        public int getCount() {
+            return count;
+        }
+        public void setCount(int count) {
+            this.count = count;
+        }
+        public double getMean() {
+            return mean;
+        }
+        public void setMean(double mean) {
+            this.mean = mean;
+        }
+        public double getMax() {
+            return max;
+        }
+        public void setMax(double max) {
+            this.max = max;
+        }
+        public double getMin() {
+            return min;
+        }
+        public void setMin(double min) {
+            this.min = min;
+        }
+    }
+
+    @JsonbProperty("mp_graphql_mpGraphQL10.metrics.MyGraphQLEndpoint.getCountWidget.count")
+    private int count;
+    @JsonbProperty("mp_graphql_mpGraphQL10.metrics.MyGraphQLEndpoint.getTimeWidget.time")
+    private Time time;
+
+    public int getCount() {
+        return count;
+    }
+    public void setCount(int count) {
+        this.count = count;
+    }
+    public Time getTime() {
+        return time;
+    }
+    public void setTime(Time time) {
+        this.time = time;
+    }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/StatsClient.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/StatsClient.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.metrics;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
+
+@Path("/metrics")
+public interface StatsClient {
+
+    @GET
+    @Path("/vendor")
+    @Consumes(MediaType.APPLICATION_JSON)
+    Stats getVendorStats();
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/Widget.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/Widget.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.metrics;
+
+public class Widget {
+
+    private String name;
+    private int count = 0;
+    private long time = 0; // in nano-seconds
+
+    public Widget() {}
+
+    public Widget(String name, int count, long time) {
+        this.name = name;
+        this.count = count;
+        this.time = time;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+
+    public long getTime() {
+        return time;
+    }
+
+    public void setTime(long time) {
+        this.time = time;
+    }
+
+    @Override
+    public String toString() {
+        return "Widget(" + name + ", " + count + ", " + time + ")";
+    }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/WidgetQueryResponse.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/WidgetQueryResponse.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.metrics;
+
+import java.util.List;
+
+public class WidgetQueryResponse {
+
+    private AllWidgetData data;
+
+    public AllWidgetData getData() {
+        return data;
+    }
+
+    public void setData(AllWidgetData data) {
+        this.data = data;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("WidgetQueryResponse[").append(System.lineSeparator()).append("  data");
+        if (data == null || data.getAllWidgets() == null) {
+            sb.append("null");
+        } else {
+            for (Widget w : data.getAllWidgets()) {
+                sb.append(" ").append(w);
+            }
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
Resolves issue #9412 - makes use of dynamic imports for metrics packages, tweaks the metric names (adding "mp_graphql" prefix), and test cases to ensure that stats are collected accurately.

This feature has not yet shipped, so it is not a release bug.