### PR TITLE
Issue #9479: Support RMI Remote throwing Exception

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/util/DeploymentUtil.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/util/DeploymentUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2016 IBM Corporation and others.
+ * Copyright (c) 1998, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -56,7 +56,7 @@ public final class DeploymentUtil
 
     /**
      * Get method name string of form:
-     * 
+     *
      * methodName(<class name of arg1>,<class name of arg2>,...)
      */
     public static String methodKey(Method m)
@@ -79,10 +79,10 @@ public final class DeploymentUtil
      * its super interfaces). Filters out methods belonging to the
      * javax.ejb.EJBObject interface (except remove) and method synonyms
      * (in case method overrides are present in the inheritance hierarchy).
-     * 
+     *
      * The same as getMethods(), except including remove method of
      * interface javax.ejb.EJBObject
-     * 
+     *
      * This method used only by EJBDeploy.
      */
     public static Method[] getAllMethods(Class<?> intf)
@@ -136,7 +136,7 @@ public final class DeploymentUtil
      * its super interfaces except the EJBObject and EJBLocal
      * interface). Filters out method synonyms (in case method
      * overrides are present in the inheritance hierarchy).
-     * 
+     *
      * This method returns the same method array as calling
      * getMethods(intf, null), but this method signature must
      * be maintained to support EJBDeploy.
@@ -150,18 +150,18 @@ public final class DeploymentUtil
      * Returns all the methods belonging to a component interface and the
      * corresponding (local or remote) business interfaces (including the
      * super interfaces, except the EJBObject and EJBLocal interface). <p>
-     * 
+     *
      * Also, filters out static methods and method synonyms (in case method
      * overrides are present in the inheritance hierarchy). <p>
-     * 
+     *
      * A combined list of methods from both the component and business
      * interfaces is desired, since any configured attributes (like
      * transaction or security) must apply to both the component and
      * busintess interfaces of the same type (local or remote). <p>
-     * 
+     *
      * @param componentInterface Local or Remote Component interface
      * @param businessInterfaces Array of Local or Remote Business interfaces
-     * 
+     *
      * @return all methods belonging to the component and business interfaces.
      */
     // d366807
@@ -301,13 +301,13 @@ public final class DeploymentUtil
 
     /**
      * Sort an ArrayList of methods using a simple insertion sort. <p>
-     * 
+     *
      * Replaced prior version of sortMethods(Method methods[]) to improve
      * performance by allowing the caller to avoid creating an intermediate
      * array object.... and just pass an ArrayList directly. <p>
-     * 
+     *
      * @param methods list of methods to be sorted.
-     * 
+     *
      * @return array of sorted methods.
      */
     // d366807.3
@@ -346,13 +346,13 @@ public final class DeploymentUtil
      * Returns a list of the non-public (and non-static) methods declared
      * on the EJB class, or inherited from a super class (excluding those
      * methods from java.lang.Object). <p>
-     * 
+     *
      * For methods which have been overriden (i.e. same name and parameters),
      * only the override will be included. <p>
-     * 
+     *
      * @param ejbClass the EJB implementation class.
      * @param publicMethods list of previously identified public methods
-     * 
+     *
      * @return List of non-public (non-static) methods declared on or inherited
      *         by the EJB implementation class.
      **/
@@ -473,11 +473,11 @@ public final class DeploymentUtil
     /**
      * Returns a list of 'checked'/Application exceptions, and also
      * performs validation. <p>
-     * 
+     *
      * RemoteException is never a 'checked' exception, and exceptions that
      * are subclasses of other 'checked' exceptios will either be eliminated,
      * or sorted in parent-last order to avoid 'unreachable' code. <p>
-     * 
+     *
      * The following rules from the EJB Specification will be checked:
      * <ul>
      * <li> Only Remote interfaces that implement java.rmi.Remote may
@@ -488,16 +488,16 @@ public final class DeploymentUtil
      * <li> All methods on an interface that implements java.rmi.Remote
      * must throw RemoteException.
      * </ul>
-     * 
+     *
      * This method is designed for use when generating the EJB Wrappers,
      * to determine which exceptions will require 'catch' blocks, and
      * when generating Ties and Stubs, to properly add code that
      * returns the 'checked' exceptions to the client. <p>
-     * 
+     *
      * @param method Java method to determine checked exceptions for.
      * @param isRmiRemote true if the interface implements java.rmi.Remote.
      * @param target the deployment target for generating code
-     * 
+     *
      * @return an array of checked/application exceptions that must be
      *         handled by the generated wrapper.
      **/
@@ -513,11 +513,11 @@ public final class DeploymentUtil
     /**
      * Returns a list of 'checked'/Application exceptions, and also
      * performs validation. <p>
-     * 
+     *
      * RemoteException is never a 'checked' exception, and exceptions that
      * are subclasses of other 'checked' exceptios will either be eliminated,
      * or sorted in parent-last order to avoid 'unreachable' code. <p>
-     * 
+     *
      * The following rules from the EJB Specification will be checked:
      * <ul>
      * <li> Only Remote interfaces that implement java.rmi.Remote may
@@ -529,18 +529,18 @@ public final class DeploymentUtil
      * <li> All methods on an interface that implements java.rmi.Remote
      * must throw RemoteException.
      * </ul>
-     * 
+     *
      * This method is designed for use when generating the EJB Wrappers,
      * to determine which exceptions will require 'catch' blocks, and
      * when generating Ties and Stubs, to properly add code that
      * returns the 'checked' exceptions to the client. <p>
-     * 
+     *
      * @param method Java method to determine checked exceptions for.
      * @param isRmiRemote true if the interface implements java.rmi.Remote.
      * @param target the deployment target for generating code
      * @param wrapperType wrapper type if target is WRAPPER and validation is
      *            required, or null otherwise
-     * 
+     *
      * @return an array of checked/application exceptions that must be
      *         handled by the generated wrapper.
      **/
@@ -559,11 +559,11 @@ public final class DeploymentUtil
     /**
      * Returns a list of 'checked'/Application exceptions, and also
      * performs validation. <p>
-     * 
+     *
      * RemoteException is never a 'checked' exception, and exceptions that
      * are subclasses of other 'checked' exceptios will either be eliminated,
      * or sorted in parent-last order to avoid 'unreachable' code. <p>
-     * 
+     *
      * The following rules from the EJB Specification will be checked:
      * <ul>
      * <li> Only Remote interfaces that implement java.rmi.Remote may
@@ -575,12 +575,12 @@ public final class DeploymentUtil
      * <li> All methods on an interface that implements java.rmi.Remote
      * must throw RemoteException.
      * </ul>
-     * 
+     *
      * This method is designed for use when generating the EJB Wrappers,
      * to determine which exceptions will require 'catch' blocks, and
      * when generating Ties and Stubs, to properly add code that
      * returns the 'checked' exceptions to the client. <p>
-     * 
+     *
      * @param method Java method to determine checked exceptions for.
      * @param isRmiRemote true if the interface implements java.rmi.Remote.
      * @param target the deployment target for generating code
@@ -590,7 +590,7 @@ public final class DeploymentUtil
      *            on the throws clause should be considered as system exceptions
      * @param declaredRemoteAreApplicationExceptions true if RemoteExceptions
      *            on the throws clause should be considered as application exceptions
-     * 
+     *
      * @return an array of checked/application exceptions that must be
      *         handled by the generated wrapper.
      **/
@@ -690,6 +690,11 @@ public final class DeploymentUtil
                     continue;
                 }
             }
+
+            // --------------------------------------------------------------------
+            // Per the spec, application exceptions must subclass Exception
+            // (not Throwable or Error)
+            // --------------------------------------------------------------------
             else if (!Exception.class.isAssignableFrom(exception)) // d608631
             {
                 String className = method.getDeclaringClass().getName();
@@ -702,6 +707,15 @@ public final class DeploymentUtil
                                                     " application exception defined on the " + method.getName() +
                                                     " method of the " + className +
                                                     " class must be defined as a subclass of the java.lang.Exception class.");
+            }
+
+            // --------------------------------------------------------------------
+            // Per the RMI specification, Remote interface methods must throw
+            // RemoteException or any superclass, so Exception and IOException
+            // count as throwing RemoteException.
+            // --------------------------------------------------------------------
+            else if (exception.isAssignableFrom(RemoteException.class)) {
+                throwsRemoteException = true;
             }
 
             // --------------------------------------------------------------------

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/.classpath
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/.classpath
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
-   	<classpathentry kind="src" path="test-applications/EJB31AppExAnnBean.jar/src"/>
-   	<classpathentry kind="src" path="test-applications/EJB31AppExAnnWeb.war/src"/>
-   	<classpathentry kind="src" path="test-applications/EJB31AppExMixBean.jar/src"/>
-   	<classpathentry kind="src" path="test-applications/EJB31AppExMixWeb.war/src"/>
-   	<classpathentry kind="src" path="test-applications/EJB31AppExXmlBean.jar/src"/>
-   	<classpathentry kind="src" path="test-applications/EJB31AppExXmlWeb.war/src"/>
+	<classpathentry kind="src" path="test-applications/EJB31AppExAnnBean.jar/src"/>
+	<classpathentry kind="src" path="test-applications/EJB31AppExAnnWeb.war/src"/>
+	<classpathentry kind="src" path="test-applications/EJB31AppExMixBean.jar/src"/>
+	<classpathentry kind="src" path="test-applications/EJB31AppExMixWeb.war/src"/>
+	<classpathentry kind="src" path="test-applications/EJB31AppExXmlBean.jar/src"/>
+	<classpathentry kind="src" path="test-applications/EJB31AppExXmlWeb.war/src"/>
+	<classpathentry kind="src" path="test-applications/ExceptionBean.jar/src"/>
+	<classpathentry kind="src" path="test-applications/ExceptionWeb.war/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/bnd.bnd
@@ -18,7 +18,9 @@ src: \
 	test-applications/EJB31AppExMixBean.jar/src, \
 	test-applications/EJB31AppExMixWeb.war/src, \
 	test-applications/EJB31AppExXmlBean.jar/src, \
-	test-applications/EJB31AppExXmlWeb.war/src
+	test-applications/EJB31AppExXmlWeb.war/src, \
+	test-applications/ExceptionBean.jar/src, \
+	test-applications/ExceptionWeb.war/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/build.gradle
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/build.gradle
@@ -24,6 +24,8 @@ configurations {
 
 dependencies {
   ejbTools 'test:com.ibm.ws.ejbcontainer.fat_tools:1.+'
+  // Dependencies needed for when running on Java 9 (EE-type APIs were removed from JDK)
+  requiredLibs 'com.ibm.ws.org.apache.yoko:yoko-spec-corba:1.5.0.31ef0b15cf'
 }
 
 task addEJBTools {
@@ -32,6 +34,11 @@ task addEJBTools {
     copy {
       from configurations.ejbTools
       into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.ejbcontainer.exception.fat.AppExceptionServer/lib/global"
+      rename 'com.ibm.ws.ejbcontainer.fat_tools-(.*).jar', 'com.ibm.ws.ejbcontainer.fat_tools.jar'
+    }
+    copy {
+      from configurations.ejbTools
+      into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.ejbcontainer.exception.fat.ExceptionServer/lib/global"
       rename 'com.ibm.ws.ejbcontainer.fat_tools-(.*).jar', 'com.ibm.ws.ejbcontainer.fat_tools.jar'
     }
   }

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/fat/src/com/ibm/ws/ejbcontainer/exception/fat/tests/ExceptionTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/fat/src/com/ibm/ws/ejbcontainer/exception/fat/tests/ExceptionTest.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.exception.fat.tests;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.ejbcontainer.exception.web.ExceptionServlet;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.annotation.TestServlets;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+
+@RunWith(FATRunner.class)
+public class ExceptionTest {
+    @Server("com.ibm.ws.ejbcontainer.exception.fat.ExceptionServer")
+    @TestServlets({ @TestServlet(servlet = ExceptionServlet.class, contextRoot = "ExceptionWeb") })
+    public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.ejbcontainer.exception.fat.ExceptionServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.exception.fat.ExceptionServer"));
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // Use ShrinkHelper to build the ExceptionApp ear
+        JavaArchive ExceptionBean = ShrinkHelper.buildJavaArchive("ExceptionBean.jar", "com.ibm.ws.ejbcontainer.exception.ejb.");
+        WebArchive ExceptionWeb = ShrinkHelper.buildDefaultApp("ExceptionWeb.war", "com.ibm.ws.ejbcontainer.exception.web.");
+
+        EnterpriseArchive ExceptionApp = ShrinkWrap.create(EnterpriseArchive.class, "ExceptionApp.ear");
+        ExceptionApp.addAsModule(ExceptionBean).addAsModule(ExceptionWeb);
+        ExceptionApp = (EnterpriseArchive) ShrinkHelper.addDirectory(ExceptionApp, "test-applications/ExceptionApp.ear/resources");
+
+        ShrinkHelper.exportDropinAppToServer(server, ExceptionApp);
+
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        // CNTR0020E: EJB threw an unexpected (non-declared) exception
+        server.stopServer("CNTR0020E");
+    }
+}

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/publish/servers/com.ibm.ws.ejbcontainer.exception.fat.ExceptionServer/bootstrap.properties
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/publish/servers/com.ibm.ws.ejbcontainer.exception.fat.ExceptionServer/bootstrap.properties
@@ -1,0 +1,2 @@
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:EJBContainer=all:JITDeploy=all

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/publish/servers/com.ibm.ws.ejbcontainer.exception.fat.ExceptionServer/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/publish/servers/com.ibm.ws.ejbcontainer.exception.fat.ExceptionServer/server.xml
@@ -1,0 +1,17 @@
+<server>
+    <featureManager>
+        <feature>servlet-3.1</feature>
+        <feature>ejbLite-3.2</feature>
+        <feature>ejbRemote-3.2</feature>
+        <feature>ejbHome-3.2</feature>
+        <feature>componenttest-1.0</feature>
+    </featureManager>
+
+    <include location="../fatTestPorts.xml"/>
+
+    <iiopEndpoint id="defaultIiopEndpoint" iiopPort="${bvt.prop.IIOP}" iiopsPort="${bvt.prop.IIOP.secure}"/>
+
+    <!-- Yoko ORB bug; org.apache.yoko.rmispec.util.UtilLoader.loadServiceClass needs doPriv around getClassLoader -->	
+    <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="line.separator" actions="read"/>
+</server>

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionApp.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionApp.ear/resources/META-INF/permissions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+    version="7">
+
+    <permission>
+        <!-- Yoko ORB bug; org.apache.yoko.rmispec.util.UtilLoader.loadServiceClass needs doPriv -->
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>getClassLoader</name>
+    </permission> 
+</permissions>

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionBean.jar/src/com/ibm/ws/ejbcontainer/exception/ejb/SLRemoteEx.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionBean.jar/src/com/ibm/ws/ejbcontainer/exception/ejb/SLRemoteEx.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.ejbcontainer.exception.ejb;
+
+import java.io.IOException;
+import java.rmi.RemoteException;
+
+import javax.ejb.EJBObject;
+
+/**
+ * Remote interface for Enterprise Bean: SLRemoteEx
+ */
+public interface SLRemoteEx extends EJBObject {
+
+    // EJBDeploy/RMIC will fail if RemoteException (or parent) is not thrown
+    // void testMethodwithNoEx(String exceptionToThrow);
+
+    void testMethodwithException(String exceptionToThrow) throws Exception;
+
+    void testMethodwithIOException(String exceptionToThrow) throws IOException;
+
+    void testMethodwithRemoteEx(String exceptionToThrow) throws RemoteException;
+
+    void testMethodwithExceptionAndRemote(String exceptionToThrow) throws Exception, RemoteException;
+
+    void testMethodwithRemoteExAndSub(String exceptionToThrow) throws RemoteException;
+}

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionBean.jar/src/com/ibm/ws/ejbcontainer/exception/ejb/SLRemoteExBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionBean.jar/src/com/ibm/ws/ejbcontainer/exception/ejb/SLRemoteExBean.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.ejbcontainer.exception.ejb;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.rmi.RemoteException;
+import java.sql.SQLException;
+import java.util.logging.Logger;
+
+import javax.ejb.EJBException;
+import javax.ejb.RemoteHome;
+import javax.ejb.SessionBean;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+
+/**
+ * Remote Enterprise Bean: SLRemoteEx
+ */
+@Stateless
+@RemoteHome(SLRemoteExHome.class)
+public class SLRemoteExBean implements SessionBean {
+    private static final long serialVersionUID = -2207952128826591889L;
+    private static final String CLASS_NAME = SLRemoteExBean.class.getName();
+    private static final Logger logger = Logger.getLogger(CLASS_NAME);
+
+    public void testMethodwithException(String exceptionToThrow) throws Exception {
+        logger.info(getClass().getSimpleName() + ".testMethodwithException : " + exceptionToThrow);
+        if ("Exception".equals(exceptionToThrow)) {
+            throw new Exception(exceptionToThrow);
+        } else if ("IOException".equals(exceptionToThrow)) {
+            throw new IOException(exceptionToThrow);
+        } else if ("RemoteException".equals(exceptionToThrow)) {
+            throw new RemoteException(exceptionToThrow);
+        } else if ("RuntimeException".equals(exceptionToThrow)) {
+            throw new RuntimeException(exceptionToThrow);
+        } else if ("IllegalStateException".equals(exceptionToThrow)) {
+            throw new IllegalStateException(exceptionToThrow);
+        } else if ("SQLException".equals(exceptionToThrow)) {
+            throw new SQLException(exceptionToThrow);
+        }
+    }
+
+    public void testMethodwithIOException(String exceptionToThrow) throws IOException {
+        logger.info(getClass().getSimpleName() + ".testMethodwithIOException : " + exceptionToThrow);
+        if ("IOException".equals(exceptionToThrow)) {
+            throw new IOException(exceptionToThrow);
+        } else if ("RemoteException".equals(exceptionToThrow)) {
+            throw new RemoteException(exceptionToThrow);
+        } else if ("RuntimeException".equals(exceptionToThrow)) {
+            throw new RuntimeException(exceptionToThrow);
+        } else if ("IllegalStateException".equals(exceptionToThrow)) {
+            throw new IllegalStateException(exceptionToThrow);
+        } else if ("FileNotFoundException".equals(exceptionToThrow)) {
+            throw new FileNotFoundException(exceptionToThrow);
+        }
+    }
+
+    public void testMethodwithRemoteEx(String exceptionToThrow) throws RemoteException {
+        logger.info(getClass().getSimpleName() + ".testMethodwithRemoteEx : " + exceptionToThrow);
+        if ("RemoteException".equals(exceptionToThrow)) {
+            throw new RemoteException(exceptionToThrow);
+        } else if ("RuntimeException".equals(exceptionToThrow)) {
+            throw new RuntimeException(exceptionToThrow);
+        } else if ("IllegalStateException".equals(exceptionToThrow)) {
+            throw new IllegalStateException(exceptionToThrow);
+        } else if ("SLRemoteException".equals(exceptionToThrow)) {
+            throw new SLRemoteException(exceptionToThrow);
+        }
+    }
+
+    public void testMethodwithExceptionAndRemote(String exceptionToThrow) throws Exception, RemoteException {
+        logger.info(getClass().getSimpleName() + ".testMethodwithExceptionAndRemote : " + exceptionToThrow);
+        if ("RemoteException".equals(exceptionToThrow)) {
+            throw new RemoteException(exceptionToThrow);
+        } else if ("RuntimeException".equals(exceptionToThrow)) {
+            throw new RuntimeException(exceptionToThrow);
+        } else if ("IllegalStateException".equals(exceptionToThrow)) {
+            throw new IllegalStateException(exceptionToThrow);
+        } else if ("SLRemoteException".equals(exceptionToThrow)) {
+            throw new SLRemoteException(exceptionToThrow);
+        }
+    }
+
+    public void testMethodwithRemoteExAndSub(String exceptionToThrow) throws RemoteException, SLRemoteException {
+        logger.info(getClass().getSimpleName() + ".testMethodwithRemoteExAndSub : " + exceptionToThrow);
+        if ("RemoteException".equals(exceptionToThrow)) {
+            throw new RemoteException(exceptionToThrow);
+        } else if ("RuntimeException".equals(exceptionToThrow)) {
+            throw new RuntimeException(exceptionToThrow);
+        } else if ("IllegalStateException".equals(exceptionToThrow)) {
+            throw new IllegalStateException(exceptionToThrow);
+        } else if ("SLRemoteException".equals(exceptionToThrow)) {
+            throw new SLRemoteException(exceptionToThrow);
+        }
+    }
+
+    @Override
+    public void ejbActivate() throws EJBException, RemoteException {
+    }
+
+    @Override
+    public void ejbPassivate() throws EJBException, RemoteException {
+    }
+
+    @Override
+    public void ejbRemove() throws EJBException, RemoteException {
+    }
+
+    @Override
+    public void setSessionContext(SessionContext arg0) throws EJBException, RemoteException {
+    }
+}

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionBean.jar/src/com/ibm/ws/ejbcontainer/exception/ejb/SLRemoteExHome.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionBean.jar/src/com/ibm/ws/ejbcontainer/exception/ejb/SLRemoteExHome.java
@@ -8,19 +8,18 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.ejbcontainer.exception.fat;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+package com.ibm.ws.ejbcontainer.exception.ejb;
 
-import com.ibm.ws.ejbcontainer.exception.fat.tests.ExceptionTest;
-import com.ibm.ws.ejbcontainer.exception.fat.tests.InheritedApplicationExceptionTest;
+import java.rmi.RemoteException;
 
-@RunWith(Suite.class)
-@SuiteClasses({
-                ExceptionTest.class,
-                InheritedApplicationExceptionTest.class
-})
-public class FATSuite {
+import javax.ejb.CreateException;
+import javax.ejb.EJBHome;
+
+/**
+ * Remote Home interface for Enterprise Bean: SLRemoteEx
+ */
+public interface SLRemoteExHome extends EJBHome {
+
+    SLRemoteEx create() throws CreateException, RemoteException;
 }

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionBean.jar/src/com/ibm/ws/ejbcontainer/exception/ejb/SLRemoteException.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionBean.jar/src/com/ibm/ws/ejbcontainer/exception/ejb/SLRemoteException.java
@@ -8,19 +8,16 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.ejbcontainer.exception.fat;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+package com.ibm.ws.ejbcontainer.exception.ejb;
 
-import com.ibm.ws.ejbcontainer.exception.fat.tests.ExceptionTest;
-import com.ibm.ws.ejbcontainer.exception.fat.tests.InheritedApplicationExceptionTest;
+import java.rmi.RemoteException;
 
-@RunWith(Suite.class)
-@SuiteClasses({
-                ExceptionTest.class,
-                InheritedApplicationExceptionTest.class
-})
-public class FATSuite {
+public class SLRemoteException extends RemoteException {
+    private static final long serialVersionUID = -3095751618089292632L;
+
+    public SLRemoteException(String message) {
+        super(message);
+    }
+
 }

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionWeb.war/src/com/ibm/ws/ejbcontainer/exception/web/ExceptionServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionWeb.war/src/com/ibm/ws/ejbcontainer/exception/web/ExceptionServlet.java
@@ -1,0 +1,311 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.ejbcontainer.exception.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.rmi.RemoteException;
+import java.rmi.ServerException;
+import java.sql.SQLException;
+
+import javax.naming.InitialContext;
+import javax.rmi.PortableRemoteObject;
+import javax.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteEx;
+import com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteExHome;
+import com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteException;
+
+import componenttest.annotation.ExpectedFFDC;
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet("/ExceptionServlet")
+public class ExceptionServlet extends FATServlet {
+
+    private SLRemoteEx lookupSLRemoteExBean() throws Exception {
+        Object stub = new InitialContext().lookup("java:app/ExceptionBean/SLRemoteExBean");
+        SLRemoteExHome home = (SLRemoteExHome) PortableRemoteObject.narrow(stub, SLRemoteExHome.class);
+        return home.create();
+    }
+
+    @Test
+    @ExpectedFFDC({ "java.lang.IllegalStateException", "java.lang.RuntimeException", "java.rmi.RemoteException" })
+    public void testRMIRemoteMethodwithException() throws Exception {
+        SLRemoteEx remoteEx = lookupSLRemoteExBean();
+
+        // verify method with throws exception may be called without an exception
+        remoteEx.testMethodwithException("none");
+
+        try {
+            remoteEx.testMethodwithException("Exception");
+            fail("Expected Exception was not thrown");
+        } catch (Exception ex) {
+            assertTrue("Exception is not Exception : " + ex.getClass().getName(), ex.getClass() == Exception.class);
+            assertEquals("Wrong Exception message received", "Exception", ex.getMessage());
+        }
+
+        try {
+            remoteEx.testMethodwithException("IOException");
+            fail("Expected IOException was not thrown");
+        } catch (IOException ex) {
+            assertTrue("Exception is not IOException : " + ex.getClass().getName(), ex.getClass() == IOException.class);
+            assertEquals("Wrong Exception message received", "IOException", ex.getMessage());
+        }
+
+        try {
+            remoteEx.testMethodwithException("RemoteException");
+            fail("Expected RemoteException was not thrown");
+        } catch (ServerException ex) {
+            Throwable rootex = ex.detail;
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            assertEquals("Wrong Exception message received", "RemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteEx.testMethodwithException("RuntimeException");
+            fail("Expected RuntimeException was not thrown");
+        } catch (ServerException ex) {
+            Throwable rootex = ex.detail;
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            rootex = rootex.getCause();
+            assertTrue("Exception is not RuntimeException : " + rootex.getClass().getName(), rootex.getClass() == RuntimeException.class);
+            assertEquals("Wrong Exception message received", "RuntimeException", rootex.getMessage());
+        }
+
+        try {
+            remoteEx.testMethodwithException("IllegalStateException");
+            fail("Expected IllegalStateException was not thrown");
+        } catch (ServerException ex) {
+            Throwable rootex = ex.detail;
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            rootex = rootex.getCause();
+            assertTrue("Exception is not IllegalStateException : " + rootex.getClass().getName(), rootex.getClass() == IllegalStateException.class);
+            assertEquals("Wrong Exception message received", "IllegalStateException", rootex.getMessage());
+        }
+
+        try {
+            remoteEx.testMethodwithException("SQLException");
+            fail("Expected SQLException was not thrown");
+        } catch (SQLException ex) {
+            assertTrue("Exception is not SQLException : " + ex.getClass().getName(), ex.getClass() == SQLException.class);
+            assertEquals("Wrong Exception message received", "SQLException", ex.getMessage());
+        }
+    }
+
+    @Test
+    @ExpectedFFDC({ "java.lang.IllegalStateException", "java.lang.RuntimeException" })
+    public void testRMIRemoteMethodwithIOException() throws Exception {
+        SLRemoteEx remoteEx = lookupSLRemoteExBean();
+
+        // verify method with throws exception may be called without an exception
+        remoteEx.testMethodwithIOException("none");
+
+        try {
+            remoteEx.testMethodwithIOException("IOException");
+            fail("Expected IOException was not thrown");
+        } catch (IOException ex) {
+            assertTrue("Exception is not IOException : " + ex.getClass().getName(), ex.getClass() == IOException.class);
+            assertEquals("Wrong Exception message received", "IOException", ex.getMessage());
+        }
+
+        try {
+            remoteEx.testMethodwithIOException("RemoteException");
+            fail("Expected RemoteException was not thrown");
+        } catch (RemoteException ex) {
+            assertTrue("Exception is not RemoteException : " + ex.getClass().getName(), ex.getClass() == RemoteException.class);
+            assertEquals("Wrong Exception message received", "RemoteException", ex.getMessage());
+        }
+
+        try {
+            remoteEx.testMethodwithIOException("RuntimeException");
+            fail("Expected RuntimeException was not thrown");
+        } catch (ServerException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            rootex = rootex.getCause();
+            assertTrue("Exception is not RuntimeException : " + rootex.getClass().getName(), rootex.getClass() == RuntimeException.class);
+            assertEquals("Wrong Exception message received", "RuntimeException", rootex.getMessage());
+        }
+
+        try {
+            remoteEx.testMethodwithIOException("IllegalStateException");
+            fail("Expected IllegalStateException was not thrown");
+        } catch (ServerException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            rootex = rootex.getCause();
+            assertTrue("Exception is not IllegalStateException : " + ex.getClass().getName(), rootex.getClass() == IllegalStateException.class);
+            assertEquals("Wrong Exception message received", "IllegalStateException", rootex.getMessage());
+        }
+
+        try {
+            remoteEx.testMethodwithIOException("FileNotFoundException");
+            fail("Expected FileNotFoundException was not thrown");
+        } catch (FileNotFoundException ex) {
+            assertTrue("Exception is not FileNotFoundException : " + ex.getClass().getName(), ex.getClass() == FileNotFoundException.class);
+            assertEquals("Wrong Exception message received", "FileNotFoundException", ex.getMessage());
+        }
+    }
+
+    @Test
+    @ExpectedFFDC({ "java.lang.IllegalStateException", "java.lang.RuntimeException", "com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteException", "java.rmi.RemoteException" })
+    public void testRMIRemoteMethodwithRemoteEx() throws Exception {
+        SLRemoteEx remoteEx = lookupSLRemoteExBean();
+
+        // verify method with throws exception may be called without an exception
+        remoteEx.testMethodwithRemoteEx("none");
+
+        try {
+            remoteEx.testMethodwithRemoteEx("RemoteException");
+            fail("Expected RemoteException was not thrown");
+        } catch (ServerException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            assertEquals("Wrong Exception message received", "RemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteEx.testMethodwithRemoteEx("SLRemoteException");
+            fail("Expected SLRemoteException was not thrown");
+        } catch (ServerException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not SLRemoteException : " + rootex.getClass().getName(), rootex.getClass() == SLRemoteException.class);
+            assertEquals("Wrong Exception message received", "SLRemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteEx.testMethodwithRemoteEx("RuntimeException");
+            fail("Expected RuntimeException was not thrown");
+        } catch (ServerException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            rootex = rootex.getCause();
+            assertTrue("Exception is not RuntimeException : " + rootex.getClass().getName(), rootex.getClass() == RuntimeException.class);
+            assertEquals("Wrong Exception message received", "RuntimeException", rootex.getMessage());
+        }
+
+        try {
+            remoteEx.testMethodwithRemoteEx("IllegalStateException");
+            fail("Expected IllegalStateException was not thrown");
+        } catch (ServerException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            rootex = rootex.getCause();
+            assertTrue("Exception is not IllegalStateException : " + ex.getClass().getName(), rootex.getClass() == IllegalStateException.class);
+            assertEquals("Wrong Exception message received", "IllegalStateException", rootex.getMessage());
+        }
+    }
+
+    @Test
+    @ExpectedFFDC({ "java.lang.IllegalStateException", "java.lang.RuntimeException" })
+    public void testRMIRemoteMethodwithExceptionAndRemote() throws Exception {
+        SLRemoteEx remoteEx = lookupSLRemoteExBean();
+
+        // verify method with throws exception may be called without an exception
+        remoteEx.testMethodwithExceptionAndRemote("none");
+
+        try {
+            remoteEx.testMethodwithExceptionAndRemote("RemoteException");
+            fail("Expected RemoteException was not thrown");
+        } catch (RemoteException ex) {
+            assertTrue("Exception is not RemoteException : " + ex.getClass().getName(), ex.getClass() == RemoteException.class);
+            assertEquals("Wrong Exception message received", "RemoteException", ex.getMessage());
+        }
+
+        try {
+            remoteEx.testMethodwithExceptionAndRemote("SLRemoteException");
+            fail("Expected SLRemoteException was not thrown");
+        } catch (SLRemoteException ex) {
+            assertTrue("Exception is not SLRemoteException : " + ex.getClass().getName(), ex.getClass() == SLRemoteException.class);
+            assertEquals("Wrong Exception message received", "SLRemoteException", ex.getMessage());
+        }
+
+        try {
+            remoteEx.testMethodwithExceptionAndRemote("RuntimeException");
+            fail("Expected RuntimeException was not thrown");
+        } catch (ServerException ex) {
+            Throwable rootex = ex.detail;
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            rootex = rootex.getCause();
+            assertTrue("Exception is not RuntimeException : " + rootex.getClass().getName(), rootex.getClass() == RuntimeException.class);
+            assertEquals("Wrong Exception message received", "RuntimeException", rootex.getMessage());
+        }
+
+        try {
+            remoteEx.testMethodwithExceptionAndRemote("IllegalStateException");
+            fail("Expected IllegalStateException was not thrown");
+        } catch (ServerException ex) {
+            Throwable rootex = ex.detail;
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            rootex = rootex.getCause();
+            assertTrue("Exception is not IllegalStateException : " + ex.getClass().getName(), rootex.getClass() == IllegalStateException.class);
+            assertEquals("Wrong Exception message received", "IllegalStateException", rootex.getMessage());
+        }
+    }
+
+    @Test
+    @ExpectedFFDC({ "java.lang.IllegalStateException", "java.lang.RuntimeException", "com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteException", "java.rmi.RemoteException" })
+    public void testRMIRemoteMethodwithRemoteExAndSub() throws Exception {
+        SLRemoteEx remoteEx = lookupSLRemoteExBean();
+
+        // verify method with throws exception may be called without an exception
+        remoteEx.testMethodwithRemoteExAndSub("none");
+
+        try {
+            remoteEx.testMethodwithRemoteExAndSub("RemoteException");
+            fail("Expected RemoteException was not thrown");
+        } catch (ServerException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            assertEquals("Wrong Exception message received", "RemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteEx.testMethodwithRemoteExAndSub("SLRemoteException");
+            fail("Expected SLRemoteException was not thrown");
+        } catch (ServerException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not SLRemoteException : " + rootex.getClass().getName(), rootex.getClass() == SLRemoteException.class);
+            assertEquals("Wrong Exception message received", "SLRemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteEx.testMethodwithRemoteExAndSub("RuntimeException");
+            fail("Expected RuntimeException was not thrown");
+        } catch (ServerException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            rootex = rootex.getCause();
+            assertTrue("Exception is not RuntimeException : " + rootex.getClass().getName(), rootex.getClass() == RuntimeException.class);
+            assertEquals("Wrong Exception message received", "RuntimeException", rootex.getMessage());
+        }
+
+        try {
+            remoteEx.testMethodwithRemoteExAndSub("IllegalStateException");
+            fail("Expected IllegalStateException was not thrown");
+        } catch (ServerException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            rootex = rootex.getCause();
+            assertTrue("Exception is not IllegalStateException : " + ex.getClass().getName(), rootex.getClass() == IllegalStateException.class);
+            assertEquals("Wrong Exception message received", "IllegalStateException", rootex.getMessage());
+        }
+    }
+
+}


### PR DESCRIPTION
JITDeploy has been updated to allow an RMI Remote method to declare throwing Exception
rather than requiring it throw RemoteException.  Spec indicates it must be RemoteException
or a parent of RemoteException.

Generatioin of EJBWrapper also updated to add catch block for RemoteException so that
it is not treated as a checked exception, like other Exception subclasses....
except when both Exception and RemoteExctption have been declared. Both Exception
and RemoteException together were allowed previously, so don't want to change the
existing behavior.

fixes #9479 