### PR TITLE
9214 Support alternate symbolic and short names for public features

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureDefinitionUtils.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureDefinitionUtils.java
@@ -72,6 +72,8 @@ public class FeatureDefinitionUtils {
     public static final String IBM_PROVISION_CAPABILITY = "IBM-Provision-Capability";
     public static final String IBM_PROCESS_TYPES = "IBM-Process-Types";
     public static final String IBM_ACTIVATION_TYPE = "WLP-Activation-Type";
+    static final String SYMBOLIC_NAME_ALIAS = "WLP-SymbolicName-Alias";
+    static final String SHORT_NAME_ALIAS = "WLP-ShortName-Alias";
 
     static final String FILTER_ATTR_NAME = "filter";
     static final String FILTER_FEATURE_KEY = "osgi.identity";
@@ -117,6 +119,8 @@ public class FeatureDefinitionUtils {
         final File featureFile;
         final long lastModified;
         final long length;
+        final List<String> symbolicNameAliases;
+        final List<String> shortNameAliases;
 
         ImmutableAttributes(String repoType,
                             String symbolicName,
@@ -134,11 +138,15 @@ public class FeatureDefinitionUtils {
                             boolean hasSpiPackages,
                             boolean isSingleton,
                             EnumSet<ProcessType> processType,
-                            ActivationType activationType) {
+                            ActivationType activationType,
+                            String symbolicNameAlias,
+                            String shortNameAlias) {
 
             this.bundleRepositoryType = repoType;
             this.symbolicName = symbolicName;
+            this.symbolicNameAliases = buildAliasList(symbolicNameAlias);
             this.shortName = shortName;
+            this.shortNameAliases = buildAliasList(shortNameAlias);
             this.featureName = buildFeatureName(repoType, symbolicName, shortName);
             this.featureVersion = featureVersion;
             this.visibility = visibility;
@@ -156,6 +164,16 @@ public class FeatureDefinitionUtils {
             this.featureFile = featureFile;
             this.lastModified = lastModified;
             this.length = fileSize;
+        }
+
+        List<String> buildAliasList(String aliases) {
+            if (aliases == null || "".equals(aliases)) {
+                return null;
+            } else {
+                // Split on "," and trim ws
+                String[] aa = aliases.split("\\s*,\\s*");
+                return (aa.length == 0) ? null : Arrays.asList(aa);
+            }
         }
 
         /**
@@ -262,7 +280,7 @@ public class FeatureDefinitionUtils {
      * manifest.
      *
      * @param details ManifestDetails containing manifest parser and accessor methods
-     *            for retrieving information from the manifest.
+     *                    for retrieving information from the manifest.
      * @return new ImmutableAttributes
      */
     static ImmutableAttributes loadAttributes(String repoType, File featureFile, ProvisioningDetails details) throws IOException {
@@ -314,6 +332,10 @@ public class FeatureDefinitionUtils {
             activationType = activationTypeHeader == null ? ActivationType.SEQUENTIAL : ActivationType.fromString(activationTypeHeader);
         }
 
+        // Alias support for public features
+        String symbolicNameAlias = (visibility != Visibility.PUBLIC ? null : details.getMainAttributeValue(SYMBOLIC_NAME_ALIAS));
+        String shortNameAlias = ((visibility != Visibility.PUBLIC || symbolicNameAlias == null) ? null : details.getMainAttributeValue(SHORT_NAME_ALIAS));
+
         ImmutableAttributes iAttr = new ImmutableAttributes(repoType,
                                                             symbolicName,
                                                             nullIfEmpty(shortName),
@@ -327,7 +349,8 @@ public class FeatureDefinitionUtils {
                                                             isAutoFeature, hasApiServices,
                                                             hasApiPackages, hasSpiPackages, isSingleton,
                                                             processTypes,
-                                                            activationType);
+                                                            activationType,
+                                                            symbolicNameAlias, shortNameAlias);
 
         // Link the details object and immutable attributes (used for diagnostic purposes:
         // the immutable attribute values are necessary for meaningful error messages)

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureRepository.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureRepository.java
@@ -371,6 +371,10 @@ public final class FeatureRepository implements FeatureResolver.Repository {
 
         out.writeUTF(iAttr.activationType.toString());
 
+        out.writeUTF(joinStringList(",", iAttr.symbolicNameAliases));
+
+        out.writeUTF(joinStringList(",", iAttr.shortNameAliases));
+
         // these attributes can be large so lets avoid the arbitrary limit of 65535 chars of writeUTF
         if (iAttr.isAutoFeature) {
             writeLongString(out, details.getCachedRawHeader(FeatureDefinitionUtils.IBM_PROVISION_CAPABILITY));
@@ -383,6 +387,19 @@ public final class FeatureRepository implements FeatureResolver.Repository {
         }
         if (iAttr.hasSpiPackages) {
             writeLongString(out, details.getCachedRawHeader(FeatureDefinitionUtils.IBM_SPI_PACKAGE));
+        }
+    }
+
+    static String joinStringList(String delimiter, List<String> strings) {
+        if (strings == null || strings.isEmpty()) {
+            return EMPTY;
+        } else if (strings.size() == 1) {
+            return strings.get(0);
+        } else {
+            StringBuilder sb = new StringBuilder(strings.get(0));
+            for (int i = 1; i < strings.size(); i++)
+                sb.append(delimiter).append(strings.get(i));
+            return sb.toString();
         }
     }
 
@@ -442,8 +459,10 @@ public final class FeatureRepository implements FeatureResolver.Repository {
             processTypes.add(valueOf(in.readUTF(), ProcessType.SERVER));
         }
         ActivationType activationType = valueOf(in.readUTF(), ActivationType.SEQUENTIAL);
+        String symbolicNameAlias = in.readUTF();
+        String shortNameAlias = in.readUTF();
         return new ImmutableAttributes(repositoryType, symbolicName, shortName, featureVersion, visibility, appRestart, version, featureFile, lastModified, fileSize, isAutoFeature,
-                                       hasApiServices, hasApiPackages, hasSpiPackages, isSingleton, processTypes, activationType);
+                                       hasApiServices, hasApiPackages, hasSpiPackages, isSingleton, processTypes, activationType, symbolicNameAlias, shortNameAlias);
     }
 
     /**
@@ -575,6 +594,12 @@ public final class FeatureRepository implements FeatureResolver.Repository {
             // -- knownFeature entry will be replaced by caller
             cachedFeatures.remove(cachedAttr.symbolicName);
             publicFeatureNameToSymbolicName.remove(lowerFeature(cachedAttr.featureName));
+            if (cachedAttr.symbolicNameAliases != null && cachedAttr.bundleRepositoryType.length() == 0)
+                for (String alias : cachedAttr.symbolicNameAliases)
+                    publicFeatureNameToSymbolicName.remove(lowerFeature(alias));
+            if (cachedAttr.shortNameAliases != null && cachedAttr.bundleRepositoryType.length() == 0)
+                for (String alias : cachedAttr.shortNameAliases)
+                    publicFeatureNameToSymbolicName.remove(lowerFeature(alias));
             if (cachedAttr.isAutoFeature)
                 autoFeatures.remove(def);
         }
@@ -613,13 +638,21 @@ public final class FeatureRepository implements FeatureResolver.Repository {
             knownFeatures.put(cachedAttr.featureFile, def);
 
             // If there is a public feature name,
-            // populate the map with down-case featureName to real symbolic name
-            // populate the map with down-case symbolicName to real symbolic name
+            // populate the map with down-case featureName to real symbolic name, including aliases
+            // populate the map with down-case symbolicName to real symbolic name, including aliases
             // Note: we only ignore case when looking up public feature names!
-            if (!cachedAttr.featureName.equals(cachedAttr.symbolicName))
+            if (!cachedAttr.featureName.equals(cachedAttr.symbolicName)) {
                 publicFeatureNameToSymbolicName.put(lowerFeature(cachedAttr.featureName), cachedAttr.symbolicName);
-            if (def.getVisibility() == Visibility.PUBLIC)
+                if (cachedAttr.shortNameAliases != null && cachedAttr.bundleRepositoryType.length() == 0)
+                    for (String shortNameAlias : cachedAttr.shortNameAliases)
+                        publicFeatureNameToSymbolicName.put(lowerFeature(shortNameAlias), cachedAttr.symbolicName);
+            }
+            if (def.getVisibility() == Visibility.PUBLIC) {
                 publicFeatureNameToSymbolicName.put(lowerFeature(cachedAttr.symbolicName), cachedAttr.symbolicName);
+                if (cachedAttr.symbolicNameAliases != null && cachedAttr.bundleRepositoryType.length() == 0)
+                    for (String symbolicNameAlias : cachedAttr.symbolicNameAliases)
+                        publicFeatureNameToSymbolicName.put(lowerFeature(symbolicNameAlias), cachedAttr.symbolicName);
+            }
 
             // If this is an auto-feature, add it to that collection
             // we're going with the bold assertion that
@@ -729,8 +762,8 @@ public final class FeatureRepository implements FeatureResolver.Repository {
     }
 
     /**
-     * @param featureName
-     * @return
+     * @param featureName The symbolic name, short name (public name), or alias of a feature.
+     * @return The feature definition corresponding to the supplied feature name.
      */
     @Override
     public ProvisioningFeatureDefinition getFeature(String featureName) {

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/provisioning/ProvisioningFeatureDefinition.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/provisioning/ProvisioningFeatureDefinition.java
@@ -12,6 +12,7 @@ package com.ibm.ws.kernel.feature.provisioning;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.List;
 import java.util.Locale;
 
 import com.ibm.ws.kernel.feature.FeatureDefinition;
@@ -148,5 +149,17 @@ public interface ProvisioningFeatureDefinition extends FeatureDefinition {
      * @return true if the feature is a singleton, false otherwise
      */
     boolean isSingleton();
+
+    /**
+     * @return A list containing the symbolic name aliases declared in the WLP-SymbolicName-Alias
+     *         header, or null if not present.
+     */
+    List<String> getWlpSymbolicNameAliases();
+
+    /**
+     * @return A list containing the short name aliases declared in the WLP-SymbolicName-Alias
+     *         header, or null if not present.
+     */
+    List<String> getWlpShortNameAliases();
 
 }

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/resolver/FeatureResolver.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/resolver/FeatureResolver.java
@@ -38,17 +38,18 @@ public interface FeatureResolver {
         /**
          * Returns all known liberty features contained in this repository
          * which are considered to be auto features.
-         * 
+         *
          * @return a collection of auto features.
          */
         Collection<ProvisioningFeatureDefinition> getAutoFeatures();
 
         /**
          * Gets a feature based on the feature name. The feature name may
-         * be the short name (if it is a public feature) or the full
-         * symbolic name. The full symbolic name will include the version
+         * be the short name (if it is a public feature), the full
+         * symbolic name, or a symbolic or short name alias (if it is
+         * a public feature.) The full symbolic name will include the version
          * (e.g. com.ibm.ws.something_1.0)
-         * 
+         *
          * @param featureName the feature name
          * @return the feature with the specified name or {@code null}.
          */
@@ -62,7 +63,7 @@ public interface FeatureResolver {
          * a list [1.0, 1.1, 1.2] to indicate that all features that include a
          * version of com.ibm.ws.something also can tolerate versions
          * 1.0, 1.1 and 1.2. This is a way to override the tolerates.
-         * 
+         *
          * @param baseSymbolicName a feature base symbolic name to allow more tolerations for.
          * @return The additional versions of the feature that can be tolerated.
          */
@@ -75,21 +76,21 @@ public interface FeatureResolver {
     public interface Result {
         /**
          * The set of feature names that are required to resolve an initial set of root features.
-         * 
+         *
          * @return the feature names that are resolved
          */
         Set<String> getResolvedFeatures();
 
         /**
          * The required features that could not be found while trying to resolve root features.
-         * 
+         *
          * @return the missing features
          */
         Set<String> getMissing();
 
         /**
          * The set of root features must be public. This will return any that are not
-         * 
+         *
          * @return the non public root features
          */
         Set<String> getNonPublicRoots();
@@ -99,21 +100,21 @@ public interface FeatureResolver {
          * is the base name of the feature that has conflicting versions required.
          * The value is a collection of dependency {@link Chain}s that transitively
          * lead to the conflicting versions of the feature.
-         * 
+         *
          * @return
          */
         Map<String, Collection<Chain>> getConflicts();
 
         /**
          * Not really used yet
-         * 
+         *
          * @return
          */
         Map<String, Chain> getWrongProcessTypes();
 
         /**
          * A quick check to tell if there are any errors in the result.
-         * 
+         *
          * @return
          * @see #getMissing()
          * @see #getNonPublicRoots()
@@ -134,10 +135,10 @@ public interface FeatureResolver {
 
         /**
          * Creates a dependency chain.
-         * 
-         * @param chain The chain of feature names that have lead to a requirement on a singleton feature
-         * @param candidates The tolerated candidates that were found which may satisfy the feature requirement
-         * @param preferredVersion The preferred version
+         *
+         * @param chain              The chain of feature names that have lead to a requirement on a singleton feature
+         * @param candidates         The tolerated candidates that were found which may satisfy the feature requirement
+         * @param preferredVersion   The preferred version
          * @param originalFeatureReq The full feature name that is required.
          */
         public Chain(Collection<String> chain, List<String> candidates, String preferredVersion, String originalFeatureReq) {
@@ -204,30 +205,31 @@ public interface FeatureResolver {
      * <code>
      * resolveFeatures(repository, Collections.emptySet(), rootFeatures, preResolved, allowMultipleVersions)
      * </code>
-     * 
-     * @param repository the feature repository to use
-     * @param rootFeatures the root features to resolve
-     * @param preResolved the set of already resolved features to base the resolution delta off of
+     *
+     * @param repository            the feature repository to use
+     * @param rootFeatures          the root features to resolve
+     * @param preResolved           the set of already resolved features to base the resolution delta off of
      * @param allowMultipleVersions a flag that allows multiple versions (this flag will effectively ignore singletons)
      * @return the resolution result
      */
     public Result resolveFeatures(Repository repository, Collection<String> rootFeatures, Set<String> preResolved, boolean allowMultipleVersions);
-    
+
     /**
      * Resolves a collection of root features against a repository
-     * 
-     * @param repository the feature repository to use
-     * @param kernelFeatures the set of kernel features to use for auto-feature processing
-     * @param rootFeatures the root features to resolve
-     * @param preResolved the set of already resolved features to base the resolution delta off of
+     *
+     * @param repository            the feature repository to use
+     * @param kernelFeatures        the set of kernel features to use for auto-feature processing
+     * @param rootFeatures          the root features to resolve
+     * @param preResolved           the set of already resolved features to base the resolution delta off of
      * @param allowMultipleVersions a flag that allows multiple versions (this flag will effectively ignore singletons)
      * @return the resolution result
      */
-    public Result resolveFeatures(Repository repository, Collection<ProvisioningFeatureDefinition> kernelFeatures, Collection<String> rootFeatures, Set<String> preResolved, boolean allowMultipleVersions);
+    public Result resolveFeatures(Repository repository, Collection<ProvisioningFeatureDefinition> kernelFeatures, Collection<String> rootFeatures, Set<String> preResolved,
+                                  boolean allowMultipleVersions);
 
     /**
      * Not really used
-     * 
+     *
      * @param repository
      * @param kernelFeatures
      * @param rootFeatures
@@ -236,6 +238,7 @@ public interface FeatureResolver {
      * @param supportedProcessTypes
      * @return
      */
-    public Result resolveFeatures(Repository repository, Collection<ProvisioningFeatureDefinition> kernelFeatures, Collection<String> rootFeatures, Set<String> preResolved, boolean allowMultipleVersions,
+    public Result resolveFeatures(Repository repository, Collection<ProvisioningFeatureDefinition> kernelFeatures, Collection<String> rootFeatures, Set<String> preResolved,
+                                  boolean allowMultipleVersions,
                                   EnumSet<ProcessType> supportedProcessTypes);
 }

--- a/dev/com.ibm.ws.kernel.feature_fat/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.feature_fat/bnd.bnd
@@ -23,11 +23,12 @@ src: \
 	test-bundles/test.service.consumer/src, \
 	test-bundles/test.service.provider/src, \
 	test-bundles/test.activation.type/src, \
-	test-bundles/test.origin.bundle/src
+	test-bundles/test.origin.bundle/src, \
+	test-bundles/test.alias/src
 
 fat.project: true
 
-tested.features: featuref-1.0, productauto:pfeaturen-1.0, productauto:pfeaturem-1.0, featuree-1.0, productauto:pfeaturel-1.0, featureg-1.0, productauto:pfeaturef-1.0, productauto:pfeatureg-1.0, productauto:pfeaturee-1.0, capabilityc-1.0, badpathtool-1.0, emptyiconheader-1.0, goldenpathtool-1.0, icondirectivestool-1.0, noheadertool-1.0, missingiconstool-1.0, jwt-1.0, servlet-3.1
+tested.features: system-1.0, jsf-2.3, featuref-1.0, productauto:pfeaturen-1.0, productauto:pfeaturem-1.0, featuree-1.0, productauto:pfeaturel-1.0, featureg-1.0, productauto:pfeaturef-1.0, productauto:pfeatureg-1.0, productauto:pfeaturee-1.0, capabilityc-1.0, badpathtool-1.0, emptyiconheader-1.0, goldenpathtool-1.0, icondirectivestool-1.0, noheadertool-1.0, missingiconstool-1.0, jwt-1.0, servlet-3.1
 	
 
 -buildpath: \

--- a/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/ActivationTypeTest.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/ActivationTypeTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.kernel.feature.fat;
 
+import static org.junit.Assert.assertNotNull;
+
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -27,16 +29,20 @@ import componenttest.topology.impl.LibertyServerFactory;
 public class ActivationTypeTest {
     private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.kernel.feature.activation.type");
 
+    private static String msg;
+
     @Test
     public void testActivationType() throws Exception {
 
         server.startServer();
-        server.waitForStringInLogUsingMark("test.activation.type.parallel.system: true");
+        msg = server.waitForStringInLogUsingMark("test.activation.type.parallel.system: true");
+        assertNotNull("Feature bundle test.activation.type.parallel.system is parallel activated", msg);
 
         server.setMarkToEndOfLog();
         server.changeFeatures(Arrays.asList("test.activation.sequential.system-1.0"));
         server.waitForConfigUpdateInLogUsingMark(Collections.<String> emptySet());
-        server.waitForStringInLogUsingMark("test.activation.type.sequential.system: false");
+        msg = server.waitForStringInLogUsingMark("test.activation.type.sequential.system: false");
+        assertNotNull("Feature bundle test.activation.type.sequential.system is not parallel activated", msg);
 
         // Note that usr/product features are never parallel activated
         server.setMarkToEndOfLog();
@@ -45,12 +51,14 @@ public class ActivationTypeTest {
         Thread.sleep(2000);
         server.changeFeatures(Arrays.asList("usr:test.activation.parallel.user-1.0"));
         server.waitForConfigUpdateInLogUsingMark(Collections.<String> emptySet());
-        server.waitForStringInLogUsingMark("test.activation.type.parallel.user: false");
+        msg = server.waitForStringInLogUsingMark("test.activation.type.parallel.user: false");
+        assertNotNull("Feature bundle test.activation.type.parallel.user is not parallel activated", msg);
 
         server.setMarkToEndOfLog();
         server.changeFeatures(Arrays.asList("usr:test.activation.sequential.user-1.0"));
         server.waitForConfigUpdateInLogUsingMark(Collections.<String> emptySet());
-        server.waitForStringInLogUsingMark("test.activation.type.sequential.user: false");
+        msg = server.waitForStringInLogUsingMark("test.activation.type.sequential.user: false");
+        assertNotNull("Feature bundle test.activation.type.sequential.user is not parallel activated", msg);
     }
 
     @BeforeClass

--- a/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/AliasTest.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/AliasTest.java
@@ -1,0 +1,194 @@
+package com.ibm.ws.kernel.feature.fat;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
+
+@RunWith(FATRunner.class)
+public class AliasTest {
+
+    private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.kernel.feature.alias");
+
+    private static String msg;
+
+    private static long shortTimeOut = 3 * 1000;
+
+    @BeforeClass
+    public static void installFeatures() throws Exception {
+        server.installSystemFeature("test.alias.public.system-1.0");
+        server.installSystemBundle("test.alias.public.system");
+        server.installUserFeature("test.alias.public.user-1.0");
+        server.installUserBundle("test.alias.public.user");
+        server.installSystemFeature("test.alias.auto.internal-1.0");
+        server.installSystemBundle("test.alias.auto.internal");
+    }
+
+    @AfterClass
+    public static void uninstallFeatures() throws Exception {
+        server.uninstallSystemFeature("test.alias.public.system-1.0");
+        server.uninstallSystemBundle("test.alias.public.system");
+
+        server.uninstallUserFeature("test.alias.public.user-1.0");
+        server.uninstallUserBundle("test.alias.public.user");
+        server.uninstallSystemFeature("test.alias.auto.internal-1.0");
+        server.uninstallSystemBundle("test.alias.auto.internal");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+    @Test
+    public void testPublicAliases() throws Exception {
+
+        // Install symbolic name on clean start
+        server.changeFeatures(Arrays.asList("test.alias.public.system-1.0")); // symbolic name!
+        server.startServer(); // clean start - reset config, bundle, feature caches
+        msg = server.waitForStringInLogUsingMark("test.alias.public.system", shortTimeOut);
+        assertNotNull("The server should provision feature bundle test.alias.public.system, but did not", msg);
+        msg = server.waitForStringInLogUsingMark("CWWKF0012I:", shortTimeOut); // short name!
+        assertTrue("The feature manager should install feature system-1.0, but did not: msg=" + msg,
+                   msg != null && msg.contains("system-1.0"));
+        server.stopServer();
+
+        // Install short alias on static update
+        server.changeFeatures(Arrays.asList("myorgSystem-1.0")); // short alias!
+        server.startServer(false); // use feature cache
+        msg = server.waitForStringInLogUsingMark("test.alias.public.system", shortTimeOut);
+        assertNotNull("The server should provision feature bundle test.alias.public.system, but did not", msg);
+        msg = server.waitForStringInLogUsingMark("CWWKF0012I:", shortTimeOut);
+        assertTrue("The feature manager should install system-1.0 using the short alias, but did not: msg=" + msg,
+                   msg != null && msg.contains("system-1.0"));
+
+        // NOTICE THE TESTS CHECK FOR SYMBOLIC OR SHORT NAME IN CWWK0012I MESSAGE.
+        // FM IS NOT MODIFIED TO EMIT ALIASES, EVEN WHEN CONFIGURED IN SERVER.XML
+
+        // ISSUE: WE SHOULD EMIT ALIASES IN MSGS WHEN CONFIGURED BY USER IN SERVER.XML,
+        // BUT ARE WE ALLOWED TO?
+
+        // Symbolic alias must not trigger reinstall on dynamic update
+        server.setMarkToEndOfLog();
+        server.changeFeatures(Arrays.asList("com.myorg.test.alias.public.system-1.0")); // symbolic alias!
+        server.waitForConfigUpdateInLogUsingMark(Collections.<String> emptySet());
+        msg = server.waitForStringInLogUsingMark("CWWKF0012I:", shortTimeOut);
+        assertNull("The feature manager should not install any features on dynamic update of this symbolic alias, but it did: msg=" + msg, msg);
+
+        // Short name must not trigger reinstall on dynamic update
+        server.setMarkToEndOfLog();
+        server.changeFeatures(Arrays.asList("system-1.0")); // short name
+        server.waitForConfigUpdateInLogUsingMark(Collections.<String> emptySet());
+        msg = server.waitForStringInLogUsingMark("CWWKF0012I:", shortTimeOut);
+        assertNull("The feature manager should not install any features on dynamic update of this short name, but it did: msg=" + msg, msg);
+
+        // Remove aliased feature on dynamic update
+        server.setMarkToEndOfLog();
+        server.changeFeatures(Arrays.asList("jsf-2.3")); // Nod to the future
+        server.waitForConfigUpdateInLogUsingMark(Collections.<String> emptySet());
+        msg = server.waitForStringInLogUsingMark("CWWKF0013I:");
+        assertTrue("The feature manager should uninstall system-1.0, previously installed using the short alias, but did not: msg=" + msg,
+                   msg != null && msg.contains("system-1.0"));
+
+        // Install symbolic alias on dynamic update
+        server.setMarkToEndOfLog();
+        server.changeFeatures(Arrays.asList("com.myorg.test.alias.public.system-1.0"));
+        server.waitForConfigUpdateInLogUsingMark(Collections.<String> emptySet());
+        assertNotNull("The server should provision feature bundle test.alias.public.system, but did not", msg);
+        msg = server.waitForStringInLogUsingMark("CWWKF0012I:");
+        assertTrue("The feature manager should (re)install system-1.0 on dynamic update using the symbolic alias, but did not: msg=" + msg,
+                   msg != null && msg.contains("system-1.0"));
+    }
+
+    @Test
+    public void testUserAliasesNotSupported() throws Exception {
+
+        // Install symbolic name on clean start
+        server.changeFeatures(Arrays.asList("test.alias.public.user-1.0")); // symbolic name, public!
+        server.startServer(); // clean start
+        msg = server.waitForStringInLogUsingMark("test.alias.public.user", shortTimeOut);
+        assertNotNull("The server should provision user feature bundle test.alias.public.user, but did not", msg);
+        msg = server.waitForStringInLogUsingMark("CWWKF0012I:", shortTimeOut); // short name!
+        assertTrue("The feature manager should install user feature user-1.0, but did not: msg=" + msg,
+                   msg != null && msg.contains("usr:user-1.0"));
+        server.stopServer();
+
+        // Aliases not supported for user features (static update)
+        server.changeFeatures(Arrays.asList("usr:myorgUser-1.0")); // short alias!
+        server.startServer(false); // use feature cache
+        msg = server.waitForStringInLogUsingMark("test.alias.public.user", shortTimeOut);
+        assertNull("The server should not provision feature bundle test.alias.public.user, but it did: msg=" + msg, msg);
+        msg = server.waitForStringInLogUsingMark("CWWKF0001E:", shortTimeOut);
+        assertTrue("The feature manager should not find a definition for user feature user-1.0 with short alias myorgUser-1.0, but it did: msg=" + msg,
+                   msg != null && msg.contains("myorguser-1.0"));
+        server.stopServer("CWWKF0001E");
+    }
+
+    @Test
+    public void testEquivalentFeatureNameAndAlias() throws Exception {
+
+        // Ignore the equivalent names w/o incident and install the feature
+        server.changeFeatures(Arrays.asList("test.alias.public.system-1.0", "myorgSystem-1.0")); // same feature
+        server.startServer();
+        msg = server.waitForStringInLogUsingMark("test.alias.public.system", shortTimeOut);
+        assertNotNull("The server should provision feature bundle test.alias.public.system, but did not", msg);
+        msg = server.waitForStringInLogUsingMark("CWWKF0012I:", shortTimeOut); // short name!
+        assertTrue("The feature manager should install feature system-1.0, but did not: msg=" + msg,
+                   msg != null && msg.contains("system-1.0"));
+
+        // ADD TEST FOR EQUIVALENT SINGLETON FEATURE, THEN EITHER 1) MODIFY TEST TO CHECK FOR
+        // MESSAGE CWWKF0033E AND CHANGE FM TO EMIT FEATURE NAME ALIAS RATHER THAN NULL, OR
+        // 2) CHECK THAT THE FEATURE INSTALLED AND MODIFY FM TO INSTALL THE SINGLETON FEATURE
+        // RATHER THAN IGNORE IT AND EMIT CWWKF0033E.  EITHER WAY, ADD DEBUG TO FM.
+
+        // ISSUE: HOW TO HANDLE EQUIVALENT FEATURE NAMES IN SERVER.XML. FM CURRENTLY IGNORES
+        // THE ALIAS UNLESS FEATURE IS SINGLETION (GROAN)
+
+        // ISSUE: WHETHER TO EMIT ALIAS NAMES TO MESSAGES WHEN ALIAS APPEARS IN SERVER.XML.
+    }
+
+    @Test
+    public void testAliasesSatisfyAutoFeatureCapability() throws Exception {
+
+        // Configure feature(s) w/ short alias that satisfies auto feature capability
+        server.changeFeatures(Arrays.asList("myorgSystem-1.0", "jsf-2.3")); // Alias for system-1.0
+        server.startServer();
+        msg = server.waitForStringInLogUsingMark("test.alias.auto.internal", shortTimeOut);
+        assertNotNull("The server should provision auto feature bundle test.alias.auto.internal, but did not", msg);
+        msg = server.waitForStringInLogUsingMark("CWWKF0012I:", shortTimeOut);
+        assertTrue("The feature manager should install autp feature test.alias.auto.internal-1.0, but did not: msg=" + msg,
+                   msg != null && msg.contains("test.alias.auto.internal-1.0"));
+        server.stopServer();
+
+        // Configure feature(s) w/ symbolic alias that satisfies auto feature capability
+        server.changeFeatures(Arrays.asList("com.myorg.test.alias.public.system-1.0", "jsf-2.3")); // Alias for system-1.0
+        server.startServer();
+        msg = server.waitForStringInLogUsingMark("test.alias.auto.internal", shortTimeOut);
+        assertNotNull("The server should provision auto feature bundle test.alias.auto.internal, but did not", msg);
+        msg = server.waitForStringInLogUsingMark("CWWKF0012I:", shortTimeOut);
+        assertTrue("The feature manager should install auto feature test.alias.auto.internal-1.0, but did not: msg=" + msg,
+                   msg != null && msg.contains("test.alias.auto.internal-1.0"));
+
+        // NO NEED TO TEST SCENARIOS WHERE AUTO-FEATURE DECLARES AN ALIASED CAPABILITY.
+        // AUTO FEATURE CAPABILITIES ARE INTERNALS THAT WILL CHANGE ALONG WITH FEATURE
+        // NAMES.
+
+        // ISSUE: DO WE SUPPORT SYMBOLIC ALIASES APPEARING IN AUTO-FEATURE CAPABILITIES?  WE
+        // MUST SUPPORT ALIASES IN SUBSYSTEM-CONTENT
+    }
+
+}

--- a/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/FATSuite.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/FATSuite.java
@@ -32,7 +32,8 @@ import org.junit.runners.Suite.SuiteClasses;
                 SystemBundleOverrideTest.class,
                 FeatureAPITest.class,
                 RegionProvisioningTest.class,
-                RemoteServerInclude.class
+                RemoteServerInclude.class,
+                AliasTest.class
 })
 /**
  * Purpose: This suite collects and runs all known good test suites.

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.alias.auto.internal-1.0.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.alias.auto.internal-1.0.mf
@@ -1,0 +1,9 @@
+Subsystem-ManifestVersion: 1
+Subsystem-SymbolicName: test.alias.auto.internal-1.0; visibility:=public
+Subsystem-Version: 1.0.0
+Subsystem-Content: test.alias.auto.internal; version="[1,1.0.100)"
+Subsystem-Type: osgi.subsystem.feature
+IBM-API-Package: test.feature.api
+IBM-Feature-Version: 2
+WLP-SymbolicName-Alias: com.myorg.test.alias.auto.internal-1.0
+IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=test.alias.public.system-1.0))", osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.jsf-2.3))"

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.alias.public.system-1.0.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.alias.public.system-1.0.mf
@@ -1,0 +1,10 @@
+Subsystem-ManifestVersion: 1
+Subsystem-SymbolicName: test.alias.public.system-1.0; visibility:=public
+Subsystem-Version: 1.0.0
+Subsystem-Content: test.alias.public.system; version="[1,1.0.100)"
+Subsystem-Type: osgi.subsystem.feature
+IBM-API-Package: test.feature.api
+IBM-Feature-Version: 2
+IBM-ShortName: system-1.0
+WLP-SymbolicName-Alias: com.myorg.test.alias.public.system-1.0
+WLP-ShortName-Alias: myorgSystem-1.0

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.alias.public.user-1.0.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.alias.public.user-1.0.mf
@@ -1,0 +1,10 @@
+Subsystem-ManifestVersion: 1
+Subsystem-SymbolicName: test.alias.public.user-1.0; visibility:=public
+Subsystem-Version: 1.0.0
+Subsystem-Content: test.alias.public.user; version="[1,1.0.100)"
+Subsystem-Type: osgi.subsystem.feature
+IBM-API-Package: test.feature.api
+IBM-Feature-Version: 2
+IBM-ShortName: user-1.0
+WLP-SymbolicName-Alias: com.myorg.test.alias.public.user-1.0
+WLP-ShortName-Alias: myorgUser-1.0

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.feature.alias/bootstrap.properties
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.feature.alias/bootstrap.properties
@@ -1,0 +1,1 @@
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.feature.alias/server.xml
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.feature.alias/server.xml
@@ -1,0 +1,9 @@
+<server>
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>test.alias.public.system-1.0</feature>
+    </featureManager>
+    
+</server>

--- a/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.alias/src/test/alias/Activator.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.alias/src/test/alias/Activator.java
@@ -1,0 +1,19 @@
+package test.alias;
+
+import org.eclipse.osgi.container.Module;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+
+public class Activator implements BundleActivator {
+
+    @Override
+    public void start(BundleContext context) throws Exception {
+        Bundle b = context.getBundle();
+        System.out.println(b.getSymbolicName() + " is starting");
+    }
+
+    @Override
+    public void stop(BundleContext context) throws Exception {}
+
+}

--- a/dev/com.ibm.ws.kernel.feature_fat/test.alias.auto.internal.bnd
+++ b/dev/com.ibm.ws.kernel.feature_fat/test.alias.auto.internal.bnd
@@ -1,0 +1,9 @@
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0.0
+
+Bundle-SymbolicName: test.alias.auto.internal
+Bundle-Description: auto feature bundle for testing symbolic and short aliases
+
+Private-Package: test.alias
+
+Bundle-Activator: test.alias.Activator

--- a/dev/com.ibm.ws.kernel.feature_fat/test.alias.public.system.bnd
+++ b/dev/com.ibm.ws.kernel.feature_fat/test.alias.public.system.bnd
@@ -1,0 +1,9 @@
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0.0
+
+Bundle-SymbolicName: test.alias.public.system
+Bundle-Description: test feature bundle for symbolic and short aliases
+
+Private-Package: test.alias
+
+Bundle-Activator: test.alias.Activator

--- a/dev/com.ibm.ws.kernel.feature_fat/test.alias.public.user.bnd
+++ b/dev/com.ibm.ws.kernel.feature_fat/test.alias.public.user.bnd
@@ -1,0 +1,9 @@
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0.0
+
+Bundle-SymbolicName: test.alias.public.user
+Bundle-Description: test user feature bundle for symbolic and short aliases
+
+Private-Package: test.alias
+
+Bundle-Activator: test.alias.Activator

--- a/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverEsa.java
+++ b/dev/com.ibm.ws.repository.resolver/src/com/ibm/ws/repository/resolver/internal/kernel/KernelResolverEsa.java
@@ -339,4 +339,14 @@ public class KernelResolverEsa implements ProvisioningFeatureDefinition {
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public List<String> getWlpSymbolicNameAliases() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> getWlpShortNameAliases() {
+        throw new UnsupportedOperationException();
+    }
+
 }


### PR DESCRIPTION
Fixes #9214

The solution to date enhances the feature manager to resolve and provision public features using alternate symbolic and short names, i.e. aliases, defined in feature metadata.

Here are the details and issues found:

**The solution assumes renamed feature metadata declare a new symbolicName and shortName, and declare the previous symbolicName and shortName as the symblicAlias and shortAlias.**

ISSUE: We could rename features by declaring new names as aliases, rather than modify the symbolic and short names. The current solution assumes that symbolic and short names are preferred for the release, which is implicit information. Preferred names will appear in messages because they are specific to a release, and it's not clear whether logs may contain the previous feature names (e.g. jsf, jakarta-ee agreements.)

ISSUE: Will we support aliases for any non-public features?  We'll need to support protected features, seeing that stack product features probably declare dependencies on renamed features. The solution requires a few tweaks to support protected features.

ISSUE: How to handle equivalent feature names and aliases in server.xml. The solution ignores them by quietly installing the preferred name.  E.G. <featureManager>jsf-2.3, faces-2.3</featureManager>

Feature metadata now may include attributes `WLP-SymbolicName-Alias` and `WLP-ShortName-Alias`, where each may declare 0 or more aliases for Subsystem-SymbolicName and IBM-ShortName, respectively. For brevity, let's refer to these as symbolicAlias, shortAlias. symbolicName, shortName.

ProvisioningFeatureDefinition (intf), SubsystemFeatureDefinitionImpl, and FeatureDefinitionUtils now collect the symbolicAlias and shortAlias from feature manifests, and provide access to both aliases. Aliases are supported for public features, only.  New unit tests are in FeatureDefinitionUtilsTest.

Support to match aliases declared in auto-feature capabilities was added to SubsystemFeatureDefinitionImpl, see method isCapabilitySatisfied().

The solution does not modify the FeatureResource intf.

FeatureRepository now populates the publicFeatureNameToSymbolicName map with elements that map a symbolicAlias and shortAlias to its feature definition, in addition to symbolicName and shortName. 

This enables its implementation of method `FeatureResolver.Respository.getFeature(byName)` to return features by alias in addition to name. Method getFeature() is now documented with the new behavior, as similar support will be required by external repositories that implement the Repository interface. Lastly, the class now reads/writes alias metadata from/to the feature cache.

FeatureResolverImpl now supports symbolic names and aliases declared in Subsystem-Content (i.e. dependencies,) where the dependency may tolerate a version of the feature that was renamed.  The solution requires renamed features have an updated symbolicName, and the previous name is declared as an alias.

Unit tests for toleration support were added to FeatureResolverInterfacesTest. A new FAT case, AliasTest, was added to the kernel feature FAT bucket. AliasTest verifies alias support for auto-feature capabilities, non-support of non-public and user features, static feature updates (restart server) over clean vs dirty workareas; dynamic updates to add and remove features, and server configurations containing equivalent feature name and alias.  