### PR TITLE
Fix Java2Sec failure in CXF Api

### DIFF
--- a/dev/com.ibm.ws.jaxws.clientcontainer/src/com/ibm/ws/jaxws/metadata/builder/HandlerChainInfoBuilder.java
+++ b/dev/com.ibm.ws.jaxws.clientcontainer/src/com/ibm/ws/jaxws/metadata/builder/HandlerChainInfoBuilder.java
@@ -12,6 +12,9 @@ package com.ibm.ws.jaxws.metadata.builder;
 
 import java.io.InputStream;
 import java.net.URL;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -60,7 +63,17 @@ public class HandlerChainInfoBuilder {
 
     static {
         try {
-            context = JAXBUtils.newInstance(PortComponentHandlerType.class);
+            try {
+                context = AccessController.doPrivileged(new PrivilegedExceptionAction<JAXBContext>() {
+                    @Override
+                    public JAXBContext run() throws Exception {
+                        return JAXBUtils.newInstance(PortComponentHandlerType.class);
+                    }
+                });
+
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.api.2.6.2/src/org/apache/cxf/staxutils/W3CDOMStreamWriter.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.api.2.6.2/src/org/apache/cxf/staxutils/W3CDOMStreamWriter.java
@@ -18,6 +18,8 @@
  */
 package org.apache.cxf.staxutils;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Stack;
@@ -131,7 +133,13 @@ public class W3CDOMStreamWriter implements XMLStreamWriter {
         }
         ((W3CNamespaceContext)context).setElement(element);
         if (appendedChildNode != null) {
-            currentNode = org.apache.cxf.helpers.DOMUtils.getDomElement(appendedChildNode);
+            final Node appChildNode = appendedChildNode;
+            currentNode = AccessController.doPrivileged(new PrivilegedAction<Node>() {
+                @Override
+                public Node run() { 
+                    return org.apache.cxf.helpers.DOMUtils.getDomElement(appChildNode);
+                }
+            });
         } else {
             currentNode = element;
         }


### PR DESCRIPTION
The com.ibm.ws.jaxws.clientcontainer_fat bucket is failing when java2sec is enabled. A fix in the API is being added to address the failure. 