### PR TITLE
Servicablity enhancement for handling NullPointerException from Infinispan session caching file name

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheStoreService.java
@@ -40,6 +40,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
+import java.nio.file.Paths;
+
 import javax.cache.Cache;
 import javax.cache.Cache.Entry;
 import javax.cache.CacheException;
@@ -223,7 +225,13 @@ public class CacheStoreService implements Introspector, SessionStoreService {
                     CacheHashMap.tcInvoke(tcCachingProvider, "getCacheManager", uri, null, vendorProperties);
                 }
 
-                cacheManager = cachingProvider.getCacheManager(uri, null, vendorProperties);
+                
+                // Catch incorrectly formatted httpSessionCache uri values from server.xml file
+                try {
+                    cacheManager = cachingProvider.getCacheManager(uri, null, vendorProperties);
+                } catch (NullPointerException e) {
+                    throw new IllegalArgumentException(Tr.formatMessage(tc, "INCORRECT_URI_SYNTAX", e), e);
+                }
 
                 return null;
             });


### PR DESCRIPTION
Modified open liberty session cache code to handle an incorrectly specified httpSessionCache uri value in server.xml when using the Infinispan provider.

Before:
```
E SESN0307E: An exception occurred when initializing the cache. The exception is: java.lang.NullPointerException
	at java.base/java.io.File.<init>(File.java:276)
	at org.infinispan.commons.util.AbstractFileLookup.lookupFileStrict(AbstractFileLookup.java:68)
	at org.infinispan.jcache.embedded.JCacheManager.getConfigurationBuilderHolder(JCacheManager.java:111)
	at org.infinispan.jcache.embedded.JCacheManager.<init>(JCacheManager.java:60)
	at org.infinispan.jcache.embedded.JCachingProvider.createCacheManager(JCachingProvider.java:46)
	at org.infinispan.jcache.AbstractJCachingProvider.getCacheManager(AbstractJCachingProvider.java:67)
```

After:
```
E SESN0307E: An exception occurred when initializing the cache. The exception is: java.lang.IllegalArgumentException: SESN0300E: Invalid syntax in httpSessionCache URI.  Cause is java.lang.NullPointerException.
	at com.ibm.ws.session.store.cache.CacheStoreService.lambda$activateLazily$0(CacheStoreService.java:233)
	at com.ibm.ws.session.store.cache.CacheStoreService$$Lambda$133.0000000000000000.run(Unknown Source)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:734)
	at com.ibm.ws.session.store.cache.CacheStoreService.activateLazily(CacheStoreService.java:205)
...
Caused by: java.lang.NullPointerException
	at java.base/java.io.File.<init>(File.java:276)
	at org.infinispan.commons.util.AbstractFileLookup.lookupFileStrict(AbstractFileLookup.java:68)
	at org.infinispan.jcache.embedded.JCacheManager.getConfigurationBuilderHolder(JCacheManager.java:111)
	at org.infinispan.jcache.embedded.JCacheManager.<init>(JCacheManager.java:60)
	at org.infinispan.jcache.embedded.JCachingProvider.createCacheManager(JCachingProvider.java:46)
	at org.infinispan.jcache.AbstractJCachingProvider.getCacheManager(AbstractJCachingProvider.java:67)
	at com.ibm.ws.session.store.cache.CacheStoreService.lambda$activateLazily$0(CacheStoreService.java:231)
	... 37 more
```