### PR TITLE
service.ranking can be removed from com.ibm.ws.persistence defaultIns…

### DIFF
--- a/dev/com.ibm.ws.persistence/resources/OSGI-INF/wlp/defaultInstances.xml
+++ b/dev/com.ibm.ws.persistence/resources/OSGI-INF/wlp/defaultInstances.xml
@@ -9,5 +9,5 @@
         IBM Corporation - initial API and implementation
  -->
 <server>
-  <databaseStore id="defaultDatabaseStore" dataSourceRef="DefaultDataSource" service.ranking="100"/>
+  <databaseStore id="defaultDatabaseStore" dataSourceRef="DefaultDataSource" />
 </server>


### PR DESCRIPTION
Delivering changes discussed with Jared Anderson on #10006