### PR TITLE
social login tai updates to construct default realm

### DIFF
--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/TAISubjectUtils.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/TAISubjectUtils.java
@@ -192,7 +192,7 @@ public class TAISubjectUtils {
 
     private String getDefaultRealm(SocialLoginConfig config) throws SettingCustomPropertiesException {
         String realm = null;
-        if (SocialUtil.isKubeConfig(config) && SocialUtil.useAccessTokenFromRequest(config)) {
+        if (SocialUtil.isKubeConfig(config)) {
             String ep = getRealmFromUserApiEndpoint(config);
             if (ep == null) {
                 if (tc.isDebugEnabled()) {

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/TAISubjectUtils.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/TAISubjectUtils.java
@@ -205,7 +205,7 @@ public class TAISubjectUtils {
             }
         } else {
             // original behavior before adding the support for kube type
-            realm = getDefaultRealmFromAuthorizationEndpoint(config);
+            realm = constructDefaultRealmFromConfig(config);
         }
         return realm;
         
@@ -247,17 +247,23 @@ public class TAISubjectUtils {
         return realm;
     }
     
-
-    String getDefaultRealmFromAuthorizationEndpoint(SocialLoginConfig config) throws SettingCustomPropertiesException {
-        String authzEndpoint = getAuthorizationEndpoint(config);
-        if (!isValidAuthorizationEndpoint(authzEndpoint)) {
+    String constructDefaultRealmFromConfig(SocialLoginConfig config) throws SettingCustomPropertiesException {
+        // try authorization endpoint first and then the userapi endpoint
+        String endpoint = getAuthorizationEndpoint(config);
+        if (!isValidEndpoint(endpoint)) {
             if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Authorization endpoint [" + authzEndpoint + "] is either empty or too short to be a valid URL");
+                Tr.debug(tc, "Authorization endpoint [" + endpoint + "] is either empty or too short to be a valid URL, try using userapi ep.");
             }
-            Tr.error(tc, "REALM_NOT_FOUND");
-            throw new SettingCustomPropertiesException();
+            endpoint = config.getUserApi();
+            if (!isValidEndpoint(endpoint)) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Userapi endpoint [" + endpoint + "] is either empty or too short to be a valid URL");
+                }
+                Tr.error(tc, "REALM_NOT_FOUND");
+                throw new SettingCustomPropertiesException();
+            }    
         }
-        return extractRealmFromAuthorizationEndpoint(authzEndpoint);
+        return extractRealmFromEndpoint(endpoint);
     }
 
     Subject buildSubject(SocialLoginConfig config, Hashtable<String, Object> customProperties) throws SocialLoginException {
@@ -425,12 +431,12 @@ public class TAISubjectUtils {
         }
     }
 
-    private boolean isValidAuthorizationEndpoint(String authzEndpoint) {
+    private boolean isValidEndpoint(String authzEndpoint) {
         int httpsStrLen = "https://".length();
         return authzEndpoint != null && !authzEndpoint.isEmpty() && authzEndpoint.length() > httpsStrLen;
     }
 
-    private String extractRealmFromAuthorizationEndpoint(String authzEndpoint) {
+    private String extractRealmFromEndpoint(String authzEndpoint) {
         // Assumes that the authorization endpoint must start with "https://"
         int httpsStrLen = "https://".length();
         String endpointWithSchemeRemoved = authzEndpoint.substring(httpsStrLen);

--- a/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/tai/TAISubjectUtilsTest.java
+++ b/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/tai/TAISubjectUtilsTest.java
@@ -931,6 +931,8 @@ public class TAISubjectUtilsTest extends CommonTestClass {
                     one(config).getUserApiType();
                     one(taiWebUtils).getAuthorizationEndpoint(config);
                     will(returnValue(null));
+                    one(config).getUserApi();
+                    will(returnValue(null));
                 }
             });
             try {
@@ -1028,6 +1030,8 @@ public class TAISubjectUtilsTest extends CommonTestClass {
                     one(config).getUserApiType();
                     one(taiWebUtils).getAuthorizationEndpoint(config);
                     will(returnValue(null));
+                    one(config).getUserApi();
+                    will(returnValue(null));
                 }
             });
             try {
@@ -1098,20 +1102,22 @@ public class TAISubjectUtilsTest extends CommonTestClass {
         }
     }
 
-    /****************************************** getDefaultRealmFromAuthorizationEndpoint ******************************************/
+    /****************************************** constructDefaultRealmFromConfig ******************************************/
 
     @Test
-    public void getDefaultRealmFromAuthorizationEndpoint_errorGettingAuthorizationEndpoint() throws Exception {
+    public void constructDefaultRealmFromConfig_errorGettingAuthorizationEndpoint() throws Exception {
         try {
             mockery.checking(new Expectations() {
                 {
                     one(taiWebUtils).getAuthorizationEndpoint(config);
                     will(throwException(new SocialLoginException(defaultExceptionMsg, null, null)));
+                    one(config).getUserApi();
+                    will(returnValue(null));
                 }
             });
 
             try {
-                String result = subjectUtils.getDefaultRealmFromAuthorizationEndpoint(config);
+                String result = subjectUtils.constructDefaultRealmFromConfig(config);
                 fail("Should have thrown an exception but got: [" + result + "].");
             } catch (SettingCustomPropertiesException e) {
                 // Do nothing - this is expected
@@ -1124,9 +1130,34 @@ public class TAISubjectUtilsTest extends CommonTestClass {
             outputMgr.failWithThrowable(testName.getMethodName(), t);
         }
     }
+    
+    @Test
+    public void constructDefaultRealmFromConfig_errorGettingAuthorizationEndpoint_useUserapi() throws Exception {
+        try {
+            final String userApi = "http://myuser-domain.com:80";
+            mockery.checking(new Expectations() {
+                {
+                    one(taiWebUtils).getAuthorizationEndpoint(config);
+                    will(throwException(new SocialLoginException(defaultExceptionMsg, null, null)));
+                    one(config).getUserApi();
+                    will(returnValue(userApi));
+                }
+            });
+
+            try {
+                String result = subjectUtils.constructDefaultRealmFromConfig(config);
+                assertEquals("Non-HTTPS, authorization endpoint is not valid, get realm from user api endpoint.", userApi, result);
+            } catch (SettingCustomPropertiesException e) {
+                // Do nothing - this is expected
+            }
+
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
 
     @Test
-    public void getDefaultRealmFromAuthorizationEndpoint_authzEndpointNotHttps_noPath() throws Exception {
+    public void constructDefaultRealmFromConfig_authzEndpointNotHttps_noPath() throws Exception {
         try {
             final String authzEndpoint = "http://my-domain.com:80";
             mockery.checking(new Expectations() {
@@ -1136,7 +1167,7 @@ public class TAISubjectUtilsTest extends CommonTestClass {
                 }
             });
 
-            String result = subjectUtils.getDefaultRealmFromAuthorizationEndpoint(config);
+            String result = subjectUtils.constructDefaultRealmFromConfig(config);
             assertEquals("Non-HTTPS authorization endpoint should still have returned host and port as the realm.", authzEndpoint, result);
 
             verifyNoLogMessage(outputMgr, MSG_BASE);
@@ -1147,7 +1178,7 @@ public class TAISubjectUtilsTest extends CommonTestClass {
     }
 
     @Test
-    public void getDefaultRealmFromAuthorizationEndpoint_authzEndpointNotHttps_withPath() throws Exception {
+    public void constructDefaultRealmFromConfig_authzEndpointNotHttps_withPath() throws Exception {
         try {
             final String host = "http://my-domain.com:80";
             final String authzEndpoint = host + "/some/path";
@@ -1158,7 +1189,7 @@ public class TAISubjectUtilsTest extends CommonTestClass {
                 }
             });
 
-            String result = subjectUtils.getDefaultRealmFromAuthorizationEndpoint(config);
+            String result = subjectUtils.constructDefaultRealmFromConfig(config);
             assertEquals("Non-HTTPS authorization endpoint should still have returned host and port as the realm.", host, result);
 
             verifyNoLogMessage(outputMgr, MSG_BASE);
@@ -1169,7 +1200,7 @@ public class TAISubjectUtilsTest extends CommonTestClass {
     }
 
     @Test
-    public void getDefaultRealmFromAuthorizationEndpoint_authzEndpointHttps_noPath() throws Exception {
+    public void constructDefaultRealmFromConfig_authzEndpointHttps_noPath() throws Exception {
         try {
             final String authzEndpoint = "https://my-domain.com:80";
             mockery.checking(new Expectations() {
@@ -1179,7 +1210,7 @@ public class TAISubjectUtilsTest extends CommonTestClass {
                 }
             });
 
-            String result = subjectUtils.getDefaultRealmFromAuthorizationEndpoint(config);
+            String result = subjectUtils.constructDefaultRealmFromConfig(config);
             assertEquals("HTTPS authorization endpoint without path component should have returned host and port as the realm.", authzEndpoint, result);
 
             verifyNoLogMessage(outputMgr, MSG_BASE);
@@ -1190,7 +1221,7 @@ public class TAISubjectUtilsTest extends CommonTestClass {
     }
 
     @Test
-    public void getDefaultRealmFromAuthorizationEndpoint_authzEndpointHttps_withPath() throws Exception {
+    public void constructDefaultRealmFromConfig_authzEndpointHttps_withPath() throws Exception {
         try {
             final String host = "https://my-domain.com:80";
             final String authzEndpoint = host + "/some/path";
@@ -1201,7 +1232,7 @@ public class TAISubjectUtilsTest extends CommonTestClass {
                 }
             });
 
-            String result = subjectUtils.getDefaultRealmFromAuthorizationEndpoint(config);
+            String result = subjectUtils.constructDefaultRealmFromConfig(config);
             assertEquals("HTTPS authorization endpoint with path component should have returned host and port as the realm.", host, result);
 
             verifyNoLogMessage(outputMgr, MSG_BASE);
@@ -1212,7 +1243,7 @@ public class TAISubjectUtilsTest extends CommonTestClass {
     }
 
     @Test
-    public void getDefaultRealmFromAuthorizationEndpoint_authzEndpointHttps_withPathAndQuery() throws Exception {
+    public void constructDefaultRealmFromConfig_authzEndpointHttps_withPathAndQuery() throws Exception {
         try {
             final String host = "https://my-domain.com:80";
             final String authzEndpoint = host + "/some/path?and=stuff";
@@ -1223,7 +1254,7 @@ public class TAISubjectUtilsTest extends CommonTestClass {
                 }
             });
 
-            String result = subjectUtils.getDefaultRealmFromAuthorizationEndpoint(config);
+            String result = subjectUtils.constructDefaultRealmFromConfig(config);
             assertEquals("HTTPS authorization endpoint with query string should have returned host and port as the realm.", host, result);
 
             verifyNoLogMessage(outputMgr, MSG_BASE);


### PR DESCRIPTION
Default realm - if kube , then use token reviews/user api  ep. If not kube, see if authz ep is available first and then fall back to user api.