### PR TITLE
Moving loginmodule to separate package

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat/.classpath
+++ b/dev/com.ibm.ws.jdbc_fat/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
-			<attribute name="module" value="true" />
+			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" path="fat/src"/>
@@ -10,6 +10,7 @@
 	<classpathentry kind="src" path="test-applications/dsdfat/src"/>
 	<classpathentry kind="src" path="test-applications/setupfat/src"/>
 	<classpathentry kind="src" path="test-applications/dsdfat_global_lib/src"/>
+	<classpathentry kind="src" path="test-resource/loginmodule/src"/>
 	<classpathentry exported="true" kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.jdbc_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat/bnd.bnd
@@ -16,6 +16,7 @@ javac.target: 1.8
 
 src: \
 	fat/src,\
+	test-resource/loginmodule/src,\
 	test-applications/basicfat/src,\
 	test-applications/dsdfat/src,\
 	test-applications/setupfat/src,\

--- a/dev/com.ibm.ws.jdbc_fat/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat/build.gradle
@@ -50,13 +50,6 @@ dependencies {
   into new File(autoFvtDir, 'publish/shared/resources/db2')
   rename 'jcc.*.jar', 'jcc.jar'
  }
- 
- task copyJarToModule(type: Copy) {
-  shouldRunAfter jar
-  from jar
-  into new File(autoFvtDir, 'publish/shared/resources/loginmodule/')
-  rename 'com.ibm.ws.jdbc_fat.jar', 'TestLoginModule.jar'
- }
 
 
  addRequiredLibraries {
@@ -65,5 +58,4 @@ dependencies {
   dependsOn addDerbyClient
   dependsOn copyAutomaticDerby
   dependsOn copyDB2
-  dependsOn copyJarToModule
  }

--- a/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/FATSuite.java
@@ -10,10 +10,13 @@
  *******************************************************************************/
 package com.ibm.ws.jdbc.fat;
 
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jdbc.fat.tests.ConfigTest;
 import com.ibm.ws.jdbc.fat.tests.DataSourceJaasTest;
 import com.ibm.ws.jdbc.fat.tests.DataSourceTest;
@@ -25,5 +28,10 @@ import com.ibm.ws.jdbc.fat.tests.DataSourceTest;
                DataSourceJaasTest.class
 })
 public class FATSuite {
-	//TODO enable database rotation
+    @BeforeClass
+    public static void beforeSuite() throws Exception {        
+        //Add TestLoginModule.jar to shared.resources.dir
+        JavaArchive TestLoginModule = ShrinkHelper.buildJavaArchive("TestLoginModule", "loginmodule");
+        ShrinkHelper.exportArtifact(TestLoginModule, "publish/shared/resources/loginmodule/");
+    }
 } 

--- a/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.fat/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.fat/server.xml
@@ -165,7 +165,7 @@
     <authData id="derbyJAAS" jaasLoginContextEntryRef="myJAASLoginEntry"/>
 -->
     <jaasLoginContextEntry id="myJAASLoginEntry" name="myJAASLoginEntry" loginModuleRef="testLoginModule" />
-	<jaasLoginModule id="testLoginModule" className="com.ibm.ws.jdbc.fat.jaas.tests.TestLoginModule" controlFlag="REQUIRED" libraryRef="customLoginLib"/>
+	<jaasLoginModule id="testLoginModule" className="loginmodule.TestLoginModule" controlFlag="REQUIRED" libraryRef="customLoginLib"/>
 	<library id="customLoginLib">
 	  <fileset dir="${shared.resource.dir}" includes="TestLoginModule.jar"/>
     </library>

--- a/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.jaas.fat/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.jaas.fat/server.xml
@@ -171,7 +171,7 @@
 -->
 
     <jaasLoginContextEntry id="myJAASLoginEntry" name="myJAASLoginEntry" loginModuleRef="testLoginModule" />
-	<jaasLoginModule id="testLoginModule" className="com.ibm.ws.jdbc.fat.tests.TestLoginModule" controlFlag="REQUIRED" libraryRef="customLoginLib"/>
+	<jaasLoginModule id="testLoginModule" className="loginmodule.TestLoginModule" controlFlag="REQUIRED" libraryRef="customLoginLib"/>
 	
 	<library id="customLoginLib">
 	  <fileset dir="${shared.resource.dir}/loginmodule" includes="TestLoginModule.jar"/>
@@ -179,7 +179,7 @@
     
     <!-- GSS Credential Config - Shares jar for login module with standard JAASLogin test -->
     <jaasLoginContextEntry id="myJAASGSSLoginEntry" name="myJAASGSSLoginEntry" loginModuleRef="testGSSLoginModule" />
-	<jaasLoginModule id="testGSSLoginModule" className="com.ibm.ws.jdbc.fat.tests.TestGSSLoginModule" controlFlag="REQUIRED" libraryRef="customLoginLib"/>
+	<jaasLoginModule id="testGSSLoginModule" className="loginmodule.TestGSSLoginModule" controlFlag="REQUIRED" libraryRef="customLoginLib"/>
     <!-- TODO what is this component and can we test it in OL? -->
     <spnego id="includeClientGSSCredentialTrue"
         includeClientGSSCredentialInSubject="true"

--- a/dev/com.ibm.ws.jdbc_fat/test-resource/loginmodule/src/loginmodule/TestGSSCredential.java
+++ b/dev/com.ibm.ws.jdbc_fat/test-resource/loginmodule/src/loginmodule/TestGSSCredential.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.jdbc.fat.tests;
+package loginmodule;
 
 import org.ietf.jgss.GSSCredential;
 import org.ietf.jgss.GSSException;
@@ -34,7 +34,7 @@ public class TestGSSCredential implements GSSCredential {
      */
     @Override
     public void dispose() throws GSSException {
-        // TODO Auto-generated method stub
+        //Auto-generated method stub
     }
 
     /*
@@ -44,7 +44,7 @@ public class TestGSSCredential implements GSSCredential {
      */
     @Override
     public GSSName getName() throws GSSException {
-        // TODO Auto-generated method stub
+        //Auto-generated method stub
         return name;
     }
 
@@ -55,7 +55,7 @@ public class TestGSSCredential implements GSSCredential {
      */
     @Override
     public GSSName getName(Oid mech) throws GSSException {
-        // TODO Auto-generated method stub
+        //Auto-generated method stub
         return name;
     }
 
@@ -66,7 +66,7 @@ public class TestGSSCredential implements GSSCredential {
      */
     @Override
     public int getRemainingLifetime() throws GSSException {
-        // TODO Auto-generated method stub
+        //Auto-generated method stub
         return Integer.MAX_VALUE;
     }
 
@@ -77,7 +77,7 @@ public class TestGSSCredential implements GSSCredential {
      */
     @Override
     public int getRemainingInitLifetime(Oid mech) throws GSSException {
-        // TODO Auto-generated method stub
+        //Auto-generated method stub
         return Integer.MAX_VALUE;
     }
 
@@ -88,7 +88,7 @@ public class TestGSSCredential implements GSSCredential {
      */
     @Override
     public int getRemainingAcceptLifetime(Oid mech) throws GSSException {
-        // TODO Auto-generated method stub
+        //Auto-generated method stub
         return Integer.MAX_VALUE;
     }
 
@@ -99,7 +99,7 @@ public class TestGSSCredential implements GSSCredential {
      */
     @Override
     public int getUsage() throws GSSException {
-        // TODO Auto-generated method stub
+        //Auto-generated method stub
         return INITIATE_AND_ACCEPT;
     }
 
@@ -110,7 +110,7 @@ public class TestGSSCredential implements GSSCredential {
      */
     @Override
     public int getUsage(Oid mech) throws GSSException {
-        // TODO Auto-generated method stub
+        //Auto-generated method stub
         return INITIATE_AND_ACCEPT;
     }
 
@@ -121,7 +121,7 @@ public class TestGSSCredential implements GSSCredential {
      */
     @Override
     public Oid[] getMechs() throws GSSException {
-        // TODO Auto-generated method stub
+        //Auto-generated method stub
         return null;
     }
 

--- a/dev/com.ibm.ws.jdbc_fat/test-resource/loginmodule/src/loginmodule/TestGSSLoginModule.java
+++ b/dev/com.ibm.ws.jdbc_fat/test-resource/loginmodule/src/loginmodule/TestGSSLoginModule.java
@@ -8,13 +8,11 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.jdbc.fat.tests;
+package loginmodule;
 
 import java.io.IOException;
 import java.util.Map;
 
-import javax.resource.spi.ManagedConnectionFactory;
-import javax.resource.spi.security.PasswordCredential;
 import javax.security.auth.Subject;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
@@ -22,10 +20,14 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.LoginException;
 import javax.security.auth.spi.LoginModule;
 
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSException;
+import org.ietf.jgss.GSSName;
+
 import com.ibm.wsspi.security.auth.callback.WSManagedConnectionFactoryCallback;
 import com.ibm.wsspi.security.auth.callback.WSMappingPropertiesCallback;
 
-public class TestLoginModule implements LoginModule {
+public class TestGSSLoginModule implements LoginModule {
 
     public CallbackHandler callbackHandler;
     public Subject subject;
@@ -49,7 +51,6 @@ public class TestLoginModule implements LoginModule {
         try {
             Callback[] callbacks = getHandledCallbacks();
             setPasswordCredentialInSubject(callbacks);
-            setPropertiesInSubject(callbacks);
         } catch (Exception e) {
             throw new LoginException(e.getMessage());
         }
@@ -65,21 +66,10 @@ public class TestLoginModule implements LoginModule {
         return callbacks;
     }
 
-    private void setPasswordCredentialInSubject(Callback[] callbacks) {
-        ManagedConnectionFactory managedConnectionFactory = ((WSManagedConnectionFactoryCallback) callbacks[0]).getManagedConnectionFacotry();
-        PasswordCredential passwordCredential = new PasswordCredential("dbuser1", "dbuser1pwd".toCharArray());
-        passwordCredential.setManagedConnectionFactory(managedConnectionFactory);
-        subject.getPrivateCredentials().add(passwordCredential);
-    }
-
-    /*
-     * The properties are set in the subject to test that they can be obtained
-     * from the WSMappingPropertiesCallback. Normal login modules are not required to do this.
-     */
-    private void setPropertiesInSubject(Callback[] callbacks) {
-        @SuppressWarnings("rawtypes")
-        Map properties = ((WSMappingPropertiesCallback) callbacks[1]).getProperties();
-        subject.getPrivateCredentials().add(properties);
+    private void setPasswordCredentialInSubject(Callback[] callbacks) throws GSSException {
+        GSSName name = new TestGSSName("dbuser1");
+        GSSCredential credential = new TestGSSCredential(name);
+        subject.getPrivateCredentials().add(credential);
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.ws.jdbc_fat/test-resource/loginmodule/src/loginmodule/TestGSSName.java
+++ b/dev/com.ibm.ws.jdbc_fat/test-resource/loginmodule/src/loginmodule/TestGSSName.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.jdbc.fat.tests;
+package loginmodule;
 
 import org.ietf.jgss.GSSException;
 import org.ietf.jgss.GSSName;
@@ -49,7 +49,7 @@ public class TestGSSName implements GSSName {
      */
     @Override
     public GSSName canonicalize(Oid mech) throws GSSException {
-        // TODO Auto-generated method stub
+        //Auto-generated method stub
         return this;
     }
 
@@ -60,7 +60,7 @@ public class TestGSSName implements GSSName {
      */
     @Override
     public byte[] export() throws GSSException {
-        // TODO Auto-generated method stub
+        //Auto-generated method stub
         return null;
     }
 
@@ -71,7 +71,7 @@ public class TestGSSName implements GSSName {
      */
     @Override
     public Oid getStringNameType() throws GSSException {
-        // TODO Auto-generated method stub
+        //Auto-generated method stub
         return null;
     }
 
@@ -82,7 +82,7 @@ public class TestGSSName implements GSSName {
      */
     @Override
     public boolean isAnonymous() {
-        // TODO Auto-generated method stub
+        //Auto-generated method stub
         return false;
     }
 
@@ -93,7 +93,7 @@ public class TestGSSName implements GSSName {
      */
     @Override
     public boolean isMN() {
-        // TODO Auto-generated method stub
+        //Auto-generated method stub
         return false;
     }
 

--- a/dev/com.ibm.ws.jdbc_fat/test-resource/loginmodule/src/loginmodule/TestLoginModule.java
+++ b/dev/com.ibm.ws.jdbc_fat/test-resource/loginmodule/src/loginmodule/TestLoginModule.java
@@ -8,11 +8,13 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.jdbc.fat.tests;
+package loginmodule;
 
 import java.io.IOException;
 import java.util.Map;
 
+import javax.resource.spi.ManagedConnectionFactory;
+import javax.resource.spi.security.PasswordCredential;
 import javax.security.auth.Subject;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
@@ -20,14 +22,10 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.LoginException;
 import javax.security.auth.spi.LoginModule;
 
-import org.ietf.jgss.GSSCredential;
-import org.ietf.jgss.GSSException;
-import org.ietf.jgss.GSSName;
-
 import com.ibm.wsspi.security.auth.callback.WSManagedConnectionFactoryCallback;
 import com.ibm.wsspi.security.auth.callback.WSMappingPropertiesCallback;
 
-public class TestGSSLoginModule implements LoginModule {
+public class TestLoginModule implements LoginModule {
 
     public CallbackHandler callbackHandler;
     public Subject subject;
@@ -51,6 +49,7 @@ public class TestGSSLoginModule implements LoginModule {
         try {
             Callback[] callbacks = getHandledCallbacks();
             setPasswordCredentialInSubject(callbacks);
+            setPropertiesInSubject(callbacks);
         } catch (Exception e) {
             throw new LoginException(e.getMessage());
         }
@@ -66,10 +65,21 @@ public class TestGSSLoginModule implements LoginModule {
         return callbacks;
     }
 
-    private void setPasswordCredentialInSubject(Callback[] callbacks) throws GSSException {
-        GSSName name = new TestGSSName("dbuser1");
-        GSSCredential credential = new TestGSSCredential(name);
-        subject.getPrivateCredentials().add(credential);
+    private void setPasswordCredentialInSubject(Callback[] callbacks) {
+        ManagedConnectionFactory managedConnectionFactory = ((WSManagedConnectionFactoryCallback) callbacks[0]).getManagedConnectionFacotry();
+        PasswordCredential passwordCredential = new PasswordCredential("dbuser1", "dbuser1pwd".toCharArray());
+        passwordCredential.setManagedConnectionFactory(managedConnectionFactory);
+        subject.getPrivateCredentials().add(passwordCredential);
+    }
+
+    /*
+     * The properties are set in the subject to test that they can be obtained
+     * from the WSMappingPropertiesCallback. Normal login modules are not required to do this.
+     */
+    private void setPropertiesInSubject(Callback[] callbacks) {
+        @SuppressWarnings("rawtypes")
+        Map properties = ((WSMappingPropertiesCallback) callbacks[1]).getProperties();
+        subject.getPrivateCredentials().add(properties);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Login module code was previously in the jdbc.fat.tests package.  As a result we were packaging the entire fat/src directory and making a copy of it so that the app could access the login module code.

Here, I have moved this code it it's own package, and export it to a jar at runtime.  

