### PR TITLE
update to MP Context Propagation 1.0.2 for TCK dependency on Jakarta EE 8

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.0.feature
@@ -1,7 +1,7 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.0
 singleton=true
--bundles=com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.0.1"
+-bundles=com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.0.2"
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.1.feature
@@ -1,7 +1,7 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.1
 singleton=true
--bundles=com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.0.1"
+-bundles=com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.0.2"
 kind=noship
 edition=full
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
     <name>MicroProfile Context Propagation TCK Runner TCK Module</name>
 
     <properties>
-        <microprofile.context.propagation.version>1.0.1</microprofile.context.propagation.version>
+        <microprofile.context.propagation.version>1.0.2</microprofile.context.propagation.version>
         <!-- Switch to the following to test a local SNAPSHOT instead of a release (1.0) or release candidate (1.0-RC3). -->
         <!-- <microprofile.context.propagation.version>1.0-SNAPSHOT</microprofile.context.propagation.version> -->
         <arquillian.version>1.3.0.Final</arquillian.version>


### PR DESCRIPTION
MicroProfile Context Propagation is releasing a 1.0.2 micro version so that its TCK dependencies can be updated from Java EE to Jakarta EE.  This pull is to update OpenLiberty to start running against the 1.0.2 TCK, which ought to be identical to the 1.0.1 TCK, but this way, OpenLiberty will be running against the very latest version in automated test.