### PR TITLE
IllegalStateException handling for selfExtractUtils

### DIFF
--- a/dev/wlp.lib.extract/src/wlp/lib/extract/SelfExtractUtils.java
+++ b/dev/wlp.lib.extract/src/wlp/lib/extract/SelfExtractUtils.java
@@ -225,7 +225,7 @@ public class SelfExtractUtils {
                     for (int read; (read = in.read(buf)) != -1;) {
                         out.write(buf, 0, read);
                     }
-                } catch (IOException ex) {
+                } catch (IOException | IllegalStateException ex) {
                     ex.printStackTrace();
                 }
             }


### PR DESCRIPTION
Issue: https://github.ibm.com/was-liberty/WS-CD-Open/issues/19131