### PR TITLE
Enable databse roation testing for locking tests

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_locking/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_locking/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -11,11 +11,18 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
+javac.source: 1.8
+javac.target: 1.8
+
 src: \
 	fat/src,\
 	test-applications/pxlocktest/src
 
 fat.project: true
+fat.test.databases: true
+
+# Uncomment to use remote docker host to simulate continuous build behavior.
+# fat.test.use.remote.docker: true
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)
@@ -24,4 +31,13 @@ fat.project: true
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
 	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
 	com.ibm.ws.concurrent.persistent;version=latest,\
-	com.ibm.websphere.javaee.transaction.1.1;version=latest
+	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
+	org.testcontainers:database-commons;version=1.12.3,\
+	org.testcontainers:jdbc;version=1.12.3,\
+	org.testcontainers:testcontainers;version=1.12.3,\
+	org.testcontainers:db2;version=1.12.3,\
+	org.testcontainers:postgresql;version=1.12.3,\
+	org.testcontainers:mssqlserver;version=1.12.3,\
+	org.testcontainers:oracle-xe;version=1.12.3,\
+	org.rnorth.duct-tape:duct-tape;version=1.0.7,\
+	org.slf4j:slf4j-api;version=1.7.7

--- a/dev/com.ibm.ws.concurrent.persistent_fat_locking/build.gradle
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_locking/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,5 +9,50 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
+configurations {
+  //Transitive dependencies in Oracle Maven pom are not necessary when just using
+  //the base JDBC driver.  Excluding these dependencies will speed up test time and reduce clutter.
+  jdbcDrivers {
+    transitive = false;
+  }
+}
 
-addRequiredLibraries.dependsOn addDerby
+dependencies {
+  //Test container libraries
+  requiredLibs 'org.testcontainers:testcontainers:1.12.3',
+               'org.testcontainers:database-commons:1.12.3',
+               'org.testcontainers:jdbc:1.12.3',
+               'org.testcontainers:oracle-xe:1.12.3',
+               'org.testcontainers:mssqlserver:1.12.3',
+               'org.testcontainers:postgresql:1.12.3',
+               'org.testcontainers:db2:1.12.3',
+               'org.apache.commons:commons-compress:1.18',
+               'org.rnorth.duct-tape:duct-tape:1.0.7',
+               'org.rnorth.visible-assertions:visible-assertions:2.1.2',
+               'org.rnorth:tcp-unix-socket-proxy:1.0.2',
+               'net.java.dev.jna:jna:5.2.0',
+               'org.slf4j:slf4j-api:1.7.7',
+               'org.slf4j:slf4j-jdk14:1.7.7'
+
+  //JDBC Drivers
+  jdbcDrivers 	'com.ibm.db2:jcc:11.1.4.4',
+  				'org.postgresql:postgresql:42.2.5',
+  				'com.microsoft.sqlserver:mssql-jdbc:7.4.1.jre8',
+  				'org.apache.derby:derby:10.11.1.1',
+  				'com.oracle.ojdbc:ojdbc8_g:19.3.0.0'
+}
+
+task addJdbcDrivers(type: Copy) {
+  shouldRunAfter jar
+  from configurations.jdbcDrivers
+  into new File(autoFvtDir, 'publish/shared/resources/jdbc')
+  rename 'derby.*.jar', 'derby.jar'
+  rename 'jcc.*.jar', 'jcc.jar'
+  rename 'mssql-jdbc.*.jar', 'mssql-jdbc.jar'
+  rename 'postgresql.*.jar', 'postgresql.jar'
+  rename 'ojdbc8_g.*.jar', 'ojdbc8_g.jar'
+}
+
+addRequiredLibraries {
+	dependsOn addJdbcDrivers
+}

--- a/dev/com.ibm.ws.concurrent.persistent_fat_locking/fat/src/com/ibm/ws/concurrent/persistent/fat/locking/DatabaseContainerFactory.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_locking/fat/src/com/ibm/ws/concurrent/persistent/fat/locking/DatabaseContainerFactory.java
@@ -1,0 +1,136 @@
+package com.ibm.ws.concurrent.persistent.fat.locking;
+
+import java.io.File;
+import java.time.Duration;
+
+import org.testcontainers.containers.Db2Container;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MSSQLServerContainer;
+import org.testcontainers.containers.OracleContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.custom.junit.runner.FATRunner;
+
+/**
+ * TODO: Since this factory class is general it should be moved to fattest simplicity in the future. </br>
+ *
+ * This is a factory class that creates database test-containers.
+ * The test container returned will be based on the {fat.bucket.db.type}
+ * system property. </br>
+ *
+ * The {fat.bucket.db.type} property is set to different databases
+ * by our test infrastructure when a fat-suite is enlisted in
+ * database rotation by setting the property {fat.test.databases} to true.</br>
+ *
+ * <br> Container Information: <br>
+ * DERBY: Uses a derby no-op test container <br>
+ * DB2: Uses <a href="https://hub.docker.com/r/ibmcom/db2">Offical DB2 Container</a> <br>
+ * Oracle: TODO replace this container with the official oracle-xe container if/when it is available without a license. <br>
+ * Postgre: Uses <a href="https://hub.docker.com/_/postgres">Offical Postgres Container</a> <br>
+ * MS SQL Server: Uses <a href="https://hub.docker.com/_/microsoft-mssql-server">Offical Microsoft SQL Container</a> <br>
+ *
+ * @see DatabaseContainerType
+ */
+public class DatabaseContainerFactory {
+    private static final Class<DatabaseContainerFactory> c = DatabaseContainerFactory.class;
+
+    /**
+     * Used for <b>database rotation testing</b>.
+     *
+     * Reads the {fat.bucket.db.type} system property and
+     * returns a container based on that property.
+     * [Postgre, DB2, Oracle, SQLServer, Derby]
+     *
+     * If {fat.bucket.db.type} is not set with a value,
+     * default to Derby Embedded.
+     *
+     * @param databaseName - String passed to derby embedded container. Example: "memory:test" or "test"
+     *
+     * @return JdbcDatabaseContainer - The test container.
+     *
+     * @throws IllegalArgumentException - if database rotation {fat.test.databases} is not set or is false,
+     *                                      or database type {fat.bucket.db.type} is unsupported.
+     */
+    public static JdbcDatabaseContainer<?> create() throws IllegalArgumentException {
+        String dbRotation = System.getProperty("fat.test.databases");
+        String dbProperty = System.getProperty("fat.bucket.db.type", "Derby");
+
+        Log.info(c, "create", "System property: fat.test.databases is " + dbRotation);
+        Log.info(c, "create", "System property: fat.bucket.db.type is " + dbProperty);
+
+        if (!"true".equals(dbRotation)) {
+            throw new IllegalArgumentException("To use a generic database, the FAT must be opted into database rotation by setting 'fat.test.databases: true' in the FAT project's bnd.bnd file");
+        }
+
+        DatabaseContainerType type = null;
+        try {
+            type = DatabaseContainerType.valueOf(dbProperty);
+            Log.info(c, "create", "FOUND: database test-container type: " + type);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("No database test-container supported for " + dbProperty, e);
+        }
+
+        return initContainer(type);
+    }
+
+    //Private Method: used to initialize test container.
+    private static JdbcDatabaseContainer<?> initContainer(DatabaseContainerType dbContainerType) {
+        //Check to see if JDBC Driver is available.
+        isJdbcDriverAvailable(dbContainerType);
+
+        //Create container
+        JdbcDatabaseContainer<?> cont = null;
+
+        switch (dbContainerType) {
+            case DB2:
+                cont = new Db2Container().acceptLicense()
+                                // Use 5m timeout for local runs, 15m timeout for remote runs
+                                .withStartupTimeout(Duration.ofMinutes(FATRunner.FAT_TEST_LOCALRUN ? 5 : 15))
+                                .withLogConsumer(dbContainerType::log);
+                break;
+            case Derby:
+                cont = new DerbyNoopContainer<>()
+                                .withLogConsumer(dbContainerType::log);
+                break;
+            case Oracle:
+                //TODO replace this container with the official oracle-xe container if/when it is available without a license
+                cont = new OracleContainer("oracleinanutshell/oracle-xe-11g")
+                                .withLogConsumer(dbContainerType::log);
+                break;
+            case Postgre:
+                cont = new PostgreSQLContainer<>()
+                                .withLogConsumer(dbContainerType::log);
+                break;
+            case SQLServer:
+                cont = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2019-GA-ubuntu-16.04")
+                                .withLogConsumer(dbContainerType::log);
+                break;
+        }
+
+        return cont;
+    }
+
+    /**
+     * Check to see if the JDBC driver necessary for this test-container is in the location
+     * where the server expects to find it. <br>
+     *
+     * JDBC drivers are not publicly available for some databases. In those cases the
+     * driver will need to be provided by the user to run this test-container.
+     *
+     * @return boolean - true if and only if driver exists. Otherwise, false.
+     */
+    private static boolean isJdbcDriverAvailable(DatabaseContainerType type) {
+        File temp = new File("publish/shared/resources/jdbc/" + type.getDriverName());
+        boolean result = temp.exists();
+
+        if (result) {
+            Log.info(c, "isJdbcDriverAvailable", "FOUND: " + type + " JDBC driver in location: " + temp.getAbsolutePath());
+        } else {
+            Log.warning(c, "MISSING: " + type + " JDBC driver not in location: " + temp.getAbsolutePath());
+        }
+
+        return result;
+    }
+}

--- a/dev/com.ibm.ws.concurrent.persistent_fat_locking/fat/src/com/ibm/ws/concurrent/persistent/fat/locking/DatabaseContainerType.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_locking/fat/src/com/ibm/ws/concurrent/persistent/fat/locking/DatabaseContainerType.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.persistent.fat.locking;
+
+import org.testcontainers.containers.Db2Container;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MSSQLServerContainer;
+import org.testcontainers.containers.OracleContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.output.OutputFrame;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+/**
+ * This is a current list of database test-containers that are in the database rotation.
+ */
+@SuppressWarnings("rawtypes")
+public enum DatabaseContainerType {
+    DB2("jcc.jar", Db2Container.class),
+    Derby("derby.jar", DerbyNoopContainer.class),
+    Oracle("ojdbc8_g.jar", OracleContainer.class),
+    Postgre("postgresql.jar", PostgreSQLContainer.class),
+    SQLServer("mssql-jdbc.jar", MSSQLServerContainer.class);
+
+    private String driverName;
+    private Class<? extends JdbcDatabaseContainer> clazz;
+
+    DatabaseContainerType(final String driverName, final Class<? extends JdbcDatabaseContainer> clazz) {
+        this.driverName = driverName;
+        this.clazz = clazz;
+    }
+
+    /**
+     * Returns the common JDBC Driver name for this test-container type.
+     * Example: 'ojdbc8_g.jar'
+     *
+     * @return String - JDBC Driver Name
+     */
+    public String getDriverName() {
+        return driverName;
+    }
+
+    /**
+     * Returns test-container class associated with this test-container type.
+     *
+     * @return Java Class
+     */
+    public Class getContainerClass() {
+        return clazz;
+    }
+
+    /**
+     * Given a JDBC test-container return the corresponding Database Container Type.
+     *
+     * @param cont - A database container.
+     * @return DatabaseContainerType - type enum
+     */
+    public static DatabaseContainerType valueOf(JdbcDatabaseContainer cont) {
+        for (DatabaseContainerType elem : values())
+            if (elem.getContainerClass() == cont.getClass())
+                return elem;
+        throw new IllegalArgumentException("Unrecognized JdbcDatabaseContainer class: " + cont.getClass().getCanonicalName());
+    }
+
+    //Private Method: used to setup logging for containers to this class.
+    public void log(OutputFrame frame) {
+        String msg = frame.getUtf8String();
+        if (msg.endsWith("\n"))
+            msg = msg.substring(0, msg.length() - 1);
+        Log.info(this.clazz, "output", msg);
+    }
+}

--- a/dev/com.ibm.ws.concurrent.persistent_fat_locking/fat/src/com/ibm/ws/concurrent/persistent/fat/locking/DatabaseContainerUtil.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_locking/fat/src/com/ibm/ws/concurrent/persistent/fat/locking/DatabaseContainerUtil.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.persistent.fat.locking;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MSSQLServerContainer;
+
+import com.ibm.websphere.simplicity.config.ConfigElementList;
+import com.ibm.websphere.simplicity.config.DataSource;
+import com.ibm.websphere.simplicity.config.DatabaseStore;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.websphere.simplicity.config.dsprops.Properties;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.topology.impl.LibertyServer;
+
+public class DatabaseContainerUtil {
+    //Logging Constants
+    private static final Class<DatabaseContainerUtil> c = DatabaseContainerUtil.class;
+
+    /**
+     * Method that does any database setup necessary prior to making a connection
+     * to the database from a servlet.
+     *
+     * @param cont         - Test container being used.
+     * @param databaseName - Name to be given to database instance.
+     * @throws SQLException - Thrown if there is a failure during connection or initialization.
+     */
+    private static void initDatabase(JdbcDatabaseContainer<?> cont) throws SQLException {
+        if (cont instanceof MSSQLServerContainer) {
+            //Create database
+            try (Connection conn = cont.createConnection("")) {
+                Statement stmt = conn.createStatement();
+                stmt.execute("CREATE DATABASE [TEST];");
+                stmt.close();
+            }
+
+            //Setup distributed connections
+            try (Connection conn = cont.createConnection("")) {
+                Statement stmt = conn.createStatement();
+                stmt.execute("EXEC sp_sqljdbc_xa_install");
+                stmt.close();
+            }
+        }
+    }
+
+    /**
+     * For use when attempting to use <b>database rotation</b>. <br>
+     *
+     * Retrieves database specific properties from the provided JdbcDatabaseContainer, such as;
+     * username, password, etc. <br>
+     *
+     * Using the ServerConfiguration API. Retrieves all &lt;dataSource&gt; elements and modifies
+     * those that have the <b>fat.modify=true</b> attribute set. <br>
+     *
+     * This will replace the datasource &lt;derby.embdedded.properties... &gt; with the corresponding properties
+     * for the provided JdbcDatabaseContainer. <br>
+     *
+     * @see com.ibm.websphere.simplicity.config.ServerConfiguration
+     *
+     * @param serv - LibertyServer server instance being used for this FAT suite.
+     * @param cont - JdbcDatabaseContainer instance being used for database connectivity.
+     *
+     * @throws Exception
+     * @throws CloneNotSupportedException
+     */
+    public static void setupDataSourceProperties(LibertyServer serv, JdbcDatabaseContainer<?> cont) throws CloneNotSupportedException, Exception {
+        if (DatabaseContainerType.valueOf(cont) == DatabaseContainerType.Derby)
+            return; //Derby used by default no need to change DS properties
+
+        initDatabase(cont);
+
+        //Get current server config
+        ServerConfiguration cloneConfig = serv.getServerConfiguration().clone();
+
+        //Get DataSource configs
+        ConfigElementList<DataSource> dataSources = cloneConfig.getDataSources();
+
+        //Inspect and modify datasource properties
+        for (DataSource ds : dataSources) {
+            if (ds.getFatModify() != null && ds.getFatModify().equalsIgnoreCase("true")) {
+                modifyDataSourceProps(ds, cloneConfig, serv, cont);
+            }
+        }
+
+        //Inspect and modify datasource properties that are nested under databasestore
+        for (DatabaseStore dbs : cloneConfig.getDatabaseStores()) {
+            for (DataSource ds : dbs.getDataSources()) {
+                if (ds.getFatModify() != null && ds.getFatModify().equalsIgnoreCase("true")) {
+                    modifyDataSourceProps(ds, cloneConfig, serv, cont);
+                }
+            }
+        }
+    }
+
+    private static void modifyDataSourceProps(DataSource ds, ServerConfiguration cloneConfig, LibertyServer serv,
+                                              JdbcDatabaseContainer<?> cont) throws CloneNotSupportedException, Exception {
+        Log.info(c, "setupDataSourceProperties", "FOUND: DataSource to be enlisted in database rotation.  ID: " + ds.getId());
+
+        //Create general properties
+        Properties props = new Properties();
+        props.setUser(cont.getUsername());
+        props.setPassword(cont.getPassword());
+        props.setURL(cont.getJdbcUrl());
+
+        //TODO this should not be required even when using general datasource properties
+        // investigating here: https://github.com/OpenLiberty/open-liberty/issues/10066
+        if (DatabaseContainerType.valueOf(cont) == DatabaseContainerType.DB2) {
+            props.setExtraAttribute("driverType", "4");
+        }
+
+        //Replace derby properties
+        ds.clearDataSourceDBProperties();
+        ds.getProperties().add(props);
+
+        //Update config
+        serv.updateServerConfiguration(cloneConfig);
+
+    }
+
+}

--- a/dev/com.ibm.ws.concurrent.persistent_fat_locking/fat/src/com/ibm/ws/concurrent/persistent/fat/locking/DerbyNoopContainer.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_locking/fat/src/com/ibm/ws/concurrent/persistent/fat/locking/DerbyNoopContainer.java
@@ -1,0 +1,80 @@
+package com.ibm.ws.concurrent.persistent.fat.locking;
+
+import java.util.concurrent.Future;
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+
+/**
+ * This is a Derby no-op database test container that is returned
+ * when attempting to test against derby embedded.
+ *
+ * This test container overrides the start and stop methods
+ * to prevent the creation of a docker container.
+ *
+ */
+class DerbyNoopContainer<SELF extends DerbyNoopContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
+
+    /**
+     * @see DerbyNoopContainer
+     */
+    public DerbyNoopContainer(final Future<String> image) {
+        super(image);
+    }
+
+    /**
+     * @see DerbyNoopContainer
+     */
+    public DerbyNoopContainer() {
+        super("");
+    }
+
+    @Override
+    public String getDockerImageName() {
+        return "";
+    }
+
+    @Override
+    public void start() {
+        //DO NOTHING
+    }
+
+    @Override
+    protected void doStart() {
+        //DO NOTHING
+    }
+
+    @Override
+    public void stop() {
+        //DO NOTHING
+    }
+
+    @Override
+    public void close() {
+        //DO NOTHING
+    }
+
+    @Override
+    public String getDriverClassName() {
+        return null;
+    }
+
+    @Override
+    public String getJdbcUrl() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    protected String getTestQueryString() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+}

--- a/dev/com.ibm.ws.concurrent.persistent_fat_locking/fat/src/com/ibm/ws/concurrent/persistent/fat/locking/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_locking/fat/src/com/ibm/ws/concurrent/persistent/fat/locking/FATSuite.java
@@ -10,12 +10,14 @@
  *******************************************************************************/
 package com.ibm.ws.concurrent.persistent.fat.locking;
 
+import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
+import componenttest.topology.utils.ExternalTestServiceDockerClientStrategy;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -24,4 +26,10 @@ import componenttest.topology.impl.LibertyServerFactory;
 })
 public class FATSuite {
     static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.concurrent.persistent.fat.locking");
+
+    @BeforeClass
+    public static void beforeSuite() throws Exception {
+        //Allows local tests to switch between using a local docker client, to using a remote docker client.
+        ExternalTestServiceDockerClientStrategy.clearTestcontainersConfig();
+    }
 }

--- a/dev/com.ibm.ws.concurrent.persistent_fat_locking/fat/src/com/ibm/ws/concurrent/persistent/fat/locking/PXLockTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_locking/fat/src/com/ibm/ws/concurrent/persistent/fat/locking/PXLockTest.java
@@ -18,23 +18,19 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.Collections;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.testcontainers.containers.JdbcDatabaseContainer;
 
-import com.ibm.websphere.simplicity.Machine;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
-import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 
 /**
@@ -43,12 +39,13 @@ import componenttest.topology.impl.LibertyServer;
 public class PXLockTest {
     private static final LibertyServer server = FATSuite.server;
 
-    private static final Set<String> appNames = Collections.singleton("pxlocktest");
-
     private static final String APP_NAME = "pxlocktest";
 
     @Rule
     public TestName testName = new TestName();
+
+    @ClassRule
+    public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
 
     /**
      * Runs a test in the servlet.
@@ -99,17 +96,13 @@ public class PXLockTest {
      */
     @BeforeClass
     public static void setUp() throws Exception {
-        // Delete the Derby-only database that is used by the persistent scheduled executor
-        Machine machine = server.getMachine();
-        String installRoot = server.getInstallRoot();
-        LibertyFileManager.deleteLibertyDirectoryAndContents(machine, installRoot + "/usr/shared/resources/data/lockdb");
+        //Get driver info
+        server.addEnvVar("DB_DRIVER", DatabaseContainerType.valueOf(testContainer).getDriverName());
+        DatabaseContainerUtil.setupDataSourceProperties(server, testContainer);
 
-        WebArchive app1 = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
-                        .addPackages(true, "web");
-        // Write the WebArchive to 'publish/servers/FATServer/apps/app1.war' and print the contents
-        ShrinkHelper.exportAppToServer(server, app1);
-        for (String name : appNames)
-            server.addInstalledAppForValidation(name);
+        //Add application to server
+        ShrinkHelper.defaultApp(server, APP_NAME, "web");
+
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.concurrent.persistent_fat_locking/fat/src/com/ibm/ws/concurrent/persistent/fat/locking/PXLockTestWithFailoverEnabled.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_locking/fat/src/com/ibm/ws/concurrent/persistent/fat/locking/PXLockTestWithFailoverEnabled.java
@@ -18,25 +18,21 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.Collections;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.testcontainers.containers.JdbcDatabaseContainer;
 
-import com.ibm.websphere.simplicity.Machine;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.PersistentExecutor;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.websphere.simplicity.log.Log;
 
-import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 
 /**
@@ -44,15 +40,15 @@ import componenttest.topology.impl.LibertyServer;
  */
 public class PXLockTestWithFailoverEnabled {
     private static final LibertyServer server = FATSuite.server;
-
-    private static final Set<String> appNames = Collections.singleton("pxlocktest");
+    private static ServerConfiguration originalConfig;
 
     private static final String APP_NAME = "pxlocktest";
 
-    private static ServerConfiguration originalConfig;
-
     @Rule
     public TestName testName = new TestName();
+
+    @ClassRule
+    public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
 
     /**
      * Runs a test in the servlet.
@@ -101,23 +97,20 @@ public class PXLockTestWithFailoverEnabled {
      */
     @BeforeClass
     public static void setUp() throws Exception {
-        // Delete the Derby-only database that is used by the persistent scheduled executor
-        Machine machine = server.getMachine();
-        String installRoot = server.getInstallRoot();
-        LibertyFileManager.deleteLibertyDirectoryAndContents(machine, installRoot + "/usr/shared/resources/data/lockdb");
-
+        //Configure PersistantExecutor with failover threshold
         originalConfig = server.getServerConfiguration();
         ServerConfiguration config = originalConfig.clone();
         PersistentExecutor myPersistentExecutor = config.getPersistentExecutors().getBy("jndiName", "concurrent/myPersistentExecutor");
         myPersistentExecutor.setExtraAttribute("missedTaskThreshold2", "10s"); // TODO rename
         server.updateServerConfiguration(config);
 
-        WebArchive app1 = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
-                        .addPackages(true, "web");
-        // Write the WebArchive to 'publish/servers/FATServer/apps/app1.war' and print the contents
-        ShrinkHelper.exportAppToServer(server, app1);
-        for (String name : appNames)
-            server.addInstalledAppForValidation(name);
+        //Get driver info
+        server.addEnvVar("DB_DRIVER", DatabaseContainerType.valueOf(testContainer).getDriverName());
+        DatabaseContainerUtil.setupDataSourceProperties(server, testContainer);
+
+        //Add application to server
+        ShrinkHelper.defaultApp(server, APP_NAME, "web");
+
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.concurrent.persistent_fat_locking/fat/src/container-license-acceptance.txt
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_locking/fat/src/container-license-acceptance.txt
@@ -1,0 +1,1 @@
+mcr.microsoft.com/mssql/server:2019-GA-ubuntu-16.04

--- a/dev/com.ibm.ws.concurrent.persistent_fat_locking/publish/servers/com.ibm.ws.concurrent.persistent.fat.locking/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_locking/publish/servers/com.ibm.ws.concurrent.persistent.fat.locking/server.xml
@@ -33,6 +33,12 @@
   
   <javaPermission codebase="${shared.resource.dir}/jdbc/${env.DB_DRIVER}" className="java.security.AllPermission"/>
 
+  <!-- Oracle and SQLServer JDBC drivers get Java 2 security errors when creating a connection. -->
+  <javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve" />
+
+  <!-- Oracle JDBC driver get Java 2 security errors when creating prepared statements, or accessing metadata -->
+  <javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers" />
+
   <variable name="onError" value="FAIL"/>
 
   <application location="pxlocktest.war" />

--- a/dev/com.ibm.ws.concurrent.persistent_fat_locking/publish/servers/com.ibm.ws.concurrent.persistent.fat.locking/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_locking/publish/servers/com.ibm.ws.concurrent.persistent.fat.locking/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -21,18 +21,17 @@
   <databaseStore id="DBTaskStore" dataSourceRef="LockTestDB"/>
 
   <!-- database for scheduled tasks -->
-  <dataSource id="LockTestDB">
-    <jdbcDriver libraryRef="DerbyLib"/>
-    <!-- The following configures in-memory Derby.  For Derby on disk, which is needed if the database
-    is required beyond a single server start, configure the databaseName with a file location such as:
-    databaseName="${shared.config.dir}/data/derbydb" -->
-    <properties.derby.embedded createDatabase="create" databaseName="memory:lockdb"/>
+  <dataSource id="LockTestDB" fat.modify="true">
+    <jdbcDriver libraryRef="JDBCLib"/>
+    <!-- properties modified by fat-suite during database rotation -->
+   	<properties.derby.embedded createDatabase="create" databaseName="memory:lockdb"/>
   </dataSource>
-  <library id="DerbyLib">
-    <fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>
+  
+  <library id="JDBCLib">
+    <fileset dir="${shared.resource.dir}/jdbc" includes="${env.DB_DRIVER}"/>
   </library>
   
-  <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+  <javaPermission codebase="${shared.resource.dir}/jdbc/${env.DB_DRIVER}" className="java.security.AllPermission"/>
 
   <variable name="onError" value="FAIL"/>
 


### PR DESCRIPTION
Enable ability to test against all supported databases for our locking tests.  
