### PR TITLE
Use proper TCCL during CDI startup

### DIFF
--- a/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/liberty/CDIRuntimeImpl.java
+++ b/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/liberty/CDIRuntimeImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 IBM Corporation and others.
+ * Copyright (c) 2015, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,9 @@ package com.ibm.ws.cdi.liberty;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -106,6 +108,7 @@ public class CDIRuntimeImpl extends AbstractCDIRuntime implements ApplicationSta
     private boolean isClientProcess;
     private RuntimeFactory runtimeFactory;
     private ProxyServicesImpl proxyServices;
+    private final Map<String, ClassLoader> appTccls = new ConcurrentHashMap<>();
 
     public void activate(ComponentContext cc) {
         containerConfigRef.activate(cc);
@@ -421,9 +424,11 @@ public class CDIRuntimeImpl extends AbstractCDIRuntime implements ApplicationSta
                 this.runtimeFactory.removeApplication(appInfo);
                 return;
             }
-            newCL = getRealAppClassLoader(application);
 
-            if (newCL != null) {
+            ClassLoader appCL = getRealAppClassLoader(application);
+            if (appCL != null) {
+                newCL = classLoadingSRRef.getServiceWithException().createThreadContextClassLoader(appCL);
+                appTccls.put(appInfo.getName(), newCL);
                 oldCl = CDIUtils.getAndSetLoader(newCL);
             }
 
@@ -486,6 +491,14 @@ public class CDIRuntimeImpl extends AbstractCDIRuntime implements ApplicationSta
                 }
             } catch (CDIException e) {
                 //FFDC and carry on
+            } finally {
+                // Clean up the application TCCL created for startup
+                // Must do this at shutdown since it's possible for the app to hold onto it and use it after startup
+                ClassLoader tccl = appTccls.get(appInfo.getName());
+                if (tccl != null) {
+                    classLoadingSRRef.getServiceWithException().destroyThreadContextClassLoader(tccl);
+                    appTccls.remove(appInfo.getName());
+                }
             }
         }
     }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/bnd.bnd
@@ -25,7 +25,9 @@ fat.project: true
 	com.ibm.websphere.org.eclipse.microprofile.reactive.messaging.1.0;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.reactive.streams.operators.1.0;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.config.1.3;version=latest,\
+	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
 	com.ibm.websphere.javaee.cdi.2.0;version=latest,\
+	com.ibm.websphere.javaee.jsonb.1.0;version=latest,\
 	com.ibm.ws.org.slf4j.api.1.7.7;version=latest,\
 	org.apache.kafka:kafka-clients;version=2.3.0,\
 	org.testcontainers:testcontainers;version=1.12.3,\

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/jsonb/JsonbBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/jsonb/JsonbBean.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.jsonb;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.eclipse.microprofile.reactive.streams.operators.ProcessorBuilder;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+
+/**
+ * Bean which uses JsonB to convert objects to json
+ * <p>
+ * Note that the Jsonb object will be created at application startup
+ */
+@ApplicationScoped
+public class JsonbBean {
+
+    @Incoming("input")
+    @Outgoing("step1")
+    public ProcessorBuilder<TestData, String> toJson() {
+        // Tests creating Jsonb at startup
+        Jsonb jsonb = JsonbBuilder.create();
+        return ReactiveStreams.<TestData> builder()
+                        .map((t) -> jsonb.toJson(t));
+    }
+
+    @Incoming("step1")
+    @Outgoing("output")
+    public TestData fromJson(String json) {
+        // Tests creating Jsonb at processing time (app fully started)
+        Jsonb jsonb = JsonbBuilder.create();
+        return jsonb.fromJson(json, TestData.class);
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/jsonb/JsonbDeliveryBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/jsonb/JsonbDeliveryBean.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.jsonb;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractDeliveryBean;
+
+/**
+ * Bean which drives the "input" channel
+ */
+@ApplicationScoped
+public class JsonbDeliveryBean extends AbstractDeliveryBean<TestData> {
+
+    @Override
+    @Outgoing("input")
+    public CompletionStage<Message<TestData>> getMessage() {
+        return super.getMessage();
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/jsonb/JsonbReceptionBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/jsonb/JsonbReceptionBean.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.jsonb;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractReceptionBean;
+
+/**
+ * Bean for checking the "output" channel
+ */
+@ApplicationScoped
+public class JsonbReceptionBean extends AbstractReceptionBean<TestData> {
+
+    @Override
+    @Incoming("output")
+    public CompletionStage<Void> recieveMessage(Message<TestData> msg) {
+        return super.recieveMessage(msg);
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/jsonb/JsonbServlet.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/jsonb/JsonbServlet.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.jsonb;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Duration;
+import java.util.List;
+
+import javax.annotation.Resource;
+import javax.enterprise.concurrent.ManagedExecutorService;
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@WebServlet("/jsonbTest")
+public class JsonbServlet extends FATServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    private JsonbDeliveryBean deliveryBean;
+
+    @Inject
+    private JsonbReceptionBean receptionBean;
+
+    @Resource
+    private ManagedExecutorService executor;
+
+    @Test
+    public void testJsonb() throws InterruptedException {
+        TestData t = new TestData();
+        t.a = "test";
+        t.b = 42;
+        executor.submit(() -> deliveryBean.sendMessage(t));
+
+        List<Message<TestData>> receivedMessages = receptionBean.getReceivedMessages(1, Duration.ofSeconds(10));
+        TestData received = receivedMessages.get(0).getPayload();
+
+        assertEquals(t, received);
+    }
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/jsonb/JsonbTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/jsonb/JsonbTest.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.jsonb;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractDeliveryBean;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractReceptionBean;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+@RunWith(FATRunner.class)
+public class JsonbTest extends FATServletClient {
+
+    public static final String APP_NAME = "jsob-messaging";
+    public static final String SERVER_NAME = "SimpleRxMessagingServer";
+
+    @Server(SERVER_NAME)
+    @TestServlet(servlet = JsonbServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addPackage(JsonbBean.class.getPackage())
+                        .addClasses(AbstractReceptionBean.class, AbstractDeliveryBean.class);
+
+        ShrinkHelper.exportDropinAppToServer(server, war, DeployOptions.SERVER_ONLY);
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void cleanup() throws Exception {
+        server.stopServer();
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/jsonb/TestData.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/jsonb/TestData.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.jsonb;
+
+import java.util.Objects;
+
+/**
+ * A very basic data class which can be serialized by jsonb
+ */
+public class TestData {
+
+    public String a;
+    public int b;
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(a, b);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        TestData other = (TestData) obj;
+        return Objects.equals(a, other.a) && b == other.b;
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/ack/auto/KafkaAutoAckReceptionBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/ack/auto/KafkaAutoAckReceptionBean.java
@@ -23,7 +23,7 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractReceptionBean;
 
 @ApplicationScoped
-public class KafkaAutoAckReceptionBean extends AbstractReceptionBean {
+public class KafkaAutoAckReceptionBean extends AbstractReceptionBean<String> {
 
     public static final String CHANNEL_IN = "auto-ack-in";
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaDeliveryBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaDeliveryBean.java
@@ -20,7 +20,7 @@ import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractDeliveryBean;
 
 @ApplicationScoped
-public class KafkaDeliveryBean extends AbstractDeliveryBean {
+public class KafkaDeliveryBean extends AbstractDeliveryBean<String> {
 
     public final static String CHANNEL_NAME = "delivery-test-output";
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaReceptionBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/delivery/KafkaReceptionBean.java
@@ -22,7 +22,7 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractReceptionBean;
 
 @ApplicationScoped
-public class KafkaReceptionBean extends AbstractReceptionBean {
+public class KafkaReceptionBean extends AbstractReceptionBean<String> {
 
     public final static String CHANNEL_NAME = "reception-test-input";
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/AbstractReceptionBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/framework/AbstractReceptionBean.java
@@ -28,11 +28,11 @@ import org.eclipse.microprofile.reactive.messaging.Message;
  * <p>
  * To use this class, subclass it and override {@link #recieveMessage(Message)} to add {@code @Incoming} and {@code @Acknowledgement} annotations.
  */
-public class AbstractReceptionBean {
+public class AbstractReceptionBean<T> {
 
-    private final Queue<Message<String>> receivedMessages = new LinkedList<>();
+    private final Queue<Message<T>> receivedMessages = new LinkedList<>();
 
-    public CompletionStage<Void> recieveMessage(Message<String> msg) {
+    public CompletionStage<Void> recieveMessage(Message<T> msg) {
         synchronized (this) {
             receivedMessages.add(msg);
             this.notifyAll();
@@ -40,8 +40,8 @@ public class AbstractReceptionBean {
         return CompletableFuture.completedFuture(null);
     }
 
-    public List<Message<String>> getReceivedMessages(int count, Duration timeout) throws InterruptedException {
-        ArrayList<Message<String>> result = new ArrayList<>();
+    public List<Message<T>> getReceivedMessages(int count, Duration timeout) throws InterruptedException {
+        ArrayList<Message<T>> result = new ArrayList<>();
         Duration remaining = timeout;
         long startTime = System.nanoTime();
         while (!remaining.isNegative() && result.size() < count) {
@@ -62,11 +62,11 @@ public class AbstractReceptionBean {
 
     /**
      * Return any messages which have been received by the bean, without waiting
-     * 
+     *
      * @return a list of messages, may be empty
      */
-    public List<Message<String>> getReceivedMessages() {
-        ArrayList<Message<String>> result = new ArrayList<>();
+    public List<Message<T>> getReceivedMessages() {
+        ArrayList<Message<T>> result = new ArrayList<>();
         synchronized (this) {
             while (!receivedMessages.isEmpty()) {
                 result.add(receivedMessages.poll());

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/PartitionTestReceptionBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/partitions/PartitionTestReceptionBean.java
@@ -22,7 +22,7 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractReceptionBean;
 
 @ApplicationScoped
-public class PartitionTestReceptionBean extends AbstractReceptionBean {
+public class PartitionTestReceptionBean extends AbstractReceptionBean<String> {
 
     public static final String CHANNEL_NAME = "partition-test-incoming-topic";
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/FATSuite.java
@@ -14,6 +14,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.microprofile.reactive.messaging.fat.jsonb.JsonbTest;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.tests.KafkaTestClientProviderTest;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.invalid.nolib.KafkaNoLibTest;
 import com.ibm.ws.microprofile.reactive.messaging.fat.loginModuleClassloading.LoginModuleClassloadingTest;
@@ -25,7 +26,8 @@ import com.ibm.ws.microprofile.reactive.messaging.fat.loginModuleClassloading.Lo
                 SaslPlainTests.class,
                 KafkaTestClientProviderTest.class,
                 LoginModuleClassloadingTest.class,
-                KafkaNoLibTest.class
+                KafkaNoLibTest.class,
+                JsonbTest.class
 })
 public class FATSuite {
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/SimpleRxMessagingServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/SimpleRxMessagingServer/server.xml
@@ -18,5 +18,7 @@
         <feature>localConnector-1.0</feature>
         <feature>mpReactiveMessaging-1.0</feature>
         <feature>servlet-4.0</feature>
+        <feature>jsonb-1.0</feature>
+        <feature>concurrent-1.0</feature>
     </featureManager>
 </server>


### PR DESCRIPTION
Fixes #10248 

Previously CDI was setting the App classloader as the TCCL.

Instead, create the TCCL through the ClassLoadingService which returns a classloader which also has access to any internal classes which need to be loaded through `ServiceLoader`.

I added a test which shows that this fixes the reported issue, but need to check if it will have any unintended consequences.