### PR TITLE
[9879] "setX" to "X" conversion for Mutations

### DIFF
--- a/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/query/PropertyOperationNameGenerator.java
+++ b/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/query/PropertyOperationNameGenerator.java
@@ -15,4 +15,13 @@ public class PropertyOperationNameGenerator extends AnnotatedOperationNameGenera
         }
         return name;
     }
+
+    @Override
+    public String generateMutationName(OperationNameGeneratorParams<Method> params) {
+        String name = super.generateMutationName(params);
+        if (Utils.isEmpty(name) && params.isMethod()) {
+            return ClassUtils.getFieldNameFromSetter((Method) params.getElement());
+        }
+        return name;
+    }
 }

--- a/dev/com.ibm.ws.microprofile.graphql.1.0/src/com/ibm/ws/microprofile/graphql/internal/MPDefaultInclusionStrategy.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0/src/com/ibm/ws/microprofile/graphql/internal/MPDefaultInclusionStrategy.java
@@ -23,14 +23,11 @@ import javax.json.bind.annotation.JsonbTransient;
 
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
-import io.leangen.graphql.annotations.Context;
-import io.leangen.graphql.annotations.Info;
 import io.leangen.graphql.metadata.strategy.InclusionStrategy;
 import io.leangen.graphql.util.ClassUtils;
 import io.leangen.graphql.util.Utils;
 
 import org.eclipse.microprofile.graphql.Ignore;
-import org.eclipse.microprofile.graphql.Source;
 
 public class MPDefaultInclusionStrategy implements InclusionStrategy {
 
@@ -51,10 +48,7 @@ public class MPDefaultInclusionStrategy implements InclusionStrategy {
 
     @Override
     public boolean includeArgument(Parameter parameter, AnnotatedType type) {
-        return !ClassUtils.hasAnnotation(parameter, Ignore.class)
-                && !parameter.isAnnotationPresent(Source.class)
-                && !parameter.isAnnotationPresent(Context.class)
-                && !parameter.isAnnotationPresent(Info.class);
+        return !ClassUtils.hasAnnotation(parameter, Ignore.class);
     }
 
     @Override

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/basicMutationApp/src/mpGraphQL10/basicMutation/BasicMutationTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/basicMutationApp/src/mpGraphQL10/basicMutation/BasicMutationTestServlet.java
@@ -11,6 +11,7 @@
 package mpGraphQL10.basicMutation;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -73,6 +74,8 @@ public class BasicMutationTestServlet extends FATServlet {
         assertTrue(schema.contains("Create a new widget for sale."));
         assertTrue(schema.contains("WidgetInput"));
         assertTrue(schema.contains("A for-sale item."));
+        assertTrue(schema.contains("quantityOnAllWidgets"));
+        assertFalse(schema.contains("setQuantityOnAllWidgets"));
     }
 
     @Test

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/basicMutationApp/src/mpGraphQL10/basicMutation/BasicMutationTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/basicMutationApp/src/mpGraphQL10/basicMutation/BasicMutationTestServlet.java
@@ -74,7 +74,7 @@ public class BasicMutationTestServlet extends FATServlet {
         assertTrue(schema.contains("Create a new widget for sale."));
         assertTrue(schema.contains("WidgetInput"));
         assertTrue(schema.contains("A for-sale item."));
-        assertTrue(schema.contains("quantityOnAllWidgets"));
+        assertTrue(schema.contains("quantityOnAllWidgets(arg0: Int!): [Widget]"));
         assertFalse(schema.contains("setQuantityOnAllWidgets"));
     }
 

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/basicMutationApp/src/mpGraphQL10/basicMutation/GraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/basicMutationApp/src/mpGraphQL10/basicMutation/GraphQLEndpoint.java
@@ -49,4 +49,12 @@ public class GraphQLEndpoint {
         allWidgets.add(newWidget);
         return newWidget;
     }
+
+    @Mutation
+    public List<Widget> setQuantityOnAllWidgets(@Name("qty") int newQuantity) {
+        for (Widget w : allWidgets) {
+            w.setQuantity(newQuantity);
+        }
+        return allWidgets;
+    }
 }

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/basicMutationApp/src/mpGraphQL10/basicMutation/GraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/basicMutationApp/src/mpGraphQL10/basicMutation/GraphQLEndpoint.java
@@ -51,7 +51,7 @@ public class GraphQLEndpoint {
     }
 
     @Mutation
-    public List<Widget> setQuantityOnAllWidgets(@Name("qty") int newQuantity) {
+    public List<Widget> setQuantityOnAllWidgets(int newQuantity) {
         for (Widget w : allWidgets) {
             w.setQuantity(newQuantity);
         }


### PR DESCRIPTION
Converts mutation with no specified names (other than the Java method name) to be the "property name" - this means that code like:
```
@Mutation
public SomeObject setSomeValueOnObject(SomeValue value) { //...
```

would have the name of "someValueOnObject" in the GraphQL schema file.  This behavior is ignored if the user specifies a name in the `@Mutation` annotation or adds a non-empty `@Name("someName")` annotation, etc.