### PR TITLE
Fix installing auto-features which depend on kernel features

### DIFF
--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/RepositoryResolver.java
@@ -55,6 +55,7 @@ public class RepositoryResolver {
     // Static data which won't change after initialization
     KernelResolverRepository resolverRepository;
     Collection<ProvisioningFeatureDefinition> installedFeatures;
+    Collection<ProvisioningFeatureDefinition> kernelFeatures;
     Map<String, SampleResource> sampleIndex;
     Collection<EsaResource> repoFeatures;
     Collection<SampleResource> repoSamples;
@@ -160,6 +161,7 @@ public class RepositoryResolver {
         this.installDefinition = installDefinition;
         fetchFromRepository(installDefinition);
         this.installedFeatures = installedFeatures;
+        this.kernelFeatures = getKernelFeatures(installedFeatures);
         indexSamples();
     }
 
@@ -174,6 +176,7 @@ public class RepositoryResolver {
         this.repoFeatures = new ArrayList<>(repoFeatures);
         this.repoSamples = new ArrayList<>(repoSamples);
         this.installedFeatures = installedFeatures;
+        this.kernelFeatures = getKernelFeatures(installedFeatures);
         this.installDefinition = Collections.emptySet();
 
         indexSamples();
@@ -215,6 +218,16 @@ public class RepositoryResolver {
         resolverRepository = new KernelResolverRepository(installDefintion, repoConnections, mode);
         resolverRepository.addInstalledFeatures(installedFeatures);
         resolverRepository.addFeatures(repoFeatures);
+    }
+
+    Collection<ProvisioningFeatureDefinition> getKernelFeatures(Collection<ProvisioningFeatureDefinition> installedFeatures) {
+        List<ProvisioningFeatureDefinition> kernelFeatures = new ArrayList<>();
+        for (ProvisioningFeatureDefinition feature : installedFeatures) {
+            if (feature.isKernel()) {
+                kernelFeatures.add(feature);
+            }
+        }
+        return kernelFeatures;
     }
 
     /**
@@ -430,7 +443,7 @@ public class RepositoryResolver {
     void resolveFeatures(ResolutionMode mode) {
         boolean allowMultipleVersions = mode == ResolutionMode.IGNORE_CONFLICTS ? true : false;
         FeatureResolver resolver = new FeatureResolverImpl();
-        Result result = resolver.resolveFeatures(resolverRepository, featureNamesToResolve, Collections.<String> emptySet(), allowMultipleVersions);
+        Result result = resolver.resolveFeatures(resolverRepository, kernelFeatures, featureNamesToResolve, Collections.<String> emptySet(), allowMultipleVersions);
 
         featureConflicts.putAll(result.getConflicts());
 

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/ResolverTestUtils.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/ResolverTestUtils.java
@@ -38,7 +38,7 @@ public class ResolverTestUtils {
      * Mocks a {@link ProvisioningFeatureDefinition}, explicitly setting the value for featureName
      */
     public static ProvisioningFeatureDefinition mockSimpleFeatureDefinition(Mockery mockery, final String provideFeature, final Version version, final String shortName,
-                                                                            final String featureName) {
+                                                                            final String featureName, final Visibility visibility, final boolean isKernel) {
         final ProvisioningFeatureDefinition featureDefinition = mockery.mock(ProvisioningFeatureDefinition.class, provideFeature);
         mockery.checking(new Expectations() {
             {
@@ -50,7 +50,7 @@ public class ResolverTestUtils {
                 will(returnValue(version));
                 allowing(featureDefinition).getHeader(with(any(String.class)));
                 allowing(featureDefinition).getVisibility();
-                will(returnValue(Visibility.PUBLIC));
+                will(returnValue(visibility));
                 allowing(featureDefinition).isAutoFeature();
                 will(returnValue(false));
                 allowing(featureDefinition).getProcessTypes();
@@ -61,6 +61,8 @@ public class ResolverTestUtils {
                 will(returnValue(featureName));
                 allowing(featureDefinition).isSingleton();
                 will(returnValue(true));
+                allowing(featureDefinition).isKernel();
+                will(returnValue(isKernel));
             }
         });
         return featureDefinition;
@@ -71,14 +73,14 @@ public class ResolverTestUtils {
      */
     public static ProvisioningFeatureDefinition mockSimpleFeatureDefinition(Mockery mockery, final String provideFeature, final Version version, final String shortName) {
         final String featureName = shortName == null ? provideFeature : shortName;
-        return mockSimpleFeatureDefinition(mockery, provideFeature, version, shortName, featureName);
+        return mockSimpleFeatureDefinition(mockery, provideFeature, version, shortName, featureName, Visibility.PUBLIC, false);
     }
 
     /**
-     * @param id required
-     * @param edition required
-     * @param version required
-     * @param license optional
+     * @param id          required
+     * @param edition     required
+     * @param version     required
+     * @param license     optional
      * @param installType optional
      * @return
      * @throws IOException

--- a/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepositoryTest.java
+++ b/dev/com.ibm.ws.repository.resolver/test/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverRepositoryTest.java
@@ -305,7 +305,7 @@ public class KernelResolverRepositoryTest {
     public void testGetFeatureByFeatureName() {
         Mockery mockery = new Mockery();
         ProvisioningFeatureDefinition installedFeature = ResolverTestUtils.mockSimpleFeatureDefinition(mockery, "com.example.featureA", Version.valueOf("1.0.0"), "featureA",
-                                                                                                       "foo:featureA");
+                                                                                                       "foo:featureA", com.ibm.ws.kernel.feature.Visibility.PUBLIC, false);
 
         KernelResolverRepository repo = new KernelResolverRepository(null, null, IGNORE_CONFLICTS);
         repo.addFeature(installedFeature);


### PR DESCRIPTION
Fixes #9441 

Kernel features are part of the platform and are always installed and started

Auto-features should be installed and started automatically when all of their dependencies are met

Previously, we weren't considering the kernel features when working out whether the dependencies of auto-features were met.

This was causing some z/OS specific Websphere Liberty auto-features not to be installed when their requirements were met.