### PR TITLE
Fixed Infinispan session cache FAT tests for Windows

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheConfigUpdateTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheConfigUpdateTest.java
@@ -209,7 +209,8 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
 
         // Monitor trace.log and wait for the message "doScheduledInvalidation scheduled hours are X and Y" before the test should continue
         // This replaces the TimeUnit.SECONDS.sleep(10) used before
-        assertNotNull("Could not find Infinispan message \"" + messageToCheckFor + "\" Has the Infinispan message changed?",
+        assertNotNull("Could not find message \"" + messageToCheckFor
+                      + "\" in the trace.log file.  Has the logging message in com.ibm.ws.session.store.common.BackedHashMap.doScheduledInvalidation() changed?",
                       server.waitForStringInTraceUsingMark(messageToCheckFor));
 
         ArrayList<String> session = new ArrayList<>();

--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheConfigUpdateTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheConfigUpdateTest.java
@@ -68,6 +68,14 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         server.updateServerConfiguration(savedConfig);
         server.waitForConfigUpdateInLogUsingMark(APP_NAMES, cleanupList);
         cleanupList = EMPTY_RECYCLE_LIST;
+
+        // In addition to starting the application, must also wait for asynchronous web module initialization to complete,
+        // otherwise tests which attempt a configuration update could end up triggering a deactivate and close of the CachingProvider
+        // while the servlet initialization code is still attempting to use the CachingProvider and/or the CacheManager and Caches that it creates.
+        List<String> session = new ArrayList<>();
+        run("getSessionId", session);
+        run("invalidateSession", session);
+
         System.out.println("server configuration restored");
     }
 

--- a/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheConfigUpdateTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheConfigUpdateTest.java
@@ -170,7 +170,8 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
 
         // Monitor trace.log and wait for the message "doScheduledInvalidation scheduled hours are X and Y" before the test should continue
         // This replaces the TimeUnit.SECONDS.sleep(10) used before
-        assertNotNull("Could not find Infinispan message \"" + messageToCheckFor + "\" Has the Infinispan message changed?",
+        assertNotNull("Could not find message \"" + messageToCheckFor
+                      + "\" in the trace.log file.  Has the logging message in com.ibm.ws.session.store.common.BackedHashMap.doScheduledInvalidation() changed?",
                       server.waitForStringInTraceUsingMark(messageToCheckFor));
 
         ArrayList<String> session = new ArrayList<>();

--- a/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheConfigUpdateTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheConfigUpdateTest.java
@@ -11,6 +11,7 @@
 package com.ibm.ws.session.cache.config.fat.infinispan;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -61,6 +62,14 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         server.updateServerConfiguration(savedConfig);
         server.waitForConfigUpdateInLogUsingMark(APP_NAMES, cleanupList);
         cleanupList = EMPTY_RECYCLE_LIST;
+
+        // In addition to starting the application, must also wait for asynchronous web module initialization to complete,
+        // otherwise tests which attempt a configuration update could end up triggering a deactivate and close of the CachingProvider
+        // while the servlet initialization code is still attempting to use the CachingProvider and/or the CacheManager and Caches that it creates.
+        List<String> session = new ArrayList<>();
+        run("getSessionId", session);
+        run("invalidateSession", session);
+
         System.out.println("server configuration restored");
     }
 
@@ -153,11 +162,16 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         httpSessionCache.setScheduleInvalidationSecondHour(Integer.toString(hour2));
         httpSessionCache.setWriteFrequency("TIME_BASED_WRITE");
         httpSessionCache.setWriteInterval("15s");
-        server.setMarkToEndOfLog();
+        server.setMarkToEndOfLog(); // Only marks messages.log, does not mark the trace file
+        server.setTraceMarkToEndOfDefaultTrace();
         server.updateServerConfiguration(config);
         server.waitForConfigUpdateInLogUsingMark(APP_NAMES, EMPTY_RECYCLE_LIST);
+        String messageToCheckFor = "doScheduledInvalidation scheduled hours are " + Integer.toString(hour1) + " and " + Integer.toString(hour2);
 
-        TimeUnit.SECONDS.sleep(10); // Due to invalidation thread delay
+        // Monitor trace.log and wait for the message "doScheduledInvalidation scheduled hours are X and Y" before the test should continue
+        // This replaces the TimeUnit.SECONDS.sleep(10) used before
+        assertNotNull("Could not find Infinispan message \"" + messageToCheckFor + "\" Has the Infinispan message changed?",
+                      server.waitForStringInTraceUsingMark(messageToCheckFor));
 
         ArrayList<String> session = new ArrayList<>();
         String response = run("testSetAttributeWithTimeout&attribute=testScheduleInvalidation&value=si1&maxInactiveInterval=1",

--- a/dev/com.ibm.ws.session.cache_fat_config_infinispan/publish/servers/com.ibm.ws.session.cache.fat.config.infinispan/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_config_infinispan/publish/servers/com.ibm.ws.session.cache.fat.config.infinispan/server.xml
@@ -15,7 +15,7 @@
     <!-- <classloader commonLibraryRef="InfinispanLib"/> causes Weld to process CDI annotations within Infinispan JARs, which causes failures -->
   </application>
 
-  <httpSessionCache libraryRef="InfinispanLib" uri="file:${shared.resource.dir}/infinispan10/infinispan.xml"/>
+  <httpSessionCache libraryRef="InfinispanLib" uri="file:///${shared.resource.dir}/infinispan10/infinispan.xml"/>
 
   <httpSession hideSessionValues="false"/>
 

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.server/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.server/server.xml
@@ -16,7 +16,7 @@
     
     <httpSession maxInMemorySessionCount="1" allowOverflow="false" hideSessionValues="false"/>
     
-    <httpSessionCache uri="file:${shared.resource.dir}/infinispan/infinispan-attr-meta-configuration.xml"
+    <httpSessionCache uri="file:///${shared.resource.dir}/infinispan/infinispan-attr-meta-configuration.xml"
                       enableBetaSupportForInfinispan="true"/> <!-- TODO remove once no longer gated -->
     
     <bell libraryRef="InfinispanLib" service="javax.cache.spi.CachingProvider"/>

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.serverA/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.serverA/server.xml
@@ -13,7 +13,7 @@
     
     <httpSession maxInMemorySessionCount="1" allowOverflow="false" hideSessionValues="false" invalidationTimeout="10m"/>
 
-    <httpSessionCache libraryRef="InfinispanLib" writeContents="GET_AND_SET_ATTRIBUTES" uri="file:${shared.resource.dir}/infinispan/infinispan-com-ibm-configuration.xml">
+    <httpSessionCache libraryRef="InfinispanLib" writeContents="GET_AND_SET_ATTRIBUTES" uri="file:///${shared.resource.dir}/infinispan/infinispan-com-ibm-configuration.xml">
         <properties/>
     </httpSessionCache>
     <httpSessionCache enableBetaSupportForInfinispan="true"/> <!-- TODO remove once no longer gated -->

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.serverB/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.serverB/server.xml
@@ -20,7 +20,7 @@
     
     <httpSession maxInMemorySessionCount="1" allowOverflow="false" hideSessionValues="false" invalidationTimeout="10m"/>
 
-    <httpSessionCache uri="file:${shared.resource.dir}/infinispan/infinispan.xml"
+    <httpSessionCache uri="file:///${shared.resource.dir}/infinispan/infinispan.xml"
                       enableBetaSupportForInfinispan="true"/> <!-- TODO remove once no longer gated -->
 
     <bell libraryRef="InfinispanLib" service="javax.cache.spi.CachingProvider"/>

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.timeoutServerA/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.timeoutServerA/server.xml
@@ -12,7 +12,7 @@
     <include location="../fatTestPorts.xml"/>
     
     <httpSession maxInMemorySessionCount="1" allowOverflow="false" hideSessionValues="false" invalidationTimeout="5" reaperPollInterval="30"/> <!-- "5s" with units causes problem with simplicity object -->
-    <httpSessionCache libraryRef="InfinispanLib" writeContents="ALL_SESSION_ATTRIBUTES" uri="file:${shared.resource.dir}/infinispan/infinispan-config-lacking-http-session-cache-name.xml"
+    <httpSessionCache libraryRef="InfinispanLib" writeContents="ALL_SESSION_ATTRIBUTES" uri="file:///${shared.resource.dir}/infinispan/infinispan-config-lacking-http-session-cache-name.xml"
     enableBetaSupportForInfinispan="true"/> <!-- TODO remove beta config once ready for GA -->
 
     <application location="sessionCacheApp.war">

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.timeoutServerB/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.timeoutServerB/server.xml
@@ -16,7 +16,7 @@
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
     
     <httpSession maxInMemorySessionCount="1" allowOverflow="false" hideSessionValues="false" invalidationTimeout="5s" reaperPollInterval="30"/>
-    <httpSessionCache libraryRef="InfinispanLib" writeContents="ALL_SESSION_ATTRIBUTES" uri="file:${shared.resource.dir}/infinispan/infinispan-config-lacking-http-session-cache-name.xml"
+    <httpSessionCache libraryRef="InfinispanLib" writeContents="ALL_SESSION_ATTRIBUTES" uri="file:///${shared.resource.dir}/infinispan/infinispan-config-lacking-http-session-cache-name.xml"
     enableBetaSupportForInfinispan="true"/> <!-- TODO remove beta config once ready for GA -->
 
     <application location="sessionCacheApp.war">


### PR DESCRIPTION
Modified Infinispan and Hazelcast session cache FAT test server.xml files to include proper formatting of the httpSessionCache uri for the Windows platform.
Pull fixes #10041