### PR TITLE
Update AnnotationScanner to take into consideration excluded packages…

### DIFF
--- a/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/AnnotationScanner.java
+++ b/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/AnnotationScanner.java
@@ -206,10 +206,16 @@ public class AnnotationScanner {
         return Collections.unmodifiableSet(restAPIClasses);
     }
 
-    public String getURLMapping() {
+    public String getURLMapping(Set<String> classesToScan) {
         this.urlMapping = null;
         try {
-            Set<String> appClassNames = getAllApplicationClasses();
+            Set<String> appClassNames = getAllApplicationClasses().stream()
+                    .filter(classesToScan::contains)
+                    .collect(Collectors.toSet());
+
+            if (OpenAPIUtils.isEventEnabled(tc)) {
+                Tr.event(tc, "Application classes after filtering: ", appClassNames);
+            }
 
             if (appClassNames.size() < 2) {
                 String urlMapping = null;

--- a/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/ApplicationProcessor.java
+++ b/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/ApplicationProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/ApplicationProcessor.java
+++ b/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/ApplicationProcessor.java
@@ -228,7 +228,7 @@ public class ApplicationProcessor {
                         }
                     }
                     Reader reader = new Reader(newDocument);
-                    reader.setApplicationPath(scanner.getURLMapping());
+                    reader.setApplicationPath(scanner.getURLMapping(classNamesToScan));
                     newDocument = reader.read(classes);
                 }
             }

--- a/dev/com.ibm.ws.openapi.3.1/src/com/ibm/ws/openapi31/OpenAPIWebProvider.java
+++ b/dev/com.ibm.ws.openapi.3.1/src/com/ibm/ws/openapi31/OpenAPIWebProvider.java
@@ -212,7 +212,7 @@ public class OpenAPIWebProvider implements OASProvider {
                     }
                 }
                 Reader reader = new Reader(document);
-                reader.setApplicationPath(scanner.getURLMapping());
+                reader.setApplicationPath(scanner.getURLMapping(classNamesToScan));
                 document = reader.read(classes);
             }
         }


### PR DESCRIPTION
… and classes

For example when
mp.openapi.scan.exclude.packages=[com.example.excluded]
AnnotationScanner still uses Application classes from that package:
com.ibm.ws.microprofile.openapi.AnnotationScanner            1 Found application classes:
[com.example.demo.DemoRestApplication, com.example.excluded.DemoRestApplication]

However `com.example.excluded.DemoRestApplication` should not be processed by openApiScanner

Signed-off-by: Anton Balaniuc anton.balaniuc@gmail.com

OpenLiberty Pull Requester,

ATTENTION, READ THIS: Updated 4/11/2018 - Read and understand this completely,
then delete this entire template. If a reviewer or merger sees this template,
they should fail the review or merge.

If this code change is fixing a user-visible bug in previously released code, it MUST
have an associated issue mentioned in the PR text or description. That Issue also
MUST be labelled “release bug”

This directs automation to scrape this fix for inclusion in the next release's
list of bugs fixed.

If this code is NOT for fixing a released bug, for example new function, fixing
a bug in unreleased function, or other improvements that do not affect the
user-space, no label is needed. An issue could or could not be used based
on the developer’s discretion, but do still delete this text block.

For full details, please see this wiki page:

https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions

