### PR TITLE
Update SQLServer Image

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/DatabaseContainerFactory.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/DatabaseContainerFactory.java
@@ -104,8 +104,7 @@ public class DatabaseContainerFactory {
 					.withLogConsumer(dbContainerType::log);
 			break;
 		case SQLServer:
-			//TODO Update this to use the PRODUCTION SQL Server 2019 container when available.  Currently using a preview version.
-			cont = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2019-CTP3.1-ubuntu")
+			cont = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2019-GA-ubuntu-16.04")
 					.withLogConsumer(dbContainerType::log);
 			break;
     	}

--- a/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/container-license-acceptance.txt
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-mcr.microsoft.com/mssql/server:2019-CTP3.1-ubuntu
+mcr.microsoft.com/mssql/server:2019-GA-ubuntu-16.04

--- a/dev/com.ibm.ws.concurrent.persistent_fat_multiple/fat/src/com/ibm/ws/concurrent/persistent/fat/multiple/DatabaseContainerFactory.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_multiple/fat/src/com/ibm/ws/concurrent/persistent/fat/multiple/DatabaseContainerFactory.java
@@ -106,8 +106,7 @@ public class DatabaseContainerFactory {
 					.withLogConsumer(dbContainerType::log);
 			break;
 		case SQLServer:
-			//TODO Update this to use the PRODUCTION SQL Server 2019 container when available.  Currently using a preview version.
-			cont = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2019-CTP3.1-ubuntu")
+			cont = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2019-GA-ubuntu-16.04")
 					.withLogConsumer(dbContainerType::log);
 			break;
     	}

--- a/dev/com.ibm.ws.concurrent.persistent_fat_multiple/fat/src/container-license-acceptance.txt
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_multiple/fat/src/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-mcr.microsoft.com/mssql/server:2019-CTP3.1-ubuntu
+mcr.microsoft.com/mssql/server:2019-GA-ubuntu-16.04

--- a/dev/com.ibm.ws.concurrent.persistent_fat_timers/fat/src/com/ibm/ws/concurrent/persistent/fat/timers/DatabaseContainerFactory.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_timers/fat/src/com/ibm/ws/concurrent/persistent/fat/timers/DatabaseContainerFactory.java
@@ -116,8 +116,7 @@ public class DatabaseContainerFactory {
 					.withLogConsumer(dbContainerType::log);
 			break;
 		case SQLServer:
-			//TODO Update this to use the PRODUCTION SQL Server 2019 container when available.  Currently using a preview version.
-			cont = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2019-CTP3.1-ubuntu")
+			cont = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2019-GA-ubuntu-16.04")
 					.withLogConsumer(dbContainerType::log);
 			break;
     	}

--- a/dev/com.ibm.ws.concurrent.persistent_fat_timers/fat/src/container-license-acceptance.txt
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_timers/fat/src/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-mcr.microsoft.com/mssql/server:2019-CTP3.1-ubuntu
+mcr.microsoft.com/mssql/server:2019-GA-ubuntu-16.04

--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/fat/src/com/ibm/ws/jdbc/fat/sqlserver/SQLServerTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/fat/src/com/ibm/ws/jdbc/fat/sqlserver/SQLServerTest.java
@@ -45,9 +45,8 @@ public class SQLServerTest extends FATServletClient {
     @TestServlet(servlet = SQLServerTestServlet.class, path = APP_NAME + '/' + SERVLET_NAME)
     public static LibertyServer server;
 
-    //TODO change this to the SQL Server 2019 official image when it is released.  Currently, using a preview image.
     @ClassRule
-    public static MSSQLServerContainer<?> sqlserver = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2019-CTP3.1-ubuntu").withLogConsumer(SQLServerTest::log);
+    public static MSSQLServerContainer<?> sqlserver = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2019-GA-ubuntu-16.04").withLogConsumer(SQLServerTest::log);
 
     //Private Method: used to setup logging for containers to this class.
     private static void log(OutputFrame frame) {

--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/fat/src/container-license-acceptance.txt
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/fat/src/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-mcr.microsoft.com/mssql/server:2019-CTP3.1-ubuntu
+mcr.microsoft.com/mssql/server:2019-GA-ubuntu-16.04


### PR DESCRIPTION
Update SQLServer image to 2019-GA and introduce use of acceptLicense() method to reduce duplication of accept-license.txt files.
