### PR TITLE
Allow for server error messages to be shown

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/js/accountManager.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/js/accountManager.js
@@ -89,7 +89,13 @@ var acctMgr = (function() {
             // Something else happended with the request.  Put up the generic error message.
             var generateTypeTitle = generateType === 'app-password' ? 'App-Password' : 'App-Token';
             var errTitle = utils.formatString(messages.GENERIC_GENERATE_FAIL, [generateTypeTitle]);
-            var errDescription = utils.formatString(messages.GENERIC_GENERATE_FAIL_MSG, [generateType, utils.encodeData(providedName)]);
+            var errDescription = "";
+            if (errResponse.responseJSON && errResponse.responseJSON.error_description) {
+                errDescription = errResponse.responseJSON.error_description;
+            } else {
+                // Display a generic error message...
+                errDescription = utils.formatString(messages.GENERIC_GENERATE_FAIL_MSG, [generateType, utils.encodeData(providedName)]);
+            }
             utils.showResultsDialog(true, errTitle, errDescription, true, true, false, table.reshowAddRegenDialog);
         });
     };

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/js/table.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/js/table.js
@@ -344,18 +344,29 @@ var table = (function() {
                 // So, if something else happended with the request, put up the generic error message.
                 var regenerateTypeTitle = authType === 'app-password' ? 'App-Password' : 'App-Token';
                 var errTitle = utils.formatString(messages.GENERIC_REGENERATE_FAIL, [regenerateTypeTitle]);
-                var errDescription = utils.formatString(messages.GENERIC_REGENERATE_FAIL_CREATE_MSG, [authType, utils.encodeData(name)]);
+                var errDescription = "";
+                if (errResponse.responseJSON && errResponse.responseJSON.error_description) {
+                    errDelDescription = errResponse.responseJSON.error_description;
+                } else {
+                    errDescription = utils.formatString(messages.GENERIC_REGENERATE_FAIL_CREATE_MSG, [authType, utils.encodeData(name)]);
+                }    
                 utils.showResultsDialog(true, errTitle, errDescription, true, true, false, reshowAddRegenDialog);
             });            
         }).fail(function(errResponse) {
             console.log("delete failed for ID" + authID);
             console.log("errResponse.status: " + errResponse.status + ":   errResponse.statusText: " + errResponse.statusText);
-            // The API returns success (200) if you attempt to delete an aauthentication
+            // The API returns success (200) if you attempt to delete an authentication
             // that is already deleted.
             // So, if something else happended with the request, put up the generic error message.
             var regenDelTitle = authType === 'app-password' ? 'App-Password' : 'App-Token';
             var errDelTitle = utils.formatString(messages.GENERIC_REGENERATE_FAIL, [regenDelTitle]);
-            var errDelDescription = utils.formatString(messages.GENERIC_REGENERATE_FAIL_MSG, [authType, utils.encodeData(name)]);
+            var errDelDescription = "";
+            if (errResponse.responseJSON && errResponse.responseJSON.error_description) {
+                errDelDescription = errResponse.responseJSON.error_description;
+            } else {
+                // Display a generic error message...
+                errDelDescription = utils.formatString(messages.GENERIC_REGENERATE_FAIL_MSG, [authType, utils.encodeData(name)]);
+            }
             utils.showResultsDialog(true, errDelTitle, errDelDescription, true, true, false, reshowAddRegenDialog);
         });
     };
@@ -419,8 +430,13 @@ var table = (function() {
             // that is already deleted.
             // So, if something else happended with the request, put up the generic error message.
             var deleteTypeTitle = authType === 'app-password' ? 'App-Password' : 'App-Token';
+            var errDescription = "";
             var errTitle = utils.formatString(messages.GENERIC_DELETE_FAIL, [deleteTypeTitle]);
-            var errDescription = utils.formatString(messages.GENERIC_DELETE_FAIL_MSG, [authType, utils.encodeData(name)]);
+            if (errResponse.responseJSON && errResponse.responseJSON.error_description) {
+                errDescription = errResponse.responseJSON.error_description;
+            } else {
+                errDescription = utils.formatString(messages.GENERIC_DELETE_FAIL_MSG, [authType, utils.encodeData(name)]);
+            }
             utils.showResultsDialog(true, errTitle, errDescription, true, true, false, __reshowDeleteDialog);
         });
     };

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/clientAdmin/js/clientAdmin.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/clientAdmin/js/clientAdmin.js
@@ -92,7 +92,12 @@ var clientAdmin = (function() {
                     // Something else happended with the request.  Put up the generic error message.
                     var errTitle = messages.GENERIC_DELETE_FAIL;
                     var errClientName = bidiUtils.getDOMSpanWithBidiTextDirection(client_name);
-                    var errDescription = utils.formatString(messages.GENERIC_DELETE_FAIL_MSG, [errClientName]);
+                    var errDescription = "";
+                    if (errResponse.responseJSON && errResponse.responseJSON.error_description) {
+                        errDescription = errResponse.responseJSON.error_description;
+                    } else {
+                        errDescription = utils.formatString(messages.GENERIC_DELETE_FAIL_MSG, [errClientName]);
+                    }
                     utils.showResultsDialog(true, errTitle, errDescription, true, true, false, __reshowDeleteDialog);
                 });
             });

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/clientAdmin/js/clientInputDialog.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/clientAdmin/js/clientInputDialog.js
@@ -277,11 +277,17 @@ var clientInputDialog = (function() {
                     //         return;     // Only field we know we can get an error on
                     //     }
                     // } 
-                    // Something happended with the request.  Put up the generic error message.
+                    // Something happended with the request.  Put up error message.
                     var errTitle = messages.GENERIC_REGISTER_FAIL;
-                    // insert bidi text direction to the client name
-                    var errClientName = bidiUtils.getDOMSpanWithBidiTextDirection(utils.encodeData(client_name));
-                    var errDescription = utils.formatString(messages.GENERIC_REGISTER_FAIL_MSG, [errClientName]);
+                    var errDescription = "";
+                    if (errResponse.responseJSON && errResponse.responseJSON.error_description) {
+                        errDescription = errResponse.responseJSON.error_description;
+                    } else {
+                        // Display a generic error message...
+                        // insert bidi text direction to the client name
+                        var errClientName = bidiUtils.getDOMSpanWithBidiTextDirection(utils.encodeData(client_name));
+                        errDescription = utils.formatString(messages.GENERIC_REGISTER_FAIL_MSG, [errClientName]);
+                    }
                     utils.showResultsDialog(true, errTitle, errDescription, true, true, false, __reshowAddEditDialog);
                 });                      
             });
@@ -353,9 +359,15 @@ var clientInputDialog = (function() {
                             return;
                         }
                     } 
-                    // Something else happended with the request.  Put up the generic error message.
+                    // Something else happed with the request.  Put up an error message...
                     var errTitle = messages.GENERIC_UPDATE_FAIL;
-                    var errDescription = utils.formatString(messages.GENERIC_UPDATE_FAIL_MSG, [msgClientName]);
+                    var errDescription = "";
+                    if (errResponse.responseJSON && errResponse.responseJSON.error_description) {
+                        errDescription = errResponse.responseJSON.error_description;
+                    } else {
+                        // Display a generic error message...
+                        errDescription = utils.formatString(messages.GENERIC_UPDATE_FAIL_MSG, [msgClientName]);
+                    }
                     utils.showResultsDialog(true, errTitle, errDescription, true, true, false, __reshowAddEditDialog);
                 });              
             });
@@ -446,13 +458,15 @@ var clientInputDialog = (function() {
 
         var field =
             "<div class='tool_modal_body_field'>" +
-            "   <label class='tool_modal_body_field_label' for=" + fldId + ">" + fldName + "</label>" +
-            "   <div class='tool_modal_body_field_helper_text'>" + fldDescription + "</div>";
+            "   <label class='tool_modal_body_field_label' for=" + fldId + ">" + fldName +
+            "      <div class='tool_modal_body_field_helper_text'>" + fldDescription + "</div>";
         if (fldId === 'client_secret') {     // Special case for the UI to include instructional statement for client_secret
-            field += "   <div id='regen_client_secret_dir' class='tool_modal_body_field_helper_text hidden'>" + messages.REGENERATE_CLIENT_SECRET + "</div>";
+            field += "      <div id='regen_client_secret_dir' class='tool_modal_body_field_helper_text hidden'>" + messages.REGENERATE_CLIENT_SECRET + "</div>";
         }
-        field +=  "   <input id=" + fldId + " type='text' class='tool_modal_body_field_input'" + fldRequired + " value='" + fldDefaultVal + "'" + fldDefault + dirValue + "></div>";
+        field +=  "      <input id=" + fldId + " type='text' class='tool_modal_body_field_input'" + fldRequired + " value='" + fldDefaultVal + "'" + fldDefault + dirValue + ">";
+        field +=  "   </label></div>";
 
+        
         return field;
     };
 
@@ -531,8 +545,8 @@ var clientInputDialog = (function() {
             var optionId = 'rb_' + option.value.replace(/\s/g, '__');
             var defaultValue = option.value === fldDefault;
             field +=
-                "       <input id='" + optionId + "' class='tool_modal_radio_button' type='radio' role='radio' aria-checked='false' name='" + fldId + "' value='" + option.value + "' data-default=" + defaultValue + "></input>" +
                 "       <label for='" + optionId + "' class='tool_modal_radio_button_label'>" +
+                "           <input id='" + optionId + "' class='tool_modal_radio_button' type='radio' role='radio' aria-checked='false' name='" + fldId + "' value='" + option.value + "' data-default=" + defaultValue + ">" +
                 "           <span class='tool_modal_radio_button_appearance'></span>" + 
                 "           " + option.value + 
                 "       </label>";
@@ -578,18 +592,16 @@ var clientInputDialog = (function() {
             "       <legend class='tool_modal_body_field_label'>" + fldName + "</legend>" +
             "       <div class='tool_modal_body_field_helper_text'>" + fldDescription + "</div>" +
             "       <div class='tool_modal_radio_button_horizontal_wrapper'>" +
-            "           <input id='" + fldId + "-true' class='tool_modal_radio_button' type='radio' role='radio' aria-checked='false' name='" + fldId + "' value='true'";
-        field += fldDefault === 'true' ? " data-default='true'" : " data-default='false'";
-        field +=
-            "></input>" +
             "           <label for='" + fldId + "-true' class='tool_modal_radio_button_label'>" +
+            "               <input id='" + fldId + "-true' class='tool_modal_radio_button' type='radio' role='radio' aria-checked='false' name='" + fldId + "' value='true'";
+        field += fldDefault === 'true' ? " data-default='true'" : " data-default='false'";
+        field += ">" +
             "               <span class='tool_modal_radio_button_appearance'></span>" + messages.TRUE + 
             "           </label>" +
-            "           <input id='" + fldId + "-false' class='tool_modal_radio_button' type='radio' role='radio' aria-checked='false' name='" + fldId + "' value='false'";
-        field += fldDefault === 'false' ? " data-default='true'" : " data-default='false'";
-        field += 
-            "></input>" +
             "           <label for='" + fldId + "-false' class='tool_modal_radio_button_label'>" +
+            "               <input id='" + fldId + "-false' class='tool_modal_radio_button' type='radio' role='radio' aria-checked='false' name='" + fldId + "' value='false'";
+            field += fldDefault === 'false' ? " data-default='true'" : " data-default='false'";
+            field += ">" +
             "               <span class='tool_modal_radio_button_appearance'></span>" + messages.FALSE +
             "           </label>" +
             "       </div>" +
@@ -621,7 +633,7 @@ var clientInputDialog = (function() {
             "           </tbody>" +
             "       </table>" + 
             "       <div class='tool_modal_array_button_div tool_modal_add_array_button_div'>" +
-            "           <button class='tool_modal_array_button tool_modal_array_add_ele' type='button'>" +
+            "           <button class='tool_modal_array_button tool_modal_array_add_ele' type='button'" + " aria-label='" + messages.ADD_VALUE + "'>" +
             "               <img src='../../WEB-CONTENT/common/images/addEntry.svg' alt='" + messages.ADD_VALUE + "' title='" +  messages.ADD_VALUE +"'>" +
             "           </button>" +
             "       </div>" +
@@ -641,7 +653,7 @@ var clientInputDialog = (function() {
         var arrayRow =
             "<tr>" +
             "   <td><input type='text' value='" + value + "' title='" + value + "' placeholder='" + messages.ENTER_PLACEHOLDER + "' " + dirValue + "></input></td>" +
-            "   <td><div class='tool_modal_array_button_div'><button class='tool_modal_array_button tool_modal_array_remove_ele' type='button'>" +
+            "   <td><div class='tool_modal_array_button_div'><button class='tool_modal_array_button tool_modal_array_remove_ele' type='button' aria-label='" + messages.REMOVE_VALUE + "'>" +
             "       <img src='../../WEB-CONTENT/common/images/removeEntry.svg' alt='" + messages.REMOVE_VALUE + "' title='" +  messages.REMOVE_VALUE +"'></button>" + 
             "   </div></td>" +
             "</tr>";

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/clientAdmin/js/table.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/clientAdmin/js/table.js
@@ -117,10 +117,16 @@ var table = (function() {
                         return;
                     }
                 } 
-                // Something else happended with the request.  Put up a generic error message.
+                // Something else happended with the request.  Put up an error message...
                 var errTitle = messages.GENERIC_MISSING_CLIENT;
-                var errDescription = utils.formatString(messages.GENERIC_RETRIEVAL_FAIL_MSG, [errClientName]);
-                utils.showResultsDialog(true, errTitle, errDescription, false, false, true);
+                var errDescription = "";
+                if (errResponse.responseJSON && errResponse.responseJSON.error_description) {
+                    errDescription = errResponse.responseJSON.error_description;
+                } else {
+                    // Display a generic error message...
+                    errDescription = utils.formatString(messages.GENERIC_RETRIEVAL_FAIL_MSG, [errClientName]);
+                }
+                utils.showResultsDialog(true, errTitle, errDescription, false, false, true); 
             });
         });
 

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/tokenManager/js/table.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/tokenManager/js/table.js
@@ -342,7 +342,12 @@ var table = (function() {
             // So, if something else happended with the request, put up the generic error message.
             var deleteTypeTitle = authType === 'app-password' ? 'App-Password' : 'App-Token';
             var errTitle = utils.formatString(messages.GENERIC_DELETE_FAIL, [deleteTypeTitle]);
-            var errDescription = utils.formatString(messages.GENERIC_DELETE_FAIL_MSG, [authType, utils.encodeData(name)]);
+            var errDescription = "";
+            if (errResponse.responseJSON && errResponse.responseJSON.error_description) {
+                errDescription = errResponse.responseJSON.error_description;
+            } else {
+                errDescription = utils.formatString(messages.GENERIC_DELETE_FAIL_MSG, [authType, utils.encodeData(name)]);
+            }
             utils.showResultsDialog(true, errTitle, errDescription, true, true, false, __reshowDeleteDialog);
         });
     };
@@ -390,7 +395,12 @@ var table = (function() {
                 // The API returns success (200) if an invalid user ID was submitted
                 // So, if something else happended with the request, put up the generic error message.
                 var errTitle = utils.formatString(messages.GENERIC_DELETE_FAIL, ["App-Tokens"]);
-                var errDescription = utils.formatString(messages.GENERIC_DELETE_ALL_FAIL_MSG, ["App-Tokens", userID]);
+                var errDescription = "";
+                if (errResponse.responseJSON && errResponse.responseJSON.error_description) {
+                    errDescription = errResponse.responseJSON.error_description;
+                } else {
+                    errDescription = utils.formatString(messages.GENERIC_DELETE_ALL_FAIL_MSG, ["App-Tokens", userID]);
+                }
                 utils.showResultsDialog(true, errTitle, errDescription, true, true, false, __reshowDeleteDialog);
                 });
         }).fail(function(errResponse) {
@@ -399,7 +409,12 @@ var table = (function() {
             // The API returns success (200) if an invalid user ID was submitted
             // So, if something else happended with the request, put up the generic error message.
             var errTitle = utils.formatString(messages.GENERIC_DELETE_FAIL, ["App-Passwords"]);
-            var errDescription = utils.formatString(messages.GENERIC_DELETE_ALL_FAIL_MSG, ["App-Passwords", userID]);
+            var errDescription = "";
+            if (errResponse.responseJSON && errResponse.responseJSON.error_description) {
+                errDescription = errResponse.responseJSON.error_description;
+            } else {
+                errDescription = utils.formatString(messages.GENERIC_DELETE_ALL_FAIL_MSG, ["App-Passwords", userID]);
+            }
             utils.showResultsDialog(true, errTitle, errDescription, true, true, false, __reshowDeleteDialog);
         });
     };


### PR DESCRIPTION
Now that detailed messages are emitted by the REST endpoints in the browser locale (see issue #8317), expose those messages when available to the UI.