### PR TITLE
Update Mongo FAT for IBMCertPathBuilderException FFDC

### DIFF
--- a/dev/com.ibm.ws.mongo_fat/fat/src/com/ibm/ws/mongo/fat/MongoSSLInvalidTrustTest.java
+++ b/dev/com.ibm.ws.mongo_fat/fat/src/com/ibm/ws/mongo/fat/MongoSSLInvalidTrustTest.java
@@ -58,7 +58,7 @@ public class MongoSSLInvalidTrustTest extends FATServletClient {
     }
 
     @Test
-    @AllowedFFDC({ "java.security.cert.CertPathBuilderException", "sun.security.validator.ValidatorException" })
+    @AllowedFFDC({ "java.security.cert.CertPathBuilderException", "sun.security.validator.ValidatorException", "com.ibm.security.cert.IBMCertPathBuilderException" })
     public void testCertAuthInvalidTrust() throws Exception {
         testInvalidConfig("mongo/testdb-invalid-certificate-trust", "MongoTimeoutException");
         // CWPKI0823E: SSL HANDSHAKE FAILURE:  A signer with SubjectDN [{0}] was sent from the host [{1}].  The signer might


### PR DESCRIPTION
It appears that the IBM JDK now emits an `IBMCertPathBuilderException` when an untrusted signer certificate is recieved from a remote host. This change updates a FAT test for this scenario to allow the new FFDC.