### PR TITLE
nonship config attribute for coordinating task ownership via a time-based claim

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/metatype/metatype.xml
@@ -28,6 +28,7 @@
   <AD id="initialPollDelay"                  type="String"  default="0" ibm:type="duration" name="%initialPollDelay" description="%initialPollDelay.desc"/>
   <AD id="jndiName"                          type="String"  required="false" ibm:unique="jndiName" name="internal" description="internal use only"/>
   <AD id="missedTaskThreshold"               type="String"  default="-1" ibm:type="duration(s)" name="internal" description="internal use only"/>
+  <AD id="missedTaskThreshold2"              type="String"  default="-1" ibm:type="duration(s)" name="internal" description="internal use only"/> <!-- TODO choose between the two variants of missedTaskThreshold and switch to beta, and later to GA -->
   <AD id="pollInterval"                      type="String"  default="-1" ibm:type="duration" name="%pollInterval" description="%pollInterval.desc"/>
   <AD id="pollSize"                          type="Integer" required="false" min="1" name="%pollSize" description="%pollSize.desc"/>
   <AD id="retryInterval"                     type="String"  default="1m" ibm:type="duration" name="%retryInterval" description="%retryInterval.desc"/>

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/Config.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/Config.java
@@ -51,6 +51,14 @@ class Config {
     final long missedTaskThreshold;
 
     /**
+     * Amount of time (in seconds) beyond a task's scheduled start time to reserve for running the next execution of the task.
+     * Other executor instances are prevented from claiming ownership of the task prior to the expiration of this interval,
+     * but if the interval elapses without successful execution of the task, then the task execution is considered to have been missed,
+     * enabling another instance to attempt to run it.
+     */
+    final long missedTaskThreshold2;
+
+    /**
      * Interval between polling for tasks to run. A value of -1 disables all polling after the initial poll.
      */
     final long pollInterval;
@@ -84,6 +92,7 @@ class Config {
         heartbeatInterval = (Long) properties.get("heartbeatInterval");
         initialPollDelay = (Long) properties.get("initialPollDelay");
         missedTaskThreshold = enableTaskExecution ? (Long) properties.get("missedTaskThreshold") : -1;
+        missedTaskThreshold2 = (Long) properties.get("missedTaskThreshold2");
         pollInterval = enableTaskExecution ? (Long) properties.get("pollInterval") : -1;
         pollSize = enableTaskExecution ? (Integer) properties.get("pollSize") : null;
         retryInterval = (Long) properties.get("retryInterval");
@@ -96,6 +105,8 @@ class Config {
             throw new IllegalArgumentException("heartbeatInterval: " + heartbeatInterval + "s");
         if (missedTaskThreshold != -1 && missedTaskThreshold < 1)
             throw new IllegalArgumentException("missedTaskThreshold: " + missedTaskThreshold + "s");
+        if ((missedTaskThreshold2 != -1 && missedTaskThreshold2 < 1) || missedTaskThreshold2 > 86400) // disallowing above 1 day. What is a reasonable upper bound?
+            throw new IllegalArgumentException("missedTaskThreshold2: " + missedTaskThreshold2 + "s");
         if (initialPollDelay < -1)
             throw new IllegalArgumentException("initialPollDelay: " + initialPollDelay + "ms");
         if (pollInterval < -1)
@@ -113,6 +124,7 @@ class Config {
                         .append(",heartbeatInterval=").append(heartbeatInterval)
                         .append("s,initialPollDelay=").append(initialPollDelay)
                         .append("ms,missedTaskThreshold=").append(missedTaskThreshold)
+                        .append("s,missedTaskThreshold2=").append(missedTaskThreshold2)
                         .append("s,pollInterval=").append(pollInterval)
                         .append("ms,pollSize=").append(pollSize)
                         .append(",retryInterval=").append(retryInterval)

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/InvokerTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/InvokerTask.java
@@ -93,7 +93,8 @@ public class InvokerTask implements Runnable, Synchronization {
 
     @Override
     @Trivial
-    public void beforeCompletion() {}
+    public void beforeCompletion() {
+    }
 
     @Override
     public boolean equals(Object other) {
@@ -115,11 +116,11 @@ public class InvokerTask implements Runnable, Synchronization {
      * In the future, when there is support for a controller, we might want to give up the task and
      * ask another instance to try it.
      *
-     * @param failure failure of the task itself or of processing related to the task, such as Trigger.getNextRunTime
-     * @param loader class loader that can load the task and any exceptions that it might raise
+     * @param failure                 failure of the task itself or of processing related to the task, such as Trigger.getNextRunTime
+     * @param loader                  class loader that can load the task and any exceptions that it might raise
      * @param consecutiveFailureCount number of consecutive task failures
-     * @param config snapshot of persistent executor configuration
-     * @param taskName identity name for the task
+     * @param config                  snapshot of persistent executor configuration
+     * @param taskName                identity name for the task
      */
     private void processRetryableTaskFailure(Throwable failure, ClassLoader loader, short consecutiveFailureCount, Config config, String taskName) {
         taskName = taskName == null || taskName.length() == 0 || taskName.length() == 1 && taskName.charAt(0) == ' ' ? String.valueOf(taskId) // empty task name
@@ -164,7 +165,8 @@ public class InvokerTask implements Runnable, Synchronization {
                         else
                             Tr.warning(tc, "CWWKC1511.retry.limit.reached.failed", persistentExecutor.name, taskName, consecutiveFailureCount, failure);
 
-                        TaskFailure taskFailure = new TaskFailure(failure, failure == null ? null : loader, persistentExecutor, TaskFailure.FAILURE_LIMIT_REACHED, Short.toString(consecutiveFailureCount));
+                        TaskFailure taskFailure = new TaskFailure(failure, failure == null ? null : loader, persistentExecutor, TaskFailure.FAILURE_LIMIT_REACHED, Short
+                                        .toString(consecutiveFailureCount));
                         // Update database with the result and state if we reached the limit
                         TaskRecord updates = new TaskRecord(false);
                         updates.setConsecutiveFailureCount(consecutiveFailureCount);
@@ -255,6 +257,7 @@ public class InvokerTask implements Runnable, Synchronization {
         Throwable failure = null;
         Short prevFailureCount = null, nextFailureCount = null;
         Long nextExecTime = null;
+        boolean claimNextExecution = false;
         TaskStore taskStore = persistentExecutor.taskStore;
         ApplicationTracker appTracker = persistentExecutor.appTrackerRef.getServiceWithException();
         TransactionManager tranMgr = persistentExecutor.tranMgrRef.getServiceWithException();
@@ -364,8 +367,9 @@ public class InvokerTask implements Runnable, Synchronization {
             byte[] triggerBytes = taskRecord.getTrigger();
             Trigger trigger = triggerBytes == null ? null : ejbSingletonRecord != null
                                                             && Arrays.equals(triggerBytes,
-                                                                             ejbSingletonRecord.getTrigger()) ? ejbSingletonLockCollaborator : (Trigger) persistentExecutor.deserialize(triggerBytes,
-                                                                                                                                                                                        loader);
+                                                                             ejbSingletonRecord.getTrigger()) ? ejbSingletonLockCollaborator : (Trigger) persistentExecutor
+                                                                                             .deserialize(triggerBytes,
+                                                                                                          loader);
             if (trigger == null) {
                 String triggerClassName = info.getClassNameForNonSerializableTrigger();
                 if (triggerClassName != null)
@@ -397,7 +401,8 @@ public class InvokerTask implements Runnable, Synchronization {
                 if (trigger != null) {
                     Long prevScheduledStart = taskRecord.getPreviousScheduledStartTime();
                     if (prevScheduledStart != null)
-                        lastExecution = new LastExecutionImpl(persistentExecutor, taskId, taskName, resultBytes, taskRecord.getPreviousStopTime(), taskRecord.getPreviousStartTime(), prevScheduledStart, loader);
+                        lastExecution = new LastExecutionImpl(persistentExecutor, taskId, taskName, resultBytes, taskRecord.getPreviousStopTime(), taskRecord
+                                        .getPreviousStartTime(), prevScheduledStart, loader);
                     try {
                         skipped = trigger.skipRun(lastExecution, new Date(taskRecord.getNextExecutionTime()));
                     } catch (RuntimeException x) {
@@ -495,7 +500,8 @@ public class InvokerTask implements Runnable, Synchronization {
                         if (updatedResultBytes == null || !Arrays.equals(resultBytes, updatedResultBytes))
                             updates.setResult(updatedResultBytes);
                     } else {
-                        updates.setResult(persistentExecutor.serialize(new TaskFailure(failure, loader, persistentExecutor, TaskFailure.FAILURE_LIMIT_REACHED, Short.toString(nextFailureCount))));
+                        updates.setResult(persistentExecutor
+                                        .serialize(new TaskFailure(failure, loader, persistentExecutor, TaskFailure.FAILURE_LIMIT_REACHED, Short.toString(nextFailureCount))));
                         state = (short) (TaskState.ENDED.bit | TaskState.FAILURE_LIMIT_REACHED.bit);
                     }
                 }
@@ -511,6 +517,17 @@ public class InvokerTask implements Runnable, Synchronization {
                     if (!Arrays.equals(triggerBytes, updatedTriggerBytes))
                         updates.setTrigger(updatedTriggerBytes);
                 }
+
+                // When updating the task entry, determine whether or not to keep a claim on the task.
+                config = persistentExecutor.configRef.get();
+                if (config.missedTaskThreshold2 > 0)
+                    if (config.enableTaskExecution && config.pollInterval > 0 && nextExecTime != null && nextExecTime <= System.currentTimeMillis() + config.pollInterval) {
+                        updates.setIdentifierOfPartition(nextExecTime + config.missedTaskThreshold2 * 1000);
+                        claimNextExecution = true;
+                    } else {
+                        updates.setIdentifierOfPartition(-1);
+                    }
+
                 TaskRecord expected = new TaskRecord(false);
                 expected.setId(taskId);
                 expected.setVersion(taskRecord.getVersion());
@@ -572,11 +589,15 @@ public class InvokerTask implements Runnable, Synchronization {
 
                     // Immediately reschedule tasks that should run in the near future if the transaction commits
                     config = persistentExecutor.configRef.get();
-                    if (config.enableTaskExecution && nextExecTime != null
-                        && (config.pollInterval < 0 || nextExecTime <= new Date().getTime() + config.pollInterval)) {
-
+                    boolean scheduleNextExecution = config.missedTaskThreshold2 > 0 //
+                                    ? claimNextExecution //
+                                    : config.enableTaskExecution && nextExecTime != null
+                                      && config.missedTaskThreshold2 < 1 // claim on next execution did not need to be written to the persistent store
+                                      && (config.pollInterval < 0
+                                          || nextExecTime <= System.currentTimeMillis() + config.pollInterval);
+                    if (scheduleNextExecution) {
                         expectedExecTime = nextExecTime;
-                        long delay = nextExecTime - new Date().getTime();
+                        long delay = nextExecTime - System.currentTimeMillis();
 
                         ScheduledExecutorService executor = persistentExecutor.scheduledExecutor;
                         if (executor == null) {

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
@@ -1186,24 +1186,26 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
             record.setIdentifierOfOwner(owner);
 
         Config config = configRef.get();
-        long identifierOfPartition;
+
+        long taskAssignmentInfo = -1;
         Long alternatePartition = null;
-        try {
-            // If the current instance isn't able to run tasks, look for one that is
-            if (!config.enableTaskExecution) {
-                Controller controller = controllerRef.getService();
-                if (controller == null) // use the partition info from the persistent store to find an instance that periodically polls
-                    alternatePartition = getPartitionThatPolls(config.missedTaskThreshold);
-                else // obtain from the controller
-                    alternatePartition = controller.getActivePartitionId();
+        if (config.missedTaskThreshold2 < 1) {
+            try {
+                // If the current instance isn't able to run tasks, look for one that is
+                if (!config.enableTaskExecution) {
+                    Controller controller = controllerRef.getService();
+                    if (controller == null) // use the partition info from the persistent store to find an instance that periodically polls
+                        alternatePartition = getPartitionThatPolls(config.missedTaskThreshold);
+                    else // obtain from the controller
+                        alternatePartition = controller.getActivePartitionId();
+                }
+                taskAssignmentInfo = alternatePartition == null ? getPartitionId() : alternatePartition;
+            } catch (RuntimeException x) {
+                throw x;
+            } catch (Exception x) {
+                throw new RejectedExecutionException(x);
             }
-            identifierOfPartition = alternatePartition == null ? getPartitionId() : alternatePartition;
-        } catch (RuntimeException x) {
-            throw x;
-        } catch (Exception x) {
-            throw new RejectedExecutionException(x);
         }
-        record.setIdentifierOfPartition(identifierOfPartition);
 
         Map<String, String> execProps = getExecutionProperties(task);
 
@@ -1216,13 +1218,16 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
 
         int txTimeout;
         String txTimeoutString = execProps.get(PersistentExecutor.TRANSACTION_TIMEOUT);
-        try {
-            txTimeout = txTimeoutString == null ? 0 : Integer.parseInt(txTimeoutString);
-            if (txTimeout < 0)
-                throw new IllegalArgumentException(PersistentExecutor.TRANSACTION_TIMEOUT + ": " + txTimeoutString);
-        } catch (NumberFormatException x) {
-            throw new IllegalArgumentException(PersistentExecutor.TRANSACTION_TIMEOUT + ": " + txTimeoutString, x);
-        }
+        if (txTimeoutString == null)
+            txTimeout = config.missedTaskThreshold2 > 0 ? (int) config.missedTaskThreshold2 : 0;
+        else
+            try {
+                txTimeout = Integer.parseInt(txTimeoutString);
+                if (txTimeout < 0)
+                    throw new IllegalArgumentException(PersistentExecutor.TRANSACTION_TIMEOUT + ": " + txTimeoutString);
+            } catch (NumberFormatException x) {
+                throw new IllegalArgumentException(PersistentExecutor.TRANSACTION_TIMEOUT + ": " + txTimeoutString, x);
+            }
         record.setTransactionTimeout(txTimeout);
 
         short flags = 0;
@@ -1237,7 +1242,7 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
             flags |= TaskRecord.Flags.EJB_TIMER.bit;
         if (taskInfo.getInterval() == -1 && taskInfo.getInitialDelay() != -1)
             flags |= TaskRecord.Flags.ONE_SHOT_TASK.bit;
-        if (ManagedTask.SUSPEND.equals(execProps.get(ManagedTask.TRANSACTION)))
+        if (config.missedTaskThreshold2 > 0 || ManagedTask.SUSPEND.equals(execProps.get(ManagedTask.TRANSACTION)))
             flags |= TaskRecord.Flags.SUSPEND_TRAN_OF_EXECUTOR_THREAD.bit;
 
         record.setMiscBinaryFlags(flags);
@@ -1311,6 +1316,17 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
                 throw new IllegalArgumentException(Utils.toString(result), x);
             }
 
+        // Determine whether or not to start out with a claim on the task
+        boolean claimFirstExecution = false;
+        long nextExecTime = record.getNextExecutionTime();
+        if (config.missedTaskThreshold2 > 0 && config.enableTaskExecution
+            && config.pollInterval > 0 && nextExecTime <= System.currentTimeMillis() + config.pollInterval) {
+            taskAssignmentInfo = nextExecTime + config.missedTaskThreshold2 * 1000;
+            claimFirstExecution = true;
+        }
+
+        record.setIdentifierOfPartition(taskAssignmentInfo); // TODO rename the methods on TaskRecord to reflect repurposed usage
+
         TransactionController tranController = new TransactionController();
         try {
             tranController.preInvoke();
@@ -1318,9 +1334,11 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
             taskStore.create(record);
 
             // Immediately schedule tasks that should run in the near future or run on other instances if the transaction commits
-            long nextExecTime = record.getNextExecutionTime();
             Synchronization autoSchedule = null;
-            if (config.enableTaskExecution && (config.pollInterval < 0 || nextExecTime <= new Date().getTime() + config.pollInterval))
+            boolean scheduleToSelf = config.missedTaskThreshold2 > 0 //
+                            ? claimFirstExecution //
+                            : config.enableTaskExecution && (config.pollInterval < 0 || nextExecTime <= System.currentTimeMillis() + config.pollInterval);
+            if (scheduleToSelf)
                 autoSchedule = new InvokerTask(this, record.getId(), nextExecTime, record.getMiscBinaryFlags(), txTimeout);
             else if (alternatePartition != null) {
                 Controller controller = controllerRef.getService();
@@ -2560,6 +2578,114 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
             return claimed;
         }
 
+        /**
+         * Polls for tasks that are owned by the current partition.
+         * TODO decide if missedTaskThreshold approach under this method, which covers missed tasks from other partitions, should be included or removed.
+         *
+         * @param config configuration of this instance.
+         * @throws Exception if an error occurs.
+         */
+        private void partitionBasedPoll(Config config) throws Exception {
+            final boolean trace = TraceComponent.isAnyTracingEnabled();
+
+            EmbeddableWebSphereTransactionManager tranMgr = tranMgrRef.getServiceWithException();
+
+            long partitionId = getPartitionId();
+            long now = System.currentTimeMillis();
+            long maxNextExecTime = config.pollInterval >= 0 ? (config.pollInterval + now) : Long.MAX_VALUE;
+            List<Object[]> results;
+            tranMgr.begin();
+            try {
+                results = taskStore.findUpcomingTasks(partitionId, maxNextExecTime, config.pollSize);
+            } finally {
+                tranMgr.commit();
+            }
+            for (Object[] result : results) {
+                long taskId = (Long) result[0];
+                Boolean previous = inMemoryTaskIds.put(taskId, Boolean.TRUE);
+                if (previous == null) {
+                    short mbits = (Short) result[1];
+                    long nextExecTime = (Long) result[2];
+                    int txTimeout = (Integer) result[3];
+                    InvokerTask task = new InvokerTask(PersistentExecutorImpl.this, taskId, nextExecTime, mbits, txTimeout);
+                    long delay = nextExecTime - new Date().getTime();
+                    if (trace && tc.isDebugEnabled())
+                        Tr.debug(PersistentExecutorImpl.this, tc, "Found task " + taskId + " for " + delay + "ms from now");
+                    scheduledExecutor.schedule(task, delay, TimeUnit.MILLISECONDS);
+                } else {
+                    if (trace && tc.isDebugEnabled())
+                        Tr.debug(PersistentExecutorImpl.this, tc, "Found task " + taskId + " already scheduled");
+                }
+            }
+
+            if (config.missedTaskThreshold > 0) {
+                if (trace && tc.isDebugEnabled())
+                    Tr.debug(PersistentExecutorImpl.this, tc, "Poll for tasks late by " + config.missedTaskThreshold + "s");
+                long lateTaskThresholdMS = TimeUnit.SECONDS.toMillis(config.missedTaskThreshold);
+                tranMgr.begin();
+                try {
+                    results = taskStore.findLateTasks(now - lateTaskThresholdMS, partitionId, config.pollSize);
+                } finally {
+                    tranMgr.commit();
+                }
+                boolean anyClaimed = false;
+                for (Object[] result : results)
+                    anyClaimed |= claimLateTask(result, config.missedTaskThreshold);
+                if (anyClaimed) {
+                    // schedule a task to clean up the properties table after claims start to expire
+                    scheduledExecutor.schedule(new PropertyCleanupTask(), config.missedTaskThreshold, TimeUnit.SECONDS);
+                }
+            }
+        }
+
+        /**
+         * Polls for all tasks that should start within the next poll interval which have not already been
+         * claimed by other executor instances.
+         *
+         * @param config configuration of this instance.
+         * @throws Exception if an error occurs.
+         */
+        private void pollForUnclaimedTasks(Config config) throws Exception {
+            final boolean trace = TraceComponent.isAnyTracingEnabled();
+
+            EmbeddableWebSphereTransactionManager tranMgr = tranMgrRef.getServiceWithException();
+
+            long now = System.currentTimeMillis();
+            long maxNextExecTime = config.pollInterval >= 0 ? (config.pollInterval + now) : Long.MAX_VALUE;
+            List<Object[]> results;
+            tranMgr.begin();
+            try {
+                results = taskStore.findUnclaimedTasks(config.missedTaskThreshold2, maxNextExecTime, config.pollSize);
+            } finally {
+                tranMgr.commit();
+            }
+
+            for (Object[] result : results) {
+                long taskId = (Long) result[0];
+                long nextExecTime = (Long) result[2];
+                int version = (Integer) result[4];
+                long claimUntilTime = nextExecTime + config.missedTaskThreshold2 * 1000;
+
+                boolean claimed;
+                tranMgr.begin();
+                try {
+                    claimed = taskStore.setPartitionIfNotLocked(taskId, version, claimUntilTime);
+                } finally {
+                    tranMgr.commit();
+                }
+
+                if (claimed) {
+                    short mbits = (Short) result[1];
+                    int txTimeout = (Integer) result[3];
+                    InvokerTask task = new InvokerTask(PersistentExecutorImpl.this, taskId, nextExecTime, mbits, txTimeout);
+                    long delay = nextExecTime - new Date().getTime();
+                    if (trace && tc.isDebugEnabled())
+                        Tr.debug(PersistentExecutorImpl.this, tc, "Found task " + taskId + " for " + delay + "ms from now");
+                    scheduledExecutor.schedule(task, delay, TimeUnit.MILLISECONDS);
+                }
+            }
+        }
+
         @Override
         public void run() {
             final boolean trace = TraceComponent.isAnyTracingEnabled();
@@ -2578,58 +2704,10 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
             try {
                 long beginPoll = System.nanoTime();
                 try {
-                    EmbeddableWebSphereTransactionManager tranMgr = tranMgrRef.getServiceWithException();
-
-                    long partitionId = getPartitionId();
-                    long now = new Date().getTime();
-                    long maxNextExecTime = config.pollInterval >= 0 ? (config.pollInterval + now) : Long.MAX_VALUE;
-                    List<Object[]> results;
-                    tranMgr.begin();
-                    try {
-                        results = taskStore.findUpcomingTasks(partitionId, maxNextExecTime, config.pollSize);
-                    } catch (Throwable x) {
-                        throw failure = x;
-                    } finally {
-                        tranMgr.commit();
-                    }
-                    for (Object[] result : results) {
-                        long taskId = (Long) result[0];
-                        Boolean previous = inMemoryTaskIds.put(taskId, Boolean.TRUE);
-                        if (previous == null) {
-                            short mbits = (Short) result[1];
-                            long nextExecTime = (Long) result[2];
-                            int txTimeout = (Integer) result[3];
-                            InvokerTask task = new InvokerTask(PersistentExecutorImpl.this, taskId, nextExecTime, mbits, txTimeout);
-                            long delay = nextExecTime - new Date().getTime();
-                            if (trace && tc.isDebugEnabled())
-                                Tr.debug(PersistentExecutorImpl.this, tc, "Found task " + taskId + " for " + delay + "ms from now");
-                            scheduledExecutor.schedule(task, delay, TimeUnit.MILLISECONDS);
-                        } else {
-                            if (trace && tc.isDebugEnabled())
-                                Tr.debug(PersistentExecutorImpl.this, tc, "Found task " + taskId + " already scheduled");
-                        }
-                    }
-
-                    if (config.missedTaskThreshold > 0) {
-                        if (trace && tc.isDebugEnabled())
-                            Tr.debug(PersistentExecutorImpl.this, tc, "Poll for tasks late by " + config.missedTaskThreshold + "s");
-                        long lateTaskThresholdMS = TimeUnit.SECONDS.toMillis(config.missedTaskThreshold);
-                        tranMgr.begin();
-                        try {
-                            results = taskStore.findLateTasks(now - lateTaskThresholdMS, partitionId, config.pollSize);
-                        } catch (Throwable x) {
-                            throw failure = x;
-                        } finally {
-                            tranMgr.commit();
-                        }
-                        boolean anyClaimed = false;
-                        for (Object[] result : results)
-                            anyClaimed |= claimLateTask(result, config.missedTaskThreshold);
-                        if (anyClaimed) {
-                            // schedule a task to clean up the properties table after claims start to expire
-                            scheduledExecutor.schedule(new PropertyCleanupTask(), config.missedTaskThreshold, TimeUnit.SECONDS);
-                        }
-                    }
+                    if (config.missedTaskThreshold2 > 0)
+                        pollForUnclaimedTasks(config);
+                    else
+                        partitionBasedPoll(config);
                 } finally {
                     // Schedule next poll
                     config = configRef.get();

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskStore.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskStore.java
@@ -23,7 +23,7 @@ import com.ibm.websphere.concurrent.persistent.TaskStatus;
 public interface TaskStore {
     /**
      * Update the record for a task in the persistent store to indicate that the task is canceled.
-     * 
+     *
      * @param taskId unique identifier for a persistent task
      * @return true if the state of the task was updated as a result of this method, otherwise false.
      * @throws Exception if an error occurs when attempting to update the persistent task store.
@@ -40,12 +40,12 @@ public interface TaskStore {
      * When using this method, tasks are canceled (not removed) regardless of the autopurge setting.
      * It is not possible to cancel tasks that have already ended. Any tasks that meet the criteria which are
      * also in an ended state are ignored.
-     * 
+     *
      * @param pattern task name pattern similar to the LIKE clause in SQL (% matches any characters, _ matches one character)
-     * @param escape escape character that indicates when matching characters like % and _ should be interpreted literally.
-     * @param state a task state. For example, TaskRecord.State.SCHEDULED.
+     * @param escape  escape character that indicates when matching characters like % and _ should be interpreted literally.
+     * @param state   a task state. For example, TaskRecord.State.SCHEDULED.
      * @param inState indicates whether to cancel tasks with or without the specified state
-     * @param owner name of owner to match as the task submitter. Null to ignore.
+     * @param owner   name of owner to match as the task submitter. Null to ignore.
      * @return count of tasks canceled.
      * @throws Exception if an error occurs updating the persistent store.
      */
@@ -65,7 +65,7 @@ public interface TaskStore {
     /**
      * Create an entry in the persistent store for a new task.
      * This method assigns a unique identifier to the task and updates the Id attribute of the TaskRecord with the value.
-     * 
+     *
      * @param task a new persistent task entry. All attributes of the task record must be specified except for the id.
      * @throws Exception if an error occurs when attempting to update the persistent task store.
      */
@@ -73,8 +73,8 @@ public interface TaskStore {
 
     /**
      * Create a property entry in the persistent store.
-     * 
-     * @param name unique name for the property.
+     *
+     * @param name  unique name for the property.
      * @param value value of the property.
      * @return true if the property was created. False if a property with the same name already exists.
      * @throws Exception if an error occurs when attempting to update the persistent task store.
@@ -83,7 +83,7 @@ public interface TaskStore {
 
     /**
      * Returns all partition entries that match the specified criteria.
-     * 
+     *
      * @param partitionRecord contains the criteria against which to compare.
      * @return all partition entries that match the specified criteria.
      * @throws Exception if an error occurs when attempting to access the persistent task store.
@@ -92,11 +92,11 @@ public interface TaskStore {
 
     /**
      * Returns the data contained within a task record in the persistent store if the task is in a SCHEDULED state.
-     * 
-     * @param taskId unique identifier for a task.
-     * @param partitionId unique identifier for a partition.
+     *
+     * @param taskId               unique identifier for a task.
+     * @param partitionId          unique identifier for a partition.
      * @param maxNextExecutionTime milliseconds at (or before) which the task must be scheduled in order to run.
-     * @param forUpdate indicates if a write lock should be obtained on the task record.
+     * @param forUpdate            indicates if a write lock should be obtained on the task record.
      * @return the task record if found and possible to lock it, otherwise null.
      *         The resulting record must contain the attributes
      *         (IdentityOfClassLoader, IdentityOfOwner, MiscBinaryFlags, Name,
@@ -108,9 +108,9 @@ public interface TaskStore {
 
     /**
      * Returns a snapshot of task state for the task with the specified unique identifier.
-     * 
-     * @param taskId unique identifier for a task
-     * @param owner name of owner to match as the task submitter. Null to ignore.
+     *
+     * @param taskId         unique identifier for a task
+     * @param owner          name of owner to match as the task submitter. Null to ignore.
      * @param includeTrigger indicates whether to include the Trigger in the status.
      * @return snapshot of task state for the task with the specified unique identifier.
      *         The resulting record must contain the attributes:
@@ -152,10 +152,10 @@ public interface TaskStore {
      * thread1 creates the entry
      * thread2 attempts to create and fails because it already exists
      * The invoker is expected to handle this by rolling back and retrying.
-     * 
+     *
      * @param record partition entry with executor/host/server/userdir to locate, or if not found, add to the persistent store.
-     *            If an entry is found, it is updated to match the Expiry and States if either of those is supplied.
-     *            The record must contain the following attributes (Executor, Host, Server, UserDir) and can optionally contain (Expiry, States).
+     *                   If an entry is found, it is updated to match the Expiry and States if either of those is supplied.
+     *                   The record must contain the following attributes (Executor, Host, Server, UserDir) and can optionally contain (Expiry, States).
      * @return unique identifier for the partition record which either already exists or was newly created.
      * @throws Exception if an error occurs when attempting to access the persistent task store.
      */
@@ -167,15 +167,15 @@ public interface TaskStore {
      * For example, to find taskIDs for the first 100 tasks belonging to app1 in partition 12 that have not completed all executions
      * and have a name that starts with "PAYROLL_TASK_",
      * taskStore.findTaskIds("PAYROLL\\_TASK\\_%", '\\', TaskState.ENDED, false, null, 100, "app1", 12);
-     * 
-     * @param pattern task name pattern similar to the LIKE clause in SQL (% matches any characters, _ matches one character). Null to ignore.
-     * @param escape escape character that indicates when matching characters like % and _ should be interpreted literally. Null to ignore.
-     * @param state a task state. For example, TaskState.CANCELED
-     * @param inState indicates whether to include or exclude results with the specified state
-     * @param minId minimum value for task id to be returned in the results. A null value means no minimum.
+     *
+     * @param pattern    task name pattern similar to the LIKE clause in SQL (% matches any characters, _ matches one character). Null to ignore.
+     * @param escape     escape character that indicates when matching characters like % and _ should be interpreted literally. Null to ignore.
+     * @param state      a task state. For example, TaskState.CANCELED
+     * @param inState    indicates whether to include or exclude results with the specified state
+     * @param minId      minimum value for task id to be returned in the results. A null value means no minimum.
      * @param maxResults limits the number of results to return to the specified maximum value. A null value means no limit.
-     * @param owner name of owner to match as the task submitter. Null to ignore.
-     * @param partition identifier of the partition in which to search for tasks. Null to ignore.
+     * @param owner      name of owner to match as the task submitter. Null to ignore.
+     * @param partition  identifier of the partition in which to search for tasks. Null to ignore.
      * @return in-memory, ordered list of task ID.
      * @throws Exception if an error occurs when attempting to access the persistent task store.
      */
@@ -187,16 +187,16 @@ public interface TaskStore {
      * (as determined by the inState attribute) of the specified state.
      * For example, to find tasks that have not completed all executions and have a name that starts with "PAYROLL_TASK_",
      * taskStore.findTaskStatus("PAYROLL\\_TASK\\_%", '\\', TaskState.ENDED, false, "app1", executor1, false);
-     * 
-     * @param pattern task name pattern similar to the LIKE clause in SQL (% matches any characters, _ matches one character)
-     * @param escape escape character that indicates when matching characters like % and _ should be interpreted literally.
-     * @param state a task state. For example, TaskState.CANCELED
-     * @param inState indicates whether to include or exclude results with the specified state
-     * @param minId minimum value for task id to be returned in the results. A null value means no minimum.
-     * @param maxResults limits the number of results to return to the specified maximum value. A null value means no limit.
-     * @param owner name of owner to match as the task submitter. Null to ignore.
+     *
+     * @param pattern        task name pattern similar to the LIKE clause in SQL (% matches any characters, _ matches one character)
+     * @param escape         escape character that indicates when matching characters like % and _ should be interpreted literally.
+     * @param state          a task state. For example, TaskState.CANCELED
+     * @param inState        indicates whether to include or exclude results with the specified state
+     * @param minId          minimum value for task id to be returned in the results. A null value means no minimum.
+     * @param maxResults     limits the number of results to return to the specified maximum value. A null value means no limit.
+     * @param owner          name of owner to match as the task submitter. Null to ignore.
      * @param includeTrigger indicates whether to include the Trigger in the status.
-     * @param executor persistent executor instance.
+     * @param executor       persistent executor instance.
      * @return list of task status matching the criteria, ordered by task id.
      * @throws Exception if an error occurs when attempting to access the persistent task store.
      */
@@ -206,10 +206,23 @@ public interface TaskStore {
 
     /**
      * Find all tasks to execute on or before maxNextExecTime (up to a maximum of maxResults).
-     * 
-     * @param partition partition number
+     * Only tasks which are not currently claimed are returned.
+     *
+     * @param missedTaskThreshold number of seconds beyond which a task is considered missed and can be claimed by a different instance.
+     * @param maxNextExecTime     maximum next execution time (in milliseconds)
+     * @param maxResults          maximum number of results to return. Null means unlimited.
+     * @return List of (Id, MiscBinaryFlags, NextExecutionTime, TransactionTimeout, Version) pairs.
+     * @throws Exception if an error occurs when attempting to access the persistent task store.
+     */
+    List<Object[]> findUnclaimedTasks(long missedTaskThreshold, long maxNextExecTime, Integer maxResults) throws Exception;
+
+    /**
+     * Find all tasks to execute on or before maxNextExecTime (up to a maximum of maxResults).
+     * Only tasks that are owned by the specified partition are returned.
+     *
+     * @param partition       partition number
      * @param maxNextExecTime maximum next execution time (in milliseconds)
-     * @param maxResults maximum number of results to return. Null means unlimited.
+     * @param maxResults      maximum number of results to return. Null means unlimited.
      * @return List of (Id, MiscBinaryFlags, NextExecutionTime, TransactionTimeout) pairs, ordered by next execution time.
      * @throws Exception if an error occurs when attempting to access the persistent task store.
      */
@@ -217,9 +230,9 @@ public interface TaskStore {
 
     /**
      * Returns a task record with information about the expected next execution time for the task with the specified id.
-     * 
+     *
      * @param taskId unique identifier for the task.
-     * @param owner name of owner (if any) to match as the task submitter.
+     * @param owner  name of owner (if any) to match as the task submitter.
      * @return task record containing information about the expected next execution time for the task with the specified id.
      *         The resulting record must contain the attributes (MiscBinaryFlags, NextExecutionTime, State).
      *         If the task is not found then <code>null</code> is returned.
@@ -252,10 +265,10 @@ public interface TaskStore {
      * Returns name/value pairs for all persisted properties that match the specified name pattern.
      * For example, to find property names that start with "MY_PROP_NAME_",
      * taskStore.getProperties("MY\\_PROP\\_NAME\\_%", '\\');
-     * 
+     *
      * @param pattern name pattern similar to the LIKE clause in SQL (% matches any characters, _ matches one character)
-     * @param escape escape character that indicates when matching characters like % and _ should be interpreted literally.
-     *            A value of null avoids designating an escape character, in which case the behavior depends on the persistent store.
+     * @param escape  escape character that indicates when matching characters like % and _ should be interpreted literally.
+     *                    A value of null avoids designating an escape character, in which case the behavior depends on the persistent store.
      * @return in-memory map of name/value pairs matching the criteria.
      * @throws Exception if an error occurs when attempting to update the persistent task store.
      */
@@ -263,7 +276,7 @@ public interface TaskStore {
 
     /**
      * Returns the value of the persisted property with the specified name. Null if the property does not exist.
-     * 
+     *
      * @param name property name.
      * @return property value.
      */
@@ -271,7 +284,7 @@ public interface TaskStore {
 
     /**
      * Returns a task record with information about the <code>Trigger</code> for the task with the specified id.
-     * 
+     *
      * @param taskId unique identifier for the task.
      * @return task record containing information about the <code>Trigger</code> for the task with the specified id.
      *         The resulting record must contain the attributes (IdOfOwner, State, Trigger).
@@ -283,7 +296,7 @@ public interface TaskStore {
     /**
      * Increment and return the consecutive failure count for a task.
      * The consecutive failure count is not incremented beyond Short.MAX_VALUE.
-     * 
+     *
      * @param taskId id of the task.
      * @return the new consecutive failure count. -1 if the task is not found in the persistent store.
      * @throws Exception if an error occurs accessing the persistent store.
@@ -292,8 +305,8 @@ public interface TaskStore {
 
     /**
      * Persist updates to a partition record in the persistent store.
-     * 
-     * @param updates updates to make to the partition entry. Only the specified fields are persisted.
+     *
+     * @param updates  updates to make to the partition entry. Only the specified fields are persisted.
      * @param expected criteria that must be matched for update to succeed.
      * @return count of entries that were updated.
      * @throws Exception if an error occurs when attempting to update the persistent store.
@@ -302,8 +315,8 @@ public interface TaskStore {
 
     /**
      * Persist updates to a task record in the persistent store.
-     * 
-     * @param updates updates to make to the task. Only the specified fields are persisted.
+     *
+     * @param updates  updates to make to the task. Only the specified fields are persisted.
      * @param expected criteria that must be matched for optimistic update to succeed. Must include Id.
      * @return true if persistent task store was updated, otherwise false.
      * @throws Exception if an error occurs when attempting to update the persistent task store.
@@ -312,9 +325,9 @@ public interface TaskStore {
 
     /**
      * Remove the record for a task from the persistent store.
-     * 
-     * @param taskId unique identifier for a persistent task
-     * @param owner name of owner to match as the task submitter. Null to ignore.
+     *
+     * @param taskId        unique identifier for a persistent task
+     * @param owner         name of owner to match as the task submitter. Null to ignore.
      * @param removeIfEnded indicates whether or not tasks that have ended can be removed.
      * @return true if the record was removed as a result of this method, otherwise false.
      * @throws Exception if an error occurs when attempting to update the persistent task store.
@@ -323,7 +336,7 @@ public interface TaskStore {
 
     /**
      * Remove partition entries matching the specified criteria.
-     * 
+     *
      * @param criteria criteria that must be matched for entries to be removed.
      * @return count of entries that were removed.
      * @throws Exception if an error occurs when attempting to update the persistent store.
@@ -335,12 +348,12 @@ public interface TaskStore {
      * (as determined by the inState attribute) of the specified state.
      * For example, to remove all canceled tasks that have a name that starts with "PAYROLL_TASK_",
      * taskStore.remove("PAYROLL\\_TASK\\_%", '\\', TaskState.CANCELED, true, "app1");
-     * 
+     *
      * @param pattern task name pattern similar to the LIKE clause in SQL (% matches any characters, _ matches one character)
-     * @param escape escape character that indicates when matching characters like % and _ should be interpreted literally.
-     * @param state a task state. For example, TaskState.UNATTEMPTED.
+     * @param escape  escape character that indicates when matching characters like % and _ should be interpreted literally.
+     * @param state   a task state. For example, TaskState.UNATTEMPTED.
      * @param inState indicates whether to remove tasks with or without the specified state
-     * @param owner name of owner to match as the task submitter. Null to ignore.
+     * @param owner   name of owner to match as the task submitter. Null to ignore.
      * @return count of tasks removed.
      * @throws Exception if an error occurs when attempting to update the persistent task store.
      */
@@ -350,10 +363,10 @@ public interface TaskStore {
      * Removes all persisted properties that match the specified name pattern.
      * For example, to remove properties with names that start with "MY_PROP_NAME_",
      * taskStore.removeProperties("MY\\_PROP\\_NAME\\_%", '\\');
-     * 
+     *
      * @param pattern name pattern similar to the LIKE clause in SQL (% matches any characters, _ matches one character)
-     * @param escape escape character that indicates when matching characters like % and _ should be interpreted literally.
-     *            A value of null avoids designating an escape character, in which case the behavior depends on the persistent store.
+     * @param escape  escape character that indicates when matching characters like % and _ should be interpreted literally.
+     *                    A value of null avoids designating an escape character, in which case the behavior depends on the persistent store.
      * @return number of properties removed.
      * @throws Exception if an error occurs when attempting to update the persistent task store.
      */
@@ -375,7 +388,7 @@ public interface TaskStore {
 
     /**
      * Removes the property with the specified name from the persistent store.
-     * 
+     *
      * @param name name of the entry.
      * @return true if removed. False if it was not found in the persistent store.
      * @throws Exception if an error occurs when attempting to update the persistent task store.
@@ -385,8 +398,8 @@ public interface TaskStore {
     /**
      * Assigns a task to the specified partition.
      * The implementation should aim to return as quickly as possible with a false value if the entry is already locked
-     * by another member, rather than waiting to make the update.  A locked task entry indicates that failover is not needed
-     * - a false positive occurred because the task was taking too long to run.  This could be caused by a lengthy timer/task
+     * by another member, rather than waiting to make the update. A locked task entry indicates that failover is not needed
+     * - a false positive occurred because the task was taking too long to run. This could be caused by a lengthy timer/task
      * that is otherwise behaving properly, in which case the customer ought to be using a larger value for missedTaskThreshold
      * so as to avoid triggering failover logic/overhead when there is no outage.
      *
@@ -400,8 +413,8 @@ public interface TaskStore {
 
     /**
      * Assigns the value of the property if it exists in the persistent store.
-     * 
-     * @param name property name.
+     *
+     * @param name  property name.
      * @param value new value for the property.
      * @return true if the property exists and was updated or already has the value.
      *         False if the property does not exist in the persistent store.
@@ -423,9 +436,9 @@ public interface TaskStore {
 
     /**
      * Transfers tasks that have not yet completed all executions to another partition.
-     * 
-     * @param taskId task id including and up to which all non-ended tasks in the partition are reassigned.
-     *            If null, all non-ended tasks in the partition are reassigned.
+     *
+     * @param taskId         task id including and up to which all non-ended tasks in the partition are reassigned.
+     *                           If null, all non-ended tasks in the partition are reassigned.
      * @param oldPartitionId partition id from which to take tasks.
      * @param newPartitionId partition id to which to assign tasks.
      * @return number of tasks updated.


### PR DESCRIPTION
Add a nonship/internal config attribute that can gate our experimentation with a time-based claim approach to coordinating task execution across multiple instances.  This pull also includes some initial steps toward the start of an implementation, but this is only partial and will be insufficient even to run a basic scenario.  Existing tests should verify the lack of impact to existing code path where this nonship attribute is not enabled.