### PR TITLE
New test case for MP Rest Client custom headers factory

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/headerPropagation12App/src/mpRestClient12/headerPropagation/ClientHeadersFactoryClient.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/headerPropagation12App/src/mpRestClient12/headerPropagation/ClientHeadersFactoryClient.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient12.headerPropagation;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@Path("/resource")
+@RegisterRestClient
+@RegisterClientHeaders(CustomClientHeadersFactory.class)
+@Produces(MediaType.TEXT_PLAIN)
+@Consumes(MediaType.TEXT_PLAIN)
+public interface ClientHeadersFactoryClient {
+
+    @GET
+    @Path("/normal")
+    String normalMethod();
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/headerPropagation12App/src/mpRestClient12/headerPropagation/CustomClientHeadersFactory.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/headerPropagation12App/src/mpRestClient12/headerPropagation/CustomClientHeadersFactory.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpRestClient12.headerPropagation;
+
+import javax.ws.rs.core.MultivaluedMap;
+
+import java.util.logging.Logger;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
+
+public class CustomClientHeadersFactory implements ClientHeadersFactory {
+
+    private static final Logger LOG = Logger.getLogger(CustomClientHeadersFactory.class.getName());
+
+    @Override
+    public MultivaluedMap<String, String> update(MultivaluedMap<String, String> incomingHeaders,
+                                                 MultivaluedMap<String, String> clientOutgoingHeaders) {
+        MultivaluedMap<String, String> myHeaders = new MultivaluedHashMap<>();
+        myHeaders.putSingle("HEADER_FROM_CUSTOM_CLIENTHEADERSFACTORY", "123");
+        LOG.info("update - adding HEADER_FROM_CUSTOM_CLIENTHEADERSFACTORY=123");
+        return myHeaders;
+        
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/headerPropagation12App/src/mpRestClient12/headerPropagation/HeaderPropagationTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/headerPropagation12App/src/mpRestClient12/headerPropagation/HeaderPropagationTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -104,6 +104,20 @@ public class HeaderPropagationTestServlet extends FATServlet {
                    allHeaders.contains("InterfaceHeader=abc"));
         assertTrue("Method level @ClientHeaderParam not sent",
                    allHeaders.contains("MethodHeader=def"));
+    }
+
+    @Test
+    public void testSendCustomHeaderViaFactory(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+
+        String allHeaders = ClientBuilder.newClient()
+                        .target(httpUrl)
+                        .path("/clientHeadersFactory")
+                        .request(MediaType.TEXT_PLAIN_TYPE)
+                        .accept(MediaType.TEXT_PLAIN_TYPE)
+                        .get(String.class);
+        LOG.log(Level.INFO, "allHeaders {0}", allHeaders);
+        assertTrue("Header from CustomClientHeadersFactory not sent",
+                   allHeaders.contains("HEADER_FROM_CUSTOM_CLIENTHEADERSFACTORY=123"));
     }
 
     private String createBasicAuthHeaderValue(String username, String password) throws UnsupportedEncodingException {

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/headerPropagation12App/src/mpRestClient12/headerPropagation/InAppConfigSource.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/headerPropagation12App/src/mpRestClient12/headerPropagation/InAppConfigSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -39,6 +39,10 @@ public class InAppConfigSource implements ConfigSource {
         PROPERTIES.put(baseUriProperty, baseUriValue);
         
         PROPERTIES.put("org.eclipse.microprofile.rest.client.propagateHeaders", "Authorization,MyCustomHeader");
+    }
+
+    public static String getUriForClient(Class<?> clientIntfClass) {
+        return PROPERTIES.get(clientIntfClass.getName() + "/mp-rest/uri");
     }
 
     @Override

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/headerPropagation12App/src/mpRestClient12/headerPropagation/Resource.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/headerPropagation12App/src/mpRestClient12/headerPropagation/Resource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -80,6 +80,18 @@ public class Resource extends Application {
         LOG.info("clientHeaderParamClient()");
         return chpClient.normalMethod();
     }
+
+    @GET
+    @Path("/clientHeadersFactory")
+    public String clientHeadersFactory() throws Exception {
+        LOG.info("clientHeadersFactory()");
+        String baseUri = InAppConfigSource.getUriForClient(Client.class);
+        ClientHeadersFactoryClient c = RestClientBuilder.newBuilder()
+                                                        .baseUri(URI.create(baseUri))
+                                                        .build(ClientHeadersFactoryClient.class);
+        return c.normalMethod();
+    }
+
     @GET
     @Path("normal")
     public String normalMethod() {


### PR DESCRIPTION
Tests that MP Rest Client headers factories are used when specified in the `@RegisterClientHeaders` annotation on the client interface.