### PR TITLE
add http session cache name if absent from infinispan config

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.serverB/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.serverB/server.xml
@@ -17,8 +17,9 @@
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
     
     <httpSession maxInMemorySessionCount="1" allowOverflow="false" hideSessionValues="false" invalidationTimeout="10m"/>
-    
-    <httpSessionCache enableBetaSupportForInfinispan="true"/> <!-- TODO remove once no longer gated -->
+
+    <httpSessionCache uri="file:${shared.resource.dir}/infinispan/infinispan.xml"
+                      enableBetaSupportForInfinispan="true"/> <!-- TODO remove once no longer gated -->
 
     <bell libraryRef="InfinispanLib" service="javax.cache.spi.CachingProvider"/>
 

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.timeoutServerA/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.timeoutServerA/server.xml
@@ -12,7 +12,8 @@
     <featureManager>
     </featureManager>   
     <httpSession maxInMemorySessionCount="1" allowOverflow="false" hideSessionValues="false" invalidationTimeout="5" reaperPollInterval="30"/> <!-- "5s" with units causes problem with simplicity object -->
-    <httpSessionCache libraryRef="InfinispanLib" writeContents="ALL_SESSION_ATTRIBUTES" uri="file:${shared.resource.dir}/infinispan/infinispan.xml"/>
+    <httpSessionCache libraryRef="InfinispanLib" writeContents="ALL_SESSION_ATTRIBUTES" uri="file:${shared.resource.dir}/infinispan/infinispan-config-lacking-http-session-cache-name.xml"
+    enableBetaSupportForInfinispan="true"/>
 
     <application location="sessionCacheApp.war">
         <classloader commonLibraryRef="InfinispanLib"/>

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/shared/resources/infinispan/infinispan-config-lacking-http-session-cache-name.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/shared/resources/infinispan/infinispan-config-lacking-http-session-cache-name.xml
@@ -1,0 +1,11 @@
+<infinispan>
+  <jgroups>
+     <stack-file name="jgroups-tcp" path="/default-configs/default-jgroups-tcp.xml"/>
+  </jgroups>
+  
+  <cache-container>
+    <transport stack="jgroups-tcp" />
+    <replicated-cache-configuration name="MyReplicatedCache"/>
+    <invalidation-cache-configuration name="MyInvalidationCache"/>
+  </cache-container>
+</infinispan>


### PR DESCRIPTION
Try to detect if the infinispan config file already has an entry for the caches that are created by HTTP sessions.  If it doesn't, add one and write to a temporary file.  This will need some further enhancement to cover a variety of ways to match.  For now, it will just identify the presence of com.ibm.ws.session.cache.