### PR TITLE
Issue #10279 set oracle.jdbc.timezoneAsRegion to false.

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corporation and others.
+ * Copyright (c) 2016, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@ package com.ibm.ws.jdbc.fat.oracle;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Properties;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -25,6 +26,7 @@ import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
+import oracle.jdbc.pool.OracleDataSource;
 import web.OracleTestServlet;
 
 @RunWith(FATRunner.class)
@@ -64,7 +66,18 @@ public class OracleTest extends FATServletClient {
     }
     
     private static void initDatabaseTables() throws SQLException {
-    	try (Connection conn = FATSuite.oracle.createConnection("")) {
+		Properties connProps = new Properties();
+		// This property prevents "ORA-01882: timezone region not found" errors due to the Oracle DB not understanding 
+		// some time zones(specifically those used by our RHEL 6 test systems).
+		connProps.put("oracle.jdbc.timezoneAsRegion", "false"); 
+		
+		OracleDataSource ds = new OracleDataSource();
+		ds.setConnectionProperties(connProps);
+		ds.setUser(FATSuite.oracle.getUsername());
+		ds.setPassword(FATSuite.oracle.getPassword());
+		ds.setURL(FATSuite.oracle.getJdbcUrl());
+		
+    	try (Connection conn = ds.getConnection()){
             Statement stmt = conn.createStatement();
             
             //Create MYTABLE for OracleTest.class

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ucp/jvm.options
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle.ucp/jvm.options
@@ -1,0 +1,1 @@
+-Doracle.jdbc.timezoneAsRegion=false

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle/jvm.options
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle/jvm.options
@@ -1,0 +1,1 @@
+-Doracle.jdbc.timezoneAsRegion=false


### PR DESCRIPTION
Setting oracle.jdbc.timezoneAsRegion to false prevents "ORA-01882: timezone region not found" errors due to the Oracle DB not understanding some time zones(specifically those used by our RHEL 6 test systems).

Pull fixes #10279