### PR TITLE
fix how claim expiry is computed and enforce requirement for commit of in-progress timers that are canceled asynchronously

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/websphere/concurrent/persistent/TaskIdAccessor.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/websphere/concurrent/persistent/TaskIdAccessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,10 +18,11 @@ import com.ibm.ws.concurrent.persistent.internal.InvokerTask;
 public class TaskIdAccessor {
     /**
      * Returns the task ID of the task that is currently running on the thread. Otherwise null.
-     * 
+     *
      * @return the task ID of the task that is currently running on the thread. Otherwise null.
      */
     public static final Long get() {
-        return InvokerTask.taskIdsOfRunningTasks.get();
+        long[] taskEntry = InvokerTask.runningTaskState.get();
+        return taskEntry == null ? null : taskEntry[0];
     }
 }

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/websphere/concurrent/persistent/mbean/PersistentExecutorMBean.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/websphere/concurrent/persistent/mbean/PersistentExecutorMBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -45,35 +45,7 @@ import javax.management.MXBean;
 
 @MXBean
 public interface PersistentExecutorMBean {
-
-    //TODO Add in a future release 134442
-//    public CompositeData findTask(long taskId);
-//
-//    public TabularData findTasks(String pattern, Character escape, String state, boolean inState, Long minId, Integer maxResults, String owner); //see findTaskStatus add owner parameter
-//
-//    public boolean cancelTask(long taskId);
-//
-//    public int cancelTasks(String pattern, Character escape, String state, boolean inState, String owner); // see remove
-//
-//    public boolean removeTask(long taskId);
-//
-//    public int removeTasks(String pattern, Character escape, String state, boolean inState, String owner);
-
-    //public boolean suspend(long taskId);
-
-    //public boolean resume(long taskId);
-    /*
-     * * Finds partition information in the persistent store. All of the parameters are optional.
-     * If a parameter is specified, entries that match the parameter only are retrieved from the persistent store.
-     * The executorIdentifier is a unique identifier for the Persistent Executor.
-     * If the Persistent Executor is nested, the identifier is the display name.
-     * For example:
-     * <br>
-     * <code> ejbContainer/timerService[default-0]/persistentExecutor[default-0] </code>
-     * <br>
-     * If the Persistent Executor is not nested, the identifier is the ID of the Persistent Executor.
-     * If an ID is not specified for the Persistent Executor, then the identifier is the JNDI name of the Persistent Executor.
-     */
+    // TODO update JavaDoc to mention that partitions do not apply in the case of failover mode.
 
     /**
      * Each task is partitioned to a persistent executor instance in a Liberty profile server with a particular

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/db/DatabaseTaskStore.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/db/DatabaseTaskStore.java
@@ -1630,12 +1630,18 @@ public class DatabaseTaskStore implements TaskStore {
     /** {@inheritDoc} */
     @FFDCIgnore({ LockTimeoutException.class, PersistenceException.class, QueryTimeoutException.class })
     @Override
-    public boolean setPartitionIfNotLocked(long taskId, int version, long newPartitionId) throws Exception {
+    public boolean claimIfNotLocked(long taskId, int version, long claimExpiryOrPartition) throws Exception {
         String update = "UPDATE Task t SET t.PARTN=:p,t.VERSION=t.VERSION+1 WHERE t.ID=:i AND t.VERSION=:v";
 
         final boolean trace = TraceComponent.isAnyTracingEnabled();
-        if (trace && tc.isEntryEnabled())
-            Tr.entry(this, tc, "setPartition", taskId + " v" + version + " assign to " + newPartitionId, update);
+        if (trace && tc.isEntryEnabled()) {
+            StringBuilder b = new StringBuilder().append(taskId).append(" v").append(version);
+            if (claimExpiryOrPartition > 1500000000000l)
+                Utils.appendDate(b.append(" claim until "), claimExpiryOrPartition);
+            else
+                b.append(" assign to partition ").append(claimExpiryOrPartition);
+            Tr.entry(this, tc, "claimIfNotLocked", b, update);
+        }
 
         EntityManager em = getPersistenceServiceUnit().createEntityManager();
         try {
@@ -1646,36 +1652,36 @@ public class DatabaseTaskStore implements TaskStore {
             // query.setHint("javax.persistence.lock.timeout", 0); // milliseconds
 
             // As a workaround, use a short query timeout,
-            query.setHint("javax.persistence.query.timeout", 5); // seconds
+            query.setHint("javax.persistence.query.timeout", 3); // seconds
 
-            query.setParameter("p", newPartitionId);
+            query.setParameter("p", claimExpiryOrPartition);
             query.setParameter("i", taskId);
             query.setParameter("v", version);
             boolean assigned = query.executeUpdate() > 0;
 
             if (trace && tc.isEntryEnabled())
-                Tr.exit(this, tc, "setPartition", assigned);
+                Tr.exit(this, tc, "claimIfNotLocked", assigned);
             return assigned;
         } catch (LockTimeoutException x) {
             if (trace && tc.isEntryEnabled())
-                Tr.exit(this, tc, "setPartition", "false: lock timeout - still owned by another member");
+                Tr.exit(this, tc, "claimIfNotLocked", "false: lock timeout - still owned by another member");
             return false;
         } catch (QueryTimeoutException x) {
             if (trace && tc.isEntryEnabled())
-                Tr.exit(this, tc, "setPartition", "false: query timeout - still owned by another member");
+                Tr.exit(this, tc, "claimIfNotLocked", "false: query timeout - still owned by another member");
             return false;
         } catch (PersistenceException x) {
             for (Throwable c = x.getCause(); c != null; c = c.getCause())
                 if (c instanceof SQLTimeoutException) {
                     if (trace && tc.isEntryEnabled())
-                        Tr.exit(this, tc, "setPartition", "false: SQLTimeoutException still owned by another member");
+                        Tr.exit(this, tc, "claimIfNotLocked", "false: SQLTimeoutException still owned by another member");
                     return false;
                 } else if (c instanceof SQLException) {
                     String ss = ((SQLException) c).getSQLState();
                     if ("XCL52".equals(ss) // Derby Network Client SQLState for query timeout
                     ) {
                         if (trace && tc.isEntryEnabled())
-                            Tr.exit(this, tc, "setPartition", "false: SQLState + " + ss + " - still owned by another member");
+                            Tr.exit(this, tc, "claimIfNotLocked", "false: SQLState + " + ss + " - still owned by another member");
                         return false;
                     }
                 }

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/db/DatabaseTaskStore.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/db/DatabaseTaskStore.java
@@ -983,7 +983,7 @@ public class DatabaseTaskStore implements TaskStore {
         }
 
         if (trace && tc.isEntryEnabled())
-            Tr.exit(this, tc, "getPartitionWithState", partitionInfo == null ? null : Arrays.asList(partitionInfo));
+            Tr.exit(this, tc, "getPartitionWithState", partitionInfo == null ? null : Arrays.toString(partitionInfo));
         return partitionInfo == null ? null : (Long) partitionInfo[0];
     }
 

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
@@ -1392,10 +1392,10 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
             return false;
 
         TransactionController tranController = new TransactionController();
-        boolean result = false;
+        boolean removed = false;
         try {
             tranController.preInvoke();
-            result = taskStore.remove(taskId, owner, true);
+            removed = taskStore.remove(taskId, owner, true);
         } catch (Throwable x) {
             tranController.setFailure(x);
         } finally {
@@ -1404,7 +1404,12 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
                 throw x;
         }
 
-        return result;
+        if (removed) {
+            long[] runningTaskState = InvokerTask.runningTaskState.get();
+            if (runningTaskState != null && runningTaskState[0] == taskId)
+                runningTaskState[1] = InvokerTask.REMOVED_BY_SELF;
+        }
+        return removed;
     }
 
     /** {@inheritDoc} */
@@ -1518,10 +1523,10 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
     @Override
     public boolean removeTimer(long taskId) throws Exception {
         TransactionController tranController = new TransactionController();
-        boolean result = false;
+        boolean removed = false;
         try {
             tranController.preInvoke();
-            result = taskStore.remove(taskId, null, true);
+            removed = taskStore.remove(taskId, null, true);
         } catch (Throwable x) {
             tranController.setFailure(x);
         } finally {
@@ -1530,7 +1535,12 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
                 throw x;
         }
 
-        return result;
+        if (removed) {
+            long[] runningTaskState = InvokerTask.runningTaskState.get();
+            if (runningTaskState != null && runningTaskState[0] == taskId)
+                runningTaskState[1] = InvokerTask.REMOVED_BY_SELF;
+        }
+        return removed;
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
@@ -2667,12 +2667,13 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
                 long taskId = (Long) result[0];
                 long nextExecTime = (Long) result[2];
                 int version = (Integer) result[4];
-                long claimUntilTime = nextExecTime + config.missedTaskThreshold2 * 1000;
+                now = System.currentTimeMillis();
+                long claimUntilTime = (now > nextExecTime ? now : nextExecTime) + config.missedTaskThreshold2 * 1000;
 
                 boolean claimed;
                 tranMgr.begin();
                 try {
-                    claimed = taskStore.setPartitionIfNotLocked(taskId, version, claimUntilTime);
+                    claimed = taskStore.claimIfNotLocked(taskId, version, claimUntilTime);
                 } finally {
                     tranMgr.commit();
                 }
@@ -2896,7 +2897,7 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
             boolean transferred;
             tranMgr.begin();
             try {
-                transferred = taskStore.setPartitionIfNotLocked(taskId, currentVersion, partition);
+                transferred = taskStore.claimIfNotLocked(taskId, currentVersion, partition);
             } finally {
                 tranMgr.commit();
             }

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskStore.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskStore.java
@@ -52,6 +52,27 @@ public interface TaskStore {
     int cancel(String pattern, Character escape, TaskState state, boolean inState, String owner) throws Exception;
 
     /**
+     * Attempts to claim the right to run a task. This happens in either of two different ways.
+     * <li>
+     * <ol>By assigning the task to the specified partition.</ol>
+     * <ol>By writing a new claim expiry value to the task entry where the previous was already expired.</ol>
+     * </li>
+     * Assigns a task to the specified partition.
+     * The implementation should aim to return as quickly as possible with a false value if the entry is already locked
+     * by another member, rather than waiting to make the update. A locked task entry indicates that failover is not needed
+     * - a false positive occurred because the task was taking too long to run. This could be caused by a lengthy timer/task
+     * that is otherwise behaving properly, in which case the customer ought to be using a larger value for missedTaskThreshold
+     * so as to avoid triggering failover logic/overhead when there is no outage.
+     *
+     * @param taskId                 id of the task to reassign.
+     * @param version                version number of the task entry which must match in order for the task to be transferred.
+     * @param claimExpiryOrPartition timestamp when the claim on task execution expires OR partition id to which to assign the task.
+     * @return true if the task was assigned. Otherwise false.
+     * @throws Exception if an error occurs when attempting to update the persistent task store.
+     */
+    boolean claimIfNotLocked(long taskId, int version, long claimExpiryOrPartition) throws Exception;
+
+    /**
      * Create a partition entry in the persistent store having the Id of the specified partitionRecord.
      *
      * @param partitionRecord a new partition entry. The record must contain the following attributes (Id, Executor, Host, Server, UserDir)
@@ -393,22 +414,6 @@ public interface TaskStore {
      * @throws Exception if an error occurs when attempting to update the persistent task store.
      */
     boolean removeProperty(String name) throws Exception;
-
-    /**
-     * Assigns a task to the specified partition.
-     * The implementation should aim to return as quickly as possible with a false value if the entry is already locked
-     * by another member, rather than waiting to make the update. A locked task entry indicates that failover is not needed
-     * - a false positive occurred because the task was taking too long to run. This could be caused by a lengthy timer/task
-     * that is otherwise behaving properly, in which case the customer ought to be using a larger value for missedTaskThreshold
-     * so as to avoid triggering failover logic/overhead when there is no outage.
-     *
-     * @param taskId         id of the task to reassign.
-     * @param version        version number of the task entry which must match in order for the task to be transferred.
-     * @param newPartitionId partition id to which to assign the task.
-     * @return true if the task was assigned. Otherwise false.
-     * @throws Exception if an error occurs when attempting to update the persistent task store.
-     */
-    boolean setPartitionIfNotLocked(long taskId, int version, long newPartitionId) throws Exception;
 
     /**
      * Assigns the value of the property if it exists in the persistent store.


### PR DESCRIPTION
The first commit fixes how expiry is computed and improves tracing in that area.
The second commit aligns with an EJB persistent timers requirement for in-progress executions of timers that get canceled asynchronously to commit.