### PR TITLE
Change test to wait for LTPA service to start before running tests

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HeaderPropagation12Test.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HeaderPropagation12Test.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.rest.client.fat;
 
+import static org.junit.Assert.assertNotNull;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -43,6 +45,7 @@ public class HeaderPropagation12Test extends FATServletClient {
     public static void setUp() throws Exception {
         ShrinkHelper.defaultApp(server, appName, "mpRestClient12.headerPropagation");
         server.startServer();
+        assertNotNull("LTPA configuration should report it is ready", server.waitForStringInLog("CWWKS4105I"));
     }
 
     @AfterClass


### PR DESCRIPTION
This should prevent an exception in the LTPA service from breaking the tests.  The exception looks like this:

```
------Start of DE processing------ = [12/2/19, 13:26:06:453 UTC]
Exception = java.lang.IllegalArgumentException
Source = com.ibm.ws.security.token.internal.TokenManagerImpl
probeid = 85
Stack Dump = java.lang.IllegalArgumentException: CWWKS4000E: A configuration exception has occurred. The requested TokenService instance of type Ltpa2 could not be found.
    at com.ibm.ws.security.token.internal.TokenManagerImpl.getTokenServiceForType(TokenManagerImpl.java:176)
    at com.ibm.ws.security.token.internal.TokenManagerImpl.createSSOToken(TokenManagerImpl.java:80)
    at com.ibm.ws.security.credentials.ssotoken.internal.SSOTokenCredentialProvider.setSsoTokenCredential(SSOTokenCredentialProvider.java:108)
    at com.ibm.ws.security.credentials.ssotoken.internal.SSOTokenCredentialProvider.setCredential(SSOTokenCredentialProvider.java:85)
    at com.ibm.ws.security.credentials.internal.CredentialsServiceImpl.setCredentials(CredentialsServiceImpl.java:76)
    at com.ibm.ws.security.authentication.internal.jaas.modules.ServerCommonLoginModule.setCredentials(ServerCommonLoginModule.java:148)
    at com.ibm.ws.security.authentication.jaas.modules.UsernameAndPasswordLoginModule.setUpTemporarySubject(UsernameAndPasswordLoginModule.java:145)
    at com.ibm.ws.security.authentication.jaas.modules.UsernameAndPasswordLoginModule.login(UsernameAndPasswordLoginModule.java:78)
    at com.ibm.ws.kernel.boot.security.LoginModuleProxy.login(LoginModuleProxy.java:51)
    at java.base/javax.security.auth.login.LoginContext.invoke(LoginContext.java:726)
    at java.base/javax.security.auth.login.LoginContext$4.run(LoginContext.java:665)
    at java.base/javax.security.auth.login.LoginContext$4.run(LoginContext.java:663)
    at java.base/java.security.AccessController.doPrivileged(AccessController.java:739)
    at java.base/javax.security.auth.login.LoginContext.invokePriv(LoginContext.java:663)
    at java.base/javax.security.auth.login.LoginContext.login(LoginContext.java:574)
    at com.ibm.ws.security.authentication.internal.jaas.JAASServiceImpl.doLoginContext(JAASServiceImpl.java:343)
    at com.ibm.ws.security.authentication.internal.jaas.JAASServiceImpl.performLogin(JAASServiceImpl.java:329)
    at com.ibm.ws.security.authentication.internal.jaas.JAASServiceImpl.performLogin(JAASServiceImpl.java:314)
    at com.ibm.ws.security.authentication.internal.AuthenticationServiceImpl.performJAASLogin(AuthenticationServiceImpl.java:481)
    at com.ibm.ws.security.authentication.internal.AuthenticationServiceImpl.authenticate(AuthenticationServiceImpl.java:207)
    at com.ibm.ws.webcontainer.security.internal.BasicAuthAuthenticator.basicAuthenticate(BasicAuthAuthenticator.java:126)
    at com.ibm.ws.webcontainer.security.internal.BasicAuthAuthenticator.handleBasicAuth(BasicAuthAuthenticator.java:117)
    at com.ibm.ws.webcontainer.security.internal.BasicAuthAuthenticator.authenticate(BasicAuthAuthenticator.java:70)
    at com.ibm.ws.webcontainer.security.WebAuthenticatorProxy.authenticate(WebAuthenticatorProxy.java:88)
    at com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl.authenticateRequest(WebAppSecurityCollaboratorImpl.java:1211)
    at com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl.setAuthenticatedSubjectIfNeeded(WebAppSecurityCollaboratorImpl.java:833)
    at com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl.optionallyAuthenticateUnprotectedResource(WebAppSecurityCollaboratorImpl.java:790)
    at com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl.determineWebReply(WebAppSecurityCollaboratorImpl.java:960)
    at com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl.performSecurityChecks(WebAppSecurityCollaboratorImpl.java:656)
    at com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl.preInvoke(WebAppSecurityCollaboratorImpl.java:574)
    at com.ibm.wsspi.webcontainer.collaborator.CollaboratorHelper.preInvokeCollaborators(CollaboratorHelper.java:459)
    at com.ibm.ws.webcontainer.osgi.collaborator.CollaboratorHelperImpl.preInvokeCollaborators(CollaboratorHelperImpl.java:270)
    at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1114)
    at com.ibm.ws.webcontainer.webapp.WebApp.handleRequest(WebApp.java:5017)
    at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.handleRequest(DynamicVirtualHost.java:314)
    at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:1007)
    at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:279)
    at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1134)
    at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:415)
    at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:374)
    at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:548)
    at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:482)
    at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:347)
    at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.ready(HttpInboundLink.java:318)
    at com.ibm.ws.channel.ssl.internal.SSLConnectionLink.determineNextChannel(SSLConnectionLink.java:1077)
    at com.ibm.ws.channel.ssl.internal.SSLConnectionLink$MyReadCompletedCallback.complete(SSLConnectionLink.java:656)
    at com.ibm.ws.channel.ssl.internal.SSLReadServiceContext$SSLReadCompletedCallback.complete(SSLReadServiceContext.java:1803)
    at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:503)
    at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:573)
    at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:954)
    at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1043)
    at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:239)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:825)
```

with errors in the logs that look like:
```
[12/2/19, 13:26:06:150 UTC] 0000002b SystemOut                                                    O >>> BEGIN: testPropagateAuthorizationHeader
[12/2/19, 13:26:06:150 UTC] 0000002b SystemOut                                                    O Request URL: http://localhost:8010/headerPropagation12App/HeaderPropagationTestServlet?testMethod=testPropagateAuthorizationHeader
[12/2/19, 13:26:06:405 UTC] 00000028 mpRestClient12.headerPropagation.InAppConfigSource           I getProperties -> {org.eclipse.microprofile.rest.client.propagateHeaders=Authorization,MyCustomHeader, mpRestClient12.headerPropagation.Client/mp-rest/uri=http://localhost:8010/headerPropagation12App, mpRestClient12.headerPropagation.SecureClient/mp-rest/uri=https://localhost:8020/headerPropagation12App, mpRestClient12.headerPropagation.ClientHeaderParamClient/mp-rest/uri=http://localhost:8010/headerPropagation12App}
[12/2/19, 13:26:06:450 UTC] 00000028 com.ibm.ws.security.token.internal.TokenManagerImpl          E CWWKS4000E: A configuration exception has occurred. The requested TokenService instance of type Ltpa2 could not be found.
[12/2/19, 13:26:06:460 UTC] 00000028 com.ibm.ws.logging.internal.impl.IncidentImpl                I FFDC1015I: An FFDC Incident has been created: "java.lang.IllegalArgumentException: CWWKS4000E: A configuration exception has occurred. The requested TokenService instance of type Ltpa2 could not be found. com.ibm.ws.security.token.internal.TokenManagerImpl 85" at ffdc_19.12.02_13.26.06.0.log
[12/2/19, 13:26:06:465 UTC] 00000028 com.ibm.ws.logging.internal.impl.IncidentImpl                I FFDC1015I: An FFDC Incident has been created: "com.ibm.websphere.security.auth.TokenCreationFailedException: CWWKS4000E: A configuration exception has occurred. The requested TokenService instance of type Ltpa2 could not be found. com.ibm.ws.security.credentials.ssotoken.internal.SSOTokenCredentialProvider 112" at ffdc_19.12.02_13.26.06.1.log
[12/2/19, 13:26:06:482 UTC] 00000028 com.ibm.ws.logging.internal.impl.IncidentImpl                I FFDC1015I: An FFDC Incident has been created: "javax.security.auth.login.CredentialException: CWWKS4000E: A configuration exception has occurred. The requested TokenService instance of type Ltpa2 could not be found. com.ibm.ws.security.authentication.jaas.modules.UsernameAndPasswordLoginModule 105" at ffdc_19.12.02_13.26.06.2.log
[12/2/19, 13:26:06:503 UTC] 00000028 mpRestClient12.headerPropagation.Resource                    I auth scheme: BASIC
[12/2/19, 13:26:06:503 UTC] 00000028 mpRestClient12.headerPropagation.Resource                    I user principal name: null
[12/2/19, 13:26:06:503 UTC] 00000028 mpRestClient12.headerPropagation.Resource                    I isSecure: true
[12/2/19, 13:26:06:504 UTC] 00000028 mpRestClient12.headerPropagation.InAppConfigSource           I getValue(org.eclipse.microprofile.rest.client.propagateHeaders) -> Authorization,MyCustomHeader
[12/2/19, 13:26:06:508 UTC] 00000027 com.ibm.ws.security.token.internal.TokenManagerImpl          E CWWKS4000E: A configuration exception has occurred. The requested TokenService instance of type Ltpa2 could not be found.
[12/2/19, 13:26:06:526 UTC] 00000027 mpRestClient12.headerPropagation.Resource                    I normalMethod
[12/2/19, 13:26:06:530 UTC] 0000002b SystemOut                                                    O ERROR: java.lang.AssertionError: Authorization header was propagated, but user is not in role
```