### PR TITLE
Switch from TCP to UDP based JGroups

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -326,7 +326,7 @@ public class CacheStoreService implements Introspector, SessionStoreService {
             try (PrintStream out = new PrintStream(new BufferedOutputStream(new FileOutputStream(tempConfigFile)))) {
                 out.println("<infinispan>");
                 out.println(" <jgroups>");
-                out.println("  <stack-file name=\"jgroups-tcp\" path=\"/default-configs/default-jgroups-tcp.xml\"/>");
+                out.println("  <stack-file name=\"jgroups-tcp\" path=\"/default-configs/default-jgroups-udp.xml\"/>");
                 out.println(" </jgroups>");
                 out.println(" <cache-container>");
                 out.println("  <transport stack=\"jgroups-tcp\"/>");

--- a/dev/com.ibm.ws.session.cache_fat_config_infinispan/publish/shared/resources/infinispan10/infinispan.xml
+++ b/dev/com.ibm.ws.session.cache_fat_config_infinispan/publish/shared/resources/infinispan10/infinispan.xml
@@ -1,10 +1,10 @@
 <infinispan>
   <jgroups>
-     <stack-file name="jgroups-tcp" path="/default-configs/default-jgroups-tcp.xml"/>
+     <stack-file name="jgroups-udp" path="/default-configs/default-jgroups-udp.xml"/>
   </jgroups>
   
   <cache-container>
-    <transport stack="jgroups-tcp" />
+    <transport stack="jgroups-udp" />
     <replicated-cache-configuration name="com.ibm.ws.session.*"/>
   </cache-container>
 </infinispan>

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/shared/resources/infinispan/infinispan.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/shared/resources/infinispan/infinispan.xml
@@ -1,10 +1,10 @@
 <infinispan>
   <jgroups>
-     <stack-file name="jgroups-tcp" path="/default-configs/default-jgroups-tcp.xml"/>
+     <stack-file name="jgroups-udp" path="/default-configs/default-jgroups-udp.xml"/>
   </jgroups>
   
   <cache-container>
-    <transport stack="jgroups-tcp" />
+    <transport stack="jgroups-udp" />
     <replicated-cache-configuration name="com.ibm.ws.session.*"/>
   </cache-container>
 </infinispan>

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/shared/resources/infinispan/infinispan.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/shared/resources/infinispan/infinispan.xml
@@ -1,10 +1,10 @@
 <infinispan>
   <jgroups>
-     <stack-file name="jgroups-tcp" path="/default-configs/default-jgroups-tcp.xml"/>
+     <stack-file name="jgroups-udp" path="/default-configs/default-jgroups-udp.xml"/>
   </jgroups>
   
   <cache-container>
-    <transport stack="jgroups-tcp" />
+    <transport stack="jgroups-udp" />
     <replicated-cache-configuration name="com.ibm.ws.session.*"/>
   </cache-container>
 </infinispan>


### PR DESCRIPTION
Switch to UDP to avoid this exception on z/OS:

org.infinispan.manager.EmbeddedCacheManagerStartupException: org.infinispan.commons.CacheException: Unable to start JGroups Channel
at org.infinispan.manager.DefaultCacheManager.internalStart(DefaultCacheManager.java:730)
at org.infinispan.manager.DefaultCacheManager.start(DefaultCacheManager.java:695)
at org.infinispan.manager.DefaultCacheManager.(DefaultCacheManager.java:381)
at org.infinispan.jcache.embedded.JCacheManager.(JCacheManager.java:70)
at org.infinispan.jcache.embedded.JCachingProvider.createCacheManager(JCachingProvider.java:46)
at org.infinispan.jcache.AbstractJCachingProvider.getCacheManager(AbstractJCachingProvider.java:67)
at com.ibm.ws.session.store.cache.CacheStoreService.lambda$activateLazily$0(CacheStoreService.java:185)
at com.ibm.ws.session.store.cache.CacheStoreService$$Lambda$9.0000000040E06B30.run(Unknown Source)
at java.security.AccessController.doPrivileged(AccessController.java:647)
at com.ibm.ws.session.store.cache.CacheStoreService.activateLazily(CacheStoreService.java:169)
at com.ibm.ws.session.store.cache.CacheHashMap.cacheInit(CacheHashMap.java:150)
at com.ibm.ws.session.store.cache.CacheHashMap.lambda$new$0(CacheHashMap.java:134)
at com.ibm.ws.session.store.cache.CacheHashMap$$Lambda$8.0000000040E03890.run(Unknown Source)
at java.security.AccessController.doPrivileged(AccessController.java:647)
at com.ibm.ws.session.store.cache.CacheHashMap.(CacheHashMap.java:133)
at com.ibm.ws.session.store.cache.CacheStore.(CacheStore.java:33)
at com.ibm.ws.session.store.cache.CacheStoreService.createStore(CacheStoreService.java:243)
at com.ibm.ws.session.SessionContext.createStore(SessionContext.java:337)
at com.ibm.ws.session.SessionContext.createCoreSessionManager(SessionContext.java:254)
at com.ibm.ws.session.SessionContext.(SessionContext.java:157)
at com.ibm.ws.webcontainer.session.impl.HttpSessionContextImpl.(HttpSessionContextImpl.java:62)
at com.ibm.ws.webcontainer31.session.impl.HttpSessionContext31Impl.(HttpSessionContext31Impl.java:37)
at com.ibm.ws.webcontainer31.session.impl.SessionContextRegistry31Impl.createSessionContextObject(SessionContextRegistry31Impl.java:40)
at com.ibm.ws.webcontainer.session.impl.SessionContextRegistryImpl.createSessionContext(SessionContextRegistryImpl.java:83)
at com.ibm.ws.webcontainer.session.impl.SessionContextRegistryImpl.getSessionContext(SessionContextRegistryImpl.java:304)
at com.ibm.ws.webcontainer.WebContainer.getSessionContext(WebContainer.java:701)
at com.ibm.ws.webcontainer.VirtualHost.getSessionContext(VirtualHost.java:188)
at com.ibm.ws.webcontainer.webapp.WebGroup.getSessionContext(WebGroup.java:156)
at com.ibm.ws.webcontainer.webapp.WebApp.createSessionContext(WebApp.java:1269)
at com.ibm.ws.webcontainer.webapp.WebApp.commonInitializationStart(WebApp.java:1252)
at com.ibm.ws.webcontainer.osgi.webapp.WebApp.commonInitializationStart(WebApp.java:255)
at com.ibm.ws.webcontainer.webapp.WebApp.initialize(WebApp.java:986)
at com.ibm.ws.webcontainer.webapp.WebApp.initialize(WebApp.java:6619)
at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost.startWebApp(DynamicVirtualHost.java:467)
at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost.startWebApplication(DynamicVirtualHost.java:462)
at com.ibm.ws.webcontainer.osgi.WebContainer.startWebApplication(WebContainer.java:1152)
at com.ibm.ws.webcontainer.osgi.WebContainer.access$000(WebContainer.java:111)
at com.ibm.ws.webcontainer.osgi.WebContainer$3.run(WebContainer.java:957)
at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:239)
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:522)
at java.util.concurrent.FutureTask.run(FutureTask.java:277)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1160)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
at java.lang.Thread.run(Thread.java:812)
Caused by: org.infinispan.commons.CacheException: Unable to start JGroups Channel
at org.infinispan.remoting.transport.jgroups.JGroupsTransport.startJGroupsChannelIfNeeded(JGroupsTransport.java:487)
at org.infinispan.remoting.transport.jgroups.JGroupsTransport.start(JGroupsTransport.java:412)
at org.infinispan.remoting.transport.jgroups.CorePackageImpl$1.start(CorePackageImpl.java:35)
at org.infinispan.remoting.transport.jgroups.CorePackageImpl$1.start(CorePackageImpl.java:23)
at org.infinispan.factories.impl.BasicComponentRegistryImpl.invokeStart(BasicComponentRegistryImpl.java:573)
at org.infinispan.factories.impl.BasicComponentRegistryImpl.doStartWrapper(BasicComponentRegistryImpl.java:564)
at org.infinispan.factories.impl.BasicComponentRegistryImpl.startWrapper(BasicComponentRegistryImpl.java:533)
at org.infinispan.factories.impl.BasicComponentRegistryImpl.access$700(BasicComponentRegistryImpl.java:31)
at org.infinispan.factories.impl.BasicComponentRegistryImpl$ComponentWrapper.running(BasicComponentRegistryImpl.java:756)
at org.infinispan.factories.impl.BasicComponentRegistryImpl.startDependencies(BasicComponentRegistryImpl.java:591)
at org.infinispan.factories.impl.BasicComponentRegistryImpl.doStartWrapper(BasicComponentRegistryImpl.java:555)
at org.infinispan.factories.impl.BasicComponentRegistryImpl.startWrapper(BasicComponentRegistryImpl.java:533)
at org.infinispan.factories.impl.BasicComponentRegistryImpl.access$700(BasicComponentRegistryImpl.java:31)
at org.infinispan.factories.impl.BasicComponentRegistryImpl$ComponentWrapper.running(BasicComponentRegistryImpl.java:756)
at org.infinispan.factories.impl.BasicComponentRegistryImpl.startDependencies(BasicComponentRegistryImpl.java:591)
at org.infinispan.factories.impl.BasicComponentRegistryImpl.doStartWrapper(BasicComponentRegistryImpl.java:555)
at org.infinispan.factories.impl.BasicComponentRegistryImpl.startWrapper(BasicComponentRegistryImpl.java:533)
at org.infinispan.factories.impl.BasicComponentRegistryImpl.access$700(BasicComponentRegistryImpl.java:31)
at org.infinispan.factories.impl.BasicComponentRegistryImpl$ComponentWrapper.running(BasicComponentRegistryImpl.java:756)
at org.infinispan.factories.AbstractComponentRegistry.internalStart(AbstractComponentRegistry.java:418)
at org.infinispan.factories.AbstractComponentRegistry.start(AbstractComponentRegistry.java:314)
at org.infinispan.manager.DefaultCacheManager.internalStart(DefaultCacheManager.java:727)
... 43 more
Caused by: java.net.SocketException: EDC8116I Address not available. (Error setting socket option)
at java.net.PlainDatagramSocketImpl.socketSetOption0(Native Method)
at java.net.PlainDatagramSocketImpl.socketSetOption(PlainDatagramSocketImpl.java:85)
at java.net.AbstractPlainDatagramSocketImpl.setOption(AbstractPlainDatagramSocketImpl.java:320)
at java.net.MulticastSocket.setInterface(MulticastSocket.java:482)
at org.jgroups.protocols.MPING.start(MPING.java:190)
at org.jgroups.stack.ProtocolStack.startStack(ProtocolStack.java:884)
at org.jgroups.JChannel.startStack(JChannel.java:980)
at org.jgroups.JChannel._preConnect(JChannel.java:844)
at org.jgroups.JChannel.connect(JChannel.java:349)
at org.jgroups.JChannel.connect(JChannel.java:343)
at org.infinispan.remoting.transport.jgroups.JGroupsTransport.startJGroupsChannelIfNeeded(JGroupsTransport.java:485)
... 64 more