### PR TITLE
add additional information for conTimeout value for 0 and -1

### DIFF
--- a/dev/com.ibm.ws.jca.cm/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.jca.cm/resources/OSGI-INF/l10n/metatype.properties
@@ -29,7 +29,7 @@ agedTimeout=Aged timeout
 agedTimeout.desc=Amount of time before a connection can be discarded by pool maintenance. A value of -1 disables this timeout. A value of 0 discards every connection, which disables connection pooling.
 
 connTimeout=Connection timeout
-connTimeout.desc=Amount of time after which a connection request times out. A value of -1 disables this timeout meaning infinite wait.  A value of 0 is immediate meaning no wait.
+connTimeout.desc=Amount of time after which a connection request times out. A value of -1 disables this timeout, meaning infinite wait. A value of 0 is immediate, meaning no wait.
 
 maxIdleTime=Maximum idle time
 maxIdleTime.desc=Amount of time a connection can be unused or idle until it can be discarded during pool maintenance, if doing so does not reduce the pool below the minimum size. A value of -1 disables this timeout.

--- a/dev/com.ibm.ws.jca.cm/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.jca.cm/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2013 IBM Corporation and others.
+# Copyright (c) 2011, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jca.cm/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.jca.cm/resources/OSGI-INF/l10n/metatype.properties
@@ -29,7 +29,7 @@ agedTimeout=Aged timeout
 agedTimeout.desc=Amount of time before a connection can be discarded by pool maintenance. A value of -1 disables this timeout. A value of 0 discards every connection, which disables connection pooling.
 
 connTimeout=Connection timeout
-connTimeout.desc=Amount of time after which a connection request times out. A value of -1 disables this timeout.
+connTimeout.desc=Amount of time after which a connection request times out. A value of -1 disables this timeout meaning infinite wait.  A value of 0 is immediate meaning no wait.
 
 maxIdleTime=Maximum idle time
 maxIdleTime.desc=Amount of time a connection can be unused or idle until it can be discarded during pool maintenance, if doing so does not reduce the pool below the minimum size. A value of -1 disables this timeout.


### PR DESCRIPTION
Added more information to conTimeout values of 0 and -1.

New metatype is

connTimeout.desc=Amount of time after which a connection request times out. A value of -1 disables this timeout meaning infinite wait.  A value of 0 is immediate meaning no wait.

