### PR TITLE
Performance improvements to cxf code

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/utils/HttpUtils.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/utils/HttpUtils.java
@@ -21,7 +21,6 @@ package org.apache.cxf.jaxrs.utils;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -63,7 +62,6 @@ import org.apache.cxf.jaxrs.impl.PathSegmentImpl;
 import org.apache.cxf.jaxrs.impl.RuntimeDelegateImpl;
 import org.apache.cxf.jaxrs.model.ParameterType;
 import org.apache.cxf.message.Message;
-import org.apache.cxf.service.model.EndpointInfo;
 import org.apache.cxf.transport.Destination;
 import org.apache.cxf.transport.http.AbstractHTTPDestination;
 import org.apache.cxf.transport.http.Headers;
@@ -467,30 +465,110 @@ public final class HttpUtils {
 
     public static String getBaseAddress(Message m) {
         String endpointAddress = getEndpointAddress(m);
-        try {
-            URI uri = new URI(endpointAddress);
-            String path = uri.getRawPath();
-            String scheme = uri.getScheme();
+        //Liberty code change start
+        String[] addr = parseURI(endpointAddress, false);
+        if (addr != null) {
+            String scheme = addr[0];
+            String path = addr[1];
             if (scheme != null && !scheme.startsWith(HttpUtils.HTTP_SCHEME)
-                && HttpUtils.isHttpRequest(m)) {
+                    && HttpUtils.isHttpRequest(m)) {
                 path = HttpUtils.toAbsoluteUri(path, m).getRawPath();
             }
             return (path == null || path.length() == 0) ? "/" : path;
-        } catch (URISyntaxException ex) {
+        } else {
             return endpointAddress == null ? "/" : endpointAddress;
         }
     }
+
+    public static String[] parseURI(String addr, boolean parseAuthority) {
+        String scheme = null;
+        String parsedAuthorityOrRawPath = null;
+        int n = addr.length();
+        int p = scan(addr, 0, n, "/?#", ":");
+        try {
+            if ((p >= 0) && at(addr, p, n, ':')) {
+                if (p == 0) {
+                    return null;
+                }    
+                scheme = addr.substring(0, p);
+                p++;
+                if (at(addr, p, n, '/')) {
+                    parsedAuthorityOrRawPath = postSchemeParse(addr, p, n, parseAuthority);
+                } else {
+                    int q = scan(addr, p, n, null, "#");
+                    if (q <= p) {
+                        return null;
+                    }    
+                }
+            } else {
+                parsedAuthorityOrRawPath = postSchemeParse(addr, 0, n, parseAuthority);
+            }
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+        return new String[] { scheme, parsedAuthorityOrRawPath };
+    }
+
+    private static String postSchemeParse(String addr, int start, int n, boolean parseAuthority) {
+        int p = start;
+        int q = -1;
+        if (at(addr, p, n, '/') && at(addr, p + 1, n, '/')) {
+            p += 2;
+            q = scan(addr, p, n, null, "/");
+            if (q > p) {
+                if (!parseAuthority) {
+                    p = q;
+                }
+            } else if (q >= n) {
+                if (parseAuthority || p == n) {
+                    throw new IllegalArgumentException();
+                } else {
+                    return null;
+                }
+            }    
+        }
+        
+        if (!parseAuthority) {
+            q = scan(addr, p, n, null, "?#");
+        } else if (p >= q) {
+            // empty authority should be null
+            return null;
+        }
+        
+        return addr.substring(p, q);
+    }
+    
+    private static boolean at(String addr, int start, int end, char c) {
+        return (start < end) && (addr.charAt(start) == c);
+    }
+    
+    private static int scan(String addr, int start, int end, String err, String stop) {
+        int p = start;
+        while (p < end) {
+            char c = addr.charAt(p);
+            if (err != null && err.indexOf(c) >= 0) {
+                return -1;
+            }
+            if (stop.indexOf(c) >= 0) {
+                break;
+            }    
+            p++;
+        }
+        return p;
+    }
+    //Liberty code change end
 
     public static String getEndpointAddress(Message m) {
         String address = null;
         Destination d = m.getExchange().getDestination();
         if (d != null) {
             if (d instanceof AbstractHTTPDestination) {
-                EndpointInfo ei = ((AbstractHTTPDestination) d).getEndpointInfo();
                 HttpServletRequest request = (HttpServletRequest) m.get(AbstractHTTPDestination.HTTP_REQUEST);
                 Object property = request != null
                     ? request.getAttribute("org.apache.cxf.transport.endpoint.address") : null;
-                address = property != null ? property.toString() : ei.getAddress();
+                //Liberty code change start
+                address = property != null ? property.toString() : ((AbstractHTTPDestination) d).getEndpointInfo().getAddress();
+                //Liberty code change end
             } else {
                 address = m.containsKey(Message.BASE_PATH)
                     ? (String)m.get(Message.BASE_PATH) : d.getAddress().getAddress().getValue();

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/utils/HttpUtils.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/utils/HttpUtils.java
@@ -467,17 +467,16 @@ public final class HttpUtils {
         String endpointAddress = getEndpointAddress(m);
         //Liberty code change start
         String[] addr = parseURI(endpointAddress, false);
-        if (addr != null) {
-            String scheme = addr[0];
-            String path = addr[1];
-            if (scheme != null && !scheme.startsWith(HttpUtils.HTTP_SCHEME)
-                    && HttpUtils.isHttpRequest(m)) {
-                path = HttpUtils.toAbsoluteUri(path, m).getRawPath();
-            }
-            return (path == null || path.length() == 0) ? "/" : path;
-        } else {
-            return endpointAddress == null ? "/" : endpointAddress;
+        if (addr == null) {
+            return endpointAddress;
         }
+        String scheme = addr[0];
+        String path = addr[1];
+        if (scheme != null && !scheme.startsWith(HttpUtils.HTTP_SCHEME)
+                && HttpUtils.isHttpRequest(m)) {
+            path = HttpUtils.toAbsoluteUri(path, m).getRawPath();
+        }
+        return (path == null || path.length() == 0) ? "/" : path;
     }
 
     public static String[] parseURI(String addr, boolean parseAuthority) {

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
@@ -635,10 +635,14 @@ public abstract class AbstractHTTPDestination
         }
 
         cacheInput(outMessage);
+        //Liberty code change start
+        Headers headers = null;
         HTTPServerPolicy sp = calcServerPolicy(outMessage);
         if (sp != null) {
-            new Headers(outMessage).setFromServerPolicy(sp);
+            headers = new Headers(outMessage);
+            headers.setFromServerPolicy(sp);
         }
+        //Liberty code change end
 
         OutputStream responseStream = null;
         boolean oneWay = isOneWay(outMessage);
@@ -654,7 +658,12 @@ public abstract class AbstractHTTPDestination
             }
         }
         response.setStatus(responseCode);
-        new Headers(outMessage).copyToResponse(response);
+        //Liberty code change start
+        if (headers == null) {
+            headers = new Headers(outMessage);
+        }
+        headers.copyToResponse(response);
+        //Liberty code change end
 
         outMessage.put(RESPONSE_HEADERS_COPIED, "true");
 

--- a/dev/com.ibm.ws.jaxrs.2.0.common/test/com/ibm/ws/jaxrs/utils/test/URIParseTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/test/com/ibm/ws/jaxrs/utils/test/URIParseTest.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.utils.test;
+
+import java.net.URI;
+
+import org.apache.cxf.jaxrs.utils.HttpUtils;
+import org.junit.Test;
+
+import junit.framework.Assert;
+
+/**
+ *
+ */
+public class URIParseTest {
+
+
+    @Test
+    public void testURIs() throws Exception {
+        //queryString
+        String u = "http://myhost:9080/abc/xyz?abc=123";
+        parse(u);
+        //domain
+        u = "https://www.google.com/";
+        parse(u);        
+        //domain
+        u = "https://www.google.com";
+        parse(u);        
+        //empty host
+        u = "ftp:///abc/xyz#wut";
+        parse(u);
+        //empty scheme
+        u = "//myhost/xyz#wut";
+        parse(u);
+        u = "ftp://ftp.is.co.za/rfc/rfc1808.txt";
+        parse(u);
+        u = "gopher://spinaltap.micro.umn.edu/00/Wea%20ther/California/Los%20Angeles";
+        parse(u);
+        u = "http://www.math.uio.no/faq/compression-faq/part1.html";
+        parse(u);
+        u = "mailto:mduerst@ifi.unizh.ch";
+        parse(u);
+        u = "news:comp.infosystems.www.servers.unix/";
+        parse(u);
+        u = "telnet://melvyl.ucop.edu/";
+        parse(u);
+        u = "http://00:10:23:45:9080/abc&zyx";
+        parse(u);
+        u = "http://user@[00:10:23:45:67:78:89:90]/?abc&zyx";
+        parse(u);
+        u = "http://user@2001:db8:1234::/48/?abc&zyx";
+        parse(u);
+    }
+    
+    @Test
+    public void testInvalidURIs() throws Exception {
+        //queryString
+        String u = "http://myhost:908a0/abc/xyz?abc=123";
+        parse(u);
+        //domain
+        u = "https://www.google.com:abc/";
+        parse(u);        
+        //domain
+        u = "https://www.google.com:80";
+        parse(u);        
+        //empty host
+        u = "ftp:///abc*/xyz#wut";
+        parse(u);
+        //empty scheme
+        u = "abc//myhost/xyz#wut";
+        parse(u);
+        u = "ftpv://ftp.is.co.za/rfc/rfc1808.txt";
+        parse(u);
+        u = "gopher/://spinaltap.micro.umn.edu/00/Wea%20ther/California/Los%20Angeles";
+        parse(u);
+        u = "http#://www.math.uio.no/faq/compression-faq/part1.html";
+        parse(u);
+        u = "mailto:mduerst@ifi.unizh.ch";
+        parse(u);
+        u = "news:comp.infosystems.www.servers.unix/";
+        parse(u);
+        u = "telnet?://melvyl.ucop.edu/";
+        parse(u);
+        u = ":http://00:10:23:45:9080/abc&zyx";
+        try {
+            parse(u);
+        } catch (IllegalArgumentException e) {
+            // caught proper exception, now need to make sure we get null from parseURI call
+            Assert.assertNull(HttpUtils.parseURI(u, true));
+            Assert.assertNull(HttpUtils.parseURI(u, false));
+        }
+        u = "http://";
+        try {
+            parse(u);
+        } catch (IllegalArgumentException e) {
+            // caught proper exception, now need to make sure we get null from parseURI call
+            Assert.assertNull(HttpUtils.parseURI(u, true));
+            Assert.assertNull(HttpUtils.parseURI(u, false));
+        }
+        u = "http://user@2001:db8:1234::/48/?abc&zyx";
+        parse(u);
+    }
+
+    private void parse(String u) {
+        URI uri = URI.create(u);
+        String[] p = HttpUtils.parseURI(u, true);
+        Assert.assertEquals(uri.getScheme(), p[0]);
+        Assert.assertEquals(uri.getRawAuthority(), p[1]);
+        p = HttpUtils.parseURI(u, false);
+        Assert.assertEquals(uri.getScheme(), p[0]);
+        Assert.assertEquals(uri.getRawPath(), p[1]);
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.0.common/test/com/ibm/ws/jaxrs/utils/test/URIParseTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/test/com/ibm/ws/jaxrs/utils/test/URIParseTest.java
@@ -92,6 +92,7 @@ public class URIParseTest {
         u = ":http://00:10:23:45:9080/abc&zyx";
         try {
             parse(u);
+            Assert.fail();
         } catch (IllegalArgumentException e) {
             // caught proper exception, now need to make sure we get null from parseURI call
             Assert.assertNull(HttpUtils.parseURI(u, true));
@@ -100,6 +101,7 @@ public class URIParseTest {
         u = "http://";
         try {
             parse(u);
+            Assert.fail();
         } catch (IllegalArgumentException e) {
             // caught proper exception, now need to make sure we get null from parseURI call
             Assert.assertNull(HttpUtils.parseURI(u, true));
@@ -107,6 +109,17 @@ public class URIParseTest {
         }
         u = "http://user@2001:db8:1234::/48/?abc&zyx";
         parse(u);
+        u = null;
+        try {
+            parse(u);
+            Assert.fail();
+        } catch (NullPointerException e) {
+            try {
+                HttpUtils.parseURI(u, true);
+                Assert.fail();
+            } catch (NullPointerException ex) {
+            }
+        }
     }
 
     private void parse(String u) {

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/.classpath
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+    <classpathentry kind="src" path="test" output="bin_test"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/bnd.bnd
@@ -42,3 +42,7 @@ javac.target: 1.8
   com.ibm.wsspi.org.osgi.service.component,\
   com.ibm.wsspi.org.osgi.service.component.annotations,\
   javax.activation:activation;version=1.1
+
+-testpath: \
+	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
+  

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/HttpUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/HttpUtils.java
@@ -21,7 +21,6 @@ package org.apache.cxf.jaxrs.utils;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -63,7 +62,6 @@ import org.apache.cxf.jaxrs.impl.PathSegmentImpl;
 import org.apache.cxf.jaxrs.impl.RuntimeDelegateImpl;
 import org.apache.cxf.jaxrs.model.ParameterType;
 import org.apache.cxf.message.Message;
-import org.apache.cxf.service.model.EndpointInfo;
 import org.apache.cxf.transport.Destination;
 import org.apache.cxf.transport.http.AbstractHTTPDestination;
 import org.apache.cxf.transport.http.Headers;
@@ -465,29 +463,110 @@ public final class HttpUtils {
 
     public static String getBaseAddress(Message m) {
         String endpointAddress = getEndpointAddress(m);
-        try {
-            URI uri = new URI(endpointAddress);
-            String path = uri.getRawPath();
-            String scheme = uri.getScheme();
+
+        //Liberty code change start
+        String[] addr = parseURI(endpointAddress, false);
+        if (addr != null) {
+            String scheme = addr[0];
+            String path = addr[1];
             if (scheme != null && !scheme.startsWith(HttpUtils.HTTP_SCHEME)
-                && HttpUtils.isHttpRequest(m)) {
+                    && HttpUtils.isHttpRequest(m)) {
                 path = HttpUtils.toAbsoluteUri(path, m).getRawPath();
             }
             return (path == null || path.length() == 0) ? "/" : path;
-        } catch (URISyntaxException ex) {
+        } else {
             return endpointAddress == null ? "/" : endpointAddress;
         }
     }
+
+    public static String[] parseURI(String addr, boolean parseAuthority) {
+        String scheme = null;
+        String parsedAuthorityOrRawPath = null;
+        int n = addr.length();
+        int p = scan(addr, 0, n, "/?#", ":");
+        try {
+            if ((p >= 0) && at(addr, p, n, ':')) {
+                if (p == 0) {
+                    return null;
+                }    
+                scheme = addr.substring(0, p);
+                p++;
+                if (at(addr, p, n, '/')) {
+                    parsedAuthorityOrRawPath = postSchemeParse(addr, p, n, parseAuthority);
+                } else {
+                    int q = scan(addr, p, n, null, "#");
+                    if (q <= p) {
+                        return null;
+                    }    
+                }
+            } else {
+                parsedAuthorityOrRawPath = postSchemeParse(addr, 0, n, parseAuthority);
+            }
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+        return new String[] { scheme, parsedAuthorityOrRawPath };
+    }
+
+    private static String postSchemeParse(String addr, int start, int n, boolean parseAuthority) {
+        int p = start;
+        int q = -1;
+        if (at(addr, p, n, '/') && at(addr, p + 1, n, '/')) {
+            p += 2;
+            q = scan(addr, p, n, null, "/");
+            if (q > p) {
+                if (!parseAuthority) {
+                    p = q;
+                }
+            } else if (q >= n) {
+                if (parseAuthority || p == n) {
+                    throw new IllegalArgumentException();
+                } else {
+                    return null;
+                }
+            }    
+        }
+        
+        if (!parseAuthority) {
+            q = scan(addr, p, n, null, "?#");
+        } else if (p >= q) {
+            // empty authority should be null
+            return null;
+        }
+        
+        return addr.substring(p, q);
+    }
+    
+    private static boolean at(String addr, int start, int end, char c) {
+        return (start < end) && (addr.charAt(start) == c);
+    }
+    
+    private static int scan(String addr, int start, int end, String err, String stop) {
+        int p = start;
+        while (p < end) {
+            char c = addr.charAt(p);
+            if (err != null && err.indexOf(c) >= 0) {
+                return -1;
+            }
+            if (stop.indexOf(c) >= 0) {
+                break;
+            }    
+            p++;
+        }
+        return p;
+    }
+    //Liberty code change end
 
     public static String getEndpointAddress(Message m) {
         String address = null;
         Destination d = m.getExchange().getDestination();
         if (d != null) {
             if (d instanceof AbstractHTTPDestination) {
-                EndpointInfo ei = ((AbstractHTTPDestination) d).getEndpointInfo();
                 HttpServletRequest request = (HttpServletRequest) m.get(AbstractHTTPDestination.HTTP_REQUEST);
                 Object property = request != null ? request.getAttribute("org.apache.cxf.transport.endpoint.address") : null;
-                address = property != null ? property.toString() : ei.getAddress();
+                //Liberty code change start
+                address = property != null ? property.toString() : ((AbstractHTTPDestination) d).getEndpointInfo().getAddress();
+                //Liberty code change end
             } else {
                 address = m.containsKey(Message.BASE_PATH) ? (String) m.get(Message.BASE_PATH) : d.getAddress().getAddress().getValue();
             }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/HttpUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/HttpUtils.java
@@ -466,17 +466,16 @@ public final class HttpUtils {
 
         //Liberty code change start
         String[] addr = parseURI(endpointAddress, false);
-        if (addr != null) {
-            String scheme = addr[0];
-            String path = addr[1];
-            if (scheme != null && !scheme.startsWith(HttpUtils.HTTP_SCHEME)
-                    && HttpUtils.isHttpRequest(m)) {
-                path = HttpUtils.toAbsoluteUri(path, m).getRawPath();
-            }
-            return (path == null || path.length() == 0) ? "/" : path;
-        } else {
-            return endpointAddress == null ? "/" : endpointAddress;
+        if (addr == null) {
+            return endpointAddress;
         }
+        String scheme = addr[0];
+        String path = addr[1];
+        if (scheme != null && !scheme.startsWith(HttpUtils.HTTP_SCHEME)
+                && HttpUtils.isHttpRequest(m)) {
+            path = HttpUtils.toAbsoluteUri(path, m).getRawPath();
+        }
+        return (path == null || path.length() == 0) ? "/" : path;
     }
 
     public static String[] parseURI(String addr, boolean parseAuthority) {

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/test/com/ibm/ws/jaxrs/utils/test/URIParseTest.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/test/com/ibm/ws/jaxrs/utils/test/URIParseTest.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.utils.test;
+
+import java.net.URI;
+
+import org.apache.cxf.jaxrs.utils.HttpUtils;
+import org.junit.Test;
+
+import junit.framework.Assert;
+
+/**
+ *
+ */
+public class URIParseTest {
+
+
+    @Test
+    public void testURIs() throws Exception {
+        //queryString
+        String u = "http://myhost:9080/abc/xyz?abc=123";
+        parse(u);
+        //domain
+        u = "https://www.google.com/";
+        parse(u);        
+        //domain
+        u = "https://www.google.com";
+        parse(u);        
+        //empty host
+        u = "ftp:///abc/xyz#wut";
+        parse(u);
+        //empty scheme
+        u = "//myhost/xyz#wut";
+        parse(u);
+        u = "ftp://ftp.is.co.za/rfc/rfc1808.txt";
+        parse(u);
+        u = "gopher://spinaltap.micro.umn.edu/00/Wea%20ther/California/Los%20Angeles";
+        parse(u);
+        u = "http://www.math.uio.no/faq/compression-faq/part1.html";
+        parse(u);
+        u = "mailto:mduerst@ifi.unizh.ch";
+        parse(u);
+        u = "news:comp.infosystems.www.servers.unix/";
+        parse(u);
+        u = "telnet://melvyl.ucop.edu/";
+        parse(u);
+        u = "http://00:10:23:45:9080/abc&zyx";
+        parse(u);
+        u = "http://user@[00:10:23:45:67:78:89:90]/?abc&zyx";
+        parse(u);
+        u = "http://user@2001:db8:1234::/48/?abc&zyx";
+        parse(u);
+    }
+    
+    @Test
+    public void testInvalidURIs() throws Exception {
+        //queryString
+        String u = "http://myhost:908a0/abc/xyz?abc=123";
+        parse(u);
+        //domain
+        u = "https://www.google.com:abc/";
+        parse(u);        
+        //domain
+        u = "https://www.google.com:80";
+        parse(u);        
+        //empty host
+        u = "ftp:///abc*/xyz#wut";
+        parse(u);
+        //empty scheme
+        u = "abc//myhost/xyz#wut";
+        parse(u);
+        u = "ftpv://ftp.is.co.za/rfc/rfc1808.txt";
+        parse(u);
+        u = "gopher/://spinaltap.micro.umn.edu/00/Wea%20ther/California/Los%20Angeles";
+        parse(u);
+        u = "http#://www.math.uio.no/faq/compression-faq/part1.html";
+        parse(u);
+        u = "mailto:mduerst@ifi.unizh.ch";
+        parse(u);
+        u = "news:comp.infosystems.www.servers.unix/";
+        parse(u);
+        u = "telnet?://melvyl.ucop.edu/";
+        parse(u);
+        u = ":http://00:10:23:45:9080/abc&zyx";
+        try {
+            parse(u);
+        } catch (IllegalArgumentException e) {
+            // caught proper exception, now need to make sure we get null from parseURI call
+            Assert.assertNull(HttpUtils.parseURI(u, true));
+            Assert.assertNull(HttpUtils.parseURI(u, false));
+        }
+        u = "http://";
+        try {
+            parse(u);
+        } catch (IllegalArgumentException e) {
+            // caught proper exception, now need to make sure we get null from parseURI call
+            Assert.assertNull(HttpUtils.parseURI(u, true));
+            Assert.assertNull(HttpUtils.parseURI(u, false));
+        }
+        u = "http://user@2001:db8:1234::/48/?abc&zyx";
+        parse(u);
+    }
+
+    private void parse(String u) {
+        URI uri = URI.create(u);
+        String[] p = HttpUtils.parseURI(u, true);
+        Assert.assertEquals(uri.getScheme(), p[0]);
+        Assert.assertEquals(uri.getRawAuthority(), p[1]);
+        p = HttpUtils.parseURI(u, false);
+        Assert.assertEquals(uri.getScheme(), p[0]);
+        Assert.assertEquals(uri.getRawPath(), p[1]);
+    }
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/test/com/ibm/ws/jaxrs/utils/test/URIParseTest.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/test/com/ibm/ws/jaxrs/utils/test/URIParseTest.java
@@ -92,6 +92,7 @@ public class URIParseTest {
         u = ":http://00:10:23:45:9080/abc&zyx";
         try {
             parse(u);
+            Assert.fail();
         } catch (IllegalArgumentException e) {
             // caught proper exception, now need to make sure we get null from parseURI call
             Assert.assertNull(HttpUtils.parseURI(u, true));
@@ -100,6 +101,7 @@ public class URIParseTest {
         u = "http://";
         try {
             parse(u);
+            Assert.fail();
         } catch (IllegalArgumentException e) {
             // caught proper exception, now need to make sure we get null from parseURI call
             Assert.assertNull(HttpUtils.parseURI(u, true));
@@ -107,6 +109,17 @@ public class URIParseTest {
         }
         u = "http://user@2001:db8:1234::/48/?abc&zyx";
         parse(u);
+        u = null;
+        try {
+            parse(u);
+            Assert.fail();
+        } catch (NullPointerException e) {
+            try {
+                HttpUtils.parseURI(u, true);
+                Assert.fail();
+            } catch (NullPointerException ex) {
+            }
+        }
     }
 
     private void parse(String u) {

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.2.6.2/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.2.6.2/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
@@ -525,9 +525,13 @@ public abstract class AbstractHTTPDestination
         }
 
         cacheInput(outMessage);
+        //Liberty code change start
+        Headers headers = null;
         if (server != null) {
-            new Headers(outMessage).setFromServerPolicy(server);
+            headers = new Headers(outMessage);
+            headers.setFromServerPolicy(server);
         }
+        //Liberty code change end
 
         OutputStream responseStream = null;
         boolean oneWay = isOneWay(outMessage);
@@ -536,10 +540,15 @@ public abstract class AbstractHTTPDestination
 
         int responseCode = getReponseCodeFromMessage(outMessage);
         response.setStatus(responseCode);
-        if (HttpURLConnection.HTTP_INTERNAL_ERROR == responseCode) {
-            new Headers(outMessage).removeContentType();
+        //Liberty code change start
+        if (headers == null) {
+            headers = new Headers(outMessage);
         }
-        new Headers(outMessage).copyToResponse(response);
+        if (HttpURLConnection.HTTP_INTERNAL_ERROR == responseCode) {
+            headers.removeContentType();
+        }
+        headers.copyToResponse(response);
+        //Liberty code change end
 
         outMessage.put(RESPONSE_HEADERS_COPIED, "true");
         

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
@@ -29,7 +29,6 @@ import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 
@@ -638,10 +637,14 @@ public abstract class AbstractHTTPDestination
         }
 
         cacheInput(outMessage);
+        //Liberty code change start
+        Headers headers = null;
         HTTPServerPolicy sp = calcServerPolicy(outMessage);
         if (sp != null) {
-            new Headers(outMessage).setFromServerPolicy(sp);
+            headers = new Headers(outMessage);
+            headers.setFromServerPolicy(sp);
         }
+        //Liberty code change end
 
         OutputStream responseStream = null;
         boolean oneWay = isOneWay(outMessage);
@@ -657,7 +660,12 @@ public abstract class AbstractHTTPDestination
             }
         }
         response.setStatus(responseCode);
-        new Headers(outMessage).copyToResponse(response);
+        //Liberty code change start
+        if (headers == null) {
+            headers = new Headers(outMessage);
+        }
+        headers.copyToResponse(response);
+        //Liberty code change end
 
         outMessage.put(RESPONSE_HEADERS_COPIED, "true");
 

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/Headers.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/Headers.java
@@ -21,16 +21,19 @@ package org.apache.cxf.transport.http;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URLConnection;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TimeZone;
 import java.util.TreeMap;
-
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -38,6 +41,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.cxf.common.logging.LogUtils;
+import org.apache.cxf.common.util.PropertyUtils;
 import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.helpers.HttpHeaderHelper;
 import org.apache.cxf.message.Message;
@@ -52,11 +56,25 @@ public class Headers {
      *  is used to get the response.
      */
     public static final String KEY_HTTP_CONNECTION = "http.connection";
+    /**
+     * Each header value is added as a separate HTTP header, example, given A header with 'a' and 'b'
+     * values, two A headers will be added as opposed to a single A header with the "a,b" value.
+     */
+    public static final String ADD_HEADERS_PROPERTY = "org.apache.cxf.http.add-headers";
+
     public static final String PROTOCOL_HEADERS_CONTENT_TYPE = Message.CONTENT_TYPE.toLowerCase();
-    private static final String HTTP_HEADERS_SETCOOKIE = "Set-Cookie";
-    private static final String ADD_HEADERS_PROPERTY = "org.apache.cxf.http.add-headers";             
-    
+    public static final String HTTP_HEADERS_SETCOOKIE = "Set-Cookie";
+    public static final String HTTP_HEADERS_LINK = "Link";
+    public static final String EMPTY_REQUEST_PROPERTY = "org.apache.cxf.empty.request";
+    private static final String SET_EMPTY_REQUEST_CT_PROPERTY = "set.content.type.for.empty.request";
+    private static final TimeZone TIME_ZONE_GMT = TimeZone.getTimeZone("GMT");
     private static final Logger LOG = LogUtils.getL7dLogger(Headers.class);
+
+    private static final List<String> SENSITIVE_HEADERS = Arrays.asList("Authorization", "Proxy-Authorization");
+    private static final List<Object> SENSITIVE_HEADER_MARKER = Arrays.asList("***");
+    private static final String ALLOW_LOGGING_SENSITIVE_HEADERS = "allow.logging.sensitive.headers";
+    private static final String USER_AGENT = initUserAgent();
+
     private final Message message;
     private final Map<String, List<String>> headers;
 
@@ -64,10 +82,51 @@ public class Headers {
         this.message = message;
         this.headers = getSetProtocolHeaders(message);
     }
+    public Headers() {
+        this.headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        this.message = null;
+    }
+
+    public static String getUserAgent() {
+        return USER_AGENT;
+    }
+
+    private static String initUserAgent() {
+        String name = Version.getName();
+        if ("Apache CXF".equals(name)) {
+            name = "Apache-CXF";
+        }
+        String version = Version.getCurrentVersion();
+        return name + "/" + version;
+    }
+
+    /**
+     * Returns a traceable string representation of the passed-in headers map.
+     * The value for any keys in the map that are in the <code>SENSITIVE_HEADERS</code>
+     * array will be filtered out of the returned string.
+     * Note that this method is expensive as it will copy the map (except for the
+     * filtered keys), so it should be used sparingly - i.e. only when debug is
+     * enabled.
+     */
+    static String toString(Map<String, List<Object>> headers, boolean logSensitiveHeaders) {
+        Map<String, List<Object>> filteredHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        filteredHeaders.putAll(headers);
+        if (!logSensitiveHeaders) {
+            for (String filteredKey : SENSITIVE_HEADERS) {
+                filteredHeaders.put(filteredKey, SENSITIVE_HEADER_MARKER);
+            }
+        }
+        return filteredHeaders.toString();
+    }
+
+    public Map<String, List<String>> headerMap() {
+        return headers;
+    }
+
 
     /**
      * Write cookie header from given session cookies
-     * 
+     *
      * @param sessionCookies
      */
     public void writeSessionCookies(Map<String, Cookie> sessionCookies) {
@@ -79,9 +138,9 @@ public class Headers {
             }
         }
         if (cookies == null) {
-            cookies = new ArrayList<String>();
+            cookies = new ArrayList<>();
         } else {
-            cookies = new ArrayList<String>(cookies);
+            cookies = new ArrayList<>(cookies);
         }
         headers.put(HttpHeaderHelper.COOKIE, cookies);
         for (Cookie c : sessionCookies.values()) {
@@ -92,8 +151,8 @@ public class Headers {
     /**
      * This call places HTTP Header strings into the headers that are relevant
      * to the ClientPolicy that is set on this conduit by configuration.
-     * 
-     * REVISIT: A cookie is set statically from configuration? 
+     *
+     * REVISIT: A cookie is set statically from configuration?
      */
     void setFromClientPolicy(HTTPClientPolicy policy) {
         if (policy == null) {
@@ -133,7 +192,7 @@ public class Headers {
                     createMutableList(policy.getCookie()));
         }
         if (policy.isSetBrowserType()) {
-            headers.put("BrowserType",
+            headers.put("User-Agent",
                     createMutableList(policy.getBrowserType()));
         }
         if (policy.isSetReferer()) {
@@ -141,7 +200,7 @@ public class Headers {
                     createMutableList(policy.getReferer()));
         }
     }
-    
+
     void setFromServerPolicy(HTTPServerPolicy policy) {
         if (policy.isSetCacheControl()) {
             headers.put("Cache-Control",
@@ -169,9 +228,8 @@ public class Headers {
         } else if (policy.isSetKeepAliveParameters()) {
             headers.put("Keep-Alive", createMutableList(policy.getKeepAliveParameters()));
         }
-        
-    
-        
+
+
     /*
      * TODO - hook up these policies
     <xs:attribute name="SuppressClientSendErrors" type="xs:boolean" use="optional" default="false">
@@ -183,24 +241,24 @@ public class Headers {
         headers.remove("Authorization");
         headers.remove("Proxy-Authorization");
     }
-    
+
     public void setAuthorization(String authorization) {
         headers.put("Authorization",
                 createMutableList(authorization));
     }
-    
+
     public void setProxyAuthorization(String authorization) {
         headers.put("Proxy-Authorization",
                 createMutableList(authorization));
     }
-    
-    
+
+
     /**
      * While extracting the Message.PROTOCOL_HEADERS property from the Message,
      * this call ensures that the Message.PROTOCOL_HEADERS property is
      * set on the Message. If it is not set, an empty map is placed there, and
      * then returned.
-     * 
+     *
      * @param message The outbound message
      * @return The PROTOCOL_HEADERS map
      */
@@ -209,11 +267,11 @@ public class Headers {
             CastUtils.cast((Map<?, ?>)message.get(Message.PROTOCOL_HEADERS));
         //Liberty code change start
         if (null == headers) {
-            headers = new TreeMap<String, List<String>>(String.CASE_INSENSITIVE_ORDER); 
+            headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
             message.put(Message.PROTOCOL_HEADERS, headers);
         } else if (headers instanceof HashMap) {
             Map<String, List<String>> headers2
-                = new TreeMap<String, List<String>>(String.CASE_INSENSITIVE_ORDER);
+                = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
             headers2.putAll(headers);
             message.put(Message.PROTOCOL_HEADERS, headers2);
             headers = headers2;
@@ -225,56 +283,108 @@ public class Headers {
     public void readFromConnection(HttpURLConnection connection) {
         Map<String, List<String>> origHeaders = connection.getHeaderFields();
         headers.clear();
-        for (String key : connection.getHeaderFields().keySet()) {
-            if (key != null) {
-                headers.put(HttpHeaderHelper.getHeaderKey(key), 
-                    origHeaders.get(key));
+        for (Entry<String, List<String>> entry : origHeaders.entrySet()) {
+            if (entry.getKey() != null) {
+                String key = HttpHeaderHelper.getHeaderKey(entry.getKey());
+                List<String> old = headers.get(key);
+                if (old != null) {
+                    List<String> nl = new ArrayList<>(old.size() + entry.getValue().size()); 
+                    nl.addAll(old);
+                    nl.addAll(entry.getValue());
+                    headers.put(key, nl);
+                } else {
+                    headers.put(key, entry.getValue());
+                }
             }
         }
     }
 
     private static List<String> createMutableList(String val) {
-        return new ArrayList<String>(Arrays.asList(new String[] {val}));
+        return new ArrayList<>(Arrays.asList(val));
     }
-    
+
     /**
-     * This procedure logs the PROTOCOL_HEADERS from the 
+     * This procedure logs the PROTOCOL_HEADERS from the
      * Message at the specified logging level.
-     * 
+     *
+     * @param logger     The Logger to log to.
      * @param level   The Logging Level.
      * @param headers The Message protocol headers.
      */
-    void logProtocolHeaders(Level level) {
-        for (String header : headers.keySet()) {
-            List<String> headerList = headers.get(header);
-            for (String value : headerList) {
-                LOG.log(level, header + ": " + value);
+    static void logProtocolHeaders(Logger logger, Level level,
+                                   Map<String, List<Object>> headersMap,
+                                   boolean logSensitiveHeaders) {
+        if (logger.isLoggable(level)) {
+            for (Map.Entry<String, List<Object>> entry : headersMap.entrySet()) {
+                String key = entry.getKey();
+                boolean sensitive = !logSensitiveHeaders && SENSITIVE_HEADERS.contains(key);
+                List<Object> headerList = sensitive ? SENSITIVE_HEADER_MARKER : entry.getValue();
+                for (Object value : headerList) {
+                    logger.log(level, key + ": "
+                        + (value == null ? "<null>" : value.toString()));
+                }
             }
         }
     }
-    
+
     /**
      * Set content type and protocol headers (Message.PROTOCOL_HEADERS) headers into the URL
-     * connection. 
+     * connection.
      * Note, this does not mean they immediately get written to the output
      * stream or the wire. They just just get set on the HTTP request.
-     * 
-     * @param connection 
+     *
+     * @param connection
      * @throws IOException
      */
     public void setProtocolHeadersInConnection(HttpURLConnection connection) throws IOException {
-        String ct = determineContentType();
-        connection.setRequestProperty(HttpHeaderHelper.CONTENT_TYPE, ct);
+        // If no Content-Type is set for empty requests then HttpUrlConnection:
+        // - sets a form Content-Type for empty POST
+        // - replaces custom Accept value with */* if HTTP proxy is used
+        boolean contentTypeSet = headers.containsKey(Message.CONTENT_TYPE);
+        if (!contentTypeSet) {
+            // if CT is not set then assume it has to be set by default
+            boolean dropContentType = false;
+            boolean getRequest = "GET".equals(message.get(Message.HTTP_REQUEST_METHOD));
+            boolean emptyRequest = getRequest || PropertyUtils.isTrue(message.get(EMPTY_REQUEST_PROPERTY));
+            // If it is an empty request (without a request body) then check further if CT still needs be set
+            if (emptyRequest) {
+                Object setCtForEmptyRequestProp = message.getContextualProperty(SET_EMPTY_REQUEST_CT_PROPERTY);
+                if (setCtForEmptyRequestProp != null) {
+                    // If SET_EMPTY_REQUEST_CT_PROPERTY is set then do as a user prefers.
+                    // CT will be dropped if setting CT for empty requests was explicitly disabled
+                    dropContentType = PropertyUtils.isFalse(setCtForEmptyRequestProp);
+                } else if (getRequest) {
+                    // otherwise if it is GET then just drop it
+                    dropContentType = true;
+                }
+            }
+            if (!dropContentType) {
+                String ct = emptyRequest && !contentTypeSet ? "*/*" : determineContentType();
+                connection.setRequestProperty(HttpHeaderHelper.CONTENT_TYPE, ct);
+            }
+        } else {
+            connection.setRequestProperty(HttpHeaderHelper.CONTENT_TYPE, determineContentType());
+        }
+
         transferProtocolHeadersToURLConnection(connection);
-        logProtocolHeaders(Level.FINE);
+
+        Map<String, List<Object>> theHeaders = CastUtils.cast(headers);
+        logProtocolHeaders(LOG, Level.FINE, theHeaders, logSensitiveHeaders());
     }
 
-    private String determineContentType() {
-        String ct  = (String)message.get(Message.CONTENT_TYPE);
+    public String determineContentType() {
+        String ct = null;
+        List<Object> ctList = CastUtils.cast(headers.get(Message.CONTENT_TYPE));
+        if (ctList != null && ctList.size() == 1 && ctList.get(0) != null) {
+            ct = ctList.get(0).toString();
+        } else {
+            ct = (String)message.get(Message.CONTENT_TYPE);
+        }
+
         String enc = (String)message.get(Message.ENCODING);
 
         if (null != ct) {
-            if (enc != null 
+            if (enc != null
                 && ct.indexOf("charset=") == -1
                 && !ct.toLowerCase().contains("multipart/related")) {
                 ct = ct + "; charset=" + enc;
@@ -286,61 +396,56 @@ public class Headers {
         }
         return ct;
     }
-    
+
     /**
      * This procedure sets the URLConnection request properties
      * from the PROTOCOL_HEADERS in the message.
      */
     private void transferProtocolHeadersToURLConnection(URLConnection connection) {
-        boolean addHeaders = MessageUtils.isTrue(
-                message.getContextualProperty(ADD_HEADERS_PROPERTY));
-        for (String header : headers.keySet()) {
-            List<String> headerList = headers.get(header);
+        boolean addHeaders = MessageUtils.getContextualBoolean(message, ADD_HEADERS_PROPERTY, false);
+        for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+            String header = entry.getKey();
             if (HttpHeaderHelper.CONTENT_TYPE.equalsIgnoreCase(header)) {
                 continue;
             }
+
+            List<String> headerList = entry.getValue();
             if (addHeaders || HttpHeaderHelper.COOKIE.equalsIgnoreCase(header)) {
-                for (String s : headerList) {
-                    connection.addRequestProperty(HttpHeaderHelper.COOKIE, s);
-                }
+                headerList.forEach(s -> connection.addRequestProperty(header, s));
             } else {
-                StringBuilder b = new StringBuilder();
-                for (int i = 0; i < headerList.size(); i++) {
-                    b.append(headerList.get(i));
-                    if (i + 1 < headerList.size()) {
-                        b.append(',');
-                    }
-                }
-                connection.setRequestProperty(header, b.toString());
+                connection.setRequestProperty(header, String.join(",", headerList));
             }
         }
         // make sure we don't add more than one User-Agent header
         if (connection.getRequestProperty("User-Agent") == null) {
-            connection.addRequestProperty("User-Agent", Version.getCompleteVersionString());
+            connection.addRequestProperty("User-Agent", USER_AGENT);
         }
     }
-    
+
     /**
      * Copy the request headers into the message.
-     * 
+     *
      * @param message the current message
      * @param headers the current set of headers
      */
     protected void copyFromRequest(HttpServletRequest req) {
-
-        //TODO how to deal with the fields        
+        //TODO how to deal with the fields
         for (Enumeration<String> e = req.getHeaderNames(); e.hasMoreElements();) {
             String fname = e.nextElement();
             String mappedName = HttpHeaderHelper.getHeaderKey(fname);
-            List<String> values;
-            if (headers.containsKey(mappedName)) {
-                values = headers.get(mappedName);
-            } else {
-                values = new ArrayList<String>();
+            List<String> values = headers.get(mappedName);
+            if (values == null) {
+                values = new ArrayList<>();
                 headers.put(mappedName, values);
             }
             for (Enumeration<String> e2 = req.getHeaders(fname); e2.hasMoreElements();) {
                 String val = e2.nextElement();
+                if ("Accept".equals(mappedName) && values.size() > 0) {
+                    //ensure we collapse Accept into first line
+                    String firstAccept = values.get(0);
+                    firstAccept = firstAccept + ", " + val;
+                    values.set(0, firstAccept);
+                }
                 values.add(val);
             }
         }
@@ -348,24 +453,30 @@ public class Headers {
             headers.put(Message.CONTENT_TYPE, Collections.singletonList(req.getContentType()));
         }
         if (LOG.isLoggable(Level.FINE)) {
-            LOG.log(Level.FINE, "Request Headers: " + headers.toString());
+            Map<String, List<Object>> theHeaders = CastUtils.cast(headers);
+            LOG.log(Level.FINE, "Request Headers: " + toString(theHeaders,
+                                                               logSensitiveHeaders()));
         }
     }
 
+    private boolean logSensitiveHeaders() {
+        // Not allowed by default
+        return PropertyUtils.isTrue(message.getContextualProperty(ALLOW_LOGGING_SENSITIVE_HEADERS));
+    }
+
     private String getContentTypeFromMessage() {
-        final String ct  = (String)message.get(Message.CONTENT_TYPE);
+        final String ct = (String)message.get(Message.CONTENT_TYPE);
         final String enc = (String)message.get(Message.ENCODING);
-        
-        if (null != ct 
+
+        if (null != ct
             && null != enc
             && ct.indexOf("charset=") == -1
             && !ct.toLowerCase().contains("multipart/related")) {
             return ct + "; charset=" + enc;
-        } else {
-            return ct;
         }
+        return ct;
     }
-    
+
     // Assumes that response body is not available only
     // if Content-Length is available and set to 0
     private boolean isResponseBodyAvailable() {
@@ -374,69 +485,102 @@ public class Headers {
             return true;
         }
         try {
-            //Liberty code change start
             if (Integer.parseInt(ctLen.get(0)) == 0) {
                 return false;
             }
-            //Liberty code change end
-        } catch (NumberFormatException e) {
+        } catch (NumberFormatException ex) {
             // ignore
         }
         return true;
     }
+
+    private boolean isSingleHeader(String header) {
+        return HTTP_HEADERS_SETCOOKIE.equalsIgnoreCase(header) || HTTP_HEADERS_LINK.equalsIgnoreCase(header);
+    }
     
     /**
      * Copy the response headers into the response.
-     * 
+     *
      * @param message the current message
      * @param headers the current set of headers
      */
     protected void copyToResponse(HttpServletResponse response) {
         String contentType = getContentTypeFromMessage();
- 
-        if (!headers.containsKey(Message.CONTENT_TYPE) && contentType != null 
+
+        if (!headers.containsKey(Message.CONTENT_TYPE) && contentType != null
             && isResponseBodyAvailable()) {
             response.setContentType(contentType);
         }
 
-        boolean addHeaders = MessageUtils.isTrue(
-                message.getContextualProperty(ADD_HEADERS_PROPERTY));
-        for (Iterator<?> iter = headers.keySet().iterator(); iter.hasNext();) {
-            String header = (String)iter.next();
-            List<?> headerList = headers.get(header);
-            
-            if (addHeaders || HTTP_HEADERS_SETCOOKIE.equals(header)) {
+        boolean addHeaders = MessageUtils.getContextualBoolean(message, ADD_HEADERS_PROPERTY, false);
+        for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+            String header = entry.getKey();
+            List<?> headerList = entry.getValue();
+
+            if (addHeaders || isSingleHeader(header)) {
                 for (int i = 0; i < headerList.size(); i++) {
-                    response.addHeader(header, headerList.get(i).toString());
+                    Object headerObject = headerList.get(i);
+                    if (headerObject != null) {
+                        response.addHeader(header, headerObjectToString(headerObject));
+                    }
                 }
             } else {
                 StringBuilder sb = new StringBuilder();
                 for (int i = 0; i < headerList.size(); i++) {
-                    sb.append(headerList.get(i));
+                    Object headerObject = headerList.get(i);
+                    if (headerObject != null) {
+                        sb.append(headerObjectToString(headerObject));
+                    }
+
                     if (i + 1 < headerList.size()) {
                         sb.append(',');
                     }
                 }
-                response.addHeader(header, sb.toString());
+                response.setHeader(header, sb.toString());
             }
-
-            
         }
     }
-    
-    void removeContentType() {
-        if (headers.containsKey(PROTOCOL_HEADERS_CONTENT_TYPE)) {
-            headers.remove(PROTOCOL_HEADERS_CONTENT_TYPE);
+
+    private String headerObjectToString(Object headerObject) {
+        if (headerObject.getClass() == String.class) {
+            // Most likely
+            return headerObject.toString();
         }
+        String headerString;
+        if (headerObject instanceof Date) {
+            headerString = toHttpDate((Date)headerObject);
+        } else if (headerObject instanceof Locale) {
+            headerString = toHttpLanguage((Locale)headerObject);
+        } else {
+            headerString = headerObject.toString();
+        }
+        return headerString;
+    }
+
+    void removeContentType() {
+        headers.remove(PROTOCOL_HEADERS_CONTENT_TYPE);
     }
 
     public String getAuthorization() {
-        if (headers.containsKey("Authorization")) {
-            List<String> authorizationLines = headers.get("Authorization"); 
+        List<String> authorizationLines = headers.get("Authorization");
+        if (authorizationLines != null && !authorizationLines.isEmpty()) {
             return authorizationLines.get(0);
-        } else {
-            return null;
         }
+        return null;
     }
 
+    public static SimpleDateFormat getHttpDateFormat() {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
+        dateFormat.setTimeZone(TIME_ZONE_GMT);
+        return dateFormat;
+    }
+
+    public static String toHttpDate(Date date) {
+        SimpleDateFormat format = getHttpDateFormat();
+        return format.format(date);
+    }
+
+    public static String toHttpLanguage(Locale locale) {
+        return locale.toString().replace('_', '-');
+    }
 }


### PR DESCRIPTION
There are a couple of performance improvements that can be made to the AbstractHTTPDestination.flushHeaders path to make it more efficient. Also, creating a new URI object is expensive, so I took that out of two different paths, only parsing out exactly what's needed form the URI. This gives us a ~2-4% throughput boost for pingperf
