### PR TITLE
Rename `@SchemaName` to `@Name` - as changed in the MP GraphQL spec

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -91,8 +91,8 @@ org.apache.cxf:cxf-rt-ws-security:2.6.2-ibm-s20180529-1900
 org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0
 org.apache.santuario:xmlsec:1.5.2-ibm
 org.apache.ws.security:wss4j:1.6.7-ibm-s20130913-2015
-org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.0-20191107
-org.eclipse.microprofile.graphql:microprofile-graphql-tck:1.0.0-20191107
+org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.0-20191112
+org.eclipse.microprofile.graphql:microprofile-graphql-tck:1.0.0-20191112
 org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.5-ea124dd
 org.eclipse.persistence:org.eclipse.persistence.asm:2.7.5-ea124dd
 org.eclipse.persistence:org.eclipse.persistence.core:2.7.5-ea124dd

--- a/dev/com.ibm.websphere.org.eclipse.microprofile.graphql.1.0/bnd.bnd
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.graphql.1.0/bnd.bnd
@@ -20,7 +20,7 @@ Export-Package: \
   org.eclipse.microprofile.graphql;version=1.0
 
 Include-Resource: \
-  @${repo;org.eclipse.microprofile.graphql:microprofile-graphql-api;1.0.0.20191107;EXACT}
+  @${repo;org.eclipse.microprofile.graphql:microprofile-graphql-api;1.0.0.20191112;EXACT}
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version>=1.8))"
 

--- a/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/bnd.bnd
+++ b/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/bnd.bnd
@@ -12,6 +12,10 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
+Bundle-Name: GraphQL SPQR
+Bundle-SymbolicName: com.ibm.ws.io.leangen.graphql.spqr.0.9.9
+Bundle-Description: GraphQL SPQR aims to make it dead simple to add a GraphQL API to any Java project. It works by dynamically generating a GraphQL schema from Java code.
+
 javac.source: 1.8
 javac.target: 1.8
 

--- a/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/query/AnnotatedArgumentBuilder.java
+++ b/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/query/AnnotatedArgumentBuilder.java
@@ -13,7 +13,7 @@ import io.leangen.graphql.util.ReservedStrings;
 import io.leangen.graphql.util.Urls;
 import org.eclipse.microprofile.graphql.DefaultValue;
 import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.SchemaName;
+import org.eclipse.microprofile.graphql.Name;
 import org.eclipse.microprofile.graphql.Source;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,7 +69,7 @@ public class AnnotatedArgumentBuilder implements ResolverArgumentBuilder {
         if (Optional.ofNullable(parameterType.getAnnotation(GraphQLId.class)).filter(GraphQLId::relayId).isPresent()) {
             return GraphQLId.RELAY_ID_FIELD_NAME;
         }
-        SchemaName meta = parameter.getAnnotation(SchemaName.class);
+        Name meta = parameter.getAnnotation(Name.class);
         if (meta != null && !meta.value().isEmpty()) {
             return messageBundle.interpolate(meta.value());
         } else {

--- a/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/value/AnnotationMappingUtils.java
+++ b/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/value/AnnotationMappingUtils.java
@@ -2,15 +2,15 @@ package io.leangen.graphql.metadata.strategy.value;
 
 import io.leangen.graphql.util.Utils;
 import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.SchemaName;
+import org.eclipse.microprofile.graphql.Name;
 
 import java.lang.reflect.Method;
 
 public class AnnotationMappingUtils {
 
     public static String inputFieldName(Method method) {
-        if (method.isAnnotationPresent(SchemaName.class)) {
-            return Utils.coalesce(method.getAnnotation(SchemaName.class).value(), method.getName());
+        if (method.isAnnotationPresent(Name.class)) {
+            return Utils.coalesce(method.getAnnotation(Name.class).value(), method.getName());
         }
         return method.getName();
     }

--- a/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/value/InputFieldInfoGenerator.java
+++ b/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/value/InputFieldInfoGenerator.java
@@ -6,8 +6,9 @@ import io.leangen.graphql.util.ReservedStrings;
 import io.leangen.graphql.util.Utils;
 import org.eclipse.microprofile.graphql.DefaultValue;
 import org.eclipse.microprofile.graphql.Description;
+import org.eclipse.microprofile.graphql.Name;
 import org.eclipse.microprofile.graphql.Query;
-import org.eclipse.microprofile.graphql.SchemaName;
+
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.AnnotatedType;
@@ -18,9 +19,9 @@ public class InputFieldInfoGenerator {
 
     public Optional<String> getName(List<AnnotatedElement> candidates, MessageBundle messageBundle) {
         Optional<String> explicit = candidates.stream()
-                .filter(element -> element.isAnnotationPresent(SchemaName.class))
+                .filter(element -> element.isAnnotationPresent(Name.class))
                 .findFirst()
-                .map(element -> element.getAnnotation(SchemaName.class).value());
+                .map(element -> element.getAnnotation(Name.class).value());
         Optional<String> implicit = candidates.stream()
                 .filter(element -> element.isAnnotationPresent(Query.class))
                 .findFirst()

--- a/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/value/jsonb/JsonbValueMapper.java
+++ b/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/value/jsonb/JsonbValueMapper.java
@@ -50,7 +50,7 @@ import io.leangen.graphql.util.ClassUtils;
 
 import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.DefaultValue;
-import org.eclipse.microprofile.graphql.SchemaName;
+import org.eclipse.microprofile.graphql.Name;
 
 public class JsonbValueMapper implements ValueMapper, InputFieldBuilder {
 
@@ -152,12 +152,12 @@ public class JsonbValueMapper implements ValueMapper, InputFieldBuilder {
                 }
 
                 String fieldName = propName;
-                SchemaName schemaNameAnno = null;
+                Name schemaNameAnno = null;
                 if (setterMethod != null) {
-                    schemaNameAnno = setterMethod.getAnnotation(SchemaName.class);
+                    schemaNameAnno = setterMethod.getAnnotation(Name.class);
                 }
                 if (schemaNameAnno == null && field != null) {
-                    schemaNameAnno = field.getAnnotation(SchemaName.class);
+                    schemaNameAnno = field.getAnnotation(Name.class);
                 }
                 if (schemaNameAnno != null) {
                     fieldName = useDefaultIfEmpty(schemaNameAnno.value(), fieldName);
@@ -281,16 +281,16 @@ public class JsonbValueMapper implements ValueMapper, InputFieldBuilder {
                        if (LOG.isLoggable(Level.FINEST)) {
                            LOG.finest("<init> checking " + propName);
                        }
-                       if (addMapping(propName, m.getAnnotation(SchemaName.class))) {
+                       if (addMapping(propName, m.getAnnotation(Name.class))) {
                            return;
                        }
                        ClassUtils.findFieldBySetter(m).ifPresent(f -> {
-                           addMapping(propName, f.getAnnotation(SchemaName.class));
+                           addMapping(propName, f.getAnnotation(Name.class));
                        });
                    });
         }
 
-        private boolean addMapping(String propName, SchemaName schemaNameAnno) {
+        private boolean addMapping(String propName, Name schemaNameAnno) {
             if (LOG.isLoggable(Level.FINEST)) {
                 LOG.finest("addMapping " + propName + " -> " + (schemaNameAnno == null ? "null" : schemaNameAnno.value()));
             }

--- a/dev/com.ibm.ws.microprofile.graphql.1.0/src/com/ibm/ws/microprofile/graphql/internal/MPOperationBuilder.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0/src/com/ibm/ws/microprofile/graphql/internal/MPOperationBuilder.java
@@ -25,6 +25,7 @@ import io.leangen.graphql.metadata.execution.MethodInvoker;
 import io.leangen.graphql.metadata.messages.MessageBundle;
 import io.leangen.graphql.metadata.strategy.query.DefaultOperationBuilder;
 
+import org.eclipse.microprofile.graphql.Name;
 import org.eclipse.microprofile.graphql.Query;
 
 
@@ -52,7 +53,16 @@ public class MPOperationBuilder extends DefaultOperationBuilder {
                 }
             }
 
-            // if no Query annotation, next check for JsonbProperty annotation
+            // if no Query annotation, next check for @Name
+            Name nameAnno = method.getAnnotation(Name.class);
+            if (nameAnno != null) {
+                String value = nameAnno.value();
+                if (!isEmpty(value)) {
+                    return value;
+                }
+            }
+
+            // still no name, try JsonbProperty annotation
             JsonbProperty jsonbPropAnno = method.getAnnotation(JsonbProperty.class);
             if (jsonbPropAnno == null) {
                 Field field = getFieldFromGetter(method);

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/basicMutationApp/src/mpGraphQL10/basicMutation/GraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/basicMutationApp/src/mpGraphQL10/basicMutation/GraphQLEndpoint.java
@@ -19,8 +19,9 @@ import javax.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Name;
 import org.eclipse.microprofile.graphql.Query;
-import org.eclipse.microprofile.graphql.SchemaName;
+
 
 import mpGraphQL10.types.WidgetImpl;
 import mpGraphQL10.types.WidgetInput;
@@ -43,7 +44,7 @@ public class GraphQLEndpoint {
 
     @Mutation("createWidget")
     @Description("Create a new widget for sale.")
-    public Widget createNewWidget(@SchemaName("widget") Widget inputWidget) {
+    public Widget createNewWidget(@Name("widget") Widget inputWidget) {
         Widget newWidget = new Widget(inputWidget);
         allWidgets.add(newWidget);
         return newWidget;

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/defaultvalueApp/src/mpGraphQL10/defaultvalue/MyGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/defaultvalueApp/src/mpGraphQL10/defaultvalue/MyGraphQLEndpoint.java
@@ -19,8 +19,9 @@ import javax.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.graphql.DefaultValue;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Name;
 import org.eclipse.microprofile.graphql.Query;
-import org.eclipse.microprofile.graphql.SchemaName;
+
 
 @GraphQLApi
 @ApplicationScoped
@@ -44,7 +45,7 @@ public class MyGraphQLEndpoint {
     }
 
     @Query("widgetByName")
-    public Widget getWidgetByName(@SchemaName("name") @DefaultValue("Pencil") String name) {
+    public Widget getWidgetByName(@Name("name") @DefaultValue("Pencil") String name) {
         switch (name) {
             case "Pencil": return new Widget("Pencil", 10, 0.5, 5.5, 0.2, 0.2);
             case "Eraser": return new Widget("Eraser", 5, 0.7, 2.2, 0.2, 0.4);
@@ -53,7 +54,7 @@ public class MyGraphQLEndpoint {
     }
 
     @Mutation("createWidget")
-    public Widget createNewWidget(@SchemaName("widget") WidgetInput input) {
+    public Widget createNewWidget(@Name("widget") WidgetInput input) {
         Widget w = Widget.fromWidgetInput(input);
         allWidgets.add(w);
         return w;
@@ -61,7 +62,7 @@ public class MyGraphQLEndpoint {
     
     @Mutation("createWidgetByString")
     public Widget createNewWidget(@DefaultValue("Widget(Oven,12,120.1,36.2,3.3,14.0)")
-                                  @SchemaName("widgetString") String input) {
+                                  @Name("widgetString") String input) {
         Widget w = Widget.fromString(input);
         allWidgets.add(w);
         return w;

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/deprecationApp/src/mpGraphQL10/deprecation/MyGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/deprecationApp/src/mpGraphQL10/deprecation/MyGraphQLEndpoint.java
@@ -18,8 +18,9 @@ import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Name;
 import org.eclipse.microprofile.graphql.Query;
-import org.eclipse.microprofile.graphql.SchemaName;
+
 
 @GraphQLApi
 @ApplicationScoped
@@ -46,7 +47,7 @@ public class MyGraphQLEndpoint {
     //@org.eclipse.microprofile.graphql.Deprecated("Deprecated mutation, please use \"createWidget\" instead.")
     @Deprecated
     @Mutation("createWidgetByHand")
-    public Widget createNewWidgetByHand(@SchemaName("widgetString") String widgetString) {
+    public Widget createNewWidgetByHand(@Name("widgetString") String widgetString) {
         Widget w = Widget.fromString(widgetString);
         allWidgets.add(w);
         return w;
@@ -54,7 +55,7 @@ public class MyGraphQLEndpoint {
     }
 
     @Mutation("createWidget")
-    public Widget createNewWidget(@SchemaName("widget") Widget input) {
+    public Widget createNewWidget(@Name("widget") Widget input) {
         Widget w = Widget.fromWidgetInput(input);
         allWidgets.add(w);
         return w;

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/graphQLInterfaceApp/src/mpGraphQL10/graphQLInterface/MyGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/graphQLInterfaceApp/src/mpGraphQL10/graphQLInterface/MyGraphQLEndpoint.java
@@ -18,8 +18,8 @@ import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Name;
 import org.eclipse.microprofile.graphql.Query;
-import org.eclipse.microprofile.graphql.SchemaName;
 
 @GraphQLApi
 @ApplicationScoped
@@ -44,7 +44,7 @@ public class MyGraphQLEndpoint {
     }
 
     @Mutation("createWidgetByHand")
-    public IWidget createNewWidgetByHand(@SchemaName("widgetString") String widgetString) {
+    public IWidget createNewWidgetByHand(@Name("widgetString") String widgetString) {
         Widget w = Widget.fromString(widgetString);
         allWidgets.add(w);
         return w;
@@ -52,7 +52,7 @@ public class MyGraphQLEndpoint {
     }
 
     @Mutation("createWidget")
-    public IWidget createNewWidget(@SchemaName("widget") Widget input) {
+    public IWidget createNewWidget(@Name("widget") Widget input) {
         Widget w = Widget.fromWidgetInput(input);
         allWidgets.add(w);
         return w;

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/ifaceApp/src/mpGraphQL10/iface/MyGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/ifaceApp/src/mpGraphQL10/iface/MyGraphQLEndpoint.java
@@ -18,8 +18,8 @@ import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Name;
 import org.eclipse.microprofile.graphql.Query;
-import org.eclipse.microprofile.graphql.SchemaName;
 
 @GraphQLApi
 @ApplicationScoped
@@ -38,7 +38,7 @@ public class MyGraphQLEndpoint {
     }
     
     @Mutation("createWidget")
-    public Widget createNewWidget(@SchemaName("widget") WidgetInput input) {
+    public Widget createNewWidget(@Name("widget") WidgetInput input) {
         if (!(input instanceof WidgetInput)) {
             String msg = String.format("Unexpected input type; expected WidgetInput, got {0}\n",
                                        input.getClass().getName());

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/ignoreApp/src/mpGraphQL10/ignore/MyGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/ignoreApp/src/mpGraphQL10/ignore/MyGraphQLEndpoint.java
@@ -18,8 +18,8 @@ import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Name;
 import org.eclipse.microprofile.graphql.Query;
-import org.eclipse.microprofile.graphql.SchemaName;
 
 @GraphQLApi
 @ApplicationScoped
@@ -44,7 +44,7 @@ public class MyGraphQLEndpoint {
     }
 
     @Mutation("createWidgetByHand")
-    public Widget createNewWidgetByHand(@SchemaName("widgetString") String widgetString) {
+    public Widget createNewWidgetByHand(@Name("widgetString") String widgetString) {
         Widget w = Widget.fromString(widgetString);
         allWidgets.add(w);
         return w;
@@ -52,7 +52,7 @@ public class MyGraphQLEndpoint {
     }
 
     @Mutation("createWidget")
-    public Widget createNewWidget(@SchemaName("widget") Widget input) {
+    public Widget createNewWidget(@Name("widget") Widget input) {
         Widget w = Widget.fromWidgetInput(input);
         allWidgets.add(w);
         return w;

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/InputFieldsTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/InputFieldsTestServlet.java
@@ -79,20 +79,20 @@ public class InputFieldsTestServlet extends FATServlet {
         
         String snippet = getSchemaInputTypeSnippet();
 
-        // check input fields from @SchemaName on Java fields
-        assertTrue("Schema does not contain field name specified via @SchemaName on Java field", 
+        // check input fields from @Name on Java fields
+        assertTrue("Schema does not contain field name specified via @Name on Java field", 
                    snippet.contains("qty:"));
-        assertTrue("Schema does not contain field description specified via @SchemaName on Java field", 
+        assertTrue("Schema does not contain field description specified via @Name on Java field", 
                    snippet.contains("Number of units to ship"));
-        assertFalse("Schema contains Java field name that should have been overwritten by @SchemaName annotation",
+        assertFalse("Schema contains Java field name that should have been overwritten by @Name annotation",
                     snippet.contains("quantity:"));
 
-        // check input fields from @SchemaName on Java setters -- currently not allowed to put @SchemaName on methods
-//        assertTrue("Schema does not contain field name specified via @SchemaName on Java setter", 
+        // check input fields from @Name on Java setters -- currently not allowed to put @Name on methods
+//        assertTrue("Schema does not contain field name specified via @Name on Java setter", 
 //                   snippet.contains("shippingWeight "));
-//        assertTrue("Schema does not contain field description specified via @SchemaName on Java setter", 
+//        assertTrue("Schema does not contain field description specified via @Name on Java setter", 
 //                   snippet.contains("Total tonnage to be shipped"));
-//        assertFalse("Schema contains Java property name that should have been overwritten by @SchemaName annotation",
+//        assertFalse("Schema contains Java property name that should have been overwritten by @Name annotation",
 //                    snippet.contains("weight "));
     }
 
@@ -102,7 +102,7 @@ public class InputFieldsTestServlet extends FATServlet {
         // check input fields from @JsonbProperty on Java fields
         assertTrue("Schema does not contain field name specified via @JsonbProperty on Java field", 
                    snippet.contains("qty2:"));
-        assertFalse("Schema contains Java field name that should have been overwritten by @SchemaName annotation",
+        assertFalse("Schema contains Java field name that should have been overwritten by @Name annotation",
                     snippet.contains("quantity2"));
     }
 
@@ -112,7 +112,7 @@ public class InputFieldsTestServlet extends FATServlet {
         // check input fields from @JsonbProperty on Java setters
         assertTrue("Schema does not contain field name specified via @JsonbProperty on Java setter", 
                    snippet.contains("shippingWeight2:"));
-        assertFalse("Schema contains Java property name that should have been overwritten by @SchemaName annotation",
+        assertFalse("Schema contains Java property name that should have been overwritten by @Name annotation",
                     snippet.contains("weight2:"));
     }
 

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/MyGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/MyGraphQLEndpoint.java
@@ -18,8 +18,8 @@ import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Name;
 import org.eclipse.microprofile.graphql.Query;
-import org.eclipse.microprofile.graphql.SchemaName;
 
 @GraphQLApi
 @ApplicationScoped
@@ -44,7 +44,7 @@ public class MyGraphQLEndpoint {
     }
 
     @Mutation("createWidgetByHand")
-    public Widget createNewWidgetByHand(@SchemaName("widgetString") String widgetString) {
+    public Widget createNewWidgetByHand(@Name("widgetString") String widgetString) {
         Widget w = Widget.fromString(widgetString);
         allWidgets.add(w);
         return w;
@@ -52,7 +52,7 @@ public class MyGraphQLEndpoint {
     }
 
     @Mutation("createWidget")
-    public Widget createNewWidget(@SchemaName("widget") Widget input) {
+    public Widget createNewWidget(@Name("widget") Widget input) {
         Widget w = Widget.fromWidgetInput(input);
         allWidgets.add(w);
         return w;

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/Widget.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/Widget.java
@@ -15,14 +15,14 @@ import java.text.DecimalFormat;
 import javax.json.bind.annotation.JsonbProperty;
 
 import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.SchemaName;
+import org.eclipse.microprofile.graphql.Name;
 /**
  * This is an implementation class of the interface entity, Widget.
  */
 public class Widget {
 
     private String name;
-    @SchemaName("qty")
+    @Name("qty")
     @Description("Number of units to ship")
     private int quantity = -1;
     private double weight = -1.0;
@@ -85,7 +85,7 @@ public class Widget {
         return weight;
     }
 
-//    @SchemaName(value = "shippingWeight", description = "Total tonnage to be shipped")
+//    @Name(value = "shippingWeight", description = "Total tonnage to be shipped")
     public void setWeight(double weight) {
         this.weight = weight;
     }

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/WidgetClientObject.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/inputFieldsApp/src/mpGraphQL10/inputFields/WidgetClientObject.java
@@ -15,14 +15,14 @@ import java.text.DecimalFormat;
 import javax.json.bind.annotation.JsonbProperty;
 
 import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.SchemaName;
+import org.eclipse.microprofile.graphql.Name;
 /**
  * This is an implementation class of the interface entity, Widget.
  */
 public class WidgetClientObject {
 
     private String name;
-    @SchemaName("qty")
+    @Name("qty")
     @Description("Number of units to ship")
     private int quantity = -1;
     private double weight = -1.0;
@@ -85,7 +85,7 @@ public class WidgetClientObject {
         return weight;
     }
 
-//    @SchemaName(value = "shippingWeight", description = "Total tonnage to be shipped")
+//    @Name(value = "shippingWeight", description = "Total tonnage to be shipped")
     public void setWeight(double weight) {
         this.weight = weight;
     }

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/outputFieldsApp/src/mpGraphQL10/outputFields/MyGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/outputFieldsApp/src/mpGraphQL10/outputFields/MyGraphQLEndpoint.java
@@ -18,8 +18,8 @@ import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Name;
 import org.eclipse.microprofile.graphql.Query;
-import org.eclipse.microprofile.graphql.SchemaName;
 
 @GraphQLApi
 @ApplicationScoped
@@ -44,7 +44,7 @@ public class MyGraphQLEndpoint {
     }
 
     @Mutation("createWidgetByHand")
-    public Widget createNewWidgetByHand(@SchemaName("widgetString") String widgetString) {
+    public Widget createNewWidgetByHand(@Name("widgetString") String widgetString) {
         Widget w = Widget.fromString(widgetString);
         allWidgets.add(w);
         return w;
@@ -52,7 +52,7 @@ public class MyGraphQLEndpoint {
     }
 
     @Mutation("createWidget")
-    public Widget createNewWidget(@SchemaName("widget") Widget input) {
+    public Widget createNewWidget(@Name("widget") Widget input) {
         Widget w = Widget.fromWidgetInput(input);
         allWidgets.add(w);
         return w;

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/typesApp/src/mpGraphQL10/types/MyGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/typesApp/src/mpGraphQL10/types/MyGraphQLEndpoint.java
@@ -18,8 +18,8 @@ import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Name;
 import org.eclipse.microprofile.graphql.Query;
-import org.eclipse.microprofile.graphql.SchemaName;
 
 @GraphQLApi
 @ApplicationScoped
@@ -39,7 +39,7 @@ public class MyGraphQLEndpoint {
     }
     
     @Mutation("createWidget")
-    public WidgetImpl createNewWidget(@SchemaName("widget") WidgetInput input) {
+    public WidgetImpl createNewWidget(@Name("widget") WidgetInput input) {
         if (!(input instanceof WidgetInput)) {
             String msg = String.format("Unexpected input type; expected WidgetInput, got {0}\n",
                                        input.getClass().getName());

--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/pom.xml
@@ -28,7 +28,7 @@
     <name>MicroProfile GraphQL TCK Runner TCK Module</name>
 
     <properties>
-        <microprofile.graphql.version>1.0.0-20191107</microprofile.graphql.version>
+        <microprofile.graphql.version>1.0.0-20191112</microprofile.graphql.version>
         <arquillian.version>1.1.13.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->


### PR DESCRIPTION
The MP GraphQL community decided to rename the `@SchemaName` annotation to `@Name` - this PR implements that change.

At the same time, the MP GraphQL TCK added tests that allow the `@Name` annotation to be used to name a query method if no name is specified in the `@Query` annotation.  This change is also reflected in this PR.

