### PR TITLE
tests for task that cancels or removes itself and blocks

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/PersistentExecutorWithFailoverEnabledTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/PersistentExecutorWithFailoverEnabledTest.java
@@ -150,6 +150,16 @@ public class PersistentExecutorWithFailoverEnabledTest extends FATServletClient 
     }
 
     @Test
+    public void testBlockRunningTaskThatCancelsSelfFE() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
+    public void testBlockRunningTaskThatRemovesSelfFE() throws Exception {
+        runTest(server, APP_NAME, testName);
+    }
+
+    @Test
     public void testCancelRunningTaskFE() throws Exception {
         runTest(server, APP_NAME, testName);
     }


### PR DESCRIPTION
Add tests where a task execution cancels or removes itself and then blocks.
Ensure that other tasks can still be scheduled, run, and themselves canceled or removed.