### PR TITLE
Update edition of noship feature to be full

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/scim-2.0/com.ibm.websphere.appserver.scim-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/scim-2.0/com.ibm.websphere.appserver.scim-2.0.feature
@@ -9,4 +9,4 @@ Subsystem-Name: System for Cross-domain Identity Management 2.0
  com.ibm.ws.com.fasterxml.jackson.2.9.1, \
   com.ibm.ws.require.java8
 kind=noship
-edition=core
+edition=full


### PR DESCRIPTION
- For all noship features, the edition is set to full.  This one feature
had it as core.  When it is moved to beta or ga, then it can be set to
core.
