### PR TITLE
Upgrade MP GraphQL TCK to get added diagnostics

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -91,8 +91,8 @@ org.apache.cxf:cxf-rt-ws-security:2.6.2-ibm-s20180529-1900
 org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0
 org.apache.santuario:xmlsec:1.5.2-ibm
 org.apache.ws.security:wss4j:1.6.7-ibm-s20130913-2015
-org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.0-20191112
-org.eclipse.microprofile.graphql:microprofile-graphql-tck:1.0.0-20191112
+org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.0-20191119
+org.eclipse.microprofile.graphql:microprofile-graphql-tck:1.0.0-20191119
 org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.5-ea124dd
 org.eclipse.persistence:org.eclipse.persistence.asm:2.7.5-ea124dd
 org.eclipse.persistence:org.eclipse.persistence.core:2.7.5-ea124dd

--- a/dev/com.ibm.websphere.org.eclipse.microprofile.graphql.1.0/bnd.bnd
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.graphql.1.0/bnd.bnd
@@ -20,7 +20,7 @@ Export-Package: \
   org.eclipse.microprofile.graphql;version=1.0
 
 Include-Resource: \
-  @${repo;org.eclipse.microprofile.graphql:microprofile-graphql-api;1.0.0.20191112;EXACT}
+  @${repo;org.eclipse.microprofile.graphql:microprofile-graphql-api;1.0.0.20191119;EXACT}
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version>=1.8))"
 

--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/pom.xml
@@ -28,7 +28,7 @@
     <name>MicroProfile GraphQL TCK Runner TCK Module</name>
 
     <properties>
-        <microprofile.graphql.version>1.0.0-20191112</microprofile.graphql.version>
+        <microprofile.graphql.version>1.0.0-20191119</microprofile.graphql.version>
         <arquillian.version>1.1.13.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->


### PR DESCRIPTION
Upgrading to a newer snapshot of MP GraphQL API and TCK - only the TCK has changed, but upgrading the API to keep them in sync.  The updated TCK contains diagnostics for a problem occurring in the z/OS builds.

Not a release bug.