### PR TITLE
beta config for EJB timer fail over

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/l10n/metatype.properties
@@ -41,7 +41,7 @@ jndiName=JNDI name
 jndiName.desc=JNDI name.
 
 missedTaskThreshold=Missed task threshold for fail over
-missedTaskThreshold.desc=Amount of time beyond a task execution's expected start to reserve for running it. Other members are prevented from running the task prior to the expiration of this interval. If the interval elapses without successful execution of the task, then the task execution is considered to have been missed, enabling another member to attempt to run it. This enables fail over.
+missedTaskThreshold.desc=Amount of time beyond the expected start of a task execution to reserve for running it. Other members are prevented from running the task before the expiration of this interval. If the interval elapses without successful execution of the task, then the task execution is considered missed, enabling another member to attempt to run it. This enables fail over.
 
 pollInterval=Poll interval
 pollInterval.desc=Interval at which the executor looks for tasks in the persistent store to run. If unspecified and fail over is enabled, a poll interval is automatically computed. If fail over is not enabled, the default is -1, which disables all polling after the initial poll.

--- a/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -40,14 +40,17 @@ initialPollDelay.desc=Duration of time to wait before this instance might poll t
 jndiName=JNDI name
 jndiName.desc=JNDI name.
 
+missedTaskThreshold=Missed task threshold for fail over
+missedTaskThreshold.desc=Amount of time beyond a task execution's expected start to reserve for running it. Other members are prevented from running the task prior to the expiration of this interval. If the interval elapses without successful execution of the task, then the task execution is considered to have been missed, enabling another member to attempt to run it. This enables fail over.
+
 pollInterval=Poll interval
-pollInterval.desc=Interval between polling for tasks to run. A value of -1 disables all polling after the initial poll.
+pollInterval.desc=Interval at which the executor looks for tasks in the persistent store to run. If unspecified and fail over is enabled, a poll interval is automatically computed. If fail over is not enabled, the default is -1, which disables all polling after the initial poll.
 
 pollSize=Poll size
 pollSize.desc=The maximum number of task entries to find when polling the persistent store for tasks to run. If unspecified, there is no limit.
 
 retryInterval=Retry interval
-retryInterval.desc=The amount of time that must pass between the second and subsequent consecutive retries of a failed task.  The first retry occurs immediately, regardless of the value of this attribute.
+retryInterval.desc=The amount of time that must pass between consecutive retries of a failed task. When fail over is enabled, the first retry occurs after the interval. When fail over is not enabled, the first retry occurs immediately. In the absence of a configured value, a default is used. If fail over is enabled, the default retry interval is computed from the poll interval and the missed task threshold. If fail over is not enabled, the default is 1 minute.
 
 retryLimit=Retry limit
 retryLimit.desc=Limit of consecutive retries for a task that has failed or rolled back, after which the task is considered permanently failed and does not attempt further retries. A value of -1 allows for unlimited retries.

--- a/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017,2019 IBM Corporation and others.
+    Copyright (c) 2017,2020 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -26,10 +26,10 @@
   <AD id="enableTaskExecution"               type="Boolean" default="true" name="%enableTaskExecution" description="%enableTaskExecution.desc"/>
   <AD id="initialPollDelay"                  type="String"  default="0" ibm:type="duration" name="%initialPollDelay" description="%initialPollDelay.desc"/>
   <AD id="jndiName"                          type="String"  required="false" ibm:unique="jndiName" name="internal" description="internal use only"/>
-  <AD id="missedTaskThreshold"               type="String"  default="-1" ibm:type="duration(s)" name="internal" description="internal use only"/>
-  <AD id="pollInterval"                      type="String"  default="-1" ibm:type="duration" name="%pollInterval" description="%pollInterval.desc"/>
+  <AD id="missedTaskThreshold"               type="String"  ibm:beta="true" default="-1" ibm:type="duration(s)" name="%missedTaskThreshold" description="%missedTaskThreshold.desc"/>
+  <AD id="pollInterval"                      type="String"  required="false" ibm:type="duration" name="%pollInterval" description="%pollInterval.desc"/>
   <AD id="pollSize"                          type="Integer" required="false" min="1" name="%pollSize" description="%pollSize.desc"/>
-  <AD id="retryInterval"                     type="String"  default="1m" ibm:type="duration" name="%retryInterval" description="%retryInterval.desc"/>
+  <AD id="retryInterval"                     type="String"  required="false" ibm:type="duration" name="%retryInterval" description="%retryInterval.desc"/>
   <AD id="retryLimit"                        type="Short"   default="10" min="-1" max="10000" name="%retryLimit" description="%retryLimit.desc"/>
   <AD id="service.ranking"                   type="Integer" default="-4000" name="internal" description="internal use only"/>
   <AD id="taskStoreRef"                      type="String"  default="defaultDatabaseStore" ibm:type="pid" ibm:reference="com.ibm.ws.persistence.databaseStore" name="%taskStore" description="%taskStore.desc"/>

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/InvokerTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/InvokerTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -116,10 +116,8 @@ public class InvokerTask implements Runnable, Synchronization {
     /**
      * In a new transaction, updates the database with the new failure count (or autopurges the task).
      * The first failure should always be retried immediately.
-     * For subsequent failures, check the failureLimit and failureRetryInterval to determine if we should
+     * For subsequent failures, check the retryLimit and retryInterval to determine if we should
      * retry, and how long we should wait before doing so.
-     * In the future, when there is support for a controller, we might want to give up the task and
-     * ask another instance to try it.
      *
      * @param failure                 failure of the task itself or of processing related to the task, such as Trigger.getNextRunTime
      * @param loader                  class loader that can load the task and any exceptions that it might raise

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/test-applications/failover1servApp/src/failover1serv/web/Failover1ServerTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/test-applications/failover1servApp/src/failover1serv/web/Failover1ServerTestServlet.java
@@ -310,7 +310,7 @@ public class Failover1ServerTestServlet extends FATServlet {
             long taskId = Long.valueOf(taskIdString);
             // The only way to find the value stored in a task's PARTN column is to query the database
             try (Connection con = ds.getConnection()) {
-                // querying only EXECUTOR and ignoring HOSTANME, USERDIR, LSERVER columns because there is only one instance
+                // querying only EXECUTOR and ignoring HOSTNAME, USERDIR, LSERVER columns because there is only one instance
                 PreparedStatement st = con.prepareStatement("SELECT ID FROM WLPPART WHERE EXECUTOR=?");
                 st.setString(1, "persistentExecRFR");
                 ResultSet result = st.executeQuery();


### PR DESCRIPTION
Add metatype and translatable names/descriptions for the property that will gate the beta capability for EJB timer fail over.  Also, updates a couple of other related properties, maintaining compatibility with the existing single-server mode.