### PR TITLE
Issue 10087: Fix merging of JVM options.

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheConfigUpdateTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheConfigUpdateTest.java
@@ -14,9 +14,9 @@ import static org.junit.Assert.assertFalse;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -70,7 +70,9 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
 
         savedConfig = server.getServerConfiguration().clone();
         String rand = UUID.randomUUID().toString();
-        server.setJvmOptions(Arrays.asList("-Dinfinispan.cluster.name=" + rand));
+        Map<String, String> options = server.getJvmOptionsAsMap();
+        options.put("-Dinfinispan.cluster.name", rand);
+        server.setJvmOptions(options);
         server.startServer();
 
         // In addition to starting the application, must also wait for asynchronous web module initialization to complete,

--- a/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheErrorPathsTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheErrorPathsTest.java
@@ -16,10 +16,10 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedInputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.UUID;
@@ -81,7 +81,9 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
         ShrinkHelper.defaultApp(server, APP_NAME, "session.cache.infinispan.web");
 
         String rand = UUID.randomUUID().toString();
-        server.setJvmOptions(Arrays.asList("-Dinfinispan.cluster.name=" + rand));
+        Map<String, String> options = server.getJvmOptionsAsMap();
+        options.put("-Dinfinispan.cluster.name", rand);
+        server.setJvmOptions(options);
         savedConfig = server.getServerConfiguration().clone();
     }
 

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheOneServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheOneServerTest.java
@@ -11,7 +11,6 @@
 package com.ibm.ws.session.cache.fat.infinispan;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -46,7 +45,9 @@ public class SessionCacheOneServerTest extends FATServletClient {
     public static void setUp() throws Exception {
         app = new SessionCacheApp(server, true, "session.cache.infinispan.web", "session.cache.infinispan.web.listener1", "session.cache.infinispan.web.listener2");
         String rand = UUID.randomUUID().toString();
-        server.setJvmOptions(Arrays.asList("-Dinfinispan.cluster.name=" + rand));
+        Map<String, String> options = server.getJvmOptionsAsMap();
+        options.put("-Dinfinispan.cluster.name", rand);
+        server.setJvmOptions(options);
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTimeoutTest.java
@@ -15,8 +15,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -55,7 +55,9 @@ public class SessionCacheTimeoutTest extends FATServletClient {
     public static void setUp() throws Exception {
         app = new SessionCacheApp(server, false, "session.cache.infinispan.web", "session.cache.infinispan.web.listener1");
         String rand = UUID.randomUUID().toString();
-        server.setJvmOptions(Arrays.asList("-Dinfinispan.cluster.name=" + rand));
+        Map<String, String> options = server.getJvmOptionsAsMap();
+        options.put("-Dinfinispan.cluster.name", rand);
+        server.setJvmOptions(options);
         server.startServer();
 
         // Access a session before the main test logic to ensure that delays caused by lazy initialization

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTwoServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTwoServerTest.java
@@ -15,8 +15,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.junit.AfterClass;
@@ -49,8 +49,12 @@ public class SessionCacheTwoServerTest extends FATServletClient {
         appB = new SessionCacheApp(serverB, true, "session.cache.infinispan.web", "session.cache.infinispan.web.cdi", "session.cache.infinispan.web.listener1");
         serverB.useSecondaryHTTPPort();
         String rand = UUID.randomUUID().toString();
-        serverA.setJvmOptions(Arrays.asList("-Dinfinispan.cluster.name=" + rand));
-        serverB.setJvmOptions(Arrays.asList("-Dinfinispan.cluster.name=" + rand));
+        Map<String, String> options = serverA.getJvmOptionsAsMap();
+        options.put("-Dinfinispan.cluster.name", rand);
+        serverA.setJvmOptions(options);
+        options = serverB.getJvmOptionsAsMap();
+        options.put("-Dinfinispan.cluster.name", rand);
+        serverB.setJvmOptions(options);
 
         serverA.startServer();
 

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTwoServerTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTwoServerTimeoutTest.java
@@ -14,8 +14,8 @@ import static componenttest.custom.junit.runner.Mode.TestMode.FULL;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.junit.AfterClass;
@@ -53,8 +53,12 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
         appB = new SessionCacheApp(serverB, false, "session.cache.infinispan.web"); // no HttpSessionListeners are registered by this app
         serverB.useSecondaryHTTPPort();
         String rand = UUID.randomUUID().toString();
-        serverA.setJvmOptions(Arrays.asList("-Dinfinispan.cluster.name=" + rand));
-        serverB.setJvmOptions(Arrays.asList("-Dinfinispan.cluster.name=" + rand));
+        Map<String, String> options = serverA.getJvmOptionsAsMap();
+        options.put("-Dinfinispan.cluster.name", rand);
+        serverA.setJvmOptions(options);
+        options = serverB.getJvmOptionsAsMap();
+        options.put("-Dinfinispan.cluster.name", rand);
+        serverB.setJvmOptions(options);
 
         serverA.startServer();
 

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.server/jvm.options
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/publish/servers/com.ibm.ws.session.cache.fat.infinispan.server/jvm.options
@@ -1,0 +1,1 @@
+-Djava.net.preferIPv4Stack=true


### PR DESCRIPTION
Fixes issue where the `-Djava.net.preferIPv4Stack=true` JVM option was being overwritten when tests were setting the `-Dinfinispan.cluster.name` JVM option.

resolves #10087 