### PR TITLE
Revert "reduce the length of classpath for windows."

### DIFF
--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -216,25 +216,6 @@
 
 		<echo message="test.bucket.path including junit: ${toString:test.bucket.path}"/>
 
-		<iff if="is.windows.platform">
-			<then>
-				<echo>generating classpath jar file.</echo>
-				<property name="classpath.jar.name" value="${basedir}/build/lib/cp.jar"/>
-				<manifestclasspath property="classpath.list" maxParentLevels="10" jarfile="${classpath.jar.name}">
-				    <classpath refid="test.bucket.path"/>
-				</manifestclasspath>
-				<jar jarfile="${classpath.jar.name}" >
-				    <manifest>
-				        <attribute name="Class-Path" value="${classpath.list}"/>
-				    </manifest>
-				</jar>
-				<path id="test.bucket.path">
-					<fileset file="${classpath.jar.name}"/>
-			    </path>
-				<echo message="modified test.bucket.path : ${toString:test.bucket.path}"/>
-			</then>
-		</iff>
-		
 		<echo>Initializing JRE logging</echo>
 		<delete dir="${dir.log}" quiet="true" />
 		<mkdir dir="${dir.log.xml}" />


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#10072

Fails when running on a mac
a) the code isn’t properly restricted to Windows and b) it doesn’t work properly anyway
```
     [echo] generating classpath jar file.

BUILD FAILED
/Users/tevans/Liberty/openLibertyGit/open-liberty/dev/com.ibm.ws.microprofile.config.1.3_fat/build/libs/autoFVT/src/ant/launch.xml:223: No suitable relative path from /Users/tevans/Liberty/openLibertyGit/open-liberty/dev/com.ibm.ws.microprofile.config.1.3_fat/build/libs/autoFVT/build/lib to /usr/local/Cellar/ant/1.10.7/libexec/lib/ant-junit.jar
```