### PR TITLE
tests for disabling fail over

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/publish/servers/com.ibm.ws.concurrent.persistent.fat.failover1serv/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/publish/servers/com.ibm.ws.concurrent.persistent.fat.failover1serv/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2019,2020 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -37,6 +37,7 @@
   </library>
   
   <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+  <javaPermission className="javax.management.MBeanServerPermission" name="createMBeanServer"/>
 
   <variable name="onError" value="FAIL"/>
 </server>


### PR DESCRIPTION
Write some tests to experiment with code paths where fail over is enabled and then disabled. We don't recommend doing that because it will leave existing tasks orphaned. The tests can experiment with ways of transferring orphaned tasks back to an available instance/member by directly accessing the database. However, there will not be any further investment in that area because it is something that users should not be doing.  If someone does come up with a need for it at some point, these tests will at least verify it is possible to transfer the tasks back and get them executing again.