### PR TITLE
restrict mbean test to public API to determine if the mbean is usable in Liberty

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_mbean/fat/src/com/ibm/ws/concurrent/persistent/fat/mbean/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_mbean/fat/src/com/ibm/ws/concurrent/persistent/fat/mbean/FATSuite.java
@@ -10,32 +10,11 @@
  *******************************************************************************/
 package com.ibm.ws.concurrent.persistent.fat.mbean;
 
-import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import com.ibm.websphere.simplicity.Machine;
-
-import componenttest.topology.impl.LibertyFileManager;
-import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.impl.LibertyServerFactory;
-
 @RunWith(Suite.class)
 @SuiteClasses({ PersistentExecutorMBeanTest.class })
 public class FATSuite {
-    static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.concurrent.persistent.fat.mbean");
-
-    @BeforeClass
-    public static void beforeSuite() throws Exception {
-        // Delete the Derby-only database that is used by the persistent executor
-        Machine machine = server.getMachine();
-        String installRoot = server.getInstallRoot();
-        LibertyFileManager.deleteLibertyDirectoryAndContents(machine, installRoot + "/usr/shared/resources/data/persistmbean");
-        LibertyFileManager.deleteLibertyDirectoryAndContents(machine, installRoot + "/usr/shared/resources/data/persistmbean2");
-        LibertyFileManager.deleteLibertyDirectoryAndContents(machine, installRoot + "/usr/shared/resources/data/persistmbean3");
-        LibertyFileManager.deleteLibertyDirectoryAndContents(machine, installRoot + "/usr/shared/resources/data/persistmbean4");
-        LibertyFileManager.deleteLibertyDirectoryAndContents(machine, installRoot + "/usr/shared/resources/data/persistmbean5");
-
-    }
 }

--- a/dev/com.ibm.ws.concurrent.persistent_fat_mbean/fat/src/com/ibm/ws/concurrent/persistent/fat/mbean/PersistentExecutorMBeanTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_mbean/fat/src/com/ibm/ws/concurrent/persistent/fat/mbean/PersistentExecutorMBeanTest.java
@@ -33,6 +33,7 @@ import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
 
 /**
  * Tests for persistent scheduled executor with task execution disabled
@@ -40,7 +41,7 @@ import componenttest.topology.impl.LibertyServer;
 @RunWith(FATRunner.class)
 public class PersistentExecutorMBeanTest {
 
-    private static final LibertyServer server = FATSuite.server;
+    private static final LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.concurrent.persistent.fat.mbean");
 
     private static final Set<String> appNames = Collections.singleton("persistentmbeantest");
     
@@ -129,6 +130,11 @@ public class PersistentExecutorMBeanTest {
     @Test
     public void testFindTaskIds() throws Exception {
         runInServlet("testFindTaskIds", null);
+    }
+
+    @Test
+    public void testPersistentExecutorMBeanClassIsNotAPI() throws Exception {
+        runInServlet("testPersistentExecutorMBeanClassIsNotAPI", null);
     }
 
     @Test

--- a/dev/com.ibm.ws.concurrent.persistent_fat_mbean/publish/files/server2.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_mbean/publish/files/server2.xml
@@ -10,8 +10,9 @@
  -->
 <server>
   <featureManager>
-    <feature>persistentExecutor-1.0</feature>
+    <feature>concurrent-1.0</feature>
     <feature>ejbPersistentTimer-3.2</feature>
+    <feature>jndi-1.0</feature>
     <feature>servlet-3.1</feature>
   </featureManager>
 

--- a/dev/com.ibm.ws.concurrent.persistent_fat_mbean/publish/servers/com.ibm.ws.concurrent.persistent.fat.mbean/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_mbean/publish/servers/com.ibm.ws.concurrent.persistent.fat.mbean/server.xml
@@ -10,8 +10,9 @@
  -->
 <server>
   <featureManager>
-    <feature>persistentExecutor-1.0</feature>
+    <feature>concurrent-1.0</feature>
     <feature>ejbPersistentTimer-3.2</feature>
+    <feature>jndi-1.0</feature>
     <feature>servlet-3.1</feature>
   </featureManager>
 


### PR DESCRIPTION
I was hoping to remove the undocumented PersistentExecutorMBean from Liberty given the different direction that we are taking for fail over.  However, it appears that existing main path code mistakenly registers PersistentExecutorMBean without restricting it to non-ship/beta code path.  To prove that it is truly accessible/usable, I updated the com.ibm.ws.concurrent.persistent_fat_mbean test bucket such that it only uses GA features rather than non-ship features/code, and that confirms it.  For now, I have also added a test case to enforce that the PersistentExecutorMBean interface never gets exposed as API.  As to whether or not the mbean can be completely removed, there will need to be further discussion.  At a minimum, we should aim to reject it when fail over is enabled (this can be done under a separate pull).