### PR TITLE
ensure cache is used before shutdown in tests

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheConfigUpdateTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheConfigUpdateTest.java
@@ -79,7 +79,16 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        // If a config update occurred just prior to this and didn't have subseuqent use of a session,
+        // then http sessions code could be initializing Infinispan asynchronously, which, if that is still ongoing,
+        // can result in errors if a server stop happens at the same time.  To avoid this, first run an operation
+        // that will wait for the intialization to complete.
+        try {
+            List<String> session = new ArrayList<>();
+            run("getSessionId", session);
+        } finally {
+            server.stopServer();
+        }
     }
 
     /**


### PR DESCRIPTION
There is some asynchronous logic after processing a configuration update where http sessions code is accessing the CacheManager.  When a test case performs server shutdown after this point without any subsequent operations on a session, there is a timing window for this CacheManager initialization to overlap the shutdown and cause errors/warnings to appear in the logs, which causes the test case to report a failure.  This pull updates the test case to work around this by forcing an operation to access a session prior to invoking shutdown.