### PR TITLE
better identification of http session cache name patterns

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/shared/resources/infinispan/infinispan-config-lacking-http-session-cache-name.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/shared/resources/infinispan/infinispan-config-lacking-http-session-cache-name.xml
@@ -5,7 +5,7 @@
   
   <cache-container>
     <transport stack="jgroups-tcp" />
-    <replicated-cache-configuration name="MyReplicatedCache"/>
-    <invalidation-cache-configuration name="MyInvalidationCache"/>
+    <replicated-cache-configuration name="com.ibm.ws.MyCache.attr"/>
+    <invalidation-cache-configuration name="*.session.*.inval"/>
   </cache-container>
 </infinispan>


### PR DESCRIPTION
Add matching logic to match configured Infinispan cache names that include the wild card (*) character.