### PR TITLE
Port oracle jdbc

### DIFF
--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -48,6 +48,7 @@ com.netflix.archaius:archaius2-api:2.1.10
 com.netflix.archaius:archaius2-core:2.1.10
 com.nimbusds:nimbus-jose-jwt:4.23
 com.oracle.ojdbc:ojdbc8_g:19.3.0.0
+com.oracle.ojdbc:ucp:19.3.0.0
 com.openpojo:openpojo:0.8.4
 com.sebastian-daschner:jaxrs-analyzer:0.9
 com.sun.faces:jsf-api:2.2.14

--- a/dev/com.ibm.ws.jdbc_fat_oracle/.classpath
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/.classpath
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="src" path="test-applications/oraclejdbcfat/src"/>
+	<classpathentry kind="src" path="test-applications/oracleucpfat/src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/com.ibm.ws.jdbc_fat_oracle/.project
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.ibm.ws.jdbc_fat_oracle</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/com.ibm.ws.jdbc_fat_oracle/.settings/org.eclipse.core.resources.prefs
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/bnd.bnd=UTF-8

--- a/dev/com.ibm.ws.jdbc_fat_oracle/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,14 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/com.ibm.ws.jdbc_fat_oracle/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/bnd.bnd
@@ -1,0 +1,35 @@
+#*******************************************************************************
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+javac.source: 1.8
+javac.target: 1.8
+
+src: \
+	fat/src,\
+	test-applications/oraclejdbcfat/src,\
+	test-applications/oracleucpfat/src
+	
+fat.project: true
+
+-buildpath: \
+	com.ibm.websphere.javaee.annotation.1.1,\
+	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
+	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
+    org.rnorth.duct-tape:duct-tape;version=1.0.7,\
+    org.testcontainers:database-commons;version=1.12.3,\
+    org.testcontainers:jdbc;version=1.12.3,\
+    org.testcontainers:oracle-xe;version=1.12.3,\
+    org.testcontainers:testcontainers;version=1.12.3,\
+    org.slf4j:slf4j-api;version=1.7.7,\
+    com.oracle.ojdbc:ojdbc8_g;version=19.3.0.0,\
+    com.oracle.ojdbc:ucp;version=19.3.0.0

--- a/dev/com.ibm.ws.jdbc_fat_oracle/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/bnd.bnd
@@ -21,6 +21,9 @@ src: \
 	
 fat.project: true
 
+# Uncomment to use remote docker host to simulate continuous build behavior.
+# fat.test.use.remote.docker: true
+
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.1,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\

--- a/dev/com.ibm.ws.jdbc_fat_oracle/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/build.gradle
@@ -30,25 +30,25 @@ dependencies {
   ucp 'com.oracle.ojdbc:ucp:19.3.0.0'
 }
 
-task copySharedOracle(type: Copy) {
+task copyAnonymousOracle(type: Copy) {
   shouldRunAfter jar
   from configurations.oracle
   into new File(autoFvtDir, 'publish/shared/resources/oracle/')
+  rename "ojdbc8_g-.*.", "oracleunknown.jar"
+}
+
+task copySharedOracle(type: Copy) {
+  shouldRunAfter jar
+  from configurations.oracle
+  into new File(autoFvtDir, 'publish/shared/resources/ucp/')
   rename "ojdbc8_g-.*.", "ojdbc8_g.jar"
 }
 
 task copySharedUCP(type: Copy) {
   shouldRunAfter jar
   from configurations.ucp
-  into new File(autoFvtDir, 'publish/shared/resources/oracle/')
+  into new File(autoFvtDir, 'publish/shared/resources/ucp/')
   rename "ucp-.*.", "ucp.jar"
-}
-
-task copyAnonymousOracle(type: Copy) {
-  shouldRunAfter jar
-  from configurations.oracle
-  into new File(autoFvtDir, 'publish/shared/resources/oracle/')
-  rename "ojdbc8_g-.*.", "oracleunknown.jar"
 }
 
 addRequiredLibraries {

--- a/dev/com.ibm.ws.jdbc_fat_oracle/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/build.gradle
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+configurations {
+  oracle {transitive = false}
+  ucp {transitive = false}
+}
+
+dependencies {
+  requiredLibs 'org.testcontainers:testcontainers:1.12.3',
+               'org.testcontainers:database-commons:1.12.3',
+               'org.testcontainers:oracle-xe:1.12.3',
+               'org.testcontainers:jdbc:1.12.3',
+               'org.apache.commons:commons-compress:1.19',
+               'org.rnorth.duct-tape:duct-tape:1.0.7',
+               'org.rnorth.visible-assertions:visible-assertions:2.1.2',
+               'org.rnorth:tcp-unix-socket-proxy:1.0.2',
+               'net.java.dev.jna:jna:5.2.0',
+               'org.slf4j:slf4j-api:1.7.7',
+               'org.slf4j:slf4j-jdk14:1.7.7'
+  oracle 'com.oracle.ojdbc:ojdbc8_g:19.3.0.0'
+  ucp 'com.oracle.ojdbc:ucp:19.3.0.0'
+}
+
+task copySharedOracle(type: Copy) {
+  shouldRunAfter jar
+  from configurations.oracle
+  into new File(autoFvtDir, 'publish/shared/resources/oracle/')
+  rename "ojdbc8_g-.*.", "ojdbc8_g.jar"
+}
+
+task copySharedUCP(type: Copy) {
+  shouldRunAfter jar
+  from configurations.ucp
+  into new File(autoFvtDir, 'publish/shared/resources/oracle/')
+  rename "ucp-.*.", "ucp.jar"
+}
+
+task copyAnonymousOracle(type: Copy) {
+  shouldRunAfter jar
+  from configurations.oracle
+  into new File(autoFvtDir, 'publish/shared/resources/oracle/')
+  rename "ojdbc8_g-.*.", "oracleunknown.jar"
+}
+
+addRequiredLibraries {
+  dependsOn copySharedOracle
+  dependsOn copySharedUCP
+  dependsOn copyAnonymousOracle
+}

--- a/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/FATSuite.java
@@ -10,20 +10,25 @@
  *******************************************************************************/
 package com.ibm.ws.jdbc.fat.oracle;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+import org.testcontainers.containers.OracleContainer;
 
-import componenttest.custom.junit.runner.AlwaysPassesTest;
 import componenttest.topology.utils.ExternalTestServiceDockerClientStrategy;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                AlwaysPassesTest.class,
                 OracleTest.class,
                 OracleUCPTest.class
 })
 public class FATSuite {
+	
+    //TODO replace this container with the official oracle-xe container if/when it is available without a license
+    @ClassRule
+    public static OracleContainer oracle = new OracleContainer("oracleinanutshell/oracle-xe-11g");
+    
     static {
         ExternalTestServiceDockerClientStrategy.clearTestcontainersConfig();
     }

--- a/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/FATSuite.java
@@ -10,14 +10,12 @@
  *******************************************************************************/
 package com.ibm.ws.jdbc.fat.oracle;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
-import componenttest.topology.database.DatabaseCluster;
+import componenttest.topology.utils.ExternalTestServiceDockerClientStrategy;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -26,18 +24,7 @@ import componenttest.topology.database.DatabaseCluster;
                 OracleUCPTest.class
 })
 public class FATSuite {
-
-    public static DatabaseCluster dbCluster;
-
-    @BeforeClass
-    public static void setUp() throws Exception {
-        dbCluster = new DatabaseCluster();
-        dbCluster.createDatabase();
+    static {
+        ExternalTestServiceDockerClientStrategy.clearTestcontainersConfig();
     }
-
-    @AfterClass
-    public static void tearDown() throws Exception {
-        dbCluster.dropDatabase();
-    }
-
 }

--- a/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/FATSuite.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jdbc.fat.oracle;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import componenttest.custom.junit.runner.AlwaysPassesTest;
+import componenttest.topology.database.DatabaseCluster;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+                AlwaysPassesTest.class,
+                OracleTest.class,
+                OracleUCPTest.class
+})
+public class FATSuite {
+
+    public static DatabaseCluster dbCluster;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        dbCluster = new DatabaseCluster();
+        dbCluster.createDatabase();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        dbCluster.dropDatabase();
+    }
+
+}

--- a/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jdbc.fat.oracle;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.MinimumJavaLevel;
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import web.OracleTestServlet;
+
+@RunWith(FATRunner.class)
+@MinimumJavaLevel(javaLevel = 8)
+public class OracleTest extends FATServletClient {
+
+    public static final String JEE_APP = "oraclejdbcfat";
+    public static final String SERVLET_NAME = "OracleTestServlet";
+
+    @Server("com.ibm.ws.jdbc.fat.oracle")
+    @TestServlet(servlet = OracleTestServlet.class, path = JEE_APP + "/" + SERVLET_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        FATSuite.dbCluster.addConfigTo(server);
+
+        // Create a normal Java EE application and export to server
+        WebArchive app = ShrinkWrap.create(WebArchive.class, JEE_APP + ".war").addPackages(true, "web");
+        ShrinkHelper.exportAppToServer(server, app);
+
+        server.addInstalledAppForValidation(JEE_APP);
+        server.startServer();
+
+        runTest(server, JEE_APP + '/' + SERVLET_NAME, "initDatabaseTables");
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (server.isStarted())
+            server.stopServer();
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleUCPTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleUCPTest.java
@@ -1,0 +1,326 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jdbc.fat.oracle;
+
+import java.util.Collections;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.ConfigElementList;
+import com.ibm.websphere.simplicity.config.ConnectionManager;
+import com.ibm.websphere.simplicity.config.DataSource;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.websphere.simplicity.config.dsprops.Properties_oracle_ucp;
+
+import componenttest.annotation.MinimumJavaLevel;
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import ucp.web.OracleUCPTestServlet;
+
+@RunWith(FATRunner.class)
+@MinimumJavaLevel(javaLevel = 8)
+public class OracleUCPTest extends FATServletClient {
+
+    public static final String JEE_APP = "oracleucpfat";
+    public static final String SERVLET_NAME = "OracleUCPTestServlet";
+
+    @Server("com.ibm.ws.jdbc.fat.oracle.ucp")
+    @TestServlet(servlet = OracleUCPTestServlet.class, path = JEE_APP + "/" + SERVLET_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        FATSuite.dbCluster.addConfigTo(server);
+
+        // Create a normal Java EE application and export to server
+        WebArchive app = ShrinkWrap.create(WebArchive.class, JEE_APP + ".war").addPackages(true, "ucp.web");
+        ShrinkHelper.exportAppToServer(server, app);
+
+        server.addInstalledAppForValidation(JEE_APP);
+        server.startServer();
+
+        runTest(server, JEE_APP + '/' + SERVLET_NAME, "initDatabaseTables");
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (server.isStarted())
+            server.stopServer("CWWKE0701E"); // CWWKE0701E expected in testOracleUCPConnectionPoolDS
+    }
+
+    //Config Update Tests
+
+    /**
+     * Config update test which tests that a datasource configured initially to use the Liberty connection pool
+     * can be updated to use UCP and the Liberty connection pool is disabled. The test then switches the config back to
+     * the Liberty conn pool and again checks that UCP is not being used.
+     */
+    @Test
+    @Mode(TestMode.FULL)
+    public void testUpdateLibertyConnPoolToUCP() throws Exception {
+        runTest(server, JEE_APP + '/' + SERVLET_NAME, "testUsingLibertyConnPool");
+
+        ServerConfiguration initialConfig = server.getServerConfiguration().clone();
+
+        ServerConfiguration config = server.getServerConfiguration().clone();
+        DataSource oracleDS = config.getDataSources().getBy("id", "oracleDS");
+        oracleDS.clearDataSourceDBProperties();
+        ConfigElementList<Properties_oracle_ucp> propsList = oracleDS.getProperties_oracle_ucp();
+        Properties_oracle_ucp props = new Properties_oracle_ucp();
+        propsList.add(props);
+        try {
+            //update to UCP
+            props.setMaxPoolSize("2");
+            props.setUser("${jdbc.user}");
+            props.setPassword("${jdbc.password}");
+            props.setURL("${jdbc.URL}");
+            props.setConnectionWaitTimeout("30");
+
+            //Update config
+            server.setMarkToEndOfLog();
+            server.updateServerConfiguration(config);
+            server.waitForConfigUpdateInLogUsingMark(Collections.singleton(JEE_APP));
+
+            //Ensure we are now using UCP
+            runTest(server, JEE_APP + '/' + SERVLET_NAME, "testUsingUCP");
+
+        } finally {
+            //Update config back to a non UCP
+            server.setMarkToEndOfLog();
+            server.updateServerConfiguration(initialConfig);
+            server.waitForConfigUpdateInLogUsingMark(Collections.singleton(JEE_APP));
+
+            //Ensure we have switched back
+            runTest(server, JEE_APP + '/' + SERVLET_NAME, "testUsingLibertyConnPool");
+        }
+    }
+
+    /**
+     * Config update test which tests that after updating the properties of a datasouce using UCP the datasource is still
+     * using UCP and Liberty connection pooling is still disabled.
+     */
+    @Test
+    @Mode(TestMode.FULL)
+    public void testConnectionManagerUCPtoUCP() throws Exception {
+        ServerConfiguration initialConfig = server.getServerConfiguration().clone();
+
+        //use ucpDS to ensure it is initialized
+        runTest(server, JEE_APP + '/' + SERVLET_NAME, "testOracleUCP");
+
+        ServerConfiguration config = server.getServerConfiguration().clone();
+        DataSource ucpDS = config.getDataSources().getBy("id", "ucpDS");
+        Properties_oracle_ucp props = ucpDS.getProperties_oracle_ucp().get(0);
+        try {
+            //update UCP Prop
+            props.setMaxIdleTime("400");;
+
+            //Update config
+            server.setMarkToEndOfLog();
+            server.updateServerConfiguration(config);
+            server.waitForConfigUpdateInLogUsingMark(Collections.singleton(JEE_APP));
+
+            //Ensure we are still using UCP
+            runTest(server, JEE_APP + '/' + SERVLET_NAME, "testOracleUCPMaxConnections");
+
+        } finally {
+            //Update config back
+            server.setMarkToEndOfLog();
+            server.updateServerConfiguration(initialConfig);
+            server.waitForConfigUpdateInLogUsingMark(Collections.singleton(JEE_APP));
+        }
+    }
+
+    /**
+     * Config update test which tests that after updating the connection manager reference of a datasouce using UCP the datasource is still
+     * using UCP and Liberty connection pooling is still disabled. We have a test for updating both the connection manager reference
+     * and embedded connection manager as the code paths are slightly different.
+     */
+    @Test
+    @Mode(TestMode.FULL)
+    public void testUCPUpdateConnManager() throws Exception {
+        ServerConfiguration initialConfig = server.getServerConfiguration().clone();
+
+        //use ucpDS to ensure it is initialized
+        runTest(server, JEE_APP + '/' + SERVLET_NAME, "testOracleUCP");
+
+        ServerConfiguration config = server.getServerConfiguration().clone();
+        ConnectionManager conMgr = config.getConnectionManagers().getBy("id", "conMgr");
+        try {
+            //this update to the connection manager should not result in any functional updates
+            //since the maxpoolsize is ignored
+            conMgr.setMaxPoolSize("1");
+
+            //Update config
+            server.setMarkToEndOfLog();
+            server.updateServerConfiguration(config);
+            server.waitForConfigUpdateInLogUsingMark(Collections.singleton(JEE_APP));
+
+            //Ensure we are still using UCP
+
+            runTest(server, JEE_APP + '/' + SERVLET_NAME, "testOracleUCPMaxConnections");
+
+        } finally {
+            //Update config back
+            server.setMarkToEndOfLog();
+            server.updateServerConfiguration(initialConfig);
+            server.waitForConfigUpdateInLogUsingMark(Collections.singleton(JEE_APP));
+        }
+    }
+
+    /**
+     * Config update which tests that after updating the embedded connection manager of a datasouce using UCP the datasource is still
+     * using UCP and Liberty connection pooling is still disabled. We have a test for updating both the connection manager reference
+     * and embedded connection manager as the code paths are slightly different.
+     */
+    @Test
+    @Mode(TestMode.FULL)
+    public void testUCPUpdateConnManagerEmbedded() throws Exception {
+        ServerConfiguration initialConfig = server.getServerConfiguration().clone();
+
+        //use ucpDS to ensure it is initialized
+        runTest(server, JEE_APP + '/' + SERVLET_NAME, "testOracleUCPEmbeddedConMgr");
+
+        ServerConfiguration config = server.getServerConfiguration().clone();
+        DataSource ucpDS = config.getDataSources().getBy("id", "ucpDSEmbeddedConMgr");
+        ConnectionManager conMgr = ucpDS.getConnectionManagers().get(0);
+        try {
+            //this update to the connection manager should not result in any functional updates
+            //since the maxpoolsize is ignored
+            conMgr.setMaxPoolSize("1");
+
+            //Update config
+            server.setMarkToEndOfLog();
+            server.updateServerConfiguration(config);
+            server.waitForConfigUpdateInLogUsingMark(Collections.singleton(JEE_APP));
+
+            //Ensure we are still using UCP
+            runTest(server, JEE_APP + '/' + SERVLET_NAME, "testOracleUCPMaxConnectionsEmbedded");
+
+        } finally {
+            //Update config back
+            server.setMarkToEndOfLog();
+            server.updateServerConfiguration(initialConfig);
+            server.waitForConfigUpdateInLogUsingMark(Collections.singleton(JEE_APP));
+        }
+    }
+
+    /**
+     * Config update test which switches a UCP datasource's connection manager from an embedded connection manager
+     * to a reference and ensures that Liberty's connection pooling is still disabled. Switches back to the embedded
+     * connection manager and again ensures that Liberty's connection pooling is still disabled.
+     */
+    @Test
+    @Mode(TestMode.FULL)
+    public void testUpdateEmbedConMgrtoRef() throws Exception {
+        ServerConfiguration initialConfig = server.getServerConfiguration().clone();
+
+        //use ucpDS to ensure it is initialized
+        runTest(server, JEE_APP + '/' + SERVLET_NAME, "testOracleUCPEmbeddedConMgr");
+
+        ServerConfiguration config = server.getServerConfiguration().clone();
+        DataSource ucpDS = config.getDataSources().getBy("id", "ucpDSEmbeddedConMgr");
+        try {
+            //this update to the connection manager should not result in any functional updates
+            //since the maxpoolsize is ignored
+            ucpDS.getConnectionManagers().remove(0);
+            ucpDS.setConnectionManagerRef("conMgrUpdate");
+
+            //Update config
+            server.setMarkToEndOfLog();
+            server.updateServerConfiguration(config);
+            server.waitForConfigUpdateInLogUsingMark(Collections.singleton(JEE_APP));
+
+            //Ensure we are still using UCP
+            runTest(server, JEE_APP + '/' + SERVLET_NAME, "testOracleUCPMaxConnectionsEmbedded");
+
+        } finally {
+            //Update config back
+            server.setMarkToEndOfLog();
+            server.updateServerConfiguration(initialConfig);
+            server.waitForConfigUpdateInLogUsingMark(Collections.singleton(JEE_APP));
+
+            //Ensure we are still using UCP
+            runTest(server, JEE_APP + '/' + SERVLET_NAME, "testOracleUCPMaxConnectionsEmbedded");
+        }
+    }
+
+    /**
+     * Config update test which tests that when any overridden data source properties are updated
+     * when using UCP that Liberty's connection pooling is still disabled.
+     */
+    @Test
+    @Mode(TestMode.FULL)
+    public void testUpdateOnlyIgnoredDSPropsWithUCP() throws Exception {
+        ServerConfiguration initialConfig = server.getServerConfiguration().clone();
+        //use ucpDS to ensure it is initialized
+        runTest(server, JEE_APP + '/' + SERVLET_NAME, "testOracleUCP");
+        ServerConfiguration config = server.getServerConfiguration().clone();
+        DataSource ucpDS = config.getDataSources().getBy("id", "ucpDS");
+        try {
+            //this update to the statementcachesize should not result in any functional updates
+            //since the property is ignored
+            ucpDS.setStatementCacheSize("20");
+            //Update config
+            server.setMarkToEndOfLog();
+            server.updateServerConfiguration(config);
+            server.waitForConfigUpdateInLogUsingMark(Collections.singleton(JEE_APP));
+            //Ensure we are now using UCP
+            runTest(server, JEE_APP + '/' + SERVLET_NAME, "testOracleUCPMaxConnections");
+        } finally {
+            //Update config back
+            server.setMarkToEndOfLog();
+            server.updateServerConfiguration(initialConfig);
+            server.waitForConfigUpdateInLogUsingMark(Collections.singleton(JEE_APP));
+        }
+    }
+
+    /**
+     * Config update test which tests that when a datasource type is updated when using
+     * UCP that the impl class is updated to the correct class.
+     */
+    @Test
+    @Mode(TestMode.FULL)
+    public void testUpdateDSType() throws Exception {
+        ServerConfiguration initialConfig = server.getServerConfiguration().clone();
+        //use ucpXADS to ensure it is initialized
+        runTest(server, JEE_APP + '/' + SERVLET_NAME, "testOracleUCPXADS");
+        ServerConfiguration config = server.getServerConfiguration().clone();
+        DataSource ucpDS = config.getDataSources().getBy("id", "ucpXADS");
+        try {
+            //Update to javax.sql.DataSource
+            ucpDS.setType("javax.sql.DataSource");
+            //Update config
+            server.setMarkToEndOfLog();
+            server.updateServerConfiguration(config);
+            server.waitForConfigUpdateInLogUsingMark(Collections.singleton(JEE_APP));
+            runTest(server, JEE_APP + '/' + SERVLET_NAME, "testUsingPoolDataSource");
+        } finally {
+            //Update config back
+            server.setMarkToEndOfLog();
+            server.updateServerConfiguration(initialConfig);
+            server.waitForConfigUpdateInLogUsingMark(Collections.singleton(JEE_APP));
+            //Test we are again using XA
+            runTest(server, JEE_APP + '/' + SERVLET_NAME, "testOracleUCPXADS");
+        }
+
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ucp/bootstrap.properties
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ucp/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2016, 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+com.ibm.ws.logging.trace.specification=*=info:RRA=all:WAS.j2c=all:oracle.*=all
+com.ibm.ws.logging.max.file.size=0
+osgi.console=5678
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ucp/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ucp/server.xml
@@ -23,7 +23,7 @@
     </application>
     
     <library id="UCPDBLib">
-    	<fileset dir="${server.config.dir}/oracle/ucp"/>
+    	<fileset dir="${shared.resource.dir}/ucp"/>
     </library>
     
     <connectionManager id="conMgr" maxPoolSize="2" enableSharingForDirectLookups="false"/> 
@@ -35,32 +35,32 @@
     <!-- This DataSource intentionally uses a connectionManagerRef -->
     <dataSource id="ucpDS" jndiName="jdbc/ucpDS" connectionManagerRef="conMgr" validationTimeout="20" >
     	<jdbcDriver libraryRef="UCPDBLib" />
-    	<properties.oracle.ucp maxStatements="5"  maxPoolSize="3" user="${jdbc.user}" password="${jdbc.password}" connectionWaitTimeout="30" URL="${jdbc.URL}" />
+    	<properties.oracle.ucp maxStatements="5"  maxPoolSize="3" user="${env.USER}" password="${env.PASSWORD}" connectionWaitTimeout="30" URL="${env.URL}" />
     </dataSource>
     
     <dataSource id="ucpDSSameConMgr" jndiName="jdbc/ucpDSSameConMgr" connectionManagerRef="sharedConMgr" validationTimeout="20" >
     	<jdbcDriver libraryRef="UCPDBLib" />
-    	<properties.oracle.ucp URL="${jdbc.URL}" user="${jdbc.user}" password="${jdbc.password}" />
+    	<properties.oracle.ucp URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}" />
     </dataSource>
     
     <dataSource id="ucpXADS" jndiName="jdbc/ucpXADS" type="javax.sql.XADataSource">
     	<jdbcDriver libraryRef="UCPDBLib" />
-    	<properties.oracle.ucp maxPoolSize="3" connectionWaitTimeout="30" URL="${jdbc.URL}" user="${jdbc.user}" password="${jdbc.password}" />
+    	<properties.oracle.ucp maxPoolSize="3" connectionWaitTimeout="30" URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}" />
     </dataSource>
     
     <dataSource id="ucpConnectionPoolDS" jndiName="jdbc/ucpConnectionPoolDS" type="javax.sql.ConnectionPoolDataSource" >
     	<jdbcDriver libraryRef="UCPDBLib" />
-    	<properties.oracle.ucp URL="${jdbc.URL}" user="${jdbc.user}" password="${jdbc.password}" />
+    	<properties.oracle.ucp URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}" />
     </dataSource>
     
     <dataSource id="ucpDriverDS" jndiName="jdbc/ucpDriverDS" type="java.sql.Driver" >
     	<jdbcDriver libraryRef="UCPDBLib" />
-    	<properties.oracle.ucp maxPoolSize="3" connectionWaitTimeout="30" URL="${jdbc.URL}" user="${jdbc.user}" password="${jdbc.password}"/>
+    	<properties.oracle.ucp maxPoolSize="3" connectionWaitTimeout="30" URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}"/>
     </dataSource>
     
     <dataSource id="ucpDSAuthData" jndiName="jdbc/ucpDSAuthData">
    	    <jdbcDriver libraryRef="UCPDBLib" />
-   		<properties.oracle.ucp URL="${jdbc.URL}" user="${jdbc.user}" password="${jdbc.password}"/>
+   		<properties.oracle.ucp URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}"/>
    		<containerAuthData user="wrong" password="wrong" />
     </dataSource>
     
@@ -69,17 +69,17 @@
     	<connectionManager maxPoolSize="2" minPoolSize="1"/> 
     	<jdbcDriver libraryRef="UCPDBLib" javax.sql.DataSource="oracle.ucp.jdbc.PoolDataSourceImpl"/>
     	<!-- TODO remove noship guard -->
-    	<properties maxPoolSize="3" connectionWaitTimeout="30" URL="${jdbc.URL}" user="${jdbc.user}" password="${jdbc.password}" connectionFactoryClassName="oracle.jdbc.pool.OracleDataSource"/>
+    	<properties maxPoolSize="3" connectionWaitTimeout="30" URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}" connectionFactoryClassName="oracle.jdbc.pool.OracleDataSource"/>
     </dataSource>
     
     <!-- This Oracle DataSource uses Liberty connection pooling rather than UCP -->
     <dataSource id="oracleDS" jndiName="jdbc/oracleDS" connectionManagerRef="sharedConMgr" type="javax.sql.DataSource">
     	<jdbcDriver libraryRef="UCPDBLib"/>
-    	<properties.oracle URL="${jdbc.URL}" user="${jdbc.user}" password="${jdbc.password}"/>
+    	<properties.oracle URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}"/>
     </dataSource>
     
-    <javaPermission codebase="${server.config.dir}oracle/ucp/ojdbc8_g.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${server.config.dir}oracle/ucp/ucp.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/ucp/ojdbc8_g.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/ucp/ucp.jar" className="java.security.AllPermission"/>
     <javaPermission codebase="${server.config.dir}/apps/oracleucpfat.war" className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
     <javaPermission codebase="${server.config.dir}/apps/oracleucpfat.war" className="javax.management.MBeanServerPermission" name="createMBeanServer"/>    
     

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ucp/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ucp/server.xml
@@ -1,0 +1,87 @@
+<!--
+    Copyright (c) 2016, 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+    <featureManager>
+      <feature>servlet-3.1</feature>
+      <feature>jdbc-4.2</feature>
+      <feature>jndi-1.0</feature>
+      <feature>componenttest-1.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+
+    <application location="oracleucpfat.war" >
+        <classloader commonLibraryRef="UCPDBLib"/>
+    </application>
+    
+    <library id="UCPDBLib">
+    	<fileset dir="${server.config.dir}/oracle/ucp"/>
+    </library>
+    
+    <connectionManager id="conMgr" maxPoolSize="2" enableSharingForDirectLookups="false"/> 
+    
+    <connectionManager id="conMgrUpdate" maxPoolSize="1" />
+    
+    <connectionManager id="sharedConMgr" maxPoolSize="1" />
+    
+    <!-- This DataSource intentionally uses a connectionManagerRef -->
+    <dataSource id="ucpDS" jndiName="jdbc/ucpDS" connectionManagerRef="conMgr" validationTimeout="20" >
+    	<jdbcDriver libraryRef="UCPDBLib" />
+    	<properties.oracle.ucp maxStatements="5"  maxPoolSize="3" user="${jdbc.user}" password="${jdbc.password}" connectionWaitTimeout="30" URL="${jdbc.URL}" />
+    </dataSource>
+    
+    <dataSource id="ucpDSSameConMgr" jndiName="jdbc/ucpDSSameConMgr" connectionManagerRef="sharedConMgr" validationTimeout="20" >
+    	<jdbcDriver libraryRef="UCPDBLib" />
+    	<properties.oracle.ucp URL="${jdbc.URL}" user="${jdbc.user}" password="${jdbc.password}" />
+    </dataSource>
+    
+    <dataSource id="ucpXADS" jndiName="jdbc/ucpXADS" type="javax.sql.XADataSource">
+    	<jdbcDriver libraryRef="UCPDBLib" />
+    	<properties.oracle.ucp maxPoolSize="3" connectionWaitTimeout="30" URL="${jdbc.URL}" user="${jdbc.user}" password="${jdbc.password}" />
+    </dataSource>
+    
+    <dataSource id="ucpConnectionPoolDS" jndiName="jdbc/ucpConnectionPoolDS" type="javax.sql.ConnectionPoolDataSource" >
+    	<jdbcDriver libraryRef="UCPDBLib" />
+    	<properties.oracle.ucp URL="${jdbc.URL}" user="${jdbc.user}" password="${jdbc.password}" />
+    </dataSource>
+    
+    <dataSource id="ucpDriverDS" jndiName="jdbc/ucpDriverDS" type="java.sql.Driver" >
+    	<jdbcDriver libraryRef="UCPDBLib" />
+    	<properties.oracle.ucp maxPoolSize="3" connectionWaitTimeout="30" URL="${jdbc.URL}" user="${jdbc.user}" password="${jdbc.password}"/>
+    </dataSource>
+    
+    <dataSource id="ucpDSAuthData" jndiName="jdbc/ucpDSAuthData">
+   	    <jdbcDriver libraryRef="UCPDBLib" />
+   		<properties.oracle.ucp URL="${jdbc.URL}" user="${jdbc.user}" password="${jdbc.password}"/>
+   		<containerAuthData user="wrong" password="wrong" />
+    </dataSource>
+    
+    <!-- This DataSource intentionally uses the generic properties element and embedded connection manager -->
+    <dataSource id="ucpDSEmbeddedConMgr" jndiName="jdbc/ucpDSEmbeddedConMgr" internalDevNonshipFunctionDoNotUseProduction="true" type="javax.sql.DataSource" validationTimeout="20" >
+    	<connectionManager maxPoolSize="2" minPoolSize="1"/> 
+    	<jdbcDriver libraryRef="UCPDBLib" javax.sql.DataSource="oracle.ucp.jdbc.PoolDataSourceImpl"/>
+    	<!-- TODO remove noship guard -->
+    	<properties maxPoolSize="3" connectionWaitTimeout="30" URL="${jdbc.URL}" user="${jdbc.user}" password="${jdbc.password}" connectionFactoryClassName="oracle.jdbc.pool.OracleDataSource"/>
+    </dataSource>
+    
+    <!-- This Oracle DataSource uses Liberty connection pooling rather than UCP -->
+    <dataSource id="oracleDS" jndiName="jdbc/oracleDS" connectionManagerRef="sharedConMgr" type="javax.sql.DataSource">
+    	<jdbcDriver libraryRef="UCPDBLib"/>
+    	<properties.oracle URL="${jdbc.URL}" user="${jdbc.user}" password="${jdbc.password}"/>
+    </dataSource>
+    
+    <javaPermission codebase="${server.config.dir}oracle/ucp/ojdbc8_g.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${server.config.dir}oracle/ucp/ucp.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${server.config.dir}/apps/oracleucpfat.war" className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+    <javaPermission codebase="${server.config.dir}/apps/oracleucpfat.war" className="javax.management.MBeanServerPermission" name="createMBeanServer"/>    
+    
+    <variable name="onError" value="FAIL"/>
+</server>

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle/bootstrap.properties
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle/bootstrap.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2016, 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+com.ibm.ws.logging.trace.specification=*=info:RRA=all
+com.ibm.ws.logging.max.file.size=0
+osgi.console=5678
+ds.loglevel=debug
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle/server.xml
@@ -23,38 +23,38 @@
     </application>
     
     <library id="DBLib">
-    	<fileset dir="${server.config.dir}/oracle"/>
+    	<fileset dir="${shared.resource.dir}/oracle"/>
     </library>
     
     <dataSource id="DefaultDataSource">
     	<jdbcDriver libraryRef="DBLib"/>
-    	<properties.oracle URL="${jdbc.URL}" user="${jdbc.user}" password="${jdbc.password}"/>
+    	<properties.oracle URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}"/>
     </dataSource>
 
     <dataSource id="casting-ds" jndiName="jdbc/casting-ds" enableConnectionCasting="true">
     	<jdbcDriver libraryRef="DBLib"/>
-    	<properties.oracle URL="${jdbc.URL}" user="${jdbc.user}" password="${jdbc.password}" roleName="TestRole"/>
+    	<properties.oracle URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}" roleName="TestRole"/>
     	<onConnect>UPDATE CONCOUNT SET NUMCONNECTIONS = NUMCONNECTIONS + 1</onConnect>
     	<onConnect>CREATE GLOBAL TEMPORARY TABLE ${TEMP_TABLE_NAME}(CURTIME NVARCHAR2(100)) ON COMMIT PRESERVE ROWS</onConnect>
     	<onConnect>INSERT INTO ${TEMP_TABLE_NAME} VALUES (CURRENT_TIMESTAMP)</onConnect>
     </dataSource>
     
     <dataSource id="driver-ds" jndiName="jdbc/driver-ds" type="java.sql.Driver">
-    	<properties.oracle URL="${jdbc.URL}" user="${jdbc.user}" password="${jdbc.password}"/>
+    	<properties.oracle URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}"/>
     	<jdbcDriver libraryRef="DBLib"/>
     </dataSource>
     
     <dataSource id="generic-driver-ds" jndiName="jdbc/generic-driver-ds">
-    	<properties URL="${jdbc.URL}" user="${jdbc.user}" password="${jdbc.password}"/>
+    	<properties URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}"/>
     	<jdbcDriver libraryRef="DBLib"/>
     </dataSource>
     
     <dataSource id="inferred-ds" jndiName="jdbc/inferred-ds">
-    	<properties databaseName="${jdbc.databaseName}" portNumber="${jdbc.portNumber}" serverName="${jdbc.serverName}" user="${jdbc.user}" password="${jdbc.password}" driverType="thin"/>
+    	<properties databaseName="${env.DBNAME}" portNumber="${env.PORT}" serverName="${env.HOST}" user="${env.USER}" password="${env.PASSWORD}" driverType="thin"/>
     	<jdbcDriver libraryRef="DBLib"/>
     </dataSource>
     
-    <javaPermission codebase="${server.config.dir}oracle/oracleunknown.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}/oracle/oracleunknown.jar" className="java.security.AllPermission"/>
     <javaPermission codebase="${server.config.dir}/apps/oraclejdbcfat.war" className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
 
     <variable name="TEMP_TABLE_NAME" value="TEMP1"/>

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle/server.xml
@@ -1,0 +1,63 @@
+<!--
+    Copyright (c) 2016, 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+    <featureManager>
+      <feature>servlet-3.1</feature>
+      <feature>jdbc-4.2</feature>
+      <feature>jndi-1.0</feature>
+      <feature>componenttest-1.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+
+    <application location="oraclejdbcfat.war" >
+        <classloader commonLibraryRef="DBLib"/>
+    </application>
+    
+    <library id="DBLib">
+    	<fileset dir="${server.config.dir}/oracle"/>
+    </library>
+    
+    <dataSource id="DefaultDataSource">
+    	<jdbcDriver libraryRef="DBLib"/>
+    	<properties.oracle URL="${jdbc.URL}" user="${jdbc.user}" password="${jdbc.password}"/>
+    </dataSource>
+
+    <dataSource id="casting-ds" jndiName="jdbc/casting-ds" enableConnectionCasting="true">
+    	<jdbcDriver libraryRef="DBLib"/>
+    	<properties.oracle URL="${jdbc.URL}" user="${jdbc.user}" password="${jdbc.password}" roleName="TestRole"/>
+    	<onConnect>UPDATE CONCOUNT SET NUMCONNECTIONS = NUMCONNECTIONS + 1</onConnect>
+    	<onConnect>CREATE GLOBAL TEMPORARY TABLE ${TEMP_TABLE_NAME}(CURTIME NVARCHAR2(100)) ON COMMIT PRESERVE ROWS</onConnect>
+    	<onConnect>INSERT INTO ${TEMP_TABLE_NAME} VALUES (CURRENT_TIMESTAMP)</onConnect>
+    </dataSource>
+    
+    <dataSource id="driver-ds" jndiName="jdbc/driver-ds" type="java.sql.Driver">
+    	<properties.oracle URL="${jdbc.URL}" user="${jdbc.user}" password="${jdbc.password}"/>
+    	<jdbcDriver libraryRef="DBLib"/>
+    </dataSource>
+    
+    <dataSource id="generic-driver-ds" jndiName="jdbc/generic-driver-ds">
+    	<properties URL="${jdbc.URL}" user="${jdbc.user}" password="${jdbc.password}"/>
+    	<jdbcDriver libraryRef="DBLib"/>
+    </dataSource>
+    
+    <dataSource id="inferred-ds" jndiName="jdbc/inferred-ds">
+    	<properties databaseName="${jdbc.databaseName}" portNumber="${jdbc.portNumber}" serverName="${jdbc.serverName}" user="${jdbc.user}" password="${jdbc.password}" driverType="thin"/>
+    	<jdbcDriver libraryRef="DBLib"/>
+    </dataSource>
+    
+    <javaPermission codebase="${server.config.dir}oracle/oracleunknown.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${server.config.dir}/apps/oraclejdbcfat.war" className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+
+    <variable name="TEMP_TABLE_NAME" value="TEMP1"/>
+
+    <variable name="onError" value="FAIL"/>
+</server>

--- a/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oraclejdbcfat/src/web/OracleTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oraclejdbcfat/src/web/OracleTestServlet.java
@@ -58,31 +58,6 @@ public class OracleTestServlet extends FATServlet {
     @Resource(lookup = "jdbc/inferred-ds")
     private DataSource inferred_ds;
 
-    public void initDatabaseTables() throws SQLException {
-        Connection con = ds.getConnection();
-        try {
-            Statement stmt = con.createStatement();
-            try {
-                stmt.execute("DROP TABLE MYTABLE");
-            } catch (SQLException x) {
-                // probably didn't exist
-            }
-            stmt.execute("CREATE TABLE MYTABLE (ID NUMBER NOT NULL PRIMARY KEY, STRVAL NVARCHAR2(40))");
-
-            try {
-                stmt.execute("DROP TABLE CONCOUNT");
-            } catch (SQLException x) {
-                // probably didn't exist
-            }
-            stmt.execute("CREATE TABLE CONCOUNT (NUMCONNECTIONS NUMBER NOT NULL)");
-            stmt.execute("INSERT INTO CONCOUNT VALUES(0)");
-
-            stmt.close();
-        } finally {
-            con.close();
-        }
-    }
-
     // Verify that connections are/are not castable to OracleConnection based on whether enableConnectionCasting=true/false.
     @Test
     public void testConnectionCasting() throws Exception {

--- a/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oraclejdbcfat/src/web/OracleTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oraclejdbcfat/src/web/OracleTestServlet.java
@@ -1,0 +1,348 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package web;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.fail;
+
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Statement;
+
+import javax.annotation.Resource;
+import javax.servlet.annotation.WebServlet;
+import javax.sql.DataSource;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import oracle.jdbc.OracleCallableStatement;
+import oracle.jdbc.OracleConnection;
+import oracle.jdbc.OraclePreparedStatement;
+import oracle.jdbc.OracleTypes;
+import oracle.jdbc.datasource.OracleCommonDataSource;
+import oracle.jdbc.datasource.OracleConnectionPoolDataSource;
+import oracle.jdbc.datasource.OracleXADataSource;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/OracleTestServlet")
+public class OracleTestServlet extends FATServlet {
+    @Resource
+    private DataSource ds;
+
+    @Resource(lookup = "jdbc/casting-ds")
+    private DataSource ds_casting;
+
+    @Resource(lookup = "jdbc/driver-ds")
+    private DataSource driver_ds;
+
+    @Resource(lookup = "jdbc/generic-driver-ds")
+    private DataSource generic_driver_ds;
+
+    @Resource(lookup = "jdbc/inferred-ds")
+    private DataSource inferred_ds;
+
+    public void initDatabaseTables() throws SQLException {
+        Connection con = ds.getConnection();
+        try {
+            Statement stmt = con.createStatement();
+            try {
+                stmt.execute("DROP TABLE MYTABLE");
+            } catch (SQLException x) {
+                // probably didn't exist
+            }
+            stmt.execute("CREATE TABLE MYTABLE (ID NUMBER NOT NULL PRIMARY KEY, STRVAL NVARCHAR2(40))");
+
+            try {
+                stmt.execute("DROP TABLE CONCOUNT");
+            } catch (SQLException x) {
+                // probably didn't exist
+            }
+            stmt.execute("CREATE TABLE CONCOUNT (NUMCONNECTIONS NUMBER NOT NULL)");
+            stmt.execute("INSERT INTO CONCOUNT VALUES(0)");
+
+            stmt.close();
+        } finally {
+            con.close();
+        }
+    }
+
+    // Verify that connections are/are not castable to OracleConnection based on whether enableConnectionCasting=true/false.
+    @Test
+    public void testConnectionCasting() throws Exception {
+        OracleConnection ocon = (OracleConnection) ds_casting.getConnection();
+        try {
+            assertTrue(ocon.isUsable());
+
+            Connection con = ocon.unwrap(Connection.class);
+            assertTrue(con.isWrapperFor(OracleConnection.class));
+
+            ocon = ocon.unwrap(OracleConnection.class);
+            assertEquals(OracleConnection.DATABASE_OK, ocon.pingDatabase());
+
+            ocon = con.unwrap(OracleConnection.class);
+            String propsUserName = ocon.getProperties().getProperty("user");
+            String metadataUserName = con.getMetaData().getUserName();
+            assertEquals(metadataUserName, propsUserName);
+        } finally {
+            ocon.close();
+        }
+
+        Connection con = ds.getConnection();
+        try {
+            assertFalse(con instanceof OracleConnection);
+
+            assertTrue(con.isWrapperFor(OracleConnection.class));
+
+            String conUserName = con.unwrap(OracleConnection.class).getUserName();
+            String metadataUserName = con.getMetaData().getUserName();
+            assertEquals(metadataUserName, conUserName);
+        } finally {
+            con.close();
+        }
+    }
+
+    // Test for oracle.jdbc.OracleCallableStatement.getCursor.  Should be able to execute a procedure that returns a cursor
+    // and use getCursor to obtain a result set.  The parent statement of the result set should be the WAS statement wrapper.
+    @Test
+    public void testCursor() throws Exception {
+        Connection con = ds.getConnection();
+        try {
+            PreparedStatement ps = con.prepareStatement("INSERT INTO MYTABLE VALUES(?,?)");
+            ps.setInt(1, 2);
+            ps.setString(2, "two");
+            ps.executeUpdate();
+            ps.close();
+
+            CallableStatement cs = con.prepareCall("BEGIN OPEN ? FOR SELECT STRVAL FROM MYTABLE WHERE ID=?; END;");
+            cs.registerOutParameter(1, OracleTypes.CURSOR);
+            cs.setInt(2, 2);
+            cs.execute();
+
+            OracleCallableStatement ocs = cs.unwrap(OracleCallableStatement.class);
+            ResultSet result = ocs.getCursor(1);
+            assertTrue(result.next());
+            assertEquals("two", result.getString(1));
+            assertFalse(result.next());
+
+            assertEquals(cs, result.getStatement());
+        } finally {
+            con.close();
+        }
+    }
+
+    // Test for the dataSource onConnect attribute that species SQL commands to Liberty to run on each new connection.
+    // In this test we cover specifying multiple onConnect SQL commands on a single data source,
+    // the use of transactional onConnect commands, as well as the use of Liberty variables in the onConnect SQL.
+    @Test
+    public void testOnConnectSQL() throws Exception {
+        Connection con = ds_casting.getConnection();
+        try {
+            con.setAutoCommit(false);
+            Statement stmt = con.createStatement();
+            ResultSet result = stmt.executeQuery("SELECT CURTIME FROM TEMP1");
+            assertTrue(result.next());
+            assertNotNull(result.getNString(1));
+            result.close();
+
+            // Make sure that onConnect SQL doesn't roll back along with the transaction
+            con.rollback();
+            con.setAutoCommit(true);
+            result = stmt.executeQuery("SELECT NUMCONNECTIONS FROM CONCOUNT");
+            assertTrue(result.next());
+            int numConnections = result.getInt(1);
+            assertTrue("onConnect SQL should have incremented connection count. Instead " + numConnections, numConnections > 0);
+        } finally {
+            con.close();
+        }
+    }
+
+    // Test for JDBC 4.2 ref cursors.  Should be able to execute a procedure that returns a cursor
+    // and use getObject to obtain a result set.  The parent statement of the result set should be the WAS statement wrapper.
+    @Test
+    public void testRefCursor() throws Exception {
+        Connection con = ds.getConnection();
+        try {
+            assertTrue(con.getMetaData().supportsRefCursors());
+
+            PreparedStatement ps = con.prepareStatement("INSERT INTO MYTABLE VALUES(?,?)");
+            ps.setInt(1, 3);
+            ps.setString(2, "three");
+            ps.executeUpdate();
+            ps.close();
+
+            CallableStatement cs = con.prepareCall("BEGIN OPEN ? FOR SELECT STRVAL FROM MYTABLE WHERE ID=?; END;");
+            cs.registerOutParameter(1, OracleTypes.CURSOR); // Why doesn't Types.REF_CURSOR from JDBC 4.2 work here? Oracle bug?
+            cs.setInt(2, 3);
+            cs.execute();
+
+            ResultSet result = cs.getObject(1, ResultSet.class);
+            assertTrue(result.next());
+            assertEquals("three", result.getString(1));
+            assertFalse(result.next());
+
+            assertEquals(cs, result.getStatement());
+            cs.close();
+            assertTrue(result.isClosed());
+        } finally {
+            con.close();
+        }
+    }
+
+    // Test for oracle.jdbc.OraclePreparedStatement.getReturnResultSet.  Should be able to execute a DML statement
+    // that returns values, obtain the return result set and use it.  The parent statement of the result set should
+    // be the WAS statement wrapper.
+    @Test
+    public void testReturnResultSet() throws Exception {
+        Connection con = ds.getConnection();
+        try {
+            PreparedStatement ps = con.prepareStatement("INSERT INTO MYTABLE VALUES(?,?)");
+            ps.setInt(1, 1);
+            ps.setString(2, "one");
+            ps.executeUpdate();
+            ps.close();
+
+            ps = con.prepareStatement("UPDATE MYTABLE SET STRVAL=STRVAL||' hundred' WHERE ID=? RETURNING STRVAL INTO ?");
+            ps.setInt(1, 1);
+            OraclePreparedStatement ops = ps.unwrap(OraclePreparedStatement.class);
+            ops.registerReturnParameter(2, OracleTypes.NVARCHAR);
+            assertEquals(1, ps.executeUpdate());
+
+            ResultSet result = ops.getReturnResultSet();
+            assertTrue(result.next());
+            assertEquals("one hundred", result.getString(1));
+            assertFalse(result.next());
+
+            assertEquals(ps, result.getStatement());
+        } finally {
+            con.close();
+        }
+    }
+
+    // Test configured value of newly supported roleName data source property for Oracle.
+    @Test
+    public void testRoleName() throws Exception {
+        // First determine if we can run this test. Oracle driver for JDBC 4.2 is not compatible with Java 9+
+        boolean atLeastJava9;
+        try {
+            Class.forName("java.lang.Runtime$Version"); // added in Java 9
+            atLeastJava9 = true;
+        } catch (ClassNotFoundException x) {
+            atLeastJava9 = false;
+        }
+        if (atLeastJava9) {
+            Connection con = ds.getConnection();
+            try {
+                DatabaseMetaData metadata = con.getMetaData();
+                int jdbcMajor = metadata.getJDBCMajorVersion();
+                int jdbcMinor = metadata.getJDBCMinorVersion();
+                if (jdbcMajor < 4 || jdbcMajor == 4 && jdbcMinor <= 2) {
+                    System.out.println("Skipped testRoleName because JDBC driver spec compliance level of " +
+                                       jdbcMajor + '.' + jdbcMinor +
+                                       " is not compatible with Java 9 or higher for unwrap operations");
+                    return;
+                }
+            } finally {
+                con.close();
+            }
+        }
+
+        OracleCommonDataSource ocds = ds_casting.unwrap(OracleCommonDataSource.class);
+        assertEquals("TestRole", ocds.getRoleName());
+
+        try {
+            ocds.setRoleName("NewRole");
+            fail("Should not be allowed to alter data source properties at run time");
+        } catch (SQLFeatureNotSupportedException x) {
+            if (!x.getMessage().contains("setRoleName"))
+                throw x;
+        }
+
+        assertEquals("TestRole", ocds.getRoleName());
+    }
+
+    //Test that a datasource backed by Driver can be used with both the generic properties element and properties.oracle
+    //element when type="java.sql.Driver"
+    @Test
+    public void testDSUsingDriver() throws Exception {
+        Connection conn = driver_ds.getConnection();
+        assertFalse("driver_ds should not wrap OracleCommonDataSource", driver_ds.isWrapperFor(OracleCommonDataSource.class));
+
+        try {
+            PreparedStatement ps = conn.prepareStatement("INSERT INTO MYTABLE VALUES(?,?)");
+            ps.setInt(1, 20);
+            ps.setString(2, "twenty");
+            ps.executeUpdate();
+            ps.close();
+        } finally {
+            conn.close();
+        }
+
+        assertFalse("generic_driver_ds should not wrap OracleCommonDataSource", generic_driver_ds.isWrapperFor(OracleCommonDataSource.class));
+        Connection conn2 = generic_driver_ds.getConnection();
+        try {
+            Statement st = conn2.createStatement();
+            ResultSet rs = st.executeQuery("SELECT STRVAL FROM MYTABLE WHERE ID = 20");
+            assertTrue("Query should have returned a result", rs.next());
+            assertEquals("Unexpected value returned", "twenty", rs.getString(1));
+            rs.close();
+        } finally {
+            conn2.close();
+        }
+    }
+
+    //Test that the proper implementation classes are used for the various datasources configured in this test bucket
+    //since the JDBC Driver used is named so as not to be recognized by the built-in logic
+    @Test
+    public void testInferOracleDataSource() throws Exception {
+        //The default datasource should continue to be inferred as an XADataSource, since it has properties.oracle configured
+        assertTrue("default datasource should wrap OracleXADataSource",
+                   ds.isWrapperFor(OracleXADataSource.class));
+
+        //ds_casting should continue to be inferred as a ConnectionPoolDataSource, since it has properties.oracle configured
+        assertTrue("ds_casting should wrap OracleConnectionPoolDataSource",
+                   ds_casting.isWrapperFor(OracleConnectionPoolDataSource.class));
+
+        //generic-driver-ds doesn't specify a type.  The presence of URL will result in the DataSource being back by Driver
+        assertFalse("The presence of the URL should result in generic-driver-ds being back by Driver",
+                    generic_driver_ds.isWrapperFor(OracleCommonDataSource.class));
+
+        //inferred ds does not specify a URL or type. This should result in inferring a datasource class name
+        //Expect it to be ConnectionPoolDataSource since that is available in the Oracle driver and it's the first type we search for
+        assertTrue("inferred-ds should wrap OracleConnectionPoolDataSource datasource since it does not have a URL property",
+                   inferred_ds.isWrapperFor(OracleConnectionPoolDataSource.class));
+
+        //try to use the inferred_ds to ensure it is usable
+        Connection conn = inferred_ds.getConnection();
+        try {
+            PreparedStatement ps = conn.prepareStatement("INSERT INTO MYTABLE VALUES(?,?)");
+            ps.setInt(1, 30);
+            ps.setString(2, "thirty");
+            ps.executeUpdate();
+            ps.close();
+            Statement st = conn.createStatement();
+            ResultSet rs = st.executeQuery("SELECT STRVAL FROM MYTABLE WHERE ID = 30");
+            assertTrue("Query should have returned a result", rs.next());
+            assertEquals("Unexpected value returned", "thirty", rs.getString(1));
+            rs.close();
+        } finally {
+            conn.close();
+        }
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oracleucpfat/src/ucp/web/OracleUCPTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oracleucpfat/src/ucp/web/OracleUCPTestServlet.java
@@ -1,0 +1,781 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package ucp.web;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.fail;
+
+import java.lang.management.ManagementFactory;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.annotation.Resource;
+import javax.annotation.sql.DataSourceDefinition;
+import javax.annotation.sql.DataSourceDefinitions;
+import javax.management.MBeanServer;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+import javax.naming.InitialContext;
+import javax.servlet.annotation.WebServlet;
+import javax.sql.DataSource;
+import javax.transaction.UserTransaction;
+
+import org.junit.Test;
+
+import componenttest.annotation.ExpectedFFDC;
+import componenttest.app.FATServlet;
+import oracle.ucp.jdbc.PoolDataSource;
+import oracle.ucp.jdbc.PoolXADataSource;
+
+@DataSourceDefinitions(value = {
+                                 @DataSourceDefinition(
+                                                       name = "java:comp/env/jdbc/dsdUCPDS",
+                                                       className = "oracle.ucp.jdbc.PoolDataSourceImpl",
+                                                       url = "${jdbc.URL}",
+                                                       isolationLevel = Connection.TRANSACTION_SERIALIZABLE,
+                                                       maxIdleTime = 30,
+                                                       minPoolSize = 1,
+                                                       initialPoolSize = 1, //This property should be allowed when using UCP
+                                                       user = "${jdbc.user}",
+                                                       password = "${jdbc.password}",
+                                                       maxPoolSize = 3,
+                                                       maxStatements = 9,
+                                                       properties = {
+                                                                      "connectionTimeout=1", //Liberty property, shouldn't take effect
+                                                                      "connectionWaitTimeout=30", //UCP property - should be used
+                                                                      "validationTimeout=30",
+                                                                      "connectionFactoryClassName=oracle.jdbc.pool.OracleDataSource"
+                                                       }),
+                                 @DataSourceDefinition(
+                                                       name = "java:comp/env/jdbc/dsdXAUCPDS",
+                                                       className = "oracle.ucp.jdbc.PoolXADataSourceImpl",
+                                                       url = "${jdbc.URL}",
+                                                       initialPoolSize = 1,
+                                                       user = "${jdbc.user}",
+                                                       password = "${jdbc.password}",
+                                                       maxStatements = 10,
+                                                       properties = {
+                                                                      "validationTimeout=30"
+                                                       })
+})
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/OracleUCPTestServlet")
+public class OracleUCPTestServlet extends FATServlet {
+
+    @Resource(lookup = "jdbc/ucpDS", shareable = false)
+    private DataSource ucpDS;
+
+    @Resource(lookup = "jdbc/oracleDS", shareable = false)
+    private DataSource oracleDS;
+
+    @Resource(lookup = "jdbc/ucpXADS", shareable = false)
+    private DataSource ucpXADS;
+
+    @Resource(lookup = "jdbc/ucpDS", shareable = true)
+    private DataSource sharedUCPDS;
+
+    @Resource(lookup = "jdbc/ucpDSEmbeddedConMgr", shareable = false)
+    private DataSource ucpDSEmbeddedConMgr;
+
+    @Resource(lookup = "java:comp/env/jdbc/dsdUCPDS", shareable = false)
+    private DataSource dsdUCPDS;
+
+    @Resource(lookup = "java:comp/env/jdbc/dsdXAUCPDS", shareable = false)
+    private DataSource dsdXAUCPDS;
+
+    @Resource(lookup = "jdbc/ucpDSAuthData")
+    private DataSource ucpDSAuthData;
+
+    private final ExecutorService executor = Executors.newFixedThreadPool(5);
+
+    @Resource
+    private UserTransaction tran;
+
+    public void initDatabaseTables() throws SQLException {
+        Connection con = ucpDS.getConnection();
+        try {
+            Statement stmt = con.createStatement();
+            try {
+                stmt.execute("DROP TABLE COLORTABLE");
+            } catch (SQLException x) {
+                // probably didn't exist
+            }
+            stmt.execute("CREATE TABLE COLORTABLE (ID NUMBER NOT NULL PRIMARY KEY, COLOR NVARCHAR2(40))");
+            PreparedStatement ps = con.prepareStatement("INSERT INTO COLORTABLE VALUES(?,?)");
+            ps.setInt(1, 1);
+            ps.setString(2, "maroon");
+            ps.executeUpdate();
+            ps.close();
+
+            stmt.close();
+        } finally {
+            con.close();
+        }
+    }
+
+    /**
+     * Basic test that we can get and use a connection when using Oracle UCP
+     */
+    @Test
+    public void testOracleUCP() throws Exception {
+        Connection con = ucpDS.getConnection();
+
+        try {
+            PreparedStatement ps = con.prepareStatement("SELECT COLOR FROM COLORTABLE WHERE ID=?");
+            ps.setInt(1, 1);
+            ResultSet result = ps.executeQuery();
+
+            assertTrue(result.next());
+            assertEquals("maroon", result.getString(1));
+            assertFalse(result.next());
+        } finally {
+            con.close();
+        }
+    }
+
+    /**
+     * Test that you cannot use UCP as a ConnectionPoolDataSource since Oracle doesn't implement
+     * a ConnectionPoolDataSource for UCP.
+     */
+    @Test
+    @ExpectedFFDC({ "java.sql.SQLNonTransientException" })
+    public void testOracleUCPConnectionPoolDS() throws Exception {
+        InitialContext ctx = new InitialContext();
+        try {
+            ctx.lookup("jdbc/ucpConnectionPoolDS");
+            fail("Should not be able to use Connection Pool DataSource when using UCP.");
+        } catch (Exception ex) {
+            System.out.println("Caught exception: " + ex);
+            //expected
+        }
+    }
+
+    /**
+     * Basic test that we can get and use a connection when using Oracle UCP with an XA datasource.
+     */
+    @Test
+    public void testOracleUCPXADS() throws Exception {
+        Connection con = ucpXADS.getConnection();
+
+        assertTrue(ucpXADS.isWrapperFor(PoolXADataSource.class));
+
+        try {
+            PreparedStatement ps = con.prepareStatement("SELECT COLOR FROM COLORTABLE WHERE ID=?");
+            ps.setInt(1, 1);
+            ResultSet result = ps.executeQuery();
+
+            assertTrue(result.next());
+            assertEquals("maroon", result.getString(1));
+            assertFalse(result.next());
+        } finally {
+            con.close();
+        }
+    }
+
+    /**
+     * Test that you cannot use UCP as a java.sql.Driver since Oracle doesn't implement
+     * the Driver interface for UCP.
+     */
+    @Test
+    @ExpectedFFDC({ "java.sql.SQLNonTransientException" })
+    public void testOracleUCPDriverDS() throws Exception {
+        InitialContext ctx = new InitialContext();
+        try {
+            ctx.lookup("jdbc/ucpDriverDS");
+            fail("Should not be able to use Driver when using UCP.");
+        } catch (Exception ex) {
+            System.out.println("Caught exception: " + ex);
+            //expected
+        }
+    }
+
+    /**
+     * Test that using UCP with XA, connections can be properly enlisted in a transaction and
+     * rolled back/committed as appropriate. Uses two resources to ensure that we are actually
+     * using XA and not just getting the 1PC optimization.
+     */
+    @Test
+    public void testOracleUCPXATranEnlistment() throws Exception {
+        Connection con = ucpXADS.getConnection();
+        Connection con2 = null;
+
+        try {
+            con2 = ucpXADS.getConnection();
+            tran.begin();
+
+            //Add a new row to the db
+            PreparedStatement ps = con.prepareStatement("INSERT INTO COLORTABLE VALUES(?,?)");
+            ps.setInt(1, 2);
+            ps.setString(2, "gold");
+            ps.executeUpdate();
+            ps.close();
+
+            //Add a new row to the db using the second 2PC resource
+            ps = con2.prepareStatement("INSERT INTO COLORTABLE VALUES(?,?)");
+            ps.setInt(1, 3);
+            ps.setString(2, "green");
+            ps.executeUpdate();
+            ps.close();
+
+            tran.commit();
+
+            //ensure our updates were committed
+            ps = con.prepareStatement("SELECT COLOR FROM COLORTABLE WHERE ID=?");
+            ps.setInt(1, 2);
+            ResultSet result = ps.executeQuery();
+
+            assertTrue(result.next());
+            assertEquals("gold", result.getString(1));
+            assertFalse(result.next());
+
+            ps = con2.prepareStatement("SELECT COLOR FROM COLORTABLE WHERE ID=?");
+            ps.setInt(1, 3);
+            result = ps.executeQuery();
+
+            assertTrue(result.next());
+            assertEquals("green", result.getString(1));
+            assertFalse(result.next());
+
+            //now add another row the db, but rollback the transaction
+            tran.begin();
+
+            ps = con.prepareStatement("INSERT INTO COLORTABLE VALUES(?,?)");
+            ps.setInt(1, 4);
+            ps.setString(2, "blue");
+            ps.executeUpdate();
+            ps.close();
+
+            tran.rollback();
+
+            //ensure our update was rolled back
+            ps = con.prepareStatement("SELECT COLOR FROM COLORTABLE WHERE ID=?");
+            ps.setInt(1, 4);
+            result = ps.executeQuery();
+
+            assertFalse(result.next());
+
+        } finally {
+            con.close();
+            if (con2 != null)
+                con2.close();
+        }
+    }
+
+    /**
+     * Test that connection sharing behaves as normal when using UCP. You should be able to take advantage
+     * of serial reuse with UCP since the connection is not actually closed until a transaction boundary
+     * is crossed.
+     */
+    @Test
+    public void testOracleUCPConnectionSharing() throws Exception {
+        Connection con = sharedUCPDS.getConnection();
+        Connection con2 = null;
+
+        try {
+            //use the connection
+            PreparedStatement ps = con.prepareStatement("SELECT COLOR FROM COLORTABLE WHERE ID=?");
+            ps.setInt(1, 1);
+            ResultSet result = ps.executeQuery();
+
+            assertTrue(result.next());
+            assertEquals("maroon", result.getString(1));
+            assertFalse(result.next());
+
+            con.close();
+            assertEquals("Pool size should still be 1 after connection is closed since we have not left the transaction scope",
+                         1, getPoolSize("jdbc/ucpDS"));
+
+            con2 = sharedUCPDS.getConnection();
+
+            assertEquals("Pool size should be 1 since we should be using the shared connection",
+                         1, getPoolSize("jdbc/ucpDS"));
+
+        } finally {
+            con.close();
+            if (con2 != null)
+                con2.close();
+        }
+
+    }
+
+    /**
+     * Basic test that we can get and use a connection when using Oracle UCP with an embedded connection
+     * manager.
+     */
+    @Test
+    public void testOracleUCPEmbeddedConMgr() throws Exception {
+        Connection con = ucpDSEmbeddedConMgr.getConnection();
+
+        try {
+            PreparedStatement ps = con.prepareStatement("SELECT COLOR FROM COLORTABLE WHERE ID=?");
+            ps.setInt(1, 1);
+            ResultSet result = ps.executeQuery();
+
+            assertTrue(result.next());
+            assertEquals("maroon", result.getString(1));
+            assertFalse(result.next());
+        } finally {
+            con.close();
+        }
+    }
+
+    /**
+     * This tests that the proper max connections value is enforced. The Liberty connection manager is
+     * configured with max connections = 2, which should be ignored since UCP is being used. UCP is configured
+     * with max connections 3, which should be enforced.
+     */
+    @Test
+    public void testOracleUCPMaxConnections() throws Exception {
+        Connection con1 = ucpDS.getConnection();
+        Connection con2 = null;
+        Connection con3 = null;
+
+        try {
+            con2 = ucpDS.getConnection();
+            //Should be able to get this connection since the Liberty config is ignored
+            con3 = ucpDS.getConnection();
+
+            //Need to request the fourth connection async since the getConnection request should hang
+            //until there is room in the pool
+            Future<Boolean> future = executor.submit(() -> {
+                try (Connection con4 = ucpDS.getConnection()) {
+                    return true;
+                }
+            });
+
+            //Wait 10 seconds, assume we would normally would obtain a connection in that amount of time
+            try {
+                fail("The task should not have completed, instead returned " + future.get(10, TimeUnit.SECONDS));
+            } catch (TimeoutException ex) {
+                //expected
+            }
+
+            //Now try to close one of the connections, which should allow the other task to complete
+            con3.close();
+            assertTrue(future.get(5, TimeUnit.MINUTES));
+
+        } finally {
+            con1.close();
+            con2.close();
+        }
+    }
+
+    /**
+     * That that if a minPoolSize is configured on a connection manager used by Oracle UCP
+     * the value is ignored.
+     */
+    @Test
+    public void testOracleUCPMinConnections() throws Exception {
+        Connection con = ucpDSEmbeddedConMgr.getConnection();
+        con.close();
+
+        assertEquals("Connection pool should be empty", 0, getPoolSize("jdbc/ucpDSEmbeddedConMgr"));
+    }
+
+    /**
+     * This tests that the proper max connections value is enforced when using an embedded connection
+     * manager. The Liberty connection manager is configured with max connections = 2, which
+     * should be ignored since UCP is being used. UCP is configured with max connections 3, which should
+     * be enforced.
+     */
+    @Test
+    public void testOracleUCPMaxConnectionsEmbedded() throws Exception {
+        Connection con1 = ucpDSEmbeddedConMgr.getConnection();
+        Connection con2 = null;
+        Connection con3 = null;
+
+        try {
+            con2 = ucpDSEmbeddedConMgr.getConnection();
+            //Should be able to get this connection since the Liberty config is ignored
+            con3 = ucpDSEmbeddedConMgr.getConnection();
+
+            //Need to request the fourth connection async since the getConnection request should hang
+            //until there is room in the pool
+            Future<Boolean> future = executor.submit(() -> {
+                try (Connection con4 = ucpDSEmbeddedConMgr.getConnection()) {
+                    return true;
+                }
+            });
+
+            //Wait 10 seconds, assume that would normally would obtain a connection in that amount of time
+            try {
+                fail("The task should not have completed, instead returned " + future.get(10, TimeUnit.SECONDS));
+            } catch (TimeoutException ex) {
+                //expected
+            }
+
+            //Now try to close one of the connections, which should allow the other task to complete
+            con3.close();
+            assertTrue(future.get(5, TimeUnit.MINUTES));
+
+        } finally {
+            con1.close();
+            con2.close();
+        }
+    }
+
+    /**
+     * Test that an Oracle DataSource using the Liberty Connection Manager and an Oracle DataSource
+     * using UCP can be used simultaneously.
+     */
+    @Test
+    public void testUCPAndLibertyConnPool() throws Exception {
+        //first get a UCP connection
+        Connection ucpCon = ucpDS.getConnection();
+        Connection con1 = oracleDS.getConnection();
+
+        try {
+
+            //Need to request the second connection async since the getConnection request should hang
+            //until there is room in the pool
+            Future<Boolean> future = executor.submit(() -> {
+                try (Connection con2 = oracleDS.getConnection()) {
+                    return true;
+                }
+            });
+
+            //Wait 10 seconds, assume that would normally would obtain a connection in that amount of time
+            try {
+                fail("The task should not have completed, instead returned " + future.get(10, TimeUnit.SECONDS));
+            } catch (TimeoutException ex) {
+                //expected
+            }
+
+            //Now try to close one of the connections, which should allow the other task to complete
+            con1.close();
+            assertTrue(future.get(5, TimeUnit.MINUTES));
+
+        } finally {
+            con1.close();
+            ucpCon.close();
+        }
+    }
+
+    /**
+     * Test that the minPoolSize property is not utilized by the Liberty connection manager
+     * when using UCP with DataSourceDefinition
+     */
+    @Test
+    public void testUCPDSDMinConnections() throws Exception {
+        Connection con = dsdUCPDS.getConnection();
+        con.close();
+
+        assertEquals("Connection pool should be empty", 0, getPoolSize("java.comp/env/jdbc/dsdUCPDS"));
+    }
+
+    /**
+     * Test that using UCP with XA in DataSourceDefinition, connections can be properly enlisted
+     * in a transaction and rolled back/committed as appropriate. Uses two resources to ensure
+     * that we are actually using XA and not just getting the 1PC optimization.
+     */
+    @Test
+    public void testOracleUCPXATranEnlistmentDSD() throws Exception {
+        Connection con = dsdXAUCPDS.getConnection();
+        Connection con2 = null;
+
+        try {
+            con2 = dsdXAUCPDS.getConnection();
+            tran.begin();
+
+            //Add a new row to the db
+            PreparedStatement ps = con.prepareStatement("INSERT INTO COLORTABLE VALUES(?,?)");
+            ps.setInt(1, 100);
+            ps.setString(2, "gray");
+            ps.executeUpdate();
+            ps.close();
+
+            //Add a new row to the db using the second 2PC resource
+            ps = con2.prepareStatement("INSERT INTO COLORTABLE VALUES(?,?)");
+            ps.setInt(1, 101);
+            ps.setString(2, "purple");
+            ps.executeUpdate();
+            ps.close();
+
+            tran.commit();
+
+            //ensure our updates were committed
+            ps = con.prepareStatement("SELECT COLOR FROM COLORTABLE WHERE ID=?");
+            ps.setInt(1, 100);
+            ResultSet result = ps.executeQuery();
+
+            assertTrue(result.next());
+            assertEquals("gray", result.getString(1));
+            assertFalse(result.next());
+
+            ps = con2.prepareStatement("SELECT COLOR FROM COLORTABLE WHERE ID=?");
+            ps.setInt(1, 101);
+            result = ps.executeQuery();
+
+            assertTrue(result.next());
+            assertEquals("purple", result.getString(1));
+            assertFalse(result.next());
+
+            //now add another row the db, but rollback the transaction
+            tran.begin();
+
+            ps = con.prepareStatement("INSERT INTO COLORTABLE VALUES(?,?)");
+            ps.setInt(1, 102);
+            ps.setString(2, "yellow");
+            ps.executeUpdate();
+            ps.close();
+
+            tran.rollback();
+
+            //ensure our update was rolled back
+            ps = con.prepareStatement("SELECT COLOR FROM COLORTABLE WHERE ID=?");
+            ps.setInt(1, 102);
+            result = ps.executeQuery();
+
+            assertFalse(result.next());
+
+        } finally {
+            con.close();
+            if (con2 != null)
+                con2.close();
+        }
+    }
+
+    /**
+     * Test that when using the maxStatements property of DataSource definition the value
+     * is properly divided by the maxPoolSize.
+     */
+    @Test
+    public void testUCPMaxStatements() throws Exception {
+        //TODO remove this restriction once Oracle release a JDBC 4.3 compliant driver
+        boolean atLeastJava9 = false;
+        //Oracle driver and UCP for JDBC 4.2 is not compatible with Java 9+
+        try {
+            Class.forName("java.lang.Runtime$Version"); // added in Java 9
+            atLeastJava9 = true;
+        } catch (ClassNotFoundException x) {
+            atLeastJava9 = false;
+        }
+
+        if (atLeastJava9) {
+            System.out.println("Skipping testUCPMaxStatements because we are running on java 9 or greater");
+            return;
+        }
+        PoolDataSource poolDataSourceDSD = dsdUCPDS.unwrap(PoolDataSource.class);
+        assertEquals("The maxStatements should be divided by the maxPoolSize", 3, poolDataSourceDSD.getMaxStatements());
+
+        PoolXADataSource poolDataSourceXADSD = dsdXAUCPDS.unwrap(PoolXADataSource.class);
+        assertEquals("The maxStatements should be 0 since maxPoolSize is not defined", 0, poolDataSourceXADSD.getMaxStatements());
+
+        PoolDataSource poolDataSource = ucpDS.unwrap(PoolDataSource.class);
+        assertEquals("maxStatements shouldn't be divided when not using DataSourceDef", 5, poolDataSource.getMaxStatements());
+    }
+
+    /**
+     * Tests that UCP properties that share a name with their Liberty equivalents are
+     * correctly passed to the UCP driver when using DataSourceDefintiion.
+     */
+    @Test
+    public void testDataSourceDefProps() throws Exception {
+        //TODO remove this restriction once Oracle release a JDBC 4.3 compliant driver
+        boolean atLeastJava9 = false;
+        //Oracle driver and UCP for JDBC 4.2 is not compatible with Java 9+
+        try {
+            Class.forName("java.lang.Runtime$Version"); // added in Java 9
+            atLeastJava9 = true;
+        } catch (ClassNotFoundException x) {
+            atLeastJava9 = false;
+        }
+
+        if (atLeastJava9) {
+            System.out.println("Skipping testDataSourceDefProps because we are running on java 9 or greater");
+            return;
+        }
+        PoolDataSource pds = dsdUCPDS.unwrap(PoolDataSource.class);
+
+        assertEquals("maxIdleTime not set on UCP", 30, pds.getMaxIdleTime());
+
+        assertEquals("maxPoolSize not set on UCP", 3, pds.getMaxPoolSize());
+
+        assertEquals("minPoolSize not set on UCP", 1, pds.getMinPoolSize());
+
+        //initialPoolSize doesn't have a Liberty equivalent so ensure it is allowed through
+        assertEquals("initialPoolSize not set on UCP", 1, pds.getInitialPoolSize());
+    }
+
+    /**
+     * Tests that when a connection manager is shared between two datasources an
+     * exception is thrown as that is not a supported configuration
+     */
+    @Test
+    @ExpectedFFDC({ "java.lang.UnsupportedOperationException" })
+    public void testSharingConMgr() throws Exception {
+        InitialContext ctx = new InitialContext();
+        try {
+            ctx.lookup("jdbc/ucpDSSameConMgr");
+            fail("Lookup should fail");
+        } catch (Exception ex) {
+            //expected
+        }
+    }
+
+    /**
+     * Test that the appropriate connection manager properties (currently just
+     * enableSharingForDirectLookups) are still enforced when using UCP
+     */
+    @Test
+    public void testOtherConnMgrPropsApplied() throws Exception {
+        //do a direct lookup of ucpDS
+        InitialContext ctx = new InitialContext();
+        DataSource ds = (DataSource) ctx.lookup("jdbc/ucpDS");
+
+        //get and close a connection
+        Connection con = ds.getConnection();
+        con.close();
+
+        //since we have enableSharingForDirectLookups=false, the connection should be closed
+        //in Liberty and returned to UCP, otherwise it would remain in the shared pool
+        assertEquals("There should be 0 connections in the pool", 0, getPoolSize("jdbc/ucpDS"));
+    }
+
+    /**
+     * Test that when supplied with a user and password in a get connection request the
+     * credentials are honored by the UCP driver
+     */
+    @Test
+    @ExpectedFFDC({ "java.sql.SQLException", "javax.resource.spi.ResourceAllocationException", "com.ibm.ws.rsadapter.exceptions.DataStoreAdapterException" })
+    public void getConnectionUserPass() throws Exception {
+        try {
+            ucpDS.getConnection("wrongUser", "wrongPassword");
+            fail("Credentials with the connection request were not honored");
+        } catch (Exception ex) {
+            //expected
+        }
+    }
+
+    /**
+     * Test that when supplied with a user and password in containerAuthData the
+     * credentials are honored by the UCP driver, even though a user and password
+     * are also required as ds props
+     */
+    @Test
+    @ExpectedFFDC({ "java.sql.SQLException", "javax.resource.spi.ResourceAllocationException", "com.ibm.ws.rsadapter.exceptions.DataStoreAdapterException" })
+    public void testAuthData() throws Exception {
+        try {
+            ucpDSAuthData.getConnection();
+            fail("User/password from containerAuthData not honored");
+        } catch (Exception ex) {
+            //expected
+        }
+    }
+
+    //Used by config update tests to verify we are using a UCP datasource and
+    //using the UCP rather than Liberty connection manager config
+    public void testUsingUCP() throws Exception {
+        assertTrue(oracleDS.isWrapperFor(PoolDataSource.class));
+        Connection con1 = oracleDS.getConnection();
+        Connection con2 = null;
+
+        try {
+            //Should be able to get a second connection as we've switched to using UCP config
+            con2 = oracleDS.getConnection();
+
+            //Need to request the third connection async since the getConnection request should hang
+            //until there is room in the pool
+            Future<Boolean> future = executor.submit(() -> {
+                try (Connection con3 = oracleDS.getConnection()) {
+                    return true;
+                }
+            });
+
+            //Wait 10 seconds, assume that would normally would obtain a connection in that amount of time
+            try {
+                fail("The task should not have completed, instead returned " + future.get(10, TimeUnit.SECONDS));
+            } catch (TimeoutException ex) {
+                //expected
+            }
+
+            //Now try to close one of the connections, which should allow the other task to complete
+            con2.close();
+            assertTrue(future.get(5, TimeUnit.MINUTES));
+
+        } finally {
+            con1.close();
+            con2.close();
+        }
+    }
+
+    //Used by config update tests to verify we are using a non UCP datasource and
+    //using the Liberty rather than UCP connection manager config
+    public void testUsingLibertyConnPool() throws Exception {
+        assertFalse(oracleDS.isWrapperFor(PoolDataSource.class));
+        Connection con1 = oracleDS.getConnection();
+
+        try {
+            //Need to request the second connection async since the getConnection request should hang
+            //until there is room in the pool
+            Future<Boolean> future = executor.submit(() -> {
+                try (Connection con2 = oracleDS.getConnection()) {
+                    return true;
+                }
+            });
+
+            //Wait 10 seconds, assume that would normally would obtain a connection in that amount of time
+            try {
+                fail("The task should not have completed, instead returned " + future.get(10, TimeUnit.SECONDS));
+            } catch (TimeoutException ex) {
+                //expected
+            }
+
+            //Now try to close one of the connections, which should allow the other task to complete
+            con1.close();
+            assertTrue(future.get(5, TimeUnit.MINUTES));
+
+        } finally {
+            con1.close();
+        }
+    }
+
+    //Used by testUpdateDSType
+    public void testUsingPoolDataSource() throws Exception {
+        assertTrue(ucpXADS.isWrapperFor(PoolDataSource.class));
+        assertFalse(ucpXADS.isWrapperFor(PoolXADataSource.class));
+    }
+
+    private ObjectInstance getMBeanObjectInstance(String jndiName) throws Exception {
+        MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+        ObjectName obn = new ObjectName("WebSphere:type=com.ibm.ws.jca.cm.mbean.ConnectionManagerMBean,jndiName=" + jndiName + ",*");
+        Set<ObjectInstance> s = mbs.queryMBeans(obn, null);
+        if (s.size() != 1) {
+            System.out.println("ERROR: Found incorrect number of MBeans (" + s.size() + ")");
+            for (ObjectInstance i : s)
+                System.out.println("  Found MBean: " + i.getObjectName());
+            throw new Exception("Expected to find exactly 1 MBean, instead found " + s.size());
+        }
+        return s.iterator().next();
+    }
+
+    private int getPoolSize(String jndiName) throws Exception {
+        MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+        ObjectInstance bean = getMBeanObjectInstance(jndiName);
+        System.out.println("Found " + bean.getObjectName().toString());
+        String contents = (String) mbs.invoke(bean.getObjectName(), "showPoolContents", null, null);
+        System.out.println("   " + contents.replace("\n", "\n   "));
+
+        return Integer.parseInt((String) mbs.getAttribute(bean.getObjectName(), "size"));
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oracleucpfat/src/ucp/web/OracleUCPTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oracleucpfat/src/ucp/web/OracleUCPTestServlet.java
@@ -50,13 +50,13 @@ import oracle.ucp.jdbc.PoolXADataSource;
                                  @DataSourceDefinition(
                                                        name = "java:comp/env/jdbc/dsdUCPDS",
                                                        className = "oracle.ucp.jdbc.PoolDataSourceImpl",
-                                                       url = "${jdbc.URL}",
+                                                       url = "${env.URL}",
                                                        isolationLevel = Connection.TRANSACTION_SERIALIZABLE,
                                                        maxIdleTime = 30,
                                                        minPoolSize = 1,
                                                        initialPoolSize = 1, //This property should be allowed when using UCP
-                                                       user = "${jdbc.user}",
-                                                       password = "${jdbc.password}",
+                                                       user = "${env.USER}",
+                                                       password = "${env.PASSWORD}",
                                                        maxPoolSize = 3,
                                                        maxStatements = 9,
                                                        properties = {
@@ -68,10 +68,10 @@ import oracle.ucp.jdbc.PoolXADataSource;
                                  @DataSourceDefinition(
                                                        name = "java:comp/env/jdbc/dsdXAUCPDS",
                                                        className = "oracle.ucp.jdbc.PoolXADataSourceImpl",
-                                                       url = "${jdbc.URL}",
+                                                       url = "${env.URL}",
                                                        initialPoolSize = 1,
-                                                       user = "${jdbc.user}",
-                                                       password = "${jdbc.password}",
+                                                       user = "${env.USER}",
+                                                       password = "${env.PASSWORD}",
                                                        maxStatements = 10,
                                                        properties = {
                                                                       "validationTimeout=30"

--- a/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oracleucpfat/src/ucp/web/OracleUCPTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oracleucpfat/src/ucp/web/OracleUCPTestServlet.java
@@ -111,28 +111,6 @@ public class OracleUCPTestServlet extends FATServlet {
     @Resource
     private UserTransaction tran;
 
-    public void initDatabaseTables() throws SQLException {
-        Connection con = ucpDS.getConnection();
-        try {
-            Statement stmt = con.createStatement();
-            try {
-                stmt.execute("DROP TABLE COLORTABLE");
-            } catch (SQLException x) {
-                // probably didn't exist
-            }
-            stmt.execute("CREATE TABLE COLORTABLE (ID NUMBER NOT NULL PRIMARY KEY, COLOR NVARCHAR2(40))");
-            PreparedStatement ps = con.prepareStatement("INSERT INTO COLORTABLE VALUES(?,?)");
-            ps.setInt(1, 1);
-            ps.setString(2, "maroon");
-            ps.executeUpdate();
-            ps.close();
-
-            stmt.close();
-        } finally {
-            con.close();
-        }
-    }
-
     /**
      * Basic test that we can get and use a connection when using Oracle UCP
      */


### PR DESCRIPTION
Moving Oracle JDBC fat tests to Open Liberty.
Having a fat bucket that uses the Oracle-XE test container outside of DB rotation will help ensure that we can detect the difference between an oracle regression and a testcontainer regression. 