### PR TITLE
Get things building in eclipse again

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.3.security/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.2.3.security/bnd.bnd
@@ -18,6 +18,8 @@ Bundle-Description: JAX-WS Transport Level and Endpoints Security
 javac.source: 1.8
 javac.target: 1.8
 
+Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=1.8))"   
+
 Import-Package: \
    com.ibm.ws.jaxws23.webcontainer, \
    com.ibm.ws.jaxws.metadata.builder, \

--- a/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/.classpath
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/.classpath
@@ -2,5 +2,6 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/.project
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/.project
@@ -10,8 +10,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
 	</natures>
 </projectDescription>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/.classpath
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/.classpath
@@ -2,5 +2,6 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/.project
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/.project
@@ -10,8 +10,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
 	</natures>
 </projectDescription>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/.classpath
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/.project
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/.project
@@ -10,8 +10,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
 	</natures>
 </projectDescription>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.microprofile.opentracing_fat_tck/.classpath
+++ b/dev/com.ibm.ws.microprofile.opentracing_fat_tck/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry exported="true" kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.microprofile.opentracing_fat_tck/.project
+++ b/dev/com.ibm.ws.microprofile.opentracing_fat_tck/.project
@@ -10,8 +10,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
 	</natures>
 </projectDescription>

--- a/dev/com.ibm.ws.microprofile.opentracing_fat_tck/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.microprofile.opentracing_fat_tck/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.opentracing.1.x_fat/.classpath
+++ b/dev/com.ibm.ws.opentracing.1.x_fat/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="src" path="test-applications/mpOpenTracing/src"/>
 	<classpathentry kind="src" path="test-applications/serviceApp/src"/>
 	<classpathentry kind="src" path="test-bundles/opentracing.mock/src"/>

--- a/dev/com.ibm.ws.opentracing.1.x_fat/.project
+++ b/dev/com.ibm.ws.opentracing.1.x_fat/.project
@@ -10,8 +10,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
 	</natures>
 </projectDescription>

--- a/dev/com.ibm.ws.security.acme/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.security.acme/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,13 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8


### PR DESCRIPTION
- Update .project and .classpath files to include the bnd build and
classpath respectively for new components
- Add Require-Capability of Java 8 to jawxs.2.3.security component
- Add bndtools prefs files for new components
- Update eclipse compiler settings to be Java 8 to match the Java 8
level in the bnd file and .classpath file.