### PR TITLE
Revert "Issue #9307: Error message in Open Tracing changes to Warning message"

### DIFF
--- a/dev/com.ibm.ws.opentracing.1.1/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
+++ b/dev/com.ibm.ws.opentracing.1.1/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
@@ -78,10 +78,6 @@ OPENTRACING_UNHANDLED_JAXRS_EXCEPTION=CWMOT0009W: The OpenTracing exception mapp
 OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.explanation=The JAX-RS-based application experienced an exception that is not handled within the application. The OpenTracing code handles it by logging the exception stack trace and returning a 500 Internal Server Error response.
 OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.useraction=This behavior might be acceptable. To handle the exception differently, the application developer can add an ExceptionMapper interface that handles the exception and maps it to a different response.
 
-OPENTRACING_TRACERFACTORY_NOT_PROVIDED=CWMOT0010W: OpenTracing cannot track JAX-RS requests because an OpentracingTracerFactory class was not provided or client libraries for tracing backend are not in the class path.
-OPENTRACING_TRACERFACTORY_NOT_PROVIDED.explanation=JAX-RS requests execute normally, but they are not tracked.
-OPENTRACING_TRACERFACTORY_NOT_PROVIDED.useraction=See the documentation about how to enable and configure OpenTracing distributed tracing. This warning can be safely ignored if OpenTracing is not being used.
-
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Opentracing error message
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/dev/com.ibm.ws.opentracing.1.1/src/com/ibm/ws/opentracing/OpentracingUserFeatureAccessService.java
+++ b/dev/com.ibm.ws.opentracing.1.1/src/com/ibm/ws/opentracing/OpentracingUserFeatureAccessService.java
@@ -46,7 +46,7 @@ public class OpentracingUserFeatureAccessService {
         factoryFirstUse = false;
 
         if (opentracingTracerFactory == null) {
-            Tr.warning(tc, "OPENTRACING_TRACERFACTORY_NOT_PROVIDED");
+            Tr.error(tc, "OPENTRACING_NO_TRACERFACTORY");
         }
     }
 
@@ -88,7 +88,7 @@ public class OpentracingUserFeatureAccessService {
             factoryFirstUse = false;
 
             if (opentracingTracerFactory == null) {
-                Tr.warning(tc, "OPENTRACING_TRACERFACTORY_NOT_PROVIDED");
+                Tr.error(tc, "OPENTRACING_NO_TRACERFACTORY");
             }
         }
 

--- a/dev/com.ibm.ws.opentracing.1.1_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATTestBase.java
+++ b/dev/com.ibm.ws.opentracing.1.1_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATTestBase.java
@@ -71,9 +71,9 @@ public class FATTestBase {
      */
     protected static void stopHelloWorldServer(LibertyServer server) throws Exception {
         try {
-            Assert.assertNotNull("Expecting CWMOT0010W message", server.waitForStringInLogUsingMark("CWMOT0010W", 0));
+            Assert.assertNotNull("Expecting CWMOT0008E message", server.waitForStringInLogUsingMark("CWMOT0008E", 0));
         } finally {
-            server.stopServer("CWMOT0010W");
+            server.stopServer("CWMOT0008E");
         }
     }
 }

--- a/dev/com.ibm.ws.opentracing.1.2/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
+++ b/dev/com.ibm.ws.opentracing.1.2/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
@@ -78,10 +78,6 @@ OPENTRACING_UNHANDLED_JAXRS_EXCEPTION=CWMOT0009W: The OpenTracing exception mapp
 OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.explanation=The JAX-RS-based application experienced an exception that is not handled within the application. The OpenTracing code handles it by logging the exception stack trace and returning a 500 Internal Server Error response.
 OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.useraction=This behavior might be acceptable. To handle the exception differently, the application developer can add an ExceptionMapper interface that handles the exception and maps it to a different response.
 
-OPENTRACING_TRACERFACTORY_NOT_PROVIDED=CWMOT0010W: OpenTracing cannot track JAX-RS requests because an OpentracingTracerFactory class was not provided or client libraries for tracing backend are not in the class path.
-OPENTRACING_TRACERFACTORY_NOT_PROVIDED.explanation=JAX-RS requests execute normally, but they are not tracked.
-OPENTRACING_TRACERFACTORY_NOT_PROVIDED.useraction=See the documentation about how to enable and configure OpenTracing distributed tracing. This warning can be safely ignored if OpenTracing is not being used.
-
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Opentracing error message
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/OpentracingUserFeatureAccessService.java
+++ b/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/OpentracingUserFeatureAccessService.java
@@ -46,7 +46,7 @@ public class OpentracingUserFeatureAccessService {
         factoryFirstUse = false;
 
         if (opentracingTracerFactory == null) {
-            Tr.warning(tc, "OPENTRACING_TRACERFACTORY_NOT_PROVIDED");
+            Tr.error(tc, "OPENTRACING_NO_TRACERFACTORY");
         }
     }
 
@@ -88,7 +88,7 @@ public class OpentracingUserFeatureAccessService {
             factoryFirstUse = false;
 
             if (opentracingTracerFactory == null) {
-                Tr.warning(tc, "OPENTRACING_TRACERFACTORY_NOT_PROVIDED");
+                Tr.error(tc, "OPENTRACING_NO_TRACERFACTORY");
             }
         }
 

--- a/dev/com.ibm.ws.opentracing.1.2_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATTestBase.java
+++ b/dev/com.ibm.ws.opentracing.1.2_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATTestBase.java
@@ -71,9 +71,9 @@ public class FATTestBase {
      */
     protected static void stopHelloWorldServer(LibertyServer server) throws Exception {
         try {
-            Assert.assertNotNull("Expecting CWMOT0010W message", server.waitForStringInLogUsingMark("CWMOT0010W", 0));
+            Assert.assertNotNull("Expecting CWMOT0008E message", server.waitForStringInLogUsingMark("CWMOT0008E", 0));
         } finally {
-            server.stopServer("CWMOT0010W");
+            server.stopServer("CWMOT0008E");
         }
     }
 }

--- a/dev/com.ibm.ws.opentracing.1.3/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
+++ b/dev/com.ibm.ws.opentracing.1.3/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
@@ -78,10 +78,6 @@ OPENTRACING_UNHANDLED_JAXRS_EXCEPTION=CWMOT0009W: The OpenTracing exception mapp
 OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.explanation=The JAX-RS-based application experienced an exception that is not handled within the application. The OpenTracing code handles it by logging the exception stack trace and returning a 500 Internal Server Error response.
 OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.useraction=This behavior might be acceptable. To handle the exception differently, the application developer can add an ExceptionMapper interface that handles the exception and maps it to a different response.
 
-OPENTRACING_TRACERFACTORY_NOT_PROVIDED=CWMOT0010W: OpenTracing cannot track JAX-RS requests because an OpentracingTracerFactory class was not provided or client libraries for tracing backend are not in the class path.
-OPENTRACING_TRACERFACTORY_NOT_PROVIDED.explanation=JAX-RS requests execute normally, but they are not tracked.
-OPENTRACING_TRACERFACTORY_NOT_PROVIDED.useraction=See the documentation about how to enable and configure OpenTracing distributed tracing. This warning can be safely ignored if OpenTracing is not being used.
-
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Opentracing error message
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/dev/com.ibm.ws.opentracing.1.3/src/com/ibm/ws/opentracing/OpentracingUserFeatureAccessService.java
+++ b/dev/com.ibm.ws.opentracing.1.3/src/com/ibm/ws/opentracing/OpentracingUserFeatureAccessService.java
@@ -46,7 +46,7 @@ public class OpentracingUserFeatureAccessService {
         factoryFirstUse = false;
 
         if (opentracingTracerFactory == null) {
-            Tr.warning(tc, "OPENTRACING_TRACERFACTORY_NOT_PROVIDED");
+            Tr.error(tc, "OPENTRACING_NO_TRACERFACTORY");
         }
     }
 
@@ -88,7 +88,7 @@ public class OpentracingUserFeatureAccessService {
             factoryFirstUse = false;
 
             if (opentracingTracerFactory == null) {
-                Tr.warning(tc, "OPENTRACING_TRACERFACTORY_NOT_PROVIDED");
+                Tr.error(tc, "OPENTRACING_NO_TRACERFACTORY");
             }
         }
 

--- a/dev/com.ibm.ws.opentracing.1.3_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATTestBase.java
+++ b/dev/com.ibm.ws.opentracing.1.3_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATTestBase.java
@@ -71,9 +71,9 @@ public class FATTestBase {
      */
     protected static void stopHelloWorldServer(LibertyServer server) throws Exception {
         try {
-            Assert.assertNotNull("Expecting CWMOT0010W message", server.waitForStringInLogUsingMark("CWMOT0010W", 0));
+            Assert.assertNotNull("Expecting CWMOT0008E message", server.waitForStringInLogUsingMark("CWMOT0008E", 0));
         } finally {
-            server.stopServer("CWMOT0010W");
+            server.stopServer("CWMOT0008E");
         }
     }
 }

--- a/dev/com.ibm.ws.opentracing/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
+++ b/dev/com.ibm.ws.opentracing/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
@@ -78,10 +78,6 @@ OPENTRACING_UNHANDLED_JAXRS_EXCEPTION=CWMOT0009W: The OpenTracing exception mapp
 OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.explanation=The JAX-RS-based application experienced an exception that is not handled within the application. The OpenTracing code handles it by logging the exception stack trace and returning a 500 Internal Server Error response.
 OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.useraction=This behavior might be acceptable. To handle the exception differently, the application developer can add an ExceptionMapper interface that handles the exception and maps it to a different response.
 
-OPENTRACING_TRACERFACTORY_NOT_PROVIDED=CWMOT0010W: OpenTracing cannot track JAX-RS requests because an OpentracingTracerFactory class was not provided or client libraries for tracing backend are not in the class path.
-OPENTRACING_TRACERFACTORY_NOT_PROVIDED.explanation=JAX-RS requests execute normally, but they are not tracked.
-OPENTRACING_TRACERFACTORY_NOT_PROVIDED.useraction=See the documentation about how to enable and configure OpenTracing distributed tracing. This warning can be safely ignored if OpenTracing is not being used.
-
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Opentracing error message
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingUserFeatureAccessService.java
+++ b/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingUserFeatureAccessService.java
@@ -46,7 +46,7 @@ public class OpentracingUserFeatureAccessService {
         factoryFirstUse = false;
 
         if (opentracingTracerFactory == null) {
-            Tr.warning(tc, "OPENTRACING_TRACERFACTORY_NOT_PROVIDED");
+            Tr.error(tc, "OPENTRACING_NO_TRACERFACTORY");
         }
     }
 
@@ -88,7 +88,7 @@ public class OpentracingUserFeatureAccessService {
             factoryFirstUse = false;
 
             if (opentracingTracerFactory == null) {
-                Tr.warning(tc, "OPENTRACING_TRACERFACTORY_NOT_PROVIDED");
+                Tr.error(tc, "OPENTRACING_NO_TRACERFACTORY");
             }
         }
 

--- a/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATTestBase.java
+++ b/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATTestBase.java
@@ -71,9 +71,9 @@ public class FATTestBase {
      */
     protected static void stopHelloWorldServer(LibertyServer server) throws Exception {
         try {
-            Assert.assertNotNull("Expecting CWMOT0010W message", server.waitForStringInLogUsingMark("CWMOT0010W", 0));
+            Assert.assertNotNull("Expecting CWMOT0008E message", server.waitForStringInLogUsingMark("CWMOT0008E", 0));
         } finally {
-            server.stopServer("CWMOT0010W");
+            server.stopServer("CWMOT0008E");
         }
     }
 }


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#9637

Caused a failure in `com.ibm.ws.microprofile.1.2_fat` - `com.ibm.ws.microprofile12.fat.suite.SimpleJAXRSCDITest`
```
java.lang.Exception: Errors/warnings were found in server MPServer logs:
 <br>[11/11/19, 9:43:57:693 UTC] 00000036 com.ibm.ws.opentracing.OpentracingUserFeatureAccessService   W CWMOT0010W: OpenTracing cannot track JAX-RS requests because an OpentracingTracerFactory class was not provided or client libraries for tracing backend are not in the class path.
	at componenttest.topology.impl.LibertyServer.checkLogsForErrorsAndWarnings(LibertyServer.java:2528)
	at componenttest.topology.impl.LibertyServer.stopServer(LibertyServer.java:2406)
```