### PR TITLE
fix testcase errors

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/FeatureTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/FeatureTest.java
@@ -228,12 +228,12 @@ public class FeatureTest extends JavaEESecTestBase {
         Log.info(logClass, getCurrentTestName(), "-----Accessing Application to test scenarios...");
         startServer(APP_SEC_2_XML_NAME, EJB_APP_NAME_noPermission);
         assertNotNull("Expected class not found error",
-                      myServer.waitForStringInLog("CWNEN0049W: Resource annotations on the methods of the web.ejb.jar.bean..*"));
+                      myServer.waitForStringInLog("CWNEN00\\d\\dW: Resource annotations on the methods of the web.ejb.jar.bean..*"));
         assertNotNull("Application was able not able to start",
                       myServer.waitForStringInLog("CWWKZ0002E: An exception occurred while starting the application securityejbinwar3."));
 
         myServer.removeInstalledAppForValidation(EJB_APP_NAME_noPermission);
-        myServer.stopServer("CWNEN0049W:*", "CWWKZ0106E:*", "CWWKZ0002E:*");
+        myServer.stopServer("CWNEN0049W:*", "CWNEN0050W:*", "CWWKZ0106E:*", "CWWKZ0002E:*");
         Log.info(logClass, getCurrentTestName(), "-----Exiting " + getCurrentTestName());
     }
 
@@ -279,12 +279,12 @@ public class FeatureTest extends JavaEESecTestBase {
         Log.info(logClass, getCurrentTestName(), "-----Accessing Application to test scenarios...");
         startServer(APP_SEC_1_XML_NAME, EJB_APP_NAME_noPermission);
         assertNotNull("Expected class not found error",
-                      myServer.waitForStringInLog("CWNEN0049W: Resource annotations on the methods of the web.ejb.jar.bean..*"));
+                      myServer.waitForStringInLog("CWNEN00\\d\\dW: Resource annotations on the methods of the web.ejb.jar.bean..*"));
         assertNotNull("Application was able not able to start",
                       myServer.waitForStringInLog("CWWKZ0002E: An exception occurred while starting the application securityejbinwar3."));
 
         myServer.removeInstalledAppForValidation(EJB_APP_NAME_noPermission);
-        myServer.stopServer("CWNEN0049W:*", "CWWKZ0106E:*", "CWWKZ0002E:*");
+        myServer.stopServer("CWNEN0049W:*", "CWNEN0050W:*", "CWWKZ0106E:*", "CWWKZ0002E:*");
         Log.info(logClass, getCurrentTestName(), "-----Exiting " + getCurrentTestName());
     }
 


### PR DESCRIPTION
fixes #9835 
There are possibility to return CWNEN0050W message instead of CWNEN0049W message. It seems like it depends on the environment. So, the testcode was modified to handle both messages.