### PR TITLE
switch the metatype attribute for infinispan support to beta

### DIFF
--- a/dev/com.ibm.ws.session.cache/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.session.cache/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018,2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -29,6 +29,9 @@ properties.desc=List of vendor specific JCache configuration properties, which a
 
 extraProperties.name=Vendor specific properties
 extraProperties.description=List of vendor specific JCache configuration properties, which are passed to the JCache provider when obtaining the CacheManager.
+
+enableBetaSupportForInfinispan.name=Enable beta of support for Infinispan
+enableBetaSupportForInfinispan.desc=Enables Infinispan to be used for HTTP session persistence as beta function.
 
 # performance group properties:
 

--- a/dev/com.ibm.ws.session.cache/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.session.cache/resources/OSGI-INF/l10n/metatype.properties
@@ -31,7 +31,7 @@ extraProperties.name=Vendor specific properties
 extraProperties.description=List of vendor specific JCache configuration properties, which are passed to the JCache provider when obtaining the CacheManager.
 
 enableBetaSupportForInfinispan.name=Enable beta of support for Infinispan
-enableBetaSupportForInfinispan.desc=This property enables Infinispan to be used for HTTP session persistence as a beta function.
+enableBetaSupportForInfinispan.desc=The enableBetaSupportForInfinispan property enables an Infinispan cache to be used for HTTP session persistence as a beta function.
 
 # performance group properties:
 

--- a/dev/com.ibm.ws.session.cache/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.session.cache/resources/OSGI-INF/l10n/metatype.properties
@@ -31,7 +31,7 @@ extraProperties.name=Vendor specific properties
 extraProperties.description=List of vendor specific JCache configuration properties, which are passed to the JCache provider when obtaining the CacheManager.
 
 enableBetaSupportForInfinispan.name=Enable beta of support for Infinispan
-enableBetaSupportForInfinispan.desc=Enables Infinispan to be used for HTTP session persistence as beta function.
+enableBetaSupportForInfinispan.desc=This property enables Infinispan to be used for HTTP session persistence as a beta function.
 
 # performance group properties:
 

--- a/dev/com.ibm.ws.session.cache/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.session.cache/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 IBM Corporation and others.
+    Copyright (c) 2018,2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -19,7 +19,7 @@
  </Designate>
 
  <OCD id="com.ibm.ws.session.cache" ibm:alias="httpSessionCache" name="%httpSessionCache" description="%httpSessionCache.desc" ibmui:localization="OSGI-INF/l10n/metatype">
-  <AD id="enableBetaSupportForInfinispan" type="Boolean" default="false" name="internal" description="internal use only"/> <!-- Add ibm:beta="true" when ready to beta -->
+  <AD id="enableBetaSupportForInfinispan" type="Boolean" ibm:beta="true" default="false" name="%enableBetaSupportForInfinispan.name" description="%enableBetaSupportForInfinispan.desc"/> <!-- Remove when ready to GA -->
   <AD id="libraryRef"                     type="String"  required="false" ibm:type="pid" ibm:reference="com.ibm.ws.classloading.sharedlibrary" cardinality="1" name="%libraryRef" description="%libraryRef.desc"/>
   <AD id="library.target"                 type="String"  default="(|(service.pid=${libraryRef})(&amp;(zero=${count(libraryRef)})(id=com.ibm.ws.session.cache.defaultprovider.library)))" ibm:final="true" name="internal" description="internal use only"/>
   <AD id="monitor.target"                 type="String"  default="(|(!(filter>=!))(filter=*Session*))" ibm:final="true" name="internal" description="internal use only"/>


### PR DESCRIPTION
Mark the metatype attribute for gating infinispan support as beta, and add a translatable name/description.