### PR TITLE
query and lock timeout on various databases

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/db/DatabaseTaskStore.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/db/DatabaseTaskStore.java
@@ -29,9 +29,12 @@ import javax.persistence.EntityManager;
 import javax.persistence.LockModeType;
 import javax.persistence.LockTimeoutException;
 import javax.persistence.PersistenceException;
+import javax.persistence.PessimisticLockException;
 import javax.persistence.Query;
 import javax.persistence.QueryTimeoutException;
 import javax.persistence.TypedQuery;
+
+import org.eclipse.persistence.platform.database.DatabasePlatform;
 
 import com.ibm.websphere.concurrent.persistent.PersistentExecutor;
 import com.ibm.websphere.concurrent.persistent.TaskState;
@@ -1056,12 +1059,20 @@ public class DatabaseTaskStore implements TaskStore {
                         EntityManager em = persistenceServiceUnitReadUncommitted.createEntityManager();
                         // This seems to apply to every subsequent usage of the persistence service unit. Can we rely on that?
                         Object dbSession = em.getClass().getMethod("getDatabaseSession").invoke(em);
-                        org.eclipse.persistence.sessions.DatabaseLogin dbLogin = (org.eclipse.persistence.sessions.DatabaseLogin) dbSession.getClass()
-                                        .getMethod("getDatasourceLogin")
-                                        .invoke(dbSession);
-                        if (!dbLogin.isAnyOracleJDBCDriver())
+
+                        // TODO is there a more efficient way to detect Oracle that doesn't require obtaining an extra connection?
+                        DatabasePlatform dbPlatform = (DatabasePlatform) dbSession.getClass().getMethod("getPlatform").invoke(dbSession);
+                        if (dbPlatform.isOracle() || dbPlatform.isOracle9()) {
+                            em.close();
+                            persistenceServiceUnitReadUncommitted.close();
+                            persistenceServiceUnitReadUncommitted = getPersistenceServiceUnit();
+                        } else {
+                            org.eclipse.persistence.sessions.DatabaseLogin dbLogin = (org.eclipse.persistence.sessions.DatabaseLogin) dbSession.getClass()
+                                            .getMethod("getDatasourceLogin")
+                                            .invoke(dbSession);
                             dbLogin.setTransactionIsolation(Connection.TRANSACTION_READ_UNCOMMITTED);
-                        em.close();
+                            em.close();
+                        }
                     }
                 } finally {
                     // Downgrade to read lock for rest of method
@@ -1680,9 +1691,10 @@ public class DatabaseTaskStore implements TaskStore {
     }
 
     /** {@inheritDoc} */
-    @FFDCIgnore({ LockTimeoutException.class, PersistenceException.class, QueryTimeoutException.class })
+    @FFDCIgnore({ LockTimeoutException.class, PersistenceException.class, PessimisticLockException.class, QueryTimeoutException.class })
     @Override
     public boolean claimIfNotLocked(long taskId, int version, long claimExpiryOrPartition) throws Exception {
+        String find = "SELECT t.ID FROM Task t WHERE t.ID=:i AND t.VERSION=:v";
         String update = "UPDATE Task t SET t.PARTN=:p,t.VERSION=t.VERSION+1 WHERE t.ID=:i AND t.VERSION=:v";
 
         final boolean trace = TraceComponent.isAnyTracingEnabled();
@@ -1692,29 +1704,43 @@ public class DatabaseTaskStore implements TaskStore {
                 Utils.appendDate(b.append(" claim until "), claimExpiryOrPartition);
             else
                 b.append(" assign to partition ").append(claimExpiryOrPartition);
-            Tr.entry(this, tc, "claimIfNotLocked", b, update);
+            Tr.entry(this, tc, "claimIfNotLocked", b, find, update);
         }
+
+        // A single update statement would be preferred over find+update. However, unfortunately EclipseLink does not allow
+        // the javax.persistence.lock.timeout hint on updates, so our only option is to first run an extra query so that
+        // databases which support lock timeout (such as SQL Server) can be given the opportunity to time out immediately
+        // when the entry is already locked.
 
         EntityManager em = getPersistenceServiceUnit().createEntityManager();
         try {
-            Query query = em.createQuery(update.toString());
+            TypedQuery<Long> lockingQuery = em.createQuery(find, Long.class);
+            lockingQuery.setLockMode(LockModeType.PESSIMISTIC_WRITE);
+            lockingQuery.setHint("javax.persistence.lock.timeout", 0); // milliseconds
 
-            // We would like the statement to return immediately if the entry is already locked (this means it doesn't need failover),
-            // however EclipseLink says lock timeout isn't valid for this type of query,
-            // query.setHint("javax.persistence.lock.timeout", 0); // milliseconds
+            // Some databases don't support lock timeout. As a workaround, use a short query timeout,
+            lockingQuery.setHint("eclipselink.query.timeout.unit", "MILLISECONDS"); // Make EclipseLink follow the JPA spec
+            lockingQuery.setHint("javax.persistence.query.timeout", 3000); // 3 seconds
 
-            // As a workaround, use a short query timeout,
-            query.setHint("eclipselink.query.timeout.unit", "MILLISECONDS"); // Make EclipseLink follow the JPA spec
-            query.setHint("javax.persistence.query.timeout", 3000); // 3 seconds
+            lockingQuery.setParameter("i", taskId);
+            lockingQuery.setParameter("v", version);
 
-            query.setParameter("p", claimExpiryOrPartition);
-            query.setParameter("i", taskId);
-            query.setParameter("v", version);
-            boolean assigned = query.executeUpdate() > 0;
+            List<Long> lockedEntries = lockingQuery.getResultList();
+            if (lockedEntries.isEmpty()) {
+                if (trace && tc.isEntryEnabled())
+                    Tr.exit(this, tc, "claimIfNotLocked", "false - still owned by another member");
+                return false;
+            }
+
+            Query updateClaim = em.createQuery(update);
+            updateClaim.setParameter("p", claimExpiryOrPartition);
+            updateClaim.setParameter("i", taskId);
+            updateClaim.setParameter("v", version);
+            boolean claimed = updateClaim.executeUpdate() > 0;
 
             if (trace && tc.isEntryEnabled())
-                Tr.exit(this, tc, "claimIfNotLocked", assigned);
-            return assigned;
+                Tr.exit(this, tc, "claimIfNotLocked", claimed);
+            return claimed;
         } catch (LockTimeoutException x) {
             if (trace && tc.isEntryEnabled())
                 Tr.exit(this, tc, "claimIfNotLocked", "false: lock timeout - still owned by another member");
@@ -1723,11 +1749,15 @@ public class DatabaseTaskStore implements TaskStore {
             if (trace && tc.isEntryEnabled())
                 Tr.exit(this, tc, "claimIfNotLocked", "false: query timeout - still owned by another member");
             return false;
+        } catch (PessimisticLockException x) {
+            if (trace && tc.isEntryEnabled())
+                Tr.exit(this, tc, "claimIfNotLocked", "false: pessimistic lock timeout - still owned by another member");
+            return false;
         } catch (PersistenceException x) {
             for (Throwable c = x.getCause(); c != null; c = c.getCause())
                 if (c instanceof SQLTimeoutException) {
                     if (trace && tc.isEntryEnabled())
-                        Tr.exit(this, tc, "claimIfNotLocked", "false: SQLTimeoutException still owned by another member");
+                        Tr.exit(this, tc, "claimIfNotLocked", "false: SQLTimeoutException - still owned by another member");
                     return false;
                 } else if (c instanceof SQLException) {
                     String ss = ((SQLException) c).getSQLState();

--- a/dev/com.ibm.ws.concurrent.persistent_fat/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/bnd.bnd
@@ -22,6 +22,9 @@ src: \
 fat.project: true
 fat.test.databases: true
 
+# To choose the database, specify one of: Postgre, DB2, Oracle, SQLServer, Derby
+# fat.bucket.db.type: Postgre
+
 # Uncomment to use remote docker host to simulate continuous build behavior.
 # fat.test.use.remote.docker: true
 

--- a/dev/com.ibm.ws.concurrent.persistent_fat/test-applications/schedtest/src/web/SchedulerFATServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/test-applications/schedtest/src/web/SchedulerFATServlet.java
@@ -87,7 +87,7 @@ public class SchedulerFATServlet extends HttpServlet {
     /**
      * Indicates if the database for the persistent executor is Derby.
      */
-    private boolean isDerby;
+    private static final boolean isDerby = System.getProperty("fat.bucket.db.type", "Derby").compareToIgnoreCase("Derby") == 0;
 
     @Resource(lookup = "concurrent/myScheduler")
     private PersistentExecutor scheduler;
@@ -190,19 +190,6 @@ public class SchedulerFATServlet extends HttpServlet {
                 }
             } finally {
                 con.close();
-            }
-
-            tran.begin();
-            try {
-                con = schedDB.getConnection();
-                try {
-                    String dbProduct = con.getMetaData().getDatabaseProductName();
-                    isDerby = dbProduct != null && dbProduct.toLowerCase().contains("apache derby");
-                } finally {
-                    con.close();
-                }
-            } finally {
-                tran.commit();
             }
         } catch (Exception x) {
             throw new ServletException(x);

--- a/dev/com.ibm.ws.concurrent.persistent_fat/test-applications/schedtest/src/web/SchedulerFATServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/test-applications/schedtest/src/web/SchedulerFATServlet.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package web;
 
+import static org.junit.Assert.assertFalse;
+
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -55,7 +57,9 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
+import javax.transaction.NotSupportedException;
 import javax.transaction.Status;
+import javax.transaction.SystemException;
 import javax.transaction.UserTransaction;
 
 import org.junit.Test;
@@ -80,6 +84,11 @@ public class SchedulerFATServlet extends HttpServlet {
      */
     private static final String SUCCESS_MESSAGE = "COMPLETED SUCCESSFULLY";
 
+    /**
+     * Indicates if the database for the persistent executor is Derby.
+     */
+    private boolean isDerby;
+
     @Resource(lookup = "concurrent/myScheduler")
     private PersistentExecutor scheduler;
 
@@ -99,7 +108,7 @@ public class SchedulerFATServlet extends HttpServlet {
     /**
      * Maximum number of nanoseconds to wait for a task to finish.
      */
-    static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(1);
+    static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(2);
 
     @Resource
     private UserTransaction tran;
@@ -182,7 +191,20 @@ public class SchedulerFATServlet extends HttpServlet {
             } finally {
                 con.close();
             }
-        } catch (SQLException x) {
+
+            tran.begin();
+            try {
+                con = schedDB.getConnection();
+                try {
+                    String dbProduct = con.getMetaData().getDatabaseProductName();
+                    isDerby = dbProduct != null && dbProduct.toLowerCase().contains("apache derby");
+                } finally {
+                    con.close();
+                }
+            } finally {
+                tran.commit();
+            }
+        } catch (Exception x) {
             throw new ServletException(x);
         }
     }
@@ -459,22 +481,47 @@ public class SchedulerFATServlet extends HttpServlet {
             if (!foundIds.containsAll(expected))
                 throw new Exception("On the second query, should have found at least task ids " + expected + " within " + foundIds);
 
-            // Simulate another instance trying to claim the same task, but timing out.
-            // This could happen if task execution outlives the missed task threshold (good configuration should avoid this)
-            // TODO enable if we can determine why query timeouts aren't timing out and fix it, then enable the following:
-            //tran.begin();
-            //try {
-            //    Method DatabaseTaskStore_claimIfNotLocked = dbTaskStore.getClass().getMethod("claimIfNotLocked", long.class, int.class, long.class);
-            //    long newClaimExpiry = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(155);
-            //    System.out.println("About to attempt claim");
-            //    long start = System.nanoTime();
-            //    DatabaseTaskStore_claimIfNotLocked.invoke(dbTaskStore, statusO.getTaskId(), 1, newClaimExpiry);
-            //    long duration = System.nanoTime() - start;
-            //    if (duration > TimeUnit.SECONDS.toNanos(20))
-            ///        throw new Exception("Claim attempt on task (" + statusO.getTaskId() + ") did not timeout within a reasonable amount of time. " + duration + " ns.");
-            //}// finally {
-            //    tran.rollback();
-            //}
+            if (!isDerby) { // skip for Derby, which does not implement query timeout or allow lock timeout to be applied on a granular basis
+                // Simulate another instance trying to claim the same task, but timing out.
+                // This could happen if task execution outlives the missed task threshold (good configuration should avoid this)
+                final Method DatabaseTaskStore_claimIfNotLocked = dbTaskStore.getClass().getMethod("claimIfNotLocked", long.class, int.class, long.class);
+                long newClaimExpiry = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(155);
+                tran.begin();
+                try {
+                    System.out.println("About to attempt claim");
+                    long start = System.nanoTime();
+                    Boolean claimed = (Boolean) DatabaseTaskStore_claimIfNotLocked.invoke(dbTaskStore, statusO.getTaskId(), 1, newClaimExpiry);
+                    long duration = System.nanoTime() - start;
+                    if (duration > TimeUnit.SECONDS.toNanos(20))
+                        throw new Exception("Claim attempt on task (" + statusO.getTaskId() + ") did not timeout within a reasonable amount of time. " + duration + " ns.");
+
+                    if (Boolean.TRUE.equals(claimed)) {
+                        // If we successfully claimed it, ensure that a second thread times out while we are still holding the lock.
+                        final long nextClaimExpiry = newClaimExpiry + TimeUnit.HOURS.toMillis(1);
+                        Future<Long> future = unmanagedExecutor.submit(new Callable<Long>() {
+                            @Override
+                            public Long call() throws Exception {
+                                tran.begin();
+                                try {
+                                    long start = System.nanoTime();
+                                    Boolean claimed = (Boolean) DatabaseTaskStore_claimIfNotLocked.invoke(dbTaskStore, statusO.getTaskId(), 2, nextClaimExpiry);
+                                    if (claimed)
+                                        throw new Error("Should not be able to claim task while other thread has a lock on it");
+                                    long duration = System.nanoTime() - start;
+                                    return duration;
+                                } finally {
+                                    tran.rollback();
+                                }
+                            }
+                        });
+                        duration = future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+                        if (duration > TimeUnit.SECONDS.toNanos(20))
+                            throw new Exception("Second claim attempt on task (" + statusO.getTaskId() + ") did not timeout within a reasonable amount of time. " + duration + " ns.");
+                    }
+                } finally {
+                    tran.rollback();
+                }
+            }
 
             // It should be possible to cancel other tasks.
             if (!statusM.cancel(false))
@@ -1156,10 +1203,34 @@ public class SchedulerFATServlet extends HttpServlet {
                 long newClaimExpiry = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(7);
                 System.out.println("About to attempt claim");
                 long start = System.nanoTime();
-                DatabaseTaskStore_claimIfNotLocked.invoke(dbTaskStore, taskStatus.getTaskId(), version, newClaimExpiry);
+                Boolean claimed = (Boolean) DatabaseTaskStore_claimIfNotLocked.invoke(dbTaskStore, taskStatus.getTaskId(), version, newClaimExpiry);
                 long duration = System.nanoTime() - start;
                 if (duration > TimeUnit.SECONDS.toNanos(20))
                     throw new Exception("Unable to attempt a claim on a task (" + taskStatus.getTaskId() + ") within a reasonable amount of time. " + duration + " ns.");
+
+                if (Boolean.TRUE.equals(claimed) && !isDerby) { // skip for Derby, which does not implement query timeout
+                    // If we successfully claimed it, ensure that a second thread times out while we are still holding the lock.
+                    final long nextClaimExpiry = newClaimExpiry + TimeUnit.MINUTES.toMillis(1);
+                    Future<Long> future = unmanagedExecutor.submit(new Callable<Long>() {
+                        @Override
+                        public Long call() throws Exception {
+                            tran.begin();
+                            try {
+                                long start = System.nanoTime();
+                                Boolean claimed = (Boolean) DatabaseTaskStore_claimIfNotLocked.invoke(dbTaskStore, taskStatus.getTaskId(), 2, nextClaimExpiry);
+                                if (claimed)
+                                    throw new Error("Should not be able to claim task while other thread has a lock on it");
+                                long duration = System.nanoTime() - start;
+                                return duration;
+                            } finally {
+                                tran.rollback();
+                            }
+                        }
+                    });
+                    duration = future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+                    if (duration > TimeUnit.SECONDS.toNanos(20))
+                        throw new Exception("Second claim attempt on task (" + taskStatus.getTaskId() + ") did not timeout within a reasonable amount of time. " + duration + " ns.");
+                }
             } finally {
                 tran.rollback();
             }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcResultSet.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcResultSet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2018 IBM Corporation and others.
+ * Copyright (c) 2001, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -2253,7 +2253,6 @@ public class WSJdbcResultSet extends WSJdbcObject implements ResultSet {
             boolean moreRows = rsetImpl.next();            
             return moreRows;
         } catch (SQLException ex) {
-            FFDCFilter.processException(ex, "com.ibm.ws.rsadapter.jdbc.WSJdbcResultSet.next", "2624", this);
             throw WSJdbcUtil.mapException(this, ex);
         } catch (NullPointerException nullX) {
             // No FFDC code needed; we might be closed.


### PR DESCRIPTION
Implement code around how query and lock timeout are established via the JPA persistence service.  Update tests for coverage with the set of databases that we typically test with.

During this effort, it was discovered that the mechanism for detecting the Oracle JDBC isn't working, and needed to be replaced.

Observed default behavior for various databases:
Oracle and PostgreSQL - timeout is unnecessary because they return from the query based on the committed state rather than being blocked by pending updates.
SQL Server - can get lock timeout immediately when EclipseLink generates SQL like: SELECT ID FROM WLPTASK WITH (UPDLOCK, NOWAIT) WHERE ((ID = ?) AND (VERSION = ?))
DB2 - blocked until query timeout occurs
Derby - does not appear to support query timeout or a more granular lock timeout.  The global 1 minute lock timeout applies, which causes a long wait.
