### PR TITLE
Resolving ispn021011 issue

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/SessionCacheOneServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/SessionCacheOneServerTest.java
@@ -429,4 +429,14 @@ public class SessionCacheOneServerTest extends FATServletClient {
             app.invalidateSession(session);
         }
     }
+
+    /**
+     * Ensure that if Infinispan exception is ever resolved, that we are notified and can switch our tests back.
+     * Error Thrown: ISPN021011: Incompatible cache value types specified, expected class java.lang.String but class java.lang.Object was specified
+     */
+    @Test
+    public void testInfinispanClassCastExpection() throws Exception {
+        //This should not fail here as this is the first test suite running.
+        app.invokeServlet("testInfinispanClassCastExpection&shouldFail=false", null);
+    }
 }

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/SessionCacheTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/SessionCacheTimeoutTest.java
@@ -97,8 +97,7 @@ public class SessionCacheTimeoutTest extends FATServletClient {
      * Test that a session can still be used if it was valid when a servlet call began, even after timeout.
      * This mimics SessionDB behavior.
      */
-    //@Test
-    // ISPN021011: Incompatible cache value types specified, expected class java.lang.String but class java.lang.Object was specified
+    @Test
     @Mode(FULL)
     public void testServletTimeout() throws Exception {
         List<String> session = newSession();
@@ -111,8 +110,7 @@ public class SessionCacheTimeoutTest extends FATServletClient {
      * Tests that a locally cached session is still usable to the end of a servlet call after being invalidated,
      * and is no longer valid in a following servlet call.
      */
-    //@Test
-    // ISPN021011: Incompatible cache value types specified, expected class java.lang.String but class java.lang.Object was specified
+    @Test
     @Mode(FULL)
     public void testServletPutTimeout() throws Exception {
         List<String> session = newSession();
@@ -123,8 +121,7 @@ public class SessionCacheTimeoutTest extends FATServletClient {
     /**
      * Tests that after a session times out session attributes are removed from the cache.
      */
-    //@Test
-    // ISPN021011: Incompatible cache value types specified, expected class java.lang.String but class java.lang.Object was specified
+    @Test
     @Mode(FULL)
     public void testCacheInvalidationAfterTimeout() throws Exception {
         List<String> session = newSession();
@@ -138,8 +135,7 @@ public class SessionCacheTimeoutTest extends FATServletClient {
     /**
      * Test that the cache is invalidated after reaching invalidation timeout during a servlet call.
      */
-    //@Test
-    // ISPN021011: Incompatible cache value types specified, expected class java.lang.String but class java.lang.Object was specified
+    @Test
     @Mode(FULL)
     public void testCacheInvalidationAfterServletTimeout() throws Exception {
         List<String> session = newSession();
@@ -198,6 +194,15 @@ public class SessionCacheTimeoutTest extends FATServletClient {
         // Verify the session is still around and has the 500s timeout set, along with other session properties
         app.invokeServlet("testTimeoutExtensionB", session);
         app.sessionGet("testTimeoutExtension-foo", "bar", session);
+    }
+
+    /**
+     * Ensure that if Infinispan exception is ever resolved, that we are notified and can switch our tests back.
+     * Error Thrown: ISPN021011: Incompatible cache value types specified, expected class java.lang.String but class java.lang.Object was specified
+     */
+    @Test
+    public void testInfinispanClassCastExpection() throws Exception {
+        app.invokeServlet("testInfinispanClassCastExpection&shouldFail=true", null);
     }
 
     /**

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/SessionCacheTwoServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/SessionCacheTwoServerTest.java
@@ -226,8 +226,7 @@ public class SessionCacheTwoServerTest extends FATServletClient {
     /**
      * Verify that SessionScoped CDI bean preserves its state across session calls.
      */
-    //@Test
-    // ISPN021011: Incompatible cache value types specified, expected class java.lang.String but class java.lang.Object was specified
+    @Test
     public void testSessionScopedBean() throws Exception {
         List<String> session = new ArrayList<>();
         String sessionId = appB.sessionPut("testSessionScopedBean-key", 123.4f, session, true);
@@ -302,5 +301,14 @@ public class SessionCacheTwoServerTest extends FATServletClient {
             }
         }
         fail("The session was not invalidated after 5 attempts.  This is likely due to a slow machine.");
+    }
+
+    /**
+     * Ensure that if Infinispan exception is ever resolved, that we are notified and can switch our tests back.
+     * Error Thrown: ISPN021011: Incompatible cache value types specified, expected class java.lang.String but class java.lang.Object was specified
+     */
+    @Test
+    public void testInfinispanClassCastExpection() throws Exception {
+        appA.invokeServlet("testInfinispanClassCastExpection&shouldFail=true", null);
     }
 }

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/SessionCacheTwoServerTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/SessionCacheTwoServerTimeoutTest.java
@@ -107,8 +107,7 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
      *
      * (This test is for ensuring Session Database parity)
      */
-    //@Test
-    // ISPN021011: Incompatible cache value types specified, expected class java.lang.String but class java.lang.Object was specified
+    @Test
     @Mode(FULL)
     public void testInvalidationServletNoLocalCacheTwoServer() throws Exception {
         List<String> session = new ArrayList<>();
@@ -123,8 +122,7 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
      *
      * (This test is for ensuring Session Database parity)
      */
-    //@Test
-    // ISPN021011: Incompatible cache value types specified, expected class java.lang.String but class java.lang.Object was specified
+    @Test
     @Mode(FULL)
     public void testInvalidationServletLocalCacheTwoServer() throws Exception {
         List<String> session = new ArrayList<>();
@@ -137,8 +135,7 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
     /**
      * Test that a session which is created on Server A is removed from the Session Cache once timed out on server B
      */
-    //@Test
-    // ISPN021011: Incompatible cache value types specified, expected class java.lang.String but class java.lang.Object was specified
+    @Test
     @Mode(FULL)
     public void testCacheInvalidationServletNoLocalCacheTwoServer() throws Exception {
         List<String> session = new ArrayList<>();
@@ -151,8 +148,7 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
      * Test that a session which is created on Server A is removed from the Session Cache once timed out on server B,
      * even if it has been locally cached.
      */
-    //@Test
-    // ISPN021011: Incompatible cache value types specified, expected class java.lang.String but class java.lang.Object was specified
+    @Test
     @Mode(FULL)
     public void testCacheInvalidationLocalCacheTwoServer() throws Exception {
         List<String> session = new ArrayList<>();
@@ -164,8 +160,7 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
     /**
      * Test that after a session is invalidated it is removed from both caches.
      */
-    //@Test
-    // ISPN021011: Incompatible cache value types specified, expected class java.lang.String but class java.lang.Object was specified
+    @Test
     @Mode(FULL)
     public void testCacheInvalidationTwoServer() throws Exception {
         List<String> session = new ArrayList<>();
@@ -176,4 +171,12 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
         appA.invokeServlet("cacheCheck&key=testCacheInvalidationTwoServer-foo&sid=" + sessionID, session);
     }
 
+    /**
+     * Ensure that if Infinispan exception is ever resolved, that we are notified and can switch our tests back.
+     * Error Thrown: ISPN021011: Incompatible cache value types specified, expected class java.lang.String but class java.lang.Object was specified
+     */
+    @Test
+    public void testInfinispanClassCastExpection() throws Exception {
+        appA.invokeServlet("testInfinispanClassCastExpection&shouldFail=true", null);
+    }
 }

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/files/infinispan/config.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/files/infinispan/config.xml
@@ -2,10 +2,9 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:infinispan:config:10.0 http://www.infinispan.org/schemas/infinispan-config-10.0.xsd
                             urn:infinispan:server:10.0 http://www.infinispan.org/schemas/infinispan-server-10.0.xsd"
-        xmlns="urn:infinispan:config:10.0"
-        xmlns:server="urn:infinispan:server:10.0">
+        xmlns="urn:infinispan:config:10.0">
 
-   <!-- Server config -->
+   <!-- Infinispan Server config -->
    <server xmlns='urn:infinispan:server:10.0'>
      <!-- Access definitions -->
      <interfaces>

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/servers/com.ibm.ws.session.cache.fat.infinispan.container.serverB/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/servers/com.ibm.ws.session.cache.fat.infinispan.container.serverB/server.xml
@@ -9,7 +9,7 @@
     
     <include location="../fatTestCommon.xml"/>
 
-    <!-- This server runs at the same time as com.ibm.ws.session.cache.fat.infinispan.serverA, so use a different set of ports -->    
+    <!-- This server runs at the same time as com.ibm.ws.session.cache.fat.infinispan.container.serverA, so use a different set of ports -->    
     <httpEndpoint id="defaultHttpEndpoint"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/servers/com.ibm.ws.session.cache.fat.infinispan.container.timeoutServerB/bootstrap.properties
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/servers/com.ibm.ws.session.cache.fat.infinispan.container.timeoutServerB/bootstrap.properties
@@ -10,3 +10,7 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.session.*=all
+
+# TODO java 2 security must remain disabled while Infinispan code lacks doPrivileged.
+# See reason in /com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.server/bootstrap.properties
+websphere.java.security.exempt=true

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/servers/com.ibm.ws.session.cache.fat.infinispan.container.timeoutServerB/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/servers/com.ibm.ws.session.cache.fat.infinispan.container.timeoutServerB/server.xml
@@ -9,6 +9,7 @@
     
     <include location="../fatTestPorts.xml"/>
     
+    <!-- This server runs at the same time as com.ibm.ws.session.cache.fat.infinispan.container.timeoutServerA, so use a different set of ports -->    
     <httpEndpoint id="defaultHttpEndpoint"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
@@ -42,7 +43,4 @@
     <javaPermission className="java.util.PropertyPermission" actions="read,write" name="*"/>
     
     <javaPermission codebase="${shared.resource.dir}/infinispan/*" className="java.security.AllPermission"/>
-
-    <!-- Needed for missing doPriv in JCache 1.1 API (see https://github.com/jsr107/jsr107spec/issues/398) -->
-    <javaPermission className="java.util.PropertyPermission" actions="read,write" name="*"/>
 </server>

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.security.AccessController;
+import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -72,11 +73,11 @@ public class SessionCacheTestServlet extends FATServlet {
     // Maximum number of nanoseconds for test to wait
     static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(2);
 
-    /**
+    /*
      * A hacky way for the tests to get access to fields of an internal object, in order to check the
      * contents of the same cache that is used by HTTP Sessions code. NEVER DO THIS IN PRODUCTION CODE.
      */
-    public static final PrivilegedExceptionAction<CacheManager> getCacheManager = () -> {
+    private static final PrivilegedExceptionAction<CacheManager> getCacheManager = () -> {
         Class<?> clclass = Thread.currentThread().getContextClassLoader().getClass();
         ClassLoader osgiLoader = clclass.getClassLoader();
         Class<?> FrameworkUtil = osgiLoader.loadClass("org.osgi.framework.FrameworkUtil");
@@ -92,6 +93,56 @@ public class SessionCacheTestServlet extends FATServlet {
         CacheStoreService_cacheManager.setAccessible(true);
         return (CacheManager) CacheStoreService_cacheManager.get(cacheStoreService);
     };
+
+    /**
+     * Due to the way we access the cache in some tests, Infinispan will throw a ClassCacheException when calling getCache() from a
+     * test class other then the one that created the cache. When this happens the mutable configuration
+     * of the cacheManager expects a request for Cache<Object, Object>. However, when the application uses
+     * the same cache, the cacheManager (correctly) expects a request for Cache<String, ArrayList> configuration.
+     * Error Thrown: ISPN021011: Incompatible cache value types specified, expected class java.lang.String but class java.lang.Object was specified
+     * Since accessing the cache in this way is not advised getMetaCache() and getAttrCache() methods work around the issue.
+     *
+     * @throws PrivilegedActionException
+     */
+    @SuppressWarnings("rawtypes")
+    public static Cache<String, ArrayList> getMetaCache() throws PrivilegedActionException {
+        CacheManager cacheManager = AccessController.doPrivileged(getCacheManager);
+        Cache<String, ArrayList> cache = cacheManager.getCache("com.ibm.ws.session.meta.default_host%2FsessionCacheApp");
+        return cache;
+    }
+
+    public static Cache<String, byte[]> getAttrCache() throws PrivilegedActionException {
+        CacheManager cacheManager = AccessController.doPrivileged(getCacheManager);
+        Cache<String, byte[]> cacheAttr = cacheManager.getCache("com.ibm.ws.session.attr.default_host%2FsessionCacheApp");
+        return cacheAttr;
+    }
+
+    /**
+     * Progressive test to ensure that when/if the ISPN021011 error stops being thrown we can get rid of our workaround
+     */
+    public void testInfinispanClassCastExpection(HttpServletRequest request, HttpServletResponse response) throws PrivilegedActionException {
+        Boolean shouldFail = Boolean.parseBoolean(request.getParameter("shouldFail"));
+        CacheManager cacheManager = AccessController.doPrivileged(getCacheManager);
+
+        if (shouldFail) {
+            try {
+                cacheManager.getCache("com.ibm.ws.session.meta.default_host%2FsessionCacheApp", String.class, ArrayList.class);
+                fail("ClassCastException not thrown when calling getCache(String, Class, Class)."
+                     + " This may indicate that the ISPN021011 bug has been resolved.");
+            } catch (ClassCastException cce) {
+            } //expected
+
+            try {
+                cacheManager.getCache("com.ibm.ws.session.attr.default_host%2FsessionCacheApp", String.class, byte[].class);
+                fail("ClassCastException not thrown when calling getCache(String, Class, Class)."
+                     + " This may indicate that the ISPN021011 bug has been resolved.");
+            } catch (ClassCastException cce) {
+            } //expected
+        } else {
+            cacheManager.getCache("com.ibm.ws.session.meta.default_host%2FsessionCacheApp", String.class, ArrayList.class);
+            cacheManager.getCache("com.ibm.ws.session.attr.default_host%2FsessionCacheApp", String.class, byte[].class);
+        }
+    }
 
     /**
      * Evict the active session from memory, if any.
@@ -596,8 +647,7 @@ public class SessionCacheTestServlet extends FATServlet {
 
         List<String> expected = expectedAttributes == null ? Collections.emptyList() : Arrays.asList(expectedAttributes.split(","));
 
-        CacheManager cacheManager = AccessController.doPrivileged(getCacheManager);
-        Cache<String, ArrayList> cache = cacheManager.getCache("com.ibm.ws.session.meta.default_host%2FsessionCacheApp", String.class, ArrayList.class);
+        Cache<String, ArrayList> cache = getMetaCache();
         ArrayList<?> values = cache.get(sessionId);
         @SuppressWarnings("unchecked")
         TreeSet<String> attributeNames = (TreeSet<String>) values.get(values.size() - 1); // last entry is the session attribute names
@@ -623,8 +673,7 @@ public class SessionCacheTestServlet extends FATServlet {
             expected.add(o == null ? null : Arrays.toString(toBytes(o)));
         }
 
-        CacheManager cacheManager = AccessController.doPrivileged(getCacheManager);
-        Cache<String, byte[]> cache = cacheManager.getCache("com.ibm.ws.session.attr.default_host%2FsessionCacheApp", String.class, byte[].class);
+        Cache<String, byte[]> cache = getAttrCache();
         byte[] bytes = cache.get(key);
 
         String strValue = bytes == null ? null : Arrays.toString(bytes);
@@ -680,8 +729,10 @@ public class SessionCacheTestServlet extends FATServlet {
         HttpSession session = request.getSession(createSession);
         if (createSession)
             System.out.println("Created a new session with sessionID=" + session.getId());
-        else
-            System.out.println("Re-using existing session with sessionID=" + session == null ? null : session.getId());
+        else {
+            String id = session == null ? null : session.getId();
+            System.out.println("Re-using existing session with sessionID=" + id);
+        }
         String key = request.getParameter("key");
         String value = request.getParameter("value");
         String type = request.getParameter("type");
@@ -742,16 +793,17 @@ public class SessionCacheTestServlet extends FATServlet {
         HttpSession session = request.getSession(createSession);
         if (createSession)
             System.out.println("Created a new session with sessionID=" + session.getId());
-        else
-            System.out.println("Re-using existing session with sessionID=" + session == null ? null : session.getId());
+        else {
+            String id = session == null ? null : session.getId();
+            System.out.println("Re-using existing session with sessionID=" + id);
+        }
         String key = request.getParameter("key");
         String expected = request.getParameter("expectedValue");
         String sessionId = session.getId();
 
         // poll for entry to be invalidated from cache
-        CacheManager cacheManager = AccessController.doPrivileged(getCacheManager);
         @SuppressWarnings("rawtypes")
-        Cache<String, ArrayList> cache = cacheManager.getCache("com.ibm.ws.session.meta.default_host%2FsessionCacheApp", String.class, ArrayList.class);
+        Cache<String, ArrayList> cache = getMetaCache();
         for (long start = System.nanoTime(); cache.containsKey(sessionId) && System.nanoTime() - start < TIMEOUT_NS; TimeUnit.MILLISECONDS.sleep(500));
 
         String actual = (String) session.getAttribute(key);
@@ -764,9 +816,8 @@ public class SessionCacheTestServlet extends FATServlet {
         String value = request.getParameter("value");
         String sessionId = session.getId();
         // poll for entry to be invalidated from cache
-        CacheManager cacheManager = AccessController.doPrivileged(getCacheManager);
         @SuppressWarnings("rawtypes")
-        Cache<String, ArrayList> cache = cacheManager.getCache("com.ibm.ws.session.meta.default_host%2FsessionCacheApp", String.class, ArrayList.class);
+        Cache<String, ArrayList> cache = getMetaCache();
 
         for (long start = System.nanoTime(); cache.containsKey(sessionId) && System.nanoTime() - start < TIMEOUT_NS; TimeUnit.MILLISECONDS.sleep(500));
         session.setAttribute(key, value);
@@ -783,16 +834,15 @@ public class SessionCacheTestServlet extends FATServlet {
         String key = request.getParameter("key");
         String value = request.getParameter("value");
         String sessionId = request.getParameter("sid");
-        CacheManager cacheManager = AccessController.doPrivileged(getCacheManager);
-        Cache<String, byte[]> cacheA = cacheManager.getCache("com.ibm.ws.session.attr.default_host%2FsessionCacheApp", String.class, byte[].class);
-        byte[] result = cacheA.get(key);
+        Cache<String, byte[]> cacheAttr = getAttrCache();
+        byte[] result = cacheAttr.get(key);
         assertEquals(value, result == null ? null : Arrays.toString(result));
 
         //Validate session existence/deletion if we pass in a sessionId
         if (sessionId != null) {
             @SuppressWarnings("rawtypes")
-            Cache<String, ArrayList> cacheM = cacheManager.getCache("com.ibm.ws.session.meta.default_host%2FsessionCacheApp", String.class, ArrayList.class);
-            assertEquals(cacheM.containsKey(sessionId), value == null ? false : true);
+            Cache<String, ArrayList> cache = getMetaCache();
+            assertEquals(cache.containsKey(sessionId), value == null ? false : true);
         }
     }
 
@@ -804,19 +854,20 @@ public class SessionCacheTestServlet extends FATServlet {
         HttpSession session = request.getSession(createSession);
         if (createSession)
             System.out.println("Created a new session with sessionID=" + session.getId());
-        else
-            System.out.println("Re-using existing session with sessionID=" + session == null ? null : session.getId());
+        else {
+            String id = session == null ? null : session.getId();
+            System.out.println("Re-using existing session with sessionID=" + id);
+        }
         String key = request.getParameter("key");
         String expected = request.getParameter("expectedValue");
         String sessionId = session.getId();
 
         // poll for entry to be invalidated from cache
-        CacheManager cacheManager = AccessController.doPrivileged(getCacheManager);
         @SuppressWarnings("rawtypes")
-        Cache<String, ArrayList> cache = cacheManager.getCache("com.ibm.ws.session.meta.default_host%2FsessionCacheApp", String.class, ArrayList.class);
+        Cache<String, ArrayList> cache = getMetaCache();
         for (long start = System.nanoTime(); cache.containsKey(sessionId) && System.nanoTime() - start < TIMEOUT_NS; TimeUnit.MILLISECONDS.sleep(500));
 
-        Cache<String, byte[]> cacheAttr = cacheManager.getCache("com.ibm.ws.session.attr.default_host%2FsessionCacheApp", String.class, byte[].class);
+        Cache<String, byte[]> cacheAttr = getAttrCache();
         byte[] result = cacheAttr.get(key);
         assertEquals(expected, result == null ? null : Arrays.toString(result));
     }

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/test-applications/sessionCacheApp/src/session/cache/infinispan/web/cdi/SessionCDITestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/test-applications/sessionCacheApp/src/session/cache/infinispan/web/cdi/SessionCDITestServlet.java
@@ -12,13 +12,11 @@ package session.cache.infinispan.web.cdi;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.security.AccessController;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.cache.Cache;
-import javax.cache.CacheManager;
 import javax.inject.Inject;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -79,8 +77,7 @@ public class SessionCDITestServlet extends FATServlet {
         String key0 = sessionId + ".WELD_S#0";
         String key1 = sessionId + ".WELD_S#1";
 
-        CacheManager cacheManager = AccessController.doPrivileged(SessionCacheTestServlet.getCacheManager);
-        Cache<String, byte[]> cache = cacheManager.getCache("com.ibm.ws.session.attr.default_host%2FsessionCacheApp", String.class, byte[].class);
+        Cache<String, byte[]> cache = SessionCacheTestServlet.getAttrCache();
         byte[] value0 = cache.get(key0);
         byte[] value1 = cache.get(key1);
 


### PR DESCRIPTION
This PR resolves the issues surrounding how our test classes access cache data reflexively by invoking com.ibm.ws.session.cache.* methods.  When using Infinispan this method results in a ClassCacheException being thrown:

```
ISPN021011: Incompatible cache value types specified, expected class java.lang.String but class java.lang.Object was specified
```

If called outside of the test class that created the cache.  I have introduced a workround, and a progressive test to make sure if this behavior ever changes we can change our tests back.

