### PR TITLE
8933-CertCacheShort COMMIT 1-3

### DIFF
--- a/dev/com.ibm.ws.security.authentication.builtin/bnd.bnd
+++ b/dev/com.ibm.ws.security.authentication.builtin/bnd.bnd
@@ -72,6 +72,10 @@ Service-Component: \
     implementation:=com.ibm.ws.security.authentication.internal.cache.keyproviders.SSOTokenBytesCacheKeyProvider; \
     provide:=com.ibm.ws.security.authentication.cache.CacheKeyProvider; \
     properties:="service.vendor=IBM", \
+  com.ibm.ws.security.authentication.internal.cache.keyproviders.X509CertCacheKeyProvider; \
+    implementation:=com.ibm.ws.security.authentication.internal.cache.keyproviders.X509CertCacheKeyProvider; \
+    provide:=com.ibm.ws.security.authentication.cache.CacheKeyProvider; \
+    properties:="service.vendor=IBM", \
   com.ibm.ws.security.authentication.internal.cache.keyproviders.CustomCacheKeyProvider; \
     implementation:=com.ibm.ws.security.authentication.internal.cache.keyproviders.CustomCacheKeyProvider; \
     provide:=com.ibm.ws.security.authentication.cache.CacheKeyProvider; \

--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/AuthenticationServiceImpl.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/AuthenticationServiceImpl.java
@@ -40,6 +40,7 @@ import com.ibm.ws.security.authentication.cache.AuthCacheService;
 import com.ibm.ws.security.authentication.internal.cache.keyproviders.BasicAuthCacheKeyProvider;
 import com.ibm.ws.security.authentication.internal.cache.keyproviders.CustomCacheKeyProvider;
 import com.ibm.ws.security.authentication.internal.jaas.JAASServiceImpl;
+import com.ibm.ws.security.authentication.jaas.modules.CertificateLoginModule;
 import com.ibm.ws.security.authentication.utility.SubjectHelper;
 import com.ibm.ws.security.credentials.CredentialsService;
 import com.ibm.ws.security.delegation.DelegationProvider;
@@ -50,6 +51,7 @@ import com.ibm.ws.security.registry.UserRegistry;
 import com.ibm.ws.security.registry.UserRegistryService;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 import com.ibm.wsspi.security.token.AttributeNameConstants;
+import java.security.cert.X509Certificate;
 
 @TraceOptions(messageBundle = "com.ibm.ws.security.authentication.internal.resources.AuthenticationMessages")
 public class AuthenticationServiceImpl implements AuthenticationService {
@@ -211,6 +213,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
             }
         } finally {
             releaseLock(authenticationData, currentLock);
+            CertificateLoginModule.collectiveCertificate.set(false);
         }
     }
 
@@ -329,12 +332,17 @@ public class AuthenticationServiceImpl implements AuthenticationService {
                 if (ssoTokenBytes != null) {
                     subject = findSubjectByTokenContents(authCacheService, null, ssoTokenBytes, authenticationData);
                 } else {
-                    String userid = (String) authenticationData.get(AuthenticationData.USERNAME);
-                    String password = getPassword((char[]) authenticationData.get(AuthenticationData.PASSWORD));
-                    if (userid != null && password != null) {
-                        subject = findSubjectByUseridAndPassword(authCacheService, userid, password);
-                    } else if (partialSubject != null) {
-                        subject = findSubjectBySubjectHashtable(authCacheService, partialSubject);
+                    X509Certificate[] certChain = (X509Certificate[])authenticationData.get(AuthenticationData.CERTCHAIN);
+                    if (certChain != null) {
+                        subject = findSubjectByX509Cert(authCacheService, certChain);
+                    } else {
+                        String userid = (String) authenticationData.get(AuthenticationData.USERNAME);
+                        String password = getPassword((char[]) authenticationData.get(AuthenticationData.PASSWORD));
+                        if (userid != null && password != null) {
+                            subject = findSubjectByUseridAndPassword(authCacheService, userid, password);
+                        } else if (partialSubject != null) {
+                            subject = findSubjectBySubjectHashtable(authCacheService, partialSubject);
+                        }
                     }
                 }
             }
@@ -342,6 +350,12 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         return subject;
     }
 
+    private Subject findSubjectByX509Cert(AuthCacheService authCacheService, X509Certificate[] certChain) {
+        int certHash = ((java.security.cert.Certificate) certChain[0]).hashCode();
+        return authCacheService.getSubject(certHash);
+    }
+
+    
     /**
      * @param authCacheService An authentication cache service
      * @param token The cache key, can be either a byte[] (SSO Token) or String (SSO Token Base64 encoded)
@@ -506,7 +520,11 @@ public class AuthenticationServiceImpl implements AuthenticationService {
             if (userid != null && password != null) {
                 authCacheService.insert(authenticatedSubject, userid, password);
             } else {
-                authCacheService.insert(authenticatedSubject);
+                if (authenticationData.get(authenticationData.CERTCHAIN) != null) {
+                    authCacheService.insert(authenticatedSubject, (X509Certificate[])authenticationData.get(AuthenticationData.CERTCHAIN));
+                } else {
+                    authCacheService.insert(authenticatedSubject);
+                }
             }
         }
     }

--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/AuthCacheServiceImpl.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/AuthCacheServiceImpl.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.security.authentication.internal.cache;
 
+import java.security.cert.X509Certificate;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -63,6 +64,21 @@ public class AuthCacheServiceImpl implements AuthCacheService, UserRegistryChang
         try {
             CacheObject cacheObject = new CacheObject(subject);
             CacheContext cacheContext = new CacheContext(authCacheConfig, cacheObject, userid, password);
+            commonInsert(cacheContext, cacheObject);
+        } catch (Exception e) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "There was a problem caching the subject.", e);
+            }
+        }
+    }
+
+    /** {@inheritDoc} */
+    @FFDCIgnore(Exception.class)
+    @Override
+    public void insert(Subject subject, X509Certificate[] certChain) {
+        try {
+            CacheObject cacheObject = new CacheObject(subject);
+            CacheContext cacheContext = new CacheContext(authCacheConfig, cacheObject, certChain);
             commonInsert(cacheContext, cacheObject);
         } catch (Exception e) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {

--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/keyproviders/X509CertCacheKeyProvider.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/keyproviders/X509CertCacheKeyProvider.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.authentication.internal.cache.keyproviders;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.security.authentication.cache.CacheContext;
+import com.ibm.ws.security.authentication.cache.CacheKeyProvider;
+import com.ibm.ws.security.authentication.internal.TraceConstants;
+import com.ibm.ws.security.authentication.jaas.modules.CertificateLoginModule;
+
+/**
+ *
+ */
+public class X509CertCacheKeyProvider implements CacheKeyProvider {
+
+    private static final TraceComponent tc = Tr.register(X509CertCacheKeyProvider.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
+
+    @Override
+    public Object provideKey(CacheContext cacheContext) {
+        int certHash;
+        Boolean isCollectiveCert = CertificateLoginModule.collectiveCertificate.get();
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(tc, "collectiveCertificate=" + isCollectiveCert);
+        if (isCollectiveCert == null || isCollectiveCert == false) {
+            final java.security.cert.X509Certificate[] cert_chain = (java.security.cert.X509Certificate[]) cacheContext.getCertChain();
+            if (cert_chain != null) {
+                certHash = ((java.security.cert.Certificate) cert_chain[0]).hashCode();
+                return certHash;
+            }
+        }
+        return null;
+    }
+
+}

--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/jaas/modules/CertificateLoginModule.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/jaas/modules/CertificateLoginModule.java
@@ -55,6 +55,7 @@ public class CertificateLoginModule extends ServerCommonLoginModule implements L
     private String authenticatedId = null;
     private String securityName = null;
     private boolean collectiveCert = false;
+    public static ThreadLocal<Boolean> collectiveCertificate = new ThreadLocal<Boolean>();
 
     /**
      * Gets the required Callback objects needed by this login module.
@@ -227,6 +228,7 @@ public class CertificateLoginModule extends ServerCommonLoginModule implements L
      */
     private void handleCollectiveLogin(X509Certificate certChain[], CollectiveAuthenticationPlugin plugin,
                                        boolean collectiveCert) throws InvalidNameException, AuthenticationException, Exception {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) Tr.debug(tc, "inbound-collectiveCertificate=" + CertificateLoginModule.collectiveCertificate.get());
         // If the chain is not authenticated, it will throw an AuthenticationException
         plugin.authenticateCertificateChain(certChain, collectiveCert);
         X509Certificate cert = certChain[0];
@@ -237,6 +239,8 @@ public class CertificateLoginModule extends ServerCommonLoginModule implements L
         username = x509Subject.getName();
         authenticatedId = x509Subject.getName();
         addCredentials(accessId);
+        collectiveCertificate.set(true);
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) Tr.debug(tc, "collectiveCertificate=" + CertificateLoginModule.collectiveCertificate.get());
     }
 
     /**

--- a/dev/com.ibm.ws.security.authentication/src/com/ibm/ws/security/authentication/cache/AuthCacheService.java
+++ b/dev/com.ibm.ws.security.authentication/src/com/ibm/ws/security/authentication/cache/AuthCacheService.java
@@ -21,15 +21,23 @@ public interface AuthCacheService {
 
     /**
      * Inserts the subject into the cache.
-     * 
+     *
      * @param subject
      */
     public void insert(Subject subject);
 
     /**
+     * Inserts the subject into the cache using a X509Certicate as the key.
+     *
+     * @param subject
+     * @param client certificate
+     */
+    public void insert(Subject subject, java.security.cert.X509Certificate[] certChain);
+
+    /**
      * Inserts the subject into the cache. The userid and password may be used by the BasicAuthCacheKeyProvider
      * to create a key.
-     * 
+     *
      * @param subject
      * @param userid
      * @param password
@@ -39,7 +47,7 @@ public interface AuthCacheService {
     /**
      * Gets the subject from the cache using the specified cache key.
      * Only valid subjects are returned. An invalid subject found is immediately removed from the cache.
-     * 
+     *
      * @param cacheKey
      * @return the valid subject or <code>null</code>.
      */
@@ -47,7 +55,7 @@ public interface AuthCacheService {
 
     /**
      * Removes the subject specified by the cache key from the cache.
-     * 
+     *
      * @param cacheKey
      */
     public void remove(@Sensitive Object cacheKey);

--- a/dev/com.ibm.ws.security.authentication/src/com/ibm/ws/security/authentication/cache/CacheContext.java
+++ b/dev/com.ibm.ws.security.authentication/src/com/ibm/ws/security/authentication/cache/CacheContext.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.security.authentication.cache;
 
+import java.security.cert.X509Certificate;
+
 import javax.security.auth.Subject;
 
 import com.ibm.websphere.ras.annotation.Sensitive;
@@ -24,6 +26,7 @@ public class CacheContext {
     private final AuthCacheConfig config;
     private String userid;
     private String password;
+    private X509Certificate[] certChain = null;
 
     /**
      * @param config
@@ -45,9 +48,15 @@ public class CacheContext {
         this.password = password;
     }
 
+    public CacheContext(AuthCacheConfig config, CacheObject cacheObject, X509Certificate[] certChain) {
+        this.config = config;
+        this.cacheObject = cacheObject;
+        this.certChain = certChain;
+    }
+
     /**
      * Gets the AuthCacheConfig object.
-     * 
+     *
      * @return
      */
     public AuthCacheConfig getAuthCacheConfig() {
@@ -56,7 +65,7 @@ public class CacheContext {
 
     /**
      * Gets the subject being cached.
-     * 
+     *
      * @return
      */
     public Subject getSubject() {
@@ -65,7 +74,7 @@ public class CacheContext {
 
     /**
      * Gets the userid currently used.
-     * 
+     *
      * @return
      */
     public String getUserid() {
@@ -74,12 +83,21 @@ public class CacheContext {
 
     /**
      * Gets the password currently used.
-     * 
+     *
      * @return
      */
     @Sensitive
     public String getPassword() {
         return password;
+    }
+
+    /**
+     * Gets the certificate currently used.
+     *
+     * @return
+     */
+    public X509Certificate[] getCertChain() {
+        return certChain;
     }
 
 }


### PR DESCRIPTION
Resolves issue #8933

Applications utilizing certificate login. Users login using a certificate. If the LtpaToken2 cookie is not returned SSO is broken. The existing Subject is not found in authentication cache, AuthCach