### PR TITLE
add blocking tests for finder operations and more

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/PersistentExecutorWithFailoverEnabledTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/PersistentExecutorWithFailoverEnabledTest.java
@@ -114,12 +114,32 @@ public class PersistentExecutorWithFailoverEnabledTest extends FATServletClient 
     }
 
     @Test
-    public void testBlockAfterCancelFE() throws Exception {
+    public void testBlockAfterCancelByIdFE() throws Exception {
         runTest(server, APP_NAME, testName);
     }
 
     @Test
-    public void testBlockAfterRemoveFE() throws Exception {
+    public void testBlockAfterCancelByNameFE() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testBlockAfterFindByIdFE() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testBlockAfterFindByNameFE() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testBlockAfterRemoveByIdFE() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testBlockAfterRemoveByNameFE() throws Exception {
         runTest(server, APP_NAME, testName);
     }
 

--- a/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/PersistentExecutorWithFailoverEnabledTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/PersistentExecutorWithFailoverEnabledTest.java
@@ -149,6 +149,11 @@ public class PersistentExecutorWithFailoverEnabledTest extends FATServletClient 
     }
 
     @Test
+    public void testBlockRunningTaskFE() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
     public void testCancelRunningTaskFE() throws Exception {
         runTest(server, APP_NAME, testName);
     }

--- a/dev/com.ibm.ws.concurrent.persistent_fat/test-applications/schedtest/src/web/SchedulerFATServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/test-applications/schedtest/src/web/SchedulerFATServlet.java
@@ -382,10 +382,106 @@ public class SchedulerFATServlet extends HttpServlet {
     }
 
     /**
-     * Cancel a task and block for a while without committing to determine if this interferes with other operations.
+     * Cancel a task given its Task ID and block for a while without committing to determine if this interferes with other operations.
      */
-    public void testBlockAfterCancelFE(PrintWriter out) throws Exception {
-        final TaskStatus<Integer> statusA = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterCancelFE-A"), 46, TimeUnit.DAYS);
+    public void testBlockAfterCancelByIdFE(PrintWriter out) throws Exception {
+        final TaskStatus<Integer> statusO = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterCancelByIdFE-O"), 55, TimeUnit.DAYS);
+
+        // Block a transaction that performs a cancel.
+        final Phaser blocker = new Phaser(1);
+        Future<Boolean> cancelAndBlockFuture = unmanagedExecutor.submit(new Callable<Boolean>() {
+            public Boolean call() throws Exception {
+                tran.begin();
+                try {
+                    System.out.println("About to cancel " + statusO);
+                    boolean cancelled = statusO.cancel(false);
+                    blocker.arrive();
+                    System.out.println("Blocking transaction...");
+                    blocker.awaitAdvanceInterruptibly(1, TIMEOUT_NS * 2, TimeUnit.NANOSECONDS);
+                    return cancelled;
+                } finally {
+                    tran.rollback();
+                }
+            }
+        });
+
+        try {
+            if (blocker.awaitAdvanceInterruptibly(0, TIMEOUT_NS, TimeUnit.NANOSECONDS) < 1)
+                throw new Exception("Unable to reach point where transaction is blocked " + cancelAndBlockFuture);
+
+            // The TASK entry is now locked with a pending cancel
+
+            // It should be possible to schedule more tasks
+            TaskStatus<Integer> statusM = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterCancelByIdFE-M"), 56, TimeUnit.DAYS);
+            TaskStatus<Integer> statusN = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterCancelByIdFE-N"), 57, TimeUnit.DAYS);
+
+            // It should be possible to run new tasks
+            DBIncrementTask taskP = new DBIncrementTask("testBlockAfterCancelByIdFE-P");
+            taskP.getExecutionProperties().put(AutoPurge.PROPERTY_NAME, AutoPurge.NEVER.name());
+            TaskStatus<Integer> statusP = scheduler.submit((Callable<Integer>) taskP);
+            for (long begin = System.nanoTime();
+                    !statusP.hasResult() && System.nanoTime() - begin < TIMEOUT_NS;
+                    statusP = scheduler.getStatus(statusP.getTaskId()))
+                Thread.sleep(POLL_INTERVAL);
+            if (!statusP.hasResult())
+                throw new Exception("Unable to run task " + statusP + " while another task " + statusO.getTaskId() + " is blocked.");
+
+            // It should be possible to find existing tasks that are eligible to be claimed.
+            // For testing purposes, directly force this code path rather than waiting for persistent executor to eventually run it
+            Field taskStore = scheduler.getClass().getDeclaredField("taskStore");
+            taskStore.setAccessible(true);
+            Object dbTaskStore = taskStore.get(scheduler);
+            long maxNextExecTime = TimeUnit.DAYS.toMillis(60) + System.currentTimeMillis();
+            Method DatabaseTaskStore_findUnclaimedTasks = dbTaskStore.getClass().getMethod("findUnclaimedTasks", long.class, Integer.class);
+
+            @SuppressWarnings("unchecked")
+            List<Object[]> found = (List<Object[]>) DatabaseTaskStore_findUnclaimedTasks.invoke(dbTaskStore, maxNextExecTime, null);
+            LinkedHashSet<Long> foundIds = new LinkedHashSet<Long>();
+            for (Object[] entry : found)
+                foundIds.add((Long) entry[0]);
+            LinkedHashSet<Long> expected = new LinkedHashSet<Long>();
+            expected.add(statusM.getTaskId());
+            expected.add(statusN.getTaskId());
+            if (foundIds.size() < found.size())
+                throw new Exception("Duplicate task entries might have been returned. " + foundIds + " vs " + found);
+            if (!foundIds.containsAll(expected))
+                throw new Exception("Should have found at least task ids " + expected + " within " + foundIds);
+
+            // Another variant of the above
+            @SuppressWarnings("unchecked")
+            List<Object[]> foundAgain = (List<Object[]>) DatabaseTaskStore_findUnclaimedTasks.invoke(dbTaskStore, maxNextExecTime, 10);
+            foundIds = new LinkedHashSet<Long>();
+            for (Object[] entry : foundAgain)
+                foundIds.add((Long) entry[0]);
+            if (foundIds.size() < found.size())
+                throw new Exception("On the second query, duplicate task entries might have been returned. " + foundIds + " vs " + foundAgain);
+            if (!foundIds.containsAll(expected))
+                throw new Exception("On the second query, should have found at least task ids " + expected + " within " + foundIds);
+
+            // It should be possible to cancel other tasks.
+            if (!statusM.cancel(false))
+                throw new Exception("Unable to cancel task " + statusM.getTaskId() + " while other task is locked.");
+
+            // It should be possible to remove other tasks.
+            if (!scheduler.remove(statusN.getTaskId()))
+                throw new Exception("Unable to remove task " + statusN.getTaskId() + " while other task is locked.");
+
+            // let the transaction complete
+            blocker.arrive();
+            cancelAndBlockFuture.get();
+        } finally {
+            if (!cancelAndBlockFuture.isDone()) {
+                blocker.arrive();
+                cancelAndBlockFuture.cancel(true);
+            }
+        }
+    }
+
+    /**
+     * Cancel a task based on a name pattern and block for a while without committing to determine if this interferes with other operations.
+     */
+    public void testBlockAfterCancelByNameFE(PrintWriter out) throws Exception {
+        final TaskStatus<Integer> statusA = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterCancelByNameFE-A"), 46, TimeUnit.DAYS);
 
         // Block a transaction that performs a cancel.
         final Phaser blocker = new Phaser(1);
@@ -394,7 +490,7 @@ public class SchedulerFATServlet extends HttpServlet {
                 tran.begin();
                 try {
                     System.out.println("About to cancel " + statusA);
-                    int numCancelled = scheduler.cancel("DBIncrementTask-testBlockAfterCancelFE-A", null, TaskState.SCHEDULED, true);
+                    int numCancelled = scheduler.cancel("DBIncrementTask-testBlockAfterCancelByNameFE-A", null, TaskState.SCHEDULED, true);
                     blocker.arrive();
                     System.out.println("Blocking transaction...");
                     blocker.awaitAdvanceInterruptibly(1, TIMEOUT_NS * 2, TimeUnit.NANOSECONDS);
@@ -412,11 +508,11 @@ public class SchedulerFATServlet extends HttpServlet {
             // The TASK entry is now locked with a pending cancel
 
             // It should be possible to schedule more tasks
-            TaskStatus<Integer> statusB = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterCancelFE-B"), 47, TimeUnit.DAYS);
-            TaskStatus<Integer> statusC = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterCancelFE-C"), 48, TimeUnit.DAYS);
+            TaskStatus<Integer> statusB = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterCancelByNameFE-B"), 47, TimeUnit.DAYS);
+            TaskStatus<Integer> statusC = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterCancelByNameFE-C"), 48, TimeUnit.DAYS);
 
             // It should be possible to run new tasks
-            DBIncrementTask taskD = new DBIncrementTask("testBlockAfterCancelFE-D");
+            DBIncrementTask taskD = new DBIncrementTask("testBlockAfterCancelByNameFE-D");
             taskD.getExecutionProperties().put(AutoPurge.PROPERTY_NAME, AutoPurge.NEVER.name());
             TaskStatus<Integer> statusD = scheduler.submit((Callable<Integer>) taskD);
             for (long begin = System.nanoTime();
@@ -461,7 +557,7 @@ public class SchedulerFATServlet extends HttpServlet {
             // It should be possible to cancel other tasks.
             // Attempting to run two multi-cancel operations at once causes locking issues
             // which may be a good reason to avoid externalizing multi-cancel,
-            // scheduler.cancel("DBIncrementTask-testBlockAfterCancelFE-C", null, TaskState.SCHEDULED, true);
+            // scheduler.cancel("DBIncrementTask-testBlockAfterCancelByNameFE-C", null, TaskState.SCHEDULED, true);
             // Instead, cancel the task by its primary key:
             if (!statusC.cancel(false))
                 throw new Exception("Unable to cancel task " + statusC.getTaskId() + " while other task is locked.");
@@ -469,7 +565,7 @@ public class SchedulerFATServlet extends HttpServlet {
             // It should be possible to remove other tasks.
             // Attempting to run multi-cancel and multi-remove operations at the same time causes locking issues
             // which may be a good reason to avoid externalizing multi-remove,
-            // scheduler.remove("DBIncrementTask-testBlockAfterCancelFE-B", null, TaskState.ANY, true);
+            // scheduler.remove("DBIncrementTask-testBlockAfterCancelByNameFE-B", null, TaskState.ANY, true);
             // Instead, remove the task by its primary key:
             if (!scheduler.remove(statusB.getTaskId()))
                 throw new Exception("Unable to remove task " + statusB.getTaskId() + " while other task is locked.");
@@ -486,10 +582,309 @@ public class SchedulerFATServlet extends HttpServlet {
     }
 
     /**
-     * Remove a task and block for a while without committing to determine if this interferes with other operations.
+     * Find a tasks based on their Task ID and block for a while without committing to determine if this interferes with other operations.
      */
-    public void testBlockAfterRemoveFE(PrintWriter out) throws Exception {
-        final TaskStatus<Integer> statusE = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterRemoveFE-E"), 49, TimeUnit.DAYS);
+    public void testBlockAfterFindByIdFE(PrintWriter out) throws Exception {
+        final TaskStatus<Integer> statusE1 = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterFindByIdFE-e1"), 64, TimeUnit.DAYS);
+        final TaskStatus<Integer> statusE2 = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterFindByIdFE-e2"), 65, TimeUnit.DAYS);
+
+        // Block a transaction that performs find by Id operations on two different tasks.
+        final Phaser blocker = new Phaser(1);
+        Future<Date[]> findAndBlockFuture = unmanagedExecutor.submit(new Callable<Date[]>() {
+            public Date[] call() throws Exception {
+                tran.begin();
+                try {
+                    System.out.println("About to getStatus of " + statusE1 + " and getNextExecutionTime of " + statusE2);
+                    TaskStatus<?> status = scheduler.getStatus(statusE1.getTaskId());
+                    Date nextExecTime1 = status.getNextExecutionTime();
+                    Date nextExecTime2 = ((TimersPersistentExecutor) scheduler).getNextExecutionTime(statusE2.getTaskId());
+                    blocker.arrive();
+                    System.out.println("Blocking transaction...");
+                    blocker.awaitAdvanceInterruptibly(1, TIMEOUT_NS * 2, TimeUnit.NANOSECONDS);
+                    return new Date[] { nextExecTime1, nextExecTime2 };
+                } finally {
+                    tran.rollback();
+                }
+            }
+        });
+
+        try {
+            if (blocker.awaitAdvanceInterruptibly(0, TIMEOUT_NS, TimeUnit.NANOSECONDS) < 1)
+                throw new Exception("Unable to reach point where transaction is blocked " + findAndBlockFuture);
+
+            // The TASK entry is now locked, having already performed find operations on 2 tasks
+
+            // It should be possible to schedule more tasks
+            TaskStatus<Integer> statusF = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterFindByIdFE-f"), 66, TimeUnit.DAYS);
+            TaskStatus<Integer> statusG = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterFindByIdFE-g"), 67, TimeUnit.DAYS);
+
+            // It should be possible to run new tasks
+            DBIncrementTask taskH = new DBIncrementTask("testBlockAfterFindByIdFE-h");
+            taskH.getExecutionProperties().put(AutoPurge.PROPERTY_NAME, AutoPurge.NEVER.name());
+            TaskStatus<Integer> statusH = scheduler.submit((Callable<Integer>) taskH);
+            for (long begin = System.nanoTime();
+                    !statusH.hasResult() && System.nanoTime() - begin < TIMEOUT_NS;
+                    statusH = scheduler.getStatus(statusH.getTaskId()))
+                Thread.sleep(POLL_INTERVAL);
+            if (!statusH.hasResult())
+                throw new Exception("Unable to run task " + statusH + " while other tasks " + statusE1.getTaskId() + " and "  + statusE2.getTaskId() + " are blocked.");
+
+            // It should be possible to find existing tasks that are eligible to be claimed.
+            // For testing purposes, directly force this code path rather than waiting for persistent executor to eventually run it
+            Field taskStore = scheduler.getClass().getDeclaredField("taskStore");
+            taskStore.setAccessible(true);
+            Object dbTaskStore = taskStore.get(scheduler);
+            long maxNextExecTime = TimeUnit.DAYS.toMillis(70) + System.currentTimeMillis();
+            Method DatabaseTaskStore_findUnclaimedTasks = dbTaskStore.getClass().getMethod("findUnclaimedTasks", long.class, Integer.class);
+
+            @SuppressWarnings("unchecked")
+            List<Object[]> found = (List<Object[]>) DatabaseTaskStore_findUnclaimedTasks.invoke(dbTaskStore, maxNextExecTime, null);
+            LinkedHashSet<Long> foundIds = new LinkedHashSet<Long>();
+            for (Object[] entry : found)
+                foundIds.add((Long) entry[0]);
+            LinkedHashSet<Long> expected = new LinkedHashSet<Long>();
+            expected.add(statusE1.getTaskId());
+            expected.add(statusE2.getTaskId());
+            expected.add(statusF.getTaskId());
+            expected.add(statusG.getTaskId());
+            if (foundIds.size() < found.size())
+                throw new Exception("Duplicate task entries might have been returned. " + foundIds + " vs " + found);
+            if (!foundIds.containsAll(expected))
+                throw new Exception("Should have found at least task ids " + expected + " within " + foundIds);
+
+            // Another variant of the above
+            @SuppressWarnings("unchecked")
+            List<Object[]> foundAgain = (List<Object[]>) DatabaseTaskStore_findUnclaimedTasks.invoke(dbTaskStore, maxNextExecTime, 10);
+            foundIds = new LinkedHashSet<Long>();
+            for (Object[] entry : foundAgain)
+                foundIds.add((Long) entry[0]);
+            if (foundIds.size() < found.size())
+                throw new Exception("On the second query, duplicate task entries might have been returned. " + foundIds + " vs " + foundAgain);
+            if (!foundIds.containsAll(expected))
+                throw new Exception("On the second query, should have found at least task ids " + expected + " within " + foundIds);
+
+            // It should be possible to cancel other tasks.
+            int count = scheduler.cancel("DBIncrementTask-testBlockAfterFindByIdFE-g", null, TaskState.SCHEDULED, true);
+            if (count != 1)
+                throw new Exception("Unable to cancel one task (" + statusG.getTaskId() + ") while other tasks are locked. Num cancelled: " + count);
+
+            // It should be possible to remove other tasks.
+            count = scheduler.remove("DBIncrementTask-testBlockAfterFindByIdFE-f", null, TaskState.ANY, true);
+            if (count != 1)
+                throw new Exception("Unable to remove one task (" + statusF.getTaskId() + ") while other tasks are locked. Num removed: " + count);
+
+            // let the transaction complete
+            blocker.arrive();
+            findAndBlockFuture.get();
+        } finally {
+            if (!findAndBlockFuture.isDone()) {
+                blocker.arrive();
+                findAndBlockFuture.cancel(true);
+            }
+        }
+    }
+
+    /**
+     * Find a task based on a name pattern and block for a while without committing to determine if this interferes with other operations.
+     */
+    public void testBlockAfterFindByNameFE(PrintWriter out) throws Exception {
+        final TaskStatus<Integer> statusA = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterFindByNameFE-a"), 61, TimeUnit.DAYS);
+
+        // Block a transaction that performs a find by name operation.
+        final Phaser blocker = new Phaser(1);
+        Future<List<TaskStatus<?>>> findAndBlockFuture = unmanagedExecutor.submit(new Callable<List<TaskStatus<?>>>() {
+            public List<TaskStatus<?>> call() throws Exception {
+                tran.begin();
+                try {
+                    System.out.println("About to find " + statusA);
+                    List<TaskStatus<?>> status = scheduler.findTaskStatus("DBIncrementTask-testBlockAfterFindByNameFE-a", null, TaskState.SCHEDULED, true, null, 20);
+                    status.iterator().next(); // access the entry within the transaction, in case it matters
+                    blocker.arrive();
+                    System.out.println("Blocking transaction...");
+                    blocker.awaitAdvanceInterruptibly(1, TIMEOUT_NS * 2, TimeUnit.NANOSECONDS);
+                    return status;
+                } finally {
+                    tran.rollback();
+                }
+            }
+        });
+
+        try {
+            if (blocker.awaitAdvanceInterruptibly(0, TIMEOUT_NS, TimeUnit.NANOSECONDS) < 1)
+                throw new Exception("Unable to reach point where transaction is blocked " + findAndBlockFuture);
+
+            // The TASK entry is now locked, having performed a find by name operation
+
+            // It should be possible to schedule more tasks
+            TaskStatus<Integer> statusB = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterFindByNameFE-b"), 62, TimeUnit.DAYS);
+            TaskStatus<Integer> statusC = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterFindByNameFE-c"), 63, TimeUnit.DAYS);
+
+            // It should be possible to run new tasks
+            DBIncrementTask taskD = new DBIncrementTask("testBlockAfterFindByNameFE-d");
+            taskD.getExecutionProperties().put(AutoPurge.PROPERTY_NAME, AutoPurge.NEVER.name());
+            TaskStatus<Integer> statusD = scheduler.submit((Callable<Integer>) taskD);
+            for (long begin = System.nanoTime();
+                    !statusD.hasResult() && System.nanoTime() - begin < TIMEOUT_NS;
+                    statusD = scheduler.getStatus(statusD.getTaskId()))
+                Thread.sleep(POLL_INTERVAL);
+            if (!statusD.hasResult())
+                throw new Exception("Unable to run task " + statusD + " while another task " + statusA.getTaskId() + " is blocked.");
+
+            // It should be possible to find existing tasks that are eligible to be claimed.
+            // For testing purposes, directly force this code path rather than waiting for persistent executor to eventually run it
+            Field taskStore = scheduler.getClass().getDeclaredField("taskStore");
+            taskStore.setAccessible(true);
+            Object dbTaskStore = taskStore.get(scheduler);
+            long maxNextExecTime = TimeUnit.DAYS.toMillis(65) + System.currentTimeMillis();
+            Method DatabaseTaskStore_findUnclaimedTasks = dbTaskStore.getClass().getMethod("findUnclaimedTasks", long.class, Integer.class);
+
+            @SuppressWarnings("unchecked")
+            List<Object[]> found = (List<Object[]>) DatabaseTaskStore_findUnclaimedTasks.invoke(dbTaskStore, maxNextExecTime, null);
+            LinkedHashSet<Long> foundIds = new LinkedHashSet<Long>();
+            for (Object[] entry : found)
+                foundIds.add((Long) entry[0]);
+            LinkedHashSet<Long> expected = new LinkedHashSet<Long>();
+            expected.add(statusA.getTaskId());
+            expected.add(statusB.getTaskId());
+            expected.add(statusC.getTaskId());
+            if (foundIds.size() < found.size())
+                throw new Exception("Duplicate task entries might have been returned. " + foundIds + " vs " + found);
+            if (!foundIds.containsAll(expected))
+                throw new Exception("Should have found at least task ids " + expected + " within " + foundIds);
+
+            // Another variant of the above
+            @SuppressWarnings("unchecked")
+            List<Object[]> foundAgain = (List<Object[]>) DatabaseTaskStore_findUnclaimedTasks.invoke(dbTaskStore, maxNextExecTime, 10);
+            foundIds = new LinkedHashSet<Long>();
+            for (Object[] entry : foundAgain)
+                foundIds.add((Long) entry[0]);
+            if (foundIds.size() < found.size())
+                throw new Exception("On the second query, duplicate task entries might have been returned. " + foundIds + " vs " + foundAgain);
+            if (!foundIds.containsAll(expected))
+                throw new Exception("On the second query, should have found at least task ids " + expected + " within " + foundIds);
+
+            // It should be possible to cancel other tasks.
+            int count = scheduler.cancel("DBIncrementTask-testBlockAfterFindByNameFE-c", null, TaskState.SCHEDULED, true);
+            if (count != 1)
+                throw new Exception("Unable to cancel one task (" + statusC.getTaskId() + ") while other task is locked. Num cancelled: " + count);
+
+            // It should be possible to remove other tasks.
+            count = scheduler.remove("DBIncrementTask-testBlockAfterFindByNameFE-b", null, TaskState.ANY, true);
+            if (count != 1)
+                throw new Exception("Unable to remove one task (" + statusB.getTaskId() + ") while other task is locked. Num removed: " + count);
+
+            // let the transaction complete
+            blocker.arrive();
+            findAndBlockFuture.get();
+        } finally {
+            if (!findAndBlockFuture.isDone()) {
+                blocker.arrive();
+                findAndBlockFuture.cancel(true);
+            }
+        }
+    }
+
+    /**
+     * Remove a task based on its unique task ID and block for a while without committing to determine if this interferes with other operations.
+     */
+    public void testBlockAfterRemoveByIdFE(PrintWriter out) throws Exception {
+        final TaskStatus<Integer> statusU = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterRemoveByIdFE-U"), 58, TimeUnit.DAYS);
+
+        // Block a transaction that performs a remove.
+        final Phaser blocker = new Phaser(1);
+        Future<Boolean> removeAndBlockFuture = unmanagedExecutor.submit(new Callable<Boolean>() {
+            public Boolean call() throws Exception {
+                tran.begin();
+                try {
+                    System.out.println("About to remove " + statusU);
+                    boolean removed = scheduler.remove(statusU.getTaskId());
+                    blocker.arrive();
+                    System.out.println("Blocking transaction...");
+                    blocker.awaitAdvanceInterruptibly(1, TIMEOUT_NS * 2, TimeUnit.NANOSECONDS);
+                    return removed;
+                } finally {
+                    tran.rollback();
+                }
+            }
+        });
+
+        try {
+            if (blocker.awaitAdvanceInterruptibly(0, TIMEOUT_NS, TimeUnit.NANOSECONDS) < 1)
+                throw new Exception("Unable to reach point where transaction is blocked " + removeAndBlockFuture);
+
+            // The TASK entry is now locked with a pending removal
+
+            // It should be possible to schedule more tasks
+            TaskStatus<Integer> statusV = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterRemoveByIdFE-V"), 59, TimeUnit.DAYS);
+            TaskStatus<Integer> statusW = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterRemoveByIdFE-W"), 60, TimeUnit.DAYS);
+
+            // It should be possible to run new tasks
+            DBIncrementTask taskX = new DBIncrementTask("testBlockAfterRemoveByIdFE-X");
+            taskX.getExecutionProperties().put(AutoPurge.PROPERTY_NAME, AutoPurge.NEVER.name());
+            TaskStatus<Integer> statusX = scheduler.submit((Callable<Integer>) taskX);
+            for (long begin = System.nanoTime();
+                    !statusX.hasResult() && System.nanoTime() - begin < TIMEOUT_NS;
+                    statusX = scheduler.getStatus(statusX.getTaskId()))
+                Thread.sleep(POLL_INTERVAL);
+            if (!statusX.hasResult())
+                throw new Exception("Unable to run task " + statusX + " while another task " + statusU.getTaskId() + " is blocked.");
+
+            // It should be possible to find existing tasks that are eligible to be claimed.
+            // For testing purposes, directly force this code path rather than waiting for persistent executor to eventually run it
+            Field taskStore = scheduler.getClass().getDeclaredField("taskStore");
+            taskStore.setAccessible(true);
+            Object dbTaskStore = taskStore.get(scheduler);
+            long maxNextExecTime = TimeUnit.DAYS.toMillis(65) + System.currentTimeMillis();
+            Method DatabaseTaskStore_findUnclaimedTasks = dbTaskStore.getClass().getMethod("findUnclaimedTasks", long.class, Integer.class);
+
+            @SuppressWarnings("unchecked")
+            List<Object[]> found = (List<Object[]>) DatabaseTaskStore_findUnclaimedTasks.invoke(dbTaskStore, maxNextExecTime, null);
+            LinkedHashSet<Long> foundIds = new LinkedHashSet<Long>();
+            for (Object[] entry : found)
+                foundIds.add((Long) entry[0]);
+            LinkedHashSet<Long> expected = new LinkedHashSet<Long>();
+            expected.add(statusV.getTaskId());
+            expected.add(statusW.getTaskId());
+            if (foundIds.size() < found.size())
+                throw new Exception("Duplicate task entries might have been returned. " + foundIds + " vs " + found);
+            if (!foundIds.containsAll(expected))
+                throw new Exception("Should have found at least task ids " + expected + " within " + foundIds);
+
+            // Another variant of the above
+            @SuppressWarnings("unchecked")
+            List<Object[]> foundAgain = (List<Object[]>) DatabaseTaskStore_findUnclaimedTasks.invoke(dbTaskStore, maxNextExecTime, 10);
+            foundIds = new LinkedHashSet<Long>();
+            for (Object[] entry : foundAgain)
+                foundIds.add((Long) entry[0]);
+            if (foundIds.size() < found.size())
+                throw new Exception("On the second query, duplicate task entries might have been returned. " + foundIds + " vs " + foundAgain);
+            if (!foundIds.containsAll(expected))
+                throw new Exception("On the second query, should have found at least task ids " + expected + " within " + foundIds);
+
+            // It should be possible to remove other tasks.
+            if (!scheduler.remove(statusV.getTaskId()))
+                throw new Exception("Unable to remove task " + statusV.getTaskId() + " while other task is locked.");
+
+            // It should be possible to cancel other tasks.
+            if (!statusW.cancel(false))
+                throw new Exception("Unable to cancel task " + statusW.getTaskId() + " while other task is locked.");
+
+            // let the transaction complete
+            blocker.arrive();
+            removeAndBlockFuture.get();
+        } finally {
+            if (!removeAndBlockFuture.isDone()) {
+                blocker.arrive();
+                removeAndBlockFuture.cancel(true);
+            }
+        }
+    }
+
+    /**
+     * Remove a task based on a name pattern and block for a while without committing to determine if this interferes with other operations.
+     */
+    public void testBlockAfterRemoveByNameFE(PrintWriter out) throws Exception {
+        final TaskStatus<Integer> statusE = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterRemoveByNameFE-E"), 49, TimeUnit.DAYS);
 
         // Block a transaction that performs a remove.
         final Phaser blocker = new Phaser(1);
@@ -498,7 +893,7 @@ public class SchedulerFATServlet extends HttpServlet {
                 tran.begin();
                 try {
                     System.out.println("About to remove " + statusE);
-                    int numRemoved = scheduler.remove("DBIncrementTask-testBlockAfterRemoveFE-E", null, TaskState.SCHEDULED, true);
+                    int numRemoved = scheduler.remove("DBIncrementTask-testBlockAfterRemoveByNameFE-E", null, TaskState.SCHEDULED, true);
                     blocker.arrive();
                     System.out.println("Blocking transaction...");
                     blocker.awaitAdvanceInterruptibly(1, TIMEOUT_NS * 2, TimeUnit.NANOSECONDS);
@@ -516,11 +911,11 @@ public class SchedulerFATServlet extends HttpServlet {
             // The TASK entry is now locked with a pending removal
 
             // It should be possible to schedule more tasks
-            TaskStatus<Integer> statusF = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterRemoveFE-F"), 50, TimeUnit.DAYS);
-            TaskStatus<Integer> statusG = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterRemoveFE-G"), 51, TimeUnit.DAYS);
+            TaskStatus<Integer> statusF = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterRemoveByNameFE-F"), 50, TimeUnit.DAYS);
+            TaskStatus<Integer> statusG = scheduler.schedule((Callable<Integer>) new DBIncrementTask("testBlockAfterRemoveByNameFE-G"), 51, TimeUnit.DAYS);
 
             // It should be possible to run new tasks
-            DBIncrementTask taskH = new DBIncrementTask("testBlockAfterRemoveFE-H");
+            DBIncrementTask taskH = new DBIncrementTask("testBlockAfterRemoveByNameFE-H");
             taskH.getExecutionProperties().put(AutoPurge.PROPERTY_NAME, AutoPurge.NEVER.name());
             TaskStatus<Integer> statusH = scheduler.submit((Callable<Integer>) taskH);
             for (long begin = System.nanoTime();


### PR DESCRIPTION
Add tests for blocking a transaction after it perform a find-by-name or find-by-taskID operation and determining if other operations to the task are permitted.  Also, includes versions of the cancel/remove test that do cancel/remove by task ID instead of by name.  Adds a couple of tests for operations that ought to be avoided by proper configuration of the missed task threshold, but where we would like to have it time out quickly (code doesn't do this yet) if a task takes too long and causes this code path to be reached.  This last two tests are commented out, for future enablement.