### PR TITLE
9392 batch remote partition recovery

### DIFF
--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/controller/impl/PartitionedStepControllerImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/controller/impl/PartitionedStepControllerImpl.java
@@ -464,7 +464,7 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
         getPartitionReplyQueue().close();
 
         // Deal with the results.
-        checkFinishedPartitions();
+        checkFinishedPartitionsForFailures();
 
     }
 
@@ -667,7 +667,7 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
     /**
      * Issue message for partition finished and add it to the finishedPartitions list.
      */
-    private void partitionFinished(PartitionReplyMsg msg) {
+    private void partitionFinishedReplyMessageReceived(PartitionReplyMsg msg) {
         JoblogUtil.logToJobLogAndTraceOnly(Level.FINE, "partition.ended", new Object[] {
                                                                                          msg.getPartitionPlanConfig().getPartitionNumber(),
                                                                                          msg.getBatchStatus(),
@@ -799,7 +799,7 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
                             analyzerExceptions.add(t);
                         }
                         if (isFinalMessageForPartition(msg)) {
-                            partitionFinished(msg);
+                            partitionFinishedReplyMessageReceived(msg);
                         }
                     } else {
                         //If no messages left, break the loop
@@ -840,7 +840,7 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
             }
 
             if (isFinalMessageForPartition(msg)) {
-                partitionFinished(msg);
+                partitionFinishedReplyMessageReceived(msg);
                 break;
             }
             // else keep looping
@@ -973,7 +973,7 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
      * check the batch status of each partition after it's done to see if we need to issue a rollback
      * start rollback if any have stopped or failed
      */
-    private void checkFinishedPartitions() {
+    private void checkFinishedPartitionsForFailures() {
 
         List<String> failingPartitionSeen = new ArrayList<String>();
         boolean stoppedPartitionSeen = false;

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/controller/impl/PartitionedStepControllerImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/controller/impl/PartitionedStepControllerImpl.java
@@ -122,14 +122,22 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
      */
     private BatchDispatcher batchJmsDispatcher = null;
 
-    /**
-     * As sub-jobs finish, they're added to this list.
-     */
-    private final List<PartitionReplyMsg> finishedWork = new ArrayList<PartitionReplyMsg>();
+    private PartitionPlanDescriptor currentPlan;
 
-    private final Date createTime = null;
+    private static class FinishedPartition {
+        int partitionNum;
+        BatchStatus batchStatus;
 
-    private PartitionPlanDescriptor plan = null;
+        FinishedPartition(int partitionNum, BatchStatus batchStatus) {
+            this.partitionNum = partitionNum;
+            this.batchStatus = batchStatus;
+        }
+    }
+
+    List<Integer> partitionsToExecute;
+    List<Integer> startedPartitions = new ArrayList<Integer>();
+    List<FinishedPartition> finishedPartitions = new ArrayList<FinishedPartition>();
+    List<Throwable> analyzerExceptions = new ArrayList<Throwable>();
 
     /**
      * CTOR.
@@ -410,10 +418,9 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
     @Override
     protected void invokeCoreStep() {
 
-        PartitionPlanDescriptor currentPlan = buildPartitionPlan();
+        currentPlan = buildPartitionPlan();
 
-        validatePlanNumberOfPartitions(currentPlan);
-        plan = currentPlan;
+        validatePlanNumberOfPartitions();
 
         if (executionType == ExecutionType.RESTART_OVERRIDE) {
             // Justification for doing this is in the spec Javadoc of PartitionPlan#setPartitionsOverride:
@@ -438,14 +445,14 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
         // We could avoid persisting if this is restart with override=false, but not sure that's best
         // Some aspects of this too, e.g. the exact ordering of this in relation to discarding the partition data,
         // are not precisely defined by the spec, and could be considered more carefully maybe if necessary.
-        persistCurrentPlanSize(currentPlan);
+        persistCurrentPlanSize();
 
         // Create the PartitionReplyQueue
         // The sub-job partitions pass back analyzer data, job status, and "partition complete" events on this queue.
         setPartitionReplyQueue(isMultiJvm ? getBatchJmsDispatcher().createPartitionReplyQueue() : new PartitionReplyQueueLocal());
 
         // kick off the threads
-        executeAndWaitForCompletion(currentPlan);
+        executeAndWaitForCompletion();
 
         // Close the PartitionReplyQueue
         // In non multi-JVM mode, this does nothing.
@@ -463,7 +470,7 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
      *
      * @throws IllegalArgumentException if it doesn't make sense.
      */
-    private void validatePlanNumberOfPartitions(PartitionPlanDescriptor currentPlan) {
+    private void validatePlanNumberOfPartitions() {
 
         int numPreviousPartitions = getTopLevelStepInstance().getPartitionPlanSize();
         int numCurrentPartitions = currentPlan.getNumPartitionsInPlan();
@@ -489,7 +496,7 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
     /**
      * Write the plan size to the DB.
      */
-    private void persistCurrentPlanSize(PartitionPlanDescriptor currentPlan) {
+    private void persistCurrentPlanSize() {
         // Don't want to have to think about whether the instance is dirty... just update from key.
         getPersistenceManagerService().updateStepThreadInstanceWithPartitionPlanSize(getTopLevelStepInstanceKey(),
                                                                                      currentPlan.getNumPartitionsInPlan());
@@ -505,7 +512,7 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
     /**
      * @return the PartitionPlanConfig.
      */
-    private PartitionPlanConfig buildPartitionPlanConfig(PartitionPlanDescriptor currentPlan, int partitionNum) {
+    private PartitionPlanConfig buildPartitionPlanConfig(int partitionNum) {
 
         PartitionPlanConfig retMe = new PartitionPlanConfig(partitionNum, currentPlan.getPartitionProperties(partitionNum));
         retMe.setStepName(getStepName());
@@ -522,7 +529,7 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
      * @return the list of partition nums to execute. If this is a fresh start, it'll
      *         return all of them. If it's a restart, only the ones that haven't been executed.
      */
-    private List<Integer> getPartitionNumbersToExecute(PartitionPlanDescriptor currentPlan) {
+    private List<Integer> getPartitionNumbersToExecute() {
         // Note: The logic below works since 'currentPlan' had been validated for RESTART_NORMAL in
         // validatePlanNumberOfPartitions(PartitionPlanDescriptor). Otherwise there would need to be
         // a check to ensure the previous plans were the same size.
@@ -579,33 +586,23 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
      * (a) they've all been started or
      * (b) we reach max threads
      *
+     * @throws JobStoppingException
      */
-    private void startPartitions(List<Integer> partitionsToExecute,
-                                 List<Integer> startedPartitions,
-                                 List<Integer> finishedPartitions,
-                                 PartitionPlanDescriptor currentPlan) {
+    private void startPartitions() throws JobStoppingException {
 
         while (startedPartitions.size() < partitionsToExecute.size()
                && startedPartitions.size() - finishedPartitions.size() < currentPlan.getThreads()) {
 
             int nextPartitionNumber = partitionsToExecute.get(startedPartitions.size());
-            PartitionPlanConfig config = buildPartitionPlanConfig(currentPlan, nextPartitionNumber);
+            PartitionPlanConfig config = buildPartitionPlanConfig(nextPartitionNumber);
 
             Boolean nextPartitionStarted = null;
             StopLock stopLock = getStopLock(); // Store in local variable to facilitate Ctrl+Shift+G search in Eclipse
             synchronized (stopLock) {
-                nextPartitionStarted = startPartition(config);
+                startPartition(config);
             }
 
-            if (nextPartitionStarted) {
-                startedPartitions.add(nextPartitionNumber);
-            } else {
-                // The partition wasn't started (probably because we're stopping).
-                // Add the partitionNumber to both the started and finished lists,
-                // so that the while-loop logic works as expected.
-                startedPartitions.add(nextPartitionNumber);
-                finishedPartitions.add(nextPartitionNumber);
-            }
+            startedPartitions.add(nextPartitionNumber);
         }
     }
 
@@ -638,11 +635,12 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
      * This method is synchronized with stop().
      *
      * @return true if the partition was started; false otherwise (because we're stopping)
+     * @throws JobStoppingException
      */
-    private boolean startPartition(PartitionPlanConfig config) {
+    private boolean startPartition(PartitionPlanConfig config) throws JobStoppingException {
 
         if (isStoppingStoppedOrFailed()) {
-            return false;
+            throw new JobStoppingException();
         }
 
         if (isMultiJvm) {
@@ -662,10 +660,9 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
     }
 
     /**
-     * Issue message for partition finished and add it to the finishedWork list.
+     * Issue message for partition finished and add it to the finishedPartitions list.
      */
     private void partitionFinished(PartitionReplyMsg msg) {
-
         JoblogUtil.logToJobLogAndTraceOnly(Level.FINE, "partition.ended", new Object[] {
                                                                                          msg.getPartitionPlanConfig().getPartitionNumber(),
                                                                                          msg.getBatchStatus(),
@@ -675,13 +672,13 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
                                                                                          msg.getPartitionPlanConfig().getTopLevelNameInstanceExecutionInfo().getExecutionId() },
                                            logger);
 
-        finishedWork.add(msg);
+        finishedPartitions.add(new FinishedPartition(msg.getPartitionPlanConfig().getPartitionNumber(), msg.getBatchStatus()));
     }
 
     /**
      * Call the analyzerProxy (if one was supplied) with the given partition data.
      */
-    private void processPartitionReplyMsg(PartitionReplyMsg msg) {
+    private void analyzePartitionReplyMsg(PartitionReplyMsg msg) {
 
         if (analyzerProxy == null) {
             return;
@@ -739,35 +736,35 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
      *
      * @return data sent back from the partition to the top-level thread or return null
      */
-    private PartitionReplyMsg waitForPartitionReplyMsgNoWait() {
+    private PartitionReplyMsg getPartitionReplyMsgNoWait() {
         return getPartitionReplyQueue().takeWithoutWaiting();
     }
 
     /**
      * Wait and process the data sent back by the partitions.
-     * This method returns as soon as the next partition sends back an "i'm finished" message.
+     * This method returns as soon as the next partition sends back a finished message.
      *
-     * @param analyzerExceptions collects any exceptions thrown by the user-supplied Analyzer
-     * @param finishedPartitions
-     *
-     * @return the partition number of the finished partition
      */
-    private void waitForNextPartitionToFinish(List<Throwable> analyzerExceptions, List<Integer> finishedPartitions) throws JobStoppingException {
+    private void waitForNextPartitionToFinish() throws JobStoppingException {
 
         //Use this counter to count the number of cycles we recieve jms reply message
         boolean isStoppingStoppedOrFailed = false;
         PartitionReplyMsg msg = null;
 
         do {
-            //TODO - We won't worry about local dispatch until we're prepated to code up
-            // the structure necessary to break free from waiting on the BlockingQueue
+
             if (isMultiJvm) {
                 if (isStoppingStoppedOrFailed()) {
                     isStoppingStoppedOrFailed = true;
                 }
+
+                checkForRecoveredRemotePartitions();
             }
 
-            //This will only be triggered when stop issued
+            //TODO - We won't worry about the case when a local dispatch has been stopped until
+            // we're prepared to code up the structure necessary to break free from waiting on
+            // the BlockingQueue
+
             if (isStoppingStoppedOrFailed) {
 
                 //TODO - Crude, and the JVM doesn't have to follow this too closely.
@@ -781,48 +778,95 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
                     // do nothing
                 }
 
+                // Process any reply messages queued up, but in order to not delay stop too long we will
+                // exit the first time we look at the queue and see there is no message.
                 while (true) {
-                    //Get the message from the replyToQueue
-                    msg = waitForPartitionReplyMsgNoWait();
-                    //If no messages left, break the loop
+                    msg = getPartitionReplyMsgNoWait();
                     if (msg != null) {
                         try {
-                            processPartitionReplyMsg(msg);
+                            analyzePartitionReplyMsg(msg);
                         } catch (Throwable t) {
                             // FFDC.
                             // Remember the exception for rollback later.
                             analyzerExceptions.add(t);
                         }
-                        //check if last message received, and process it.
-                        receivedLastMessageForPartition(msg, finishedPartitions);
+                        if (isFinalMessageForPartition(msg)) {
+                            partitionFinished(msg);
+                        }
                     } else {
+                        //If no messages left, break the loop
                         throw new JobStoppingException();
                     }
                 }
             } else {
                 //This is executed when stop has not been issued
                 msg = waitForPartitionReplyMsg();
-                //If waitForPartitionReplyMsg times out after 15 seconds, go back to the top and check
-                //if stop has been issued or not
                 if (msg == null) {
+                    //If waitForPartitionReplyMsg times out after 15 seconds, go back to the top
                     continue;
                 }
             }
-            //This should never be executed while msg == null cause it the loop would have been broken or continued
+
             try {
-                processPartitionReplyMsg(msg);
+                analyzePartitionReplyMsg(msg);
             } catch (Throwable t) {
                 // FFDC.
                 // Remember the exception for rollback later.
                 analyzerExceptions.add(t);
             }
 
-        } while (msg == null || !receivedLastMessageForPartition(msg, finishedPartitions));
+            if (isFinalMessageForPartition(msg)) {
+                partitionFinished(msg);
+                break;
+            }
+            // else keep looping
+        } while (true);
+    }
 
+    /**
+     *
+     */
+    private void checkForRecoveredRemotePartitions() {
+        // We shouldn't be seeing recovered remote partitions too often, so we won't try to optimize either the query itself or the process of matching the results against the list of recovered partitions
+        // that we've already processed.
+        long stepExecId = runtimeStepExecution.getTopLevelStepExecutionId();
+        List<Integer> recoveredPartitions = getPersistenceManagerService().getRemotablePartitionsRecoveredForStepExecution(stepExecId);
+        if (recoveredPartitions.size() > 0) {
+            logger.finer("Found list: " + recoveredPartitions + " of new recovered remote partitions for stepExecId = " + stepExecId);
+        } else {
+            logger.finer("Did not find any recovered partitions for stepExecId = " + stepExecId);
+        }
+        for (int recoveredPartitionNum : recoveredPartitions) {
+            for (FinishedPartition p : finishedPartitions) {
+                if (recoveredPartitionNum == p.partitionNum) {
+                    logger.finer("Recovered remote partition # " + recoveredPartitionNum + " is already marked as finished.");
+                    continue;
+                }
+            }
+            logger.finer("Found new recovered remote partition # " + recoveredPartitionNum);
+            handleRecoveredRemotePartition(recoveredPartitionNum);
+        }
+    }
+
+    /**
+     * @param recoveredPartitionNum
+     */
+    private void handleRecoveredRemotePartition(int recoveredPartitionNum) {
+
+        JoblogUtil.logToJobLogAndTraceOnly(Level.FINE, "partition.ended", new Object[] {
+                                                                                         recoveredPartitionNum,
+                                                                                         BatchStatus.FAILED,
+                                                                                         "FAILED",
+                                                                                         getStepName(),
+                                                                                         runtimeWorkUnitExecution.getTopLevelNameInstanceExecutionInfo().getInstanceId(),
+                                                                                         runtimeWorkUnitExecution.getTopLevelNameInstanceExecutionInfo().getExecutionId() },
+                                           logger);
+
+        finishedPartitions.add(new FinishedPartition(recoveredPartitionNum, BatchStatus.FAILED));
     }
 
     /*
-     * Check if its the last message received for this partition
+     * Check if it's the last message received for a partition
      *
      * We are still checking for THREAD_COMPLETE to maintain compatibility with 8.5.5.7,
      * which sends FINAL_STATUS without a partitionNumber ,and THREAD_COMPLETE with a partitionNumber,
@@ -832,21 +876,16 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
      *
      * @returns false if more messages are to be received for the partition
      */
-    private boolean receivedLastMessageForPartition(PartitionReplyMsg msg, List<Integer> finishedPartitions) {
+    private boolean isFinalMessageForPartition(PartitionReplyMsg msg) {
 
         switch (msg.getMsgType()) {
-
             case PARTITION_FINAL_STATUS:
                 if (msg.getPartitionPlanConfig() != null) {
-                    partitionFinished(msg);
-                    finishedPartitions.add(msg.getPartitionPlanConfig().getPartitionNumber());
                     return true;
                 } else {
                     return false;
                 }
             case PARTITION_THREAD_COMPLETE:
-                partitionFinished(msg);
-                finishedPartitions.add(msg.getPartitionPlanConfig().getPartitionNumber());
                 return true;
             default:
                 return false;
@@ -857,7 +896,7 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
      * Spawn the partitions and wait for them to complete.
      */
     @FFDCIgnore(JobStoppingException.class)
-    private void executeAndWaitForCompletion(PartitionPlanDescriptor currentPlan) throws JobRestartException {
+    private void executeAndWaitForCompletion() throws JobRestartException {
         if (isStoppingStoppedOrFailed()) {
             logger.fine("Job already in "
                         + runtimeWorkUnitExecution.getWorkUnitJobContext().getBatchStatus().toString()
@@ -865,19 +904,19 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
             return;
         }
 
-        List<Integer> partitionsToExecute = getPartitionNumbersToExecute(currentPlan);
+        partitionsToExecute = getPartitionNumbersToExecute();
 
         logger.fine("Partitions to execute in this run: " + partitionsToExecute
                     + ".  Total number of partitions in step: " + currentPlan.getNumPartitionsInPlan());
 
-        List<Integer> startedPartitions = new ArrayList<Integer>();
-        List<Integer> finishedPartitions = new ArrayList<Integer>();
-        List<Throwable> analyzerExceptions = new ArrayList<Throwable>();
-
         // Keep looping until all partitions have finished.
         while (finishedPartitions.size() < partitionsToExecute.size()) {
 
-            startPartitions(partitionsToExecute, startedPartitions, finishedPartitions, currentPlan);
+            try {
+                startPartitions();
+            } catch (JobStoppingException e) {
+                break;
+            }
 
             // Check that there are still un-finished partitions running.
             // If not, break out of the loop.
@@ -885,11 +924,9 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
                 break;
             }
 
-            //Break this loop when nextPartitionFinished is -1
             try {
-                waitForNextPartitionToFinish(analyzerExceptions, finishedPartitions);
+                waitForNextPartitionToFinish();
             } catch (JobStoppingException e) {
-                // break the loop
                 break;
             }
         }
@@ -909,21 +946,24 @@ public class PartitionedStepControllerImpl extends BaseStepControllerImpl {
         List<String> failingPartitionSeen = new ArrayList<String>();
         boolean stoppedPartitionSeen = false;
 
-        for (PartitionReplyMsg replyMsg : finishedWork) {
-            BatchStatus batchStatus = replyMsg.getBatchStatus();
+        for (FinishedPartition p : finishedPartitions) {
+
+            int partitionNumber = p.partitionNum;
+            BatchStatus batchStatus = p.batchStatus;
 
             if (logger.isLoggable(Level.FINE)) {
                 logger.fine("For partitioned step: " + getStepName() + ", the partition # " +
-                            replyMsg.getPartitionPlanConfig().getPartitionNumber() + " ended with status '" + batchStatus);
+                            partitionNumber + " ended with status '" + batchStatus);
             }
 
             // Keep looping, just to see the log messages perhaps.
             if (batchStatus.equals(BatchStatus.FAILED)) {
 
                 String msg = "For partitioned step: " + getStepName() + ", the partition # " +
-                             replyMsg.getPartitionPlanConfig().getPartitionNumber() + " ended with status '" + batchStatus;
+                             partitionNumber + " ended with status '" + batchStatus;
                 failingPartitionSeen.add(msg);
             }
+
             // This code seems to suggest it might be valid for a partition to end up in STOPPED state without
             // the "top-level" step having been aware of this.   It's unclear from the spec if this is even possible
             // or a desirable spec interpretation.  Nevertheless, we'll code it as such noting the ambiguity.

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/execution/impl/JobExecutionHelper.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/execution/impl/JobExecutionHelper.java
@@ -1,13 +1,13 @@
 /*
  * Copyright 2012 International Business Machines Corp.
- * 
+ *
  * See the NOTICE file distributed with this work for additional information
- * regarding copyright ownership. Licensed under the Apache License, 
+ * regarding copyright ownership. Licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -57,7 +57,7 @@ public class JobExecutionHelper {
 
     /**
      * BatchKernelImpl delegates some operations to this class.
-     * 
+     *
      * The ref back is needed to resolve DS service refs maintained by BatchKernelImpl.
      */
     private final BatchKernelImpl batchKernelImpl;
@@ -78,9 +78,9 @@ public class JobExecutionHelper {
 
     /**
      * Note: this method is called on the job submission thread.
-     * 
+     *
      * Updates the jobinstance record with the jobXML and jobname (jobid in jobxml).
-     * 
+     *
      * @return a new RuntimeJobExecution record, ready to be dispatched.
      */
     public RuntimeJobExecution createJobStartExecution(final WSJobInstance jobInstance,
@@ -107,7 +107,7 @@ public class JobExecutionHelper {
             }
 
         } catch (IllegalStateException ie) {
-            // If no execution exists, request came from old dispatch path.  
+            // If no execution exists, request came from old dispatch path.
             jobExec = getPersistenceManagerService().createJobExecution(instanceId, jobParameters, new Date());
             BatchEventsPublisher eventsPublisher = batchKernelImpl.getBatchEventsPublisher();
             if (eventsPublisher != null) {
@@ -121,12 +121,12 @@ public class JobExecutionHelper {
         return new RuntimeJobExecution(topLevelInfo, jobParameters, navigator);
     }
 
-    public RuntimeJobExecution createJobRestartExecution(long jobInstanceId, IJobXMLSource jobXML, Properties restartJobParameters, long executionId)
-                    throws JobRestartException, JobExecutionAlreadyCompleteException, JobExecutionNotMostRecentException, NoSuchJobExecutionException {
+    public RuntimeJobExecution createJobRestartExecution(long jobInstanceId, IJobXMLSource jobXML, Properties restartJobParameters,
+                                                         long executionId) throws JobRestartException, JobExecutionAlreadyCompleteException, JobExecutionNotMostRecentException, NoSuchJobExecutionException {
 
         JobInstanceEntity jobInstance = getPersistenceManagerService().getJobInstance(jobInstanceId);
 
-        // Check if the job XML has not been persisted yet. Could happen if job was stopped before 
+        // Check if the job XML has not been persisted yet. Could happen if job was stopped before
         // any executions were created.
         if (StringUtils.isEmpty(jobInstance.getJobXml())) {
             createFirstExecution(jobInstance, jobXML, restartJobParameters);
@@ -140,7 +140,7 @@ public class JobExecutionHelper {
             logger.fine("On restart execution with jobInstance Id = " + jobInstanceId + ", batchStatus = " + jobInstance.getBatchStatus().name());
         }
 
-        // TODO: we never check the state of the most-recent executionId. if it's still running (STARTED), 
+        // TODO: we never check the state of the most-recent executionId. if it's still running (STARTED),
         //       then we'll end up creating an invalid execution record for the restart.  the invalid execution record will forever remain in state STARTING.
         // Timestamp now = new Timestamp(System.currentTimeMillis());
         JobExecutionEntity newExecution = null;
@@ -156,7 +156,7 @@ public class JobExecutionHelper {
         } else {
             newExecution = getPersistenceManagerService().getJobExecutionMostRecent(jobInstanceId);
             // Check to make sure the executionId belongs to the most recent execution.
-            // If not, another restart may have occurred. So, fail this restart.	
+            // If not, another restart may have occurred. So, fail this restart.
             // Also check to make sure a stop did not come in while the start was on the queue.
             BatchStatus currentBatchStatus = newExecution.getBatchStatus();
             if (newExecution.getExecutionId() != executionId ||
@@ -169,9 +169,7 @@ public class JobExecutionHelper {
             logger.fine("On restartExecution got new execution id = " + newExecution.getExecutionId());
         }
 
-        TopLevelNameInstanceExecutionInfo topLevelInfo = new TopLevelNameInstanceExecutionInfo(navigator.getRootModelElement().getId(),
-                        jobInstanceId,
-                        newExecution.getExecutionId());
+        TopLevelNameInstanceExecutionInfo topLevelInfo = new TopLevelNameInstanceExecutionInfo(navigator.getRootModelElement().getId(), jobInstanceId, newExecution.getExecutionId());
 
         return new RuntimeJobExecution(topLevelInfo, restartJobParameters, restartOnFromLastExecution, navigator);
     }
@@ -213,11 +211,8 @@ public class JobExecutionHelper {
                                                               JSLJob partitionJobModel,
                                                               boolean isRemoteDispatch) throws JobStartException {
 
-        RemotablePartitionKey partitionKey = new RemotablePartitionKey(partitionPlanConfig.getTopLevelNameInstanceExecutionInfo().getExecutionId(),
-                        partitionPlanConfig.getStepName(),
-                        partitionPlanConfig.getPartitionNumber());
+        RemotablePartitionKey partitionKey = new RemotablePartitionKey(partitionPlanConfig.getTopLevelNameInstanceExecutionInfo().getExecutionId(), partitionPlanConfig.getStepName(), partitionPlanConfig.getPartitionNumber());
 
-        getPersistenceManagerService().createPartitionExecution(partitionKey, new Date());
         ModelNavigator<JSLJob> navigator = getResolvedPartitionNavigator(partitionJobModel, partitionPlanConfig.getPartitionPlanProperties());
 
         return new RuntimePartitionExecution(partitionPlanConfig, navigator, isRemoteDispatch);

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/execution/impl/RuntimePartitionExecution.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/execution/impl/RuntimePartitionExecution.java
@@ -137,19 +137,16 @@ public class RuntimePartitionExecution extends RuntimeWorkUnitExecution {
     @Override
     public void workStarted(Date date) {
         batchStatus = BatchStatus.STARTED;
-        getPersistenceManagerService().updatePartitionExecution(this, batchStatus, date);
         publishPartitionEvent();
     }
 
     @Override
     public void workStopping(Date date) {
         batchStatus = BatchStatus.STOPPING;
-        getPersistenceManagerService().updatePartitionExecution(this, batchStatus, date);
     }
 
     @Override
     public void workEnded(Date date) {
-        getPersistenceManagerService().updatePartitionExecution(this, batchStatus, date);
         publishPartitionEvent();
     }
 

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobExecutionEntity.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobExecutionEntity.java
@@ -36,6 +36,7 @@ import javax.persistence.OneToMany;
 import org.eclipse.persistence.annotations.ClassExtractor;
 
 import com.ibm.jbatch.container.ws.WSJobExecution;
+import com.ibm.websphere.ras.annotation.Trivial;
 
 @NamedQueries({
                 @NamedQuery(name = JobExecutionEntity.UPDATE_JOB_EXECUTION_AND_INSTANCE_SERVER_NOT_SET, query = "UPDATE JobExecutionEntity x SET x.batchStatus = :batchStatus, x.lastUpdatedTime = :lastUpdatedTime WHERE x.jobExecId = :jobExecId AND x.serverId IS NULL"),
@@ -112,6 +113,7 @@ public class JobExecutionEntity extends JobThreadExecutionBase implements JobExe
     private Collection<StepThreadExecutionEntity> stepThreadExecutions;
 
     // For JPA
+    @Trivial
     public JobExecutionEntity() {
     }
 

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobExecutionEntityExtractor.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobExecutionEntityExtractor.java
@@ -29,21 +29,21 @@ public class JobExecutionEntityExtractor extends ClassExtractor {
 
         //
         // If we understood the lifecycle of ClassExtractor within EclipseLink we
-        // might want to cache the tableversion here, but to be safe, let's call
+        // might want to cache the entityVersion here, but to be safe, let's call
         // each time, (and there's no particular reason to be concerned about performance here).
         //
 
-        Integer tableversion = null;
+        Integer entityVersion = null;
 
         try {
-            tableversion = ServicesManagerStaticAnchor.getServicesManager().getPersistenceManagerService().getJobExecutionTableVersionField();
+            entityVersion = ServicesManagerStaticAnchor.getServicesManager().getPersistenceManagerService().getJobExecutionEntityVersionField();
         } catch (Exception ex) {
             throw new BatchRuntimeException(ex);
         }
 
-        if (tableversion == 3) {
+        if (entityVersion == 3) {
             return JobExecutionEntityV3.class;
-        } else if (tableversion == 2) {
+        } else if (entityVersion == 2) {
             return JobExecutionEntityV2.class;
         } else {
             return JobExecutionEntity.class;

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobExecutionEntityV2.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobExecutionEntityV2.java
@@ -20,6 +20,8 @@ import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 
+import com.ibm.websphere.ras.annotation.Trivial;
+
 @Entity
 public class JobExecutionEntityV2 extends JobExecutionEntity {
 
@@ -31,6 +33,7 @@ public class JobExecutionEntityV2 extends JobExecutionEntity {
     private Set<JobParameter> jobParameterElements;
 
     // For JPA
+    @Trivial
     public JobExecutionEntityV2() {
         super();
     }

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobExecutionEntityV3.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobExecutionEntityV3.java
@@ -24,9 +24,6 @@ import com.ibm.websphere.ras.annotation.Trivial;
 public class JobExecutionEntityV3 extends JobExecutionEntityV2 {
 
     @OneToMany(mappedBy = "jobExec", cascade = CascadeType.REMOVE)
-    private Collection<RemotablePartitionEntity> partitionExecutions;
-
-    @OneToMany(mappedBy = "jobExec", cascade = CascadeType.REMOVE)
     private Collection<RemotablePartitionEntity> remotablePartitions;
 
     // For JPA

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobExecutionEntityV3.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobExecutionEntityV3.java
@@ -18,6 +18,8 @@ import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.OneToMany;
 
+import com.ibm.websphere.ras.annotation.Trivial;
+
 @Entity
 public class JobExecutionEntityV3 extends JobExecutionEntityV2 {
 
@@ -28,6 +30,7 @@ public class JobExecutionEntityV3 extends JobExecutionEntityV2 {
     private Collection<RemotablePartitionEntity> remotablePartitions;
 
     // For JPA
+    @Trivial
     public JobExecutionEntityV3() {
         super();
     }

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobInstanceEntity.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobInstanceEntity.java
@@ -39,6 +39,7 @@ import org.eclipse.persistence.annotations.ClassExtractor;
 
 import com.ibm.jbatch.container.ws.InstanceState;
 import com.ibm.jbatch.container.ws.WSJobInstance;
+import com.ibm.websphere.ras.annotation.Trivial;
 
 @NamedQueries({
                 @NamedQuery(name = JobInstanceEntity.GET_JOBINSTANCEIDS_BY_NAME_AND_STATUSES_QUERY, query = "SELECT i.instanceId FROM JobInstanceEntity i WHERE i.batchStatus IN :status AND i.jobName = :name"),
@@ -75,7 +76,9 @@ public class JobInstanceEntity implements JobInstance, WSJobInstance, EntityCons
     private long instanceId;
 
     // JPA
-    public JobInstanceEntity() {}
+    @Trivial
+    public JobInstanceEntity() {
+    }
 
     // in-memory
     public JobInstanceEntity(long instanceId) {
@@ -268,7 +271,8 @@ public class JobInstanceEntity implements JobInstance, WSJobInstance, EntityCons
         return null;
     }
 
-    public void setLastUpdatedTime(Date lastUpdatedTime) {}
+    public void setLastUpdatedTime(Date lastUpdatedTime) {
+    }
 
     public int getNumberOfExecutions() {
         return numberOfExecutions;

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobInstanceEntityExtractor.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobInstanceEntityExtractor.java
@@ -30,21 +30,21 @@ public class JobInstanceEntityExtractor extends ClassExtractor {
 
         //
         // If we understood the lifecycle of ClassExtractor within EclipseLink we
-        // might want to cache the tableversion here, but to be safe, let's call
+        // might want to cache the entityVersion here, but to be safe, let's call
         // each time, (and there's no particular reason to be concerned about performance here).
         //
 
-        Integer tableversion = null;
+        Integer entityVersion = null;
 
         try {
-            tableversion = ServicesManagerStaticAnchor.getServicesManager().getPersistenceManagerService().getJobInstanceTableVersionField();
+            entityVersion = ServicesManagerStaticAnchor.getServicesManager().getPersistenceManagerService().getJobInstanceEntityVersionField();
         } catch (Exception ex) {
             throw new BatchRuntimeException(ex);
         }
 
-        if (tableversion == 3) {
+        if (entityVersion == 3) {
             return JobInstanceEntityV3.class;
-        } else if (tableversion == 2) {
+        } else if (entityVersion == 2) {
             return JobInstanceEntityV2.class;
         } else {
             return JobInstanceEntity.class;

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobInstanceEntityV2.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobInstanceEntityV2.java
@@ -16,10 +16,13 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Temporal;
 
+import com.ibm.websphere.ras.annotation.Trivial;
+
 @Entity
 public class JobInstanceEntityV2 extends JobInstanceEntity {
 
     // JPA
+    @Trivial
     public JobInstanceEntityV2() { super(); }
 
     // in-memory

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobInstanceEntityV3.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobInstanceEntityV3.java
@@ -29,6 +29,8 @@ import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 
+import com.ibm.websphere.ras.annotation.Trivial;
+
 /**
  *
  */
@@ -41,6 +43,7 @@ public class JobInstanceEntityV3 extends JobInstanceEntityV2 {
     private Set<String> groupNames;
 
     // For JPA
+    @Trivial
     public JobInstanceEntityV3() {
         super();
     }

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/RemotablePartitionEntity.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/RemotablePartitionEntity.java
@@ -25,11 +25,9 @@ import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
-import javax.persistence.UniqueConstraint;
 
 import com.ibm.jbatch.container.ws.RemotablePartitionState;
 import com.ibm.jbatch.container.ws.WSRemotablePartitionExecution;
-
 import com.ibm.websphere.ras.annotation.Trivial;
 
 /**
@@ -44,7 +42,7 @@ import com.ibm.websphere.ras.annotation.Trivial;
 })
 
 @IdClass(RemotablePartitionKey.class)
-@Table(uniqueConstraints = @UniqueConstraint(columnNames = { "FK_JOBEXECUTIONID", "STEPNAME", "PARTNUM" }))
+@Table
 @Entity
 public class RemotablePartitionEntity implements WSRemotablePartitionExecution {
 

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/RemotablePartitionEntity.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/RemotablePartitionEntity.java
@@ -39,7 +39,7 @@ import com.ibm.websphere.ras.annotation.Trivial;
                 @NamedQuery(name = RemotablePartitionEntity.GET_ALL_RELATED_REMOTABLE_PARTITIONS, query = "SELECT r FROM RemotablePartitionEntity r WHERE r.stepExecutionEntity.stepExecutionId IN (SELECT s.stepExecutionId FROM StepThreadExecutionEntity s WHERE s.topLevelStepExecution.stepExecutionId = :topLevelStepExecutionId AND TYPE(s) = StepThreadExecutionEntity ) ORDER BY r.stepExecutionEntity.partitionNumber ASC"),
 
                 @NamedQuery(name = RemotablePartitionEntity.GET_PARTITION_STEP_THREAD_EXECUTIONIDS_BY_SERVERID_AND_STATUSES_QUERY, query = "SELECT r FROM RemotablePartitionEntity r WHERE r.serverId = :serverid AND r.stepExecutionEntity.batchStatus IN :status ORDER BY r.stepExecutionEntity.startTime DESC"),
-                @NamedQuery(name = RemotablePartitionEntity.GET_RECOVERED_REMOTABLE_PARITIONS, query = "SELECT r.partitionNumber FROM RemotablePartitionEntity r WHERE r.internalStatus = com.ibm.jbatch.container.ws.WSRemotablePartitionState.RECOVERED AND r.stepExecutionEntity.topLevelStepExecution.stepExecutionId = :topLevelStepExecutionId ORDER BY r.stepExecutionEntity.partitionNumber ASC"),
+                @NamedQuery(name = RemotablePartitionEntity.GET_RECOVERED_REMOTABLE_PARTITIONS, query = "SELECT r.partitionNumber FROM RemotablePartitionEntity r WHERE r.internalStatus = com.ibm.jbatch.container.ws.WSRemotablePartitionState.RECOVERED AND r.stepExecutionEntity.topLevelStepExecution.stepExecutionId = :topLevelStepExecutionId ORDER BY r.stepExecutionEntity.partitionNumber ASC"),
 })
 
 @IdClass(RemotablePartitionKey.class)
@@ -57,7 +57,7 @@ public class RemotablePartitionEntity implements WSRemotablePartitionExecution {
 
     public static final String GET_ALL_RELATED_REMOTABLE_PARTITIONS = "RemotablePartitionEntity.getAllRelatedRemotablePartitions";
     public static final String GET_PARTITION_STEP_THREAD_EXECUTIONIDS_BY_SERVERID_AND_STATUSES_QUERY = "RemotablePartitionEntity.getPartitionStepExecutionByServerIdAndStatusesQuery";
-    public static final String GET_RECOVERED_REMOTABLE_PARITIONS = "RemotablePartitionEntity.getRecoveredRemotablePartitions";
+    public static final String GET_RECOVERED_REMOTABLE_PARTITIONS = "RemotablePartitionEntity.getRecoveredRemotablePartitions";
 
     @Id
     @ManyToOne()

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/RemotablePartitionEntity.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/RemotablePartitionEntity.java
@@ -26,8 +26,8 @@ import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 
-import com.ibm.jbatch.container.ws.RemotablePartitionState;
 import com.ibm.jbatch.container.ws.WSRemotablePartitionExecution;
+import com.ibm.jbatch.container.ws.WSRemotablePartitionState;
 import com.ibm.websphere.ras.annotation.Trivial;
 
 /**
@@ -39,7 +39,7 @@ import com.ibm.websphere.ras.annotation.Trivial;
                 @NamedQuery(name = RemotablePartitionEntity.GET_ALL_RELATED_REMOTABLE_PARTITIONS, query = "SELECT r FROM RemotablePartitionEntity r WHERE r.stepExecutionEntity.stepExecutionId IN (SELECT s.stepExecutionId FROM StepThreadExecutionEntity s WHERE s.topLevelStepExecution.stepExecutionId = :topLevelStepExecutionId AND TYPE(s) = StepThreadExecutionEntity ) ORDER BY r.stepExecutionEntity.partitionNumber ASC"),
 
                 @NamedQuery(name = RemotablePartitionEntity.GET_PARTITION_STEP_THREAD_EXECUTIONIDS_BY_SERVERID_AND_STATUSES_QUERY, query = "SELECT r FROM RemotablePartitionEntity r WHERE r.serverId = :serverid AND r.stepExecutionEntity.batchStatus IN :status ORDER BY r.stepExecutionEntity.startTime DESC"),
-                @NamedQuery(name = RemotablePartitionEntity.GET_RECOVERED_REMOTABLE_PARITIONS, query = "SELECT r.stepExecutionEntity.partitionNumber FROM RemotablePartitionEntity r, StepThreadExecutionEntity s WHERE r.internalStatus = com.ibm.jbatch.container.ws.RemotablePartitionState.RECOVERED AND r.stepExecutionEntity.topLevelStepExecution.stepExecutionId = :topLevelStepExecutionId ORDER BY r.stepExecutionEntity.partitionNumber ASC"),
+                @NamedQuery(name = RemotablePartitionEntity.GET_RECOVERED_REMOTABLE_PARITIONS, query = "SELECT r.stepExecutionEntity.partitionNumber FROM RemotablePartitionEntity r, StepThreadExecutionEntity s WHERE r.internalStatus = com.ibm.jbatch.container.ws.WSRemotablePartitionState.RECOVERED AND r.stepExecutionEntity.topLevelStepExecution.stepExecutionId = :topLevelStepExecutionId ORDER BY r.stepExecutionEntity.partitionNumber ASC"),
 })
 
 @IdClass(RemotablePartitionKey.class)
@@ -76,7 +76,7 @@ public class RemotablePartitionEntity implements WSRemotablePartitionExecution {
     private int partitionNumber;
 
     @Column(name = "INTERNALSTATE")
-    private RemotablePartitionState internalStatus;
+    private WSRemotablePartitionState internalStatus;
 
     @Column(name = "SERVERID", length = 256)
     private String serverId;
@@ -140,11 +140,11 @@ public class RemotablePartitionEntity implements WSRemotablePartitionExecution {
         this.partitionNumber = partitionNumber;
     }
 
-    public RemotablePartitionState getInternalStatus() {
+    public WSRemotablePartitionState getInternalStatus() {
         return internalStatus;
     }
 
-    public void setInternalStatus(RemotablePartitionState execution) {
+    public void setInternalStatus(WSRemotablePartitionState execution) {
         this.internalStatus = execution;
     }
 

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/RemotablePartitionEntity.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/RemotablePartitionEntity.java
@@ -39,7 +39,7 @@ import com.ibm.websphere.ras.annotation.Trivial;
                 @NamedQuery(name = RemotablePartitionEntity.GET_ALL_RELATED_REMOTABLE_PARTITIONS, query = "SELECT r FROM RemotablePartitionEntity r WHERE r.stepExecutionEntity.stepExecutionId IN (SELECT s.stepExecutionId FROM StepThreadExecutionEntity s WHERE s.topLevelStepExecution.stepExecutionId = :topLevelStepExecutionId AND TYPE(s) = StepThreadExecutionEntity ) ORDER BY r.stepExecutionEntity.partitionNumber ASC"),
 
                 @NamedQuery(name = RemotablePartitionEntity.GET_PARTITION_STEP_THREAD_EXECUTIONIDS_BY_SERVERID_AND_STATUSES_QUERY, query = "SELECT r FROM RemotablePartitionEntity r WHERE r.serverId = :serverid AND r.stepExecutionEntity.batchStatus IN :status ORDER BY r.stepExecutionEntity.startTime DESC"),
-                @NamedQuery(name = RemotablePartitionEntity.GET_RECOVERED_REMOTABLE_PARITIONS, query = "SELECT r.stepExecutionEntity.partitionNumber FROM RemotablePartitionEntity r, StepThreadExecutionEntity s WHERE r.internalStatus = com.ibm.jbatch.container.ws.WSRemotablePartitionState.RECOVERED AND r.stepExecutionEntity.topLevelStepExecution.stepExecutionId = :topLevelStepExecutionId ORDER BY r.stepExecutionEntity.partitionNumber ASC"),
+                @NamedQuery(name = RemotablePartitionEntity.GET_RECOVERED_REMOTABLE_PARITIONS, query = "SELECT r.partitionNumber FROM RemotablePartitionEntity r WHERE r.internalStatus = com.ibm.jbatch.container.ws.WSRemotablePartitionState.RECOVERED AND r.stepExecutionEntity.topLevelStepExecution.stepExecutionId = :topLevelStepExecutionId ORDER BY r.stepExecutionEntity.partitionNumber ASC"),
 })
 
 @IdClass(RemotablePartitionKey.class)

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/RemotablePartitionEntity.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/RemotablePartitionEntity.java
@@ -30,6 +30,8 @@ import javax.persistence.UniqueConstraint;
 import com.ibm.jbatch.container.ws.RemotablePartitionState;
 import com.ibm.jbatch.container.ws.WSRemotablePartitionExecution;
 
+import com.ibm.websphere.ras.annotation.Trivial;
+
 /**
  * @author skurz
  *
@@ -89,6 +91,7 @@ public class RemotablePartitionEntity implements WSRemotablePartitionExecution {
     @Column(name = "LASTUPDATED")
     private Date lastUpdated;
 
+    @Trivial
     public RemotablePartitionEntity() {
     }
 

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/RemotablePartitionEntity.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/RemotablePartitionEntity.java
@@ -39,6 +39,7 @@ import com.ibm.websphere.ras.annotation.Trivial;
                 @NamedQuery(name = RemotablePartitionEntity.GET_ALL_RELATED_REMOTABLE_PARTITIONS, query = "SELECT r FROM RemotablePartitionEntity r WHERE r.stepExecutionEntity.stepExecutionId IN (SELECT s.stepExecutionId FROM StepThreadExecutionEntity s WHERE s.topLevelStepExecution.stepExecutionId = :topLevelStepExecutionId AND TYPE(s) = StepThreadExecutionEntity ) ORDER BY r.stepExecutionEntity.partitionNumber ASC"),
 
                 @NamedQuery(name = RemotablePartitionEntity.GET_PARTITION_STEP_THREAD_EXECUTIONIDS_BY_SERVERID_AND_STATUSES_QUERY, query = "SELECT r FROM RemotablePartitionEntity r WHERE r.serverId = :serverid AND r.stepExecutionEntity.batchStatus IN :status ORDER BY r.stepExecutionEntity.startTime DESC"),
+                @NamedQuery(name = RemotablePartitionEntity.GET_RECOVERED_REMOTABLE_PARITIONS, query = "SELECT r.stepExecutionEntity.partitionNumber FROM RemotablePartitionEntity r, StepThreadExecutionEntity s WHERE r.internalStatus = com.ibm.jbatch.container.ws.RemotablePartitionState.RECOVERED AND r.stepExecutionEntity.topLevelStepExecution.stepExecutionId = :topLevelStepExecutionId ORDER BY r.stepExecutionEntity.partitionNumber ASC"),
 })
 
 @IdClass(RemotablePartitionKey.class)
@@ -56,6 +57,7 @@ public class RemotablePartitionEntity implements WSRemotablePartitionExecution {
 
     public static final String GET_ALL_RELATED_REMOTABLE_PARTITIONS = "RemotablePartitionEntity.getAllRelatedRemotablePartitions";
     public static final String GET_PARTITION_STEP_THREAD_EXECUTIONIDS_BY_SERVERID_AND_STATUSES_QUERY = "RemotablePartitionEntity.getPartitionStepExecutionByServerIdAndStatusesQuery";
+    public static final String GET_RECOVERED_REMOTABLE_PARITIONS = "RemotablePartitionEntity.getRecoveredRemotablePartitions";
 
     @Id
     @ManyToOne()

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/RemotableSplitFlowEntity.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/RemotableSplitFlowEntity.java
@@ -17,6 +17,8 @@ import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.ManyToOne;
 
+import com.ibm.websphere.ras.annotation.Trivial;
+
 /**
  * @author skurz
  *
@@ -42,6 +44,7 @@ public class RemotableSplitFlowEntity extends JobThreadExecutionBase {
 
     private int internalStatus;
 
+    @Trivial
     public RemotableSplitFlowEntity() {}
 
     /**

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/StepThreadExecutionEntity.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/StepThreadExecutionEntity.java
@@ -38,6 +38,8 @@ import com.ibm.jbatch.container.context.impl.MetricImpl;
 import com.ibm.jbatch.container.ws.WSPartitionStepThreadExecution;
 import com.ibm.ws.serialization.DeserializationObjectInputStream;
 
+import com.ibm.websphere.ras.annotation.Trivial;
+
 @DiscriminatorColumn(name = "THREADTYPE", discriminatorType = DiscriminatorType.CHAR)
 @DiscriminatorValue("P")
 // The base level is (P)artition, and (T)op-level extends this
@@ -51,6 +53,7 @@ public class StepThreadExecutionEntity implements WSPartitionStepThreadExecution
 
     // Not a useful constructor from the "real" flow of creating a step execution for the first time,
     // for which the other constructor below encapsulates important logic.
+    @Trivial
     public StepThreadExecutionEntity() {
         super();
     }

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/StepThreadExecutionEntityExtractor.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/StepThreadExecutionEntityExtractor.java
@@ -29,19 +29,19 @@ public class StepThreadExecutionEntityExtractor extends ClassExtractor {
 
         //
         // If we understood the lifecycle of ClassExtractor within EclipseLink we
-        // might want to cache the tableversion here, but to be safe, let's call
+        // might want to cache the entityVersion here, but to be safe, let's call
         // each time, (and there's no particular reason to be concerned about performance here).
         //
 
-        Integer tableversion = null;
+        Integer entityVersion = null;
 
         try {
-            tableversion = ServicesManagerStaticAnchor.getServicesManager().getPersistenceManagerService().getStepThreadExecutionTableVersionField();
+            entityVersion = ServicesManagerStaticAnchor.getServicesManager().getPersistenceManagerService().getStepThreadExecutionEntityVersionField();
         } catch (Exception ex) {
             throw new BatchRuntimeException(ex);
         }
 
-        if (tableversion == 2) {
+        if (entityVersion == 2) {
             return StepThreadExecutionEntityV2.class;
         } else {
             return StepThreadExecutionEntity.class;

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/StepThreadExecutionEntityV2.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/StepThreadExecutionEntityV2.java
@@ -14,6 +14,8 @@ import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.OneToOne;
 
+import com.ibm.websphere.ras.annotation.Trivial;
+
 @Entity
 public class StepThreadExecutionEntityV2 extends StepThreadExecutionEntity {
 
@@ -21,6 +23,7 @@ public class StepThreadExecutionEntityV2 extends StepThreadExecutionEntity {
     private RemotablePartitionEntity remotablePartition;
 
     // For JPA
+    @Trivial
     public StepThreadExecutionEntityV2() {
         super();
     }

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/StepThreadInstanceEntity.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/StepThreadInstanceEntity.java
@@ -63,6 +63,7 @@ public class StepThreadInstanceEntity implements EntityConstants {
 
 	// Not a useful constructor from the "real" flow of creating a step execution for the first time,
 	// for which the other constructor below encapsulates important logic. I think JPA impl uses it though.
+    @Trivial
 	public StepThreadInstanceEntity() {}
 
 	public StepThreadInstanceEntity(JobInstanceEntity jobInstance, String stepName, int partitionNumber) {

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/TopLevelStepExecutionEntity.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/TopLevelStepExecutionEntity.java
@@ -23,6 +23,8 @@ import javax.persistence.OneToMany;
 
 import com.ibm.jbatch.container.ws.WSTopLevelStepExecution;
 
+import com.ibm.websphere.ras.annotation.Trivial;
+
 @Entity
 @DiscriminatorValue("T") // The base level is (P)artition, and (T)op-level extends this
 @NamedQueries({
@@ -43,6 +45,7 @@ public class TopLevelStepExecutionEntity extends StepThreadExecutionEntity imple
 
     // Not a useful constructor from the "real" flow of creating a step execution for the first time,
     // for which the other constructor below encapsulates important logic.
+    @Trivial
     public TopLevelStepExecutionEntity() {
         super();
     }

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/TopLevelStepInstanceEntity.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/TopLevelStepInstanceEntity.java
@@ -16,6 +16,8 @@ import javax.persistence.Entity;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 
+import com.ibm.websphere.ras.annotation.Trivial;
+
 @Entity
 @DiscriminatorValue("T") // The base level is (P)artition, and (T)op-level extends this
 
@@ -52,6 +54,7 @@ public class TopLevelStepInstanceEntity extends StepThreadInstanceEntity {
 	
 	// Not a useful constructor from the "real" flow of creating a step execution for the first time,
 	// for which the other constructor below encapsulates important logic.
+    @Trivial
 	public TopLevelStepInstanceEntity() {}
 
 	public TopLevelStepInstanceEntity(JobInstanceEntity jobInstance, String stepName, boolean isPartitionedStep) {

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/IPersistenceManagerService.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/IPersistenceManagerService.java
@@ -560,7 +560,7 @@ public interface IPersistenceManagerService extends IBatchServiceBase {
      * @return job executions table version number
      * @throws Exception
      */
-    int getJobExecutionTableVersion() throws Exception;
+    int getJobExecutionEntityVersion() throws Exception;
 
     /**
      * Get the job repository table version number. This will initialize the persistent store (database)
@@ -569,20 +569,20 @@ public interface IPersistenceManagerService extends IBatchServiceBase {
      * @return job instances table version number
      * @throws Exception
      */
-    int getJobInstanceTableVersion() throws Exception;
+    int getJobInstanceEntityVersion() throws Exception;
 
     /**
      * @return the job execution version field, initialized or not (may return 'null')
      */
-    Integer getJobExecutionTableVersionField();
+    Integer getJobExecutionEntityVersionField();
 
     /**
      * @return the job instance version field, initialized or not, (may return 'null')
      */
-    Integer getJobInstanceTableVersionField();
+    Integer getJobInstanceEntityVersionField();
 
     /**
      * @return the step thread execution version field, initialized or not (may return 'null')
      */
-    Integer getStepThreadExecutionTableVersionField();
+    Integer getStepThreadExecutionEntityVersionField();
 }

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/IPersistenceManagerService.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/IPersistenceManagerService.java
@@ -31,7 +31,6 @@ import javax.batch.runtime.StepExecution;
 import com.ibm.jbatch.container.exception.BatchIllegalJobStatusTransitionException;
 import com.ibm.jbatch.container.exception.ExecutionAssignedToServerException;
 import com.ibm.jbatch.container.exception.JobStoppedException;
-import com.ibm.jbatch.container.execution.impl.RuntimePartitionExecution;
 import com.ibm.jbatch.container.execution.impl.RuntimeSplitFlowExecution;
 import com.ibm.jbatch.container.execution.impl.RuntimeStepExecution;
 import com.ibm.jbatch.container.persistence.jpa.JobExecutionEntity;
@@ -494,12 +493,6 @@ public interface IPersistenceManagerService extends IBatchServiceBase {
      * @return
      */
     public RemotablePartitionEntity createPartitionExecution(RemotablePartitionKey partitionKey, Date createTime);
-
-    /**
-     * @param runtimePartitionExecution
-     * @param date
-     */
-    public RemotablePartitionEntity updatePartitionExecution(RuntimePartitionExecution runtimePartitionExecution, BatchStatus newBatchStatus, Date date);
 
     /**
      * @param key

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/IPersistenceManagerService.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/IPersistenceManagerService.java
@@ -585,4 +585,10 @@ public interface IPersistenceManagerService extends IBatchServiceBase {
      * @return the step thread execution version field, initialized or not (may return 'null')
      */
     Integer getStepThreadExecutionEntityVersionField();
+
+    /**
+     * @param topLevelStepExecutionId
+     * @return List of partition numbers, sorted low partition number to high, of related partitions in the recovery state.
+     */
+    public List<Integer> getRemotablePartitionsRecoveredForStepExecution(long topLevelStepExecutionId);
 }

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/IPersistenceManagerService.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/IPersistenceManagerService.java
@@ -46,7 +46,8 @@ import com.ibm.jbatch.container.persistence.jpa.TopLevelStepExecutionEntity;
 import com.ibm.jbatch.container.persistence.jpa.TopLevelStepInstanceEntity;
 import com.ibm.jbatch.container.persistence.jpa.TopLevelStepInstanceKey;
 import com.ibm.jbatch.container.ws.InstanceState;
-import com.ibm.jbatch.container.ws.RemotablePartitionState;
+import com.ibm.jbatch.container.ws.WSRemotablePartitionExecution;
+import com.ibm.jbatch.container.ws.WSRemotablePartitionState;
 import com.ibm.jbatch.container.ws.WSStepThreadExecutionAggregate;
 import com.ibm.jbatch.spi.services.IBatchServiceBase;
 
@@ -489,12 +490,6 @@ public interface IPersistenceManagerService extends IBatchServiceBase {
     public RemotableSplitFlowEntity updateSplitFlowExecutionLogDir(RemotableSplitFlowKey key, String logDirPath);
 
     /**
-     * @param partitionKey
-     * @return
-     */
-    public RemotablePartitionEntity createPartitionExecution(RemotablePartitionKey partitionKey, Date createTime);
-
-    /**
      * @param key
      * @param logDirPath
      */
@@ -517,20 +512,6 @@ public interface IPersistenceManagerService extends IBatchServiceBase {
      *
      */
     public List<JobInstanceEntity> getJobInstances(IJPAQueryHelper queryHelper, int page, int pageSize);
-
-    /**
-     * Creates an entry for this remote partition in the RemotablePartition table
-     */
-    RemotablePartitionEntity createRemotablePartition(long jobExecId,
-                                                      String stepName, int partitionNum,
-                                                      RemotablePartitionState partitionState);
-
-    /**
-     * updates an entry for this remote partition in the RemotablePartition table with given internalStatus
-     */
-    RemotablePartitionEntity updateRemotablePartitionInternalState(
-                                                                   long jobExecId, String stepName, int partitionNum,
-                                                                   RemotablePartitionState internalStatus);
 
     /**
      * @return
@@ -591,4 +572,16 @@ public interface IPersistenceManagerService extends IBatchServiceBase {
      * @return List of partition numbers, sorted low partition number to high, of related partitions in the recovery state.
      */
     public List<Integer> getRemotablePartitionsRecoveredForStepExecution(long topLevelStepExecutionId);
+
+    /**
+     * @param remotablePartitionKey
+     * @return
+     */
+    public WSRemotablePartitionExecution createRemotablePartition(RemotablePartitionKey remotablePartitionKey);
+
+    /**
+     * @param remotablePartitionKey
+     * @return
+     */
+    public WSRemotablePartitionState getRemotablePartitionInternalState(RemotablePartitionKey remotablePartitionKey);
 }

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/AbstractPersistenceManager.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/AbstractPersistenceManager.java
@@ -348,12 +348,6 @@ public abstract class AbstractPersistenceManager implements IPersistenceManagerS
     }
 
     @Override
-    public RemotablePartitionEntity createPartitionExecution(
-                                                             RemotablePartitionKey partitionKey, Date createTime) {
-        return null;
-    }
-
-    @Override
     public RemotablePartitionEntity updatePartitionExecutionLogDir(
                                                                    RemotablePartitionKey key, String logDirPath) {
         return null;

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/AbstractPersistenceManager.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/AbstractPersistenceManager.java
@@ -38,7 +38,6 @@ import com.ibm.jbatch.container.RASConstants;
 import com.ibm.jbatch.container.context.impl.MetricImpl;
 import com.ibm.jbatch.container.exception.BatchIllegalJobStatusTransitionException;
 import com.ibm.jbatch.container.exception.PersistenceException;
-import com.ibm.jbatch.container.execution.impl.RuntimePartitionExecution;
 import com.ibm.jbatch.container.execution.impl.RuntimeSplitFlowExecution;
 import com.ibm.jbatch.container.execution.impl.RuntimeStepExecution;
 import com.ibm.jbatch.container.persistence.jpa.JobExecutionEntity;
@@ -226,8 +225,8 @@ public abstract class AbstractPersistenceManager implements IPersistenceManagerS
      * @param stepExecutionId
      * @return
      * @throws IllegalArgumentException if either:
-     *             1) we have no entry at all with id equal to <code>stepExecutionId</code>
-     *             2) we have a partition-level StepThreadExecutionEntity with this id (but not a top-level entry).
+     *                                      1) we have no entry at all with id equal to <code>stepExecutionId</code>
+     *                                      2) we have a partition-level StepThreadExecutionEntity with this id (but not a top-level entry).
      */
     @Override
     public TopLevelStepExecutionEntity getStepExecutionTopLevel(long stepExecutionId) throws IllegalArgumentException {
@@ -355,13 +354,6 @@ public abstract class AbstractPersistenceManager implements IPersistenceManagerS
     }
 
     @Override
-    public RemotablePartitionEntity updatePartitionExecution(
-                                                             RuntimePartitionExecution runtimePartitionExecution,
-                                                             BatchStatus newBatchStatus, Date date) {
-        return null;
-    }
-
-    @Override
     public RemotablePartitionEntity updatePartitionExecutionLogDir(
                                                                    RemotablePartitionKey key, String logDirPath) {
         return null;
@@ -389,11 +381,6 @@ public abstract class AbstractPersistenceManager implements IPersistenceManagerS
                 throw new BatchIllegalJobStatusTransitionException("Job execution: " + exec.getExecutionId()
                                                                    + " cannot be transitioned from Batch Status: " + exec.getBatchStatus().name()
                                                                    + " to " + toStatus.name());
-            case STARTING:
-            case STARTED:
-            case STOPPING:
-            case FAILED:
-
             default:
         }
 
@@ -418,11 +405,6 @@ public abstract class AbstractPersistenceManager implements IPersistenceManagerS
                 throw new BatchIllegalJobStatusTransitionException("Job instance: " + instance.getInstanceId()
                                                                    + " cannot be transitioned from Batch Status: " + instance.getBatchStatus().name()
                                                                    + " to " + toStatus.name());
-            case STARTING:
-            case STARTED:
-            case STOPPING:
-            case FAILED:
-
             default:
         }
 
@@ -448,11 +430,6 @@ public abstract class AbstractPersistenceManager implements IPersistenceManagerS
                 throw new BatchIllegalJobStatusTransitionException("Job Step Thread execution: " + stepExec.getStepExecutionId()
                                                                    + " cannot be transitioned from Batch Status: " + stepExec.getBatchStatus().name()
                                                                    + " to " + toStatus.name());
-            case STARTING:
-            case STARTED:
-            case STOPPING:
-            case FAILED:
-
             default:
         }
 
@@ -478,12 +455,6 @@ public abstract class AbstractPersistenceManager implements IPersistenceManagerS
                 throw new BatchIllegalJobStatusTransitionException("Job Instance: " + jobInstance.getInstanceId()
                                                                    + " cannot be transitioned from Instance State: " + jobInstance.getInstanceState().name()
                                                                    + " to " + toState.name());
-            case SUBMITTED:
-            case JMS_QUEUED:
-            case JMS_CONSUMED:
-            case DISPATCHED:
-            case FAILED:
-            case STOPPED:
             default:
         }
 

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/JPAPersistenceManagerImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/JPAPersistenceManagerImpl.java
@@ -1396,6 +1396,11 @@ public class JPAPersistenceManagerImpl extends AbstractPersistenceManager implem
     public List<Integer> getRemotablePartitionsRecoveredForStepExecution(final long topLevelStepExecutionId) {
         final EntityManager em = psu.createEntityManager();
 
+        // Just ignore if we don't have the remotable partition table
+        if (partitionVersion < 2) {
+            return new ArrayList<Integer>();
+        }
+
         try {
             List<Integer> exec = new TranRequest<List<Integer>>(em) {
                 @Override

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/JPAPersistenceManagerImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/JPAPersistenceManagerImpl.java
@@ -85,6 +85,7 @@ import com.ibm.jbatch.container.ws.WSPartitionStepThreadExecution;
 import com.ibm.jbatch.container.ws.WSStepThreadExecutionAggregate;
 import com.ibm.jbatch.container.ws.impl.WSStartupRecoveryServiceImpl;
 import com.ibm.jbatch.spi.services.IBatchConfig;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.LocalTransaction.LocalTransactionCoordinator;
 import com.ibm.ws.LocalTransaction.LocalTransactionCurrent;
 import com.ibm.ws.Transaction.UOWCurrent;
@@ -2842,6 +2843,7 @@ public class JPAPersistenceManagerImpl extends AbstractPersistenceManager implem
             throw new PersistenceException(caughtThrowable);
         }
 
+        @Trivial
         protected void resumeAnyExistingLTC() {
             logger.fine("Will resume any LTC");
             if (suspendedLTC != null) {

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/JPAPersistenceManagerImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/JPAPersistenceManagerImpl.java
@@ -1391,6 +1391,32 @@ public class JPAPersistenceManagerImpl extends AbstractPersistenceManager implem
         }
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public List<Integer> getRemotablePartitionsRecoveredForStepExecution(final long topLevelStepExecutionId) {
+        final EntityManager em = psu.createEntityManager();
+
+        try {
+            List<Integer> exec = new TranRequest<List<Integer>>(em) {
+                @Override
+                public List<Integer> call() throws Exception {
+                    TypedQuery<Integer> query = em.createNamedQuery(RemotablePartitionEntity.GET_RECOVERED_REMOTABLE_PARITIONS,
+                                                                    Integer.class);
+                    query.setParameter("topLevelStepExecutionId", topLevelStepExecutionId);
+                    List<Integer> result = query.getResultList();
+                    if (result == null) {
+                        return new ArrayList<Integer>();
+                    }
+                    return result;
+                }
+            }.runInNewOrExistingGlobalTran();
+
+            return exec;
+        } finally {
+            em.close();
+        }
+    }
+
     /**
      * This method is called during recovery processing.
      *
@@ -1398,7 +1424,7 @@ public class JPAPersistenceManagerImpl extends AbstractPersistenceManager implem
      *
      * @return List<RemotablePartitionEntity> of partitions with a "running" status and this server's serverId
      */
-    public List<RemotablePartitionEntity> getPartitionsRunningLocalToServer(PersistenceServiceUnit psu) {
+    public List<RemotablePartitionEntity> getRemotablePartitionsRunningLocalToServer(PersistenceServiceUnit psu) {
 
         final EntityManager em = psu.createEntityManager();
 

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/JPAPersistenceManagerImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/JPAPersistenceManagerImpl.java
@@ -3161,13 +3161,17 @@ public class JPAPersistenceManagerImpl extends AbstractPersistenceManager implem
                 public RemotablePartitionEntity call() throws Exception {
                     RemotablePartitionEntity rp = em.find(RemotablePartitionEntity.class, remotablePartitionKey);
                     if (rp == null) {
-                        throw new IllegalArgumentException("No remotable partition found for rp key = " + remotablePartitionKey);
+                        logger.finer("No RemotablePartition found for key = " + remotablePartitionKey
+                                     + ", maybe because it was dispatched from a JVM configured to use the older table/entity versions.");
+                        // This can be null because if the partition dispatcher uses an older version, and so never created the remotable partition
+                        return null;
                     }
                     return rp;
                 }
             }.runInNewOrExistingGlobalTran();
 
-            return rp.getInternalStatus();
+            return rp != null ? rp.getInternalStatus() : null;
+
         } finally {
             em.close();
         }

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/JPAPersistenceManagerImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/JPAPersistenceManagerImpl.java
@@ -337,21 +337,21 @@ public class JPAPersistenceManagerImpl extends AbstractPersistenceManager implem
         partitionVersion = MAX_PARTITION_VERSION;
 
         // If any tables are not up to the current code level, re-load the PSU with backleveled entities.
-        setPartitionTableVersion(retMe);
+        setPartitionEntityVersion(retMe);
         if (partitionVersion < 2) {
             logger.fine("The REMOTABLEPARTITION table could not be found. The persistence service unit will exclude the remotable partition entity.");
             retMe.close();
             retMe = createPsu(instanceVersion, executionVersion, partitionVersion);
         }
 
-        setJobInstanceTableVersion(retMe);
+        setJobInstanceEntityVersion(retMe);
         if (instanceVersion < 3) {
             logger.fine("The GROUPNAMES column could not be found. The persistence service unit will exclude the V3 instance entity.");
             retMe.close();
             retMe = createPsu(instanceVersion, executionVersion, partitionVersion);
         }
 
-        setJobExecutionTableVersion(retMe);
+        setJobExecutionEntityVersion(retMe);
         if (executionVersion < 2) {
             logger.fine("The JOBPARAMETERS table could not be found. The persistence service unit will exclude the V2 execution entity.");
             retMe.close();
@@ -2881,7 +2881,7 @@ public class JPAPersistenceManagerImpl extends AbstractPersistenceManager implem
      * @throws Exception
      **/
     @Override
-    public Integer getJobExecutionTableVersionField() {
+    public Integer getJobExecutionEntityVersionField() {
         return executionVersion;
     }
 
@@ -2891,15 +2891,15 @@ public class JPAPersistenceManagerImpl extends AbstractPersistenceManager implem
      * @throws Exception
      **/
     @Override
-    public int getJobExecutionTableVersion() throws Exception {
+    public int getJobExecutionEntityVersion() throws Exception {
         if (executionVersion != null) {
-            setJobExecutionTableVersion(getPsu());
+            setJobExecutionEntityVersion(getPsu());
         }
         return executionVersion;
     }
 
     @FFDCIgnore(PersistenceException.class)
-    private void setJobExecutionTableVersion(PersistenceServiceUnit psu) throws Exception {
+    private void setJobExecutionEntityVersion(PersistenceServiceUnit psu) throws Exception {
 
         // If we have the RemotablePartition table, we're up to date and need the V3 execution entity
         if (partitionVersion == 2) {
@@ -2953,7 +2953,7 @@ public class JPAPersistenceManagerImpl extends AbstractPersistenceManager implem
      * @throws Exception
      **/
     @Override
-    public Integer getJobInstanceTableVersionField() {
+    public Integer getJobInstanceEntityVersionField() {
         return instanceVersion;
     }
 
@@ -2963,15 +2963,15 @@ public class JPAPersistenceManagerImpl extends AbstractPersistenceManager implem
      * @throws Exception
      **/
     @Override
-    public int getJobInstanceTableVersion() throws Exception {
+    public int getJobInstanceEntityVersion() throws Exception {
         if (instanceVersion == null) {
-            setJobInstanceTableVersion(getPsu());
+            setJobInstanceEntityVersion(getPsu());
         }
         return instanceVersion;
     }
 
     @FFDCIgnore(PersistenceException.class)
-    private void setJobInstanceTableVersion(PersistenceServiceUnit psu) throws Exception {
+    private void setJobInstanceEntityVersion(PersistenceServiceUnit psu) throws Exception {
 
         final EntityManager em = psu.createEntityManager();
 
@@ -3085,7 +3085,7 @@ public class JPAPersistenceManagerImpl extends AbstractPersistenceManager implem
     }
 
     @FFDCIgnore(PersistenceException.class)
-    private void setPartitionTableVersion(PersistenceServiceUnit psu) throws Exception {
+    private void setPartitionEntityVersion(PersistenceServiceUnit psu) throws Exception {
 
         final EntityManager em = psu.createEntityManager();
         try {
@@ -3131,7 +3131,7 @@ public class JPAPersistenceManagerImpl extends AbstractPersistenceManager implem
 
     // Step thread exec version is tied to partition version with RemotablePartition update, may have to decouple in the future
     @Override
-    public Integer getStepThreadExecutionTableVersionField() {
+    public Integer getStepThreadExecutionEntityVersionField() {
         return partitionVersion;
     }
 

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/JPAPersistenceManagerImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/JPAPersistenceManagerImpl.java
@@ -2932,7 +2932,7 @@ public class JPAPersistenceManagerImpl extends AbstractPersistenceManager implem
                 logger.fine("Next chained JobExecutionEntityV2 persistence exception: exc class = " + causeClassName + "; causeMsg = " + causeMsg);
                 if ((cause instanceof SQLSyntaxErrorException || causeClassName.contains("SqlSyntaxErrorException")) &&
                     causeMsg != null &&
-                    causeMsg.contains("JOBPARAMETER")) {
+                    (causeMsg.contains("JOBPARAMETER") || causeMsg.contains("ORA-00942"))) {
                     // The table isn't there.
                     logger.fine("The JOBPARAMETER table does not exist, job execution entity version = 1");
                     executionVersion = 1;
@@ -2999,7 +2999,7 @@ public class JPAPersistenceManagerImpl extends AbstractPersistenceManager implem
                     logger.fine("Next chained JobInstanceEntityV2 persistence exception: exc class = " + causeClassName + "; causeMsg = " + causeMsg);
                     if ((cause instanceof SQLSyntaxErrorException || causeClassName.contains("SqlSyntaxErrorException")) &&
                         causeMsg != null &&
-                        causeMsg.contains("UPDATETIME")) {
+                        (causeMsg.contains("UPDATETIME") || causeMsg.contains("ORA-00942"))) {
                         // The UPDATETIME column isn't there.
                         logger.fine("The UPDATETIME column does not exist, job instance entity version = 1");
                         instanceVersion = 1;
@@ -3039,7 +3039,7 @@ public class JPAPersistenceManagerImpl extends AbstractPersistenceManager implem
                     logger.fine("Next chained JobInstanceEntityV3 persistence exception: exc class = " + causeClassName + "; causeMsg = " + causeMsg);
                     if ((cause instanceof SQLSyntaxErrorException || causeClassName.contains("SqlSyntaxErrorException")) &&
                         causeMsg != null &&
-                        causeMsg.contains("GROUPASSOCIATION") || causeMsg.contains("GROUPNAMES")) {
+                        (causeMsg.contains("GROUPASSOCIATION") || causeMsg.contains("GROUPNAMES") || causeMsg.contains("ORA-00942"))) {
                         // The GROUPASSOCIATION support isn't there.
                         logger.fine("The GROUPASSOCIATION table does not exist, job instance entity version = 2");
                         instanceVersion = 2;
@@ -3112,7 +3112,7 @@ public class JPAPersistenceManagerImpl extends AbstractPersistenceManager implem
                 logger.fine("Next chained RemotablePartition persistence exception: exc class = " + causeClassName + "; causeMsg = " + causeMsg);
                 if ((cause instanceof SQLSyntaxErrorException || causeClassName.contains("SqlSyntaxErrorException")) &&
                     causeMsg != null &&
-                    causeMsg.contains("REMOTABLEPARTITION")) {
+                    (causeMsg.contains("REMOTABLEPARTITION") || causeMsg.contains("ORA-00942"))) {
                     // The table isn't there.
                     logger.fine("The REMOTABLEPARTITION table does not exist, partition entity version = 1");
                     partitionVersion = 1;

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/JPAPersistenceManagerImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/JPAPersistenceManagerImpl.java
@@ -1405,7 +1405,7 @@ public class JPAPersistenceManagerImpl extends AbstractPersistenceManager implem
             List<Integer> exec = new TranRequest<List<Integer>>(em) {
                 @Override
                 public List<Integer> call() throws Exception {
-                    TypedQuery<Integer> query = em.createNamedQuery(RemotablePartitionEntity.GET_RECOVERED_REMOTABLE_PARITIONS,
+                    TypedQuery<Integer> query = em.createNamedQuery(RemotablePartitionEntity.GET_RECOVERED_REMOTABLE_PARTITIONS,
                                                                     Integer.class);
                     query.setParameter("topLevelStepExecutionId", topLevelStepExecutionId);
                     List<Integer> result = query.getResultList();

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/MemoryPersistenceManagerImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/MemoryPersistenceManagerImpl.java
@@ -1413,4 +1413,10 @@ public class MemoryPersistenceManagerImpl extends AbstractPersistenceManager imp
         return 2;
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public List<Integer> getRemotablePartitionsRecoveredForStepExecution(long topLevelStepExecutionId) {
+        return new ArrayList<Integer>();
+    }
+
 }

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/MemoryPersistenceManagerImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/MemoryPersistenceManagerImpl.java
@@ -1385,31 +1385,31 @@ public class MemoryPersistenceManagerImpl extends AbstractPersistenceManager imp
 
     /** {@inheritDoc} */
     @Override
-    public int getJobExecutionTableVersion() {
-        return getJobExecutionTableVersionField();
+    public int getJobExecutionEntityVersion() {
+        return getJobExecutionEntityVersionField();
     }
 
     /** {@inheritDoc} */
     @Override
-    public int getJobInstanceTableVersion() {
-        return getJobInstanceTableVersionField();
+    public int getJobInstanceEntityVersion() {
+        return getJobInstanceEntityVersionField();
     }
 
     /** {@inheritDoc} */
     @Override
-    public Integer getJobExecutionTableVersionField() {
+    public Integer getJobExecutionEntityVersionField() {
         return 3;
     }
 
     /** {@inheritDoc} */
     @Override
-    public Integer getJobInstanceTableVersionField() {
+    public Integer getJobInstanceEntityVersionField() {
         return 3;
     }
 
     /** {@inheritDoc} */
     @Override
-    public Integer getStepThreadExecutionTableVersionField() {
+    public Integer getStepThreadExecutionEntityVersionField() {
         return 2;
     }
 

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/MemoryPersistenceManagerImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/MemoryPersistenceManagerImpl.java
@@ -74,9 +74,9 @@ import com.ibm.jbatch.container.util.WSPartitionStepAggregateImpl;
 import com.ibm.jbatch.container.util.WSStepThreadExecutionAggregateImpl;
 import com.ibm.jbatch.container.ws.BatchLocationService;
 import com.ibm.jbatch.container.ws.InstanceState;
-import com.ibm.jbatch.container.ws.RemotablePartitionState;
 import com.ibm.jbatch.container.ws.WSPartitionStepAggregate;
 import com.ibm.jbatch.container.ws.WSPartitionStepThreadExecution;
+import com.ibm.jbatch.container.ws.WSRemotablePartitionState;
 import com.ibm.jbatch.container.ws.WSStepThreadExecutionAggregate;
 import com.ibm.jbatch.container.ws.WSTopLevelStepExecution;
 import com.ibm.jbatch.spi.services.IBatchConfig;
@@ -643,6 +643,9 @@ public class MemoryPersistenceManagerImpl extends AbstractPersistenceManager imp
             remotablePartition = data.partitionData.get(remotablePartitionKey);
             remotablePartition.setStepExecution(stepExecution);
             stepExecution.setRemotablePartition(remotablePartition);
+            remotablePartition.setInternalStatus(WSRemotablePartitionState.CONSUMED);
+            remotablePartition.setServerId(batchLocationService.getServerId());
+            remotablePartition.setRestUrl(batchLocationService.getBatchRestUrl());
         }
 
         // 4. persist
@@ -701,6 +704,9 @@ public class MemoryPersistenceManagerImpl extends AbstractPersistenceManager imp
             RemotablePartitionKey remotablePartitionKey = new RemotablePartitionKey(newJobExecution.getExecutionId(), stepThreadInstance.getStepName(), stepThreadInstance.getPartitionNumber());
             remotablePartition = data.partitionData.get(remotablePartitionKey);
             remotablePartition.setStepExecution(newStepExecution);
+            remotablePartition.setInternalStatus(WSRemotablePartitionState.CONSUMED);
+            remotablePartition.setServerId(batchLocationService.getServerId());
+            remotablePartition.setRestUrl(batchLocationService.getBatchRestUrl());
 
             newStepExecution.setRemotablePartition(remotablePartition);
         }
@@ -1332,32 +1338,14 @@ public class MemoryPersistenceManagerImpl extends AbstractPersistenceManager imp
     }
 
     @Override
-    public RemotablePartitionEntity createRemotablePartition(long jobExecId,
-                                                             String stepName,
-                                                             int partitionNum,
-                                                             RemotablePartitionState partitionState) {
-        RemotablePartitionKey partitionKey = new RemotablePartitionKey(jobExecId, stepName, partitionNum);
-        JobExecutionEntity jobExecution = data.executionInstanceData.get(partitionKey.getJobExec());
-        RemotablePartitionEntity partition = new RemotablePartitionEntity(jobExecution, partitionKey);
-        partition.setInternalStatus(RemotablePartitionState.QUEUED);
+    public RemotablePartitionEntity createRemotablePartition(RemotablePartitionKey remotablePartitionKey) {
+        JobExecutionEntity jobExecution = data.executionInstanceData.get(remotablePartitionKey.getJobExec());
+        RemotablePartitionEntity partition = new RemotablePartitionEntity(jobExecution, remotablePartitionKey);
+        partition.setInternalStatus(WSRemotablePartitionState.QUEUED);
         partition.setLastUpdated(new Date());
-        data.partitionData.put(partitionKey, partition);
+        data.partitionData.put(remotablePartitionKey, partition);
 
         jobExecution.getRemotablePartitions().add(partition);
-        return partition;
-    }
-
-    @Override
-    public RemotablePartitionEntity updateRemotablePartitionInternalState(
-                                                                          long jobExecId, String stepName, int partitionNum,
-                                                                          RemotablePartitionState internalStatus) {
-        RemotablePartitionKey partitionKey = new RemotablePartitionKey(jobExecId, stepName, partitionNum);
-        RemotablePartitionEntity partition = data.partitionData.get(partitionKey);
-        partition.setInternalStatus(internalStatus);
-        partition.setRestUrl(batchLocationService.getBatchRestUrl());
-        partition.setServerId(batchLocationService.getServerId());
-        partition.setLastUpdated(new Date());
-
         return partition;
     }
 
@@ -1417,6 +1405,17 @@ public class MemoryPersistenceManagerImpl extends AbstractPersistenceManager imp
     @Override
     public List<Integer> getRemotablePartitionsRecoveredForStepExecution(long topLevelStepExecutionId) {
         return new ArrayList<Integer>();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public WSRemotablePartitionState getRemotablePartitionInternalState(RemotablePartitionKey remotablePartitionKey) {
+        RemotablePartitionEntity rp = data.partitionData.get(remotablePartitionKey);
+        if (rp != null) {
+            return rp.getInternalStatus();
+        } else {
+            throw new IllegalArgumentException("RemotablePartition not found for RemotablePartitionKey = " + remotablePartitionKey);
+        }
     }
 
 }

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/RemotablePartitionState.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/RemotablePartitionState.java
@@ -15,5 +15,5 @@ package com.ibm.jbatch.container.ws;
  *
  */
 public enum RemotablePartitionState {
- QUEUED, CONSUMED
+    QUEUED, CONSUMED, RECOVERED
 }

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/WSJobRepository.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/WSJobRepository.java
@@ -23,6 +23,7 @@ import javax.batch.runtime.BatchStatus;
 
 import com.ibm.jbatch.container.exception.BatchIllegalJobStatusTransitionException;
 import com.ibm.jbatch.container.exception.ExecutionAssignedToServerException;
+import com.ibm.jbatch.container.persistence.jpa.RemotablePartitionKey;
 import com.ibm.jbatch.container.services.IJPAQueryHelper;
 
 /**
@@ -103,7 +104,7 @@ public interface WSJobRepository {
      *
      * @param jobInstanceId
      * @param jobParameters
-     * @param create time
+     * @param create        time
      * @return jobExecution
      */
     public abstract WSJobExecution createJobExecution(long jobInstanceId, Properties jobParameters);
@@ -261,25 +262,17 @@ public interface WSJobRepository {
     /**
      * Creates an entry for this remote partition in the RemotablePartition table
      *
-     * @param jobExecutionId the id for the top level job execution that this partition is associated with
-     * @param stepName the name of the step
-     * @param internalState the state of the partition that is being dispatched
+     * @param remotablePartitionKey
      * @return
      */
-    public abstract WSRemotablePartitionExecution createRemotablePartition(long jobExecutionId,
-                                                                           String stepName, int partitionNumber, RemotablePartitionState internalState);
+    public abstract WSRemotablePartitionExecution createRemotablePartition(RemotablePartitionKey remotablePartitionKey);
 
     /**
-     * Updates an entry for this remote partition in the RemotablePartition table with the given internalStatus
-     * If the remotable partition is not found, then it just returns
-     *
-     * @param jobExecutionId the id for the top level job execution that this partition is associated with
-     * @param stepName the name of the step
-     * @param internalState the state of the partition that is being dispatched
+     * @param remotablePartitionKey
      * @return
+     * @throws IllegalArgumentException if partition isn't found via key
      */
-    public abstract WSRemotablePartitionExecution updateRemotablePartitionInternalState(long jobExecutionId,
-                                                                                        String stepName, int partitionNumber, RemotablePartitionState internalState);
+    public abstract WSRemotablePartitionState getRemotablePartitionInternalState(RemotablePartitionKey remotablePartitionKey);
 
     /**
      * Check the version of the job execution table in the job repository.

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/WSJobRepository.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/WSJobRepository.java
@@ -284,12 +284,12 @@ public interface WSJobRepository {
     /**
      * Check the version of the job execution table in the job repository.
      */
-    int getJobExecutionTableVersion() throws Exception;
+    int getJobExecutionEntityVersion() throws Exception;
 
     /**
      * Check the version of the job instance table in the job repository.
      */
-    int getJobInstanceTableVersion() throws Exception;
+    int getJobInstanceEntityVersion() throws Exception;
 
     public WSJobInstance updateJobInstanceWithGroupNames(long jobInstanceId, Set<String> groupNames);
 

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/WSRemotablePartitionState.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/WSRemotablePartitionState.java
@@ -14,6 +14,6 @@ package com.ibm.jbatch.container.ws;
  * @author skurz
  *
  */
-public enum RemotablePartitionState {
+public enum WSRemotablePartitionState {
     QUEUED, CONSUMED, RECOVERED
 }

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/impl/WSJobRepositoryImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/impl/WSJobRepositoryImpl.java
@@ -382,8 +382,8 @@ public class WSJobRepositoryImpl implements WSJobRepository {
      * @throws Exception
      */
     @Override
-    public int getJobExecutionTableVersion() throws Exception {
-        return persistenceManagerService.getJobExecutionTableVersion();
+    public int getJobExecutionEntityVersion() throws Exception {
+        return persistenceManagerService.getJobExecutionEntityVersion();
     }
 
     /**
@@ -392,8 +392,8 @@ public class WSJobRepositoryImpl implements WSJobRepository {
      * @throws Exception
      */
     @Override
-    public int getJobInstanceTableVersion() throws Exception {
-        return persistenceManagerService.getJobInstanceTableVersion();
+    public int getJobInstanceEntityVersion() throws Exception {
+        return persistenceManagerService.getJobInstanceEntityVersion();
     }
 
     @Override

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/impl/WSJobRepositoryImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/impl/WSJobRepositoryImpl.java
@@ -16,6 +16,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.batch.operations.JobSecurityException;
@@ -30,6 +31,7 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
 
+import com.ibm.jbatch.container.RASConstants;
 import com.ibm.jbatch.container.exception.BatchIllegalJobStatusTransitionException;
 import com.ibm.jbatch.container.exception.ExecutionAssignedToServerException;
 import com.ibm.jbatch.container.persistence.jpa.JobInstanceEntity;
@@ -44,8 +46,6 @@ import com.ibm.jbatch.container.ws.WSJobRepository;
 import com.ibm.jbatch.container.ws.WSRemotablePartitionExecution;
 import com.ibm.jbatch.container.ws.WSStepThreadExecutionAggregate;
 import com.ibm.jbatch.spi.BatchSecurityHelper;
-import com.ibm.websphere.ras.Tr;
-import com.ibm.websphere.ras.TraceComponent;
 
 /**
  * {@inheritDoc}
@@ -54,9 +54,7 @@ import com.ibm.websphere.ras.TraceComponent;
 public class WSJobRepositoryImpl implements WSJobRepository {
 
     private final static String CLASSNAME = WSJobRepositoryImpl.class.getName();
-    private final static Logger logger = Logger.getLogger(CLASSNAME);
-
-    private static final TraceComponent tc = Tr.register(WSJobRepositoryImpl.class);
+    private final static Logger logger = Logger.getLogger(CLASSNAME, RASConstants.BATCH_MSG_BUNDLE);
 
     private IPersistenceManagerService persistenceManagerService;
 
@@ -402,9 +400,8 @@ public class WSJobRepositoryImpl implements WSJobRepository {
     public WSJobInstance updateJobInstanceWithGroupNames(long jobInstanceId, Set<String> groupNames) {
 
         if (authService == null) {
-            //issue a new message indicating security is not available
             // no auth service (ie security feature not present, so cannot perform group security
-            Tr.warning(tc, "BATCH_SECURITY_NOT_ACTIVE", jobInstanceId);
+            logger.log(Level.WARNING, "BATCH_SECURITY_NOT_ACTIVE", new Object[] { jobInstanceId });
 
             // no groups should be persisted - pass in an empty set
             return persistenceManagerService.updateJobInstanceWithGroupNames(jobInstanceId, new HashSet<String>());

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/impl/WSJobRepositoryImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/impl/WSJobRepositoryImpl.java
@@ -35,15 +35,16 @@ import com.ibm.jbatch.container.RASConstants;
 import com.ibm.jbatch.container.exception.BatchIllegalJobStatusTransitionException;
 import com.ibm.jbatch.container.exception.ExecutionAssignedToServerException;
 import com.ibm.jbatch.container.persistence.jpa.JobInstanceEntity;
+import com.ibm.jbatch.container.persistence.jpa.RemotablePartitionKey;
 import com.ibm.jbatch.container.services.IJPAQueryHelper;
 import com.ibm.jbatch.container.services.IPersistenceManagerService;
 import com.ibm.jbatch.container.ws.InstanceState;
-import com.ibm.jbatch.container.ws.RemotablePartitionState;
 import com.ibm.jbatch.container.ws.WSBatchAuthService;
 import com.ibm.jbatch.container.ws.WSJobExecution;
 import com.ibm.jbatch.container.ws.WSJobInstance;
 import com.ibm.jbatch.container.ws.WSJobRepository;
 import com.ibm.jbatch.container.ws.WSRemotablePartitionExecution;
+import com.ibm.jbatch.container.ws.WSRemotablePartitionState;
 import com.ibm.jbatch.container.ws.WSStepThreadExecutionAggregate;
 import com.ibm.jbatch.spi.BatchSecurityHelper;
 
@@ -365,15 +366,13 @@ public class WSJobRepositoryImpl implements WSJobRepository {
     }
 
     @Override
-    public WSRemotablePartitionExecution createRemotablePartition(long jobExecutionId, String stepName,
-                                                                  int partitionNumber, RemotablePartitionState internalState) {
-        return persistenceManagerService.createRemotablePartition(jobExecutionId, stepName, partitionNumber, internalState);
+    public WSRemotablePartitionExecution createRemotablePartition(RemotablePartitionKey remotablePartitionKey) {
+        return persistenceManagerService.createRemotablePartition(remotablePartitionKey);
     }
 
     @Override
-    public WSRemotablePartitionExecution updateRemotablePartitionInternalState(long jobExecutionId, String stepName,
-                                                                               int partitionNumber, RemotablePartitionState internalState) {
-        return persistenceManagerService.updateRemotablePartitionInternalState(jobExecutionId, stepName, partitionNumber, internalState);
+    public WSRemotablePartitionState getRemotablePartitionInternalState(RemotablePartitionKey remotablePartitionKey) {
+        return persistenceManagerService.getRemotablePartitionInternalState(remotablePartitionKey);
     }
 
     /**

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/impl/WSStartupRecoveryServiceImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/impl/WSStartupRecoveryServiceImpl.java
@@ -29,7 +29,7 @@ import com.ibm.wsspi.persistence.PersistenceServiceUnit;
 /**
  * Perform recovery of jobs that were running when a previous instance of this server
  * shutdown abruptly and left them in an "in-flight" state in the DB.
- * 
+ *
  */
 public class WSStartupRecoveryServiceImpl {
 
@@ -53,7 +53,7 @@ public class WSStartupRecoveryServiceImpl {
 
     /**
      * inject
-     * 
+     *
      * @return this
      */
     public WSStartupRecoveryServiceImpl setIPersistenceManagerService(JPAPersistenceManagerImpl pms) {
@@ -63,7 +63,7 @@ public class WSStartupRecoveryServiceImpl {
 
     /**
      * injection
-     * 
+     *
      * @return this
      */
     public WSStartupRecoveryServiceImpl setPersistenceServiceUnit(PersistenceServiceUnit psu) {
@@ -81,7 +81,7 @@ public class WSStartupRecoveryServiceImpl {
         String methodName = "recoverLocalPartitionsInInflightStates";
 
         try {
-            List<RemotablePartitionEntity> remotablePartitions = persistenceManagerService.getPartitionsRunningLocalToServer(psu);
+            List<RemotablePartitionEntity> remotablePartitions = persistenceManagerService.getRemotablePartitionsRunningLocalToServer(psu);
 
             for (RemotablePartitionEntity partition : remotablePartitions) {
 

--- a/dev/com.ibm.jbatch.container/test/com/ibm/jbatch/container/services/impl/MemoryPersistenceManagerImplTest.java
+++ b/dev/com.ibm.jbatch.container/test/com/ibm/jbatch/container/services/impl/MemoryPersistenceManagerImplTest.java
@@ -24,13 +24,12 @@ import org.mockito.MockitoAnnotations;
 
 import com.ibm.jbatch.container.persistence.jpa.JobExecutionEntity;
 import com.ibm.jbatch.container.persistence.jpa.JobInstanceEntity;
-import com.ibm.jbatch.container.persistence.jpa.RemotablePartitionEntity;
+import com.ibm.jbatch.container.persistence.jpa.RemotablePartitionKey;
 import com.ibm.jbatch.container.persistence.jpa.StepThreadExecutionEntity;
 import com.ibm.jbatch.container.persistence.jpa.StepThreadInstanceKey;
 import com.ibm.jbatch.container.persistence.jpa.TopLevelStepExecutionEntity;
 import com.ibm.jbatch.container.persistence.jpa.TopLevelStepInstanceKey;
 import com.ibm.jbatch.container.ws.BatchLocationService;
-import com.ibm.jbatch.container.ws.RemotablePartitionState;
 import com.ibm.jbatch.container.ws.WSPartitionStepAggregate;
 import com.ibm.jbatch.container.ws.WSStepThreadExecutionAggregate;
 
@@ -54,13 +53,13 @@ public class MemoryPersistenceManagerImplTest {
 
         this.jobInstanceEntity = service.createJobInstance("mockApp", "mockXML", "mockUser", new Date());
         this.jobExecutionEntity = service.createJobExecution(jobInstanceEntity.getInstanceId(), new Properties(), new Date());
-        RemotablePartitionEntity remotablePartition1 = service.createRemotablePartition(jobExecutionEntity.getExecutionId(), "mockStep", 0, RemotablePartitionState.QUEUED);
-        RemotablePartitionEntity remotablePartition2 = service.createRemotablePartition(jobExecutionEntity.getExecutionId(), "mockStep", 1, RemotablePartitionState.QUEUED);
+        RemotablePartitionKey remotablePartitionKey1 = new RemotablePartitionKey(jobExecutionEntity.getExecutionId(), "mockStep", 0);
+        RemotablePartitionKey remotablePartitionKey2 = new RemotablePartitionKey(jobExecutionEntity.getExecutionId(), "mockStep", 1);
+        service.createRemotablePartition(remotablePartitionKey1);
+        service.createRemotablePartition(remotablePartitionKey2);
 
         this.topLevelStepExecution = service.createTopLevelStepExecutionAndNewThreadInstance(jobExecutionEntity.getExecutionId(),
                                                                                              new TopLevelStepInstanceKey(jobInstanceEntity.getInstanceId(), "mockStep"), true);
-        service.updateRemotablePartitionInternalState(jobExecutionEntity.getExecutionId(), "mockStep", 0, RemotablePartitionState.CONSUMED);
-        service.updateRemotablePartitionInternalState(jobExecutionEntity.getExecutionId(), "mockStep", 1, RemotablePartitionState.CONSUMED);
 
         this.partition1 = service.createPartitionStepExecutionAndNewThreadInstance(jobExecutionEntity.getExecutionId(),
                                                                                    new StepThreadInstanceKey(jobInstanceEntity.getInstanceId(), "mockStep", 1), true);

--- a/dev/com.ibm.ws.jbatch.jms/src/com/ibm/ws/jbatch/jms/internal/dispatcher/BatchJmsDispatcher.java
+++ b/dev/com.ibm.ws.jbatch.jms/src/com/ibm/ws/jbatch/jms/internal/dispatcher/BatchJmsDispatcher.java
@@ -54,7 +54,7 @@ import com.ibm.jbatch.container.ws.BatchJobNotLocalException;
 import com.ibm.jbatch.container.ws.InstanceState;
 import com.ibm.jbatch.container.ws.PartitionPlanConfig;
 import com.ibm.jbatch.container.ws.PartitionReplyQueue;
-import com.ibm.jbatch.container.ws.RemotablePartitionState;
+import com.ibm.jbatch.container.ws.WSRemotablePartitionState;
 import com.ibm.jbatch.container.ws.WSJobExecution;
 import com.ibm.jbatch.container.ws.WSJobInstance;
 import com.ibm.jbatch.container.ws.WSJobRepository;
@@ -744,7 +744,7 @@ public class BatchJmsDispatcher implements BatchDispatcher {
                                       securityContext,
                                       (PartitionReplyQueueJms)partitionReplyQueue);
             
-            jobRepository.createRemotablePartition(partitionPlanConfig.getTopLevelExecutionId(), partitionPlanConfig.getStepName(), partitionPlanConfig.getPartitionNumber(), RemotablePartitionState.QUEUED);
+            jobRepository.createRemotablePartition(partitionKey);
             
             // TODO: publish partition event?
 

--- a/dev/com.ibm.ws.jbatch.jms/src/com/ibm/ws/jbatch/jms/internal/listener/BatchJmsEndpointListener.java
+++ b/dev/com.ibm.ws.jbatch.jms/src/com/ibm/ws/jbatch/jms/internal/listener/BatchJmsEndpointListener.java
@@ -489,8 +489,8 @@ public class BatchJmsEndpointListener implements MessageListener {
 
             // get the op group names and create a mapping to each for the job instance id
             if (batchOperationGroup != null) {
-                int instanceTableVersion = jobRepositoryProxy.getJobInstanceTableVersion();
-                if (instanceTableVersion >= 3) {
+                int instanceEntityVersion = jobRepositoryProxy.getJobInstanceEntityVersion();
+                if (instanceEntityVersion >= 3) {
                     if (jobInstance.getGroupNames() == null || jobInstance.getGroupNames().size() == 0) {
                         if(tc.isDebugEnabled()) {
                             Tr.debug(BatchJmsEndpointListener.this, tc, "On restart, null/empty operation group mapping. Give it another chance.");
@@ -503,7 +503,7 @@ public class BatchJmsEndpointListener implements MessageListener {
                     }
                 } else {
                     if(tc.isDebugEnabled()) {
-                        Tr.debug(BatchJmsEndpointListener.this, tc, "Skip group names update because job instance table version = " + instanceTableVersion); 
+                        Tr.debug(BatchJmsEndpointListener.this, tc, "Skip group names update because job instance table version = " + instanceEntityVersion); 
                     }
                 }
             }
@@ -568,12 +568,12 @@ public class BatchJmsEndpointListener implements MessageListener {
 
             // get the op group names and create a mapping to each for the job instance id
             if (batchOperationGroup != null) {
-                int instanceTableVersion = jobRepositoryProxy.getJobInstanceTableVersion();
-                if (instanceTableVersion >= 3) {
+                int instanceEntityVersion = jobRepositoryProxy.getJobInstanceEntityVersion();
+                if (instanceEntityVersion >= 3) {
                     jobRepositoryProxy.updateJobInstanceWithGroupNames(instanceId, batchOperationGroup.getGroupNames());
                 } else {
                     if(tc.isDebugEnabled()) {
-                        Tr.debug(BatchJmsEndpointListener.this, tc, "Skip group names update because job instance table version = " + instanceTableVersion); 
+                        Tr.debug(BatchJmsEndpointListener.this, tc, "Skip group names update because job instance table version = " + instanceEntityVersion); 
                     }
                 }
             }

--- a/dev/com.ibm.ws.jbatch.jms/src/com/ibm/ws/jbatch/jms/internal/listener/BatchJmsEndpointListener.java
+++ b/dev/com.ibm.ws.jbatch.jms/src/com/ibm/ws/jbatch/jms/internal/listener/BatchJmsEndpointListener.java
@@ -376,10 +376,6 @@ public class BatchJmsEndpointListener implements MessageListener {
                 return;
             }
 
-            // The RemotablePartitionState is essentially just for monitoring.  We don't have logic conditionally depending on the state.  So there's not really
-            // a need to worry about locking to guard against inconsistencies for now.
-            jobRepositoryProxy.updateRemotablePartitionInternalState(jobExecutionId, config.getStepName(), config.getPartitionNumber(), RemotablePartitionState.CONSUMED);
-             
             // UPDATE: 2019-09-24 - I'm sure this comment below isn't 100% correct or up-to-date, but I'm leaving it
             // because it enumerates a bunch of considerations that we should keep in mind.
             //

--- a/dev/com.ibm.ws.jbatch.rest/src/com/ibm/ws/jbatch/rest/internal/resources/JobInstances.java
+++ b/dev/com.ibm.ws.jbatch.rest/src/com/ibm/ws/jbatch/rest/internal/resources/JobInstances.java
@@ -832,13 +832,13 @@ public class JobInstances implements RESTHandler {
  	    					unrecognized = "sort="+split[i];
  	    				}
  					} else if (field.equals("lastUpdatedTime")
- 			      			&& (jobRepository.getJobInstanceTableVersion() < 2)) {
+ 			      			&& (jobRepository.getJobInstanceEntityVersion() < 2)) {
  			      		throw new RequestException(HttpURLConnection.HTTP_NOT_IMPLEMENTED, "A search or sort by last update time was requested, but the job instance table does not contain the UPDATETIME column.");
  			      	}
 
  				}
      		} else if (entry.getKey().equals("lastUpdatedTime")
-     				&& (jobRepository.getJobInstanceTableVersion() < 2)) {
+     				&& (jobRepository.getJobInstanceEntityVersion() < 2)) {
      			throw new RequestException(HttpURLConnection.HTTP_NOT_IMPLEMENTED, "A search or sort by last update time was requested, but the job instance table does not contain the UPDATETIME column.");
      		}
      	}
@@ -869,7 +869,7 @@ public class JobInstances implements RESTHandler {
     		}
     	}
 
-        if ((!jobParams.isEmpty()) && (jobRepository.getJobExecutionTableVersion() < 2)) {
+        if ((!jobParams.isEmpty()) && (jobRepository.getJobExecutionEntityVersion() < 2)) {
        	 throw new RequestException(HttpURLConnection.HTTP_NOT_IMPLEMENTED, ResourceBundleRest.getMessage("db.tables.not.created.for.jobparm.search"));
         }
 

--- a/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/DatabaseStoreImpl.java
+++ b/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/DatabaseStoreImpl.java
@@ -403,165 +403,187 @@ public class DatabaseStoreImpl implements DatabaseStore {
             Tr.entry(this, tc, "createOrmFileContentsForBatch");
 
         StringBuilder orm = new StringBuilder(4 * tablePrefixLength + schemaLength + 2000) // Wild guess.
-                        .append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>").append(EOLN)
+        .append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>").append(EOLN)
                         .append("<entity-mappings xmlns=\"http://xmlns.jcp.org/xml/ns/persistence/orm\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://xmlns.jcp.org/xml/ns/persistence/orm http://xmlns.jcp.org/xml/ns/persistence/orm_2_1.xsd\" version=\"2.1\">").append(EOLN);
         if (schemaLength >= 0)
             orm.append(" <schema>").append(schema).append("</schema>").append(EOLN);
+
+        // JOBEXECUTION - V1 entity - UNCONDITIONAL (v1, v2, or v3)
         orm
-        .append(" <entity class=\"com.ibm.jbatch.container.persistence.jpa.JobExecutionEntity\">").append(EOLN)
-        .append("  <table name=\"").append(tablePrefix).append("JOBEXECUTION\">").append(EOLN)
-        //adding index
-        .append(" <index name=\"").append(tablePrefix).append("JE_FKINSTANCEID_IX\" column-list=\"FK_JOBINSTANCEID\" unique=\"false\"/>")
-        //end index
-        .append(EOLN).append("  </table>").append(EOLN)
-        .append("  <inheritance strategy=\"SINGLE_TABLE\"/>").append(EOLN)
-        .append("  <class-extractor class=\"com.ibm.jbatch.container.persistence.jpa.JobExecutionEntityExtractor\"/>").append(EOLN);
+                        .append(" <entity class=\"com.ibm.jbatch.container.persistence.jpa.JobExecutionEntity\">").append(EOLN)
+                        .append("  <table name=\"").append(tablePrefix).append("JOBEXECUTION\">").append(EOLN)
+                        .append("    <index name=\"").append(tablePrefix).append("JE_FKINSTANCEID_IX\" column-list=\"FK_JOBINSTANCEID\" unique=\"false\"/>")
+                        .append(EOLN).append("  </table>").append(EOLN)
+                        .append("  <inheritance strategy=\"SINGLE_TABLE\"/>").append(EOLN)
+                        .append("  <class-extractor class=\"com.ibm.jbatch.container.persistence.jpa.JobExecutionEntityExtractor\"/>").append(EOLN);
         if (!"IDENTITY".equals(strategy)) {
             orm
-            .append("  <attributes>").append(EOLN)
-            .append("   <id name=\"jobExecId\">").append(EOLN)
-            .append("    <column name=\"JOBEXECID\" nullable=\"false\"/>").append(EOLN)
-            .append("    <generated-value generator=\"JOBEXECIDGEN\" strategy=\"").append(strategy).append("\"/>").append(EOLN);
+                            .append("  <attributes>").append(EOLN)
+                            .append("   <id name=\"jobExecId\">").append(EOLN)
+                            .append("    <column name=\"JOBEXECID\" nullable=\"false\"/>").append(EOLN)
+                            .append("    <generated-value generator=\"JOBEXECIDGEN\" strategy=\"").append(strategy).append("\"/>").append(EOLN);
             if ("TABLE".equals(strategy)) {
                 orm
-                .append("    <table-generator name=\"JOBEXECIDGEN\" table=\"").append(tablePrefix).append("GEN\"");
+                                .append("    <table-generator name=\"JOBEXECIDGEN\" table=\"").append(tablePrefix).append("GEN\"");
                 if (schema != null)
                     orm.append(" schema=\"").append(schema).append('"');
                 orm.append("/>").append(EOLN);
             } else
                 orm
-                .append("    <sequence-generator name=\"JOBEXECIDGEN\" sequence-name=\"").append(tablePrefix).append("SEQ\"/>").append(EOLN);
+                                .append("    <sequence-generator name=\"JOBEXECIDGEN\" sequence-name=\"").append(tablePrefix).append("SEQ\"/>").append(EOLN);
             orm
-            .append("   </id>").append(EOLN)
-            .append("  </attributes>").append(EOLN);
+                            .append("   </id>").append(EOLN)
+                            .append("  </attributes>").append(EOLN);
         }
         orm
-        .append(" </entity>").append(EOLN);
-        if (Arrays.asList(entityClassNames).contains("com.ibm.jbatch.container.persistence.jpa.JobExecutionEntityV2")) {
+                        .append(" </entity>").append(EOLN);
+
+        // JOBEXECUTION - V2 entity - CONDITIONAL (v2 or v3)
+        if ( Arrays.asList(entityClassNames).contains("com.ibm.jbatch.container.persistence.jpa.JobExecutionEntityV2") ||
+             Arrays.asList(entityClassNames).contains("com.ibm.jbatch.container.persistence.jpa.JobExecutionEntityV3") ) {
             orm
-            .append(" <entity class=\"com.ibm.jbatch.container.persistence.jpa.JobExecutionEntityV2\">").append(EOLN)
-            //.append("  <table name=\"").append(tablePrefix).append("JOBEXECUTION\"/>").append(EOLN);
-            .append("  <table name=\"").append(tablePrefix).append("JOBEXECUTION\">").append(EOLN)
-            //adding index
-            .append("  <index name=\"").append(tablePrefix).append("JE_FKINSTANCEID_IX\" column-list=\"FK_JOBINSTANCEID\" unique=\"false\"/>")
-            //end index
-            .append(EOLN).append("  </table>").append(EOLN)
-            .append("  <attributes>").append(EOLN)
-            .append("   <element-collection name=\"jobParameterElements\" target-class=\"com.ibm.jbatch.container.persistence.jpa.JobParameter\">").append(EOLN)
-            .append("    <collection-table name=\"").append(tablePrefix).append("JOBPARAMETER\">").append(EOLN)
-            .append("     <join-column name=\"FK_JOBEXECID\"/>").append(EOLN)
-            .append("     <index name=\"").append(tablePrefix).append("JP_FKJOBEXECID_IX\" column-list=\"FK_JOBEXECID\" unique=\"false\"/>").append(EOLN)
-            .append("    </collection-table>").append(EOLN)
-            .append("   </element-collection>").append(EOLN)
-            .append("  </attributes>").append(EOLN)
-            .append(" </entity>").append(EOLN);
+                            .append(" <entity class=\"com.ibm.jbatch.container.persistence.jpa.JobExecutionEntityV2\">").append(EOLN)
+                            .append("  <table name=\"").append(tablePrefix).append("JOBEXECUTION\">").append(EOLN)
+                            .append("  <index name=\"").append(tablePrefix).append("JE_FKINSTANCEID_IX\" column-list=\"FK_JOBINSTANCEID\" unique=\"false\"/>")
+                            .append(EOLN).append("  </table>").append(EOLN)
+                            .append("  <attributes>").append(EOLN)
+                            .append("   <element-collection name=\"jobParameterElements\" target-class=\"com.ibm.jbatch.container.persistence.jpa.JobParameter\">").append(EOLN)
+                            .append("    <collection-table name=\"").append(tablePrefix).append("JOBPARAMETER\">").append(EOLN)
+                            .append("     <join-column name=\"FK_JOBEXECID\"/>").append(EOLN)
+                            .append("     <index name=\"").append(tablePrefix).append("JP_FKJOBEXECID_IX\" column-list=\"FK_JOBEXECID\" unique=\"false\"/>").append(EOLN)
+                            .append("    </collection-table>").append(EOLN)
+                            .append("   </element-collection>").append(EOLN)
+                            .append("  </attributes>").append(EOLN)
+                            .append(" </entity>").append(EOLN);
         }
+        // JOBEXECUTION - V3 entity - CONDITIONAL (v3 only)
+        if ( Arrays.asList(entityClassNames).contains("com.ibm.jbatch.container.persistence.jpa.JobExecutionEntityV3")) {
+            orm
+                            .append(" <entity class=\"com.ibm.jbatch.container.persistence.jpa.JobExecutionEntityV3\">").append(EOLN)
+                            .append("  <table name=\"").append(tablePrefix).append("JOBEXECUTION\">").append(EOLN)
+                            .append("  </table>").append(EOLN)
+                            .append(" </entity>").append(EOLN);
+
+        }
+
+        // JOBINSTANCE - V1 entity - UNCONDITIONAL (v1, v2, or v3)
         orm
-        .append(" <entity class=\"com.ibm.jbatch.container.persistence.jpa.JobInstanceEntity\">").append(EOLN)
-        .append("  <table name=\"").append(tablePrefix).append("JOBINSTANCE\"/>").append(EOLN)
-        .append("  <inheritance strategy=\"SINGLE_TABLE\"/>").append(EOLN)
-        .append("  <class-extractor class=\"com.ibm.jbatch.container.persistence.jpa.JobInstanceEntityExtractor\"/>").append(EOLN);
+                        .append(" <entity class=\"com.ibm.jbatch.container.persistence.jpa.JobInstanceEntity\">").append(EOLN)
+                        .append("  <table name=\"").append(tablePrefix).append("JOBINSTANCE\"/>").append(EOLN)
+                        .append("  <inheritance strategy=\"SINGLE_TABLE\"/>").append(EOLN)
+                        .append("  <class-extractor class=\"com.ibm.jbatch.container.persistence.jpa.JobInstanceEntityExtractor\"/>").append(EOLN);
         if (!"IDENTITY".equals(strategy)) {
             orm
-            .append("  <attributes>").append(EOLN)
-            .append("   <id name=\"instanceId\">").append(EOLN)
-            .append("    <column name=\"JOBINSTANCEID\" nullable=\"false\"/>").append(EOLN)
-            .append("    <generated-value generator=\"JOBINSTANCEIDGEN\" strategy=\"").append(strategy).append("\"/>").append(EOLN);
+                            .append("  <attributes>").append(EOLN)
+                            .append("   <id name=\"instanceId\">").append(EOLN)
+                            .append("    <column name=\"JOBINSTANCEID\" nullable=\"false\"/>").append(EOLN)
+                            .append("    <generated-value generator=\"JOBINSTANCEIDGEN\" strategy=\"").append(strategy).append("\"/>").append(EOLN);
             if ("TABLE".equals(strategy)) {
                 orm
-                .append("    <table-generator name=\"JOBINSTANCEIDGEN\" table=\"").append(tablePrefix).append("GEN\"");
+                                .append("    <table-generator name=\"JOBINSTANCEIDGEN\" table=\"").append(tablePrefix).append("GEN\"");
                 if (schema != null)
                     orm.append(" schema=\"").append(schema).append('"');
                 orm.append("/>").append(EOLN);
             } else
                 orm
-                .append("    <sequence-generator name=\"JOBINSTANCEIDGEN\" sequence-name=\"").append(tablePrefix).append("SEQ\"/>").append(EOLN);
+                                .append("    <sequence-generator name=\"JOBINSTANCEIDGEN\" sequence-name=\"").append(tablePrefix).append("SEQ\"/>").append(EOLN);
             orm
-            .append("   </id>").append(EOLN)
-            .append("  </attributes>").append(EOLN);
+                            .append("   </id>").append(EOLN)
+                            .append("  </attributes>").append(EOLN);
         }
         orm
-        .append(" </entity>").append(EOLN);
+                        .append(" </entity>").append(EOLN);
+
+        // JOBINSTANCE - V2 entity - CONDITIONAL (v2 only)
         if (Arrays.asList(entityClassNames).contains("com.ibm.jbatch.container.persistence.jpa.JobInstanceEntityV2")) {
             orm
-            .append(" <entity class=\"com.ibm.jbatch.container.persistence.jpa.JobInstanceEntityV2\">").append(EOLN)
-            .append("  <table name=\"").append(tablePrefix).append("JOBINSTANCE\"/>").append(EOLN)
-            .append(" </entity>").append(EOLN);
+                            .append(" <entity class=\"com.ibm.jbatch.container.persistence.jpa.JobInstanceEntityV2\">").append(EOLN)
+                            .append("  <table name=\"").append(tablePrefix).append("JOBINSTANCE\"/>").append(EOLN)
+                            .append(" </entity>").append(EOLN);
         }
+        // JOBINSTANCE - V2 and V3 entities - CONDITIONAL (v3 only)
         if (Arrays.asList(entityClassNames).contains("com.ibm.jbatch.container.persistence.jpa.JobInstanceEntityV3")) {
             orm
-            .append(" <entity class=\"com.ibm.jbatch.container.persistence.jpa.JobInstanceEntityV2\">").append(EOLN)
-            .append("  <table name=\"").append(tablePrefix).append("JOBINSTANCE\"/>").append(EOLN)
-            .append(" </entity>").append(EOLN)
-            .append(" <entity class=\"com.ibm.jbatch.container.persistence.jpa.JobInstanceEntityV3\">").append(EOLN)
-            .append("  <table name=\"").append(tablePrefix).append("JOBINSTANCE\"/>").append(EOLN)
-            .append("  <attributes>").append(EOLN)
-            .append("   <element-collection name=\"groupNames\" target-class=\"java.lang.String\">").append(EOLN)
-            .append("    <collection-table name=\"").append(tablePrefix).append("GROUPASSOCIATION\">").append(EOLN)
-            .append("     <join-column name=\"FK_JOBINSTANCEID\"/>").append(EOLN)
-            .append("     <index name=\"").append(tablePrefix).append("GA_FKINSTANCEID_IX\" column-list=\"FK_JOBINSTANCEID\" unique=\"false\"/>").append(EOLN)
-            .append("    </collection-table>").append(EOLN)
-            .append("   </element-collection>").append(EOLN)
-            .append("  </attributes>").append(EOLN)
-            .append(" </entity>").append(EOLN);
+                            .append(" <entity class=\"com.ibm.jbatch.container.persistence.jpa.JobInstanceEntityV2\">").append(EOLN)
+                            .append("  <table name=\"").append(tablePrefix).append("JOBINSTANCE\"/>").append(EOLN)
+                            .append(" </entity>").append(EOLN)
+                            .append(" <entity class=\"com.ibm.jbatch.container.persistence.jpa.JobInstanceEntityV3\">").append(EOLN)
+                            .append("  <table name=\"").append(tablePrefix).append("JOBINSTANCE\"/>").append(EOLN)
+                            .append("  <attributes>").append(EOLN)
+                            .append("   <element-collection name=\"groupNames\" target-class=\"java.lang.String\">").append(EOLN)
+                            .append("    <collection-table name=\"").append(tablePrefix).append("GROUPASSOCIATION\">").append(EOLN)
+                            .append("     <join-column name=\"FK_JOBINSTANCEID\"/>").append(EOLN)
+                            .append("     <index name=\"").append(tablePrefix).append("GA_FKINSTANCEID_IX\" column-list=\"FK_JOBINSTANCEID\" unique=\"false\"/>").append(EOLN)
+                            .append("    </collection-table>").append(EOLN)
+                            .append("   </element-collection>").append(EOLN)
+                            .append("  </attributes>").append(EOLN)
+                            .append(" </entity>").append(EOLN);
 
         }
+        // STEPTHREADEXECUTION - V1 entity - UNCONDITIONAL (v1 or v2)
         orm
-        .append(" <entity class=\"com.ibm.jbatch.container.persistence.jpa.StepThreadExecutionEntity\">").append(EOLN)
-        .append("  <table name=\"").append(tablePrefix).append("STEPTHREADEXECUTION\">").append(EOLN)
-        .append("   <unique-constraint>").append(EOLN)
-        .append("    <column-name>FK_JOBEXECID</column-name>").append(EOLN)
-        .append("    <column-name>STEPNAME</column-name>").append(EOLN)
-        .append("    <column-name>PARTNUM</column-name>").append(EOLN)
-        .append("   </unique-constraint>").append(EOLN)
-        //adding indexes
-        .append(" <index name=\"").append(tablePrefix).append("STE_FKJOBEXECID_IX\" column-list=\"FK_JOBEXECID\" unique=\"false\"/>").append(EOLN)
-        .append(" <index name=\"").append(tablePrefix).append("STE_FKTLSTEPEID_IX\" column-list=\"FK_TOPLVL_STEPEXECID\" unique=\"false\"/>").append(EOLN)
-        //end indexes
-        .append("  </table>").append(EOLN);
+                        .append(" <entity class=\"com.ibm.jbatch.container.persistence.jpa.StepThreadExecutionEntity\">").append(EOLN)
+                        .append("  <table name=\"").append(tablePrefix).append("STEPTHREADEXECUTION\">").append(EOLN)
+                        .append("   <unique-constraint>").append(EOLN)
+                        .append("    <column-name>FK_JOBEXECID</column-name>").append(EOLN)
+                        .append("    <column-name>STEPNAME</column-name>").append(EOLN)
+                        .append("    <column-name>PARTNUM</column-name>").append(EOLN)
+                        .append("   </unique-constraint>").append(EOLN)
+                        //adding indexes
+                        .append(" <index name=\"").append(tablePrefix).append("STE_FKJOBEXECID_IX\" column-list=\"FK_JOBEXECID\" unique=\"false\"/>").append(EOLN)
+                        .append(" <index name=\"").append(tablePrefix).append("STE_FKTLSTEPEID_IX\" column-list=\"FK_TOPLVL_STEPEXECID\" unique=\"false\"/>").append(EOLN)
+                        //end indexes
+                        .append("  </table>").append(EOLN);
         if (!"IDENTITY".equals(strategy)) {
             orm
-            .append("  <attributes>").append(EOLN)
-            .append("   <id name=\"stepExecutionId\">").append(EOLN)
-            .append("    <column name=\"STEPEXECID\" nullable=\"false\"/>").append(EOLN)
-            .append("    <generated-value generator=\"STEPEXECIDGEN\" strategy=\"").append(strategy).append("\"/>").append(EOLN);
+                            .append("  <attributes>").append(EOLN)
+                            .append("   <id name=\"stepExecutionId\">").append(EOLN)
+                            .append("    <column name=\"STEPEXECID\" nullable=\"false\"/>").append(EOLN)
+                            .append("    <generated-value generator=\"STEPEXECIDGEN\" strategy=\"").append(strategy).append("\"/>").append(EOLN);
             if ("TABLE".equals(strategy)) {
                 orm
-                .append("    <table-generator name=\"STEPEXECIDGEN\" table=\"").append(tablePrefix).append("GEN\"");
+                                .append("    <table-generator name=\"STEPEXECIDGEN\" table=\"").append(tablePrefix).append("GEN\"");
                 if (schema != null)
                     orm.append(" schema=\"").append(schema).append('"');
                 orm.append("/>").append(EOLN);
             } else
                 orm
-                .append("    <sequence-generator name=\"STEPEXECIDGEN\" sequence-name=\"").append(tablePrefix).append("SEQ\"/>").append(EOLN);
+                                .append("    <sequence-generator name=\"STEPEXECIDGEN\" sequence-name=\"").append(tablePrefix).append("SEQ\"/>").append(EOLN);
             orm
-            .append("   </id>").append(EOLN)
-            .append("  </attributes>").append(EOLN);
+                            .append("   </id>").append(EOLN)
+                            .append("  </attributes>").append(EOLN);
         }
         orm
-        .append(" </entity>").append(EOLN)
+                        .append(" </entity>").append(EOLN);
 
-        .append(" <entity class=\"com.ibm.jbatch.container.persistence.jpa.StepThreadInstanceEntity\">").append(EOLN)
-        .append("  <table name=\"").append(tablePrefix).append("STEPTHREADINSTANCE\">").append(EOLN)
-        //adding indexes
-        .append("   <index name=\"").append(tablePrefix).append("STI_FKINSTANCEID_IX\" column-list=\"FK_JOBINSTANCEID\" unique=\"false\"/>").append(EOLN)
-        .append("   <index name=\"").append(tablePrefix).append("STI_FKLATEST_SEI_IX\" column-list=\"FK_LATEST_STEPEXECID\" unique=\"false\"/>").append(EOLN)
-        //end indexes
-        .append("  </table>").append(EOLN)
-        .append(" </entity>").append(EOLN);
-
-        if (Arrays.asList(entityClassNames).contains("com.ibm.jbatch.container.persistence.jpa.RemotablePartitionEntity")) {
-            orm.append(" <entity class=\"com.ibm.jbatch.container.persistence.jpa.RemotablePartitionEntity\">").append(EOLN)
-               .append("  <table name=\"").append(tablePrefix).append("REMOTABLEPARTITION\">").append(EOLN)
-               .append("   <unique-constraint>").append(EOLN)
-               .append("    <column-name>FK_JOBEXECUTIONID</column-name>").append(EOLN)
-               .append("    <column-name>STEPNAME</column-name>").append(EOLN)
-               .append("    <column-name>PARTNUM</column-name>").append(EOLN)
-               .append("   </unique-constraint>").append(EOLN)
-               .append("  </table>").append(EOLN)
-               .append(" </entity>").append(EOLN);
+        // STEPTHREADEXECUTION - V2 entity - CONDITIONAL (v2 only)
+        if (Arrays.asList(entityClassNames).contains("com.ibm.jbatch.container.persistence.jpa.StepThreadExecutionEntityV2")) {
+            orm
+                            .append(" <entity class=\"com.ibm.jbatch.container.persistence.jpa.StepThreadExecutionEntityV2\">").append(EOLN)
+                            .append("  <table name=\"").append(tablePrefix).append("STEPTHREADEXECUTION\">").append(EOLN)
+                            .append("  </table>").append(EOLN)
+                            .append(" </entity>").append(EOLN);
         }
 
+        // STEPTHREADINSTANCE - V1 entity - UNCONDITIONAL
+        orm.append(" <entity class=\"com.ibm.jbatch.container.persistence.jpa.StepThreadInstanceEntity\">").append(EOLN)
+                        .append("  <table name=\"").append(tablePrefix).append("STEPTHREADINSTANCE\">").append(EOLN)
+                        //adding indexes
+                        .append("   <index name=\"").append(tablePrefix).append("STI_FKINSTANCEID_IX\" column-list=\"FK_JOBINSTANCEID\" unique=\"false\"/>").append(EOLN)
+                        .append("   <index name=\"").append(tablePrefix).append("STI_FKLATEST_SEI_IX\" column-list=\"FK_LATEST_STEPEXECID\" unique=\"false\"/>").append(EOLN)
+                        //end indexes
+                        .append("  </table>").append(EOLN)
+                        .append(" </entity>").append(EOLN);
+
+        // REMOTABLEPARTITION - V1 entity - CONDITIONAL (on presence of RemotablePartitionEntity only)
+        if (Arrays.asList(entityClassNames).contains("com.ibm.jbatch.container.persistence.jpa.RemotablePartitionEntity")) {
+            orm.append(" <entity class=\"com.ibm.jbatch.container.persistence.jpa.RemotablePartitionEntity\">").append(EOLN)
+                               .append("  <table name=\"").append(tablePrefix).append("REMOTABLEPARTITION\">").append(EOLN)
+                               .append("  </table>").append(EOLN)
+                               .append(" </entity>").append(EOLN);
+        }
+
+        // ALL DONE
         orm.append("</entity-mappings>").append(EOLN);
 
         if (trace && tc.isDebugEnabled())


### PR DESCRIPTION
## CHANGES

### Mark RemotablePartition consumed 
(JPAPersistenceManagerImpl.java, MemoryPersistenceManagerImpl.java, BatchJmsEndpointListener.java)

* update to consumed, serverid, restURL when step thread exec created
* in BatchJmsEndpointListener.java,  abort `if (!rpState.equals(WSRemotablePartitionState.QUEUED)) {`
* we maintain memory persistence path for test purposes.. could be used by customer to test batch JMS config as well.. obviously limited usefulness of having a single-JVM-scoped repository
	
### Fix PSU creation, Oracle DB old tables
(JPAPersistenceManagerImpl.java, DatabaseStoreImpl
* createPSU   build the list of entities to pass to DBStoreImpl such that it only includes one for each entity type (instance, execution) and refactored the logic in DBStoreImpl to account for this.   This is in contrast with the recent idea of passing multiple entities in certain cases and having each trigger a different stanza within DBStoreImpl
* in DBStoreImpl also added comments clarifying the major logic branches
* Acknowledge  "ORA-00942" as a message which indicates new Oracle DB table hasn't been created

### Poll for recovered partitions

The problem with aborting a non-QUEUED RemotablePartition is that it prevents a redelivery from producing a failure msg which gets sent back as a reply msg to the top-level job.  (One problem with trying to consume such a message is that it could interfere with a partition currently executing, which is why we made the change in the first place.)

In **dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/controller/impl/PartitionedStepControllerImpl.java** we have changes to:
* switch from local vars to fields in a couple places (e.g.  currentPlan,  analyzerExceptions) to reduce passing objs around 
    * **NOTE**: This eliminates entry/exit logging so make sure we re-add anything good we'd lose
* throw JobStoppingException if job is stopped while a partition is starting (better flow of control instead of passing back return codes)
* keep an extra  finishedPartitionNumbers data structure for a Set view to compare against
* In waitForNextPartitionToFinish loop
    * changed to while(true) loop 
    * receivedLastMessageForPartition=> isFinalMessageForPartition
        * broke apart test for partition end vs. handling of this condition
    * add checkForRecoveredRemotePartitions() 

### Misc. refactoring

The rest is all fairly minor, deleting things no longer used, etc., removing some trivial trace.  


**dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/execution/impl/JobExecutionHelper.java**
* remove no-op  createPartitionExecution (seems confusing to have it)
* format

**dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/execution/impl/RuntimePartitionExecution.java**
* remove no-op  updatePartitionExecution (seems confusing to have it)

JPA entities 
* trivial trace

JPA entity extractors
* rename:  "table version" => "entity version"

**dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobExecutionEntityV3.java**
* remove duplicate @OneToMany field

**dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/RemotablePartitionEntity.java**
* remove redundant uniqueConstraints

**dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/IPersistenceManagerService.java**
* remove unsed methods, create/get by RPKey, 

**dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/AbstractPersistenceManager.java**
* remove other illegal state values to emphasize this is only preventing move out of COMPLETED/ABANDONED
    * we **DO NOT** want to start disallowing other state transitions we think shouldn't happen since this effects the JMS executor redelivery path.

**dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/RemotablePartitionState.java → dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/WSRemotablePartitionState.java**
* rename to follow class naming convention

**dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/ws/impl/WSJobRepositoryImpl.java**
* method name, PK refactoring
* fix of failure to use msg bundle in  "BATCH_SECURITY_NOT_ACTIVE"   (could lead to FAT failures though you'd think I'd have caught it if my test builds were broad enough)

**dev/com.ibm.ws.jbatch.jms/src/com/ibm/ws/jbatch/jms/internal/dispatcher/BatchJmsDispatcher.java**
* passing around an "exceptionMessage" as parm can be a bit misleading when looking at trace, say FAT failures... for someone on the L3 team somewhat new to the code. 
