### PR TITLE
[9878] Handle `@Id` on entity fields

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -91,8 +91,8 @@ org.apache.cxf:cxf-rt-ws-security:2.6.2-ibm-s20180529-1900
 org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0
 org.apache.santuario:xmlsec:1.5.2-ibm
 org.apache.ws.security:wss4j:1.6.7-ibm-s20130913-2015
-org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.0-20191119
-org.eclipse.microprofile.graphql:microprofile-graphql-tck:1.0.0-20191119
+org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.0-20191203
+org.eclipse.microprofile.graphql:microprofile-graphql-tck:1.0.0-20191203
 org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.5-ea124dd
 org.eclipse.persistence:org.eclipse.persistence.asm:2.7.5-ea124dd
 org.eclipse.persistence:org.eclipse.persistence.core:2.7.5-ea124dd

--- a/dev/com.ibm.websphere.org.eclipse.microprofile.graphql.1.0/bnd.bnd
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.graphql.1.0/bnd.bnd
@@ -20,7 +20,7 @@ Export-Package: \
   org.eclipse.microprofile.graphql;version=1.0
 
 Include-Resource: \
-  @${repo;org.eclipse.microprofile.graphql:microprofile-graphql-api;1.0.0.20191119;EXACT}
+  @${repo;org.eclipse.microprofile.graphql:microprofile-graphql-api;1.0.0.20191203;EXACT}
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version>=1.8))"
 

--- a/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/type/DefaultTypeInfoGenerator.java
+++ b/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/type/DefaultTypeInfoGenerator.java
@@ -5,7 +5,7 @@ import io.leangen.graphql.metadata.messages.MessageBundle;
 import io.leangen.graphql.util.ClassUtils;
 import io.leangen.graphql.util.Utils;
 import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.InputType;
+import org.eclipse.microprofile.graphql.Input;
 import org.eclipse.microprofile.graphql.Type;
 
 import java.beans.Introspector;
@@ -43,7 +43,7 @@ public class DefaultTypeInfoGenerator implements TypeInfoGenerator {
 
     @Override
     public String generateInputTypeName(AnnotatedType type, MessageBundle messageBundle) {
-        return Optional.ofNullable(type.getAnnotation(InputType.class))
+        return Optional.ofNullable(type.getAnnotation(Input.class))
                 .map(ann -> messageBundle.interpolate(ann.value()))
                 .filter(Utils::isNotEmpty)
                 .orElse(TypeInfoGenerator.super.generateInputTypeName(type, messageBundle));

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/defaultvalueApp/src/mpGraphQL10/defaultvalue/WidgetInput.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/defaultvalueApp/src/mpGraphQL10/defaultvalue/WidgetInput.java
@@ -11,9 +11,9 @@
 package mpGraphQL10.defaultvalue;
 
 import org.eclipse.microprofile.graphql.DefaultValue;
-import org.eclipse.microprofile.graphql.InputType;
+import org.eclipse.microprofile.graphql.Input;
 
-@InputType("WidgetInput")
+@Input("WidgetInput")
 public class WidgetInput {
 
     @DefaultValue("Crockpot")

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/ifaceApp/src/mpGraphQL10/iface/WidgetInput.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/ifaceApp/src/mpGraphQL10/iface/WidgetInput.java
@@ -4,9 +4,9 @@
 package mpGraphQL10.iface;
 
 import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.InputType;
+import org.eclipse.microprofile.graphql.Input;
 
-@InputType("WidgetInput")
+@Input("WidgetInput")
 @Description("A for-sale item object used for input.")
 public class WidgetInput{
 

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/typesApp/src/mpGraphQL10/types/WidgetInput.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/typesApp/src/mpGraphQL10/types/WidgetInput.java
@@ -4,9 +4,9 @@
 package mpGraphQL10.types;
 
 import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.InputType;
+import org.eclipse.microprofile.graphql.Input;
 
-@InputType("WidgetInput")
+@Input("WidgetInput")
 @Description("A for-sale item object used for input.")
 public class WidgetInput{
 

--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/pom.xml
@@ -28,7 +28,7 @@
     <name>MicroProfile GraphQL TCK Runner TCK Module</name>
 
     <properties>
-        <microprofile.graphql.version>1.0.0-20191119</microprofile.graphql.version>
+        <microprofile.graphql.version>1.0.0-20191203</microprofile.graphql.version>
         <arquillian.version>1.1.13.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->


### PR DESCRIPTION
This allows `@Id` to be specified on fields/methods and be properly
reflected as ID types in the generated schema.

Because this change pulls in the latest version of the API/TCK, this change also includes the renaming of `@InputType` to `@Input` in the runtime and FAT test case code.