### PR TITLE
Issue #9436: Fix LdapHelper.replaceRDC(...) so that it only considers…

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapHelper.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapHelper.java
@@ -291,32 +291,57 @@ public class LdapHelper {
         return RDN;
     }
 
-    public static String replaceRDN(String DN, String[] RDNAttrTypes, String[] RDNAttrValues) {
-        String parentDN = getParentDN(DN);
-        if (RDNAttrTypes == null || RDNAttrValues == null || RDNAttrTypes.length != RDNAttrValues.length
-            || RDNAttrTypes.length == 0) {
-            return DN;
+    public static String replaceRDN(String dn, String[] rdnAttrTypes, String[] rdnAttrValues) {
+        if (rdnAttrTypes == null || rdnAttrValues == null || rdnAttrTypes.length != rdnAttrValues.length
+            || rdnAttrTypes.length == 0) {
+            return dn;
         }
-        StringBuffer RDN = new StringBuffer();
-        String[] oldRDNValues = getRDNValues(DN);
-        for (int i = 0; i < RDNAttrTypes.length; i++) {
+
+        /*
+         * Strip the parent DN from the end of the DN. We want just the leading RDN.
+         */
+        String parentDN = getParentDN(dn);
+        if (!parentDN.isEmpty()) {
+            dn = dn.replace("," + parentDN, "");
+        }
+
+        /*
+         * Retrieve the values for the leading RDN.
+         */
+        String[] oldRDNValues = getRDNValues(dn);
+
+        /*
+         * Iterate over all the RDN attribute types.
+         */
+        StringBuffer rdn = new StringBuffer();
+        for (int i = 0; i < rdnAttrTypes.length; i++) {
+            /*
+             * Multi-attribute RDNs require a '+' between each attribute type and value.
+             */
             if (i != 0) {
-                RDN.append("+");
+                rdn.append("+");
             }
-            String newRDNValue = RDNAttrValues[i];
+
+            /*
+             * If there is a new value, replace the value of the RDN.
+             */
+            String newRDNValue = rdnAttrValues[i];
             if (newRDNValue == null) {
                 newRDNValue = oldRDNValues[i];
             }
-            RDN.append(RDNAttrTypes[i] + "=" + Rdn.escapeValue(newRDNValue));
+            rdn.append(rdnAttrTypes[i] + "=" + Rdn.escapeValue(newRDNValue));
         }
 
-        if (parentDN.length() == 0) {
-            DN = RDN.toString();
+        /*
+         * Append the parent DN back onto the end of the DN.
+         */
+        if (parentDN.isEmpty()) {
+            dn = rdn.toString();
         } else {
-            DN = RDN.append("," + parentDN).toString();
+            dn = rdn.append("," + parentDN).toString();
         }
 
-        return DN;
+        return dn;
     }
 
     public static String getParentDN(String DN) {

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/test/com/ibm/ws/security/wim/adapter/ldap/LdapHelperTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/test/com/ibm/ws/security/wim/adapter/ldap/LdapHelperTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.wim.adapter.ldap;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class LdapHelperTest {
+    @Test
+    public void replaceRDN() {
+
+        /*
+         * Test argument values that immediately return the input DN.
+         */
+        assertEquals("Null RDN attributes types should immediately return input DN.", "uid=user,ou=users,o=ibm.com",
+                     LdapHelper.replaceRDN("uid=user,ou=users,o=ibm.com", null, new String[] { "newuser" }));
+        assertEquals("Null RDN attributes values should immediately return input DN.", "uid=user,ou=users,o=ibm.com",
+                     LdapHelper.replaceRDN("uid=user,ou=users,o=ibm.com", new String[] { "uid" }, null));
+        assertEquals("Empty RDN attributes types should immediately return input DN.", "uid=user,ou=users,o=ibm.com",
+                     LdapHelper.replaceRDN("uid=user,ou=users,o=ibm.com", new String[] {}, new String[] { "newuser" }));
+        assertEquals("Empty RDN attributes values should immediately return input DN.", "uid=user,ou=users,o=ibm.com",
+                     LdapHelper.replaceRDN("uid=user,ou=users,o=ibm.com", new String[] { "uid" }, new String[] {}));
+
+        /*
+         * Replace a value in the RDN.
+         */
+        assertEquals("RDN value should be replaced.", "uid=newuser,ou=users,o=ibm.com",
+                     LdapHelper.replaceRDN("uid=user,ou=users,o=ibm.com", new String[] { "uid" }, new String[] { "newuser" }));
+
+        /*
+         * Replace a single attribute RDN with a multi-attribute RDN.
+         */
+        assertEquals("RDN value should be replaced.", "uid=uid1+cn=cn1,ou=users,o=ibm.com",
+                     LdapHelper.replaceRDN("uid=user,ou=users,o=ibm.com", new String[] { "uid", "cn" }, new String[] { "uid1", "cn1" }));
+
+        /*
+         * Replace a multi-attribute RDN with new values.
+         */
+        assertEquals("RDN value should be replaced.", "uid=uid2+cn=cn2,ou=users,o=ibm.com",
+                     LdapHelper.replaceRDN("uid=uid1+cn=cn1,ou=users,o=ibm.com", new String[] { "uid", "cn" }, new String[] { "uid2", "cn2" }));
+
+        /*
+         * Replace a value in the RDN.
+         */
+        assertEquals("No values to replace should result in no change.", "uid=newuser,ou=users,o=ibm.com",
+                     LdapHelper.replaceRDN("uid=user,ou=users,o=ibm.com", new String[] { "uid" }, new String[] { "newuser" }));
+
+        /*
+         * Test to ensure there is no regression in a fix to an issue where the full DN was considered the RDN value when
+         * RDN values were passed in as null. The
+         * errant return value looked something like this: uid=user\,ou\=users\,o\=ibm.com,ou=users,o=ibm.com
+         */
+        assertEquals("Expected no change when there are null values.", "uid=user,ou=users,o=ibm.com",
+                     LdapHelper.replaceRDN("uid=user,ou=users,o=ibm.com", new String[] { "uid" }, new String[] { null }));
+    }
+}


### PR DESCRIPTION
… the leading RDN when replacing values.

fixes #9436