### PR TITLE
Prevent GraphQL apps from starting when they have a `@Query` annotation on a void method

### DIFF
--- a/dev/com.ibm.ws.microprofile.graphql.1.0/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0/bnd.bnd
@@ -26,7 +26,8 @@ instrument.ffdc: false
     com.ibm.ws.microprofile.graphql.component.*
 
 Private-Package: \
-  com.ibm.ws.microprofile.graphql.internal
+  com.ibm.ws.microprofile.graphql.internal,\
+  com.ibm.ws.microprofile.graphql.resources
 
 Export-Package: \
   com.ibm.ws.microprofile.graphql.component;thread-context=true

--- a/dev/com.ibm.ws.microprofile.graphql.1.0/resources/com/ibm/ws/microprofile/graphql/resources/MPGraphQL.nlsprops
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0/resources/com/ibm/ws/microprofile/graphql/resources/MPGraphQL.nlsprops
@@ -24,7 +24,7 @@
 # Messages used by MP GraphQL Impl -  range is 0000-2999, plus 9999 for the emergency message
 #-----------------------------------------------------------------------------------------------------------------------------
 
-ERROR_GENERATING_SCHEMA_CWMGQ0001E=CWMGQ0001E: An error was detected that prevents the MicroProfile GraphQL application from starting in web module, {0}.
+ERROR_GENERATING_SCHEMA_CWMGQ0001E=CWMGQ0001E: An error in the {0} web module prevented the MicroProfile GraphQL application from starting.
 ERROR_GENERATING_SCHEMA_CWMGQ0001E.explanation=A severe error was detected while processing the MP GraphQL application in the specified module. This error prevents the application from starting successfully.
 ERROR_GENERATING_SCHEMA_CWMGQ0001E.useraction=Examine the logs to determine the error(s) in the GraphQL application, resolve them and redeploy the application.
 

--- a/dev/com.ibm.ws.microprofile.graphql.1.0/resources/com/ibm/ws/microprofile/graphql/resources/MPGraphQL.nlsprops
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0/resources/com/ibm/ws/microprofile/graphql/resources/MPGraphQL.nlsprops
@@ -1,0 +1,30 @@
+#CMVCPATHNAME N/A
+#COMPONENTPREFIX CWMGQ
+#COMPONENTNAMEFOR CWMGQ MicroProfile GraphQL API 
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#ISMESSAGEFILE true
+# #########################################################################
+###############################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+# This file follows the WebSphere Message Guidelines.
+# For more information, visit: 
+# http://washome.austin.ibm.com/xwiki/bin/view/MessagesTeam/
+#
+
+#-----------------------------------------------------------------------------------------------------------------------------
+# Messages used by MP GraphQL Impl -  range is 0000-2999, plus 9999 for the emergency message
+#-----------------------------------------------------------------------------------------------------------------------------
+
+ERROR_GENERATING_SCHEMA_CWMGQ0001E=CWMGQ0001E: An error was detected that prevents the MicroProfile GraphQL application from starting in web module, {0}.
+ERROR_GENERATING_SCHEMA_CWMGQ0001E.explanation=A severe error was detected while processing the MP GraphQL application in the specified module. This error prevents the application from starting successfully.
+ERROR_GENERATING_SCHEMA_CWMGQ0001E.useraction=Examine the logs to determine the error(s) in the GraphQL application, resolve them and redeploy the application.
+

--- a/dev/com.ibm.ws.microprofile.graphql.1.0/src/com/ibm/ws/microprofile/graphql/component/GraphQLServletContainerInitializer.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0/src/com/ibm/ws/microprofile/graphql/component/GraphQLServletContainerInitializer.java
@@ -58,6 +58,7 @@ public class GraphQLServletContainerInitializer implements ServletContainerIniti
         try {
             schema = GraphQLExtension.createSchema(beanManager);
         } catch (Throwable t) {
+            Tr.error(tc, "ERROR_GENERATING_SCHEMA_CWMGQ0001E", sc.getServletContextName());
             throw new ServletException(t);
         }
 

--- a/dev/com.ibm.ws.microprofile.graphql.1.0/src/com/ibm/ws/microprofile/graphql/component/package-info.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0/src/com/ibm/ws/microprofile/graphql/component/package-info.java
@@ -12,7 +12,7 @@
  * @version 1.0
  */
 @org.osgi.annotation.versioning.Version("1.0")
-@TraceOptions(traceGroup = "GraphQL")
+@TraceOptions(traceGroup = "GraphQL", messageBundle = "com.ibm.ws.microprofile.graphql.resources.MPGraphQL")
 package com.ibm.ws.microprofile.graphql.component;
 
 import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/.classpath
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/.classpath
@@ -12,6 +12,7 @@
 	<classpathentry kind="src" path="test-applications/metricsApp/src"/>
 	<classpathentry kind="src" path="test-applications/outputFieldsApp/src"/>
 	<classpathentry kind="src" path="test-applications/typesApp/src"/>
+	<classpathentry kind="src" path="test-applications/voidQueryApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/bnd.bnd
@@ -24,6 +24,7 @@ src: \
   test-applications/inputFieldsApp/src,\
   test-applications/outputFieldsApp/src,\
   test-applications/typesApp/src,\
+  test-applications/voidQueryApp/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/FATSuite.java
@@ -27,6 +27,7 @@ import org.junit.runners.Suite.SuiteClasses;
                 InputFieldsTest.class,
                 MetricsTest.class,
                 OutputFieldsTest.class,
-                TypesTest.class
+                TypesTest.class,
+                VoidQueryTest.class
 })
 public class FATSuite {}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/VoidQueryTest.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/VoidQueryTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.graphql.fat;
+
+import java.util.List;
+
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertThat;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import mpGraphQL10.voidQuery.VoidQueryTestServlet;
+
+@RunWith(FATRunner.class)
+public class VoidQueryTest extends FATServletClient {
+
+    private static final String SERVER = "mpGraphQL10.voidQuery";
+    private static final String APP_NAME = "voidQueryApp";
+
+    @Server(SERVER)
+    @TestServlet(servlet = VoidQueryTestServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultDropinApp(server, APP_NAME, "mpGraphQL10.voidQuery");
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        try {
+            List<String> expectedErrorMsgs = server.findStringsInLogs(" E ");
+            assertThat(expectedErrorMsgs, hasItem(containsString("voidMethod")));
+            assertThat(expectedErrorMsgs, hasItem(containsString("CWMGQ0001E")));
+            assertThat(expectedErrorMsgs, hasItem(containsString(APP_NAME)));
+        } finally {
+            server.stopServer("CWWWC0001W", "SRVE0190E", "CWMGQ0001E");
+        }
+    }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.voidQuery/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.voidQuery/bootstrap.properties
@@ -1,0 +1,4 @@
+com.ibm.ws.logging.trace.specification=*=info:LogService=all:com.ibm.ws.microprofile.*=all
+com.ibm.ws.logging.max.file.size=0
+osgi.console=5678
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.voidQuery/jvm.options
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.voidQuery/jvm.options
@@ -1,0 +1,1 @@
+-Dmicroprofile.rest.client.disable.default.mapper=true

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.voidQuery/server.xml
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.voidQuery/server.xml
@@ -1,0 +1,23 @@
+<server>
+  <featureManager>
+    <feature>componenttest-1.0</feature>
+    <feature>mpRestClient-1.2</feature>
+    <feature>mpGraphQL-1.0</feature>
+    <feature>jaxrsClient-2.1</feature>
+    <feature>jsonp-1.1</feature>
+    <feature>jsonb-1.0</feature>
+  </featureManager>
+
+  <include location="../fatTestPorts.xml"/>
+
+  <keyStore id="defaultKeyStore" password="passw0rd" />
+
+  <!--  the self-signed cert from the server should only be available in the client keystore -->
+  <ssl id="mySSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" />
+  <keyStore id="clientKeyStore" location="key.jks" type="JKS" password="passw0rd" />
+  <keyStore id="clientTrustStore" location="trust.jks" type="JKS" password="passw0rd" />
+
+  <!--  Required to read the server's port system property -->
+  <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
+
+</server>

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.voidQuery/server.xml
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.voidQuery/server.xml
@@ -10,13 +10,6 @@
 
   <include location="../fatTestPorts.xml"/>
 
-  <keyStore id="defaultKeyStore" password="passw0rd" />
-
-  <!--  the self-signed cert from the server should only be available in the client keystore -->
-  <ssl id="mySSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" />
-  <keyStore id="clientKeyStore" location="key.jks" type="JKS" password="passw0rd" />
-  <keyStore id="clientTrustStore" location="trust.jks" type="JKS" password="passw0rd" />
-
   <!--  Required to read the server's port system property -->
   <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
 

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/resources/graphiql.html
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/resources/graphiql.html
@@ -1,0 +1,142 @@
+<!--
+ *  Copyright (c) Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the license found in the
+ *  LICENSE file in the root directory of this source tree.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            height: 100%;
+            margin: 0;
+            width: 100%;
+            overflow: hidden;
+        }
+        #graphiql {
+            height: 100vh;
+        }
+    </style>
+
+    <!--
+      This GraphiQL example depends on Promise and fetch, which are available in
+      modern browsers, but can be "polyfilled" for older browsers.
+      GraphiQL itself depends on React DOM.
+      If you do not want to rely on a CDN, you can host these files locally or
+      include them directly in your favored resource bunder.
+    -->
+    <script src="//cdn.jsdelivr.net/es6-promise/4.0.5/es6-promise.auto.min.js"></script>
+    <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
+    <script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
+    <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
+
+    <!--
+      These two files can be found in the npm module, however you may wish to
+      copy them directly into your environment, or perhaps include them in your
+      favored resource bundler.
+     -->
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphiql@0.11.2/graphiql.css" />
+    <script src="//cdn.jsdelivr.net/npm/graphiql@0.11.2/graphiql.js"></script>
+
+</head>
+<body>
+<div id="graphiql">Loading...</div>
+<script>
+    /**
+     * This GraphiQL example illustrates how to use some of GraphiQL's props
+     * in order to enable reading and updating the URL parameters, making
+     * link sharing of queries a little bit easier.
+     *
+     * This is only one example of this kind of feature, GraphiQL exposes
+     * various React params to enable interesting integrations.
+     */
+        // Parse the search string to get url parameters.
+    var search = window.location.search;
+    var parameters = {};
+    search.substr(1).split('&').forEach(function (entry) {
+        var eq = entry.indexOf('=');
+        if (eq >= 0) {
+            parameters[decodeURIComponent(entry.slice(0, eq))] =
+                decodeURIComponent(entry.slice(eq + 1));
+        }
+    });
+    // if variables was provided, try to format it.
+    if (parameters.variables) {
+        try {
+            parameters.variables =
+                JSON.stringify(JSON.parse(parameters.variables), null, 2);
+        } catch (e) {
+            // Do nothing, we want to display the invalid JSON as a string, rather
+            // than present an error.
+        }
+    }
+    // When the query and variables string is edited, update the URL bar so
+    // that it can be easily shared
+    function onEditQuery(newQuery) {
+        parameters.query = newQuery;
+        updateURL();
+    }
+    function onEditVariables(newVariables) {
+        parameters.variables = newVariables;
+        updateURL();
+    }
+    function onEditOperationName(newOperationName) {
+        parameters.operationName = newOperationName;
+        updateURL();
+    }
+    function updateURL() {
+        var newSearch = '?' + Object.keys(parameters).filter(function (key) {
+                return Boolean(parameters[key]);
+            }).map(function (key) {
+                return encodeURIComponent(key) + '=' +
+                       encodeURIComponent(parameters[key]);
+            }).join('&');
+        history.replaceState(null, null, newSearch);
+    }
+    // Defines a GraphQL fetcher using the fetch API. You're not required to
+    // use fetch, and could instead implement graphQLFetcher however you like,
+    // as long as it returns a Promise or Observable.
+    function graphQLFetcher(graphQLParams) {
+        // This example expects a GraphQL server at the path /graphql.
+        // Change this to point wherever you host your GraphQL server.
+        // Changes by JJS to run on Payara
+        return fetch('graphql', {
+            method: 'post',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+                'Authorization': '5c54174535fc171980956533',
+            },
+            body: JSON.stringify(graphQLParams),
+            credentials: 'include',
+        }).then(function (response) {
+            return response.text();
+        }).then(function (responseBody) {
+            try {
+                return JSON.parse(responseBody);
+            } catch (error) {
+                return responseBody;
+            }
+        });
+    }
+    // Render <GraphiQL /> into the body.
+    // See the README in the top level of this module to learn more about
+    // how you can customize GraphiQL by providing different values or
+    // additional child elements.
+    ReactDOM.render(
+        React.createElement(GraphiQL, {
+            fetcher: graphQLFetcher,
+            query: parameters.query,
+            variables: parameters.variables,
+            operationName: parameters.operationName,
+            onEditQuery: onEditQuery,
+            onEditVariables: onEditVariables,
+            onEditOperationName: onEditOperationName
+        }),
+        document.getElementById('graphiql')
+    );
+</script>
+</body>
+</html>

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/src/mpGraphQL10/voidQuery/AllWidgetData.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/src/mpGraphQL10/voidQuery/AllWidgetData.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.voidQuery;
+
+import java.util.List;
+import java.util.Set;
+
+public class AllWidgetData {
+
+    private List<Widget> allWidgets;
+    private Set<Widget> allWidgetsSet;
+
+    public List<Widget> getAllWidgets() {
+        return allWidgets;
+    }
+
+    public void setAllWidgets(List<Widget> allWidgets) {
+        this.allWidgets = allWidgets;
+    }
+    
+    public List<Widget> getAllWidgetsUnableToSerialize() {
+        return allWidgets;
+    }
+
+    public void setAllWidgetsUnableToSerialize(List<Widget> allWidgets) {
+        this.allWidgets = allWidgets;
+    }
+
+    public Set<Widget> getAllWidgetsSet() {
+        return allWidgetsSet;
+    }
+
+    public void setAllWidgetsSet(Set<Widget> allWidgetsSet) {
+        this.allWidgetsSet = allWidgetsSet;
+    }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/src/mpGraphQL10/voidQuery/Expected404Exception.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/src/mpGraphQL10/voidQuery/Expected404Exception.java
@@ -1,0 +1,48 @@
+/**
+ * 
+ */
+package mpGraphQL10.voidQuery;
+
+/**
+ *  Expected exception (404 Not Found) when the app fails to start
+ */
+@SuppressWarnings("serial")
+public class Expected404Exception extends Exception {
+
+    public Expected404Exception() {
+        super();
+    }
+
+    /**
+     * @param message
+     */
+    public Expected404Exception(String message) {
+        super(message);
+    }
+
+    /**
+     * @param cause
+     */
+    public Expected404Exception(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * @param message
+     * @param cause
+     */
+    public Expected404Exception(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * @param message
+     * @param cause
+     * @param enableSuppression
+     * @param writableStackTrace
+     */
+    public Expected404Exception(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/src/mpGraphQL10/voidQuery/My404ResponseExceptionMapper.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/src/mpGraphQL10/voidQuery/My404ResponseExceptionMapper.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.voidQuery;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
+
+/**
+ * Maps 404s to <code>Expected404Exception</code>
+ */
+public class My404ResponseExceptionMapper implements ResponseExceptionMapper<Expected404Exception> {
+
+    @Override
+    public boolean handles(int status, MultivaluedMap<String, Object> headers) {
+        return status == 404;
+    }
+
+    @Override
+    public Expected404Exception toThrowable(Response response) {
+        return new Expected404Exception();
+    }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/src/mpGraphQL10/voidQuery/Query.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/src/mpGraphQL10/voidQuery/Query.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.voidQuery;
+
+public class Query {
+
+    private String query;
+    private String variables;
+    private String operationName;
+
+    public String getQuery() {
+        return query;
+    }
+    public void setQuery(String query) {
+        this.query = query;
+    }
+    public String getVariables() {
+        return variables;
+    }
+    public void setVariables(String variables) {
+        this.variables = variables;
+    }
+    public String getOperationName() {
+        return operationName;
+    }
+    public void setOperationName(String operationName) {
+        this.operationName = operationName;
+    }
+    
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/src/mpGraphQL10/voidQuery/QueryClient.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/src/mpGraphQL10/voidQuery/QueryClient.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.voidQuery;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public interface QueryClient {
+
+    @POST
+    WidgetQueryResponse allWidgets(Query query) throws Expected404Exception;
+
+    @Produces(MediaType.TEXT_PLAIN)
+    @Path("/schema.graphql")
+    @GET
+    String schema() throws Expected404Exception;
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/src/mpGraphQL10/voidQuery/QueryInfo.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/src/mpGraphQL10/voidQuery/QueryInfo.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.voidQuery;
+
+/**
+ * Model object used for determining the object ID of the query object
+ */
+public class QueryInfo {
+
+    private String instanceId;
+
+    public QueryInfo() {}
+
+    public QueryInfo(String instanceId) {
+        this.instanceId = instanceId;
+    }
+
+    public String getInstanceId() {
+        return instanceId;
+    }
+
+    public void setInstanceId(String instanceId) {
+        this.instanceId = instanceId;
+    }
+
+    @Override
+    public String toString() {
+        return "QueryInfo(query instanceId=" + instanceId;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        return (o instanceof QueryInfo) && ((QueryInfo)o).instanceId.equals(this.instanceId);
+    }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/src/mpGraphQL10/voidQuery/QueryInfoQueryResponse.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/src/mpGraphQL10/voidQuery/QueryInfoQueryResponse.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.voidQuery;
+
+import java.util.List;
+
+public class QueryInfoQueryResponse {
+
+    public static class AllQueryInfoData {
+
+        private List<QueryInfo> allQueryInstances;
+
+        public List<QueryInfo> getAllQueryInstancesRequestScope() {
+            return allQueryInstances;
+        }
+
+        public void setAllQueryInstancesRequestScope(List<QueryInfo> allQueryInfos) {
+            this.allQueryInstances = allQueryInfos;
+        }
+
+        public List<QueryInfo> getAllQueryInstancesAppScope() {
+            return allQueryInstances;
+        }
+
+        public void setAllQueryInstancesAppScope(List<QueryInfo> allQueryInfos) {
+            this.allQueryInstances = allQueryInfos;
+        }
+
+        public List<QueryInfo> getAllQueryInstances() {
+            return allQueryInstances;
+        }
+    }
+
+    private AllQueryInfoData data;
+
+    public AllQueryInfoData getData() {
+        return data;
+    }
+
+    public void setData(AllQueryInfoData data) {
+        this.data = data;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("QueryInfoQueryResponse[");
+        if (data == null || data.getAllQueryInstancesRequestScope() == null) {
+            sb.append("null");
+        } else {
+            for (QueryInfo q : data.getAllQueryInstancesRequestScope()) {
+                sb.append(" ").append(q);
+            }
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/src/mpGraphQL10/voidQuery/SingletonGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/src/mpGraphQL10/voidQuery/SingletonGraphQLEndpoint.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.voidQuery;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.GraphQLApi;
+
+@GraphQLApi
+public class SingletonGraphQLEndpoint {
+
+    private final List<Widget> allWidgets = new ArrayList<>();
+
+    public SingletonGraphQLEndpoint() {
+        allWidgets.add(new Widget("Notebook", 20, 2.0));
+        allWidgets.add(new Widget("Pencil", 200, 0.5));
+    }
+
+    @Query("allWidgets")
+    public List<Widget> getAllWidgets() {
+        return allWidgets;
+    }
+
+    @Query("voidMethod") //should cause a deployment failure
+    public void voidMethod() {
+        System.out.println("Should not be executed");
+    }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/src/mpGraphQL10/voidQuery/VoidQueryTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/src/mpGraphQL10/voidQuery/VoidQueryTestServlet.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.voidQuery;
+
+import static org.junit.Assert.fail;
+
+import java.net.URI;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.logging.Logger;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/VoidQueryTestServlet")
+public class VoidQueryTestServlet extends FATServlet {
+    Logger LOG = Logger.getLogger(VoidQueryTestServlet.class.getName());
+
+    private RestClientBuilder builder;
+
+    private static String getSysProp(String key, String defaultValue) {
+        return AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty(key, defaultValue));
+    }
+
+    @Override
+    public void init() throws ServletException {
+        String contextPath = getSysProp("com.ibm.ws.microprofile.graphql.fat.contextpath", "graphql");
+        String baseUriStr = "http://localhost:" + getSysProp("bvt.prop.HTTP_default", "8010") + "/voidQueryApp/" + contextPath;
+        LOG.info("baseUrl = " + baseUriStr);
+        URI baseUri = URI.create(baseUriStr);
+        builder = RestClientBuilder.newBuilder()
+                        .property("com.ibm.ws.jaxrs.client.receive.timeout", "120000")
+                        .property("com.ibm.ws.jaxrs.client.connection.timeout", "120000")
+                        .register(new My404ResponseExceptionMapper())
+                        .baseUri(baseUri);
+    }
+
+    @Test
+    public void testSchemaIsNotGenerated(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        QueryClient client = builder.build(QueryClient.class);
+        try {
+            String schema = client.schema();
+            fail("did not throw expected 404 exception - instead, got schema data: " + schema);
+        } catch (Expected404Exception expected) {
+            return; //PASS
+        } catch (Throwable t) {
+            t.printStackTrace();
+            fail("caught an unexected exception " + t);
+        }
+    }
+
+    @Test
+    public void testSimpleQueryFails(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        QueryClient client = builder.build(QueryClient.class);
+        Query query = new Query();
+        query.setOperationName("allWidgets");
+        query.setQuery("query allWidgets {" + System.lineSeparator() +
+                       "  allWidgets {" + System.lineSeparator() +
+                       "    name," + System.lineSeparator() +
+                       "    quantity" + System.lineSeparator() +
+                       "  }" + System.lineSeparator() +
+                       "}");
+
+        try {
+            WidgetQueryResponse response = client.allWidgets(query);
+            fail("did not throw expected 404 exception - instead got data from query: " +response);
+        } catch (Expected404Exception expected) {
+            return; //PASS
+        } catch (Throwable t) {
+            t.printStackTrace();
+            fail("caught an unexected exception " + t);
+        }
+    }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/src/mpGraphQL10/voidQuery/Widget.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/src/mpGraphQL10/voidQuery/Widget.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.voidQuery;
+
+/**
+ * Basic model object on the client side. This class is the client side
+ * "replica" of the server side's <code>remoteApp.basic.Widget</code>
+ */
+public class Widget {
+
+    private String name;
+    private int quantity = -1;
+    private double weight = -1.0;
+
+    public Widget() {}
+
+    public Widget(String name, int quantity, double weight) {
+        this.name = name;
+        this.quantity = quantity;
+        this.weight = weight;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(int quantity) {
+        this.quantity = quantity;
+    }
+
+    public double getWeight() {
+        return weight;
+    }
+
+    public void setWeight(double weight) {
+        this.weight = weight;
+    }
+
+    @Override
+    public String toString() {
+        return "Widget(" + name + ", " + quantity + ", " + weight + ")";
+    }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/src/mpGraphQL10/voidQuery/WidgetQueryResponse.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/voidQueryApp/src/mpGraphQL10/voidQuery/WidgetQueryResponse.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.voidQuery;
+
+import java.util.List;
+
+public class WidgetQueryResponse {
+
+    private AllWidgetData data;
+
+    public AllWidgetData getData() {
+        return data;
+    }
+
+    public void setData(AllWidgetData data) {
+        this.data = data;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("WidgetQueryResponse[").append(System.lineSeparator()).append("  data");
+        if (data == null || data.getAllWidgets() == null) {
+            sb.append("null");
+        } else {
+            for (Widget w : data.getAllWidgets()) {
+                sb.append(" ").append(w);
+            }
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
Per the MP GraphQL spec, a query method should always have a return type, and putting a `@Query` annotation on a void method is considered a deployment error.

This change enforces that and provides a new error message for deployment errors.

It also tests that the GraphQL application does not start, and that the new error message is printed when a query method has a void return type.