### PR TITLE
Add WSSecurityPropationHelper class

### DIFF
--- a/dev/com.ibm.websphere.security/src/com/ibm/websphere/security/auth/ValidationFailedException.java
+++ b/dev/com.ibm.websphere.security/src/com/ibm/websphere/security/auth/ValidationFailedException.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.security.auth;
+
+/**
+ *
+ */
+public class ValidationFailedException extends InvalidTokenException {
+
+    private static final long serialVersionUID = -5920252763989441670L; //@vj1: Take versioning into account if incompatible changes are made to this class
+
+    public ValidationFailedException() {
+        super();
+    }
+
+    public ValidationFailedException(String debug_message) {
+        super(debug_message);
+    }
+
+    public ValidationFailedException(Throwable t) {
+        super(t);
+    }
+
+    public ValidationFailedException(String debug_message, Throwable t) {
+        super(debug_message, t);
+    }
+}

--- a/dev/com.ibm.ws.security.token/bnd.bnd
+++ b/dev/com.ibm.ws.security.token/bnd.bnd
@@ -46,7 +46,14 @@ Service-Component: \
     dynamic:='tokenService'; \
     optional:='tokenService'; \
     multiple:='tokenService'; \
-    properties:='service.vendor=IBM'
+    properties:='service.vendor=IBM', \
+  com.ibm.wsspi.security.token.WSSecurityPropagationHelper;\
+    implementation:=com.ibm.wsspi.security.token.WSSecurityPropagationHelper;\
+    configuration-policy:=ignore;\
+    activate:=activate;\
+    deactivate:=deactivate;\
+    tokenManager=com.ibm.ws.security.token.TokenManager;\
+    properties:="service.vendor=IBM"     
 
 instrument.classesExcludes: com/ibm/ws/security/token/internal/resources/*.class
 

--- a/dev/com.ibm.ws.security.token/src/com/ibm/ws/security/token/internal/ValidationResultImpl.java
+++ b/dev/com.ibm.ws.security.token/src/com/ibm/ws/security/token/internal/ValidationResultImpl.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.token.internal;
+
+import com.ibm.wsspi.security.token.ValidationResult;
+import com.ibm.wsspi.security.token.WSSecurityPropagationHelper;
+
+/**
+ * @see com.ibm.wsspi.security.token.ValidationResult
+ *
+ * @author IBM Corp.
+ * @version 7.0.0
+ * @since 7.0.0
+ * @ibm-spi
+ *
+ */
+public class ValidationResultImpl implements ValidationResult {
+
+    private final String uniqueId;
+
+    public ValidationResultImpl(String uniqueId) {
+        this.uniqueId = uniqueId;
+    }
+
+    @Override
+    public String getRealmFromUniqueId() {
+        String result = WSSecurityPropagationHelper.getRealmFromUniqueID(uniqueId);
+        return result;
+    }
+
+    @Override
+    public String getUniqueId() {
+        String result = uniqueId;
+        return result;
+    }
+
+    @Override
+    public String getUserFromUniqueId() {
+        String result = WSSecurityPropagationHelper.getUserFromUniqueID(uniqueId);
+        return result;
+    }
+
+    // Not support
+    @Override
+    public boolean requiresLogin() {
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + " uniqueId = " + uniqueId;
+    }
+}

--- a/dev/com.ibm.ws.security.token/src/com/ibm/wsspi/security/token/ValidationResult.java
+++ b/dev/com.ibm.ws.security.token/src/com/ibm/wsspi/security/token/ValidationResult.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.wsspi.security.token;
+
+/**
+ * This interface represents the successful result of validating an LTPA token.
+ * Stack products may use the interface to determine if a JAAS login is
+ * necessary for the validated token or to obtain the WAS representation of
+ * the user id, realm name, etc.
+ * Instances of this interface are created by the
+ * <code>WSSecurityPropagationHelper.validateToken( byte[] token )</code>
+ * operation.
+ *
+ * @author IBM Corp.
+ * @version 7.0.0
+ * @since 7.0.0
+ * @ibm-spi
+ *
+ */
+public interface ValidationResult {
+
+    /**
+     * @return true if the result of validating the token indicates a JAAS login
+     *         is required.
+     */
+    boolean requiresLogin();
+
+    /**
+     * @return the WAS unique id obtained by validating the token
+     */
+    String getUniqueId();
+
+    /**
+     * @return the WAS user id extracted from the WAS unique id.
+     */
+    String getUserFromUniqueId();
+
+    /**
+     * @return the WAS realm name extracted from the WAS unique id.
+     */
+    String getRealmFromUniqueId();
+
+}

--- a/dev/com.ibm.ws.security.token/src/com/ibm/wsspi/security/token/WSSecurityPropagationHelper.java
+++ b/dev/com.ibm.ws.security.token/src/com/ibm/wsspi/security/token/WSSecurityPropagationHelper.java
@@ -1,0 +1,217 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.wsspi.security.token;
+
+import java.util.Map;
+
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.ComponentContext;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.security.WSSecurityException;
+import com.ibm.websphere.security.auth.InvalidTokenException;
+import com.ibm.websphere.security.auth.TokenExpiredException;
+import com.ibm.websphere.security.auth.ValidationFailedException;
+import com.ibm.websphere.security.auth.WSLoginFailedException;
+import com.ibm.ws.security.jaas.common.callback.AuthenticationHelper;
+import com.ibm.ws.security.token.TokenManager;
+import com.ibm.ws.security.token.internal.ValidationResultImpl;
+import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
+import com.ibm.wsspi.security.ltpa.Token;
+
+/**
+ * This class provides some propagation helper methods including
+ * whether propagation is enabled or not.
+ *
+ * @author IBM Corporation
+ * @version 5.1.1
+ * @since 5.1.1
+ * @ibm-spi
+ **/
+
+public class WSSecurityPropagationHelper {
+    private static final TraceComponent tc = Tr.register(WSSecurityPropagationHelper.class);
+    private static final AtomicServiceReference<TokenManager> tokenManagerRef = new AtomicServiceReference<TokenManager>("tokenManager");
+    public final static String REALM_DELIMITER = "/";
+    public final static String TYPE_DELIMITER = ":";
+    public final static String USER_TYPE_DELIMITER = "user:";
+    public final static String EMPTY_STRING = new String("");
+
+    /**
+     * <p>
+     * This method validates an LTPA token and will return a ValidationResult object.
+     *
+     * If the token cannot be validated or is expired, a ValidationFailedException
+     * will be thrown.
+     * uniqueid.
+     *
+     * @see getRealmFromUniqueID (uniqueID)
+     * @see getUserFromUniqueID (uniqueID)
+     *      </p>
+     *
+     * @param byte[] (LtpaToken2)
+     * @return String WebSphere uniqueID
+     * @exception WSLoginFailedException
+     **/
+    public static ValidationResult validateToken(byte[] token) throws ValidationFailedException {
+        ValidationResult result = null;
+        try {
+            String uniqueID = validateLTPAToken(token);
+            result = new ValidationResultImpl(uniqueID);
+        } catch (WSSecurityException e) {
+            throw new ValidationFailedException(e.getLocalizedMessage());
+        }
+
+        return result;
+    }
+
+    /**
+     * <p>
+     * This method validates an LTPA token and will return a uniqueID in
+     * the format of realm/username. The username portion of the uniqueID
+     * is a unique username from the registry (example, for LDAP, this is the DN).
+     * If the token cannot be validated or is expired, a WSLoginFailedException
+     * will be thrown. Otherwise, the uniqueID is returned. Some helper
+     * methods are provided to parse the realm and user uniqueid from the
+     * uniqueid.
+     *
+     * @see getRealmFromUniqueID (uniqueID)
+     * @see getUserFromUniqueID (uniqueID)
+     *      </p>
+     *
+     *      <p>
+     *      The validateLTPAToken API requires a Java 2 Security permission,
+     *      WebSphereRuntimePermission "validateLTPAToken".
+     *      </p>
+     *
+     * @param byte[] (LtpaToken or LtpaToken2)
+     * @return String WebSphere uniqueID
+     * @exception WSLoginFailedException
+     **/
+
+    public static String validateLTPAToken(byte[] token) throws WSSecurityException {
+        String accessId = null;
+        if (token != null) {
+            try {
+                Token recreatedToken = recreateTokenFromBytes(token);
+                if (recreatedToken != null) {
+                    accessId = recreatedToken.getAttributes("u")[0];
+                }
+            } catch (WSSecurityException e) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "validateLTPAToken caught exception: " + e.getMessage());
+                }
+                throw e;
+            }
+        }
+        return accessId;
+
+    }
+
+    /**
+     * <p>
+     * This method accepts the uniqueID returned from the validateLTPAToken method.
+     * You can also use this method to parse the uniqueID returned from the
+     * UserRegistry.getUniqueUserId (uid) method. It returns the unique userid
+     * portion of this string. For an LDAP registry, this is the DN. For a
+     * LocalOS registry, this is the LocalOS unique identifier.
+     * </p>
+     *
+     * @param String WebSphere uniqueID
+     * @return String registry uniqueID
+     **/
+
+    public static String getUserFromUniqueID(String uniqueID) {
+        if (uniqueID == null) {
+            return EMPTY_STRING;
+        }
+        if (uniqueID.startsWith(USER_TYPE_DELIMITER)) {
+            uniqueID = uniqueID.trim();
+            int realmDelimiterIndex = uniqueID.indexOf(REALM_DELIMITER);
+            if (realmDelimiterIndex < 0) {
+                return EMPTY_STRING;
+            } else {
+                return uniqueID.substring(realmDelimiterIndex + 1);
+            }
+        }
+        return EMPTY_STRING;
+    }
+
+    /**
+     * <p>
+     * This method accepts the uniqueID returned from the validateLTPAToken method.
+     * It returns the realm portion of this string. The realm can be used to
+     * determine where the token came from.
+     * </p>
+     *
+     * @param String WebSphere uniqueID
+     * @return String registry realm
+     **/
+
+    public static String getRealmFromUniqueID(String uniqueID) {
+
+        int index = uniqueID.indexOf(TYPE_DELIMITER);
+
+        if (uniqueID.startsWith(USER_TYPE_DELIMITER)) {
+            uniqueID = uniqueID.substring(index + 1);
+        }
+        return getRealm(uniqueID);
+    }
+
+    private static String getRealm(String realmSecurityName) {
+        if (realmSecurityName == null)
+            return EMPTY_STRING;
+
+        realmSecurityName = realmSecurityName.trim();
+
+        {
+            int realmDelimiterIndex = realmSecurityName.indexOf(REALM_DELIMITER);
+            if (realmDelimiterIndex < 0) {
+                return null;
+            }
+            return realmSecurityName.substring(0, realmDelimiterIndex);
+        }
+    }
+
+    /**
+     * @param attributes
+     * @param ssoToken
+     * @return
+     * @throws InvalidTokenException
+     * @throws TokenExpiredException
+     */
+    private static Token recreateTokenFromBytes(byte[] ssoToken) throws InvalidTokenException, TokenExpiredException {
+        Token token = null;
+        TokenManager tokenManager = tokenManagerRef.getService();
+        if (tokenManager != null) {
+            byte[] credToken = AuthenticationHelper.copyCredToken(ssoToken);
+            token = tokenManager.recreateTokenFromBytes(credToken);
+        }
+        return token;
+    }
+
+    protected void setTokenManager(ServiceReference<TokenManager> ref) {
+        tokenManagerRef.setReference(ref);
+    }
+
+    protected void unsetTokenManager(ServiceReference<TokenManager> ref) {
+        tokenManagerRef.unsetReference(ref);
+    }
+
+    protected void activate(ComponentContext cc, Map<String, Object> properties) {
+        tokenManagerRef.activate(cc);
+    }
+
+    protected void deactivate(ComponentContext cc) {
+        tokenManagerRef.deactivate(cc);
+    }
+}


### PR DESCRIPTION
#build
#spawn.fullfat.buckets=com.ibm.websphere.security_fat,com.ibm.ws.collective.security_fat,com.ibm.ws.collective.security_zfat,com.ibm.ws.ejbcontainer.security.3.2_fat,com.ibm.ws.ejbcontainer.security.jacc_fat_java7,com.ibm.ws.ejbcontainer.security_fat,com.ibm.ws.ejbcontainer.security_fat.features,com.ibm.ws.security.audit_fat.config,com.ibm.ws.security.audit_fat.example,com.ibm.ws.security.audit_fat.features,com.ibm.ws.security.auth.data_fat,com.ibm.ws.security.authentication.builtin_fat,com.ibm.ws.security.authentication.tai_fat,com.ibm.ws.security.authorization.saf_zfat,com.ibm.ws.security.client_fat_java7,com.ibm.ws.security.context_fat,com.ibm.ws.security.credentials.saf_zfat,com.ibm.ws.security.csiv2_fat,com.ibm.ws.security.java2sec_fat,com.ibm.ws.security.jwt_fat.builder,com.ibm.ws.security.jwt_fat.consumer,com.ibm.ws.security.oauth_fat,com.ibm.ws.security.openidconnect.client_fat,com.ibm.ws.security.openidconnect.client_fat.config,com.ibm.ws.security.openidconnect.client_fat.e2e,com.ibm.ws.security.openidconnect.client_fat.jaxrs,com.ibm.ws.security.openidconnect.client_fat.saml,com.ibm.ws.security.openidconnect.server_fat,com.ibm.ws.security.openidconnect.server_fat.config,com.ibm.ws.security.openidconnect.server_fat.endpoint.authorize,com.ibm.ws.security.openidconnect.server_fat.endpoint.clientregistration,com.ibm.ws.security.openidconnect.server_fat.endpoint.coveragemap,com.ibm.ws.security.openidconnect.server_fat.endpoint.discovery,com.ibm.ws.security.openidconnect.server_fat.endpoint.end_session,com.ibm.ws.security.openidconnect.server_fat.endpoint.introspect,com.ibm.ws.security.openidconnect.server_fat.endpoint.token,com.ibm.ws.security.openidconnect.server_fat.endpoint.userinfo,com.ibm.ws.security.openidconnect.server_fat.feature,com.ibm.ws.security.openidconnect.server_fat.granttype.jwt,com.ibm.ws.security.openidconnect.server_fat.jaxrs,com.ibm.ws.security.openidconnect.server_fat.jaxrs.config,com.ibm.ws.security.openidconnect.server_fat.oauth,com.ibm.ws.security.openidconnect.server_fat.oidc,com.ibm.ws.security.openidconnect.server_fat.saml,com.ibm.ws.security.quickstart_fat,com.ibm.ws.security.registry.saf_zfat,com.ibm.ws.security.registry_fat,com.ibm.ws.security.saml.sso_fat.config,com.ibm.ws.security.saml.sso_fat.config.mapToUserRegistry,com.ibm.ws.security.saml.sso_fat.endpoint.samlmetadata,com.ibm.ws.security.saml.sso_fat.jaxrs,com.ibm.ws.security.saml.sso_fat.jaxrs.config,com.ibm.ws.security.social_fat,com.ibm.ws.security.social_fat.LibertyOP,com.ibm.ws.security.spnego_fat,com.ibm.ws.security.thread.identity_fat,com.ibm.ws.security.thread.zos.context_zfat,com.ibm.ws.security.thread.zos_zfat,com.ibm.ws.security.token.ltpa_fat,com.ibm.ws.security.utility_fat,com.ibm.ws.security.wim.scim_fat,com.ibm.ws.security.wim.scim_zfat,com.ibm.ws.security_fat,com.ibm.ws.security_fat.features,com.ibm.ws.webcontainer.security.feature_fat,com.ibm.ws.webcontainer.security.jacc.1.5_fat,com.ibm.ws.webcontainer.security_fat,com.ibm.ws.webcontainer.security_fat.features,com.ibm.ws.webcontainer.security_fat.passwordutil,com.ibm.ws.security.openidconnect.client_fat.spnego,com.ibm.ws.security.openidconnect.server_fat.spnego