### PR TITLE
add new oauth error message

### DIFF
--- a/dev/com.ibm.ws.security.oauth/resources/com/ibm/ws/security/oauth20/internal/resources/OAuthMessages.nlsprops
+++ b/dev/com.ibm.ws.security.oauth/resources/com/ibm/ws/security/oauth20/internal/resources/OAuthMessages.nlsprops
@@ -454,7 +454,7 @@ JAVA8_REQUIRED_FOR_AT_HASHING.explanation=The Java version in use is not 8 or hi
 JAVA8_REQUIRED_FOR_AT_HASHING.useraction=Install Java version 8 or higher to use the mentioned configuration option.
 
 # {1} already contains brackets, ex [a,b,c]
-WRONG_TOKEN_GRANTTYPE=CWWKS1497E: The token with grant type [{0}] is not allowed.  Allowed grant types are {1}.
+WRONG_TOKEN_GRANTTYPE=CWWKS1497E: The token with grant type [{0}] is not allowed. Allowed grant types are {1}.
 WRONG_TOKEN_GRANTTYPE.explanation=The token is not valid because its grant type is not allowed.
 WRONG_TOKEN_GRANTTYPE.useraction=Use a token with a grant type that is allowed.
 

--- a/dev/com.ibm.ws.security.oauth/resources/com/ibm/ws/security/oauth20/internal/resources/OAuthMessages.nlsprops
+++ b/dev/com.ibm.ws.security.oauth/resources/com/ibm/ws/security/oauth20/internal/resources/OAuthMessages.nlsprops
@@ -453,6 +453,11 @@ JAVA8_REQUIRED_FOR_AT_HASHING=CWWKS1496W: The {0} OpenID Connect provider has th
 JAVA8_REQUIRED_FOR_AT_HASHING.explanation=The Java version in use is not 8 or higher.
 JAVA8_REQUIRED_FOR_AT_HASHING.useraction=Install Java version 8 or higher to use the mentioned configuration option.
 
+# {1} already contains brackets, ex [a,b,c]
+WRONG_TOKEN_GRANTTYPE=CWWKS1497E: The token with grant type [{0}] is not allowed.  Allowed grant types are {1}.
+WRONG_TOKEN_GRANTTYPE.explanation=The token is not valid because its grant type is not allowed.
+WRONG_TOKEN_GRANTTYPE.useraction=Use a token with a grant type that is allowed.
+
 # html title of logout page
 LOGOUT_PAGE_TITLE=Logout
 # html body of logout page


### PR DESCRIPTION
#build 
#spawn.fullfat.buckets=com.ibm.ws.security.openidconnect.server_fat.endpoint.app-passwords,com.ibm.ws.security.openidconnect.server_fat.endpoint.app-passwords.DerbyDB.jwt,com.ibm.ws.security.openidconnect.server_fat.endpoint.app-passwords.LocalStore,com.ibm.ws.security.openidconnect.server_fat.endpoint.app-passwords.DerbyDB.opaque,com.ibm.ws.security.openidconnect.server_fat.endpoint.app-passwords.DerbyDB,com.ibm.ws.security.openidconnect.server_fat.endpoint.app-passwords.LocalStore.opaque,com.ibm.ws.security.openidconnect.server_fat.endpoint.app-passwords.LocalStore.jwt,com.ibm.ws.security.openidconnect.server_fat.endpoint.app-tokens,com.ibm.ws.security.openidconnect.server_fat.endpoint.app-tokens.LocalStore.jwt,com.ibm.ws.security.openidconnect.server_fat.endpoint.app-tokens.DerbyDB.opaque,com.ibm.ws.security.openidconnect.server_fat.endpoint.app-tokens.DerbyDB.jwt,com.ibm.ws.security.openidconnect.server_fat.endpoint.app-tokens.LocalStore.opaque