### PR TITLE
Introduce startup script for sql server

### DIFF
--- a/dev/fattest.databases/bnd.bnd
+++ b/dev/fattest.databases/bnd.bnd
@@ -21,6 +21,9 @@ Bundle-Description: FAT infrastructure; version=${bVersion}
 
 Export-Package: \
 	componenttest.topology.database.container;version=1.0.16
+	
+Include-Resource: \
+  resources=resources
 
 test.project: true
 

--- a/dev/fattest.databases/resources/init-sqlserver.sql
+++ b/dev/fattest.databases/resources/init-sqlserver.sql
@@ -1,0 +1,5 @@
+-- Create database
+CREATE DATABASE TEST;
+
+-- Enable XA connections
+EXEC sp_sqljdbc_xa_install;

--- a/dev/fattest.databases/src/componenttest/topology/database/container/DatabaseContainerFactory.java
+++ b/dev/fattest.databases/src/componenttest/topology/database/container/DatabaseContainerFactory.java
@@ -118,6 +118,9 @@ public class DatabaseContainerFactory {
 	            	//Accept license agreement
 	            	Method acceptSQLServerLicense = cont.getClass().getMethod("acceptLicense");
 	            	acceptSQLServerLicense.invoke(cont);
+	            	//Init Script
+	            	Method initScript = cont.getClass().getMethod("withInitScript", String.class);
+	            	initScript.invoke(cont, "resources/init-sqlserver.sql");
 	                break;
 	        }
 	        

--- a/dev/fattest.databases/src/componenttest/topology/database/container/DatabaseContainerUtil.java
+++ b/dev/fattest.databases/src/componenttest/topology/database/container/DatabaseContainerUtil.java
@@ -10,10 +10,6 @@
  *******************************************************************************/
 package componenttest.topology.database.container;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
-
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import com.ibm.websphere.simplicity.config.ConfigElementList;
@@ -31,32 +27,6 @@ public final class DatabaseContainerUtil {
     
     private DatabaseContainerUtil() {
     	//No objects should be created from this class
-    }
-
-    /**
-     * Method that does any database setup necessary prior to making a connection
-     * to the database from a servlet.
-     *
-     * @param cont         - Test container being used.
-     * @param databaseName - Name to be given to database instance.
-     * @throws SQLException - Thrown if there is a failure during connection or initialization.
-     */
-    private static void initDatabase(JdbcDatabaseContainer<?> cont) throws SQLException {
-        if (cont instanceof SQLServerContainer) {
-            //Create database
-            try (Connection conn = cont.createConnection("")) {
-                Statement stmt = conn.createStatement();
-                stmt.execute("CREATE DATABASE [TEST];");
-                stmt.close();
-            }
-
-            //Setup distributed connections
-            try (Connection conn = cont.createConnection("")) {
-                Statement stmt = conn.createStatement();
-                stmt.execute("EXEC sp_sqljdbc_xa_install");
-                stmt.close();
-            }
-        }
     }
 
     /**
@@ -80,10 +50,9 @@ public final class DatabaseContainerUtil {
      * @throws CloneNotSupportedException
      */
     public static void setupDataSourceProperties(LibertyServer serv, JdbcDatabaseContainer<?> cont) throws CloneNotSupportedException, Exception {
-        if (DatabaseContainerType.valueOf(cont) == DatabaseContainerType.Derby)
+        //Skip for Derby
+    	if (DatabaseContainerType.valueOf(cont) == DatabaseContainerType.Derby)
             return; //Derby used by default no need to change DS properties
-
-        initDatabase(cont);
 
         //Get current server config
         ServerConfiguration cloneConfig = serv.getServerConfiguration().clone();


### PR DESCRIPTION
SQLServer needs to have the database created at startup and a stored procedure to run to enable XA connections.  Previously this was being done after the server by making a connection and running sql commands.  Instead, we can provide testcontainers with a .sql file and it will be run just after container creation.  This eliminates the need to create extra connections and should speed up our startup time. 