### PR TITLE
fix pacakge version and kept an old method

### DIFF
--- a/dev/com.ibm.ws.webcontainer.security/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.security/bnd.bnd
@@ -50,7 +50,6 @@ Service-Component: \
     activate:=activate;\
     deactivate:=deactivate;\
     tokenManager=com.ibm.ws.security.token.TokenManager;\
-    dynamic:='tokenService';\
     properties:="service.vendor=IBM",\
   com.ibm.ws.webcontainer.security.internal.WebSecurityHelperImpl;\
     implementation:=com.ibm.ws.webcontainer.security.internal.WebSecurityHelperImpl;\
@@ -58,7 +57,6 @@ Service-Component: \
     activate:=activate;\
     deactivate:=deactivate;\
     tokenManager=com.ibm.ws.security.token.TokenManager;\
-    dynamic:='tokenService';\
     properties:="service.vendor=IBM"
 
 -dsannotations: com.ibm.ws.webcontainer.security.internal.WebAuthenticatorFactoryImpl

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/websphere/security/web/WebSecurityHelper.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/websphere/security/web/WebSecurityHelper.java
@@ -29,6 +29,24 @@ public class WebSecurityHelper {
 
     /**
      * Extracts the Single Sign-On (SSO) token from the subject of the current thread
+     * and builds an SSO cookie out of it and builds an SSO cookie out of it for use on downstream web invocations.
+     * The caller must check for a null return value.
+     * <p>
+     * Return null if there is an invalid or expired SSO token, no subject on the current thread, no SSO token in subject or no webAppSecurityConfig object.
+     * If the returned value is not null, use Cookie methods getName() and getValue()
+     * to set the Cookie header on an HTTP request with header value of
+     * Cookie.getName()=Cookie.getValue()
+     *
+     * @return An object of type javax.servlet.http.Cookie. May return {@code null}
+     *
+     */
+
+    public static Cookie getSSOCookieFromSSOToken() throws Exception {
+        return WebSecurityHelperImpl.getSSOCookieFromSSOToken();
+    }
+
+    /**
+     * Extracts the Single Sign-On (SSO) token from the subject of the current thread
      * and builds an SSO cookie out of it. The new SSO token does not include the attributes specified in the removeAttributes parameter for use on downstream web invocations.
      * The caller must check for a null return value.
      * The security permission WebSphereRuntimePermission("updateToken") is needed when security manager is enabled.

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/websphere/security/web/package-info.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/websphere/security/web/package-info.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 /**
- * @version 1.3
+ * @version 1.4
  */
-@org.osgi.annotation.versioning.Version("1.3")
+@org.osgi.annotation.versioning.Version("1.4")
 package com.ibm.websphere.security.web;

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/WebSecurityHelperImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/WebSecurityHelperImpl.java
@@ -235,7 +235,7 @@ public class WebSecurityHelperImpl {
     }
 
     protected void unsetTokenManager(ServiceReference<TokenManager> ref) {
-        tokenManagerRef.setReference(ref);
+        tokenManagerRef.unsetReference(ref);
     }
 
     protected void activate(ComponentContext cc, Map<String, Object> properties) {


### PR DESCRIPTION
#build
#spawn.fullfat.buckets=com.ibm.websphere.security_fat,com.ibm.ws.collective.security_fat,com.ibm.ws.collective.security_zfat,com.ibm.ws.ejbcontainer.security.3.2_fat,com.ibm.ws.ejbcontainer.security.jacc_fat_java7,com.ibm.ws.ejbcontainer.security_fat,com.ibm.ws.ejbcontainer.security_fat.features,com.ibm.ws.security.audit_fat.config,com.ibm.ws.security.audit_fat.example,com.ibm.ws.security.audit_fat.features,com.ibm.ws.security.auth.data_fat,com.ibm.ws.security.authentication.builtin_fat,com.ibm.ws.security.authentication.tai_fat,com.ibm.ws.security.authorization.saf_zfat,com.ibm.ws.security.client_fat_java7,com.ibm.ws.security.context_fat,com.ibm.ws.security.credentials.saf_zfat,com.ibm.ws.security.csiv2_fat,com.ibm.ws.security.java2sec_fat,com.ibm.ws.security.jwt_fat.builder,com.ibm.ws.security.jwt_fat.consumer,com.ibm.ws.security.oauth_fat,com.ibm.ws.security.openidconnect.client_fat,com.ibm.ws.security.openidconnect.client_fat.config,com.ibm.ws.security.openidconnect.client_fat.e2e,com.ibm.ws.security.openidconnect.client_fat.jaxrs,com.ibm.ws.security.openidconnect.client_fat.saml,com.ibm.ws.security.openidconnect.server_fat,com.ibm.ws.security.openidconnect.server_fat.config,com.ibm.ws.security.openidconnect.server_fat.endpoint.authorize,com.ibm.ws.security.openidconnect.server_fat.endpoint.clientregistration,com.ibm.ws.security.openidconnect.server_fat.endpoint.coveragemap,com.ibm.ws.security.openidconnect.server_fat.endpoint.discovery,com.ibm.ws.security.openidconnect.server_fat.endpoint.end_session,com.ibm.ws.security.openidconnect.server_fat.endpoint.introspect,com.ibm.ws.security.openidconnect.server_fat.endpoint.token,com.ibm.ws.security.openidconnect.server_fat.endpoint.userinfo,com.ibm.ws.security.openidconnect.server_fat.feature,com.ibm.ws.security.openidconnect.server_fat.granttype.jwt,com.ibm.ws.security.openidconnect.server_fat.jaxrs,com.ibm.ws.security.openidconnect.server_fat.jaxrs.config,com.ibm.ws.security.openidconnect.server_fat.oauth,com.ibm.ws.security.openidconnect.server_fat.oidc,com.ibm.ws.security.openidconnect.server_fat.saml,com.ibm.ws.security.quickstart_fat,com.ibm.ws.security.registry.saf_zfat,com.ibm.ws.security.registry_fat,com.ibm.ws.security.saml.sso_fat.config,com.ibm.ws.security.saml.sso_fat.config.mapToUserRegistry,com.ibm.ws.security.saml.sso_fat.endpoint.samlmetadata,com.ibm.ws.security.saml.sso_fat.jaxrs,com.ibm.ws.security.saml.sso_fat.jaxrs.config,com.ibm.ws.security.social_fat,com.ibm.ws.security.social_fat.LibertyOP,com.ibm.ws.security.spnego_fat,com.ibm.ws.security.thread.identity_fat,com.ibm.ws.security.thread.zos.context_zfat,com.ibm.ws.security.thread.zos_zfat,com.ibm.ws.security.token.ltpa_fat,com.ibm.ws.security.utility_fat,com.ibm.ws.security.wim.scim_fat,com.ibm.ws.security.wim.scim_zfat,com.ibm.ws.security_fat,com.ibm.ws.security_fat.features,com.ibm.ws.webcontainer.security.feature_fat,com.ibm.ws.webcontainer.security.jacc.1.5_fat,com.ibm.ws.webcontainer.security_fat,com.ibm.ws.webcontainer.security_fat.features,com.ibm.ws.webcontainer.security_fat.passwordutil,com.ibm.ws.security.openidconnect.client_fat.spnego,com.ibm.ws.security.openidconnect.server_fat.spnego

