### PR TITLE
Add runtime update trace by default

### DIFF
--- a/dev/fattest.simplicity/autoFVT-defaults/testports.properties
+++ b/dev/fattest.simplicity/autoFVT-defaults/testports.properties
@@ -143,7 +143,7 @@ osgi.console=5678
 com.ibm.ws.logging.max.file.size=0
 
 # If a FAT does not specify any trace spec, they will get this setting by default
-com.ibm.ws.logging.trace.specification=*=info:logservice=detail
+com.ibm.ws.logging.trace.specification=*=info:logservice=detail:com.ibm.ws.runtime.update.*=all
 #ds.loglevel=debug
 
 # property for the file containing the FFDCs that need to be ignored


### PR DESCRIPTION
Enable runtime update trace by default so that we have information when some random test bucket gets a quiesce failure. This is a trivial amount of trace when there are no quiesce failures. 