### PR TITLE
display generated infinispan config

### DIFF
--- a/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
+++ b/dev/com.ibm.ws.session.cache/resources/com/ibm/ws/session/store/cache/resources/WASSessionCache.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018,2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -56,6 +56,11 @@ ERROR_CONFIG_INVALID_HTTPSESSIONCACHE.useraction=Verify that the server configur
 ERROR_CONFIG_EMPTY_LIBRARY=SESN0309E: The {0} session cache library is empty. {1}
 ERROR_CONFIG_EMPTY_LIBRARY.explanation=The sessionCache feature could not find a JCache provider to load.
 ERROR_CONFIG_EMPTY_LIBRARY.useraction=Verify that the library contains a JCache provider and all paths are specified correctly.
+
+# do not translate: httpSessionCache, uri
+SESN0310_GEN_INFINISPAN_CONFIG=SESN0310I: Generated Infinispan configuration for HTTP session persistence: {0}. To override, configure the uri attribute of the httpSessionCache configuration element.
+SESN0310_GEN_INFINISPAN_CONFIG.explanation=The Infinispan caches that are used for HTTP session persistence require additional configuration to persist sessions across servers. Liberty generates this configuration when it is not provided by the user.
+SESN0310_GEN_INFINISPAN_CONFIG.useraction=No action is required if you are satisfied with the generated configuration. Otherwise, the generated configuration can be used as a starting point.
 
 INTERNAL_SERVER_ERROR=Internal Server Error
 

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -26,9 +26,11 @@ import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Properties;
@@ -339,18 +341,25 @@ public class CacheStoreService implements Introspector, SessionStoreService {
             tempConfigFile = File.createTempFile("infinispan", ".xml");
             tempConfigFile.setReadable(true);
             tempConfigFile.setWritable(true);
-            // TODO determine the best config to generate based on where/how this is running?
-            try (PrintStream out = new PrintStream(new BufferedOutputStream(new FileOutputStream(tempConfigFile)))) {
-                out.println("<infinispan>");
-                out.println(" <jgroups>");
-                out.println("  <stack-file name=\"jgroups-udp\" path=\"/default-configs/default-jgroups-udp.xml\"/>");
-                out.println(" </jgroups>");
-                out.println(" <cache-container>");
-                out.println("  <transport stack=\"jgroups-udp\"/>");
-                out.println("  <replicated-cache-configuration name=\"com.ibm.ws.session.*\"/>");
-                out.println(" </cache-container>");
-                out.println("</infinispan>");
+            StringWriter sw = new StringWriter();
+            try (PrintStream out = new PrintStream(new BufferedOutputStream(new FileOutputStream(tempConfigFile)));
+                            PrintWriter pw = new PrintWriter(sw)) {
+                final List<String> lines = Arrays.asList("<infinispan>",
+                                                         " <jgroups>",
+                                                         "  <stack-file name=\"jgroups-udp\" path=\"/default-configs/default-jgroups-udp.xml\"/>",
+                                                         " </jgroups>",
+                                                         " <cache-container>",
+                                                         "  <transport stack=\"jgroups-udp\"/>",
+                                                         "  <replicated-cache-configuration name=\"com.ibm.ws.session.*\"/>",
+                                                         " </cache-container>",
+                                                         "</infinispan>");
+                pw.println();
+                for (String line : lines) {
+                    out.println(line);
+                    pw.println(line);
+                }
             }
+            Tr.info(tc, "SESN0310_GEN_INFINISPAN_CONFIG", sw.toString());
             return tempConfigFile.toURI();
         }
 
@@ -397,7 +406,6 @@ public class CacheStoreService implements Introspector, SessionStoreService {
 
             // A cache name matching com.ibm.ws.session.* was not found in the provided configuration. Add it to cache-container.
             for (Node cacheContainer : cacheContainers) {
-                // TODO determine the best config to generate based on where/how this is running?
                 Element replicatedCacheConfig = doc.createElement("replicated-cache-configuration");
                 Attr nameAttribute = doc.createAttribute("name");
                 nameAttribute.setNodeValue("com.ibm.ws.session.*");
@@ -423,7 +431,23 @@ public class CacheStoreService implements Introspector, SessionStoreService {
             transformer.transform(source, uriResult);
 
             if (trace && tc.isDebugEnabled()) {
-                // TODO: will likely need to stop tracing this due to concern about passwords or other sensitive information being logged
+                // Avoid tracing passwords:
+                NodeList allElements = doc.getElementsByTagName("*");
+                for (int i = allElements.getLength() - 1; i >= 0; i--) {
+                    Node element = allElements.item(i);
+                    String elementName = element.getNodeName();
+                    if (!"jgroups".equals(elementName) && !"stack".equals(elementName) && !"stack-file".equals(elementName) && !"transport".equals(elementName)
+                                    && !elementName.endsWith("-cache") && !elementName.endsWith("-cache-configuration")) {
+                        NamedNodeMap attrs = element.getAttributes();
+                        if (attrs != null) {
+                            for (int j = attrs.getLength() - 1; j >= 0; j--) {
+                                Node attr = attrs.item(j);
+                                attr.setNodeValue("***");
+                            }
+                        }
+                    }
+                }
+
                 StringWriter sw = new StringWriter();
                 StreamResult loggableResult = new StreamResult(sw);
                 transformer.transform(source, loggableResult);


### PR DESCRIPTION
When configuration for Infinispan is generated, display that information to the user, so that they have a starting point if they wish to override it.  Also, avoid tracing passwords in user-provided Infinispan config that we add the HTTP session persistence caches to.

Here is the trace output when applying the updates there were made under this pull:

```
[11/20/19, 12:20:57:220 CST] 0000004e id=a824fa70 com.ibm.ws.session.store.cache.CacheStoreService             3 generateOrUpdateInfinispanConfig 
                                                                                                               /Users/njr/lgit/open-liberty/dev/com.ibm.ws.session.cache_fat_infinispan/build/libs/autoFVT/build/tmp/infinispan10600525141598196471.xml
                                                                                                               <?xml version="1.0" encoding="UTF-8" standalone="no"?><infinispan>
  <jgroups>
     <stack-file name="jgroups-udp" path="/default-configs/default-jgroups-udp.xml"/>
     <stack name="jgroups-unused">
       <AUTH keystore_password="***"/>
     </stack>
  </jgroups>
...
```