### PR TITLE
[9293] Log JAXRS exception handled by OT ExceptionMapper

### DIFF
--- a/dev/com.ibm.ws.microprofile.opentracing.jaeger_fat/fat/src/com/ibm/ws/microprofile/opentracing/jaeger_fat/JaegerConfigTest.java
+++ b/dev/com.ibm.ws.microprofile.opentracing.jaeger_fat/fat/src/com/ibm/ws/microprofile/opentracing/jaeger_fat/JaegerConfigTest.java
@@ -80,7 +80,7 @@ public class JaegerConfigTest {
     @After
     public void tearDown() throws Exception {
     	if (currentServer != null && currentServer.isStarted()) {
-        	currentServer.stopServer("CWMOT0008E");
+        	currentServer.stopServer("CWMOT0008E", "CWMOT0009W");
         }
     }
     

--- a/dev/com.ibm.ws.opentracing.1.1/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
+++ b/dev/com.ibm.ws.opentracing.1.1/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
@@ -74,6 +74,11 @@ OPENTRACING_NO_TRACERFACTORY=CWMOT0008E: OpenTracing cannot track JAX-RS request
 OPENTRACING_NO_TRACERFACTORY.explanation=OpenTracing will not function properly because an OpentracingTracerFactory class was not provided. JAX-RS requests will execute normally, but they will not be tracked.
 OPENTRACING_NO_TRACERFACTORY.useraction=For more information, see the documentation about how to enable OpenTracing distributed tracing.
 
+OPENTRACING_UNHANDLED_JAXRS_EXCEPTION=CWMOT0009W: The OpenTracing exception mapper has detected and is handling an unhandled exception from the JAX-RS application.
+OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.explanation=The JAX-RS-based application has experienced and exception that is not handled within the application. The OpenTracing code will handle it by logging the exception stack trace and returning a 500 Internal Server Error response.
+OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.useraction=This may be acceptable behavior.  To handle the exception differently, the application developer can add an ExceptionMapper that handles the exception and maps it to a different response.
+
+
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Opentracing error message
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/dev/com.ibm.ws.opentracing.1.1/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
+++ b/dev/com.ibm.ws.opentracing.1.1/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
@@ -74,10 +74,9 @@ OPENTRACING_NO_TRACERFACTORY=CWMOT0008E: OpenTracing cannot track JAX-RS request
 OPENTRACING_NO_TRACERFACTORY.explanation=OpenTracing will not function properly because an OpentracingTracerFactory class was not provided. JAX-RS requests will execute normally, but they will not be tracked.
 OPENTRACING_NO_TRACERFACTORY.useraction=For more information, see the documentation about how to enable OpenTracing distributed tracing.
 
-OPENTRACING_UNHANDLED_JAXRS_EXCEPTION=CWMOT0009W: The OpenTracing exception mapper has detected and is handling an unhandled exception from the JAX-RS application.
-OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.explanation=The JAX-RS-based application has experienced and exception that is not handled within the application. The OpenTracing code will handle it by logging the exception stack trace and returning a 500 Internal Server Error response.
-OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.useraction=This may be acceptable behavior.  To handle the exception differently, the application developer can add an ExceptionMapper that handles the exception and maps it to a different response.
-
+OPENTRACING_UNHANDLED_JAXRS_EXCEPTION=CWMOT0009W: The OpenTracing exception mapper detected and is handling an unhandled exception from the JAX-RS application.
+OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.explanation=The JAX-RS-based application experienced an exception that is not handled within the application. The OpenTracing code handles it by logging the exception stack trace and returning a 500 Internal Server Error response.
+OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.useraction=This behavior might be acceptable. To handle the exception differently, the application developer can add an ExceptionMapper interface that handles the exception and maps it to a different response.
 
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Opentracing error message

--- a/dev/com.ibm.ws.opentracing.1.1/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
+++ b/dev/com.ibm.ws.opentracing.1.1/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
@@ -274,6 +274,7 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
     /** {@inheritDoc} */
     @Override
     public Response toResponse(Throwable exception) {
+        Tr.warning(tc, "OPENTRACING_UNHANDLED_JAXRS_EXCEPTION", exception);
         return Response.serverError().header(EXCEPTION_KEY, exception).build();
     }
 }

--- a/dev/com.ibm.ws.opentracing.1.1_fat/fat/src/com/ibm/ws/testing/opentracing/test/OpentracingTCKLauncher.java
+++ b/dev/com.ibm.ws.opentracing.1.1_fat/fat/src/com/ibm/ws/testing/opentracing/test/OpentracingTCKLauncher.java
@@ -47,7 +47,7 @@ public class OpentracingTCKLauncher {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer("CWMOT0009W");
     }
 
     @Test

--- a/dev/com.ibm.ws.opentracing.1.2/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
+++ b/dev/com.ibm.ws.opentracing.1.2/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
@@ -74,6 +74,11 @@ OPENTRACING_NO_TRACERFACTORY=CWMOT0008E: OpenTracing cannot track JAX-RS request
 OPENTRACING_NO_TRACERFACTORY.explanation=OpenTracing will not function properly because an OpentracingTracerFactory class was not provided. JAX-RS requests will execute normally, but they will not be tracked.
 OPENTRACING_NO_TRACERFACTORY.useraction=For more information, see the documentation about how to enable OpenTracing distributed tracing.
 
+OPENTRACING_UNHANDLED_JAXRS_EXCEPTION=CWMOT0009W: The OpenTracing exception mapper has detected and is handling an unhandled exception from the JAX-RS application.
+OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.explanation=The JAX-RS-based application has experienced and exception that is not handled within the application. The OpenTracing code will handle it by logging the exception stack trace and returning a 500 Internal Server Error response.
+OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.useraction=This may be acceptable behavior.  To handle the exception differently, the application developer can add an ExceptionMapper that handles the exception and maps it to a different response.
+
+
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Opentracing error message
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/dev/com.ibm.ws.opentracing.1.2/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
+++ b/dev/com.ibm.ws.opentracing.1.2/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
@@ -74,10 +74,9 @@ OPENTRACING_NO_TRACERFACTORY=CWMOT0008E: OpenTracing cannot track JAX-RS request
 OPENTRACING_NO_TRACERFACTORY.explanation=OpenTracing will not function properly because an OpentracingTracerFactory class was not provided. JAX-RS requests will execute normally, but they will not be tracked.
 OPENTRACING_NO_TRACERFACTORY.useraction=For more information, see the documentation about how to enable OpenTracing distributed tracing.
 
-OPENTRACING_UNHANDLED_JAXRS_EXCEPTION=CWMOT0009W: The OpenTracing exception mapper has detected and is handling an unhandled exception from the JAX-RS application.
-OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.explanation=The JAX-RS-based application has experienced and exception that is not handled within the application. The OpenTracing code will handle it by logging the exception stack trace and returning a 500 Internal Server Error response.
-OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.useraction=This may be acceptable behavior.  To handle the exception differently, the application developer can add an ExceptionMapper that handles the exception and maps it to a different response.
-
+OPENTRACING_UNHANDLED_JAXRS_EXCEPTION=CWMOT0009W: The OpenTracing exception mapper detected and is handling an unhandled exception from the JAX-RS application.
+OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.explanation=The JAX-RS-based application experienced an exception that is not handled within the application. The OpenTracing code handles it by logging the exception stack trace and returning a 500 Internal Server Error response.
+OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.useraction=This behavior might be acceptable. To handle the exception differently, the application developer can add an ExceptionMapper interface that handles the exception and maps it to a different response.
 
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Opentracing error message

--- a/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
+++ b/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
@@ -275,6 +275,7 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
     /** {@inheritDoc} */
     @Override
     public Response toResponse(Throwable exception) {
+        Tr.warning(tc, "OPENTRACING_UNHANDLED_JAXRS_EXCEPTION", exception);
         return Response.serverError().header(EXCEPTION_KEY, exception).build();
     }
 }

--- a/dev/com.ibm.ws.opentracing.1.2_fat/fat/src/com/ibm/ws/testing/opentracing/test/OpentracingTCKLauncher.java
+++ b/dev/com.ibm.ws.opentracing.1.2_fat/fat/src/com/ibm/ws/testing/opentracing/test/OpentracingTCKLauncher.java
@@ -47,7 +47,7 @@ public class OpentracingTCKLauncher {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer("CWMOT0009W");
     }
 
     @Test

--- a/dev/com.ibm.ws.opentracing.1.3/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
+++ b/dev/com.ibm.ws.opentracing.1.3/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
@@ -74,9 +74,9 @@ OPENTRACING_NO_TRACERFACTORY=CWMOT0008E: OpenTracing cannot track JAX-RS request
 OPENTRACING_NO_TRACERFACTORY.explanation=OpenTracing will not function properly because an OpentracingTracerFactory class was not provided. JAX-RS requests will execute normally, but they will not be tracked.
 OPENTRACING_NO_TRACERFACTORY.useraction=For more information, see the documentation about how to enable OpenTracing distributed tracing.
 
-OPENTRACING_UNHANDLED_JAXRS_EXCEPTION=CWMOT0009W: The OpenTracing exception mapper has detected and is handling an unhandled exception from the JAX-RS application.
-OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.explanation=The JAX-RS-based application has experienced and exception that is not handled within the application. The OpenTracing code will handle it by logging the exception stack trace and returning a 500 Internal Server Error response.
-OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.useraction=This may be acceptable behavior.  To handle the exception differently, the application developer can add an ExceptionMapper that handles the exception and maps it to a different response.
+OPENTRACING_UNHANDLED_JAXRS_EXCEPTION=CWMOT0009W: The OpenTracing exception mapper detected and is handling an unhandled exception from the JAX-RS application.
+OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.explanation=The JAX-RS-based application experienced an exception that is not handled within the application. The OpenTracing code handles it by logging the exception stack trace and returning a 500 Internal Server Error response.
+OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.useraction=This behavior might be acceptable. To handle the exception differently, the application developer can add an ExceptionMapper interface that handles the exception and maps it to a different response.
 
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Opentracing error message

--- a/dev/com.ibm.ws.opentracing.1.3/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
+++ b/dev/com.ibm.ws.opentracing.1.3/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
@@ -74,6 +74,10 @@ OPENTRACING_NO_TRACERFACTORY=CWMOT0008E: OpenTracing cannot track JAX-RS request
 OPENTRACING_NO_TRACERFACTORY.explanation=OpenTracing will not function properly because an OpentracingTracerFactory class was not provided. JAX-RS requests will execute normally, but they will not be tracked.
 OPENTRACING_NO_TRACERFACTORY.useraction=For more information, see the documentation about how to enable OpenTracing distributed tracing.
 
+OPENTRACING_UNHANDLED_JAXRS_EXCEPTION=CWMOT0009W: The OpenTracing exception mapper has detected and is handling an unhandled exception from the JAX-RS application.
+OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.explanation=The JAX-RS-based application has experienced and exception that is not handled within the application. The OpenTracing code will handle it by logging the exception stack trace and returning a 500 Internal Server Error response.
+OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.useraction=This may be acceptable behavior.  To handle the exception differently, the application developer can add an ExceptionMapper that handles the exception and maps it to a different response.
+
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Opentracing error message
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/dev/com.ibm.ws.opentracing.1.3/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
+++ b/dev/com.ibm.ws.opentracing.1.3/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
@@ -275,6 +275,7 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
     /** {@inheritDoc} */
     @Override
     public Response toResponse(Throwable exception) {
+        Tr.warning(tc, "OPENTRACING_UNHANDLED_JAXRS_EXCEPTION", exception);
         return Response.serverError().header(EXCEPTION_KEY, exception).build();
     }
 }

--- a/dev/com.ibm.ws.opentracing.1.3_fat/fat/src/com/ibm/ws/testing/opentracing/test/OpentracingTCKLauncher.java
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/fat/src/com/ibm/ws/testing/opentracing/test/OpentracingTCKLauncher.java
@@ -47,7 +47,7 @@ public class OpentracingTCKLauncher {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer("CWMOT0009W");
     }
 
     @Test

--- a/dev/com.ibm.ws.opentracing.1.3_fat/fat/src/com/ibm/ws/testing/opentracing/test/OpentracingTCKLauncherMicroProfile.java
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/fat/src/com/ibm/ws/testing/opentracing/test/OpentracingTCKLauncherMicroProfile.java
@@ -49,7 +49,7 @@ public class OpentracingTCKLauncherMicroProfile {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer("CWMOT0009W");
     }
 
     @Test

--- a/dev/com.ibm.ws.opentracing/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
+++ b/dev/com.ibm.ws.opentracing/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
@@ -74,6 +74,10 @@ OPENTRACING_NO_TRACERFACTORY=CWMOT0008E: OpenTracing cannot track JAX-RS request
 OPENTRACING_NO_TRACERFACTORY.explanation=OpenTracing will not function properly because an OpentracingTracerFactory class was not provided. JAX-RS requests will execute normally, but they will not be tracked.
 OPENTRACING_NO_TRACERFACTORY.useraction=For more information, see the documentation about how to enable OpenTracing distributed tracing.
 
+OPENTRACING_UNHANDLED_JAXRS_EXCEPTION=CWMOT0009W: The OpenTracing exception mapper detected and is handling an unhandled exception from the JAX-RS application.
+OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.explanation=The JAX-RS-based application experienced an exception that is not handled within the application. The OpenTracing code handles it by logging the exception stack trace and returning a 500 Internal Server Error response.
+OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.useraction=This behavior might be acceptable. To handle the exception differently, the application developer can add an ExceptionMapper interface that handles the exception and maps it to a different response.
+
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Opentracing error message
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
+++ b/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
@@ -266,6 +266,7 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
     /** {@inheritDoc} */
     @Override
     public Response toResponse(Throwable exception) {
+        Tr.warning(tc, "OPENTRACING_UNHANDLED_JAXRS_EXCEPTION", exception);
         return Response.serverError().header(EXCEPTION_KEY, exception).build();
     }
 }

--- a/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/OpentracingTCKLauncher.java
+++ b/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/OpentracingTCKLauncher.java
@@ -37,7 +37,7 @@ public class OpentracingTCKLauncher {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer("CWMOT0009W");
     }
 
     @Test


### PR DESCRIPTION
This change resolves issue #9293.

The OT code currently handles exceptions from the JAX-RS application by mapping them to responses with a 500 Internal Server Error status code and a header with an exception key.  By doing this, the JAX-RS runtime does not log the exception - assuming it to be handled.

In order to log the exception so that the user is still notified of otherwise-unhandled exceptions, this change logs the exception as a warning.