### PR TITLE
Fix invalid delimiter in acmeCA-2.0 feature and move to full edition

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/acmeCA-2.0/com.ibm.websphere.appserver.acmeCA-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/acmeCA-2.0/com.ibm.websphere.appserver.acmeCA-2.0.feature
@@ -6,10 +6,9 @@ IBM-ShortName: acmeCA-2.0
 Subsystem-Version: 2.0
 Subsystem-Name: Automatic Certificate Management Environment (ACME) Support 2.0
 -features=\
-  com.ibm.wsspi.appserver.webBundle-1.0
+  com.ibm.wsspi.appserver.webBundle-1.0,\
   com.ibm.websphere.appserver.appSecurity-1.0
 -bundles=\
   com.ibm.ws.security.acme; start-phase:=APPLICATION_EARLY
-
 kind=noship
-edition=core
+edition=full


### PR DESCRIPTION
The features clause in this feature was missing a delimiter which caused
the com.ibm.websphere.appserver.appSecurity-1.0 feature to not be included
in the generated .mf file
