### PR TITLE
Add message for missing Kafka Lib

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.adapter/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.adapter/bnd.bnd
@@ -29,7 +29,8 @@ WS-TraceGroup: REACTIVEMESSAGE
 
 Export-Package: com.ibm.ws.microprofile.reactive.messaging.kafka.adapter
 
-Import-Package: *
+Import-Package: com.ibm.ws.microprofile.reactive.messaging.kafka.resources,\
+                *
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.adapter/src/com/ibm/ws/microprofile/reactive/messaging/kafka/adapter/KafkaAdapterException.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.adapter/src/com/ibm/ws/microprofile/reactive/messaging/kafka/adapter/KafkaAdapterException.java
@@ -25,4 +25,11 @@ public class KafkaAdapterException extends RuntimeException {
         super(cause);
     }
 
+    /**
+     * @param message
+     */
+    public KafkaAdapterException(String message) {
+        super(message);
+    }
+
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.adapter/src/com/ibm/ws/microprofile/reactive/messaging/kafka/adapter/package-info.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.adapter/src/com/ibm/ws/microprofile/reactive/messaging/kafka/adapter/package-info.java
@@ -12,7 +12,7 @@
  * @version 1.0
  */
 @org.osgi.annotation.versioning.Version("1.0")
-@TraceOptions(traceGroup = "REACTIVEMESSAGE")
+@TraceOptions(traceGroup = "REACTIVEMESSAGE", messageBundle = "com.ibm.ws.microprofile.reactive.messaging.kafka.resources.ReactiveMessaging")
 package com.ibm.ws.microprofile.reactive.messaging.kafka.adapter;
 
 import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/bnd.bnd
@@ -28,10 +28,10 @@ WS-TraceGroup: REACTIVEMESSAGE
 -dsannotations: com.ibm.ws.microprofile.reactive.messaging.kafka.KafkaConnectorCDIExtension
 
 Export-Package: com.ibm.ws.microprofile.reactive.messaging.kafka,\
-                com.ibm.ws.kafka.security
+                com.ibm.ws.kafka.security,\
+                com.ibm.ws.microprofile.reactive.messaging.kafka.resources;version=1.0
 
-Private-Package: com.ibm.ws.microprofile.reactive.messaging.kafka.classloader,\
-                com.ibm.ws.microprofile.reactive.messaging.kafka.resources
+Private-Package: com.ibm.ws.microprofile.reactive.messaging.kafka.classloader
 
 Import-Package: *
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/resources/com/ibm/ws/microprofile/reactive/messaging/kafka/resources/ReactiveMessaging.nlsprops
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/resources/com/ibm/ws/microprofile/reactive/messaging/kafka/resources/ReactiveMessaging.nlsprops
@@ -56,9 +56,9 @@ kafka.groupid.not.set.CWMRX1005E.explanation=The Kafka consumer group ID must be
 kafka.groupid.not.set.CWMRX1005E.useraction=Set the property in one of the MicroProfile ConfigSource locations for this application, for example, the microprofile-config.properties file.
 
 #Do not translate "kafka-clients", "Apache Kafka" or "Maven Central"
-kafka.library.not.present.CWMRX1006E=CWMRX1006E: Classes from the kafka-clients jar could not be loaded. Ensure that the kafka-clients jar and its dependencies are available as libraries to your application.
-kafka.library.not.present.CWMRX1006E.explanation=Applications which use the Reactive Messaging Kafka Client must provide the Apache Kafka clients jar and its dependencies, either by packaging it as a library within the application, or by providing it as a shared library.
-kafka.library.not.present.CWMRX1006E.useraction=Package the kafka-clients jar and its dependencies as libraries in your application, or as a shared library. The kafka-clients jar can be downloaded from the Apache Kafka website or from Maven Central.
+kafka.library.not.present.CWMRX1006E=CWMRX1006E: Classes from the kafka-clients JAR file could not be loaded. Ensure that the kafka-clients JAR file and its dependencies are available as libraries to your application.
+kafka.library.not.present.CWMRX1006E.explanation=Applications that use the Reactive Messaging Kafka Client must provide the kafka-clients JAR file and its dependencies. They can provide this file and its dependencies either by packaging it as a library within the application or by providing it as a shared library.
+kafka.library.not.present.CWMRX1006E.useraction=Package the kafka-clients JAR file and its dependencies as libraries in your application or as a shared library. The kafka-clients JAR file can be downloaded from the Apache Kafka website or from Maven Central.
 
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Reactive Messaging error message

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/resources/com/ibm/ws/microprofile/reactive/messaging/kafka/resources/ReactiveMessaging.nlsprops
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/resources/com/ibm/ws/microprofile/reactive/messaging/kafka/resources/ReactiveMessaging.nlsprops
@@ -55,6 +55,11 @@ kafka.groupid.not.set.CWMRX1005E=CWMRX1005E: The group.id property was not set i
 kafka.groupid.not.set.CWMRX1005E.explanation=The Kafka consumer group ID must be set to allow Reactive Messaging to function properly.
 kafka.groupid.not.set.CWMRX1005E.useraction=Set the property in one of the MicroProfile ConfigSource locations for this application, for example, the microprofile-config.properties file.
 
+#Do not translate "kafka-clients", "Apache Kafka" or "Maven Central"
+kafka.library.not.present.CWMRX1006E=CWMRX1006E: Classes from the kafka-clients jar could not be loaded. Ensure that the kafka-clients jar and its dependencies are available as libraries to your application.
+kafka.library.not.present.CWMRX1006E.explanation=Applications which use the Reactive Messaging Kafka Client must provide the Apache Kafka clients jar and its dependencies, either by packaging it as a library within the application, or by providing it as a shared library.
+kafka.library.not.present.CWMRX1006E.useraction=Package the kafka-clients jar and its dependencies as libraries in your application, or as a shared library. The kafka-clients jar can be downloaded from the Apache Kafka website or from Maven Central.
+
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Reactive Messaging error message
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/nolib/KafkaNoLibTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/nolib/KafkaNoLibTest.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.invalid.nolib;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.ConnectorProperties.simpleIncomingChannel;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.ConnectorProperties.simpleOutgoingChannel;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils.kafkaPermissions;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.PropertiesAsset;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ConnectorProperties;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * Test with the Kafka lib missing
+ */
+@RunWith(FATRunner.class)
+public class KafkaNoLibTest {
+
+    private static final String APP_NAME = "KafkaNoLib";
+    private static final String APP_GROUP_ID = "no-lib-test-group";
+
+    @Server("SimpleRxMessagingServer")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void teardownTest() throws Exception {
+        server.stopServer("CWMRX1006E", // Expected error message
+                          "CWWKZ0002E" // Generic "Exception starting app" message
+        );
+    }
+
+    @Test
+    @AllowedFFDC
+    public void testDeploymentFailure() throws Exception {
+        ConnectorProperties outgoingProperties = simpleOutgoingChannel("example.com", NoLibMessagingBean.CHANNEL_OUT);
+
+        ConnectorProperties incomingProperties = simpleIncomingChannel("example.com", NoLibMessagingBean.CHANNEL_IN, APP_GROUP_ID);
+
+        PropertiesAsset appConfig = new PropertiesAsset()
+                        .include(incomingProperties)
+                        .include(outgoingProperties);
+
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addAsManifestResource(kafkaPermissions(), "permissions.xml")
+                        .addClass(NoLibMessagingBean.class)
+                        .addAsResource(appConfig, "META-INF/microprofile-config.properties");
+
+        server.setMarkToEndOfLog();
+        // Deploy the application
+        ShrinkHelper.exportToServer(server, "dropins", war, SERVER_ONLY);
+
+        // Wait for either the app to start, or for the expected deployment error
+        String logLine = server.waitForStringInLogUsingMark("CWWKZ0001I.*" + APP_NAME + "|" + "CWMRX1006E:");
+
+        // Check that we actually got the expected string
+        assertThat(logLine, containsString("CWMRX1006E:"));
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/nolib/NoLibMessagingBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/nolib/NoLibMessagingBean.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.invalid.nolib;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+@ApplicationScoped
+public class NoLibMessagingBean {
+
+    public static final String CHANNEL_IN = "shared-lib-in";
+    public static final String CHANNEL_OUT = "shared-lib-out";
+
+    @Incoming(CHANNEL_IN)
+    @Outgoing(CHANNEL_OUT)
+    public String reverseString(String in) {
+        StringBuilder sb = new StringBuilder(in);
+        sb.reverse();
+        return sb.toString();
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/FATSuite.java
@@ -15,6 +15,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.tests.KafkaTestClientProviderTest;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.invalid.nolib.KafkaNoLibTest;
 import com.ibm.ws.microprofile.reactive.messaging.fat.loginModuleClassloading.LoginModuleClassloadingTest;
 
 @RunWith(Suite.class)
@@ -24,6 +25,7 @@ import com.ibm.ws.microprofile.reactive.messaging.fat.loginModuleClassloading.Lo
                 SaslPlainTests.class,
                 KafkaTestClientProviderTest.class,
                 LoginModuleClassloadingTest.class,
+                KafkaNoLibTest.class
 })
 public class FATSuite {
 


### PR DESCRIPTION
When using the Kafka connector for Reactive Messaging, the kafka client jar must be included in the app or in a shared library.

Add a more helpful error message if it is not present.