### PR TITLE
Close URLClassLoader to fix resource leak

### DIFF
--- a/dev/com.ibm.ws.install.map/src/com/ibm/ws/install/map/InstallMap.java
+++ b/dev/com.ibm.ws.install.map/src/com/ibm/ws/install/map/InstallMap.java
@@ -216,6 +216,8 @@ public class InstallMap implements Map {
      * Clears the map and closes all resources.
      *
      * <b>MUST</b> be used when the map is no longer needed.
+     * 
+     * Throws RuntimeException if resources could not be closed.
      */
     @Override
     public void clear() {

--- a/dev/com.ibm.ws.install.map/src/com/ibm/ws/install/map/InstallMap.java
+++ b/dev/com.ibm.ws.install.map/src/com/ibm/ws/install/map/InstallMap.java
@@ -143,8 +143,10 @@ public class InstallMap implements Map {
 
     private Locale locale;
     private ResourceBundle messagesRes;
+    private URLClassLoader loader;
 
-    public InstallMap() {}
+    public InstallMap() {
+    }
 
     private String getMessage(String key, Object... args) {
         if (messagesRes == null) {
@@ -211,11 +213,21 @@ public class InstallMap implements Map {
     }
 
     /**
-     * Unsupported operation
+     * Clears the map and closes all resources.
+     *
+     * <b>MUST</b> be used when the map is no longer needed.
      */
     @Override
     public void clear() {
-        throw new UnsupportedOperationException();
+        installKernelMap = null;
+        data.clear();
+        if (loader != null) {
+            try {
+                loader.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 
     /**
@@ -318,7 +330,7 @@ public class InstallMap implements Map {
      * Sort the files depending on the comparison
      *
      * @param jarsList -abstract representation of file/directory names
-     * @param fName - name of file
+     * @param fName    - name of file
      */
     public static void sortFile(List<File> jarsList, final String fName) {
         Collections.sort(jarsList, new Comparator<File>() {
@@ -342,9 +354,9 @@ public class InstallMap implements Map {
      * The file is accepted if either min/max is null or the newly created Version is null
      *
      * @param fName - file name
-     * @param name - string value
-     * @param min - Version
-     * @param max - Version
+     * @param name  - string value
+     * @param min   - Version
+     * @param max   - Version
      * @return boolean value depending on acceptance
      */
     public static boolean accept(String fName, String name, Version min, Version max) {
@@ -535,12 +547,11 @@ public class InstallMap implements Map {
         if (jars == null) {
             return ERROR;
         }
+        loader = new URLClassLoader(jars, getClass().getClassLoader());
         try {
             installKernelMap = AccessController.doPrivileged(new PrivilegedExceptionAction<Map<String, Object>>() {
                 @Override
                 public Map<String, Object> run() throws Exception {
-                    @SuppressWarnings("resource")
-                    ClassLoader loader = new URLClassLoader(jars, getClass().getClassLoader());
                     Class<Map<String, Object>> clazz;
                     clazz = (Class<Map<String, Object>>) loader.loadClass("com.ibm.ws.install.internal.InstallKernelMap");
                     return clazz.newInstance();


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/open-liberty/issues/10178

When installing features, InstallMap.java uses a URLClassLoader with all of the Liberty jar files.  However, this class loader is never closed.  Since Gradle uses a long running daemon and doesn't exit the JVM after the task is finished, installing features through Gradle will cause the resources to be held.  This causes both a memory leak and prevents the Liberty directory from being deleted.

The fix is to close the URLClassLoader in the map's `clear()` method, which must be called by the Gradle task.  This method call is needed because otherwise the caller just uses `put()` and `get()` methods, with clear no indication on when the resources can be closed.