### PR TITLE
Increasing timeout for DB2 container

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/FATSuite.java
@@ -33,8 +33,8 @@ public class FATSuite {
     @ClassRule
     public static Db2Container db2 = new Db2Container()
                     .acceptLicense()
-                    // Use 5m timeout for local runs, 15m timeout for remote runs
-                    .withStartupTimeout(Duration.ofMinutes(FATRunner.FAT_TEST_LOCALRUN ? 5 : 15))
+                    // Use 5m timeout for local runs, 25m timeout for remote runs (extra time since the DB2 container can be slow to start)
+                    .withStartupTimeout(Duration.ofMinutes(FATRunner.FAT_TEST_LOCALRUN ? 5 : 25))
                     .withLogConsumer(FATSuite::log);
 
     private static void log(OutputFrame frame) {


### PR DESCRIPTION
Increasing remote timeout for DB2 Container for 15 to 25 minutes to tolerate machine slowdowns.