### PR TITLE
Improve equinox trace enablement

### DIFF
--- a/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/Activator.java
+++ b/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/Activator.java
@@ -85,9 +85,9 @@ public class Activator implements BundleActivator {
         // The LogService comes from the framework and is always there;
         // We also never remove our listener because that will be done automatically when 
         // we are stopped.
-        LogReaderService logReader = context.getService(context.getServiceReference(ExtendedLogReaderService.class));
-        logReader.addLogListener(new TrOSGiLogForwarder());
-
+        ExtendedLogReaderService logReader = context.getService(context.getServiceReference(ExtendedLogReaderService.class));
+        TrOSGiLogForwarder logForwarder = new TrOSGiLogForwarder();
+        logReader.addLogListener(logForwarder, logForwarder);
     }
 
     /**

--- a/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/LoggingConfigurationService.java
+++ b/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/LoggingConfigurationService.java
@@ -233,12 +233,12 @@ public class LoggingConfigurationService implements ManagedService {
         traceMapToLevel.put("debug", LogLevel.DEBUG);
 
         // alias {finer, entryexit}
-        traceMapToLevel.put("finer", LogLevel.DEBUG);
-        traceMapToLevel.put("entryexit", LogLevel.DEBUG);
+        traceMapToLevel.put("finer", LogLevel.INFO);
+        traceMapToLevel.put("entryexit", LogLevel.INFO);
 
         // alias {fine, event}
-        traceMapToLevel.put("fine", LogLevel.DEBUG);
-        traceMapToLevel.put("event", LogLevel.DEBUG);
+        traceMapToLevel.put("fine", LogLevel.INFO);
+        traceMapToLevel.put("event", LogLevel.INFO);
 
         traceMapToLevel.put("detail", LogLevel.INFO);
 

--- a/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/TrOSGiLogForwarder.java
+++ b/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/TrOSGiLogForwarder.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.equinox.log.ExtendedLogEntry;
+import org.eclipse.equinox.log.LogFilter;
 import org.eclipse.equinox.log.SynchronousLogListener;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleEvent;
@@ -32,7 +33,7 @@ import com.ibm.websphere.ras.TrConfigurator;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.FFDCFilter;
 
-public class TrOSGiLogForwarder implements SynchronousLogListener, SynchronousBundleListener {
+public class TrOSGiLogForwarder implements SynchronousLogListener, SynchronousBundleListener, LogFilter {
     private static final TraceComponent _tc = Tr.register(TrOSGiLogForwarder.class,OsgiLogConstants.TRACE_GROUP, OsgiLogConstants.MESSAGE_BUNDLE);
 
     final static class OSGiTraceComponent extends TraceComponent {
@@ -261,5 +262,49 @@ public class TrOSGiLogForwarder implements SynchronousLogListener, SynchronousBu
             return false;
         }
         return true;
+    }
+
+    @Override
+    public boolean isLoggable(Bundle b, String loggerName, int level) {
+        if (b == null) {
+            // This is possible in rare conditions;
+            // For example log entries for service events when the service is unregistered
+            // before we could get the bundle
+            return false;
+        }
+        boolean isAnyTraceEnabled = TraceComponent.isAnyTracingEnabled();
+        OSGiTraceComponent tc = getTraceComponent(b);
+
+        // Do error first because we don't do the check below for errors
+        if (level == LogLevel.ERROR.ordinal()) {
+            return tc.isErrorEnabled();
+        }
+
+        // check for events specifically to log them with Tr.event
+        if (loggerName != null && loggerName.startsWith(LOGGER_EVENTS_PREFIX))  {
+            return isAnyTraceEnabled && tc.isEventEnabled();
+        }
+
+        if (level == LogLevel.AUDIT.ordinal()) {
+            return tc.isAuditEnabled();
+        }
+
+        if (level == LogLevel.INFO.ordinal()) {
+            return tc.isInfoEnabled();
+        }
+
+        if (level == LogLevel.WARN.ordinal()) {
+            return tc.isWarningEnabled();
+        }
+
+        if (level == LogLevel.DEBUG.ordinal()) {
+            return isAnyTraceEnabled && tc.isDebugEnabled();
+        }
+
+        if (level == LogLevel.TRACE.ordinal()) {
+            return isAnyTraceEnabled && tc.isDumpEnabled();
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
- Make TrOSGiLogForwarder a LogFilter as well and add it when adding the
LogListener.  Without a filter all trace is considered enabled and does
extra processing when trace isn't actually enabled for the logger.
- Update the map of Liberty log levels to equinox log levels to only do
debug if it is finest/debug and not set it to debug for fine/event and
finer/entryexit because it won't log debug anyway when it is that
liberty level.