### PR TITLE
Fix defaulting and reading of WLP_DEBUG_REMOTE env var

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -56,7 +56,8 @@
 #              The default value is y. 
 #
 # WLP_DEBUG_REMOTE - Whether to allow remote debugging or not. This can be set
-#              to y to allow remote debugging. The default value is n. 
+#              to y to allow remote debugging. By default, this value is not
+#              defined, which does not allow remote debugging on newer JDK/JREs.
 #
 # WLP_SKIP_UMASK -  Skip setting the umask value to allow the default value 
 #              to be used.

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
@@ -49,7 +49,8 @@
 @REM              The default value is y.
 @REM
 @REM WLP_DEBUG_REMOTE - Whether to allow remote debugging or not. This can be set
-@REM              to y to allow remote debugging. The default value is n. 
+@REM              to y to allow remote debugging. By default, this value is not
+@REM              defined, which does not allow remote debugging on newer JDK/JREs.
 @REM
 @REM ----------------------------------------------------------------------------
 
@@ -239,8 +240,8 @@ goto:eof
 
   if not defined WLP_DEBUG_ADDRESS set WLP_DEBUG_ADDRESS=7777
   if not defined WLP_DEBUG_SUSPEND set WLP_DEBUG_SUSPEND=y
-  if not defined WLP_DEBUG_REMOTE set WLP_DEBUG_REMOTE_HOST="0.0.0.0:"
-  if not defined WLP_DEBUG_REMOTE_HOST set WLP_DEBUG_REMOTE_HOST=""
+  if /I "%WLP_DEBUG_REMOTE%" == "Y" set WLP_DEBUG_REMOTE_HOST="0.0.0.0:"
+  if not defined WLP_DEBUG_REMOTE_HOST set WLP_DEBUG_REMOTE_HOST=
   set JAVA_PARAMS_QUOTED=-Dwas.debug.mode=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend="!WLP_DEBUG_SUSPEND!",address="!WLP_DEBUG_REMOTE_HOST!!WLP_DEBUG_ADDRESS!" !JAVA_PARAMS_QUOTED!
 
   call:serverExists true


### PR DESCRIPTION
Fixes the "INCIDENTAL PROBLEM" detected debugging #9734, described in [this comment](https://github.com/OpenLiberty/open-liberty/issues/9734#issuecomment-554405966).

