### PR TITLE
Handle forthcoming package rename of MetricRegistryFactory

### DIFF
--- a/dev/com.ibm.ws.microprofile.graphql.1.0/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0/bnd.bnd
@@ -33,12 +33,14 @@ Export-Package: \
   com.ibm.ws.microprofile.graphql.component;thread-context=true
 
 DynamicImport-Package: \
-  com.ibm.ws.microprofile.metrics.cdi.producer; version="[1.0.0,2.0.0)",\
+  com.ibm.ws.microprofile.metrics.cdi.producer,\
+  com.ibm.ws.microprofile.metrics.cdi20.producer,\
   org.eclipse.microprofile.config,\
   org.eclipse.microprofile.metrics
 
 Import-Package: \
   !com.ibm.ws.microprofile.metrics.cdi.producer,\
+  !com.ibm.ws.microprofile.metrics.cdi20.producer,\
   !org.eclipse.microprofile.config,\
   !org.eclipse.microprofile.metrics,\
   *

--- a/dev/com.ibm.ws.microprofile.graphql.1.0/src/com/ibm/ws/microprofile/graphql/component/GraphQLExtension.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0/src/com/ibm/ws/microprofile/graphql/component/GraphQLExtension.java
@@ -72,7 +72,7 @@ public class GraphQLExtension implements Extension, WebSphereCDIExtension, Intro
         AnnotatedType<TracingInterceptor> interceptorType = beanManager.createAnnotatedType(TracingInterceptor.class);
         beforeBeanDiscovery.addAnnotatedType(interceptorType, CDIServiceUtils.getAnnotatedTypeIdentifier(interceptorType, this.getClass()));
 
-        if (canLoad("com.ibm.ws.microprofile.metrics.cdi.producer.MetricRegistryFactory") && metricsEnabled) {
+        if (MetricsInterceptor.metrics != null && metricsEnabled) {
             AnnotatedType<MetricsInterceptor> metricsInterceptorType = beanManager.createAnnotatedType(MetricsInterceptor.class);
             beforeBeanDiscovery.addAnnotatedType(metricsInterceptorType, CDIServiceUtils.getAnnotatedTypeIdentifier(metricsInterceptorType, this.getClass()));
         }
@@ -123,24 +123,13 @@ public class GraphQLExtension implements Extension, WebSphereCDIExtension, Intro
         return schema;
     }
 
-//    static Set<Bean<?>> getGraphQLComponents() {
-//        Set<Bean<?>> set = graphQLComponents.get(getModuleMetaData());
-//        return set == null ? Collections.emptySet() : set;
-//    }
-
     static ModuleMetaData getModuleMetaData() {
         ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
         ModuleMetaData mmd = cmd.getModuleMetaData();
         return mmd;
     }
 
-    private boolean canLoad(String className) {
-        try {
-            return Class.forName(className) != null;
-        } catch (Throwable t) {
-            return false;
-        }
-    }
+    
 
     // Introspector methods:
     @Override

--- a/dev/com.ibm.ws.microprofile.graphql.1.0/src/com/ibm/ws/microprofile/graphql/component/MetricsInterceptor.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0/src/com/ibm/ws/microprofile/graphql/component/MetricsInterceptor.java
@@ -13,6 +13,7 @@ package com.ibm.ws.microprofile.graphql.component;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.Priority;
@@ -31,7 +32,6 @@ import org.eclipse.microprofile.metrics.Timer.Context;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
-import com.ibm.ws.microprofile.metrics.cdi.producer.MetricRegistryFactory;
 
 @Trivial
 @Dependent
@@ -42,7 +42,33 @@ public class MetricsInterceptor {
 
     private final static String PREFIX = "mp_graphql_";
     private final static TraceComponent tc = Tr.register(MetricsInterceptor.class);
-    private final static MetricRegistry metrics = MetricRegistryFactory.getVendorRegistry();
+    final static MetricRegistry metrics;
+
+    static {
+        Supplier<MetricRegistry> metricsSupplier = null;
+        if (canLoad("com.ibm.ws.microprofile.metrics.cdi.producer.MetricRegistryFactory")) {
+            metricsSupplier = () -> {
+                return com.ibm.ws.microprofile.metrics.cdi.producer.MetricRegistryFactory.getVendorRegistry();
+            };
+//        } else if (canLoad("com.ibm.ws.microprofile.metrics.cdi20.producer.MetricRegistryFactory")) {
+//            metricsSupplier = () -> {
+//                return com.ibm.ws.microprofile.metrics.cdi20.producer.MetricRegistryFactory.getVendorRegistry();
+//            };
+        }
+        if (metricsSupplier != null) {
+            metrics = metricsSupplier.get();
+        } else {
+            metrics = null;
+        }
+    }
+
+    private static boolean canLoad(String className) {
+        try {
+            return Class.forName(className) != null;
+        } catch (Throwable t) {
+            return false;
+        }
+    }
 
     @AroundInvoke
     public Object captureMetrics(InvocationContext ctx) throws Exception {


### PR DESCRIPTION
The MP Metrics 2.X implementation is planning to change the package of the MetricRegistryFactory, so this change is planning to handle it by using both packages (just not relying on the new one until it is committed.