### PR TITLE
Update the FT TCK trace spec

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/publish/servers/FaultTolerance11TCKServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/publish/servers/FaultTolerance11TCKServer/bootstrap.properties
@@ -9,4 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:APPCONFIG=all:FAULTTOLERANCE=all
+com.ibm.ws.logging.trace.specification=*=info:Threading=event:FAULTTOLERANCE=all

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/servers/FaultTolerance20TCKServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/servers/FaultTolerance20TCKServer/bootstrap.properties
@@ -9,4 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:APPCONFIG=all:FAULTTOLERANCE=all
+com.ibm.ws.logging.trace.specification=*=info:Threading=event:FAULTTOLERANCE=all

--- a/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/publish/servers/FaultToleranceTCKServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/publish/servers/FaultToleranceTCKServer/bootstrap.properties
@@ -9,4 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:APPCONFIG=all:FAULTTOLERANCE=all
+com.ibm.ws.logging.trace.specification=*=info:Threading=event:FAULTTOLERANCE=all


### PR DESCRIPTION
Remove `APPCONFIG` because it's very noisy and rarely helpful

Add `Threading=event` so that we can see if pauses in fault tolerance
tests are caused by running out of threads. Will also give us visibility
of whether the expected number of threads are running at any point in
the test run.