### PR TITLE
Fix test suite reporting when using TestContainers

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_db2/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_db2/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jdbc_fat_db2/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_db2/bnd.bnd
@@ -21,6 +21,9 @@ src: \
 
 fat.project: true
 
+# Uncomment to use remote docker host to simulate continuous build behavior.
+#fat.test.use.remote.docker: true
+
 -buildpath: \
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.1;version=latest,\

--- a/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/DB2Test.java
+++ b/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/DB2Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/DB2Test.java
+++ b/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/DB2Test.java
@@ -10,13 +10,17 @@
  *******************************************************************************/
 package com.ibm.ws.jdbc.fat.db2;
 
-import static com.ibm.ws.jdbc.fat.db2.FATSuite.db2;
+import java.time.Duration;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
+import org.testcontainers.containers.Db2Container;
+import org.testcontainers.containers.output.OutputFrame;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -34,6 +38,20 @@ public class DB2Test extends FATServletClient {
     @Server("com.ibm.ws.jdbc.fat.db2")
     @TestServlet(servlet = DB2TestServlet.class, path = APP_NAME + '/' + SERVLET_NAME)
     public static LibertyServer server;
+
+    @ClassRule
+    public static Db2Container db2 = new Db2Container()
+                    .acceptLicense()
+                    // Use 5m timeout for local runs, 25m timeout for remote runs (extra time since the DB2 container can be slow to start)
+                    .withStartupTimeout(Duration.ofMinutes(FATRunner.FAT_TEST_LOCALRUN ? 5 : 25))
+                    .withLogConsumer(DB2Test::log);
+
+    private static void log(OutputFrame frame) {
+        String msg = frame.getUtf8String();
+        if (msg.endsWith("\n"))
+            msg = msg.substring(0, msg.length() - 1);
+        Log.info(DB2Test.class, "db2", msg);
+    }
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/FATSuite.java
@@ -10,18 +10,12 @@
  *******************************************************************************/
 package com.ibm.ws.jdbc.fat.db2;
 
-import java.time.Duration;
-
-import org.junit.ClassRule;
+import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.testcontainers.containers.Db2Container;
-import org.testcontainers.containers.output.OutputFrame;
 
-import com.ibm.websphere.simplicity.log.Log;
-
-import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.utils.ExternalTestServiceDockerClientStrategy;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -29,18 +23,9 @@ import componenttest.custom.junit.runner.FATRunner;
                 SQLJTest.class
 })
 public class FATSuite {
-
-    @ClassRule
-    public static Db2Container db2 = new Db2Container()
-                    .acceptLicense()
-                    // Use 5m timeout for local runs, 25m timeout for remote runs (extra time since the DB2 container can be slow to start)
-                    .withStartupTimeout(Duration.ofMinutes(FATRunner.FAT_TEST_LOCALRUN ? 5 : 25))
-                    .withLogConsumer(FATSuite::log);
-
-    private static void log(OutputFrame frame) {
-        String msg = frame.getUtf8String();
-        if (msg.endsWith("\n"))
-            msg = msg.substring(0, msg.length() - 1);
-        Log.info(DB2Test.class, "db2", msg);
+    @BeforeClass
+    public static void beforeSuite() throws Exception {
+        //Allows local tests to switch between using a local docker client, to using a remote docker client.
+        ExternalTestServiceDockerClientStrategy.clearTestcontainersConfig();
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/SQLJTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/SQLJTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2019 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corporation and others.
+ * Copyright (c) 2016, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/FATSuite.java
@@ -10,11 +10,10 @@
  *******************************************************************************/
 package com.ibm.ws.jdbc.fat.oracle;
 
-import org.junit.ClassRule;
+import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.testcontainers.containers.OracleContainer;
 
 import componenttest.topology.utils.ExternalTestServiceDockerClientStrategy;
 
@@ -24,12 +23,9 @@ import componenttest.topology.utils.ExternalTestServiceDockerClientStrategy;
                 OracleUCPTest.class
 })
 public class FATSuite {
-	
-    //TODO replace this container with the official oracle-xe container if/when it is available without a license
-    @ClassRule
-    public static OracleContainer oracle = new OracleContainer("oracleinanutshell/oracle-xe-11g");
-    
-    static {
+    @BeforeClass
+    public static void beforeSuite() throws Exception {
+        //Allows local tests to switch between using a local docker client, to using a remote docker client. 
         ExternalTestServiceDockerClientStrategy.clearTestcontainersConfig();
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleUCPTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleUCPTest.java
@@ -19,8 +19,11 @@ import java.util.Properties;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.testcontainers.containers.OracleContainer;
+import org.testcontainers.containers.output.OutputFrame;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.ConfigElementList;
@@ -28,6 +31,7 @@ import com.ibm.websphere.simplicity.config.ConnectionManager;
 import com.ibm.websphere.simplicity.config.DataSource;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.websphere.simplicity.config.dsprops.Properties_oracle_ucp;
+import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -48,13 +52,24 @@ public class OracleUCPTest extends FATServletClient {
     @Server("com.ibm.ws.jdbc.fat.oracle.ucp")
     @TestServlet(servlet = OracleUCPTestServlet.class, path = JEE_APP + "/" + SERVLET_NAME)
     public static LibertyServer server;
+    
+    //TODO replace this container with the official oracle-xe container if/when it is available without a license
+    @ClassRule
+    public static OracleContainer oracle = new OracleContainer("oracleinanutshell/oracle-xe-11g").withLogConsumer(OracleUCPTest::log);
+    
+    private static void log(OutputFrame frame) {
+        String msg = frame.getUtf8String();
+        if (msg.endsWith("\n"))
+            msg = msg.substring(0, msg.length() - 1);
+        Log.info(OracleUCPTest.class, "oracle", msg);
+    }
 
     @BeforeClass
     public static void setUp() throws Exception {
     	// Set server environment variables
-        server.addEnvVar("URL", FATSuite.oracle.getJdbcUrl());
-        server.addEnvVar("USER", FATSuite.oracle.getUsername());
-        server.addEnvVar("PASSWORD", FATSuite.oracle.getPassword());
+        server.addEnvVar("URL", oracle.getJdbcUrl());
+        server.addEnvVar("USER", oracle.getUsername());
+        server.addEnvVar("PASSWORD", oracle.getPassword());
         
     	// Create a normal Java EE application and export to server
     	ShrinkHelper.defaultApp(server, JEE_APP, "ucp.web");
@@ -80,11 +95,11 @@ public class OracleUCPTest extends FATServletClient {
 		
 		OracleDataSource ds = new OracleDataSource();
 		ds.setConnectionProperties(connProps);
-		ds.setUser(FATSuite.oracle.getUsername());
-		ds.setPassword(FATSuite.oracle.getPassword());
-		ds.setURL(FATSuite.oracle.getJdbcUrl());
+		ds.setUser(oracle.getUsername());
+		ds.setPassword(oracle.getPassword());
+		ds.setURL(oracle.getJdbcUrl());
 		
-    	try (Connection conn = ds.getConnection()){
+    	try (Connection conn = ds.getConnection()) {
             Statement stmt = conn.createStatement();
             
             //Create COLORTABLE for OracleUCPTest.class


### PR DESCRIPTION
Test suites are failing to report errors correctly when a docker host cannot be found on z/OS.
This seems to only happen in test suites that create a test container in the FATSuite.java file.
