### PR TITLE
Change the OSGI to liberty log mapping of log level detail.

### DIFF
--- a/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/LoggingConfigurationService.java
+++ b/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/LoggingConfigurationService.java
@@ -240,7 +240,7 @@ public class LoggingConfigurationService implements ManagedService {
         traceMapToLevel.put("fine", LogLevel.DEBUG);
         traceMapToLevel.put("event", LogLevel.DEBUG);
 
-        traceMapToLevel.put("detail", LogLevel.DEBUG);
+        traceMapToLevel.put("detail", LogLevel.INFO);
 
         traceMapToLevel.put("info", LogLevel.INFO);
 


### PR DESCRIPTION
This should not change the external behavior of Liberty logging from that of the current version.
This will eliminate the generation of log messages from OSGI level that were already not being
forwarded to the Liberty logs.

fixes #9262 