### PR TITLE
testing for new failover approach via the test bucket that simulates failover with multiple executors on one server

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/fat/src/com/ibm/ws/concurrent/persistent/fat/failover1serv/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/fat/src/com/ibm/ws/concurrent/persistent/fat/failover1serv/FATSuite.java
@@ -15,6 +15,9 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
-@SuiteClasses({ Failover1ServerTest.class })
+@SuiteClasses({
+    Failover1ServerTest.class,
+    Failover1ServerTest2.class
+    })
 public class FATSuite {
 }

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/test-applications/failover1servApp/src/failover1serv/web/Failover1ServerTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/test-applications/failover1servApp/src/failover1serv/web/Failover1ServerTestServlet.java
@@ -88,7 +88,6 @@ public class Failover1ServerTestServlet extends FATServlet {
     /**
      * testHeartbeatsAreRepeatedlySent - verifies that heart beats are being sent periodically, with an increasing expiry timestamp.
      */
-    @Test
     public void testHeartbeatsAreRepeatedlySent() throws Exception {
         // Ensure the database tables are present
         PersistentExecutor executor = InitialContext.doLookup("persistent/exec2");
@@ -136,7 +135,6 @@ public class Failover1ServerTestServlet extends FATServlet {
      * testMissedHeartbeatsClearOldPartitionData - insert entries representing missed heartbeats directly into the
      * database. Verify that they are automatically removed (happens when heartbeat information is checked).
      */
-    @Test
     public void testMissedHeartbeatsClearOldPartitionData(HttpServletRequest request, HttpServletResponse response) throws Exception {
         // Ensure the database tables are present
         PersistentExecutor executor = InitialContext.doLookup("persistent/exec2");


### PR DESCRIPTION
Update the test bucket to also run tests when using the new failover approach.  The two tests for heartbeating are excluded in this case because the new failover approach does not involve heartbeating.