### PR TITLE
test where transaction blocks after cancelling task

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent/bnd.bnd
@@ -52,6 +52,7 @@ instrument.classesExcludes: com/ibm/ws/concurrent/persistent/resources/*.class
 -buildpath: \
 	com.ibm.websphere.appserver.spi.logging,\
 	com.ibm.websphere.appserver.spi.kernel.service,\
+	com.ibm.websphere.appserver.thirdparty.eclipselink,\
 	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
 	com.ibm.websphere.javaee.persistence.2.1;version=latest,\
 	com.ibm.ws.app.manager;version=latest,\

--- a/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/PersistentExecutorWithFailoverEnabledTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/PersistentExecutorWithFailoverEnabledTest.java
@@ -119,6 +119,16 @@ public class PersistentExecutorWithFailoverEnabledTest extends FATServletClient 
     }
 
     @Test
+    public void testBlockAfterRemoveFE() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testBlockAfterScheduleFE() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
     public void testCancelRunningTaskFE() throws Exception {
         runTest(server, APP_NAME, testName);
     }

--- a/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/PersistentExecutorWithFailoverEnabledTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/PersistentExecutorWithFailoverEnabledTest.java
@@ -114,6 +114,11 @@ public class PersistentExecutorWithFailoverEnabledTest extends FATServletClient 
     }
 
     @Test
+    public void testBlockAfterCancelFE() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
     public void testCancelRunningTaskFE() throws Exception {
         runTest(server, APP_NAME, testName);
     }

--- a/dev/com.ibm.ws.concurrent.persistent_fat/test-applications/schedtest/src/web/SchedulerFATServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/test-applications/schedtest/src/web/SchedulerFATServlet.java
@@ -458,18 +458,21 @@ public class SchedulerFATServlet extends HttpServlet {
             if (!foundIds.containsAll(expected))
                 throw new Exception("On the second query, should have found at least task ids " + expected + " within " + foundIds);
 
-            if (true)
-                return; // TODO determine if the following can be enabled and whether there are locking issues for these paths
-
             // It should be possible to cancel other tasks.
-            int numCancelled = scheduler.cancel("DBIncrementTask-testBlockAfterCancelFE-C", null, TaskState.SCHEDULED, true);
-            if (numCancelled != 1)
-                throw new Exception("Unable to cancel 1 task while other task is locked. Instead: " + numCancelled);
+            // Attempting to run two multi-cancel operations at once causes locking issues
+            // which may be a good reason to avoid externalizing multi-cancel,
+            // scheduler.cancel("DBIncrementTask-testBlockAfterCancelFE-C", null, TaskState.SCHEDULED, true);
+            // Instead, cancel the task by its primary key:
+            if (!statusC.cancel(false))
+                throw new Exception("Unable to cancel task " + statusC.getTaskId() + " while other task is locked.");
 
             // It should be possible to remove other tasks.
-            int numRemoved = scheduler.remove("DBIncrementTask-testBlockAfterCancelFE-B", null, TaskState.ANY, true);
-            if (numRemoved != 1)
-                throw new Exception("Unable to remove 1 task while other task is locked. Instead: " + numRemoved);
+            // Attempting to run multi-cancel and multi-remove operations at the same time causes locking issues
+            // which may be a good reason to avoid externalizing multi-remove,
+            // scheduler.remove("DBIncrementTask-testBlockAfterCancelFE-B", null, TaskState.ANY, true);
+            // Instead, remove the task by its primary key:
+            if (!scheduler.remove(statusB.getTaskId()))
+                throw new Exception("Unable to remove task " + statusB.getTaskId() + " while other task is locked.");
 
             // let the transaction complete
             blocker.arrive();
@@ -478,6 +481,196 @@ public class SchedulerFATServlet extends HttpServlet {
             if (!cancelAndBlockFuture.isDone()) {
                 blocker.arrive();
                 cancelAndBlockFuture.cancel(true);
+            }
+        }
+    }
+
+    /**
+     * Remove a task and block for a while without committing to determine if this interferes with other operations.
+     */
+    public void testBlockAfterRemoveFE(PrintWriter out) throws Exception {
+        final TaskStatus<Integer> statusE = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterRemoveFE-E"), 49, TimeUnit.DAYS);
+
+        // Block a transaction that performs a remove.
+        final Phaser blocker = new Phaser(1);
+        Future<Integer> removeAndBlockFuture = unmanagedExecutor.submit(new Callable<Integer>() {
+            public Integer call() throws Exception {
+                tran.begin();
+                try {
+                    System.out.println("About to remove " + statusE);
+                    int numRemoved = scheduler.remove("DBIncrementTask-testBlockAfterRemoveFE-E", null, TaskState.SCHEDULED, true);
+                    blocker.arrive();
+                    System.out.println("Blocking transaction...");
+                    blocker.awaitAdvanceInterruptibly(1, TIMEOUT_NS * 2, TimeUnit.NANOSECONDS);
+                    return numRemoved;
+                } finally {
+                    tran.rollback();
+                }
+            }
+        });
+
+        try {
+            if (blocker.awaitAdvanceInterruptibly(0, TIMEOUT_NS, TimeUnit.NANOSECONDS) < 1)
+                throw new Exception("Unable to reach point where transaction is blocked " + removeAndBlockFuture);
+
+            // The TASK entry is now locked with a pending removal
+
+            // It should be possible to schedule more tasks
+            TaskStatus<Integer> statusF = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterRemoveFE-F"), 50, TimeUnit.DAYS);
+            TaskStatus<Integer> statusG = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterRemoveFE-G"), 51, TimeUnit.DAYS);
+
+            // It should be possible to run new tasks
+            DBIncrementTask taskH = new DBIncrementTask("testBlockAfterRemoveFE-H");
+            taskH.getExecutionProperties().put(AutoPurge.PROPERTY_NAME, AutoPurge.NEVER.name());
+            TaskStatus<Integer> statusH = scheduler.submit((Callable<Integer>) taskH);
+            for (long begin = System.nanoTime();
+                    !statusH.hasResult() && System.nanoTime() - begin < TIMEOUT_NS;
+                    statusH = scheduler.getStatus(statusH.getTaskId()))
+                Thread.sleep(POLL_INTERVAL);
+            if (!statusH.hasResult())
+                throw new Exception("Unable to run task " + statusH + " while another task " + statusE.getTaskId() + " is blocked.");
+
+            // It should be possible to find existing tasks that are eligible to be claimed.
+            // For testing purposes, directly force this code path rather than waiting for persistent executor to eventually run it
+            Field taskStore = scheduler.getClass().getDeclaredField("taskStore");
+            taskStore.setAccessible(true);
+            Object dbTaskStore = taskStore.get(scheduler);
+            long maxNextExecTime = TimeUnit.DAYS.toMillis(55) + System.currentTimeMillis();
+            Method DatabaseTaskStore_findUnclaimedTasks = dbTaskStore.getClass().getMethod("findUnclaimedTasks", long.class, Integer.class);
+
+            @SuppressWarnings("unchecked")
+            List<Object[]> found = (List<Object[]>) DatabaseTaskStore_findUnclaimedTasks.invoke(dbTaskStore, maxNextExecTime, null);
+            LinkedHashSet<Long> foundIds = new LinkedHashSet<Long>();
+            for (Object[] entry : found)
+                foundIds.add((Long) entry[0]);
+            LinkedHashSet<Long> expected = new LinkedHashSet<Long>();
+            expected.add(statusF.getTaskId());
+            expected.add(statusG.getTaskId());
+            if (foundIds.size() < found.size())
+                throw new Exception("Duplicate task entries might have been returned. " + foundIds + " vs " + found);
+            if (!foundIds.containsAll(expected))
+                throw new Exception("Should have found at least task ids " + expected + " within " + foundIds);
+
+            // Another variant of the above
+            @SuppressWarnings("unchecked")
+            List<Object[]> foundAgain = (List<Object[]>) DatabaseTaskStore_findUnclaimedTasks.invoke(dbTaskStore, maxNextExecTime, 10);
+            foundIds = new LinkedHashSet<Long>();
+            for (Object[] entry : foundAgain)
+                foundIds.add((Long) entry[0]);
+            if (foundIds.size() < found.size())
+                throw new Exception("On the second query, duplicate task entries might have been returned. " + foundIds + " vs " + foundAgain);
+            if (!foundIds.containsAll(expected))
+                throw new Exception("On the second query, should have found at least task ids " + expected + " within " + foundIds);
+
+            // It should be possible to remove other tasks.
+            if (!scheduler.remove(statusF.getTaskId()))
+                throw new Exception("Unable to remove task " + statusF.getTaskId() + " while other task is locked.");
+
+            // It should be possible to cancel other tasks.
+            if (!statusG.cancel(false))
+                throw new Exception("Unable to cancel task " + statusG.getTaskId() + " while other task is locked.");
+
+            // let the transaction complete
+            blocker.arrive();
+            removeAndBlockFuture.get();
+        } finally {
+            if (!removeAndBlockFuture.isDone()) {
+                blocker.arrive();
+                removeAndBlockFuture.cancel(true);
+            }
+        }
+    }
+
+    /**
+     * Schedule a task and block for a while without committing to determine if this interferes with other operations.
+     */
+    public void testBlockAfterScheduleFE(PrintWriter out) throws Exception {
+        // Block a transaction that performs a cancel.
+        final Phaser blocker = new Phaser(1);
+        Future<TaskStatus<Integer>> scheduleAndBlockFuture = unmanagedExecutor.submit(new Callable<TaskStatus<Integer>>() {
+            public TaskStatus<Integer> call() throws Exception {
+                tran.begin();
+                try {
+                    System.out.println("About to schedule");
+                    TaskStatus<Integer> statusI = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterScheduleFE-I"), 52, TimeUnit.DAYS);
+                    blocker.arrive();
+                    System.out.println("Blocking transaction...");
+                    blocker.awaitAdvanceInterruptibly(1, TIMEOUT_NS * 2, TimeUnit.NANOSECONDS);
+                    return statusI;
+                } finally {
+                    tran.rollback();
+                }
+            }
+        });
+
+        try {
+            if (blocker.awaitAdvanceInterruptibly(0, TIMEOUT_NS, TimeUnit.NANOSECONDS) < 1)
+                throw new Exception("Unable to reach point where transaction is blocked " + scheduleAndBlockFuture);
+
+            // The TASK entry is now locked with a pending schedule
+
+            // It should be possible to schedule more tasks
+            TaskStatus<Integer> statusJ = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterScheduleFE-J"), 53, TimeUnit.DAYS);
+            TaskStatus<Integer> statusK = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterScheduleFE-K"), 54, TimeUnit.DAYS);
+
+            // It should be possible to run new tasks
+            DBIncrementTask taskL = new DBIncrementTask("testBlockAfterScheduleFE-L");
+            taskL.getExecutionProperties().put(AutoPurge.PROPERTY_NAME, AutoPurge.NEVER.name());
+            TaskStatus<Integer> statusL = scheduler.submit((Callable<Integer>) taskL);
+            for (long begin = System.nanoTime();
+                    !statusL.hasResult() && System.nanoTime() - begin < TIMEOUT_NS;
+                    statusL = scheduler.getStatus(statusL.getTaskId()))
+                Thread.sleep(POLL_INTERVAL);
+            if (!statusL.hasResult())
+                throw new Exception("Unable to run task " + statusL + " while schedule of another task is blocked.");
+
+            // It should be possible to find existing tasks that are eligible to be claimed.
+            // For testing purposes, directly force this code path rather than waiting for persistent executor to eventually run it
+            Field taskStore = scheduler.getClass().getDeclaredField("taskStore");
+            taskStore.setAccessible(true);
+            Object dbTaskStore = taskStore.get(scheduler);
+            long maxNextExecTime = TimeUnit.DAYS.toMillis(60) + System.currentTimeMillis();
+            Method DatabaseTaskStore_findUnclaimedTasks = dbTaskStore.getClass().getMethod("findUnclaimedTasks", long.class, Integer.class);
+
+            @SuppressWarnings("unchecked")
+            List<Object[]> found = (List<Object[]>) DatabaseTaskStore_findUnclaimedTasks.invoke(dbTaskStore, maxNextExecTime, null);
+            LinkedHashSet<Long> foundIds = new LinkedHashSet<Long>();
+            for (Object[] entry : found)
+                foundIds.add((Long) entry[0]);
+            LinkedHashSet<Long> expected = new LinkedHashSet<Long>();
+            expected.add(statusJ.getTaskId());
+            expected.add(statusK.getTaskId());
+            if (foundIds.size() < found.size())
+                throw new Exception("Duplicate task entries might have been returned. " + foundIds + " vs " + found);
+            if (!foundIds.containsAll(expected))
+                throw new Exception("Should have found at least task ids " + expected + " within " + foundIds);
+
+            // Another variant of the above
+            @SuppressWarnings("unchecked")
+            List<Object[]> foundAgain = (List<Object[]>) DatabaseTaskStore_findUnclaimedTasks.invoke(dbTaskStore, maxNextExecTime, 10);
+            foundIds = new LinkedHashSet<Long>();
+            for (Object[] entry : foundAgain)
+                foundIds.add((Long) entry[0]);
+            if (foundIds.size() < found.size())
+                throw new Exception("On the second query, duplicate task entries might have been returned. " + foundIds + " vs " + foundAgain);
+            if (!foundIds.containsAll(expected))
+                throw new Exception("On the second query, should have found at least task ids " + expected + " within " + foundIds);
+
+            // It should be possible to cancel other tasks.
+            if (!statusK.cancel(false))
+                throw new Exception("Unable to cancel task " + statusK.getTaskId() + " while other task is locked.");
+
+            // It should be possible to remove other tasks.
+            if (!scheduler.remove(statusJ.getTaskId()))
+                throw new Exception("Unable to remove task " + statusJ.getTaskId() + " while other task is locked.");
+
+            // let the transaction complete
+            blocker.arrive();
+            scheduleAndBlockFuture.get();
+        } finally {
+            if (!scheduleAndBlockFuture.isDone()) {
+                blocker.arrive();
+                scheduleAndBlockFuture.cancel(true);
             }
         }
     }

--- a/dev/com.ibm.ws.concurrent.persistent_fat/test-applications/schedtest/src/web/SchedulerFATServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/test-applications/schedtest/src/web/SchedulerFATServlet.java
@@ -16,7 +16,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -27,6 +29,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +40,7 @@ import java.util.concurrent.Delayed;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.Phaser;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -374,6 +378,107 @@ public class SchedulerFATServlet extends HttpServlet {
         } finally {
             SharedRollbackTask.execProps.clear();
             SharedRollbackTask.rollBackOn.clear();
+        }
+    }
+
+    /**
+     * Cancel a task and block for a while without committing to determine if this interferes with other operations.
+     */
+    public void testBlockAfterCancelFE(PrintWriter out) throws Exception {
+        final TaskStatus<Integer> statusA = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterCancelFE-A"), 46, TimeUnit.DAYS);
+
+        // Block a transaction that performs a cancel.
+        final Phaser blocker = new Phaser(1);
+        Future<Integer> cancelAndBlockFuture = unmanagedExecutor.submit(new Callable<Integer>() {
+            public Integer call() throws Exception {
+                tran.begin();
+                try {
+                    System.out.println("About to cancel " + statusA);
+                    int numCancelled = scheduler.cancel("DBIncrementTask-testBlockAfterCancelFE-A", null, TaskState.SCHEDULED, true);
+                    blocker.arrive();
+                    System.out.println("Blocking transaction...");
+                    blocker.awaitAdvanceInterruptibly(1, TIMEOUT_NS * 2, TimeUnit.NANOSECONDS);
+                    return numCancelled;
+                } finally {
+                    tran.rollback();
+                }
+            }
+        });
+
+        try {
+            if (blocker.awaitAdvanceInterruptibly(0, TIMEOUT_NS, TimeUnit.NANOSECONDS) < 1)
+                throw new Exception("Unable to reach point where transaction is blocked " + cancelAndBlockFuture);
+
+            // The TASK entry is now locked with a pending cancel
+
+            // It should be possible to schedule more tasks
+            TaskStatus<Integer> statusB = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterCancelFE-B"), 47, TimeUnit.DAYS);
+            TaskStatus<Integer> statusC = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterCancelFE-C"), 48, TimeUnit.DAYS);
+
+            // It should be possible to run new tasks
+            DBIncrementTask taskD = new DBIncrementTask("testBlockAfterCancelFE-D");
+            taskD.getExecutionProperties().put(AutoPurge.PROPERTY_NAME, AutoPurge.NEVER.name());
+            TaskStatus<Integer> statusD = scheduler.submit((Callable<Integer>) taskD);
+            for (long begin = System.nanoTime();
+                    !statusD.hasResult() && System.nanoTime() - begin < TIMEOUT_NS;
+                    statusD = scheduler.getStatus(statusD.getTaskId()))
+                Thread.sleep(POLL_INTERVAL);
+            if (!statusD.hasResult())
+                throw new Exception("Unable to run task " + statusD + " while another task " + statusA.getTaskId() + " is blocked.");
+
+            // It should be possible to find existing tasks that are eligible to be claimed.
+            Field taskStore = scheduler.getClass().getDeclaredField("taskStore");
+            taskStore.setAccessible(true);
+            Object dbTaskStore = taskStore.get(scheduler);
+            long maxNextExecTime = TimeUnit.DAYS.toMillis(50) + System.currentTimeMillis();
+            Method DatabaseTaskStore_findUnclaimedTasks = dbTaskStore.getClass().getMethod("findUnclaimedTasks", long.class, Integer.class);
+
+            if (true) // TODO enable more of this test when locking is improved
+                return;
+
+            @SuppressWarnings("unchecked")
+            List<Object[]> found = (List<Object[]>) DatabaseTaskStore_findUnclaimedTasks.invoke(dbTaskStore, maxNextExecTime, null);
+            LinkedHashSet<Long> foundIds = new LinkedHashSet<Long>();
+            for (Object[] entry : found)
+                foundIds.add((Long) entry[0]);
+            LinkedHashSet<Long> expected = new LinkedHashSet<Long>();
+            expected.add(statusA.getTaskId());
+            expected.add(statusB.getTaskId());
+            expected.add(statusC.getTaskId());
+            if (foundIds.size() < found.size())
+                throw new Exception("Duplicate task entries might have been returned. " + foundIds + " vs " + found);
+            if (!foundIds.containsAll(expected))
+                throw new Exception("Should have found at least task ids " + expected + " within " + foundIds);
+
+            // Another variant of the above
+            @SuppressWarnings("unchecked")
+            List<Object[]> foundAgain = (List<Object[]>) DatabaseTaskStore_findUnclaimedTasks.invoke(dbTaskStore, maxNextExecTime, 10);
+            foundIds = new LinkedHashSet<Long>();
+            for (Object[] entry : foundAgain)
+                foundIds.add((Long) entry[0]);
+            if (foundIds.size() < found.size())
+                throw new Exception("On the second query, duplicate task entries might have been returned. " + foundIds + " vs " + foundAgain);
+            if (!foundIds.containsAll(expected))
+                throw new Exception("On the second query, should have found at least task ids " + expected + " within " + foundIds);
+
+            // It should be possible to cancel other tasks.
+            int numCancelled = scheduler.cancel("DBIncrementTask-testBlockAfterCancelFE-C", null, TaskState.SCHEDULED, true);
+            if (numCancelled != 1)
+                throw new Exception("Unable to cancel 1 task while other task is locked. Instead: " + numCancelled);
+
+            // It should be possible to remove other tasks.
+            int numRemoved = scheduler.remove("DBIncrementTask-testBlockAfterCancelFE-B", null, TaskState.ANY, true);
+            if (numRemoved != 1)
+                throw new Exception("Unable to remove 1 task while other task is locked. Instead: " + numRemoved);
+
+            // let the transaction complete
+            blocker.arrive();
+            cancelAndBlockFuture.get();
+        } finally {
+            if (!cancelAndBlockFuture.isDone()) {
+                blocker.arrive();
+                cancelAndBlockFuture.cancel(true);
+            }
         }
     }
 

--- a/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/DatabaseStoreImpl.java
+++ b/dev/com.ibm.ws.persistence/src/com/ibm/wsspi/persistence/internal/DatabaseStoreImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2016 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -296,7 +296,11 @@ public class DatabaseStoreImpl implements DatabaseStore {
             }
 
             if ((Boolean) properties.get("createTables"))
-                createTables(persistenceServiceUnit);
+                if (entitySet.equals(SpecialEntitySet.PERSISTENT_EXECUTOR) && entityClassNames.length == 1)
+                    ; // ignore table creation for extra PersistenceServiceUnit that persistent executor creates to allow TRANSACTION_READ_UNCOMMITTED
+                      // TODO is there a better way to accomplish this?
+                else
+                    createTables(persistenceServiceUnit);
 
             if (deactivated) {
                 if (trace && tc.isEntryEnabled())


### PR DESCRIPTION
Write a test of the scenario where a user cancels a task within a transaction but doesn't commit right away, so that the task entry remains locked.  It turns out this blocks a number of other operations (even those for different tasks).  For now, I'm delivering the test case with portions commented out where we would like to see what improvements can be made, such that more the test can be enabled.