### PR TITLE
Clean up and consolidate some OpenShift social login code

### DIFF
--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/AuthUtils.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/AuthUtils.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.common.http;
+
+import javax.servlet.http.HttpServletRequest;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+public class AuthUtils {
+
+    public static final TraceComponent tc = Tr.register(AuthUtils.class);
+
+    public String getBearerTokenFromHeader(HttpServletRequest req) {
+        return getBearerTokenFromHeader(req, "Authorization");
+    }
+
+    public String getBearerTokenFromHeader(HttpServletRequest req, String... headersToCheck) {
+        if (headersToCheck == null) {
+            return null;
+        }
+        for (String headerName : headersToCheck) {
+            String hdrValue = req.getHeader(headerName);
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, headerName + " header=", hdrValue);
+            }
+            String bearerAuthzMethod = "Bearer ";
+            if (hdrValue != null && hdrValue.startsWith(bearerAuthzMethod)) {
+                hdrValue = hdrValue.substring(bearerAuthzMethod.length());
+            }
+            return hdrValue;
+        }
+        return null;
+    }
+
+}

--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/HttpUtils.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/HttpUtils.java
@@ -257,6 +257,9 @@ public class HttpUtils {
 
     public String readConnectionResponse(HttpURLConnection con) throws IOException {
         InputStream responseStream = getResponseStream(con);
+        if (responseStream == null) {
+            return null;
+        }
         BufferedReader in = new BufferedReader(new InputStreamReader(responseStream, "UTF-8"));
         String line;
         String response = "";
@@ -287,8 +290,20 @@ public class HttpUtils {
         int responseCode = con.getResponseCode();
         if (responseCode < 400) {
             responseStream = con.getInputStream();
+            if (responseStream == null) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Failed to obtain response stream from InputStream. Getting ErrorStream instead");
+                }
+                responseStream = con.getErrorStream();
+            }
         } else {
             responseStream = con.getErrorStream();
+            if (responseStream == null) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Failed to obtain response stream from ErrorStream. Getting InputStream instead");
+                }
+                responseStream = con.getInputStream();
+            }
         }
         return responseStream;
     }

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/Oauth2LoginConfigImpl.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/Oauth2LoginConfigImpl.java
@@ -173,7 +173,7 @@ public class Oauth2LoginConfigImpl implements SocialLoginConfig {
     protected boolean useSystemPropertiesForHttpClientConnections = false;
 
     public static final String KEY_userApiType = "userApiType";
-    protected String userApiType = null;
+    protected String userApiType = "basic";
 
     public static final String KEY_userApiToken = "userApiToken";
     protected String userApiToken = null;
@@ -258,7 +258,7 @@ public class Oauth2LoginConfigImpl implements SocialLoginConfig {
 
     protected void setRequiredConfigAttributesForOpenShift(Map<String, Object> props) {
         this.userApiToken = getRequiredSerializableProtectedStringConfigAttribute(props, KEY_userApiToken);
-        this.userApi = getRequiredConfigAttribute(props, KEY_userApi);
+        this.userApi = configUtils.getRequiredConfigAttributeWithConfigId(props, KEY_userApi, uniqueId);
     }
 
     protected void setOptionalConfigAttributes(Map<String, Object> props) throws SocialLoginException {
@@ -299,8 +299,8 @@ public class Oauth2LoginConfigImpl implements SocialLoginConfig {
         this.accessTokenHeaderName = configUtils.getConfigAttribute(props, KEY_accessTokenHeaderName);
         if (!accessTokenRequired && !accessTokenSupported) {
             // If we aren't using the OpenShift proxy configuration, we MUST have the authorizationEndpoint and tokenEndpoint
-            this.authorizationEndpoint = configUtils.getRequiredConfigAttribute(props, KEY_authorizationEndpoint);
-            this.tokenEndpoint = configUtils.getRequiredConfigAttribute(props, KEY_tokenEndpoint);
+            this.authorizationEndpoint = configUtils.getRequiredConfigAttributeWithConfigId(props, KEY_authorizationEndpoint, uniqueId);
+            this.tokenEndpoint = configUtils.getRequiredConfigAttributeWithConfigId(props, KEY_tokenEndpoint, uniqueId);
         }
     }
 

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/TAIWebUtils.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/TAIWebUtils.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.social.tai;
 
@@ -17,6 +17,7 @@ import javax.servlet.http.HttpServletResponse;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.security.common.http.AuthUtils;
 import com.ibm.ws.security.common.web.WebUtils;
 import com.ibm.ws.security.social.SocialLoginConfig;
 import com.ibm.ws.security.social.TraceConstants;
@@ -42,6 +43,7 @@ public class TAIWebUtils {
     private static final String ACCESS_TOKEN = "access_token";
     WebUtils webUtils = new WebUtils();
     SocialWebUtils socialWebUtils = new SocialWebUtils();
+    AuthUtils authUtils = new AuthUtils();
     ReferrerURLCookieHandler referrerURLCookieHandler = null;
 
     public TAIWebUtils() {
@@ -144,67 +146,73 @@ public class TAIWebUtils {
     }
 
     public String getBearerAccessToken(HttpServletRequest req, Oauth2LoginConfigImpl clientConfig) {
-
         String headerName = clientConfig.getAccessTokenHeaderName();
         if (headerName != null) {
-            String hdrValue = req.getHeader(headerName);
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, headerName + " content=", hdrValue);
-            }
-            if (hdrValue != null) {
-                if (hdrValue.startsWith("Bearer ")) {
-                    hdrValue = hdrValue.substring(7);
-                }
-                return hdrValue.trim();
-            } else {
-                StringBuffer sb1 = new StringBuffer(headerName);
-                sb1.append(JWT_SEGMENTS);
-                String headerSegments = req.getHeader(sb1.toString());
-                if (headerSegments != null) {
-                    try {
-                        int iSegs = Integer.parseInt(headerSegments);
-                        StringBuffer sb3 = new StringBuffer();
-                        for (int i = 1; i < iSegs + 1; i++) {
-                            StringBuffer sb2 = new StringBuffer(headerName);
-                            sb2.append(JWT_SEGMENT_INDEX).append(i);
-                            String segHdrValue = req.getHeader(sb2.toString());
-                            if (segHdrValue != null) {
-                                sb3.append(segHdrValue.trim());
-                            }
-                        }
-                        hdrValue = sb3.toString();
-                        if (hdrValue != null && hdrValue.isEmpty()) {
-                            hdrValue = null;
-                        }
-                    } catch (Exception e) {
-                        //can be ignored
-                        if (tc.isDebugEnabled()) {
-                            Tr.debug(tc, "Fail to read Header Segments:", e.getMessage());
-                        }
-                    }
-                    return hdrValue;
-                } else {
-                    return null;
-                }
-            }
+            return getBearerTokenFromCustomHeader(req, headerName);
         } else {
-            String hdrValue = req.getHeader(Authorization_Header);
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Authorization header=", hdrValue);
+            return getBearerTokenFromAuthzHeaderOrRequestBody(req);
+        }
+    }
+
+    String getBearerTokenFromCustomHeader(HttpServletRequest req, String headerName) {
+        String hdrValue = authUtils.getBearerTokenFromHeader(req, headerName);
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, headerName + " content=", hdrValue);
+        }
+        if (hdrValue != null) {
+            return hdrValue.trim();
+        } else {
+            return getBearerTokenFromCustomHeaderSegments(req, headerName);
+        }
+    }
+
+    @FFDCIgnore(Exception.class)
+    String getBearerTokenFromCustomHeaderSegments(HttpServletRequest req, String headerName) {
+        String headerSegments = req.getHeader(headerName + JWT_SEGMENTS);
+        if (headerSegments == null) {
+            return null;
+        }
+        String hdrValue = null;
+        try {
+            hdrValue = buildBearerTokenFromCustomHeaderSegments(req, headerName, Integer.parseInt(headerSegments));
+            if (hdrValue != null && hdrValue.isEmpty()) {
+                hdrValue = null;
             }
-            if (hdrValue != null && hdrValue.startsWith("Bearer ")) {
-                hdrValue = hdrValue.substring(7);
-            } else {
-                String reqMethod = req.getMethod();
-                if (ClientConstants.REQ_METHOD_POST.equalsIgnoreCase(reqMethod)) {
-                    String contentType = req.getHeader(ClientConstants.REQ_CONTENT_TYPE_NAME);
-                    if (ClientConstants.REQ_CONTENT_TYPE_APP_FORM_URLENCODED.equals(contentType)) {
-                        hdrValue = req.getParameter(ACCESS_TOKEN);
-                    }
+        } catch (Exception e) {
+            //can be ignored
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Fail to read Header Segments:", e.getMessage());
+            }
+        }
+        return hdrValue;
+    }
+
+    String buildBearerTokenFromCustomHeaderSegments(HttpServletRequest req, String headerName, int numberOfSegments) {
+        StringBuffer tokenStringBuilder = new StringBuffer();
+        for (int i = 1; i < numberOfSegments + 1; i++) {
+            String segHdrValue = req.getHeader(headerName + JWT_SEGMENT_INDEX + i);
+            if (segHdrValue != null) {
+                tokenStringBuilder.append(segHdrValue.trim());
+            }
+        }
+        return tokenStringBuilder.toString();
+    }
+
+    String getBearerTokenFromAuthzHeaderOrRequestBody(HttpServletRequest req) {
+        String hdrValue = authUtils.getBearerTokenFromHeader(req);
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "Authorization header=", hdrValue);
+        }
+        if (hdrValue == null) {
+            String reqMethod = req.getMethod();
+            if (ClientConstants.REQ_METHOD_POST.equalsIgnoreCase(reqMethod)) {
+                String contentType = req.getHeader(ClientConstants.REQ_CONTENT_TYPE_NAME);
+                if (ClientConstants.REQ_CONTENT_TYPE_APP_FORM_URLENCODED.equals(contentType)) {
+                    hdrValue = req.getParameter(ACCESS_TOKEN);
                 }
             }
-            return hdrValue;
         }
+        return hdrValue;
     }
 
 }

--- a/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/tai/TAIWebUtilsTest.java
+++ b/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/tai/TAIWebUtilsTest.java
@@ -1,17 +1,18 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corporation and others.
+ * Copyright (c) 2016, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.social.tai;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -28,10 +29,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 
+import com.ibm.ws.security.common.http.AuthUtils;
 import com.ibm.ws.security.common.random.RandomUtils;
 import com.ibm.ws.security.social.SocialLoginConfig;
 import com.ibm.ws.security.social.error.SocialLoginException;
 import com.ibm.ws.security.social.internal.Oauth2LoginConfigImpl;
+import com.ibm.ws.security.social.internal.utils.ClientConstants;
 import com.ibm.ws.security.social.test.CommonTestClass;
 import com.ibm.ws.security.social.web.utils.SocialWebUtils;
 import com.ibm.ws.webcontainer.security.ReferrerURLCookieHandler;
@@ -61,7 +64,9 @@ public class TAIWebUtilsTest extends CommonTestClass {
     final SocialLoginConfig config = mockery.mock(SocialLoginConfig.class);
     final ReferrerURLCookieHandler referrerURLCookieHandler = mockery.mock(ReferrerURLCookieHandler.class);
     final Cookie cookie = mockery.mock(Cookie.class);
+    final Oauth2LoginConfigImpl oauth2Config = mockery.mock(Oauth2LoginConfigImpl.class);
     final SocialWebUtils socialWebUtils = mockery.mock(SocialWebUtils.class);
+    final AuthUtils authUtils = mockery.mock(AuthUtils.class);
 
     @Rule
     public final TestName testName = new TestName();
@@ -78,6 +83,7 @@ public class TAIWebUtilsTest extends CommonTestClass {
         utils = new TAIWebUtils();
         utils.referrerURLCookieHandler = referrerURLCookieHandler;
         utils.socialWebUtils = socialWebUtils;
+        utils.authUtils = authUtils;
     }
 
     @After
@@ -382,6 +388,474 @@ public class TAIWebUtilsTest extends CommonTestClass {
             String expected = "https://" + serverName;
             String result = utils.getHostAndPort(request);
             assertEquals("Host did not match expected result.", expected, result);
+
+            verifyNoLogMessage(outputMgr, MSG_BASE);
+
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /************************************** getBearerAccessToken **************************************/
+
+    @Test
+    public void test_getBearerAccessToken_customHeaderName() throws Exception {
+        try {
+            final String customHeaderName = "My Header";
+            final String expectedTokenValue = "Expected Token Value";
+            mockery.checking(new Expectations() {
+                {
+                    one(oauth2Config).getAccessTokenHeaderName();
+                    will(returnValue(customHeaderName));
+                    one(authUtils).getBearerTokenFromHeader(request, customHeaderName);
+                    will(returnValue(expectedTokenValue));
+                }
+            });
+
+            String result = utils.getBearerAccessToken(request, oauth2Config);
+            assertEquals("Returned bearer token value did not match expected result.", expectedTokenValue, result);
+
+            verifyNoLogMessage(outputMgr, MSG_BASE);
+
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_getBearerAccessToken_noConfiguredHeaderName_bearerTokenInAuthzHeader() throws Exception {
+        try {
+            final String expectedTokenValue = "Expected Token Value";
+            mockery.checking(new Expectations() {
+                {
+                    one(oauth2Config).getAccessTokenHeaderName();
+                    will(returnValue(null));
+                    one(authUtils).getBearerTokenFromHeader(request);
+                    will(returnValue(expectedTokenValue));
+                }
+            });
+
+            String result = utils.getBearerAccessToken(request, oauth2Config);
+            assertEquals("Returned bearer token value did not match expected result.", expectedTokenValue, result);
+
+            verifyNoLogMessage(outputMgr, MSG_BASE);
+
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /************************************** getBearerTokenFromCustomHeader **************************************/
+
+    @Test
+    public void test_getBearerTokenFromCustomHeader_emptyHeaderName() throws Exception {
+        try {
+            final String customHeaderName = "";
+            final String expectedTokenValue = "Expected Token Value";
+            mockery.checking(new Expectations() {
+                {
+                    one(authUtils).getBearerTokenFromHeader(request, customHeaderName);
+                    will(returnValue(expectedTokenValue));
+                }
+            });
+
+            String result = utils.getBearerTokenFromCustomHeader(request, customHeaderName);
+            assertEquals("Returned bearer token value did not match expected result.", expectedTokenValue, result);
+
+            verifyNoLogMessage(outputMgr, MSG_BASE);
+
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_getBearerTokenFromCustomHeader_emptyBearerValue() throws Exception {
+        try {
+            final String customHeaderName = "My Custom Header";
+            final String expectedTokenValue = "";
+            mockery.checking(new Expectations() {
+                {
+                    one(authUtils).getBearerTokenFromHeader(request, customHeaderName);
+                    will(returnValue(expectedTokenValue));
+                }
+            });
+
+            String result = utils.getBearerTokenFromCustomHeader(request, customHeaderName);
+            assertEquals("Returned bearer token value did not match expected result.", expectedTokenValue, result);
+
+            verifyNoLogMessage(outputMgr, MSG_BASE);
+
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_getBearerTokenFromCustomHeader_normalBearerValue() throws Exception {
+        try {
+            final String customHeaderName = "My Custom Header";
+            final String expectedTokenValue = "Expected Token Value";
+            mockery.checking(new Expectations() {
+                {
+                    one(authUtils).getBearerTokenFromHeader(request, customHeaderName);
+                    will(returnValue(expectedTokenValue));
+                }
+            });
+
+            String result = utils.getBearerTokenFromCustomHeader(request, customHeaderName);
+            assertEquals("Returned bearer token value did not match expected result.", expectedTokenValue, result);
+
+            verifyNoLogMessage(outputMgr, MSG_BASE);
+
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_getBearerTokenFromCustomHeader_missingCustomHeaders() throws Exception {
+        try {
+            final String customHeaderName = "My Custom Header";
+            mockery.checking(new Expectations() {
+                {
+                    one(authUtils).getBearerTokenFromHeader(request, customHeaderName);
+                    will(returnValue(null));
+                    one(request).getHeader(customHeaderName + "-segments");
+                    will(returnValue(null));
+                }
+            });
+
+            String result = utils.getBearerTokenFromCustomHeader(request, customHeaderName);
+            assertNull("Returned bearer token value should have been null but was [" + result + "].", result);
+
+            verifyNoLogMessage(outputMgr, MSG_BASE);
+
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /************************************** getBearerTokenFromCustomHeaderSegments **************************************/
+
+    @Test
+    public void test_getBearerTokenFromCustomHeaderSegments_nonNumberSegmentsHeader() throws Exception {
+        try {
+            final String customHeaderName = "My Custom Header";
+            mockery.checking(new Expectations() {
+                {
+                    one(request).getHeader(customHeaderName + "-segments");
+                    will(returnValue("not a number"));
+                }
+            });
+
+            String result = utils.getBearerTokenFromCustomHeaderSegments(request, customHeaderName);
+            assertNull("Returned bearer token value should have been null but was [" + result + "].", result);
+
+            verifyNoLogMessage(outputMgr, MSG_BASE);
+
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_getBearerTokenFromCustomHeaderSegments_oneSegmentHeader_missingValue() throws Exception {
+        try {
+            final String customHeaderName = "My Custom Header";
+            mockery.checking(new Expectations() {
+                {
+                    one(request).getHeader(customHeaderName + "-segments");
+                    will(returnValue("1"));
+                    one(request).getHeader(customHeaderName + "-1");
+                    will(returnValue(null));
+                }
+            });
+
+            String result = utils.getBearerTokenFromCustomHeaderSegments(request, customHeaderName);
+            assertNull("Returned bearer token value should have been null but was [" + result + "].", result);
+
+            verifyNoLogMessage(outputMgr, MSG_BASE);
+
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_getBearerTokenFromCustomHeaderSegments_oneSegmentHeader() throws Exception {
+        try {
+            final String customHeaderName = "My Custom Header";
+            final String expectedTokenValue = "Expected Token Value";
+            mockery.checking(new Expectations() {
+                {
+                    one(request).getHeader(customHeaderName + "-segments");
+                    will(returnValue("1"));
+                    one(request).getHeader(customHeaderName + "-1");
+                    will(returnValue(expectedTokenValue));
+                }
+            });
+
+            String result = utils.getBearerTokenFromCustomHeaderSegments(request, customHeaderName);
+            assertEquals("Returned bearer token value did not match expected result.", expectedTokenValue, result);
+
+            verifyNoLogMessage(outputMgr, MSG_BASE);
+
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /************************************** buildBearerTokenFromCustomHeaderSegments **************************************/
+
+    @Test
+    public void test_buildBearerTokenFromCustomHeaderSegments_negativeNumberOfSegments() throws Exception {
+        try {
+            final String customHeaderName = "My Custom Header";
+            int numberOfSegments = -42;
+
+            String result = utils.buildBearerTokenFromCustomHeaderSegments(request, customHeaderName, numberOfSegments);
+            assertEquals("Returned bearer token value should have been an empty string but was not.", "", result);
+
+            verifyNoLogMessage(outputMgr, MSG_BASE);
+
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_buildBearerTokenFromCustomHeaderSegments_zeroSegments() throws Exception {
+        try {
+            final String customHeaderName = "My Custom Header";
+            int numberOfSegments = 0;
+
+            String result = utils.buildBearerTokenFromCustomHeaderSegments(request, customHeaderName, numberOfSegments);
+            assertEquals("Returned bearer token value should have been an empty string but was not.", "", result);
+
+            verifyNoLogMessage(outputMgr, MSG_BASE);
+
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_buildBearerTokenFromCustomHeaderSegments_oneSegment_missingSegmentHeader() throws Exception {
+        try {
+            final String customHeaderName = "My Custom Header";
+            int numberOfSegments = 1;
+
+            mockery.checking(new Expectations() {
+                {
+                    one(request).getHeader(customHeaderName + "-1");
+                    will(returnValue(null));
+                }
+            });
+
+            String result = utils.buildBearerTokenFromCustomHeaderSegments(request, customHeaderName, numberOfSegments);
+            assertEquals("Returned bearer token value should have been an empty string but was not.", "", result);
+
+            verifyNoLogMessage(outputMgr, MSG_BASE);
+
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_buildBearerTokenFromCustomHeaderSegments_oneSegment_segmentHeaderIsWhiteSpace() throws Exception {
+        try {
+            final String customHeaderName = "My Custom Header";
+            int numberOfSegments = 1;
+
+            mockery.checking(new Expectations() {
+                {
+                    one(request).getHeader(customHeaderName + "-1");
+                    will(returnValue(" \t\r \n "));
+                }
+            });
+
+            String result = utils.buildBearerTokenFromCustomHeaderSegments(request, customHeaderName, numberOfSegments);
+            assertEquals("Returned bearer token value should have been an empty string but was not.", "", result);
+
+            verifyNoLogMessage(outputMgr, MSG_BASE);
+
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_buildBearerTokenFromCustomHeaderSegments_oneSegment_segmentHeaderContainsWhiteSpace() throws Exception {
+        try {
+            final String customHeaderName = "My Custom Header";
+            int numberOfSegments = 1;
+            final String expectedValue = "This is the expected value.";
+
+            mockery.checking(new Expectations() {
+                {
+                    one(request).getHeader(customHeaderName + "-1");
+                    will(returnValue(" \t\r \n " + expectedValue + "      "));
+                }
+            });
+
+            String result = utils.buildBearerTokenFromCustomHeaderSegments(request, customHeaderName, numberOfSegments);
+            assertEquals("Returned bearer token value did not match the expected value.", expectedValue, result);
+
+            verifyNoLogMessage(outputMgr, MSG_BASE);
+
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_buildBearerTokenFromCustomHeaderSegments_multipleSegments() throws Exception {
+        try {
+            final String customHeaderName = "My Custom Header";
+            int numberOfSegments = 4;
+            final String tokenPart1 = "First";
+            final String tokenPart2 = "Second";
+            final String tokenPart4 = "Fourth";
+            final String expectedTokenValue = tokenPart1 + tokenPart2 + tokenPart4;
+            mockery.checking(new Expectations() {
+                {
+                    one(request).getHeader(customHeaderName + "-1");
+                    will(returnValue(tokenPart1 + " \n\r\t"));
+                    one(request).getHeader(customHeaderName + "-2");
+                    will(returnValue("  " + tokenPart2));
+                    one(request).getHeader(customHeaderName + "-3"); // One segment happens to be missing
+                    will(returnValue(null));
+                    one(request).getHeader(customHeaderName + "-4");
+                    will(returnValue(tokenPart4));
+                }
+            });
+
+            String result = utils.buildBearerTokenFromCustomHeaderSegments(request, customHeaderName, numberOfSegments);
+            assertEquals("Returned bearer token value did not match expected result.", expectedTokenValue, result);
+
+            verifyNoLogMessage(outputMgr, MSG_BASE);
+
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    /************************************** getBearerTokenFromAuthzHeaderOrRequestBody **************************************/
+
+    @Test
+    public void test_getBearerTokenFromAuthzHeaderOrRequestBody_bearerTokenInAuthzHeader() throws Exception {
+        try {
+            final String expectedTokenValue = "Expected Token Value";
+            mockery.checking(new Expectations() {
+                {
+                    one(authUtils).getBearerTokenFromHeader(request);
+                    will(returnValue(expectedTokenValue));
+                }
+            });
+
+            String result = utils.getBearerTokenFromAuthzHeaderOrRequestBody(request);
+            assertEquals("Returned bearer token value did not match expected result.", expectedTokenValue, result);
+
+            verifyNoLogMessage(outputMgr, MSG_BASE);
+
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_getBearerTokenFromAuthzHeaderOrRequestBody_nonPostRequest() throws Exception {
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    one(authUtils).getBearerTokenFromHeader(request);
+                    will(returnValue(null));
+                    one(request).getMethod();
+                    will(returnValue("GET"));
+                }
+            });
+
+            String result = utils.getBearerTokenFromAuthzHeaderOrRequestBody(request);
+            assertNull("Returned bearer token value should have been null but was [" + result + "].", result);
+
+            verifyNoLogMessage(outputMgr, MSG_BASE);
+
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_getBearerTokenFromAuthzHeaderOrRequestBody_nonUrlEncodedRequest() throws Exception {
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    one(authUtils).getBearerTokenFromHeader(request);
+                    will(returnValue(null));
+                    one(request).getMethod();
+                    will(returnValue("POST"));
+                    one(request).getHeader(ClientConstants.REQ_CONTENT_TYPE_NAME);
+                    will(returnValue("application/json"));
+                }
+            });
+
+            String result = utils.getBearerTokenFromAuthzHeaderOrRequestBody(request);
+            assertNull("Returned bearer token value should have been null but was [" + result + "].", result);
+
+            verifyNoLogMessage(outputMgr, MSG_BASE);
+
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_getBearerTokenFromAuthzHeaderOrRequestBody_missingAccessTokenParameter() throws Exception {
+        try {
+            mockery.checking(new Expectations() {
+                {
+                    one(authUtils).getBearerTokenFromHeader(request);
+                    will(returnValue(null));
+                    one(request).getMethod();
+                    will(returnValue("POST"));
+                    one(request).getHeader(ClientConstants.REQ_CONTENT_TYPE_NAME);
+                    will(returnValue(ClientConstants.REQ_CONTENT_TYPE_APP_FORM_URLENCODED));
+                    one(request).getParameter("access_token");
+                    will(returnValue(null));
+                }
+            });
+
+            String result = utils.getBearerTokenFromAuthzHeaderOrRequestBody(request);
+            assertNull("Returned bearer token value should have been null but was [" + result + "].", result);
+
+            verifyNoLogMessage(outputMgr, MSG_BASE);
+
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_getBearerTokenFromAuthzHeaderOrRequestBody_tokenIncludedAsParameter() throws Exception {
+        try {
+            final String expectedTokenValue = "Expected Token Value";
+            mockery.checking(new Expectations() {
+                {
+                    one(authUtils).getBearerTokenFromHeader(request);
+                    will(returnValue(null));
+                    one(request).getMethod();
+                    will(returnValue("POST"));
+                    one(request).getHeader(ClientConstants.REQ_CONTENT_TYPE_NAME);
+                    will(returnValue(ClientConstants.REQ_CONTENT_TYPE_APP_FORM_URLENCODED));
+                    one(request).getParameter("access_token");
+                    will(returnValue(expectedTokenValue));
+                }
+            });
+
+            String result = utils.getBearerTokenFromAuthzHeaderOrRequestBody(request);
+            assertEquals("Returned bearer token value did not match expected result.", expectedTokenValue, result);
 
             verifyNoLogMessage(outputMgr, MSG_BASE);
 


### PR DESCRIPTION
- Creates a common method for extracting Bearer tokens from `HttpServletRequest` headers
- Fixes a potential NPE from happening in `HttpUtils.readConnectionResponse()`
- Fixes the default `userApiType` value in `OAuth2LoginConfigImpl`
- Changes error messages emitted when required config attributes are missing in OpenShift scenario
- Splits up, cleans up, and adds unit tests for `TAIWebUtils.getBearerAccessToken()`