### PR TITLE
construct default realm from token review ep for oauth proxy flow

### DIFF
--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/utils/SocialUtil.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/utils/SocialUtil.java
@@ -30,8 +30,10 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.websphere.security.cred.WSCredential;
 import com.ibm.ws.security.common.web.CommonWebConstants;
 import com.ibm.ws.security.social.Constants;
+import com.ibm.ws.security.social.SocialLoginConfig;
 import com.ibm.ws.security.social.TraceConstants;
 import com.ibm.ws.security.social.error.SocialLoginException;
+import com.ibm.ws.security.social.internal.Oauth2LoginConfigImpl;
 
 /**
  * Collection of utility methods for String to byte[] conversion.
@@ -237,6 +239,29 @@ public class SocialUtil {
         if (!SocialUtil.validateQueryString(query)) {
             throw new SocialLoginException("EXCEPTION_INITIALIZING_URL", null, new Object[] { endpointUrl, "" });
         }
+    }
+    
+    public static boolean isOpenShiftConfig(SocialLoginConfig clientConfig) {
+        boolean isOpenShiftConfig = false;
+        if (clientConfig instanceof Oauth2LoginConfigImpl) {
+            Oauth2LoginConfigImpl config = (Oauth2LoginConfigImpl) clientConfig;
+            String userApiType = config.getUserApiType();
+            return (userApiType != null && ClientConstants.USER_API_TYPE_KUBE.equals(userApiType));
+        }
+        return isOpenShiftConfig;
+    }
+   
+    public static boolean useAccessTokenFromRequest(SocialLoginConfig clientConfig) {
+        
+        if (clientConfig instanceof Oauth2LoginConfigImpl) {
+            Oauth2LoginConfigImpl config = (Oauth2LoginConfigImpl) clientConfig;
+            if (config.isAccessTokenRequired() || config.isAccessTokenSupported()) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+        return false;
     }
 
 }

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/OAuthLoginFlow.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/OAuthLoginFlow.java
@@ -72,7 +72,7 @@ public class OAuthLoginFlow {
         String tokenFromRequest = taiWebUtils.getBearerAccessToken(request, clientConfig);
         if (requestShouldHaveToken((Oauth2LoginConfigImpl) clientConfig)) {
             if (!validAccessToken(tokenFromRequest)) {
-                // TODO: print error about required token being null or not valid
+                Tr.error(tc,  "OPENSHIFT_ACCESS_TOKEN_MISSING");
                 return taiWebUtils.sendToErrorPage(response, TAIResult.create(HttpServletResponse.SC_UNAUTHORIZED));
             }
             return handleAccessToken(tokenFromRequest, request, response, clientConfig);

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/OAuthLoginFlow.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/OAuthLoginFlow.java
@@ -45,7 +45,7 @@ public class OAuthLoginFlow {
     }
 
     TAIResult handleOAuthRequest(HttpServletRequest request, HttpServletResponse response, SocialLoginConfig clientConfig) throws WebTrustAssociationFailedException {
-        if (clientConfig instanceof Oauth2LoginConfigImpl && useAccessTokenFromRequest((Oauth2LoginConfigImpl) clientConfig)) {
+        if (clientConfig instanceof Oauth2LoginConfigImpl && SocialUtil.useAccessTokenFromRequest((Oauth2LoginConfigImpl) clientConfig)) {
             return handleAccessTokenFlow(request, response, (Oauth2LoginConfigImpl) clientConfig);
 
         }
@@ -57,14 +57,6 @@ public class OAuthLoginFlow {
         }
     }
 
-    private boolean useAccessTokenFromRequest(Oauth2LoginConfigImpl clientConfig) {
-
-        if (clientConfig.isAccessTokenRequired() || clientConfig.isAccessTokenSupported()) {
-            return true;
-        } else {
-            return false;
-        }
-    }
 
     private TAIResult handleAccessTokenFlow(HttpServletRequest request, HttpServletResponse response, Oauth2LoginConfigImpl clientConfig) throws WebTrustAssociationFailedException {
         TAIResult result = null;

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/TAISubjectUtils.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/TAISubjectUtils.java
@@ -38,6 +38,7 @@ import com.ibm.ws.security.social.internal.Oauth2LoginConfigImpl;
 import com.ibm.ws.security.social.internal.utils.CacheToken;
 import com.ibm.ws.security.social.internal.utils.ClientConstants;
 import com.ibm.ws.security.social.internal.utils.SocialHashUtils;
+import com.ibm.ws.security.social.internal.utils.SocialUtil;
 import com.ibm.wsspi.security.tai.TAIResult;
 import com.ibm.wsspi.security.token.AttributeNameConstants;
 
@@ -185,15 +186,14 @@ public class TAISubjectUtils {
         String realm = attributeToSubject.getMappedRealm();
         if (realm == null) {
             realm = getDefaultRealm(config);
-            //realm = getDefaultRealmFromAuthorizationEndpoint(config);
         }
         return realm;
     }
 
     private String getDefaultRealm(SocialLoginConfig config) throws SettingCustomPropertiesException {
         String realm = null;
-        if (isOpenShiftConfig(config) && useAccessTokenFromRequest(config)) {
-            String ep = getUserApiEndpoint(config);
+        if (SocialUtil.isOpenShiftConfig(config) && SocialUtil.useAccessTokenFromRequest(config)) {
+            String ep = getRealmFromUserApiEndpoint(config);
             if (ep == null) {
                 if (tc.isDebugEnabled()) {
                     Tr.debug(tc, "User api endpoint [" + config.getUserApi() + "] is either empty or too short to be a valid URL");
@@ -211,7 +211,7 @@ public class TAISubjectUtils {
         
     }
 
-    private String getUserApiEndpoint(SocialLoginConfig config) {
+    private String getRealmFromUserApiEndpoint(SocialLoginConfig config) {
         
         String defaultKubeService = "https://kubernetes.default.svc";  
         String ep = config.getUserApi();
@@ -243,33 +243,10 @@ public class TAISubjectUtils {
         String realm = config.getRealmName();
         if (realm == null) {
             realm = getDefaultRealm(config);
-            //realm = getDefaultRealmFromAuthorizationEndpoint(config);
         }
         return realm;
     }
     
-    private boolean isOpenShiftConfig(SocialLoginConfig clientConfig) {
-        boolean isOpenShiftConfig = false;
-        if (clientConfig instanceof Oauth2LoginConfigImpl) {
-            Oauth2LoginConfigImpl config = (Oauth2LoginConfigImpl) clientConfig;
-            String userApiType = config.getUserApiType();
-            return (userApiType != null && ClientConstants.USER_API_TYPE_KUBE.equals(userApiType));
-        }
-        return isOpenShiftConfig;
-    }
-    
-    private boolean useAccessTokenFromRequest(SocialLoginConfig clientConfig) {
-        
-        if (clientConfig instanceof Oauth2LoginConfigImpl) {
-            Oauth2LoginConfigImpl config = (Oauth2LoginConfigImpl) clientConfig;
-            if (config.isAccessTokenRequired() || config.isAccessTokenSupported()) {
-                return true;
-            } else {
-                return false;
-            }
-        }
-        return false;
-    }
 
     String getDefaultRealmFromAuthorizationEndpoint(SocialLoginConfig config) throws SettingCustomPropertiesException {
         String authzEndpoint = getAuthorizationEndpoint(config);

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/TAIUserApiUtils.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/TAIUserApiUtils.java
@@ -26,9 +26,9 @@ import com.ibm.ws.security.social.UserApiConfig;
 import com.ibm.ws.security.social.error.SocialLoginException;
 import com.ibm.ws.security.social.internal.LinkedinLoginConfigImpl;
 import com.ibm.ws.security.social.internal.Oauth2LoginConfigImpl;
-import com.ibm.ws.security.social.internal.utils.ClientConstants;
 import com.ibm.ws.security.social.internal.utils.OAuthClientUtil;
 import com.ibm.ws.security.social.internal.utils.OpenShiftUserApiUtils;
+import com.ibm.ws.security.social.internal.utils.SocialUtil;
 
 public class TAIUserApiUtils {
 
@@ -44,7 +44,7 @@ public class TAIUserApiUtils {
         UserApiConfig userApiConfig = userinfoCfg[0];
         String userinfoApi = userApiConfig.getApi();
         try {
-            if (isOpenShiftConfig(clientConfig)) {
+            if (SocialUtil.isOpenShiftConfig(clientConfig)) {
                 return getUserApiResponseFromOpenShift((Oauth2LoginConfigImpl) clientConfig, accessToken, sslSocketFactory);
             }
             String userApiResp = clientUtil.getUserApiResponse(userinfoApi,
@@ -70,15 +70,6 @@ public class TAIUserApiUtils {
         }
     }
 
-    private boolean isOpenShiftConfig(SocialLoginConfig clientConfig) {
-        boolean isOpenShiftConfig = false;
-        if (clientConfig instanceof Oauth2LoginConfigImpl) {
-            Oauth2LoginConfigImpl config = (Oauth2LoginConfigImpl) clientConfig;
-            String userApiType = config.getUserApiType();
-            return (userApiType != null && ClientConstants.USER_API_TYPE_KUBE.equals(userApiType));
-        }
-        return isOpenShiftConfig;
-    }
 
     private String getUserApiResponseFromOpenShift(Oauth2LoginConfigImpl config, @Sensitive String accessToken, SSLSocketFactory sslSocketFactory) throws IOException, SocialLoginException, JoseException {
         OpenShiftUserApiUtils openShiftUtils = new OpenShiftUserApiUtils(config);


### PR DESCRIPTION
If the realmName attribute is not configured, then we depend on authorizationEndpoint attribute in the oauth2Login configuration to construct the default realm.
In the OAuth proxy flow scenario, authorizationEndpoint is not a required attribute but the tokenReviewEndpoint is..(which can be specified by the userApi). 