### PR TITLE
Correct processing of specific annotations.

### DIFF
--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/classsource/internal/ClassSourceImpl_MappedContainer.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/classsource/internal/ClassSourceImpl_MappedContainer.java
@@ -366,14 +366,16 @@ public class ClassSourceImpl_MappedContainer
         throws ClassSource_Exception {
 
         String methodName = "processSpecific";
-        if ( logger.isLoggable(Level.FINER) ) {
+
+    	boolean doLog = logger.isLoggable(Level.FINER);
+        if ( doLog ) {
             logger.logp(Level.FINER, CLASS_NAME, methodName, "[ {0} ] [ {1} ]",
                 new Object[] { getHashText(), Integer.valueOf(i_classNames.size()) });
         }
 
         Container useContainer = getContainer();
         if ( useContainer == null ) {
-            if ( logger.isLoggable(Level.FINER) ) {
+            if ( doLog ) {
                 logger.logp(Level.FINER, CLASS_NAME, methodName, "[ {0} ] RETURN", getHashText());
             }
             return;
@@ -394,6 +396,11 @@ public class ClassSourceImpl_MappedContainer
             }
 
             if ( nextEntry == null ) {
+                if ( doLog ) {
+                    logger.logp(Level.FINER, CLASS_NAME, methodName,
+                        "Skip [ {0} ] as [ {1} ]",
+                        new Object[] { i_className, resourceName });
+                }
                 continue;
             }
 
@@ -410,7 +417,7 @@ public class ClassSourceImpl_MappedContainer
         setProcessTime(scanTime);
         setProcessCount( i_classNames.size() );
 
-        if ( logger.isLoggable(Level.FINER) ) {
+        if ( doLog ) {
             logger.logp(Level.FINER, CLASS_NAME, methodName, "[ {0} ] RETURN", getHashText());
         }
     }

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsScannerBaseImpl.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsScannerBaseImpl.java
@@ -644,7 +644,12 @@ public class TargetsScannerBaseImpl {
     // Does not need to be synchronized.  No write is performed
     // on the merged annotations.
 
-    protected void mergeInternalResults(TargetsTableImpl[] useResultTables) {
+    // Control parameter: When scanning specific classes, the scan policy of the table
+    // is ignored.  All specific scan results are considered SEED.
+
+    protected boolean FORCE_SEED_RESULTS = true;
+
+    protected void mergeInternalResults(TargetsTableImpl[] useResultTables, boolean forceSeedResults) {
         Set<String> i_addedPackageNames = createIdentityStringSet();
         Set<String> i_addedClassNames = createIdentityStringSet();
 
@@ -652,6 +657,10 @@ public class TargetsScannerBaseImpl {
 
         for ( ClassSource classSource : useRootClassSource.getClassSources() ) {
             ScanPolicy scanPolicy = useRootClassSource.getScanPolicy(classSource);
+            if ( forceSeedResults ) {
+            	scanPolicy = ScanPolicy.SEED;
+            } 
+
             if ( scanPolicy == ScanPolicy.EXTERNAL ) {
                 continue;
             }

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsScannerOverallImpl.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsScannerOverallImpl.java
@@ -1766,7 +1766,7 @@ public class TargetsScannerOverallImpl extends TargetsScannerBaseImpl {
 
             TargetsTableImpl[] newTables = createResultTables();
 
-            mergeInternalResults(newTables);
+            mergeInternalResults(newTables, !FORCE_SEED_RESULTS);
 
 //            int useWriteLimit = getWriteLimit();
 //            if ( logger.isLoggable(Level.FINER) ) {

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsScannerSpecificImpl.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsScannerSpecificImpl.java
@@ -88,21 +88,23 @@ public class TargetsScannerSpecificImpl extends TargetsScannerBaseImpl {
                 }
                 continue;
 
-            } else if ( scanPolicy == ScanPolicy.EXTERNAL ) {
-                if (logger.isLoggable(Level.FINER)) {
-                    logger.logp(Level.FINER, CLASS_NAME, methodName,
-                                "[ {0} ] [ {1} ] [ {2} ] [ {3} ] Skip: External; Remaining [ {4} ]",
-                                new Object[] { getHashText(),
-                                               classSourceName, classSource.getHashText(),
-                                               scanPolicy,
-                                               Integer.valueOf(i_specificClassNames.size()) });
-                }
-                continue;
+// Don't skip external class sources when doing a specific scan.
+//
+//            } else if ( scanPolicy == ScanPolicy.EXTERNAL ) {
+//                if (logger.isLoggable(Level.FINER)) {
+//                    logger.logp(Level.FINER, CLASS_NAME, methodName,
+//                                "[ {0} ] [ {1} ] [ {2} ] [ {3} ] Skip: External; Remaining [ {4} ]",
+//                                new Object[] { getHashText(),
+//                                               classSourceName, classSource.getHashText(),
+//                                               scanPolicy,
+//                                               Integer.valueOf(i_specificClassNames.size()) });
+//                }
+//                continue;
 
             } else {
                 if (logger.isLoggable(Level.FINER)) {
                     logger.logp(Level.FINER, CLASS_NAME, methodName,
-                                "[ {0} ] [ {1} ] [ {2} ] [ {3} ] Remaining [ {4} ]",
+                                "[ {0} ] [ {1} ] [ {2} ] [ {3} ] Scan: Remaining [ {4} ]",
                                 new Object[] { getHashText(),
                                                classSourceName, classSource.getHashText(),
                                                scanPolicy,
@@ -126,7 +128,7 @@ public class TargetsScannerSpecificImpl extends TargetsScannerBaseImpl {
             putTargetsTable(classSourceName, targetTable);
         }
 
-        mergeInternalResults( getResultTables() );
+        mergeInternalResults( getResultTables(), FORCE_SEED_RESULTS );
 
         TargetsTableClassesMultiImpl useClassTable = createClassTable();
         mergeClasses(useClassTable);

--- a/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/annocache/internal/SpecificAnnotationsImpl.java
+++ b/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/annocache/internal/SpecificAnnotationsImpl.java
@@ -42,7 +42,7 @@ public class SpecificAnnotationsImpl implements SpecificAnnotations {
         Set<String> selectedClassNames =
             specificTargets.getAnnotatedClasses(
                 annotationClassName,
-                AnnotationTargets_Targets.POLICY_PARTIAL);
+                AnnotationTargets_Targets.POLICY_SEED);
         return selectedClassNames;
     }
 }


### PR DESCRIPTION
Fix for test failures in JSF 2.2 full tests.

These test failures were noted when running full FAT tests:

com.ibm.ws.jsf.2.2_fat FAT tests | 376 | 4 | 0 |   |  
com.ibm.ws.jsf22.fat.tests.JSF22AparTests | 50 | 2 | 0 | 18 s | 29
testPI67525 | 1 | 1 | 0 | 0 s | 15
testPI67525_JSF-2.3 | 1 | 1 | 0 | 0 s | 40
com.ibm.ws.jsf22.fat.tests.JSF22InputFileTests | 2 | 2 | 0 | 14 s | 27
testInputFile | 1 | 1 | 0 | 7 s | 1
testInputFile_JSF-2.3

Other non-webcontainer failures were noted, but are not addressed by this update.