### PR TITLE
Change to use `@SchemaName` instead of `@Argument` or `@InputField`

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -91,7 +91,8 @@ org.apache.cxf:cxf-rt-ws-security:2.6.2-ibm-s20180529-1900
 org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0
 org.apache.santuario:xmlsec:1.5.2-ibm
 org.apache.ws.security:wss4j:1.6.7-ibm-s20130913-2015
-org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.0-20191003
+org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.0-20191107
+org.eclipse.microprofile.graphql:microprofile-graphql-tck:1.0.0-20191107
 org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.5-ea124dd
 org.eclipse.persistence:org.eclipse.persistence.asm:2.7.5-ea124dd
 org.eclipse.persistence:org.eclipse.persistence.core:2.7.5-ea124dd

--- a/dev/com.ibm.websphere.org.eclipse.microprofile.graphql.1.0/bnd.bnd
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.graphql.1.0/bnd.bnd
@@ -20,7 +20,7 @@ Export-Package: \
   org.eclipse.microprofile.graphql;version=1.0
 
 Include-Resource: \
-  @${repo;org.eclipse.microprofile.graphql:microprofile-graphql-api;1.0.0.20191003;EXACT}
+  @${repo;org.eclipse.microprofile.graphql:microprofile-graphql-api;1.0.0.20191107;EXACT}
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version>=1.8))"
 

--- a/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/query/AnnotatedArgumentBuilder.java
+++ b/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/query/AnnotatedArgumentBuilder.java
@@ -11,9 +11,9 @@ import io.leangen.graphql.metadata.strategy.value.JsonDefaultValueProvider;
 import io.leangen.graphql.util.ClassUtils;
 import io.leangen.graphql.util.ReservedStrings;
 import io.leangen.graphql.util.Urls;
-import org.eclipse.microprofile.graphql.Argument;
 import org.eclipse.microprofile.graphql.DefaultValue;
 import org.eclipse.microprofile.graphql.Description;
+import org.eclipse.microprofile.graphql.SchemaName;
 import org.eclipse.microprofile.graphql.Source;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,7 +69,7 @@ public class AnnotatedArgumentBuilder implements ResolverArgumentBuilder {
         if (Optional.ofNullable(parameterType.getAnnotation(GraphQLId.class)).filter(GraphQLId::relayId).isPresent()) {
             return GraphQLId.RELAY_ID_FIELD_NAME;
         }
-        Argument meta = parameter.getAnnotation(Argument.class);
+        SchemaName meta = parameter.getAnnotation(SchemaName.class);
         if (meta != null && !meta.value().isEmpty()) {
             return messageBundle.interpolate(meta.value());
         } else {

--- a/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/query/PublicResolverBuilder.java
+++ b/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/query/PublicResolverBuilder.java
@@ -6,6 +6,7 @@ import io.leangen.graphql.generator.JavaDeprecationMappingConfig;
 import io.leangen.graphql.metadata.Resolver;
 import io.leangen.graphql.metadata.execution.MethodInvoker;
 import io.leangen.graphql.metadata.execution.SingletonMethodInvoker;
+import io.leangen.graphql.metadata.strategy.value.jsonb.JsonbValueMapper;
 import io.leangen.graphql.util.ClassUtils;
 import io.leangen.graphql.util.Utils;
 import org.eclipse.microprofile.graphql.Description;
@@ -15,6 +16,7 @@ import javax.json.bind.annotation.JsonbDateFormat;
 import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -60,7 +62,7 @@ public class PublicResolverBuilder extends FilteredResolverBuilder {
             if (dateFormat != null) {
                 return dateFormat.value();
             }
-            return "";
+            return JsonbValueMapper.getDefaultDateDescriptionFor(method.getAnnotatedReturnType());
         };
         this.deprecationReasonMapper = method ->
                 javaDeprecationConfig.enabled && method.isAnnotationPresent(Deprecated.class) ? javaDeprecationConfig.deprecationReason : null;

--- a/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/value/AnnotationMappingUtils.java
+++ b/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/value/AnnotationMappingUtils.java
@@ -2,15 +2,15 @@ package io.leangen.graphql.metadata.strategy.value;
 
 import io.leangen.graphql.util.Utils;
 import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.InputField;
+import org.eclipse.microprofile.graphql.SchemaName;
 
 import java.lang.reflect.Method;
 
 public class AnnotationMappingUtils {
 
     public static String inputFieldName(Method method) {
-        if (method.isAnnotationPresent(InputField.class)) {
-            return Utils.coalesce(method.getAnnotation(InputField.class).value(), method.getName());
+        if (method.isAnnotationPresent(SchemaName.class)) {
+            return Utils.coalesce(method.getAnnotation(SchemaName.class).value(), method.getName());
         }
         return method.getName();
     }

--- a/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/value/InputFieldInfoGenerator.java
+++ b/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/value/InputFieldInfoGenerator.java
@@ -6,8 +6,8 @@ import io.leangen.graphql.util.ReservedStrings;
 import io.leangen.graphql.util.Utils;
 import org.eclipse.microprofile.graphql.DefaultValue;
 import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.InputField;
 import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.SchemaName;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.AnnotatedType;
@@ -18,9 +18,9 @@ public class InputFieldInfoGenerator {
 
     public Optional<String> getName(List<AnnotatedElement> candidates, MessageBundle messageBundle) {
         Optional<String> explicit = candidates.stream()
-                .filter(element -> element.isAnnotationPresent(InputField.class))
+                .filter(element -> element.isAnnotationPresent(SchemaName.class))
                 .findFirst()
-                .map(element -> element.getAnnotation(InputField.class).value());
+                .map(element -> element.getAnnotation(SchemaName.class).value());
         Optional<String> implicit = candidates.stream()
                 .filter(element -> element.isAnnotationPresent(Query.class))
                 .findFirst()

--- a/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/value/jsonb/JsonbValueMapper.java
+++ b/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/value/jsonb/JsonbValueMapper.java
@@ -21,6 +21,9 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -47,6 +50,7 @@ import io.leangen.graphql.util.ClassUtils;
 
 import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.DefaultValue;
+import org.eclipse.microprofile.graphql.SchemaName;
 
 public class JsonbValueMapper implements ValueMapper, InputFieldBuilder {
 
@@ -134,27 +138,36 @@ public class JsonbValueMapper implements ValueMapper, InputFieldBuilder {
             }
             for (PropertyDescriptor propDesc : beanInfo.getPropertyDescriptors()) {
                 String propName = propDesc.getName();
+                Method setterMethod = propDesc.getWriteMethod();
                 Field field = getDeclaredField(declaringClass, propName);
-                if (field == null) {
+                if (field == null && setterMethod == null) {
                     continue;
                 }
-                Method setterMethod = propDesc.getWriteMethod();
-                AnnotatedType fieldType = field.getAnnotatedType();
-                if (!params.getEnvironment().inclusionStrategy.includeInputField(declaringClass, setterMethod, fieldType)) {
+                
+                AnnotatedType fieldType = field != null ? field.getAnnotatedType() : setterMethod.getAnnotatedReturnType();
+                // no need to proceed if the field or setter has an @Ignore annotation on it:
+                if ((field != null && !params.getEnvironment().inclusionStrategy.includeInputField(declaringClass, field, fieldType)) ||
+                    (setterMethod != null && !params.getEnvironment().inclusionStrategy.includeInputField(declaringClass, setterMethod, fieldType))) {
                     continue;
                 }
 
                 String fieldName = propName;
-                org.eclipse.microprofile.graphql.InputField inputFieldAnno = setterMethod.getAnnotation(org.eclipse.microprofile.graphql.InputField.class);
-                if (inputFieldAnno == null) {
-                    inputFieldAnno = field.getAnnotation(org.eclipse.microprofile.graphql.InputField.class);
+                SchemaName schemaNameAnno = null;
+                if (setterMethod != null) {
+                    schemaNameAnno = setterMethod.getAnnotation(SchemaName.class);
                 }
-                if (inputFieldAnno != null) {
-                    fieldName = useDefaultIfEmpty(inputFieldAnno.value(), fieldName);
+                if (schemaNameAnno == null && field != null) {
+                    schemaNameAnno = field.getAnnotation(SchemaName.class);
+                }
+                if (schemaNameAnno != null) {
+                    fieldName = useDefaultIfEmpty(schemaNameAnno.value(), fieldName);
                 } else {
                     // try JSON-B annotations
-                    JsonbProperty jsonbPropAnno = setterMethod.getAnnotation(JsonbProperty.class);
-                    if (jsonbPropAnno == null) {
+                    JsonbProperty jsonbPropAnno = null;
+                    if (setterMethod != null) {
+                        jsonbPropAnno = setterMethod.getAnnotation(JsonbProperty.class);
+                    }
+                    if (jsonbPropAnno == null && field != null) {
                         jsonbPropAnno = field.getAnnotation(JsonbProperty.class);
                     }
                     if (jsonbPropAnno != null) {
@@ -163,8 +176,11 @@ public class JsonbValueMapper implements ValueMapper, InputFieldBuilder {
                 }
 
                 String fieldDesc = "";
-                Description descAnno = setterMethod.getAnnotation(Description.class);
-                if (descAnno == null) {
+                Description descAnno = null;
+                if (setterMethod != null) {
+                    descAnno = setterMethod.getAnnotation(Description.class);
+                }
+                if (descAnno == null && field != null) {
                     descAnno = field.getAnnotation(Description.class);
                 }
                 if (descAnno != null) {
@@ -178,7 +194,7 @@ public class JsonbValueMapper implements ValueMapper, InputFieldBuilder {
                         jsonbDateFormatAnno = field.getAnnotation(JsonbDateFormat.class);
                     }
                     if (jsonbDateFormatAnno != null) {
-                        fieldDesc = useDefaultIfEmpty(jsonbDateFormatAnno.value(), "");
+                        fieldDesc = useDefaultIfEmpty(jsonbDateFormatAnno.value(), getDefaultDateDescriptionFor(fieldType));
                     }
                 }
 
@@ -233,6 +249,23 @@ public class JsonbValueMapper implements ValueMapper, InputFieldBuilder {
         return (s == null || "".equals(s.trim())) ? defaultValue : s;
     }
 
+    public static String getDefaultDateDescriptionFor(AnnotatedType annoType) {
+        Type t = annoType.getType();
+        if (t instanceof Class) {
+            Class<?> cls = (Class<?>) t;
+            if (LocalDate.class.isAssignableFrom(cls)) {
+                return "yyyy-MM-dd";
+            }
+            if (LocalTime.class.isAssignableFrom(cls)) {
+                return "HH:mm:ss";
+            }
+            if (LocalDateTime.class.isAssignableFrom(cls)) {
+                return "yyyy-MM-dd'T'HH:mm:ss'Z'";
+            }
+        }
+        return "";
+    }
+
     private static class InputFieldPropertyNamingStrategy implements PropertyNamingStrategy {
 
         final Map<String, String> propertyMap = new ConcurrentHashMap<>();
@@ -248,21 +281,21 @@ public class JsonbValueMapper implements ValueMapper, InputFieldBuilder {
                        if (LOG.isLoggable(Level.FINEST)) {
                            LOG.finest("<init> checking " + propName);
                        }
-                       if (addMapping(propName, m.getAnnotation(org.eclipse.microprofile.graphql.InputField.class))) {
+                       if (addMapping(propName, m.getAnnotation(SchemaName.class))) {
                            return;
                        }
                        ClassUtils.findFieldBySetter(m).ifPresent(f -> {
-                           addMapping(propName, f.getAnnotation(org.eclipse.microprofile.graphql.InputField.class));
+                           addMapping(propName, f.getAnnotation(SchemaName.class));
                        });
                    });
         }
 
-        private boolean addMapping(String propName, org.eclipse.microprofile.graphql.InputField inputFieldAnno) {
+        private boolean addMapping(String propName, SchemaName schemaNameAnno) {
             if (LOG.isLoggable(Level.FINEST)) {
-                LOG.finest("addMapping " + propName + " -> " + (inputFieldAnno == null ? "null" : inputFieldAnno.value()));
+                LOG.finest("addMapping " + propName + " -> " + (schemaNameAnno == null ? "null" : schemaNameAnno.value()));
             }
-            if (inputFieldAnno != null) {
-                propertyMap.put(propName, inputFieldAnno.value());
+            if (schemaNameAnno != null) {
+                propertyMap.put(propName, schemaNameAnno.value());
                 return true;
             }
             return false;

--- a/dev/com.ibm.ws.microprofile.graphql.1.0/src/com/ibm/ws/microprofile/graphql/internal/MPDateTimeScalarMapperExtension.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0/src/com/ibm/ws/microprofile/graphql/internal/MPDateTimeScalarMapperExtension.java
@@ -16,6 +16,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
 import graphql.language.IntValue;
@@ -53,6 +54,16 @@ public class MPDateTimeScalarMapperExtension implements ScalarMapperExtension {
             public String serialize(Object dataFetcherResult) {
                 if (dataFetcherResult instanceof String) {
                     return (String) dataFetcherResult;
+                }
+                // if unformatted by JSON-B, use default ISO formatter
+                if (dataFetcherResult instanceof LocalDate) {
+                    return DateTimeFormatter.ISO_DATE.format((LocalDate)dataFetcherResult);
+                }
+                if (dataFetcherResult instanceof LocalTime) {
+                    return DateTimeFormatter.ISO_TIME.format((LocalTime)dataFetcherResult);
+                }
+                if (dataFetcherResult instanceof LocalDateTime) {
+                    return DateTimeFormatter.ISO_DATE_TIME.format((LocalDateTime)dataFetcherResult);
                 }
                 throw Scalars.serializationException(dataFetcherResult, type);
             }

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/basicMutationApp/src/mpGraphQL10/basicMutation/GraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/basicMutationApp/src/mpGraphQL10/basicMutation/GraphQLEndpoint.java
@@ -16,11 +16,11 @@ import java.util.List;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 
-import org.eclipse.microprofile.graphql.Argument;
 import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Mutation;
 import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.SchemaName;
 
 import mpGraphQL10.types.WidgetImpl;
 import mpGraphQL10.types.WidgetInput;
@@ -43,7 +43,7 @@ public class GraphQLEndpoint {
 
     @Mutation("createWidget")
     @Description("Create a new widget for sale.")
-    public Widget createNewWidget(@Argument("widget") Widget inputWidget) {
+    public Widget createNewWidget(@SchemaName("widget") Widget inputWidget) {
         Widget newWidget = new Widget(inputWidget);
         allWidgets.add(newWidget);
         return newWidget;

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/defaultvalueApp/src/mpGraphQL10/defaultvalue/MyGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/defaultvalueApp/src/mpGraphQL10/defaultvalue/MyGraphQLEndpoint.java
@@ -16,11 +16,11 @@ import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
 
-import org.eclipse.microprofile.graphql.Argument;
 import org.eclipse.microprofile.graphql.DefaultValue;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Mutation;
 import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.SchemaName;
 
 @GraphQLApi
 @ApplicationScoped
@@ -44,7 +44,7 @@ public class MyGraphQLEndpoint {
     }
 
     @Query("widgetByName")
-    public Widget getWidgetByName(@Argument("name") @DefaultValue("Pencil") String name) {
+    public Widget getWidgetByName(@SchemaName("name") @DefaultValue("Pencil") String name) {
         switch (name) {
             case "Pencil": return new Widget("Pencil", 10, 0.5, 5.5, 0.2, 0.2);
             case "Eraser": return new Widget("Eraser", 5, 0.7, 2.2, 0.2, 0.4);
@@ -53,7 +53,7 @@ public class MyGraphQLEndpoint {
     }
 
     @Mutation("createWidget")
-    public Widget createNewWidget(@Argument("widget") WidgetInput input) {
+    public Widget createNewWidget(@SchemaName("widget") WidgetInput input) {
         Widget w = Widget.fromWidgetInput(input);
         allWidgets.add(w);
         return w;
@@ -61,7 +61,7 @@ public class MyGraphQLEndpoint {
     
     @Mutation("createWidgetByString")
     public Widget createNewWidget(@DefaultValue("Widget(Oven,12,120.1,36.2,3.3,14.0)")
-                                  @Argument("widgetString") String input) {
+                                  @SchemaName("widgetString") String input) {
         Widget w = Widget.fromString(input);
         allWidgets.add(w);
         return w;

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/deprecationApp/src/mpGraphQL10/deprecation/MyGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/deprecationApp/src/mpGraphQL10/deprecation/MyGraphQLEndpoint.java
@@ -16,10 +16,10 @@ import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
 
-import org.eclipse.microprofile.graphql.Argument;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Mutation;
 import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.SchemaName;
 
 @GraphQLApi
 @ApplicationScoped
@@ -46,7 +46,7 @@ public class MyGraphQLEndpoint {
     //@org.eclipse.microprofile.graphql.Deprecated("Deprecated mutation, please use \"createWidget\" instead.")
     @Deprecated
     @Mutation("createWidgetByHand")
-    public Widget createNewWidgetByHand(@Argument("widgetString") String widgetString) {
+    public Widget createNewWidgetByHand(@SchemaName("widgetString") String widgetString) {
         Widget w = Widget.fromString(widgetString);
         allWidgets.add(w);
         return w;
@@ -54,7 +54,7 @@ public class MyGraphQLEndpoint {
     }
 
     @Mutation("createWidget")
-    public Widget createNewWidget(@Argument("widget") Widget input) {
+    public Widget createNewWidget(@SchemaName("widget") Widget input) {
         Widget w = Widget.fromWidgetInput(input);
         allWidgets.add(w);
         return w;

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/graphQLInterfaceApp/src/mpGraphQL10/graphQLInterface/MyGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/graphQLInterfaceApp/src/mpGraphQL10/graphQLInterface/MyGraphQLEndpoint.java
@@ -16,10 +16,10 @@ import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
 
-import org.eclipse.microprofile.graphql.Argument;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Mutation;
 import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.SchemaName;
 
 @GraphQLApi
 @ApplicationScoped
@@ -44,7 +44,7 @@ public class MyGraphQLEndpoint {
     }
 
     @Mutation("createWidgetByHand")
-    public IWidget createNewWidgetByHand(@Argument("widgetString") String widgetString) {
+    public IWidget createNewWidgetByHand(@SchemaName("widgetString") String widgetString) {
         Widget w = Widget.fromString(widgetString);
         allWidgets.add(w);
         return w;
@@ -52,7 +52,7 @@ public class MyGraphQLEndpoint {
     }
 
     @Mutation("createWidget")
-    public IWidget createNewWidget(@Argument("widget") Widget input) {
+    public IWidget createNewWidget(@SchemaName("widget") Widget input) {
         Widget w = Widget.fromWidgetInput(input);
         allWidgets.add(w);
         return w;

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/ifaceApp/src/mpGraphQL10/iface/MyGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/ifaceApp/src/mpGraphQL10/iface/MyGraphQLEndpoint.java
@@ -16,10 +16,10 @@ import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
 
-import org.eclipse.microprofile.graphql.Argument;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Mutation;
 import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.SchemaName;
 
 @GraphQLApi
 @ApplicationScoped
@@ -38,7 +38,7 @@ public class MyGraphQLEndpoint {
     }
     
     @Mutation("createWidget")
-    public Widget createNewWidget(@Argument("widget") WidgetInput input) {
+    public Widget createNewWidget(@SchemaName("widget") WidgetInput input) {
         if (!(input instanceof WidgetInput)) {
             String msg = String.format("Unexpected input type; expected WidgetInput, got {0}\n",
                                        input.getClass().getName());

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/ignoreApp/src/mpGraphQL10/ignore/MyGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/ignoreApp/src/mpGraphQL10/ignore/MyGraphQLEndpoint.java
@@ -16,10 +16,10 @@ import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
 
-import org.eclipse.microprofile.graphql.Argument;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Mutation;
 import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.SchemaName;
 
 @GraphQLApi
 @ApplicationScoped
@@ -44,7 +44,7 @@ public class MyGraphQLEndpoint {
     }
 
     @Mutation("createWidgetByHand")
-    public Widget createNewWidgetByHand(@Argument("widgetString") String widgetString) {
+    public Widget createNewWidgetByHand(@SchemaName("widgetString") String widgetString) {
         Widget w = Widget.fromString(widgetString);
         allWidgets.add(w);
         return w;
@@ -52,7 +52,7 @@ public class MyGraphQLEndpoint {
     }
 
     @Mutation("createWidget")
-    public Widget createNewWidget(@Argument("widget") Widget input) {
+    public Widget createNewWidget(@SchemaName("widget") Widget input) {
         Widget w = Widget.fromWidgetInput(input);
         allWidgets.add(w);
         return w;

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/InputFieldsTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/InputFieldsTestServlet.java
@@ -79,20 +79,20 @@ public class InputFieldsTestServlet extends FATServlet {
         
         String snippet = getSchemaInputTypeSnippet();
 
-        // check input fields from @InputField on Java fields
-        assertTrue("Schema does not contain field name specified via @InputField on Java field", 
+        // check input fields from @SchemaName on Java fields
+        assertTrue("Schema does not contain field name specified via @SchemaName on Java field", 
                    snippet.contains("qty:"));
-        assertTrue("Schema does not contain field description specified via @InputField on Java field", 
+        assertTrue("Schema does not contain field description specified via @SchemaName on Java field", 
                    snippet.contains("Number of units to ship"));
-        assertFalse("Schema contains Java field name that should have been overwritten by @InputField annotation",
+        assertFalse("Schema contains Java field name that should have been overwritten by @SchemaName annotation",
                     snippet.contains("quantity:"));
 
-        // check input fields from @InputField on Java setters -- currently not allowed to put @InputField on methods
-//        assertTrue("Schema does not contain field name specified via @InputField on Java setter", 
+        // check input fields from @SchemaName on Java setters -- currently not allowed to put @SchemaName on methods
+//        assertTrue("Schema does not contain field name specified via @SchemaName on Java setter", 
 //                   snippet.contains("shippingWeight "));
-//        assertTrue("Schema does not contain field description specified via @InputField on Java setter", 
+//        assertTrue("Schema does not contain field description specified via @SchemaName on Java setter", 
 //                   snippet.contains("Total tonnage to be shipped"));
-//        assertFalse("Schema contains Java property name that should have been overwritten by @InputField annotation",
+//        assertFalse("Schema contains Java property name that should have been overwritten by @SchemaName annotation",
 //                    snippet.contains("weight "));
     }
 
@@ -102,7 +102,7 @@ public class InputFieldsTestServlet extends FATServlet {
         // check input fields from @JsonbProperty on Java fields
         assertTrue("Schema does not contain field name specified via @JsonbProperty on Java field", 
                    snippet.contains("qty2:"));
-        assertFalse("Schema contains Java field name that should have been overwritten by @InputField annotation",
+        assertFalse("Schema contains Java field name that should have been overwritten by @SchemaName annotation",
                     snippet.contains("quantity2"));
     }
 
@@ -112,7 +112,7 @@ public class InputFieldsTestServlet extends FATServlet {
         // check input fields from @JsonbProperty on Java setters
         assertTrue("Schema does not contain field name specified via @JsonbProperty on Java setter", 
                    snippet.contains("shippingWeight2:"));
-        assertFalse("Schema contains Java property name that should have been overwritten by @InputField annotation",
+        assertFalse("Schema contains Java property name that should have been overwritten by @SchemaName annotation",
                     snippet.contains("weight2:"));
     }
 

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/MyGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/MyGraphQLEndpoint.java
@@ -16,10 +16,10 @@ import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
 
-import org.eclipse.microprofile.graphql.Argument;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Mutation;
 import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.SchemaName;
 
 @GraphQLApi
 @ApplicationScoped
@@ -44,7 +44,7 @@ public class MyGraphQLEndpoint {
     }
 
     @Mutation("createWidgetByHand")
-    public Widget createNewWidgetByHand(@Argument("widgetString") String widgetString) {
+    public Widget createNewWidgetByHand(@SchemaName("widgetString") String widgetString) {
         Widget w = Widget.fromString(widgetString);
         allWidgets.add(w);
         return w;
@@ -52,7 +52,7 @@ public class MyGraphQLEndpoint {
     }
 
     @Mutation("createWidget")
-    public Widget createNewWidget(@Argument("widget") Widget input) {
+    public Widget createNewWidget(@SchemaName("widget") Widget input) {
         Widget w = Widget.fromWidgetInput(input);
         allWidgets.add(w);
         return w;

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/Widget.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/Widget.java
@@ -15,14 +15,14 @@ import java.text.DecimalFormat;
 import javax.json.bind.annotation.JsonbProperty;
 
 import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.InputField;
+import org.eclipse.microprofile.graphql.SchemaName;
 /**
  * This is an implementation class of the interface entity, Widget.
  */
 public class Widget {
 
     private String name;
-    @InputField("qty")
+    @SchemaName("qty")
     @Description("Number of units to ship")
     private int quantity = -1;
     private double weight = -1.0;
@@ -85,7 +85,7 @@ public class Widget {
         return weight;
     }
 
-//    @InputField(value = "shippingWeight", description = "Total tonnage to be shipped")
+//    @SchemaName(value = "shippingWeight", description = "Total tonnage to be shipped")
     public void setWeight(double weight) {
         this.weight = weight;
     }

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/WidgetClientObject.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/WidgetClientObject.java
@@ -15,14 +15,14 @@ import java.text.DecimalFormat;
 import javax.json.bind.annotation.JsonbProperty;
 
 import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.InputField;
+import org.eclipse.microprofile.graphql.SchemaName;
 /**
  * This is an implementation class of the interface entity, Widget.
  */
 public class WidgetClientObject {
 
     private String name;
-    @InputField("qty")
+    @SchemaName("qty")
     @Description("Number of units to ship")
     private int quantity = -1;
     private double weight = -1.0;
@@ -85,7 +85,7 @@ public class WidgetClientObject {
         return weight;
     }
 
-//    @InputField(value = "shippingWeight", description = "Total tonnage to be shipped")
+//    @SchemaName(value = "shippingWeight", description = "Total tonnage to be shipped")
     public void setWeight(double weight) {
         this.weight = weight;
     }

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/outputFieldsApp/src/mpGraphQL10/outputFields/MyGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/outputFieldsApp/src/mpGraphQL10/outputFields/MyGraphQLEndpoint.java
@@ -16,10 +16,10 @@ import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
 
-import org.eclipse.microprofile.graphql.Argument;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Mutation;
 import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.SchemaName;
 
 @GraphQLApi
 @ApplicationScoped
@@ -44,7 +44,7 @@ public class MyGraphQLEndpoint {
     }
 
     @Mutation("createWidgetByHand")
-    public Widget createNewWidgetByHand(@Argument("widgetString") String widgetString) {
+    public Widget createNewWidgetByHand(@SchemaName("widgetString") String widgetString) {
         Widget w = Widget.fromString(widgetString);
         allWidgets.add(w);
         return w;
@@ -52,7 +52,7 @@ public class MyGraphQLEndpoint {
     }
 
     @Mutation("createWidget")
-    public Widget createNewWidget(@Argument("widget") Widget input) {
+    public Widget createNewWidget(@SchemaName("widget") Widget input) {
         Widget w = Widget.fromWidgetInput(input);
         allWidgets.add(w);
         return w;

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/typesApp/src/mpGraphQL10/types/MyGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/typesApp/src/mpGraphQL10/types/MyGraphQLEndpoint.java
@@ -16,10 +16,10 @@ import java.util.Map;
 
 import javax.enterprise.context.ApplicationScoped;
 
-import org.eclipse.microprofile.graphql.Argument;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Mutation;
 import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.SchemaName;
 
 @GraphQLApi
 @ApplicationScoped
@@ -39,7 +39,7 @@ public class MyGraphQLEndpoint {
     }
     
     @Mutation("createWidget")
-    public WidgetImpl createNewWidget(@Argument("widget") WidgetInput input) {
+    public WidgetImpl createNewWidget(@SchemaName("widget") WidgetInput input) {
         if (!(input instanceof WidgetInput)) {
             String msg = String.format("Unexpected input type; expected WidgetInput, got {0}\n",
                                        input.getClass().getName());

--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/pom.xml
@@ -12,13 +12,23 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <repositories>
+    	<repository>
+    		<id>ibmdhe</id>
+    		<name>IBM_DHE File Server</name>
+    		<url>http://public.dhe.ibm.com/ibmdl/export/pub/software/olrepo</url>
+    		<releases><enabled>true</enabled><updatePolicy>always</updatePolicy></releases>
+            <snapshots><enabled>true</enabled><updatePolicy>always</updatePolicy></snapshots>
+    	</repository>
+    </repositories>
+
     <groupId>com.ibm.ws.microprofile.graphql</groupId>
     <artifactId>tck.runner.tck</artifactId>
     <version>1.0-SNAPSHOT</version>
     <name>MicroProfile GraphQL TCK Runner TCK Module</name>
 
     <properties>
-        <microprofile.graphql.version>1.0-M3</microprofile.graphql.version>
+        <microprofile.graphql.version>1.0.0-20191107</microprofile.graphql.version>
         <arquillian.version>1.1.13.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->


### PR DESCRIPTION
This is due to changes in the spec under MP GraphQL PR 99:
https://github.com/eclipse/microprofile-graphql/pull/99

Changes include:
- updates to the API/TCK version (using a snapshot)
- updates to the SPQR and MP implementation to ensure new APIs work
- updates to FAT test - changing refs to old APIs to `@SchemaName`

Because this uses a snapshot build that supersedes the M4 release, this PR should supersede PR #9356. MP GraphQL is not yet released, so this is not a release bug.