### PR TITLE
enforce limits on configured duration values

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/l10n/metatype.properties
@@ -41,7 +41,7 @@ jndiName=JNDI name
 jndiName.desc=JNDI name.
 
 missedTaskThreshold=Missed task threshold for fail over
-missedTaskThreshold.desc=Amount of time beyond a task execution's expected start to reserve for running it. Other members are prevented from running the task prior to the expiration of this interval. If the interval elapses without successful execution of the task, then the task execution is considered to have been missed, enabling another member to attempt to run it. This enables fail over.
+missedTaskThreshold.desc=Amount of time beyond the expected start of a task execution to reserve for running it. Other members are prevented from running the task before the expiration of this interval. If the interval elapses without successful execution of the task, then the task execution is considered missed, enabling another member to attempt to run it. This enables fail over.
 
 pollInterval=Poll interval
 pollInterval.desc=Interval at which the executor looks for tasks in the persistent store to run. If unspecified and fail over is enabled, a poll interval is automatically computed. If fail over is not enabled, the default is -1, which disables all polling after the initial poll.

--- a/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -40,14 +40,17 @@ initialPollDelay.desc=Duration of time to wait before this instance might poll t
 jndiName=JNDI name
 jndiName.desc=JNDI name.
 
+missedTaskThreshold=Missed task threshold for fail over
+missedTaskThreshold.desc=Amount of time beyond a task execution's expected start to reserve for running it. Other members are prevented from running the task prior to the expiration of this interval. If the interval elapses without successful execution of the task, then the task execution is considered to have been missed, enabling another member to attempt to run it. This enables fail over.
+
 pollInterval=Poll interval
-pollInterval.desc=Interval between polling for tasks to run. A value of -1 disables all polling after the initial poll.
+pollInterval.desc=Interval at which the executor looks for tasks in the persistent store to run. If unspecified and fail over is enabled, a poll interval is automatically computed. If fail over is not enabled, the default is -1, which disables all polling after the initial poll.
 
 pollSize=Poll size
 pollSize.desc=The maximum number of task entries to find when polling the persistent store for tasks to run. If unspecified, there is no limit.
 
 retryInterval=Retry interval
-retryInterval.desc=The amount of time that must pass between the second and subsequent consecutive retries of a failed task.  The first retry occurs immediately, regardless of the value of this attribute.
+retryInterval.desc=The amount of time that must pass between consecutive retries of a failed task. When fail over is enabled, the first retry occurs after the interval. When fail over is not enabled, the first retry occurs immediately. In the absence of a configured value, a default is used. If fail over is enabled, the default retry interval is computed from the poll interval and the missed task threshold. If fail over is not enabled, the default is 1 minute.
 
 retryLimit=Retry limit
 retryLimit.desc=Limit of consecutive retries for a task that has failed or rolled back, after which the task is considered permanently failed and does not attempt further retries. A value of -1 allows for unlimited retries.

--- a/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017,2019 IBM Corporation and others.
+    Copyright (c) 2017,2020 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -26,10 +26,10 @@
   <AD id="enableTaskExecution"               type="Boolean" default="true" name="%enableTaskExecution" description="%enableTaskExecution.desc"/>
   <AD id="initialPollDelay"                  type="String"  default="0" ibm:type="duration" name="%initialPollDelay" description="%initialPollDelay.desc"/>
   <AD id="jndiName"                          type="String"  required="false" ibm:unique="jndiName" name="internal" description="internal use only"/>
-  <AD id="missedTaskThreshold"               type="String"  default="-1" ibm:type="duration(s)" name="internal" description="internal use only"/>
-  <AD id="pollInterval"                      type="String"  default="-1" ibm:type="duration" name="%pollInterval" description="%pollInterval.desc"/>
+  <AD id="missedTaskThreshold"               type="String"  ibm:beta="true" default="-1" ibm:type="duration(s)" name="%missedTaskThreshold" description="%missedTaskThreshold.desc"/>
+  <AD id="pollInterval"                      type="String"  required="false" ibm:type="duration" name="%pollInterval" description="%pollInterval.desc"/>
   <AD id="pollSize"                          type="Integer" required="false" min="1" name="%pollSize" description="%pollSize.desc"/>
-  <AD id="retryInterval"                     type="String"  default="1m" ibm:type="duration" name="%retryInterval" description="%retryInterval.desc"/>
+  <AD id="retryInterval"                     type="String"  required="false" ibm:type="duration" name="%retryInterval" description="%retryInterval.desc"/>
   <AD id="retryLimit"                        type="Short"   default="10" min="-1" max="10000" name="%retryLimit" description="%retryLimit.desc"/>
   <AD id="service.ranking"                   type="Integer" default="-4000" name="internal" description="internal use only"/>
   <AD id="taskStoreRef"                      type="String"  default="defaultDatabaseStore" ibm:type="pid" ibm:reference="com.ibm.ws.persistence.databaseStore" name="%taskStore" description="%taskStore.desc"/>

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/InvokerTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/InvokerTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -116,10 +116,8 @@ public class InvokerTask implements Runnable, Synchronization {
     /**
      * In a new transaction, updates the database with the new failure count (or autopurges the task).
      * The first failure should always be retried immediately.
-     * For subsequent failures, check the failureLimit and failureRetryInterval to determine if we should
+     * For subsequent failures, check the retryLimit and retryInterval to determine if we should
      * retry, and how long we should wait before doing so.
-     * In the future, when there is support for a controller, we might want to give up the task and
-     * ask another instance to try it.
      *
      * @param failure                 failure of the task itself or of processing related to the task, such as Trigger.getNextRunTime
      * @param loader                  class loader that can load the task and any exceptions that it might raise

--- a/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/PersistentExecutorWithFailoverEnabledTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/PersistentExecutorWithFailoverEnabledTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -73,8 +73,10 @@ public class PersistentExecutorWithFailoverEnabledTest extends FATServletClient 
         originalConfig = server.getServerConfiguration();
         ServerConfiguration config = originalConfig.clone();
         PersistentExecutor myScheduler = config.getPersistentExecutors().getBy("jndiName", "concurrent/myScheduler");
-        myScheduler.setPollInterval("3h"); // the test case does not expect polling, so set a large value that will never be reached
-        myScheduler.setMissedTaskThreshold("1m");
+        myScheduler.setPollInterval("2h30m"); // the test case does not expect polling, so set a large value that will never be reached
+        myScheduler.setRetryInterval("6s");
+        myScheduler.setMissedTaskThreshold("6s");
+        myScheduler.setExtraAttribute("ignore.minimum.for.test.use.only", "true");
         server.updateServerConfiguration(config);
 
         server.startServer();

--- a/dev/com.ibm.ws.concurrent.persistent_fat_compat/fat/src/com/ibm/ws/concurrent/persistent/fat/compat/PersistentExecutorCompatibilityWithFailoverEnabledTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_compat/fat/src/com/ibm/ws/concurrent/persistent/fat/compat/PersistentExecutorCompatibilityWithFailoverEnabledTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -62,9 +62,12 @@ public class PersistentExecutorCompatibilityWithFailoverEnabledTest {
 
         PersistentExecutor myExecutor = config.getPersistentExecutors().getBy("jndiName", "concurrent/myExecutor");
         myExecutor.setMissedTaskThreshold("4s");
+        myExecutor.setExtraAttribute("ignore.minimum.for.test.use.only", "true");
 
         PersistentExecutor mySchedulerWithContext = config.getPersistentExecutors().getBy("jndiName", "concurrent/mySchedulerWithContext");
         mySchedulerWithContext.setMissedTaskThreshold("1m14s");
+        mySchedulerWithContext.setExtraAttribute("ignore.minimum.for.test.use.only", "true");
+
 
         // config.getEJBContainer().getTimerService() lacks a way to get to the nested persistentExecutor, so this is left as is.
 

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/fat/src/com/ibm/ws/concurrent/persistent/fat/errorpaths/PersistentExecutorErrorPathsTestWithFailoverEnabledNoPolling.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/fat/src/com/ibm/ws/concurrent/persistent/fat/errorpaths/PersistentExecutorErrorPathsTestWithFailoverEnabledNoPolling.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -96,8 +96,9 @@ public class PersistentExecutorErrorPathsTestWithFailoverEnabledNoPolling {
         originalConfig = server.getServerConfiguration();
         ServerConfiguration config = originalConfig.clone();
         PersistentExecutor persistentExecutor = config.getPersistentExecutors().getBy("jndiName", "concurrent/myScheduler");
+        persistentExecutor.setExtraAttribute("ignore.minimum.for.test.use.only", "true");
         persistentExecutor.setInitialPollDelay("-1");
-        persistentExecutor.setMissedTaskThreshold("15s");
+        persistentExecutor.setMissedTaskThreshold("4s");
         config.getDataSources().getById("SchedDB").getConnectionManagers().get(0).setMaxPoolSize("10");
         server.updateServerConfiguration(config);
 

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/PersistentErrorTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/PersistentErrorTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -32,6 +32,7 @@ import javax.enterprise.concurrent.AbortedException;
 import javax.enterprise.concurrent.ManagedTask;
 import javax.enterprise.concurrent.SkippedException;
 import javax.enterprise.concurrent.Trigger;
+import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -317,6 +318,19 @@ public class PersistentErrorTestServlet extends HttpServlet {
             SharedFailingTask.clear();
         }
 
+    }
+
+    /**
+     * testMissedTaskThresholdExceedsMaximum - attempt to use a persistent executor where the missedTaskThreshold value exceeds
+     * the maximum allowed. Expect IllegalArgumentException with a translatable message.
+     */
+    public void testMissedTaskThresholdExceedsMaximum(PrintWriter out) throws Exception {
+        try {
+            PersistentExecutor misconfiguredExecutor = InitialContext.doLookup("concurrent/exceedsMaxMissedTaskThreshold");
+            throw new Exception("Should not be able to obtain misconfigured persistentExecutor where missedTaskThreshold value exceeds the maximum allowed " + misconfiguredExecutor);
+        } catch (NamingException x) {
+            // expected
+        }
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent.persistent_fat_execdisabled/fat/src/com/ibm/ws/concurrent/persistent/fat/execdisabled/PersistentExecutorExecutionDisabledTestWithFailoverEnabled.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_execdisabled/fat/src/com/ibm/ws/concurrent/persistent/fat/execdisabled/PersistentExecutorExecutionDisabledTestWithFailoverEnabled.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -100,6 +100,7 @@ public class PersistentExecutorExecutionDisabledTestWithFailoverEnabled {
         ServerConfiguration config = originalConfig.clone();
         PersistentExecutor persistentExecutor = config.getPersistentExecutors().getBy("jndiName", "concurrent/myScheduler");
         persistentExecutor.setMissedTaskThreshold("6s");
+        persistentExecutor.setExtraAttribute("ignore.minimum.for.test.use.only", "true");
         server.updateServerConfiguration(config);
 
         ShrinkHelper.defaultDropinApp(server, APP_NAME, "web");

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/fat/src/com/ibm/ws/concurrent/persistent/fat/failover1serv/Failover1ServerTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/fat/src/com/ibm/ws/concurrent/persistent/fat/failover1serv/Failover1ServerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -167,6 +167,7 @@ public class Failover1ServerTest extends FATServletClient {
             persistentExec3.setPollInterval("2s");
             persistentExec3.setPollSize("4");
             persistentExec3.setMissedTaskThreshold("3s");
+            persistentExec3.setExtraAttribute("ignore.minimum.for.test.use.only", "true");
             config.getPersistentExecutors().add(persistentExec3);
 
             PersistentExecutor persistentExec4 = new PersistentExecutor();
@@ -174,6 +175,7 @@ public class Failover1ServerTest extends FATServletClient {
             persistentExec4.setPollInterval("2s");
             persistentExec4.setPollSize("4");
             persistentExec4.setMissedTaskThreshold("3s");
+            persistentExec4.setExtraAttribute("ignore.minimum.for.test.use.only", "true");
             config.getPersistentExecutors().add(persistentExec4);
 
             PersistentExecutor persistentExec5 = new PersistentExecutor();
@@ -181,6 +183,7 @@ public class Failover1ServerTest extends FATServletClient {
             persistentExec5.setPollInterval("2s");
             persistentExec5.setPollSize("4");
             persistentExec5.setMissedTaskThreshold("3s");
+            persistentExec5.setExtraAttribute("ignore.minimum.for.test.use.only", "true");
             config.getPersistentExecutors().add(persistentExec5);
 
             server.setMarkToEndOfLog();
@@ -260,18 +263,21 @@ public class Failover1ServerTest extends FATServletClient {
             persistentExec3.setId("persistentExec3");
             persistentExec3.setPollInterval("1s500ms");
             persistentExec3.setMissedTaskThreshold("2s");
+            persistentExec3.setExtraAttribute("ignore.minimum.for.test.use.only", "true");
             config.getPersistentExecutors().add(persistentExec3);
 
             PersistentExecutor persistentExec4 = new PersistentExecutor();
             persistentExec4.setId("persistentExec4");
             persistentExec4.setPollInterval("1s500ms");
             persistentExec4.setMissedTaskThreshold("2s");
+            persistentExec4.setExtraAttribute("ignore.minimum.for.test.use.only", "true");
             config.getPersistentExecutors().add(persistentExec4);
 
             PersistentExecutor persistentExec5 = new PersistentExecutor();
             persistentExec5.setId("persistentExec5");
             persistentExec5.setPollInterval("1s500ms");
             persistentExec5.setMissedTaskThreshold("2s");
+            persistentExec5.setExtraAttribute("ignore.minimum.for.test.use.only", "true");
             config.getPersistentExecutors().add(persistentExec5);
 
             server.setMarkToEndOfLog();
@@ -351,6 +357,7 @@ public class Failover1ServerTest extends FATServletClient {
             persistentExec1.setInitialPollDelay("200ms");
             persistentExec1.setPollInterval("1s500ms");
             persistentExec1.setMissedTaskThreshold("2s");
+            persistentExec1.setExtraAttribute("ignore.minimum.for.test.use.only", "true");
             server.setMarkToEndOfLog();
             server.updateServerConfiguration(config);
             server.waitForConfigUpdateInLogUsingMark(APP_NAMES);
@@ -385,7 +392,7 @@ public class Failover1ServerTest extends FATServletClient {
         PersistentExecutor persistentExec1 = config.getPersistentExecutors().getById("persistentExec1");
         persistentExec1.setMissedTaskThreshold(null);
         PersistentExecutor persistentExec2 = config.getPersistentExecutors().getById("persistentExec2");
-        persistentExec2.setMissedTaskThreshold("5h"); // even though this value is unreasonably long, it does not impact the ability to take over an unassigned task
+        persistentExec2.setMissedTaskThreshold("2h"); // even though this value is unreasonably long, it does not impact the ability to take over an unassigned task
 
         server.setMarkToEndOfLog();
         server.updateServerConfiguration(config);

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/publish/servers/com.ibm.ws.concurrent.persistent.fat.failover1serv/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/publish/servers/com.ibm.ws.concurrent.persistent.fat.failover1serv/server.xml
@@ -21,10 +21,11 @@
   <include location="../fatTestPorts.xml"/>
 
   <!-- cannot run tasks -->
-  <persistentExecutor id="persistentExec1" jndiName="persistent/exec1" enableTaskExecution="false" missedTaskThreshold2="10h"/>
+  <persistentExecutor id="persistentExec1" jndiName="persistent/exec1" enableTaskExecution="false" missedTaskThreshold="2h30m"/>
 
   <!-- runs its own tasks and takes late tasks from others -->
-  <persistentExecutor id="persistentExec2" jndiName="persistent/exec2" pollInterval="2s" missedTaskThreshold="3s"/>
+  <persistentExecutor id="persistentExec2" jndiName="persistent/exec2" pollInterval="2s" missedTaskThreshold="3s"
+                      ignore.minimum.for.test.use.only="true"/>
 
   <!-- database for scheduled tasks -->
   <dataSource id="DefaultDataSource">

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/test-applications/failover1servApp/src/failover1serv/web/Failover1ServerTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failover1serv/test-applications/failover1servApp/src/failover1serv/web/Failover1ServerTestServlet.java
@@ -310,7 +310,7 @@ public class Failover1ServerTestServlet extends FATServlet {
             long taskId = Long.valueOf(taskIdString);
             // The only way to find the value stored in a task's PARTN column is to query the database
             try (Connection con = ds.getConnection()) {
-                // querying only EXECUTOR and ignoring HOSTANME, USERDIR, LSERVER columns because there is only one instance
+                // querying only EXECUTOR and ignoring HOSTNAME, USERDIR, LSERVER columns because there is only one instance
                 PreparedStatement st = con.prepareStatement("SELECT ID FROM WLPPART WHERE EXECUTOR=?");
                 st.setString(1, "persistentExecRFR");
                 ResultSet result = st.executeQuery();

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/publish/servers/com.ibm.ws.concurrent.persistent.fat.failovertimers.serverA/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/publish/servers/com.ibm.ws.concurrent.persistent.fat.failovertimers.serverA/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2019,2020 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -21,7 +21,8 @@
 
   <application location="failoverTimersApp.war"/>
 
-  <persistentExecutor id="defaultEJBPersistentTimerExecutor" pollInterval="1s400ms" retryInterval="600ms" missedTaskThreshold="3s"/>
+  <persistentExecutor id="defaultEJBPersistentTimerExecutor" pollInterval="1s400ms" retryInterval="600ms" missedTaskThreshold="3s"
+                      ignore.minimum.for.test.use.only="true"/>
 
   <!-- database for persistent EJB timerss -->
   <dataSource id="DefaultDataSource">

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/publish/servers/com.ibm.ws.concurrent.persistent.fat.failovertimers.serverB/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/publish/servers/com.ibm.ws.concurrent.persistent.fat.failovertimers.serverB/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2019,2020 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -21,7 +21,8 @@
 
   <application location="failoverTimersApp.war"/>
 
-  <persistentExecutor id="defaultEJBPersistentTimerExecutor" pollInterval="1s500ms" missedTaskThreshold="3s"/>
+  <persistentExecutor id="defaultEJBPersistentTimerExecutor" pollInterval="1s500ms" missedTaskThreshold="3s"
+                      ignore.minimum.for.test.use.only="true"/>
 
   <!-- database for persistent EJB timerss -->
   <dataSource id="DefaultDataSource">

--- a/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/fat/src/com/ibm/ws/concurrent/persistent/fat/load/LoadTestWithFailoverEnabled.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_loadtest/fat/src/com/ibm/ws/concurrent/persistent/fat/load/LoadTestWithFailoverEnabled.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -56,6 +56,8 @@ public class LoadTestWithFailoverEnabled extends FATServletClient {
         PersistentExecutor myScheduler = config.getPersistentExecutors().getBy("jndiName", "concurrent/myScheduler");
         myScheduler.setPollInterval("1m");
         myScheduler.setMissedTaskThreshold("40s");
+        myScheduler.setExtraAttribute("ignore.minimum.for.test.use.only", "true"); // allows retryInterval and missedTaskThreshold values for test
+
         server.updateServerConfiguration(config);
 
     	ShrinkHelper.defaultDropinApp(server, APP_NAME, "web", "web.task");

--- a/dev/com.ibm.ws.concurrent.persistent_fat_locking/fat/src/com/ibm/ws/concurrent/persistent/fat/locking/PXLockTestWithFailoverEnabled.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_locking/fat/src/com/ibm/ws/concurrent/persistent/fat/locking/PXLockTestWithFailoverEnabled.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2019 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -105,6 +105,7 @@ public class PXLockTestWithFailoverEnabled {
         ServerConfiguration config = originalConfig.clone();
         PersistentExecutor myPersistentExecutor = config.getPersistentExecutors().getBy("jndiName", "concurrent/myPersistentExecutor");
         myPersistentExecutor.setMissedTaskThreshold("10s");
+        myPersistentExecutor.setExtraAttribute("ignore.minimum.for.test.use.only", "true");
         server.updateServerConfiguration(config);
 
         //Get driver info

--- a/dev/com.ibm.ws.concurrent.persistent_fat_multiple/fat/src/com/ibm/ws/concurrent/persistent/fat/multiple/MultiplePersistentExecutorsWithFailoverEnabledTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_multiple/fat/src/com/ibm/ws/concurrent/persistent/fat/multiple/MultiplePersistentExecutorsWithFailoverEnabledTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -68,6 +68,8 @@ public class MultiplePersistentExecutorsWithFailoverEnabledTest extends FATServl
         ConfigElementList<PersistentExecutor> executors = failoverEnabledConfig.getPersistentExecutors();
         executors.getById("executor1").setMissedTaskThreshold("15s");
         executors.getById("executor2").setMissedTaskThreshold("16s");
+        executors.getById("executor1").setExtraAttribute("ignore.minimum.for.test.use.only", "true");
+        executors.getById("executor2").setExtraAttribute("ignore.minimum.for.test.use.only", "true");
         server.updateServerConfiguration(failoverEnabledConfig);
 
     	//Start server

--- a/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/fat/src/com/ibm/ws/concurrent/persistent/fat/oneexec/OneExecutorRunsAllWithFailoverEnabledTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_oneexec/fat/src/com/ibm/ws/concurrent/persistent/fat/oneexec/OneExecutorRunsAllWithFailoverEnabledTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -118,6 +118,9 @@ public class OneExecutorRunsAllWithFailoverEnabledTest {
         executors.getById("executorA").setMissedTaskThreshold("21s");
         executors.getById("executorB").setMissedTaskThreshold("22s");
         executors.getById("executorC").setMissedTaskThreshold("23s");
+        executors.getById("executorA").setExtraAttribute("ignore.minimum.for.test.use.only", "true");
+        executors.getById("executorB").setExtraAttribute("ignore.minimum.for.test.use.only", "true");
+        executors.getById("executorC").setExtraAttribute("ignore.minimum.for.test.use.only", "true");
         server.updateServerConfiguration(failoverConfig);
 
         server.startServer();

--- a/dev/com.ibm.ws.concurrent.persistent_fat_retry/fat/src/com/ibm/ws/concurrent/persistent/fat/retry/FailureRetryTests.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_retry/fat/src/com/ibm/ws/concurrent/persistent/fat/retry/FailureRetryTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -249,8 +249,9 @@ public class FailureRetryTests {
     public void testRetryTwiceDefaultIntervalWithFailoverEnabled() throws Exception {
         ServerConfiguration config = updateConfiguration("2", null);
         PersistentExecutor myScheduler = config.getPersistentExecutors().getBy("jndiName", "concurrent/myScheduler");
-        myScheduler.setPollInterval("3h30m"); // test does not need polling, but the fail over feature requires it, so set to a large value
+        myScheduler.setPollInterval("1h30m"); // test does not need polling, but the fail over feature requires it, so set to a large value
         myScheduler.setMissedTaskThreshold("30s");
+        myScheduler.setExtraAttribute("ignore.minimum.for.test.use.only", "true");
         server.updateServerConfiguration(config);
 
         server.startServer("testRetryTwiceDefaultIntervalFE.log");
@@ -333,8 +334,9 @@ public class FailureRetryTests {
     public void testRetrySixWithTwoPassesWithFailoverEnabled() throws Exception {
         ServerConfiguration config = updateConfiguration("3", null);
         PersistentExecutor myScheduler = config.getPersistentExecutors().getBy("jndiName", "concurrent/myScheduler");
-        myScheduler.setPollInterval("3h31m"); // test does not need polling, but the fail over feature requires it, so set to a large value
+        myScheduler.setPollInterval("1h31m"); // test does not need polling, but the fail over feature requires it, so set to a large value
         myScheduler.setMissedTaskThreshold("31s");
+        myScheduler.setExtraAttribute("ignore.minimum.for.test.use.only", "true");
         server.updateServerConfiguration(config);
 
         server.startServer("testRetrySixWithTwoPassesFE.log");
@@ -368,8 +370,9 @@ public class FailureRetryTests {
     public void testRetryFourWithOneSkipWithFailoverEnabled() throws Exception {
         ServerConfiguration config = updateConfiguration("3", null);
         PersistentExecutor myScheduler = config.getPersistentExecutors().getBy("jndiName", "concurrent/myScheduler");
-        myScheduler.setPollInterval("3h32m"); // test does not need polling, but the fail over feature requires it, so set to a large value
+        myScheduler.setPollInterval("1h32m"); // test does not need polling, but the fail over feature requires it, so set to a large value
         myScheduler.setMissedTaskThreshold("32s");
+        myScheduler.setExtraAttribute("ignore.minimum.for.test.use.only", "true");
         server.updateServerConfiguration(config);
 
         server.startServer("testRetryFourWithOneSkipFE.log");
@@ -403,8 +406,9 @@ public class FailureRetryTests {
     public void testRetryFourWithOneSkipFailWithFailoverEnabled() throws Exception {
         ServerConfiguration config = updateConfiguration("3", null);
         PersistentExecutor myScheduler = config.getPersistentExecutors().getBy("jndiName", "concurrent/myScheduler");
-        myScheduler.setPollInterval("3h33m"); // test does not need polling, but the fail over feature requires it, so set to a large value
+        myScheduler.setPollInterval("1h33m"); // test does not need polling, but the fail over feature requires it, so set to a large value
         myScheduler.setMissedTaskThreshold("33s");
+        myScheduler.setExtraAttribute("ignore.minimum.for.test.use.only", "true");
         server.updateServerConfiguration(config);
 
         server.startServer("testRetryFourWithOneSkipFailFE.log");
@@ -440,8 +444,9 @@ public class FailureRetryTests {
     public void testRetryFourTimesAutoPurgeAlwaysWithFailoverEnabled() throws Exception {
         ServerConfiguration config = updateConfiguration("3", null);
         PersistentExecutor myScheduler = config.getPersistentExecutors().getBy("jndiName", "concurrent/myScheduler");
-        myScheduler.setPollInterval("3h34m"); // test does not need polling, but the fail over feature requires it, so set to a large value
+        myScheduler.setPollInterval("1h34m"); // test does not need polling, but the fail over feature requires it, so set to a large value
         myScheduler.setMissedTaskThreshold("34s");
+        myScheduler.setExtraAttribute("ignore.minimum.for.test.use.only", "true");
         server.updateServerConfiguration(config);
 
         server.startServer("testRetryFourTimesAutoPurgeAlwaysFE.log");
@@ -545,6 +550,7 @@ public class FailureRetryTests {
         // In this test, polling matters because task execution might still be claimed by server instance 1 when server instance 3 comes up.
         myScheduler.setPollInterval("3s");
         myScheduler.setMissedTaskThreshold("25s");
+        myScheduler.setExtraAttribute("ignore.minimum.for.test.use.only", "true");
         server.updateServerConfiguration(cfg);
 
         server.startServer("testRetryCountWrapFE-1.log");


### PR DESCRIPTION
Enforce upper/lower limits on various configured duration values (missedTaskThreshold, pollInterval, retryInterval) when fail over is enabled to help ensure the user is running with reasonable values.  Translatable message will be added in a separate pull, once this part is reviewed and working.