### PR TITLE
Temporarily re-enable Java 7 support

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.tools/src/com/ibm/ws/kernel/boot/cmdline/Main.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.tools/src/com/ibm/ws/kernel/boot/cmdline/Main.java
@@ -14,11 +14,11 @@ import java.util.ResourceBundle;
 
 /**
  * Check's the version of the Java running before starting the server or running commands,
- * if Java 7 (or below) is being used a translated error message is thrown.
+ * if Java 6 (or below) is being used a translated error message is thrown.
  */
 public class Main {
 
-    private static final int CLASS_MAJOR_VERSION_JAVA8 = 52;
+    private static final int CLASS_MAJOR_VERSION_JAVA7 = 51;
 
     // See Launcher.ReturnCode.
     private static final int ERROR_BAD_JAVA_VERSION = 30;
@@ -35,7 +35,7 @@ public class Main {
         // gij (GNU libgcj) is installed as "java" on some Linux machines.
         // This interpreter really only supports Java 5, but unhelpfully fails
         // to throw UnsupportedClassVersionError for Java 6 classes.
-        if (getClassMajorVersion() < CLASS_MAJOR_VERSION_JAVA8) {
+        if (getClassMajorVersion() < CLASS_MAJOR_VERSION_JAVA7) {
             badVersion();
         }
 
@@ -76,7 +76,7 @@ public class Main {
         if (classVersion == null) {
             // JVM didn't supply the system property.  Let's hope it throws
             // UnsupportedClassVersionError if necessary.
-            return CLASS_MAJOR_VERSION_JAVA8;
+            return CLASS_MAJOR_VERSION_JAVA7;
         }
 
         int index = classVersion.indexOf('.');
@@ -87,7 +87,7 @@ public class Main {
         } catch (NumberFormatException ex) {
             // We couldn't parse the version string.  Let's hope the JVM throws
             // UnsupportedClassVersionError if necessary.
-            return CLASS_MAJOR_VERSION_JAVA8;
+            return CLASS_MAJOR_VERSION_JAVA7;
         }
     }
 }

--- a/dev/com.ibm.ws.kernel.boot.cmdline/src/com/ibm/ws/kernel/boot/cmdline/EnvCheck.java
+++ b/dev/com.ibm.ws.kernel.boot.cmdline/src/com/ibm/ws/kernel/boot/cmdline/EnvCheck.java
@@ -16,11 +16,11 @@ import com.ibm.ws.kernel.boot.Launcher;
 
 /**
  * Check's the version of the Java running before starting the server or running commands,
- * if Java 7 (or below) is being used a translated error message is thrown.
+ * if Java 6 (or below) is being used a translated error message is thrown.
  */
 public class EnvCheck {
 
-    private static final int CLASS_MAJOR_VERSION_JAVA8 = 52;
+    private static final int CLASS_MAJOR_VERSION_JAVA7 = 51;
 
     // See Launcher.ReturnCode.
     private static final int ERROR_BAD_JAVA_VERSION = 30;
@@ -39,7 +39,7 @@ public class EnvCheck {
         // gij (GNU libgcj) is installed as "java" on some Linux machines.
         // This interpreter really only supports Java 5, but unhelpfully fails
         // to throw UnsupportedClassVersionError for Java 6 classes.
-        if (getClassMajorVersion() < CLASS_MAJOR_VERSION_JAVA8) {
+        if (getClassMajorVersion() < CLASS_MAJOR_VERSION_JAVA7) {
             badVersion();
         }
 
@@ -84,7 +84,7 @@ public class EnvCheck {
         if (classVersion == null) {
             // JVM didn't supply the system property.  Let's hope it throws
             // UnsupportedClassVersionError if necessary.
-            return CLASS_MAJOR_VERSION_JAVA8;
+            return CLASS_MAJOR_VERSION_JAVA7;
         }
 
         int index = classVersion.indexOf('.');
@@ -95,7 +95,7 @@ public class EnvCheck {
         } catch (NumberFormatException ex) {
             // We couldn't parse the version string.  Let's hope the JVM throws
             // UnsupportedClassVersionError if necessary.
-            return CLASS_MAJOR_VERSION_JAVA8;
+            return CLASS_MAJOR_VERSION_JAVA7;
         }
     }
 }

--- a/dev/com.ibm.ws.kernel.boot.cmdline/src/com/ibm/ws/kernel/boot/cmdline/Main.java
+++ b/dev/com.ibm.ws.kernel.boot.cmdline/src/com/ibm/ws/kernel/boot/cmdline/Main.java
@@ -14,11 +14,11 @@ import java.util.ResourceBundle;
 
 /**
  * Check's the version of the Java running before starting the server or running commands,
- * if Java 7 (or below) is being used a translated error message is thrown.
+ * if Java 6 (or below) is being used a translated error message is thrown.
  */
 public class Main {
 
-    private static final int CLASS_MAJOR_VERSION_JAVA8 = 52;
+    private static final int CLASS_MAJOR_VERSION_JAVA7 = 51;
 
     // See Launcher.ReturnCode.
     private static final int ERROR_BAD_JAVA_VERSION = 30;
@@ -36,7 +36,7 @@ public class Main {
         // gij (GNU libgcj) is installed as "java" on some Linux machines.
         // This interpreter really only supports Java 5, but unhelpfully fails
         // to throw UnsupportedClassVersionError for Java 6 classes.
-        if (getClassMajorVersion() < CLASS_MAJOR_VERSION_JAVA8) {
+        if (getClassMajorVersion() < CLASS_MAJOR_VERSION_JAVA7) {
             badVersion();
         }
 
@@ -77,7 +77,7 @@ public class Main {
         if (classVersion == null) {
             // JVM didn't supply the system property.  Let's hope it throws
             // UnsupportedClassVersionError if necessary.
-            return CLASS_MAJOR_VERSION_JAVA8;
+            return CLASS_MAJOR_VERSION_JAVA7;
         }
 
         int index = classVersion.indexOf('.');
@@ -88,7 +88,7 @@ public class Main {
         } catch (NumberFormatException ex) {
             // We couldn't parse the version string.  Let's hope the JVM throws
             // UnsupportedClassVersionError if necessary.
-            return CLASS_MAJOR_VERSION_JAVA8;
+            return CLASS_MAJOR_VERSION_JAVA7;
         }
     }
 }

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/BootstrapConfig.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/BootstrapConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2019 IBM Corporation and others.
+ * Copyright (c) 2010, 2013 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -37,6 +37,9 @@ import com.ibm.ws.kernel.boot.internal.KernelUtils;
 import com.ibm.ws.kernel.boot.internal.PasswordGenerator;
 import com.ibm.ws.kernel.boot.internal.ServerLock;
 
+/**
+ *
+ */
 public class BootstrapConfig {
     /** ${} */
     final static Pattern SYMBOL_DEF = Pattern.compile("\\$\\{([^\\$\\{\\}]*?)\\}");
@@ -1205,6 +1208,11 @@ public class BootstrapConfig {
                 if (serverEnvContents != null)
                     toWrite += System.getProperty("line.separator");
                 toWrite += "keystore_password=" + new String(keystorePass);
+            }
+            if (jvmLevel >= 1.8 && (serverEnvContents == null || !serverEnvContents.contains("WLP_SKIP_MAXPERMSIZE="))) {
+                if (serverEnvContents != null || !toWrite.isEmpty())
+                    toWrite += System.getProperty("line.separator");
+                toWrite += "WLP_SKIP_MAXPERMSIZE=true";
             }
 
             if (serverEnvContents == null)

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -560,6 +560,7 @@ serverEnvDefaults()
         substitutePrefixVar "${WLP_DEFAULT_JAVA_HOME}" WLP_INSTALL_DIR "${WLP_INSTALL_DIR}"
         JAVA_HOME=${substitutePrefixVarResult}
         JAVA_CMD=${JAVA_HOME}/bin/java
+        WLP_SKIP_MAXPERMSIZE=${WLP_DEFAULT_SKIP_MAXPERMSIZE}
       fi
     else
       JAVA_HOME=${JRE_HOME}
@@ -629,6 +630,11 @@ serverEnvAndJVMOptions()
   # Declare allowAttachSelf=true so that the VM will permit a late self attach if localConnector-1.0 is enabled
   JVM_OPTIONS_QUOTED="-Djava.awt.headless=true -Djdk.attach.allowAttachSelf=true"
   SERVER_JVM_OPTIONS_QUOTED=${JVM_OPTIONS_QUOTED}
+
+  # Add -XX:MaxPermSize unless WLP_SKIP_MAXPERMSIZE is set.
+  if [ -z "${WLP_SKIP_MAXPERMSIZE}" ]; then
+    SERVER_JVM_OPTIONS_QUOTED="${SERVER_JVM_OPTIONS_QUOTED} -XX:MaxPermSize=256m"
+  fi
 
   rc=0
 

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
@@ -496,6 +496,7 @@ goto:eof
           set WLP_DEFAULT_JAVA_HOME=!WLP_INSTALL_DIR!!WLP_DEFAULT_JAVA_HOME:~17!
         )
         set JAVA_CMD_QUOTED="!WLP_DEFAULT_JAVA_HOME!\bin\java"
+        set WLP_SKIP_MAXPERMSIZE=!WLP_DEFAULT_SKIP_MAXPERMSIZE!
       )
     ) else (
       set JAVA_CMD_QUOTED="%JRE_HOME%\bin\java"
@@ -537,7 +538,13 @@ goto:eof
 :serverEnvAndJVMOptions
   call:serverEnv
 
-  set JVM_OPTIONS=
+  @REM By default, set -XX:MaxPermSize.  This option should be ignored by JVMs
+  @REM that don't support the option.
+  if not defined WLP_SKIP_MAXPERMSIZE (
+    set JVM_OPTIONS=-XX:MaxPermSize=256m
+  ) else (
+    set JVM_OPTIONS=
+  )
   @REM Avoid HeadlessException.
   set JVM_OPTIONS=-Djava.awt.headless=true !JVM_OPTIONS!
   @REM allow late self attach for when the localConnector-1.0 feature is enabled

--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -440,7 +440,7 @@ error.create.unknownJavaLevel.useraction=Ensure that you are using a supported J
 
 error.create.java8serverenv=CWWKE0103E: Unable to create a server.env file in the following location: {0}
 error.create.java8serverenv.explanation=The process that is attempting to create the server was not able to generate a server.env file in the specified location.  This file provides the required JVM arguments for the server to function properly.
-error.create.java8serverenv.useraction=Ensure that you have write access to the server directory and that you have sufficient disk space. You must ensure that the server process has read access to this file.
+error.create.java8serverenv.useraction=Ensure that you have write access to the server directory and that you have sufficient disk space.  Additionally, you can manually create the server.env file with the following value:  WLP_SKIP_MAXPERMSIZE=true.  You must ensure that the server process has read access to this file.
 
 audit.licenseRestriction.early_access.ilar=CWWKE0104I: This product is a beta and cannot be used in production. The full license terms can be viewed here: {0}
 audit.licenseRestriction.early_access.ilar.explanation=This product is a beta and must be used according to the terms of the beta license.

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/CreateCommandTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandline/CreateCommandTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,6 +23,7 @@ import com.ibm.websphere.simplicity.Machine;
 import com.ibm.websphere.simplicity.ProgramOutput;
 
 import componenttest.common.apiservices.Bootstrap;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.utils.FileUtils;
 import componenttest.topology.utils.LibertyServerUtils;
@@ -81,7 +82,8 @@ public class CreateCommandTest {
 
         String serverEnvContents = FileUtils.readFile(serverEnvPath);
         assertTrue("Expected server.env to contain generated keystore password at " + serverEnvPath, serverEnvContents.contains("keystore_password="));
-        assertTrue("Expected server.env to NOT contain WLP_SKIP_MAXPERMSIZE at: " + serverEnvPath, !serverEnvContents.contains("WLP_SKIP_MAXPERMSIZE"));
+        if (JavaInfo.JAVA_VERSION >= 8)
+            assertTrue("Expected server.env to contain WLP_SKIP_MAXPERMSIZE=true at: " + serverEnvPath, serverEnvContents.contains("WLP_SKIP_MAXPERMSIZE=true"));
     }
 
     @Test
@@ -100,7 +102,7 @@ public class CreateCommandTest {
         assertTrue("Expected server.env file to exist at " + serverEnvPath + ", but does not", LibertyFileManager.libertyFileExists(machine, serverEnvPath));
         String serverEnvContents = FileUtils.readFile(serverEnvPath);
         assertFalse("Expected server.env to NOT contain generated keystore password at " + serverEnvPath, serverEnvContents.contains("keystore_password="));
-        assertTrue("Expected server.env to NOT contain WLP_SKIP_MAXPERMSIZE at: " + serverEnvPath,
-                   !serverEnvContents.contains("WLP_SKIP_MAXPERMSIZE"));
+        assertTrue("Expected server.env to " + (JavaInfo.JAVA_VERSION == 7 ? "not " : " ") + "contain WLP_SKIP_MAXPERMSIZE=true at: " + serverEnvPath,
+                   JavaInfo.JAVA_VERSION == 7 ? !serverEnvContents.contains("WLP_SKIP_MAXPERMSIZE=true") : serverEnvContents.contains("WLP_SKIP_MAXPERMSIZE=true"));
     }
 }

--- a/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/boot/BootstrapConfigTest.java
+++ b/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/boot/BootstrapConfigTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2019 IBM Corporation and others.
+ * Copyright (c) 2010, 2013 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -56,6 +56,9 @@ import test.common.SharedOutputManager;
 import test.shared.Constants;
 import test.shared.TestUtils;
 
+/**
+ *
+ */
 public class BootstrapConfigTest {
     static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
     static final File defaultServer = new File(Constants.TEST_TMP_ROOT, "defaultServer");
@@ -718,6 +721,8 @@ public class BootstrapConfigTest {
             assertTrue("Server env file should contain WLP_MY_ENV_VAR=true as the first line", "WLP_MY_ENV_VAR=true".equals(customAdditionLine));
             assertTrue("Server env file should contain keystore_password=liberty as the second line but was: " + keystorePasswordLine,
                        "keystore_password=liberty".equals(keystorePasswordLine));
+            assertTrue("Server env file should contain WLP_SKIP_MAXPERMSIZE=true as the third line", "WLP_SKIP_MAXPERMSIZE=true".equals(maxPermSizeLine));
+
         } finally {
             TestUtils.cleanTempFiles(newServerDir.getParentFile()); // servers dir
         }
@@ -770,6 +775,8 @@ public class BootstrapConfigTest {
                        keystorePasswordLine.startsWith("keystore_password="));
             assertEquals("Generated keystore password should be 23 chars long: " + keystorePasswordLine, 23,
                          keystorePasswordLine.substring("keystore_password=".length()).length());
+            assertTrue("Server env file should contain WLP_SKIP_MAXPERMSIZE=true as the third line", "WLP_SKIP_MAXPERMSIZE=true".equals(maxPermSizeLine));
+
         } finally {
             TestUtils.cleanTempFiles(newServerDir.getParentFile()); // servers dir
         }
@@ -898,15 +905,13 @@ public class BootstrapConfigTest {
     }
 
     protected class TestBootstrapConfig extends BootstrapConfig {
-        TestBootstrapConfig() {
-        }
+        TestBootstrapConfig() {}
 
         TestBootstrapConfig(Map<String, String> initProps) {
             super.initProps = initProps;
         }
 
         @Override
-        protected void verifyProcess(VerifyServer verify, LaunchArguments args) throws LaunchException {
-        }
+        protected void verifyProcess(VerifyServer verify, LaunchArguments args) throws LaunchException {}
     }
 }


### PR DESCRIPTION
Revert the necessary changes in PR #8634 and PR #9297 to allow the server and tools to start with Java 7 again.