### PR TITLE
Sync ResolveFileAction and add trace

### DIFF
--- a/dev/com.ibm.ws.jsfContainer_fat_2.2/publish/servers/jsf.container.2.2_fat/bootstrap.properties
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.2/publish/servers/jsf.container.2.2_fat/bootstrap.properties
@@ -9,4 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jsf.*=all:com.ibm.ws.jsf.container=all
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jsf.*=all:com.ibm.ws.jsf.container=all:com.ibm.ws.app.manager.*=all

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/servers/jsf.container.2.3_fat/bootstrap.properties
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/servers/jsf.container.2.3_fat/bootstrap.properties
@@ -9,4 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jsf.*=all:com.ibm.ws.jsf.container=all
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.jsf.*=all:com.ibm.ws.jsf.container=all:com.ibm.ws.app.manager=all


### PR DESCRIPTION
Ensures that ResolveFileAction only operates in a valid state and adds some trace to JSF buckets. 