### PR TITLE
Removed unnecessary derby call

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/PersistentExecutorTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/PersistentExecutorTest.java
@@ -72,10 +72,6 @@ public class PersistentExecutorTest extends FATServletClient {
 		//Add application to server
         ShrinkHelper.defaultDropinApp(server, APP_NAME, "web");
 
-        //Create Derby DB if using derby
-        if (dbContainerType == DatabaseContainerType.Derby)
-            DerbyEmbeddedUtilities.createDB(server, "TaskStoreDS", "userx", "passx");
-
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/PersistentExecutorWithFailoverEnabledTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/PersistentExecutorWithFailoverEnabledTest.java
@@ -83,10 +83,6 @@ public class PersistentExecutorWithFailoverEnabledTest extends FATServletClient 
 		//Add application to server
         ShrinkHelper.defaultDropinApp(server, APP_NAME, "web");
 
-        //Create Derby DB if using derby
-        if (dbContainerType == DatabaseContainerType.Derby)
-            DerbyEmbeddedUtilities.createDB(server, "TaskStoreDS", "userx", "passx");
-
         server.startServer();
     }
 


### PR DESCRIPTION
Removed the `DerbyEmbeddedUtilities.createDB` call.  This is unnecessary since we are setting the `createDatabase="create"` property on the datasource in server.xml.