### PR TITLE
New test for injecting MP Rest Client into ctor, setter, and field

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/basicCdiClientApp/src/mpRestClient10/basicCdi/BasicClientTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/basicCdiClientApp/src/mpRestClient10/basicCdi/BasicClientTestServlet.java
@@ -37,11 +37,33 @@ public class BasicClientTestServlet extends FATServlet {
     Logger LOG = Logger.getLogger(BasicClientTestServlet.class.getName());
 
     @Inject
+    private MyCdiManagedObject obj;
+
+    @Inject
     @RestClient
     private BasicServiceClient client;
 
     @Test
-    public void testSimplePostGetDelete(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+    public void testSimplePostGetDelete_injectedIntoFieldOnServlet(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        testSimplePostGetDelete(req, resp, this.client);
+    }
+
+    @Test
+    public void testSimplePostGetDelete_injectedIntoCtorOnCdiObject(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        testSimplePostGetDelete(req, resp, this.obj.getClientFromCtor());
+    }
+
+    @Test
+    public void testSimplePostGetDelete_injectedIntoFieldOnCdiObject(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        testSimplePostGetDelete(req, resp, this.obj.getClientFromField());
+    }
+
+    @Test
+    public void testSimplePostGetDelete_injectedIntoMethodOnCdiObject(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        testSimplePostGetDelete(req, resp, this.obj.getClientFromMethod());
+    }
+
+    private void testSimplePostGetDelete(HttpServletRequest req, HttpServletResponse resp, BasicServiceClient client) throws Exception {
         try {
             client.createNewWidget(new Widget("Pencils", 100, 0.2));
             assertTrue("POSTed widget does not show up in query", client.getWidgetNames().contains("Pencils"));

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/basicCdiClientApp/src/mpRestClient10/basicCdi/MyCdiManagedObject.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/basicCdiClientApp/src/mpRestClient10/basicCdi/MyCdiManagedObject.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient10.basicCdi;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+@Dependent
+public class MyCdiManagedObject {
+
+    private BasicServiceClient injectedFromCtor;
+
+    private BasicServiceClient injectedFromSetter;
+
+    @Inject
+    @RestClient
+    private BasicServiceClient injectedFromField;
+
+    @Inject
+    @RestClient
+    public MyCdiManagedObject(BasicServiceClient client) {
+        this.injectedFromCtor = client;
+    }
+
+    @Inject
+    @RestClient
+    public void setClient(BasicServiceClient client) {
+        this.injectedFromSetter = client;
+    }
+
+    public BasicServiceClient getClientFromCtor() {
+        return injectedFromCtor;
+    }
+
+    public BasicServiceClient getClientFromField() {
+        return injectedFromField;
+    }
+
+    public BasicServiceClient getClientFromMethod() {
+        return injectedFromSetter;
+    }
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/src/org/apache/cxf/microprofile/client/MPRestClientCallback.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.2/src/org/apache/cxf/microprofile/client/MPRestClientCallback.java
@@ -20,6 +20,8 @@
 package org.apache.cxf.microprofile.client;
 
 import java.lang.reflect.Type;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -45,7 +47,12 @@ public class MPRestClientCallback<T> extends JaxrsClientCallback<T> {
                                 Type outGenericType) {
         super(handler, responseClass, outGenericType);
         ExecutorService es = outMessage.get(ExecutorService.class);
-        executor = es != null ? es : ForkJoinPool.commonPool();
+        if (es == null) {
+            es = AccessController.doPrivileged((PrivilegedAction<ExecutorService>)() -> {
+                return ForkJoinPool.commonPool();
+            });
+        }
+        executor = es;
     }
 
     @SuppressWarnings("unchecked")

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.3/src/org/apache/cxf/microprofile/client/MPRestClientCallback.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.3/src/org/apache/cxf/microprofile/client/MPRestClientCallback.java
@@ -20,6 +20,8 @@
 package org.apache.cxf.microprofile.client;
 
 import java.lang.reflect.Type;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -45,7 +47,12 @@ public class MPRestClientCallback<T> extends JaxrsClientCallback<T> {
                                 Type outGenericType) {
         super(handler, responseClass, outGenericType);
         ExecutorService es = outMessage.get(ExecutorService.class);
-        executor = es != null ? es : ForkJoinPool.commonPool();
+        if (es == null) {
+            es = AccessController.doPrivileged((PrivilegedAction<ExecutorService>)() -> {
+                return ForkJoinPool.commonPool();
+            });
+        }
+        executor = es;
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Tests changes made in the API at https://github.com/eclipse/microprofile-rest-client/pull/241

Also resolves a Java 2 security issue with calling `ForkJoinPool.commonPool()`