### PR TITLE
EJB Timer Service needs a way to check if fail over is enabled

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/ejb/TimersPersistentExecutor.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/ejb/TimersPersistentExecutor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015,2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -85,6 +85,13 @@ public interface TimersPersistentExecutor extends PersistentExecutor {
      * @throws Exception if an error occurs accessing the persistent store.
      */
     <T> TimerStatus<T> getTimerStatus(long taskId) throws Exception;
+
+    /**
+     * Indicates whether or not fail over is enabled.
+     *
+     * @return true if fail over is enabled, otherwise false.
+     */
+    boolean isFailOverEnabled();
 
     /**
      * Removes all persisted properties that match the specified name pattern.

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
@@ -1068,6 +1068,13 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
 
     /** {@inheritDoc} */
     @Override
+    public boolean isFailOverEnabled() {
+        // TODO update below once we officially decide between the two failover implementations.
+        return configRef.get().missedTaskThreshold > 0 || configRef.get().missedTaskThreshold2 > 0;
+    }
+
+    /** {@inheritDoc} */
+    @Override
     @Trivial
     public boolean isShutdown() {
         // Section 3.1.6.1 of the Concurrency Utilities spec requires IllegalStateException

--- a/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/fat/src/com/ibm/ws/concurrent/persistent/fat/oneexec/OneExecutorRunsAllTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/fat/src/com/ibm/ws/concurrent/persistent/fat/oneexec/OneExecutorRunsAllTest.java
@@ -143,6 +143,14 @@ public class OneExecutorRunsAllTest {
     }
 
     /**
+     * Verify that the interface to EJB Timer Service indicates that fail over is not enabled.
+     */
+    @Test
+    public void testFailOverIsNotEnabled() throws Exception {
+        runInServlet("test=testFailOverIsNotEnabled");
+    }
+
+    /**
      * Schedule tasks from two persistentExecutor instances with execution disabled.
      * Verify the tasks run on a third instance, which has task execution enabled.
      * Remove the third instance. Schedule another task.

--- a/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/fat/src/com/ibm/ws/concurrent/persistent/fat/oneexec/OneExecutorRunsAllWithFailoverEnabledTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/fat/src/com/ibm/ws/concurrent/persistent/fat/oneexec/OneExecutorRunsAllWithFailoverEnabledTest.java
@@ -157,6 +157,14 @@ public class OneExecutorRunsAllWithFailoverEnabledTest {
     }
 
     /**
+     * Verify that the interface to EJB Timer Service indicates that fail over is enabled.
+     */
+    @Test
+    public void testFailOverIsEnabled() throws Exception {
+        runInServlet("test=testFailOverIsEnabled");
+    }
+
+    /**
      * Schedule tasks from two persistentExecutor instances with execution disabled.
      * Verify the tasks run on a third instance, which has task execution enabled.
      * Remove the third instance. Schedule another task.

--- a/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/test-applications/persistoneexectest/src/web/OneExecutorRunsAllTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/test-applications/persistoneexectest/src/web/OneExecutorRunsAllTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2015, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,6 +33,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.transaction.UserTransaction;
+
+import org.junit.Test;
 
 import com.ibm.websphere.concurrent.persistent.PersistentExecutor;
 import com.ibm.websphere.concurrent.persistent.TaskState;
@@ -219,6 +221,34 @@ public class OneExecutorRunsAllTestServlet extends HttpServlet {
             throw new Exception("Task status " + statusAAA + " obtained via getTimerStatus does not match " + statusA);
         if (!statusAA.equals(statusAAA))
             throw new Exception("Task status " + statusAAA + " obtained via getTimerStatus does not match " + statusAA + " obtained via findTimerStatus");
+    }
+
+    /**
+     * Verify that the interface to EJB Timer Service indicates that fail over is enabled.
+     */
+    public void testFailOverIsEnabled(HttpServletRequest request, PrintWriter out) throws Exception {
+        TimersPersistentExecutor executorB = (TimersPersistentExecutor) new InitialContext().lookup("concurrent/executorB");
+        TimersPersistentExecutor executorC = (TimersPersistentExecutor) new InitialContext().lookup("concurrent/executorC");
+
+        if (!executorB.isFailOverEnabled())
+            throw new Exception("persistentExecutor with a positive missedTaskThreshold and with polling disabled reports that fail over is not enabled.");
+
+        if (!executorC.isFailOverEnabled())
+            throw new Exception("persistentExecutor with a positive missedTaskThreshold and with polling enabled reports that fail over is not enabled.");
+    }
+
+    /**
+     * Verify that the interface to EJB Timer Service indicates that fail over is not enabled.
+     */
+    public void testFailOverIsNotEnabled(HttpServletRequest request, PrintWriter out) throws Exception {
+        TimersPersistentExecutor executorB = (TimersPersistentExecutor) new InitialContext().lookup("concurrent/executorB");
+        TimersPersistentExecutor executorC = (TimersPersistentExecutor) new InitialContext().lookup("concurrent/executorC");
+
+        if (executorB.isFailOverEnabled())
+            throw new Exception("persistentExecutor without a missedTaskThreshold and with polling disabled reports that fail over is enabled.");
+
+        if (executorC.isFailOverEnabled())
+            throw new Exception("persistentExecutor without a missedTaskThreshold and with polling enabled reports that fail over is enabled.");
     }
 
     /**


### PR DESCRIPTION
Add an isFailOverEnabled method to the existing TimersPersistentExecutor interface which the EJB Timer Service has access to.