### PR TITLE
Fix FULL FAT test case URIs for the Windows platform

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheErrorPathsTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheErrorPathsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheErrorPathsTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheErrorPathsTest.java
@@ -197,7 +197,7 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
     @Test
     public void testInvalidURI() throws Exception {
         // Start the server with invalid httpSessionCache uri
-        String invalidHazelcastURI = "file:" + new java.io.File(server.getUserDir() + "/servers/sessionCacheServer/server.xml").getAbsolutePath();
+        String invalidHazelcastURI = "file:///" + new java.io.File(server.getUserDir() + "/servers/sessionCacheServer/server.xml").getAbsolutePath();
         ServerConfiguration config = savedConfig.clone();
         config.getHttpSessionCaches().get(0).setUri(invalidHazelcastURI);
         server.updateServerConfiguration(config);
@@ -208,7 +208,7 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
             run("testSessionCacheNotAvailable", session);
 
             // Correct the URI
-            String validHazelcastURI = "file:" + new java.io.File(server.getUserDir() + "/shared/resources/hazelcast/" + hazelcastConfigFile).getAbsolutePath();
+            String validHazelcastURI = "file:///" + new java.io.File(server.getUserDir() + "/shared/resources/hazelcast/" + hazelcastConfigFile).getAbsolutePath();
             config.getHttpSessionCaches().get(0).setUri(validHazelcastURI);
             server.setMarkToEndOfLog();
             server.updateServerConfiguration(config);
@@ -402,23 +402,23 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
             assertTrue(dumpInfo, lines.contains("  is statistics enabled? true"));
             assertFalse(dumpInfo, lines.contains("  is statistics enabled? false"));
 
-            assertTrue(dumpInfo, lines.parallelStream().anyMatch(s -> s
-                            .matches("  average put time:    \\d+\\.\\d+ms")));
+            assertTrue(dumpInfo, lines.parallelStream()
+                            .anyMatch(s -> s.matches("  average put time:    \\d+\\.\\d+ms")));
 
-            assertTrue(dumpInfo, lines.parallelStream().anyMatch(s -> s
-                            .matches("  cache gets:      \\d+")));
+            assertTrue(dumpInfo, lines.parallelStream()
+                            .anyMatch(s -> s.matches("  cache gets:      \\d+")));
 
-            assertTrue(dumpInfo, lines.parallelStream().anyMatch(s -> s
-                            .matches("  cache hit percentage:  \\d+\\.\\d+%")));
+            assertTrue(dumpInfo, lines.parallelStream()
+                            .anyMatch(s -> s.matches("  cache hit percentage:  \\d+\\.\\d+%")));
 
-            assertTrue(dumpInfo, lines.parallelStream().anyMatch(s -> s
-                            .matches("  cache miss percentage: \\d+\\.\\d+%")));
+            assertTrue(dumpInfo, lines.parallelStream()
+                            .anyMatch(s -> s.matches("  cache miss percentage: \\d+\\.\\d+%")));
 
-            assertTrue(dumpInfo, lines.parallelStream().anyMatch(s -> s
-                            .matches("    session \\S+: SessionInfo for anonymous created \\d+ accessed \\d+ listeners 0 maxInactive 2100 \\[testServerDumpWithMonitoring1\\]")));
+            assertTrue(dumpInfo, lines.parallelStream()
+                            .anyMatch(s -> s.matches("    session \\S+: SessionInfo for anonymous created \\d+ accessed \\d+ listeners 0 maxInactive 2100 \\[testServerDumpWithMonitoring1\\]")));
 
-            assertTrue(dumpInfo, lines.parallelStream().anyMatch(s -> s
-                            .matches("    session \\S+: SessionInfo for anonymous created \\d+ accessed \\d+ listeners 0 maxInactive 2200 \\[testServerDumpWithMonitoring2\\]")));
+            assertTrue(dumpInfo, lines.parallelStream()
+                            .anyMatch(s -> s.matches("    session \\S+: SessionInfo for anonymous created \\d+ accessed \\d+ listeners 0 maxInactive 2200 \\[testServerDumpWithMonitoring2\\]")));
         } finally {
             run("invalidateSession", session1);
             run("invalidateSession", session2);
@@ -468,14 +468,14 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
 
             assertFalse(dumpInfo, lines.contains("  is statistics enabled? true"));
 
-            assertFalse(dumpInfo, lines.parallelStream().anyMatch(s -> s
-                            .matches("  average put time:.*")));
+            assertFalse(dumpInfo, lines.parallelStream()
+                            .anyMatch(s -> s.matches("  average put time:.*")));
 
-            assertTrue(dumpInfo, lines.parallelStream().anyMatch(s -> s
-                            .matches("    session \\S+: SessionInfo for anonymous created \\d+ accessed \\d+ listeners 0 maxInactive 1900 \\[testServerDumpWithoutMonitoring1\\]")));
+            assertTrue(dumpInfo, lines.parallelStream()
+                            .anyMatch(s -> s.matches("    session \\S+: SessionInfo for anonymous created \\d+ accessed \\d+ listeners 0 maxInactive 1900 \\[testServerDumpWithoutMonitoring1\\]")));
 
-            assertTrue(dumpInfo, lines.parallelStream().anyMatch(s -> s
-                            .matches("    session \\S+: SessionInfo for anonymous created \\d+ accessed \\d+ listeners 0 maxInactive 2000 \\[testServerDumpWithoutMonitoring2\\]")));
+            assertTrue(dumpInfo, lines.parallelStream()
+                            .anyMatch(s -> s.matches("    session \\S+: SessionInfo for anonymous created \\d+ accessed \\d+ listeners 0 maxInactive 2000 \\[testServerDumpWithoutMonitoring2\\]")));
         } finally {
             run("invalidateSession", session1);
             run("invalidateSession", session2);

--- a/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheErrorPathsTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheErrorPathsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheErrorPathsTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config_infinispan/fat/src/com/ibm/ws/session/cache/config/fat/infinispan/SessionCacheErrorPathsTest.java
@@ -192,7 +192,7 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
     @Test
     public void testInvalidURI() throws Exception {
         // Start the server with invalid httpSessionCache uri
-        String invalidInfinispanURI = "file:" + new java.io.File(server.getUserDir() + "/servers/com.ibm.ws.session.cache.fat.config.infinispan/server.xml").getAbsolutePath();
+        String invalidInfinispanURI = "file:///" + new java.io.File(server.getUserDir() + "/servers/com.ibm.ws.session.cache.fat.config.infinispan/server.xml").getAbsolutePath();
         ServerConfiguration config = savedConfig.clone();
         config.getHttpSessionCaches().get(0).setUri(invalidInfinispanURI);
         server.updateServerConfiguration(config);
@@ -203,7 +203,7 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
             run("testSessionCacheNotAvailable", session);
 
             // Correct the URI
-            String validInfinispanURI = "file:" + new java.io.File(server.getUserDir() + "/shared/resources/infinispan10/" + infinispanConfigFile).getAbsolutePath();
+            String validInfinispanURI = "file:///" + new java.io.File(server.getUserDir() + "/shared/resources/infinispan10/" + infinispanConfigFile).getAbsolutePath();
             config.getHttpSessionCaches().get(0).setUri(validInfinispanURI);
             server.setMarkToEndOfLog();
             server.updateServerConfiguration(config);
@@ -396,23 +396,23 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
             assertTrue(dumpInfo, lines.contains("  is statistics enabled? true"));
             assertFalse(dumpInfo, lines.contains("  is statistics enabled? false"));
 
-            assertTrue(dumpInfo, lines.parallelStream().anyMatch(s -> s
-                            .matches("  average put time:    \\d+\\.\\d+ms")));
+            assertTrue(dumpInfo, lines.parallelStream()
+                            .anyMatch(s -> s.matches("  average put time:    \\d+\\.\\d+ms")));
 
-            assertTrue(dumpInfo, lines.parallelStream().anyMatch(s -> s
-                            .matches("  cache gets:      \\d+")));
+            assertTrue(dumpInfo, lines.parallelStream()
+                            .anyMatch(s -> s.matches("  cache gets:      \\d+")));
 
-            assertTrue(dumpInfo, lines.parallelStream().anyMatch(s -> s
-                            .matches("  cache hit percentage:  \\d+\\.\\d+%")));
+            assertTrue(dumpInfo, lines.parallelStream()
+                            .anyMatch(s -> s.matches("  cache hit percentage:  \\d+\\.\\d+%")));
 
-            assertTrue(dumpInfo, lines.parallelStream().anyMatch(s -> s
-                            .matches("  cache miss percentage: \\d+\\.\\d+%")));
+            assertTrue(dumpInfo, lines.parallelStream()
+                            .anyMatch(s -> s.matches("  cache miss percentage: \\d+\\.\\d+%")));
 
-            assertTrue(dumpInfo, lines.parallelStream().anyMatch(s -> s
-                            .matches("    session \\S+: SessionInfo for anonymous created \\d+ accessed \\d+ listeners 0 maxInactive 2100 \\[testServerDumpWithMonitoring1\\]")));
+            assertTrue(dumpInfo, lines.parallelStream()
+                            .anyMatch(s -> s.matches("    session \\S+: SessionInfo for anonymous created \\d+ accessed \\d+ listeners 0 maxInactive 2100 \\[testServerDumpWithMonitoring1\\]")));
 
-            assertTrue(dumpInfo, lines.parallelStream().anyMatch(s -> s
-                            .matches("    session \\S+: SessionInfo for anonymous created \\d+ accessed \\d+ listeners 0 maxInactive 2200 \\[testServerDumpWithMonitoring2\\]")));
+            assertTrue(dumpInfo, lines.parallelStream()
+                            .anyMatch(s -> s.matches("    session \\S+: SessionInfo for anonymous created \\d+ accessed \\d+ listeners 0 maxInactive 2200 \\[testServerDumpWithMonitoring2\\]")));
         } finally {
             run("invalidateSession", session1);
             run("invalidateSession", session2);
@@ -461,14 +461,14 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
 
             assertFalse(dumpInfo, lines.contains("  is statistics enabled? true"));
 
-            assertFalse(dumpInfo, lines.parallelStream().anyMatch(s -> s
-                            .matches("  average put time:.*")));
+            assertFalse(dumpInfo, lines.parallelStream()
+                            .anyMatch(s -> s.matches("  average put time:.*")));
 
-            assertTrue(dumpInfo, lines.parallelStream().anyMatch(s -> s
-                            .matches("    session \\S+: SessionInfo for anonymous created \\d+ accessed \\d+ listeners 0 maxInactive 1900 \\[testServerDumpWithoutMonitoring1\\]")));
+            assertTrue(dumpInfo, lines.parallelStream()
+                            .anyMatch(s -> s.matches("    session \\S+: SessionInfo for anonymous created \\d+ accessed \\d+ listeners 0 maxInactive 1900 \\[testServerDumpWithoutMonitoring1\\]")));
 
-            assertTrue(dumpInfo, lines.parallelStream().anyMatch(s -> s
-                            .matches("    session \\S+: SessionInfo for anonymous created \\d+ accessed \\d+ listeners 0 maxInactive 2000 \\[testServerDumpWithoutMonitoring2\\]")));
+            assertTrue(dumpInfo, lines.parallelStream()
+                            .anyMatch(s -> s.matches("    session \\S+: SessionInfo for anonymous created \\d+ accessed \\d+ listeners 0 maxInactive 2000 \\[testServerDumpWithoutMonitoring2\\]")));
         } finally {
             run("invalidateSession", session1);
             run("invalidateSession", session2);


### PR DESCRIPTION
Modified Infinispan and Hazelcast session cache FAT test method testInvalidURI().  This method is only run during the FULL testing and was missed during the LITE testing.  The testInvalidURI() method constructs the URI manually and uses a slightly different format that was missed during my initial search.  The testInvalidURI() method was changed to include proper formatting for the Windows platform.
Pull fixes #10041

My IDE also reformatted the assertions near the end of the 2 files changed, but no code changes were made to those lines.