### PR TITLE
Add a test to ensure FT 1.x messages are produced

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDIBulkheadTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/CDIBulkheadTest.java
@@ -11,6 +11,7 @@
 package com.ibm.websphere.microprofile.faulttolerance_fat.tests;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 import java.util.concurrent.ExecutorService;
@@ -34,6 +35,7 @@ import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.custom.junit.runner.RepeatTestFilter;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -99,6 +101,13 @@ public class CDIBulkheadTest extends FATServletClient {
 
         // Third task should fail with a Bulkhead exception
         assertThat("Task Three", future3.get(TIMEOUT + FUTURE_THRESHOLD, TimeUnit.MILLISECONDS), containsString("BulkheadException"));
+
+        if (RepeatFaultTolerance.MP20_FEATURES_ID.equals(RepeatTestFilter.CURRENT_REPEAT_ACTION)) {
+            // Check for the correct message for FT 1.x
+            assertThat("Task Three message should have correct code", future3.get(), containsString("CWMFT0001E"));
+            // Ensure that the message substitution has happened
+            assertThat("Task Three message should be substituted", future3.get(), not(containsString("bulkhead.no.threads.CWMFT0001E")));
+        }
     }
 
 }


### PR DESCRIPTION
This would have caught the error where we weren't exporting and
importing the message bundle packages correctly.

Fixes #10165 