### PR TITLE
Issue 9458: Add a silent delete on InMemoryLdapServer for FAT tests

### DIFF
--- a/dev/com.ibm.ws.com.unboundid/src/com/ibm/ws/com/unboundid/InMemoryLDAPServer.java
+++ b/dev/com.ibm.ws.com.unboundid/src/com/ibm/ws/com/unboundid/InMemoryLDAPServer.java
@@ -52,8 +52,7 @@ public class InMemoryLDAPServer {
      * service.
      *
      * @param bases The base entries to create for this in-memory LDAP server.
-     * @throws Exception
-     *             If something went wrong
+     * @throws Exception If something went wrong
      */
     public InMemoryLDAPServer(String... bases) throws Exception {
 
@@ -174,5 +173,19 @@ public class InMemoryLDAPServer {
      */
     public void delete(DeleteRequest dr) throws LDAPException {
         ds.delete(dr);
+    }
+
+    /**
+     * Delete an entry from the LDAP server. Eat any exceptions.
+     * Use on test clean up if the user may have already been deleted.
+     *
+     * @param dn
+     */
+    public void silentDelete(String dn) {
+        try {
+            ds.delete(dn);
+        } catch (Exception e) {
+            // if the user or group doesn't exist, that's fine.
+        }
     }
 }


### PR DESCRIPTION
Fixes #9458 

Adding a silent delete to the InMemoryLdapServer for FAT tests. No fat tests changed in this PR as the target FAT test is in Commercial Liberty space. This is a test only change.