### PR TITLE
Added the RA's CMD to the thread during configureResourceAdapter

### DIFF
--- a/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/internal/BootstrapContextImpl.java
+++ b/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/internal/BootstrapContextImpl.java
@@ -491,8 +491,8 @@ public class BootstrapContextImpl implements BootstrapContext, ApplicationRecycl
             }
         }
         if (bvalHelper != null) {
-            ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
-            if (cmd != null) {
+            ResourceAdapterMetaData raMetaData = resourceAdapterSvc.getResourceAdapterMetaData();
+            if (raMetaData != null) {
                 // Use raMetaData.getModuleMetaData() to make sure we get the RA's MMD when the RA is embedded.
                 bvalHelper.validateInstance(raMetaData.getModuleMetaData(), resourceAdapterSvc.getClassLoader(), instance);
             }

--- a/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/internal/BootstrapContextImpl.java
+++ b/dev/com.ibm.ws.jca/src/com/ibm/ws/jca/internal/BootstrapContextImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2018 IBM Corporation and others.
+ * Copyright (c) 2012, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -308,7 +308,13 @@ public class BootstrapContextImpl implements BootstrapContext, ApplicationRecycl
             bvalHelper.setBeanValidationSvc(svc);
         }
 
-        resourceAdapter = configureResourceAdapter();
+        try {
+            beginContext(raMetaData);
+            resourceAdapter = configureResourceAdapter();
+        } finally {
+            endContext(raMetaData);
+        }
+
         if (resourceAdapter != null) {
             propagateThreadContext = !"(service.pid=com.ibm.ws.context.manager)".equals(properties.get("contextService.target"));
             workManager = new WorkManagerImpl(this);
@@ -487,7 +493,8 @@ public class BootstrapContextImpl implements BootstrapContext, ApplicationRecycl
         if (bvalHelper != null) {
             ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
             if (cmd != null) {
-                bvalHelper.validateInstance(cmd.getModuleMetaData(), resourceAdapterSvc.getClassLoader(), instance);
+                // Use raMetaData.getModuleMetaData() to make sure we get the RA's MMD when the RA is embedded.
+                bvalHelper.validateInstance(raMetaData.getModuleMetaData(), resourceAdapterSvc.getClassLoader(), instance);
             }
         }
 


### PR DESCRIPTION
Added the RA's CMD to the thread during configureResourceAdapter as bval requires it for looking up the correct CDI bean manager. Also update the MMD used by the bvalHelper to use the RA's MMD. Otherwise embedded RA incorrectly use the application's MMD instead of the RA's.

This PR fixes release bug issue #9848 