### PR TITLE
Fix cleanup issues for feature utility fat

### DIFF
--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
@@ -129,7 +129,6 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
         deleteFeaturesAndLafilesFolders(METHOD_NAME);
 
 
-
         Log.exiting(c, METHOD_NAME);
     }
 

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
@@ -112,6 +112,8 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
         Log.entering(c, METHOD_NAME);
 
         String[] param1s = { "installFeature", "adminCenter-1.0" };
+
+        deleteFeaturesAndLafilesFolders(METHOD_NAME);
         ProgramOutput po = runFeatureUtility(METHOD_NAME, param1s);
         assertEquals("Exit code should be 21", 21, po.getReturnCode());
         String output = po.getStdout();
@@ -123,6 +125,8 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
         assertEquals("Exit code should be 21", 21, po.getReturnCode());
         output = po.getStdout();
         assertTrue("Should contain CWWKF1402E", (output.indexOf("CWWKF1402E") >= 0));
+
+        deleteFeaturesAndLafilesFolders(METHOD_NAME);
 
 
 

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/test/utils/TestUtils.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/test/utils/TestUtils.java
@@ -26,36 +26,59 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
-import com.ibm.websphere.simplicity.log.Log;
-
 public class TestUtils {
-        public static boolean deleteFolder(File file) {
-                Path path = file.toPath();
-                if (!path.toFile().exists()) {
-                        return true;
-                }
-                try {
-                        Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
-                                @Override
-                                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-                                                throws IOException {
-                                        Files.delete(file);
-                                        return FileVisitResult.CONTINUE;
-                                }
 
-                                @Override
-                                public FileVisitResult postVisitDirectory(Path dir, IOException exc)
-                                                throws IOException {
-                                        Files.delete(dir);
-                                        return FileVisitResult.CONTINUE;
+        public static boolean deleteFolder(final File directory) {
+                if (directory.isDirectory()) {
+                        File[] files = directory.listFiles();
+                        if (null != files) {
+                                for (File file : files) {
+                                        if (file.isDirectory()) {
+                                                deleteFolder(file);
+                                        } else {
+                                                if (!file.delete()) {
+                                                        file.deleteOnExit();
+                                                }
+                                        }
                                 }
-                        });
-                } catch (IOException e) {
-                        file.deleteOnExit();
-
+                        }
                 }
-                return !file.exists();
+                if(!directory.delete()){
+                        directory.deleteOnExit();
+                        return false;
+                }
+                return true;
         }
+
+        // public static boolean deleteFolder(File file) {
+        //         Path path = file.toPath();
+        //         if (!path.toFile().exists()) {
+        //                 return true;
+        //         }
+        //         try {
+        //                 Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+        //                         @Override
+        //                         public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+        //                                         throws IOException {
+        //                                 Files.delete(file);
+        //                                 return FileVisitResult.CONTINUE;
+        //                         }
+
+        //                         @Override
+        //                         public FileVisitResult postVisitDirectory(Path dir, IOException exc)
+        //                                         throws IOException {
+        //                                 Files.delete(dir);
+        //                                 return FileVisitResult.CONTINUE;
+        //                         }
+        //                 });
+        //         } catch (IOException e) {
+        //                 file.deleteOnExit();
+
+        //         }
+        //         return !file.exists();
+        // }
+
+
 
         public static void zipDirectory(String sourceFile, String outFile) throws IOException {
                 FileOutputStream fos = new FileOutputStream(outFile);

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/test/utils/TestUtils.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/test/utils/TestUtils.java
@@ -26,25 +26,34 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
+import com.ibm.websphere.simplicity.log.Log;
+
 public class TestUtils {
-        public static boolean deleteFolder(File file) throws IOException {
+        public static boolean deleteFolder(File file) {
                 Path path = file.toPath();
                 if (!path.toFile().exists()) {
                         return true;
                 }
-                Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
-                        @Override
-                        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                                Files.delete(file);
-                                return FileVisitResult.CONTINUE;
-                        }
+                try {
+                        Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+                                @Override
+                                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                                                throws IOException {
+                                        Files.delete(file);
+                                        return FileVisitResult.CONTINUE;
+                                }
 
-                        @Override
-                        public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-                                Files.delete(dir);
-                                return FileVisitResult.CONTINUE;
-                        }
-                });
+                                @Override
+                                public FileVisitResult postVisitDirectory(Path dir, IOException exc)
+                                                throws IOException {
+                                        Files.delete(dir);
+                                        return FileVisitResult.CONTINUE;
+                                }
+                        });
+                } catch (IOException e) {
+                        file.deleteOnExit();
+
+                }
                 return !file.exists();
         }
 


### PR DESCRIPTION
Addresses the following defects

- **[270409](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=270409)** - cant delete wlp.zip because it is being used by another process
- **[270403](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=270403)**- did not remove closed liberty feature (adminCenter-1.0) prior to installation test case