### PR TITLE
Get featureUtility projects building in eclipse

### DIFF
--- a/dev/com.ibm.ws.install.featureUtility.featureutil/.classpath
+++ b/dev/com.ibm.ws.install.featureUtility.featureutil/.classpath
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
-		<attributes>
-			<attribute name="owner.project.facets" value="java"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.ws.install.featureUtility"/>
-	<classpathentry kind="output" path="build/classes"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.install.featureUtility.featureutil/.project
+++ b/dev/com.ibm.ws.install.featureUtility.featureutil/.project
@@ -11,13 +11,13 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.wst.common.project.facet.core.builder</name>
+			<name>bndtools.core.bndbuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.wst.common.project.facet.core.nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
 	</natures>
 </projectDescription>

--- a/dev/com.ibm.ws.install.featureUtility.featureutil/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.install.featureUtility.featureutil/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.install.featureUtility/.classpath
+++ b/dev/com.ibm.ws.install.featureUtility/.classpath
@@ -2,15 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="resources"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
-		<attributes>
-			<attribute name="owner.project.facets" value="java"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.ws.install"/>
-	<classpathentry kind="src" path="/com.ibm.ws.kernel.boot.core"/>
-	<classpathentry kind="src" path="/com.ibm.ws.kernel.feature.cmdline"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.ws.repository.resolver"/>
-	<classpathentry kind="src" path="/com.ibm.ws.product.utility"/>
-	<classpathentry kind="output" path="build/classes"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.install.featureUtility/.project
+++ b/dev/com.ibm.ws.install.featureUtility/.project
@@ -11,13 +11,13 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.wst.common.project.facet.core.builder</name>
+			<name>bndtools.core.bndbuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.wst.common.project.facet.core.nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
 	</natures>
 </projectDescription>

--- a/dev/com.ibm.ws.install.featureUtility/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.install.featureUtility/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.install.featureUtility_fat/.classpath
+++ b/dev/com.ibm.ws.install.featureUtility_fat/.classpath
@@ -1,27 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
-		<attributes>
-			<attribute name="owner.project.facets" value="java"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="/fattest.simplicity"/>
-	<classpathentry kind="src" path="/com.ibm.ws.install"/>
-	<classpathentry kind="lib" path="/Users/tayyab.waqar@ibm.com/.m2/repository/com/ibm/ws/componenttest/public.api/1.0.0/public.api-1.0.0.jar">
-		<attributes>
-			<attribute name="bsn" value="com.ibm.ws.componenttest:public.api"/>
-			<attribute name="type" value="REPO"/>
-			<attribute name="project" value="build.example_fat"/>
-			<attribute name="version" value="1.0.0"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="lib" path="/Users/tayyab.waqar@ibm.com/.p2/pool/plugins/org.junit_4.12.0.v201504281640/junit.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="http://junit.org/junit4/javadoc/latest/"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
-	<classpathentry kind="output" path="build/classes"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.install.featureUtility_fat/.project
+++ b/dev/com.ibm.ws.install.featureUtility_fat/.project
@@ -11,13 +11,13 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.wst.common.project.facet.core.builder</name>
+			<name>bndtools.core.bndbuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.wst.common.project.facet.core.nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
 	</natures>
 </projectDescription>

--- a/dev/com.ibm.ws.install.featureUtility_fat/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.install.featureUtility_fat/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.security.acme/.classpath
+++ b/dev/com.ibm.ws.security.acme/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="test"/>
+	<classpathentry kind="src" path="test" output="bin_test"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>


### PR DESCRIPTION
- Update .classpath files to only reference bnd classpath
- Switch to use bnd builder in .project files
- Add missing bndtools prefs files
- Make output bin_test for unit test directory for security.acme project