### PR TITLE
translatable error messages for invalid config

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/resources/com/ibm/ws/concurrent/persistent/resources/CWWKCMessages.nlsprops
+++ b/dev/com.ibm.ws.concurrent.persistent/resources/com/ibm/ws/concurrent/persistent/resources/CWWKCMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2014, 2015 IBM Corporation and others.
+# Copyright (c) 2014, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -50,6 +50,14 @@ CWWKC1510.retry.limit.reached.rollback.useraction=If the rollbacks or failures a
 CWWKC1511.retry.limit.reached.failed=CWWKC1511W: Persistent executor {0} aborted task {1} because it rolled back or failed {2} consecutive times. The final failure is {3}.
 CWWKC1511.retry.limit.reached.failed.explanation=The task has reached the limit of consecutive retries and will not be attempted again.
 CWWKC1511.retry.limit.reached.failed.useraction=If the failures or rollbacks are unexpected, determine the cause and reschedule the task. If the rollbacks and failures are intermittent, consider increasing the retry limit. 
+
+CWWKC1520.out.of.range=CWWKC1520E: Configured value {0} for {1} is not within the range of {2} to {3}.
+CWWKC1520.out.of.range.explanation=A value that is outside of the allowed range is configured for the specified property.
+CWWKC1520.out.of.range.useraction=Configure a value within the allowed range.
+
+CWWKC1521.less.than.min=CWWKC1521E: Configured value {0} for {1} cannot be less than the configured value for {2}, which is {3}.
+CWWKC1521.less.than.min.explanation=Configuring a larger retryInterval encourages other servers to retry the failed task instead of the server on which it failed.
+CWWKC1521.less.than.min.useraction=Configure a retryInterval that is larger than the missedTaskThreshold.
 
 CWWKC1540.thread.cannot.submit.tasks=CWWKC1540E: You cannot schedule persistent tasks from the current thread context.
 CWWKC1540.thread.cannot.submit.tasks.explanation=Schedule persistent tasks only from a thread that is associated with an application or feature with a serializable class loader identity.

--- a/dev/com.ibm.ws.concurrent.persistent/resources/com/ibm/ws/concurrent/persistent/resources/CWWKCMessages.nlsprops
+++ b/dev/com.ibm.ws.concurrent.persistent/resources/com/ibm/ws/concurrent/persistent/resources/CWWKCMessages.nlsprops
@@ -57,7 +57,7 @@ CWWKC1520.out.of.range.useraction=Configure a value within the allowed range.
 
 CWWKC1521.less.than.min=CWWKC1521E: Configured value {0} for {1} cannot be less than the configured value for {2}, which is {3}.
 CWWKC1521.less.than.min.explanation=Configuring a larger retryInterval encourages other servers to retry the failed task instead of the server on which it failed.
-CWWKC1521.less.than.min.useraction=Configure a retryInterval that is larger than the missedTaskThreshold.
+CWWKC1521.less.than.min.useraction=Configure the retryInterval property so that it is larger than the missedTaskThreshold.
 
 CWWKC1540.thread.cannot.submit.tasks=CWWKC1540E: You cannot schedule persistent tasks from the current thread context.
 CWWKC1540.thread.cannot.submit.tasks.explanation=Schedule persistent tasks only from a thread that is associated with an application or feature with a serializable class loader identity.

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/Config.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/Config.java
@@ -124,18 +124,18 @@ class Config {
         // Range checking on duration values, which cannot be enforced via metatype
         if ((missedTaskThreshold != -1 && !ignoreMin && missedTaskThreshold < 100) || missedTaskThreshold > 9000) // disallow below 100 seconds and above 2.5 hours
             throw new IllegalArgumentException(Tr.formatMessage(tc, "CWWKC1520.out.of.range",
-                                                                "missedTaskThreshold", missedTaskThreshold + "s", "100s", "2h30m"));
+                                                                toString(missedTaskThreshold, TimeUnit.SECONDS), "missedTaskThreshold", "100s", "2h30m"));
         if (initialPollDelay < -1)
             throw new IllegalArgumentException("initialPollDelay: " + initialPollDelay + "ms");
         if (pollInterval < -1 || missedTaskThreshold > 0 && (!ignoreMin && pollInterval < 100000 && pollInterval != -1 || pollInterval > 9000000)) // disallow below 100 seconds and above 2.5 hours
             throw new IllegalArgumentException(Tr.formatMessage(tc, "CWWKC1520.out.of.range",
-                                                                "pollInterval", pollInterval + "ms", "100s", "2h30m"));
+                                                                toString(pollInterval, TimeUnit.MILLISECONDS), "pollInterval", "100s", "2h30m"));
         if (retryInterval < 0)
             throw new IllegalArgumentException("retryInterval: " + retryInterval + "ms");
         else if (missedTaskThreshold > 0 && retryIntrvl != null && retryLimit != 0 && !ignoreMin && retryIntrvl < missedTaskThreshold * 1000)
             throw new IllegalArgumentException(Tr.formatMessage(tc, "CWWKC1521.less.than.min",
-                                                                retryInterval + "ms", "retryInterval",
-                                                                "missedTaskThreshold", missedTaskThreshold + "s"));
+                                                                toString(retryInterval, TimeUnit.MILLISECONDS), "retryInterval",
+                                                                "missedTaskThreshold", toString(missedTaskThreshold, TimeUnit.SECONDS)));
     }
 
     @Override
@@ -164,5 +164,44 @@ class Config {
                         .append(",id=")
                         .append(id)
                         .toString();
+    }
+
+    /**
+     * Display the duration value in the least granular unit possible without losing precision.
+     *
+     * @param duration the duration
+     * @param unit     the units
+     * @return string value for display in messages.
+     */
+    private String toString(long duration, TimeUnit unit) {
+        if (TimeUnit.MILLISECONDS.equals(unit)) {
+            long s = duration / 1000;
+            if (s * 1000 == duration) {
+                duration = s;
+                unit = TimeUnit.SECONDS;
+            }
+        }
+
+        if (TimeUnit.SECONDS.equals(unit)) {
+            long m = duration / 60;
+            if (m * 60 == duration) {
+                duration = m;
+                unit = TimeUnit.MINUTES;
+            }
+        }
+
+        if (TimeUnit.MINUTES.equals(unit)) {
+            long h = duration / 60;
+            if (h * 60 == duration) {
+                duration = h;
+                unit = TimeUnit.HOURS;
+            }
+        }
+
+        return duration + (unit == TimeUnit.MILLISECONDS ? "ms" //
+                        : unit == TimeUnit.SECONDS ? "s" //
+                                        : unit == TimeUnit.MINUTES ? "m" //
+                                                        : unit == TimeUnit.HOURS ? "h" //
+                                                                        : "d");
     }
 }

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/PersistentErrorTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/PersistentErrorTestServlet.java
@@ -321,8 +321,21 @@ public class PersistentErrorTestServlet extends HttpServlet {
     }
 
     /**
+     * testMissedTaskThresholdBelowMinimum - attempt to use a persistent executor where the missedTaskThreshold value is less than
+     * the minimum allowed. The detailed error message that is logged is tested by the caller of this method.
+     */
+    public void testMissedTaskThresholdBelowMinimum(PrintWriter out) throws Exception {
+        try {
+            PersistentExecutor misconfiguredExecutor = InitialContext.doLookup("concurrent/belowMinMissedTaskThreshold");
+            throw new Exception("Should not be able to obtain misconfigured persistentExecutor where the missedTaskThreshold value is less than the minimum allowed " + misconfiguredExecutor);
+        } catch (NamingException x) {
+            // expected
+        }
+    }
+
+    /**
      * testMissedTaskThresholdExceedsMaximum - attempt to use a persistent executor where the missedTaskThreshold value exceeds
-     * the maximum allowed. Expect IllegalArgumentException with a translatable message.
+     * the maximum allowed. The detailed error message that is logged is tested by the caller of this method.
      */
     public void testMissedTaskThresholdExceedsMaximum(PrintWriter out) throws Exception {
         try {
@@ -635,6 +648,32 @@ public class PersistentErrorTestServlet extends HttpServlet {
     }
 
     /**
+     * testPollIntervalBelowMinimum - attempt to use a persistent executor where the pollInterval value is less than
+     * the minimum allowed. The detailed error message that is logged is tested by the caller of this method.
+     */
+    public void testPollIntervalBelowMinimum(PrintWriter out) throws Exception {
+        try {
+            PersistentExecutor misconfiguredExecutor = InitialContext.doLookup("concurrent/belowMinPollInterval");
+            throw new Exception("Should not be able to obtain misconfigured persistentExecutor where the pollInterval value is less than the minimum allowed. " + misconfiguredExecutor);
+        } catch (NamingException x) {
+            // expected
+        }
+    }
+
+    /**
+     * testPollIntervalThresholdExceedsMaximum - attempt to use a persistent executor where the pollInterval value exceeds
+     * the maximum allowed. The detailed error message that is logged is tested by the caller of this method.
+     */
+    public void testPollIntervalExceedsMaximum(PrintWriter out) throws Exception {
+        try {
+            PersistentExecutor misconfiguredExecutor = InitialContext.doLookup("concurrent/exceedsMaxPollInterval");
+            throw new Exception("Should not be able to obtain misconfigured persistentExecutor where the pollInterval value exceeds the maximum allowed " + misconfiguredExecutor);
+        } catch (NamingException x) {
+            // expected
+        }
+    }
+
+    /**
      * Attempt to schedule a task with a predetermined result that declares itself serializable but fails to serialize.
      */
     public void testPredeterminedResultFailsToSerialize(PrintWriter out) throws Exception {
@@ -803,6 +842,19 @@ public class PersistentErrorTestServlet extends HttpServlet {
                 throw new Exception("Task should be attempted exactly 2 times (with the first attempting failing). Instead " + result);
         } finally {
             SharedFailingTask.clear();
+        }
+    }
+
+    /**
+     * testRetryIntervalBelowMissedTaskThreshold - attempt to use a persistent executor where the retryInterval value is less than
+     * the missedTaskThreshold. The detailed error message that is logged is tested by the caller of this method.
+     */
+    public void testRetryIntervalBelowMissedTaskThreshold(PrintWriter out) throws Exception {
+        try {
+            PersistentExecutor misconfiguredExecutor = InitialContext.doLookup("concurrent/retryIntervalBelowMissedTaskThreshold");
+            throw new Exception("Should not be able to obtain misconfigured persistentExecutor where the retryInterval value is less than the missedTaskThreshold. " + misconfiguredExecutor);
+        } catch (NamingException x) {
+            // expected
         }
     }
 


### PR DESCRIPTION
Add translatable error messages explaining the what is incorrect when IllegalArgumentException is raised for duration values that are out of range.