### PR TITLE
Switch from TCP to UDP, and cleanup transport stack name.

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -343,10 +343,10 @@ public class CacheStoreService implements Introspector, SessionStoreService {
             try (PrintStream out = new PrintStream(new BufferedOutputStream(new FileOutputStream(tempConfigFile)))) {
                 out.println("<infinispan>");
                 out.println(" <jgroups>");
-                out.println("  <stack-file name=\"jgroups-tcp\" path=\"/default-configs/default-jgroups-udp.xml\"/>");
+                out.println("  <stack-file name=\"jgroups-udp\" path=\"/default-configs/default-jgroups-udp.xml\"/>");
                 out.println(" </jgroups>");
                 out.println(" <cache-container>");
-                out.println("  <transport stack=\"jgroups-tcp\"/>");
+                out.println("  <transport stack=\"jgroups-udp\"/>");
                 out.println("  <replicated-cache-configuration name=\"com.ibm.ws.session.*\"/>");
                 out.println(" </cache-container>");
                 out.println("</infinispan>");

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/shared/resources/infinispan/infinispan-config-lacking-http-session-cache-name.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/shared/resources/infinispan/infinispan-config-lacking-http-session-cache-name.xml
@@ -1,10 +1,10 @@
 <infinispan>
   <jgroups>
-     <stack-file name="jgroups-tcp" path="/default-configs/default-jgroups-tcp.xml"/>
+     <stack-file name="jgroups-udp" path="/default-configs/default-jgroups-udp.xml"/>
   </jgroups>
   
   <cache-container>
-    <transport stack="jgroups-tcp" />
+    <transport stack="jgroups-udp" />
     <replicated-cache-configuration name="com.ibm.ws.MyCache.attr"/>
     <invalidation-cache-configuration name="*.session.*.inval"/>
   </cache-container>


### PR DESCRIPTION
Fix the infinispan timeout server tests on z/OS.  Using TCP for jgroups on z/OS doesn't work.