### PR TITLE
Mark start time when session is created instead of when first read.

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTimeoutTest.java
@@ -152,11 +152,12 @@ public class SessionCacheTimeoutTest extends FATServletClient {
         for (int attempt = 0; attempt < 5; attempt++) {
             // Initialize a session attribute
             List<String> session = newSession();
+            long start = 0, prevStart = 0;
+            start = System.nanoTime();
             app.sessionPut("testRefreshInvalidation-foo", "bar", session, true);
 
             // Read the session attribute every 3 seconds, looping several times.  Reading the session attribute will
             // prevent the session from becoming invalid after 5 seconds because it refreshes the timer on each access.
-            long start = 0, prevStart = 0;
             try {
                 for (int i = 0; i < refreshes; i++) {
                     prevStart = start;

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTimeoutTest.java
@@ -160,10 +160,10 @@ public class SessionCacheTimeoutTest extends FATServletClient {
             // prevent the session from becoming invalid after 5 seconds because it refreshes the timer on each access.
             try {
                 for (int i = 0; i < refreshes; i++) {
-                    prevStart = start;
-                    start = System.nanoTime();
                     TimeUnit.SECONDS.sleep(3);
                     app.sessionGet("testRefreshInvalidation-foo", "bar", session);
+                    prevStart = start;
+                    start = System.nanoTime();
                 }
                 return; // test successful
             } catch (AssertionError e) {

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTimeoutTest.java
@@ -147,7 +147,7 @@ public class SessionCacheTimeoutTest extends FATServletClient {
      */
     @Test
     public void testRefreshInvalidation() throws Exception {
-        int refreshes = TestModeFilter.FRAMEWORK_TEST_MODE == TestMode.FULL ? 15 : 3;
+        int refreshes = TestModeFilter.FRAMEWORK_TEST_MODE == TestMode.FULL ? 45 : 9;
 
         for (int attempt = 0; attempt < 5; attempt++) {
             // Initialize a session attribute
@@ -156,11 +156,11 @@ public class SessionCacheTimeoutTest extends FATServletClient {
             start = System.nanoTime();
             app.sessionPut("testRefreshInvalidation-foo", "bar", session, true);
 
-            // Read the session attribute every 3 seconds, looping several times.  Reading the session attribute will
+            // Read the session attribute every 1 second, looping several times.  Reading the session attribute will
             // prevent the session from becoming invalid after 5 seconds because it refreshes the timer on each access.
             try {
                 for (int i = 0; i < refreshes; i++) {
-                    TimeUnit.SECONDS.sleep(3);
+                    TimeUnit.SECONDS.sleep(1);
                     app.sessionGet("testRefreshInvalidation-foo", "bar", session);
                     prevStart = start;
                     start = System.nanoTime();

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/SessionCacheTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/SessionCacheTimeoutTest.java
@@ -161,10 +161,10 @@ public class SessionCacheTimeoutTest extends FATServletClient {
             // prevent the session from becoming invalid after 5 seconds because it refreshes the timer on each access.
             try {
                 for (int i = 0; i < refreshes; i++) {
-                    prevStart = start;
-                    start = System.nanoTime();
                     TimeUnit.SECONDS.sleep(3);
                     app.sessionGet("testRefreshInvalidation-foo", "bar", session);
+                    prevStart = start;
+                    start = System.nanoTime();
                 }
                 return; // test successful
             } catch (AssertionError e) {

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/SessionCacheTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/SessionCacheTimeoutTest.java
@@ -148,7 +148,7 @@ public class SessionCacheTimeoutTest extends FATServletClient {
      */
     @Test
     public void testRefreshInvalidation() throws Exception {
-        int refreshes = TestModeFilter.FRAMEWORK_TEST_MODE == TestMode.FULL ? 15 : 3;
+        int refreshes = TestModeFilter.FRAMEWORK_TEST_MODE == TestMode.FULL ? 45 : 9;
 
         for (int attempt = 0; attempt < 5; attempt++) {
             // Initialize a session attribute
@@ -157,11 +157,11 @@ public class SessionCacheTimeoutTest extends FATServletClient {
             start = System.nanoTime();
             app.sessionPut("testRefreshInvalidation-foo", "bar", session, true);
 
-            // Read the session attribute every 3 seconds, looping several times.  Reading the session attribute will
+            // Read the session attribute every 1 second, looping several times.  Reading the session attribute will
             // prevent the session from becoming invalid after 5 seconds because it refreshes the timer on each access.
             try {
                 for (int i = 0; i < refreshes; i++) {
-                    TimeUnit.SECONDS.sleep(3);
+                    TimeUnit.SECONDS.sleep(1);
                     app.sessionGet("testRefreshInvalidation-foo", "bar", session);
                     prevStart = start;
                     start = System.nanoTime();

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/SessionCacheTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/SessionCacheTimeoutTest.java
@@ -153,11 +153,12 @@ public class SessionCacheTimeoutTest extends FATServletClient {
         for (int attempt = 0; attempt < 5; attempt++) {
             // Initialize a session attribute
             List<String> session = newSession();
+            long start = 0, prevStart = 0;
+            start = System.nanoTime();
             app.sessionPut("testRefreshInvalidation-foo", "bar", session, true);
 
             // Read the session attribute every 3 seconds, looping several times.  Reading the session attribute will
             // prevent the session from becoming invalid after 5 seconds because it refreshes the timer on each access.
-            long start = 0, prevStart = 0;
             try {
                 for (int i = 0; i < refreshes; i++) {
                     prevStart = start;


### PR DESCRIPTION
The test logic for handling slow systems was incorrect when marking what time a session was started.  The test was making the start time when the session was being read for the first time instead of when the session was originally created.