### PR TITLE
Handles "unassociated" types/enums

### DIFF
--- a/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/generator/Validator.java
+++ b/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/generator/Validator.java
@@ -62,7 +62,7 @@ class Validator {
         }
         mappedTypes.putIfAbsent(graphQLType.getName(), resolvedType);
         AnnotatedType knownType = mappedTypes.get(graphQLType.getName());
-        if (isMappingAllowed(resolvedType, knownType)) {
+        if (isMappingAllowed(resolvedType, knownType) || resolvedType.getType().getTypeName().startsWith("java.lang")) {
             return ValidationResult.valid();
         }
         return ValidationResult.invalid(String.format("Potential type name collision detected: '%s' bound to multiple types:" +

--- a/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/generator/mapping/common/CachingMapper.java
+++ b/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/generator/mapping/common/CachingMapper.java
@@ -2,6 +2,7 @@ package io.leangen.graphql.generator.mapping.common;
 
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLInputType;
+import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLTypeReference;
@@ -57,10 +58,13 @@ public abstract class CachingMapper<O extends GraphQLOutputType, I extends Graph
             return typeInfoGenerator.generateScalarTypeName(javaType, messageBundle);
         }
         if (GenericTypeReflector.isSuperType(GraphQLEnumType.class, graphQLType.getType())) {
-            return typeInfoGenerator.generateTypeName(javaType, messageBundle);
+            return typeInfoGenerator.generateEnumName(javaType, messageBundle);
         }
         if (GenericTypeReflector.isSuperType(GraphQLInputType.class, graphQLType.getType())) {
             return typeInfoGenerator.generateInputTypeName(javaType, messageBundle);
+        }
+        if (GenericTypeReflector.isSuperType(GraphQLInterfaceType.class, graphQLType.getType())) {
+            return typeInfoGenerator.generateInterfaceName(javaType, messageBundle);
         }
         return typeInfoGenerator.generateTypeName(javaType, messageBundle);
     }

--- a/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/generator/mapping/common/InterfaceMapper.java
+++ b/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/generator/mapping/common/InterfaceMapper.java
@@ -7,10 +7,14 @@ import graphql.schema.GraphQLObjectType;
 import io.leangen.graphql.generator.BuildContext;
 import io.leangen.graphql.generator.OperationMapper;
 import io.leangen.graphql.generator.mapping.strategy.InterfaceMappingStrategy;
+import io.leangen.graphql.metadata.messages.MessageBundle;
 import io.leangen.graphql.util.Directives;
 import io.leangen.graphql.util.Utils;
 
+import org.eclipse.microprofile.graphql.Input;
 import org.eclipse.microprofile.graphql.Interface;
+import org.eclipse.microprofile.graphql.Name;
+import org.eclipse.microprofile.graphql.Type;
 
 import java.lang.reflect.AnnotatedType;
 import java.util.List;
@@ -63,9 +67,10 @@ public class InterfaceMapper extends CachingMapper<GraphQLInterfaceType, GraphQL
 
     private void registerImplementations(AnnotatedType javaType, GraphQLInterfaceType type, OperationMapper operationMapper, BuildContext buildContext) {
 
-        buildContext.implDiscoveryStrategy.findImplementations(javaType, getScanPackages(javaType), buildContext).forEach(impl ->
-            getImplementingType(impl, operationMapper, buildContext)
-                .ifPresent(implType -> buildContext.typeRegistry.registerDiscoveredCovariantType(type.getName(), impl, implType)));
+        buildContext.implDiscoveryStrategy.findImplementations(javaType, getScanPackages(javaType), buildContext).forEach(impl -> {
+            getImplementingType(impl, operationMapper, buildContext).ifPresent(implType -> 
+                buildContext.typeRegistry.registerDiscoveredCovariantType(type.getName(), impl, implType));
+        });
 
     }
 
@@ -82,8 +87,13 @@ public class InterfaceMapper extends CachingMapper<GraphQLInterfaceType, GraphQL
     private Optional<GraphQLObjectType> getImplementingType(AnnotatedType implType, OperationMapper operationMapper, BuildContext buildContext) {
         return Optional.of(implType)
                 .filter(impl -> !interfaceStrategy.supports(impl))
+                .filter(impl -> !isInputOnly(impl))
                 .map(impl -> operationMapper.toGraphQLType(impl, buildContext))
                 .filter(impl -> impl instanceof GraphQLObjectType)
                 .map(impl -> (GraphQLObjectType) impl);
+    }
+
+    private boolean isInputOnly(AnnotatedType javaType) {
+        return javaType.isAnnotationPresent(Input.class) && !javaType.isAnnotationPresent(Type.class);
     }
 }

--- a/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/generator/mapping/common/NonNullMapper.java
+++ b/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/generator/mapping/common/NonNullMapper.java
@@ -19,6 +19,7 @@ import io.leangen.graphql.metadata.OperationArgument;
 import io.leangen.graphql.metadata.TypedElement;
 import io.leangen.graphql.util.ClassUtils;
 import io.leangen.graphql.util.GraphQLUtils;
+import org.eclipse.microprofile.graphql.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,15 +51,7 @@ public class NonNullMapper implements TypeMapper, Comparator<AnnotatedType>, Sch
 
     @SuppressWarnings("unchecked")
     public NonNullMapper() {
-        Set<Class<? extends Annotation>> annotations = new HashSet<>();
-        annotations.add(io.leangen.graphql.annotations.GraphQLNonNull.class);
-        for (String additional : COMMON_NON_NULL_ANNOTATIONS) {
-            try {
-                annotations.add((Class<? extends Annotation>) ClassUtils.forName(additional));
-            } catch (ClassNotFoundException e) {
-                /*no-op*/
-            }
-        }
+        Set<Class<? extends Annotation>> annotations = Collections.singleton(NonNull.class);
         this.nonNullAnnotations = Collections.unmodifiableSet(annotations);
     }
 
@@ -128,7 +121,8 @@ public class NonNullMapper implements TypeMapper, Comparator<AnnotatedType>, Sch
 
     @Override
     public boolean supports(AnnotatedType type) {
-        return nonNullAnnotations.stream().anyMatch(type::isAnnotationPresent) || ClassUtils.getRawType(type.getType()).isPrimitive();
+        return type.isAnnotationPresent(NonNull.class) || 
+                        ClassUtils.getRawType(type.getType()).isPrimitive(); 
     }
 
     @Override

--- a/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/generator/mapping/strategy/AnnotatedInterfaceStrategy.java
+++ b/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/generator/mapping/strategy/AnnotatedInterfaceStrategy.java
@@ -39,10 +39,6 @@ public class AnnotatedInterfaceStrategy extends AbstractInterfaceMappingStrategy
             }
         }
         if (log.isDebugEnabled()) {
-//            log.debug("hello");
-//            log.debug(interfaceName);
-//            log.debug(typeName);
-//            log.debug(interfaceAnno != null ? interfaceAnno.value() : "no annotation");
             log.debug("name, " + interfaceName + ", derived from ( " + typeName + ", " + 
                             (interfaceAnno != null ? interfaceAnno.value() : "no annotation") + " )");
         }

--- a/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/type/DefaultTypeInfoGenerator.java
+++ b/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/type/DefaultTypeInfoGenerator.java
@@ -5,7 +5,10 @@ import io.leangen.graphql.metadata.messages.MessageBundle;
 import io.leangen.graphql.util.ClassUtils;
 import io.leangen.graphql.util.Utils;
 import org.eclipse.microprofile.graphql.Description;
+import org.eclipse.microprofile.graphql.Enum;
 import org.eclipse.microprofile.graphql.Input;
+import org.eclipse.microprofile.graphql.Interface;
+import org.eclipse.microprofile.graphql.Name;
 import org.eclipse.microprofile.graphql.Type;
 
 import java.beans.Introspector;
@@ -30,6 +33,13 @@ public class DefaultTypeInfoGenerator implements TypeInfoGenerator {
                     .forEach(argName -> genericName.append("_").append(argName));
             return genericName.toString();
         }
+        Type typeAnno = type.getAnnotation(Type.class);
+        if (typeAnno != null) {
+            String typeAnnoValue = typeAnno.value();
+            if (Utils.isNotEmpty(typeAnnoValue)) {
+                return typeAnnoValue;
+            }
+        }
         return generateSimpleName(type, messageBundle);
     }
 
@@ -42,11 +52,35 @@ public class DefaultTypeInfoGenerator implements TypeInfoGenerator {
     }
 
     @Override
+    public String generateInterfaceName(AnnotatedType type, MessageBundle messageBundle) {
+        Interface ifaceAnno = type.getAnnotation(Interface.class);
+        if (ifaceAnno != null) {
+            String ifaceAnnoValue = ifaceAnno.value();
+            if (Utils.isNotEmpty(ifaceAnnoValue)) {
+                return ifaceAnnoValue;
+            }
+        }
+        return generateSimpleName(type, messageBundle);
+    }
+
+    @Override
     public String generateInputTypeName(AnnotatedType type, MessageBundle messageBundle) {
         return Optional.ofNullable(type.getAnnotation(Input.class))
                 .map(ann -> messageBundle.interpolate(ann.value()))
                 .filter(Utils::isNotEmpty)
                 .orElse(TypeInfoGenerator.super.generateInputTypeName(type, messageBundle));
+    }
+
+    @Override
+    public String generateEnumName(AnnotatedType type, MessageBundle messageBundle) {
+        Enum enumAnno = type.getAnnotation(Enum.class);
+        if (enumAnno != null) {
+            String enumAnnoValue = enumAnno.value();
+            if (Utils.isNotEmpty(enumAnnoValue)) {
+                return enumAnnoValue;
+            }
+        }
+        return generateSimpleName(type, messageBundle);
     }
 
     @Override
@@ -80,8 +114,8 @@ public class DefaultTypeInfoGenerator implements TypeInfoGenerator {
 
     @SuppressWarnings("unchecked")
     private String generateSimpleName(AnnotatedType type, MessageBundle messageBundle) {
-        Optional<String> name = Optional.ofNullable(type.getAnnotation(Type.class))
-                .map(Type::value)
+        Optional<String> name = Optional.ofNullable(type.getAnnotation(Name.class))
+                .map(Name::value)
                 .filter(Utils::isNotEmpty);
         return messageBundle.interpolate(name.orElseGet(() -> getSimpleName(ClassUtils.getRawType(type.getType()))));
     }

--- a/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/type/TypeInfoGenerator.java
+++ b/dev/com.ibm.ws.io.leangen.graphql.spqr.0.9.9/src/io/leangen/graphql/metadata/strategy/type/TypeInfoGenerator.java
@@ -17,6 +17,10 @@ public interface TypeInfoGenerator {
 
     String generateTypeDescription(AnnotatedType type, MessageBundle messageBundle);
 
+    String generateInterfaceName(AnnotatedType type, MessageBundle messageBundle);
+
+    String generateEnumName(AnnotatedType type, MessageBundle messageBundle);
+
     String[] getFieldOrder(AnnotatedType type, MessageBundle messageBundle);
 
     default String generateInputTypeName(AnnotatedType type, MessageBundle messageBundle) {

--- a/dev/com.ibm.ws.microprofile.graphql.1.0/src/com/ibm/ws/microprofile/graphql/component/GraphQLExtension.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0/src/com/ibm/ws/microprofile/graphql/component/GraphQLExtension.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.WeakHashMap;
 
 import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.Annotated;
 import javax.enterprise.inject.spi.AnnotatedType;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
@@ -28,13 +29,19 @@ import javax.enterprise.inject.spi.Extension;
 import javax.enterprise.inject.spi.ProcessBean;
 
 import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLType;
 import graphql.schema.idl.SchemaPrinter;
 
 import io.leangen.graphql.GraphQLSchemaGenerator;
+import io.leangen.graphql.generator.mapping.TypeMapper;
+import io.leangen.graphql.generator.mapping.TypeMapperRegistry;
 import io.leangen.graphql.metadata.strategy.query.AnnotatedResolverBuilder;
 import io.leangen.graphql.metadata.strategy.value.jsonb.JsonbValueMapperFactory;
 
+import org.eclipse.microprofile.graphql.Enum;
 import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Input;
+import org.eclipse.microprofile.graphql.Type;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 
@@ -79,23 +86,28 @@ public class GraphQLExtension implements Extension, WebSphereCDIExtension, Intro
     }
 
     public <X> void detectGraphQLComponent(@Observes ProcessBean<X> event) {
-        if (event.getAnnotated().isAnnotationPresent(GraphQLApi.class)) {
-            Bean<?> bean = event.getBean();
+        Annotated annotated = event.getAnnotated();
+        Bean<?> bean = event.getBean();
+        if (annotated.isAnnotationPresent(GraphQLApi.class)) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "adding GraphQLApi bean: " + bean);
             }
-            //TODO: add interceptor(s) set via DS - i.e. metric capturing interceptor
-            ModuleMetaData mmd = getModuleMetaData();
-            graphQLComponents.computeIfAbsent(mmd, k -> {
-                return new HashSet<>();
-            });
-            graphQLComponents.get(mmd).add(bean);
+            addBeanToMMDMap(bean, graphQLComponents);
         }
+    }
+
+    private static void addBeanToMMDMap(Bean<?> bean, Map<ModuleMetaData, Set<Bean<?>>> map) {
+        //TODO: add interceptor(s) set via DS - i.e. metric capturing interceptor
+        ModuleMetaData mmd = getModuleMetaData();
+        map.computeIfAbsent(mmd, k -> {
+            return new HashSet<>();
+        });
+        map.get(mmd).add(bean);
     }
 
     static GraphQLSchema createSchema(BeanManager beanManager) {
         ModuleMetaData mmd = getModuleMetaData();
-        Set<Bean<?>> beans = graphQLComponents.get(getModuleMetaData());
+        Set<Bean<?>> beans = graphQLComponents.get(mmd);
         if (beans == null || beans.size() < 1) {
             return null;
         }


### PR DESCRIPTION
These types/enums are indirectly associated with top level queries or mutations via an interface of input type that is directly associated with a top level query/mutation.

Implements feature https://github.com/eclipse/microprofile-graphql/issues/125
