### PR TITLE
enable main test bucket for for Infinispan 10.0.0.Final

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_infinispan/build.gradle
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/build.gradle
@@ -12,6 +12,8 @@
 configurations {
   caffeine
   gson
+  infinispanCDICommon
+  infinispanCDIEmbedded
   infinispanCommons
   infinispanCore
   infinispanJCache
@@ -22,22 +24,26 @@ configurations {
   protostream
   reactiveStreams
   rxjava
+  smallryeMetrics
 }
 
 // Define G:A:V coordinates of each dependency
 dependencies {
   caffeine 'com.github.ben-manes.caffeine:caffeine:2.8.0'
   gson 'com.google.code.gson:gson:2.8.2'
-  infinispanCommons 'org.infinispan:infinispan-commons:10.0.0.CR1'
-  infinispanCore 'org.infinispan:infinispan-core:10.0.0.CR1'
-  infinispanJCache 'org.infinispan:infinispan-jcache:10.0.0.CR1'
-  infinispanJCacheCommons 'org.infinispan:infinispan-jcache-commons:10.0.0.CR1'
+  infinispanCDICommon 'org.infinispan:infinispan-cdi-common:10.0.0.Final'
+  infinispanCDIEmbedded 'org.infinispan:infinispan-cdi-embedded:10.0.0.Final'
+  infinispanCommons 'org.infinispan:infinispan-commons:10.0.0.Final'
+  infinispanCore 'org.infinispan:infinispan-core:10.0.0.Final'
+  infinispanJCache 'org.infinispan:infinispan-jcache:10.0.0.Final'
+  infinispanJCacheCommons 'org.infinispan:infinispan-jcache-commons:10.0.0.Final'
   protoparser 'com.squareup:protoparser:4.0.3'
-  protostream 'org.infinispan.protostream:protostream:4.3.0.Alpha11'
-  jbossLogging 'org.jboss.logging:jboss-logging:3.3.2.Final'
-  jGroups 'org.jgroups:jgroups:4.1.2.Final'
+  protostream 'org.infinispan.protostream:protostream:4.3.0.Alpha13'
+  jbossLogging 'org.jboss.logging:jboss-logging:3.4.1.Final'
+  jGroups 'org.jgroups:jgroups:4.1.6.Final'
   reactiveStreams 'org.reactivestreams:reactive-streams:1.0.2'
-  rxjava 'io.reactivex.rxjava2:rxjava:2.2.6'
+  rxjava 'io.reactivex.rxjava2:rxjava:2.2.9'
+  smallryeMetrics 'io.smallrye:smallrye-metrics:2.1.5'
 }
 
 task addCaffeineToSharedDir(type: Copy) {
@@ -50,6 +56,18 @@ task addGSONToSharedDir(type: Copy) {
   from configurations.gson
   into new File(autoFvtDir, 'publish/shared/resources/infinispan')
   rename 'gson-*.jar', 'gson.jar'
+}
+
+task addInfinispanCDICommonToSharedDir(type: Copy) {
+  from configurations.infinispanCDICommon
+  into new File(autoFvtDir, 'publish/shared/resources/infinispan')
+  rename 'infinispan-cdi-common-10.*.jar', 'infinispan-cdi-common.jar'
+}
+
+task addInfinispanCDIEmbeddedToSharedDir(type: Copy) {
+  from configurations.infinispanCDIEmbedded
+  into new File(autoFvtDir, 'publish/shared/resources/infinispan')
+  rename 'infinispan-cdi-embedded-10.*.jar', 'infinispan-cdi-embedded.jar'
 }
 
 task addInfinispanCommonsToSharedDir(type: Copy) {
@@ -112,10 +130,18 @@ task addRxJavaToSharedDir(type: Copy) {
   rename 'rxjava-*.jar', 'rxjava.jar'
 }
 
+task addSmallRyeMetricsToSharedDir(type: Copy) {
+  from configurations.smallryeMetrics
+  into new File(autoFvtDir, 'publish/shared/resources/infinispan')
+  rename 'smallrye-metrics-*.jar', 'smallrye-metrics.jar'
+}
+
 addRequiredLibraries {
   dependsOn addDerby
   dependsOn addCaffeineToSharedDir
   dependsOn addGSONToSharedDir
+  dependsOn addInfinispanCDICommonToSharedDir
+  dependsOn addInfinispanCDIEmbeddedToSharedDir
   dependsOn addInfinispanCommonsToSharedDir
   dependsOn addInfinispanCoreToSharedDir
   dependsOn addInfinispanJCacheToSharedDir
@@ -126,4 +152,5 @@ addRequiredLibraries {
   dependsOn addProtoStreamToSharedDir
   dependsOn addReactiveStreamsToSharedDir
   dependsOn addRxJavaToSharedDir
+  dependsOn addSmallRyeMetricsToSharedDir
 }

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/build.gradle
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/build.gradle
@@ -12,15 +12,12 @@
 configurations {
   caffeine
   gson
-  infinispanCDICommon
-  infinispanCDIEmbedded
   infinispanCommons
   infinispanCore
   infinispanJCache
   infinispanJCacheCommons
   jbossLogging
   jGroups
-  protoparser
   protostream
   reactiveStreams
   rxjava
@@ -31,13 +28,10 @@ configurations {
 dependencies {
   caffeine 'com.github.ben-manes.caffeine:caffeine:2.8.0'
   gson 'com.google.code.gson:gson:2.8.2'
-  infinispanCDICommon 'org.infinispan:infinispan-cdi-common:10.0.0.Final'
-  infinispanCDIEmbedded 'org.infinispan:infinispan-cdi-embedded:10.0.0.Final'
   infinispanCommons 'org.infinispan:infinispan-commons:10.0.0.Final'
   infinispanCore 'org.infinispan:infinispan-core:10.0.0.Final'
   infinispanJCache 'org.infinispan:infinispan-jcache:10.0.0.Final'
   infinispanJCacheCommons 'org.infinispan:infinispan-jcache-commons:10.0.0.Final'
-  protoparser 'com.squareup:protoparser:4.0.3'
   protostream 'org.infinispan.protostream:protostream:4.3.0.Alpha13'
   jbossLogging 'org.jboss.logging:jboss-logging:3.4.1.Final'
   jGroups 'org.jgroups:jgroups:4.1.6.Final'
@@ -56,18 +50,6 @@ task addGSONToSharedDir(type: Copy) {
   from configurations.gson
   into new File(autoFvtDir, 'publish/shared/resources/infinispan')
   rename 'gson-*.jar', 'gson.jar'
-}
-
-task addInfinispanCDICommonToSharedDir(type: Copy) {
-  from configurations.infinispanCDICommon
-  into new File(autoFvtDir, 'publish/shared/resources/infinispan')
-  rename 'infinispan-cdi-common-10.*.jar', 'infinispan-cdi-common.jar'
-}
-
-task addInfinispanCDIEmbeddedToSharedDir(type: Copy) {
-  from configurations.infinispanCDIEmbedded
-  into new File(autoFvtDir, 'publish/shared/resources/infinispan')
-  rename 'infinispan-cdi-embedded-10.*.jar', 'infinispan-cdi-embedded.jar'
 }
 
 task addInfinispanCommonsToSharedDir(type: Copy) {
@@ -106,12 +88,6 @@ task addJGroupsToSharedDir(type: Copy) {
   rename 'jgroups-*.jar', 'jgroups.jar'
 }
 
-task addProtoParserToSharedDir(type: Copy) {
-  from configurations.protoparser
-  into new File(autoFvtDir, 'publish/shared/resources/infinispan')
-  rename 'protoparser-*.jar', 'protoparser.jar'
-}
-
 task addProtoStreamToSharedDir(type: Copy) {
   from configurations.protostream
   into new File(autoFvtDir, 'publish/shared/resources/infinispan')
@@ -140,15 +116,12 @@ addRequiredLibraries {
   dependsOn addDerby
   dependsOn addCaffeineToSharedDir
   dependsOn addGSONToSharedDir
-  dependsOn addInfinispanCDICommonToSharedDir
-  dependsOn addInfinispanCDIEmbeddedToSharedDir
   dependsOn addInfinispanCommonsToSharedDir
   dependsOn addInfinispanCoreToSharedDir
   dependsOn addInfinispanJCacheToSharedDir
   dependsOn addInfinispanJCacheCommonsToSharedDir
   dependsOn addJbossLoggingToSharedDir
   dependsOn addJGroupsToSharedDir
-  dependsOn addProtoParserToSharedDir
   dependsOn addProtoStreamToSharedDir
   dependsOn addReactiveStreamsToSharedDir
   dependsOn addRxJavaToSharedDir

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/FATSuite.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/FATSuite.java
@@ -33,8 +33,8 @@ import componenttest.topology.utils.HttpUtils;
 @SuiteClasses({
                 SessionCacheOneServerTest.class,
                 SessionCacheTwoServerTest.class,
-                SessionCacheTimeoutTest.class,
-                SessionCacheTwoServerTimeoutTest.class
+                //SessionCacheTimeoutTest.class, // TODO enable once working for Infinispan 10.0.0.Final
+                //SessionCacheTwoServerTimeoutTest.class // TODO enable once working for Infinispan 10.0.0.Final
                 // A separate test suite covers Infinispan client/server scenarios
 })
 

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/FATSuite.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/FATSuite.java
@@ -33,8 +33,8 @@ import componenttest.topology.utils.HttpUtils;
 @SuiteClasses({
                 SessionCacheOneServerTest.class,
                 SessionCacheTwoServerTest.class,
-                //SessionCacheTimeoutTest.class, // TODO enable once working for Infinispan 10.0.0.Final
-                //SessionCacheTwoServerTimeoutTest.class // TODO enable once working for Infinispan 10.0.0.Final
+                SessionCacheTimeoutTest.class,
+                SessionCacheTwoServerTimeoutTest.class
                 // A separate test suite covers Infinispan client/server scenarios
 })
 

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.server/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.server/server.xml
@@ -7,6 +7,7 @@
         <feature>jdbc-4.1</feature>
         <feature>jndi-1.0</feature>
         <feature>monitor-1.0</feature>
+        <feature>mpMetrics-2.0</feature> <!-- one of the Infinispan JARs has a hard dependency on MicroProfile Metrics API -->
         <feature>sessionCache-1.0</feature>
     </featureManager>
     

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.serverA/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.serverA/server.xml
@@ -4,6 +4,7 @@
         <!-- This server provides coverage for minimal feature set. Do not add more features. -->
         <feature>servlet-4.0</feature>
         <feature>componenttest-1.0</feature>
+        <feature>mpMetrics-2.0</feature> <!-- one of the Infinispan JARs has a hard dependency on MicroProfile Metrics API -->
         <feature>sessionCache-1.0</feature>
     </featureManager>
     

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.serverB/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.serverB/server.xml
@@ -5,6 +5,7 @@
         <feature>cdi-2.0</feature>
         <feature>servlet-4.0</feature>
         <feature>componenttest-1.0</feature>
+        <feature>mpMetrics-2.0</feature> <!-- one of the Infinispan JARs has a hard dependency on MicroProfile Metrics API -->
         <feature>sessionCache-1.0</feature>
         <feature>timedexit-1.0</feature>
     </featureManager>

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.timeoutServerA/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.timeoutServerA/server.xml
@@ -5,18 +5,17 @@
         <feature>sessionCache-1.0</feature>
         <feature>componenttest-1.0</feature>
         <feature>jndi-1.0</feature>
+        <feature>mpMetrics-2.0</feature> <!-- one of the Infinispan JARs has a hard dependency on MicroProfile Metrics API -->
     </featureManager>
     
     <include location="../fatTestPorts.xml"/>
     
-    <featureManager>
-    </featureManager>   
     <httpSession maxInMemorySessionCount="1" allowOverflow="false" hideSessionValues="false" invalidationTimeout="5" reaperPollInterval="30"/> <!-- "5s" with units causes problem with simplicity object -->
     <httpSessionCache libraryRef="InfinispanLib" writeContents="ALL_SESSION_ATTRIBUTES" uri="file:${shared.resource.dir}/infinispan/infinispan-config-lacking-http-session-cache-name.xml"
-    enableBetaSupportForInfinispan="true"/>
+    enableBetaSupportForInfinispan="true"/> <!-- TODO remove beta config once ready for GA -->
 
     <application location="sessionCacheApp.war">
-        <classloader commonLibraryRef="InfinispanLib"/>
+        <!-- <classloader commonLibraryRef="InfinispanLib"/> causes Weld to process CDI annotations within Infinispan JARs, which causes failures -->
     </application>
 
     <library id="InfinispanLib">
@@ -34,5 +33,4 @@
 
     <!-- Needed for missing doPriv in JCache 1.1 API (see https://github.com/jsr107/jsr107spec/issues/398) -->
     <javaPermission className="java.util.PropertyPermission" actions="read,write" name="*"/>
-    
 </server>

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.timeoutServerB/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.timeoutServerB/server.xml
@@ -5,6 +5,7 @@
         <feature>componenttest-1.0</feature>
         <feature>jndi-1.0</feature>
         <feature>sessionCache-1.0</feature>
+        <feature>mpMetrics-2.0</feature> <!-- one of the Infinispan JARs has a hard dependency on MicroProfile Metrics API -->
     </featureManager>
     
     <include location="../fatTestPorts.xml"/>
@@ -14,10 +15,11 @@
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
     
     <httpSession maxInMemorySessionCount="1" allowOverflow="false" hideSessionValues="false" invalidationTimeout="5s" reaperPollInterval="30"/>
-    <httpSessionCache libraryRef="InfinispanLib" writeContents="ALL_SESSION_ATTRIBUTES" uri="file:${shared.resource.dir}/infinispan/infinispan.xml"/>
+    <httpSessionCache libraryRef="InfinispanLib" writeContents="ALL_SESSION_ATTRIBUTES" uri="file:${shared.resource.dir}/infinispan/infinispan-config-lacking-http-session-cache-name.xml"
+    enableBetaSupportForInfinispan="true"/> <!-- TODO remove beta config once ready for GA -->
 
     <application location="sessionCacheApp.war">
-        <classloader commonLibraryRef="InfinispanLib"/>
+        <!-- <classloader commonLibraryRef="InfinispanLib"/> causes Weld (implicitly enabled by mpMetrics) to process CDI annotations within Infinispan JARs, which causes failures -->
     </application>
     
     <library id="InfinispanLib">


### PR DESCRIPTION
Update our test dependencies to Infinispan 10.0.0.Final, which just recently became available.
Unfortunately, after doing so, things don't work so well.  One of the main issues was a new hard dependency on mpMetrics, which this pull covers for two test classes in the main bucket that I was able to get working.  There is complication with CDI annotations in the Infinispan JARs that prevent applications from being able to declare libraryRef to the Infinispan JARs when CDI is enabled, which is all of the time due to mpMetrics.