### PR TITLE
Enable SessionCacheTwoServerTimeoutTests

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/FATSuite.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/FATSuite.java
@@ -44,7 +44,7 @@ import componenttest.topology.utils.HttpUtils;
                 SessionCacheOneServerTest.class,
                 //SessionCacheTwoServerTest.class,
                 SessionCacheTimeoutTest.class,
-                //SessionCacheTwoServerTimeoutTest.class,
+                SessionCacheTwoServerTimeoutTest.class,
                 //HazelcastClientTest.class
 })
 
@@ -72,7 +72,7 @@ public class FATSuite {
      */
     @ClassRule
     public static GenericContainer<?> infinispan = new GenericContainer<>(new ImageFromDockerfile()
-                    .withDockerfileFromBuilder(builder -> builder.from("infinispan/server:10.0.0.CR3-4")
+                    .withDockerfileFromBuilder(builder -> builder.from("infinispan/server:10.0.1.Final")
                                     .user("root")
                                     .copy("/opt/infinispan_config/config.xml", "/opt/infinispan_config/config.xml")
                                     .copy("/opt/infinispan/server/conf/users.properties", "/opt/infinispan/server/conf/users.properties")

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/SessionCacheTwoServerTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/SessionCacheTwoServerTimeoutTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.session.cache.fat.infinispan.container;
 
+import static com.ibm.ws.session.cache.fat.infinispan.container.FATSuite.infinispan;
 import static componenttest.custom.junit.runner.Mode.TestMode.FULL;
 import static org.junit.Assert.assertNotNull;
 
@@ -51,12 +52,14 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
         appB = new SessionCacheApp(serverB, false, "session.cache.infinispan.web"); // no HttpSessionListeners are registered by this app
         serverB.useSecondaryHTTPPort();
 
-        serverA.startServer();
+        serverA.addEnvVar("INF_SERVERLIST", infinispan.getContainerIpAddress() + ":" + infinispan.getMappedPort(11222));
+        serverB.addEnvVar("INF_SERVERLIST", infinispan.getContainerIpAddress() + ":" + infinispan.getMappedPort(11222));
 
         // Use HTTP session on serverA before running any tests, so that the time it takes to initialize
         // the JCache provider does not interfere with timing of tests. Invoking this before starting
         // serverB, also ensures the JCache provider cluster in serverA is ready to accept a node from
         // serverB. Otherwise, serverB could start up its own separate cluster.
+        serverA.startServer();
         List<String> sessionA = new ArrayList<>();
         appA.sessionPut("init-app-A", "A", sessionA, true);
         appA.invalidateSession(sessionA);
@@ -75,7 +78,7 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
         try {
             serverA.stopServer();
         } finally {
-            serverB.stopServer();
+            serverB.stopServer("CWWKL0058W:.*InfinispanLib"); // TODO why does occur for Infinispan jar, but not Hazelcast?
         }
     }
 
@@ -104,7 +107,8 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
      *
      * (This test is for ensuring Session Database parity)
      */
-    @Test
+    //@Test
+    // ISPN021011: Incompatible cache value types specified, expected class java.lang.String but class java.lang.Object was specified
     @Mode(FULL)
     public void testInvalidationServletNoLocalCacheTwoServer() throws Exception {
         List<String> session = new ArrayList<>();
@@ -119,7 +123,8 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
      *
      * (This test is for ensuring Session Database parity)
      */
-    @Test
+    //@Test
+    // ISPN021011: Incompatible cache value types specified, expected class java.lang.String but class java.lang.Object was specified
     @Mode(FULL)
     public void testInvalidationServletLocalCacheTwoServer() throws Exception {
         List<String> session = new ArrayList<>();
@@ -132,7 +137,8 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
     /**
      * Test that a session which is created on Server A is removed from the Session Cache once timed out on server B
      */
-    @Test
+    //@Test
+    // ISPN021011: Incompatible cache value types specified, expected class java.lang.String but class java.lang.Object was specified
     @Mode(FULL)
     public void testCacheInvalidationServletNoLocalCacheTwoServer() throws Exception {
         List<String> session = new ArrayList<>();
@@ -145,7 +151,8 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
      * Test that a session which is created on Server A is removed from the Session Cache once timed out on server B,
      * even if it has been locally cached.
      */
-    @Test
+    //@Test
+    // ISPN021011: Incompatible cache value types specified, expected class java.lang.String but class java.lang.Object was specified
     @Mode(FULL)
     public void testCacheInvalidationLocalCacheTwoServer() throws Exception {
         List<String> session = new ArrayList<>();
@@ -157,7 +164,8 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
     /**
      * Test that after a session is invalidated it is removed from both caches.
      */
-    @Test
+    //@Test
+    // ISPN021011: Incompatible cache value types specified, expected class java.lang.String but class java.lang.Object was specified
     @Mode(FULL)
     public void testCacheInvalidationTwoServer() throws Exception {
         List<String> session = new ArrayList<>();

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/servers/com.ibm.ws.session.cache.fat.infinispan.container.timeoutServerA/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/servers/com.ibm.ws.session.cache.fat.infinispan.container.timeoutServerA/server.xml
@@ -1,5 +1,5 @@
 <server>
-	<!-- Used for SessionCacheTimeoutTest suite -->
+	<!-- Used for SessionCacheTimeoutTest and SessionCacheTwoServerTimeoutTest suite -->
     <featureManager>
         <feature>servlet-3.1</feature>
         <feature>sessionCache-1.0</feature>
@@ -8,17 +8,17 @@
     </featureManager>
     
     <include location="../fatTestPorts.xml"/>
-     
+    
     <httpSession maxInMemorySessionCount="1" allowOverflow="false" hideSessionValues="false" invalidationTimeout="5s" reaperPollInterval="30"/>
     
-    <httpSessionCache libraryRef="InfinispanLib" writeContents="ALL_SESSION_ATTRIBUTES">
+    <httpSessionCache libraryRef="InfinispanLib" writeContents="ALL_SESSION_ATTRIBUTES"> 
     	<properties infinispan.client.hotrod.server_list="${INF_SERVERLIST}"/>
 		<properties infinispan.client.hotrod.auth_username="user"/> <!-- set in users.properties -->
 		<properties infinispan.client.hotrod.auth_password="pass"/> <!-- set in users.properties -->
 		<properties infinispan.client.hotrod.auth_realm="default"/>
 		<properties infinispan.client.hotrod.sasl_mechanism="PLAIN"/>
     </httpSessionCache>
-    
+
     <application location="sessionCacheApp.war">
         <classloader commonLibraryRef="InfinispanLib"/>
     </application>
@@ -34,6 +34,9 @@
     <javaPermission codebase="${server.config.dir}/dropins/sessionCacheApp.war" className="org.osgi.framework.AdminPermission" actions="context" name="*"/>
     <javaPermission codebase="${server.config.dir}/dropins/sessionCacheApp.war" className="org.osgi.framework.ServicePermission" actions="get" name="*"/>
 
+    <!-- Needed for missing doPriv in JCache 1.1 API (see https://github.com/jsr107/jsr107spec/issues/398) -->
+    <javaPermission className="java.util.PropertyPermission" actions="read,write" name="*"/>
+    
     <javaPermission codebase="${shared.resource.dir}/infinispan/*" className="java.security.AllPermission"/>
 
     <!-- Needed for missing doPriv in JCache 1.1 API (see https://github.com/jsr107/jsr107spec/issues/398) -->

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/servers/com.ibm.ws.session.cache.fat.infinispan.container.timeoutServerB/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/servers/com.ibm.ws.session.cache.fat.infinispan.container.timeoutServerB/server.xml
@@ -1,5 +1,5 @@
 <server>
-
+	<!-- Used by SessionCacheTwoServerTimeoutTest -->
     <featureManager>
         <feature>servlet-3.1</feature>
         <feature>componenttest-1.0</feature>
@@ -14,7 +14,14 @@
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
     
     <httpSession maxInMemorySessionCount="1" allowOverflow="false" hideSessionValues="false" invalidationTimeout="5s" reaperPollInterval="30"/>
-    <httpSessionCache libraryRef="InfinispanLib" writeContents="ALL_SESSION_ATTRIBUTES" uri="file:${shared.resource.dir}/infinispan/infinispan.xml"/>
+    
+    <httpSessionCache libraryRef="InfinispanLib" writeContents="ALL_SESSION_ATTRIBUTES"> 
+    	<properties infinispan.client.hotrod.server_list="${INF_SERVERLIST}"/>
+		<properties infinispan.client.hotrod.auth_username="user"/> <!-- set in users.properties -->
+		<properties infinispan.client.hotrod.auth_password="pass"/> <!-- set in users.properties -->
+		<properties infinispan.client.hotrod.auth_realm="default"/>
+		<properties infinispan.client.hotrod.sasl_mechanism="PLAIN"/>
+    </httpSessionCache>
 
     <application location="sessionCacheApp.war">
         <classloader commonLibraryRef="InfinispanLib"/>
@@ -31,6 +38,9 @@
     <javaPermission codebase="${server.config.dir}/dropins/sessionCacheApp.war" className="org.osgi.framework.AdminPermission" actions="context" name="*"/>
     <javaPermission codebase="${server.config.dir}/dropins/sessionCacheApp.war" className="org.osgi.framework.ServicePermission" actions="get" name="*"/>
 
+    <!-- Needed for missing doPriv in JCache 1.1 API (see https://github.com/jsr107/jsr107spec/issues/398) -->
+    <javaPermission className="java.util.PropertyPermission" actions="read,write" name="*"/>
+    
     <javaPermission codebase="${shared.resource.dir}/infinispan/*" className="java.security.AllPermission"/>
 
     <!-- Needed for missing doPriv in JCache 1.1 API (see https://github.com/jsr107/jsr107spec/issues/398) -->


### PR DESCRIPTION
Enabling two server timeout tests.
Most tests failing due to ISPN021011: Incompatible cache value types specified, expected class java.lang.String but class java.lang.Object was specified

This error is happening with specific tests across test suites and will be fixed in a separate PR.
