### PR TITLE
don't add cert to read only keystore

### DIFF
--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/WSKeyStore.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/WSKeyStore.java
@@ -757,7 +757,12 @@ public class WSKeyStore extends Properties {
             Tr.info(tc, "Successfully loaded default keystore: " + this.location + " of type: " + this.type);
 
         // Check to see if any certificates entries from the environment need to be added to the keystore
-        addCertEntriesFromEnv();
+        if (!this.readOnly)
+            addCertEntriesFromEnv();
+        else {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                Tr.debug(tc, "The " + name + " keystore is read only will not look for an environment variable cert_" + name + " to be set");
+        }
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
             Tr.exit(tc, "do_getKeyStore", myKeyStore);


### PR DESCRIPTION
Don't add a certificate that comes from an environment variable to a read-only keystore.