### PR TITLE
Issue #9307: Changing error message in Open Tracing to Warning message

### DIFF
--- a/dev/com.ibm.ws.microprofile.1.0_fat/fat/src/com/ibm/ws/microprofile10/fat/suite/SimpleJAXRSCDITest.java
+++ b/dev/com.ibm.ws.microprofile.1.0_fat/fat/src/com/ibm/ws/microprofile10/fat/suite/SimpleJAXRSCDITest.java
@@ -65,7 +65,7 @@ public class SimpleJAXRSCDITest {
     @AfterClass
     public static void tearDown() throws Exception {
         if (server != null) {
-            server.stopServer("CWMOT0008E"); //CWMOT0008E: OpenTracing cannot track JAX-RS requests because an OpentracingTracerFactory class was not provided.
+            server.stopServer("CWMOT0010W"); //CWMOT0010W: OpenTracing cannot track JAX-RS requests because an OpentracingTracerFactory class was not provided or client libraries for tracing backend are not in the class path.
         }
     }
 

--- a/dev/com.ibm.ws.microprofile.1.2_fat/fat/src/com/ibm/ws/microprofile12/fat/suite/SimpleJAXRSCDITest.java
+++ b/dev/com.ibm.ws.microprofile.1.2_fat/fat/src/com/ibm/ws/microprofile12/fat/suite/SimpleJAXRSCDITest.java
@@ -68,7 +68,7 @@ public class SimpleJAXRSCDITest {
     @AfterClass
     public static void tearDown() throws Exception {
         if (server != null) {
-            server.stopServer("CWMOT0008E"); //CWMOT0008E: OpenTracing cannot track JAX-RS requests because an OpentracingTracerFactory class was not provided.
+            server.stopServer("CWMOT0010W"); //CWMOT0010W: OpenTracing cannot track JAX-RS requests because an OpentracingTracerFactory class was not provided or client libraries for tracing backend are not in the class path.
         }
     }
 

--- a/dev/com.ibm.ws.microprofile.opentracing.jaeger_fat/fat/src/com/ibm/ws/microprofile/opentracing/jaeger_fat/JaegerConfigTest.java
+++ b/dev/com.ibm.ws.microprofile.opentracing.jaeger_fat/fat/src/com/ibm/ws/microprofile/opentracing/jaeger_fat/JaegerConfigTest.java
@@ -91,7 +91,7 @@ public class JaegerConfigTest {
     @After
     public void tearDown() throws Exception {
     	if (currentServer != null && currentServer.isStarted()) {
-        	currentServer.stopServer("CWMOT0008E", "CWMOT0009W");
+        	currentServer.stopServer("CWMOT0009W", "CWMOT0010W");
         }
     }
     
@@ -130,7 +130,7 @@ public class JaegerConfigTest {
         } catch (IOException e) {
         	// Error should be thrown when hitting endpoint
         }
-        String logMsg = server2.waitForStringInLog("CWMOT0008E");
+        String logMsg = server2.waitForStringInLog("CWMOT0010W");
         FATLogging.info(CLASS, methodName, "Actual Response", logMsg);
         Assert.assertNotNull(logMsg);
     }

--- a/dev/com.ibm.ws.microprofile.opentracing.jaeger_fat/fat/src/com/ibm/ws/microprofile/opentracing/jaeger_fat/JaegerTraceTest.java
+++ b/dev/com.ibm.ws.microprofile.opentracing.jaeger_fat/fat/src/com/ibm/ws/microprofile/opentracing/jaeger_fat/JaegerTraceTest.java
@@ -82,7 +82,7 @@ public class JaegerTraceTest {
     @After
     public void tearDown() throws Exception {
         if (currentServer != null && currentServer.isStarted()) {
-            currentServer.stopServer("CWMOT0008E", "CWMOT0009W");
+            currentServer.stopServer("CWMOT0009W", "CWMOT0010W");
         }
     }
     

--- a/dev/com.ibm.ws.opentracing.1.1/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
+++ b/dev/com.ibm.ws.opentracing.1.1/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
@@ -78,6 +78,10 @@ OPENTRACING_UNHANDLED_JAXRS_EXCEPTION=CWMOT0009W: The OpenTracing exception mapp
 OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.explanation=The JAX-RS-based application experienced an exception that is not handled within the application. The OpenTracing code handles it by logging the exception stack trace and returning a 500 Internal Server Error response.
 OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.useraction=This behavior might be acceptable. To handle the exception differently, the application developer can add an ExceptionMapper interface that handles the exception and maps it to a different response.
 
+OPENTRACING_TRACERFACTORY_NOT_PROVIDED=CWMOT0010W: OpenTracing cannot track JAX-RS requests because an OpentracingTracerFactory class was not provided or client libraries for tracing backend are not in the class path.
+OPENTRACING_TRACERFACTORY_NOT_PROVIDED.explanation=JAX-RS requests run normally, but they are not tracked.
+OPENTRACING_TRACERFACTORY_NOT_PROVIDED.useraction=See the documentation about how to enable and configure OpenTracing distributed tracing. This warning can be safely ignored if OpenTracing is not being used.
+
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Opentracing error message
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/dev/com.ibm.ws.opentracing.1.1/src/com/ibm/ws/opentracing/OpentracingUserFeatureAccessService.java
+++ b/dev/com.ibm.ws.opentracing.1.1/src/com/ibm/ws/opentracing/OpentracingUserFeatureAccessService.java
@@ -46,7 +46,7 @@ public class OpentracingUserFeatureAccessService {
         factoryFirstUse = false;
 
         if (opentracingTracerFactory == null) {
-            Tr.error(tc, "OPENTRACING_NO_TRACERFACTORY");
+            Tr.warning(tc, "OPENTRACING_TRACERFACTORY_NOT_PROVIDED");
         }
     }
 
@@ -88,7 +88,7 @@ public class OpentracingUserFeatureAccessService {
             factoryFirstUse = false;
 
             if (opentracingTracerFactory == null) {
-                Tr.error(tc, "OPENTRACING_NO_TRACERFACTORY");
+                Tr.warning(tc, "OPENTRACING_TRACERFACTORY_NOT_PROVIDED");
             }
         }
 

--- a/dev/com.ibm.ws.opentracing.1.2/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
+++ b/dev/com.ibm.ws.opentracing.1.2/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
@@ -78,6 +78,10 @@ OPENTRACING_UNHANDLED_JAXRS_EXCEPTION=CWMOT0009W: The OpenTracing exception mapp
 OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.explanation=The JAX-RS-based application experienced an exception that is not handled within the application. The OpenTracing code handles it by logging the exception stack trace and returning a 500 Internal Server Error response.
 OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.useraction=This behavior might be acceptable. To handle the exception differently, the application developer can add an ExceptionMapper interface that handles the exception and maps it to a different response.
 
+OPENTRACING_TRACERFACTORY_NOT_PROVIDED=CWMOT0010W: OpenTracing cannot track JAX-RS requests because an OpentracingTracerFactory class was not provided or client libraries for tracing backend are not in the class path.
+OPENTRACING_TRACERFACTORY_NOT_PROVIDED.explanation=JAX-RS requests run normally, but they are not tracked.
+OPENTRACING_TRACERFACTORY_NOT_PROVIDED.useraction=See the documentation about how to enable and configure OpenTracing distributed tracing. This warning can be safely ignored if OpenTracing is not being used.
+
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Opentracing error message
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/OpentracingUserFeatureAccessService.java
+++ b/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/OpentracingUserFeatureAccessService.java
@@ -46,7 +46,7 @@ public class OpentracingUserFeatureAccessService {
         factoryFirstUse = false;
 
         if (opentracingTracerFactory == null) {
-            Tr.error(tc, "OPENTRACING_NO_TRACERFACTORY");
+            Tr.warning(tc, "OPENTRACING_TRACERFACTORY_NOT_PROVIDED");
         }
     }
 
@@ -88,7 +88,7 @@ public class OpentracingUserFeatureAccessService {
             factoryFirstUse = false;
 
             if (opentracingTracerFactory == null) {
-                Tr.error(tc, "OPENTRACING_NO_TRACERFACTORY");
+                Tr.warning(tc, "OPENTRACING_TRACERFACTORY_NOT_PROVIDED");
             }
         }
 

--- a/dev/com.ibm.ws.opentracing.1.3/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
+++ b/dev/com.ibm.ws.opentracing.1.3/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
@@ -78,6 +78,10 @@ OPENTRACING_UNHANDLED_JAXRS_EXCEPTION=CWMOT0009W: The OpenTracing exception mapp
 OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.explanation=The JAX-RS-based application experienced an exception that is not handled within the application. The OpenTracing code handles it by logging the exception stack trace and returning a 500 Internal Server Error response.
 OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.useraction=This behavior might be acceptable. To handle the exception differently, the application developer can add an ExceptionMapper interface that handles the exception and maps it to a different response.
 
+OPENTRACING_TRACERFACTORY_NOT_PROVIDED=CWMOT0010W: OpenTracing cannot track JAX-RS requests because an OpentracingTracerFactory class was not provided or client libraries for tracing backend are not in the class path.
+OPENTRACING_TRACERFACTORY_NOT_PROVIDED.explanation=JAX-RS requests run normally, but they are not tracked.
+OPENTRACING_TRACERFACTORY_NOT_PROVIDED.useraction=See the documentation about how to enable and configure OpenTracing distributed tracing. This warning can be safely ignored if OpenTracing is not being used.
+
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Opentracing error message
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/dev/com.ibm.ws.opentracing.1.3/src/com/ibm/ws/opentracing/OpentracingUserFeatureAccessService.java
+++ b/dev/com.ibm.ws.opentracing.1.3/src/com/ibm/ws/opentracing/OpentracingUserFeatureAccessService.java
@@ -46,7 +46,7 @@ public class OpentracingUserFeatureAccessService {
         factoryFirstUse = false;
 
         if (opentracingTracerFactory == null) {
-            Tr.error(tc, "OPENTRACING_NO_TRACERFACTORY");
+            Tr.warning(tc, "OPENTRACING_TRACERFACTORY_NOT_PROVIDED");
         }
     }
 
@@ -88,7 +88,7 @@ public class OpentracingUserFeatureAccessService {
             factoryFirstUse = false;
 
             if (opentracingTracerFactory == null) {
-                Tr.error(tc, "OPENTRACING_NO_TRACERFACTORY");
+                Tr.warning(tc, "OPENTRACING_TRACERFACTORY_NOT_PROVIDED");
             }
         }
 

--- a/dev/com.ibm.ws.opentracing.1.x_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATTestBase.java
+++ b/dev/com.ibm.ws.opentracing.1.x_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATTestBase.java
@@ -71,9 +71,9 @@ public class FATTestBase {
      */
     protected static void stopHelloWorldServer(LibertyServer server) throws Exception {
         try {
-            Assert.assertNotNull("Expecting CWMOT0008E message", server.waitForStringInLogUsingMark("CWMOT0008E", 0));
+            Assert.assertNotNull("Expecting CWMOT0010W message", server.waitForStringInLogUsingMark("CWMOT0010W", 0));
         } finally {
-            server.stopServer("CWMOT0008E");
+            server.stopServer("CWMOT0010W");
         }
     }
 }

--- a/dev/com.ibm.ws.opentracing/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
+++ b/dev/com.ibm.ws.opentracing/resources/com/ibm/ws/opentracing/resources/Opentracing.nlsprops
@@ -78,6 +78,10 @@ OPENTRACING_UNHANDLED_JAXRS_EXCEPTION=CWMOT0009W: The OpenTracing exception mapp
 OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.explanation=The JAX-RS-based application experienced an exception that is not handled within the application. The OpenTracing code handles it by logging the exception stack trace and returning a 500 Internal Server Error response.
 OPENTRACING_UNHANDLED_JAXRS_EXCEPTION.useraction=This behavior might be acceptable. To handle the exception differently, the application developer can add an ExceptionMapper interface that handles the exception and maps it to a different response.
 
+OPENTRACING_TRACERFACTORY_NOT_PROVIDED=CWMOT0010W: OpenTracing cannot track JAX-RS requests because an OpentracingTracerFactory class was not provided or client libraries for tracing backend are not in the class path.
+OPENTRACING_TRACERFACTORY_NOT_PROVIDED.explanation=JAX-RS requests run normally, but they are not tracked.
+OPENTRACING_TRACERFACTORY_NOT_PROVIDED.useraction=See the documentation about how to enable and configure OpenTracing distributed tracing. This warning can be safely ignored if OpenTracing is not being used.
+
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Opentracing error message
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingUserFeatureAccessService.java
+++ b/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingUserFeatureAccessService.java
@@ -46,7 +46,7 @@ public class OpentracingUserFeatureAccessService {
         factoryFirstUse = false;
 
         if (opentracingTracerFactory == null) {
-            Tr.error(tc, "OPENTRACING_NO_TRACERFACTORY");
+            Tr.warning(tc, "OPENTRACING_TRACERFACTORY_NOT_PROVIDED");
         }
     }
 
@@ -88,7 +88,7 @@ public class OpentracingUserFeatureAccessService {
             factoryFirstUse = false;
 
             if (opentracingTracerFactory == null) {
-                Tr.error(tc, "OPENTRACING_NO_TRACERFACTORY");
+                Tr.warning(tc, "OPENTRACING_TRACERFACTORY_NOT_PROVIDED");
             }
         }
 

--- a/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATTestBase.java
+++ b/dev/com.ibm.ws.opentracing_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATTestBase.java
@@ -71,9 +71,9 @@ public class FATTestBase {
      */
     protected static void stopHelloWorldServer(LibertyServer server) throws Exception {
         try {
-            Assert.assertNotNull("Expecting CWMOT0008E message", server.waitForStringInLogUsingMark("CWMOT0008E", 0));
+            Assert.assertNotNull("Expecting CWMOT0010W message", server.waitForStringInLogUsingMark("CWMOT0010W", 0));
         } finally {
-            server.stopServer("CWMOT0008E");
+            server.stopServer("CWMOT0010W");
         }
     }
 }


### PR DESCRIPTION
Error message appears when MP Open Tracing feature is enabled but not in use.
Warning message will be used instead.