### PR TITLE
Fix wsat.recovery_fat component to build in eclipse

### DIFF
--- a/dev/com.ibm.ws.wsat.recovery_fat/.classpath
+++ b/dev/com.ibm.ws.wsat.recovery_fat/.classpath
@@ -1,19 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
-	<classpathentry kind="src" path="test-applications/wsatAppOptional.war/src"/>
-	<classpathentry kind="src" path="test-bundles/wsatfat/src"/>
-	<classpathentry kind="src" path="test-applications/wsatEJBCDIApp.war/src"/>
-	<classpathentry kind="src" path="test-applications/wsatApp.war/src"/>
-	<classpathentry kind="src" path="test-applications/threadedClient.war/src"/>
-	<classpathentry kind="src" path="test-applications/threadedServer.war/src"/>
-	<classpathentry kind="src" path="test-applications/LPSClient.war/src"/>
-	<classpathentry kind="src" path="test-applications/LPSServer.war/src"/>
-	<classpathentry kind="src" path="test-applications/simpleServer.war/src"/>
-	<classpathentry kind="src" path="test-applications/simpleClient.war/src"/>
-	<classpathentry kind="src" path="test-applications/oneway.war/src"/>
-	<classpathentry kind="src" path="test-applications/endtoend.war/src"/>
-	<classpathentry kind="src" path="test-applications/assertion.war/src"/>
+	<classpathentry kind="src" path="test-applications/recoveryClient.war/src"/>
+	<classpathentry kind="src" path="test-applications/recoveryServer.war/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>


### PR DESCRIPTION
- Remove non existent source directories and add the right ones for the
fat test suite.
