### PR TITLE
Exclude EE6 from openliberty-all zip

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -137,6 +137,23 @@ class PackageLibertyWithFeatures extends DefaultTask {
     }
 }
 
+def testFeatures() {
+    def testFeatures = []
+    def tree = fileTree(dir: "$projectDir/wlp/lib/features", include: '*.mf')
+    tree.each {
+        Scanner scanner = new Scanner(it)
+        String line
+        while(scanner.hasNextLine()) {
+            line = scanner.nextLine()
+            if (line.indexOf("IBM-Test-Feature: true") != -1) {
+                testFeatures.add(it.getName())
+                break
+            }
+        }
+    }
+    testFeatures
+}
+
 def allFeatures() {
     String features = ""
     // Exec ./bin/productInfo featureInfo
@@ -182,13 +199,25 @@ def microProfile3Features() {
 }
 
 def removeFeature(feature) {
-    def file = new File("$projectDir/wlp/lib/features/com.ibm.websphere.appserver." + feature + ".mf")
-    file.renameTo(new File("$projectDir/wlp/lib/features/com.ibm.websphere.appserver." + feature + ".mf.bak"))
+    def file
+    if (feature.endsWith(".mf")) {
+        file = new File("$projectDir/wlp/lib/features/" + feature)
+        file.renameTo(new File("$projectDir/wlp/lib/features/" + feature + ".bak"))
+    } else {
+        file = new File("$projectDir/wlp/lib/features/com.ibm.websphere.appserver." + feature + ".mf")
+        file.renameTo(new File("$projectDir/wlp/lib/features/com.ibm.websphere.appserver." + feature + ".mf.bak"))
+    }
 }
 
 def restoreFeature(feature) {
-    def file = new File("$projectDir/wlp/lib/features/com.ibm.websphere.appserver." + feature + ".mf.bak")
-    file.renameTo(new File("$projectDir/wlp/lib/features/com.ibm.websphere.appserver." + feature + ".mf"))
+    def file
+    if (feature.endsWith(".mf")) {
+        file = new File("$projectDir/wlp/lib/features/" + feature + ".bak")
+        file.renameTo(new File("$projectDir/wlp/lib/features/" + feature))
+    } else {
+        file = new File("$projectDir/wlp/lib/features/com.ibm.websphere.appserver." + feature + ".mf.bak")
+        file.renameTo(new File("$projectDir/wlp/lib/features/com.ibm.websphere.appserver." + feature + ".mf"))
+    }
 }
 
 def excludedFeatures = ['cdi-1.2',
@@ -205,8 +234,11 @@ def excludedFeatures = ['cdi-1.2',
 
 if (isAutomatedBuild) {
     task packageOpenLibertyAll(type: PackageLibertyWithFeatures) {
+        def excludedAndTestFeatures = []
         doFirst {
-            excludedFeatures.each {
+            excludedAndTestFeatures.addAll(excludedFeatures)
+            excludedAndTestFeatures.addAll(testFeatures())
+            excludedAndTestFeatures.each {
                 this.&removeFeature("${it}")
             }
         }
@@ -216,7 +248,7 @@ if (isAutomatedBuild) {
         withFeatures this.&allFeatures
         outputTo packageDir
         doLast {
-            excludedFeatures.each {
+            excludedAndTestFeatures.each {
                 this.&restoreFeature("${it}")
             }
         }

--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -137,6 +137,27 @@ class PackageLibertyWithFeatures extends DefaultTask {
     }
 }
 
+def allFeatures() {
+    String features = ""
+    // Exec ./bin/productInfo featureInfo
+    new ByteArrayOutputStream().withStream { os ->
+        project.exec {
+            workingDir project.file('wlp/bin')
+            def args = ["featureInfo"]
+            if (OperatingSystem.current().windows) {
+                commandLine = ["cmd", "/c", "productInfo"] + args
+            } else {
+                commandLine = ["./productInfo"] + args
+            }
+            standardOutput = os
+        }
+        os.toString().eachLine {
+            features += '<feature>' + it.substring(0, it.indexOf(' ')) + '</feature>\n'
+        }
+    }
+    features
+}
+
 def gaPublicFeatures() {
     String features = ""
     gaFeatures(true).each {
@@ -176,9 +197,31 @@ def excludedFeatures = ['cdi-1.2',
                         'jdbc-4.0',
                         'jdbc-4.1',
                         'jaxrsClient-2.0',
-                        'servlet-3.1']
+                        'servlet-3.1',
+                        'jaxb-2.2',
+                        'jaxws-2.2',
+                        'wasJmsServer-1.0',
+                        'wasJmsSecurity-1.0']
 
 if (isAutomatedBuild) {
+    task packageOpenLibertyAll(type: PackageLibertyWithFeatures) {
+        doFirst {
+            excludedFeatures.each {
+                this.&removeFeature("${it}")
+            }
+        }
+        enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
+        dependsOn parent.subprojects.assemble
+        dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
+        withFeatures this.&allFeatures
+        outputTo packageDir
+        doLast {
+            excludedFeatures.each {
+                this.&restoreFeature("${it}")
+            }
+        }
+    }
+
     task packageOpenLiberty(type: PackageLibertyWithFeatures) {
         enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
         dependsOn parent.subprojects.assemble
@@ -272,24 +315,34 @@ if (isAutomatedBuild) {
     }
 }
 
-// Includes all features.
-task zipOpenLibertyAll(type: Zip) {
+// Includes all features. For use in development.
+task zipOpenLibertyDev(type: Zip) {
     dependsOn parent.subprojects.assemble
     dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
-    baseName 'openliberty-all'
+    baseName 'openliberty-dev'
     from projectDir
     include 'wlp/**'
     exclude 'wlp/usr/servers/**'
     destinationDir distsDir
     version releaseVersion
-    doLast {
-        rootProject.userProps.setProperty('zipopenliberty.archivename', archivePath.toString())
-        rootProject.storeProps()
-    }
 }
-publish.dependsOn zipOpenLibertyAll
+publish.dependsOn zipOpenLibertyDev
 
 if (isAutomatedBuild) {
+    // Includes all features except excluded features.
+    task zipOpenLibertyAll(type: Zip) {
+        dependsOn packageOpenLibertyAll
+        baseName 'openliberty-all'
+        from packageDir
+        destinationDir distsDir
+        version releaseVersion
+        doLast {
+            rootProject.userProps.setProperty('zipopenliberty.archivename', archivePath.toString())
+            rootProject.storeProps()
+        }
+    }
+    publish.dependsOn zipOpenLibertyAll
+
     // Includes only kind=ga features.
     task zipOpenLiberty(type: Zip) {
         dependsOn packageOpenLiberty
@@ -367,12 +420,17 @@ clean.doLast {
 
 publishing {
     publications {
-        maven(MavenPublication) {
+        openLibertyDev(MavenPublication) {
             artifactId 'openliberty'
             version project.version
-            artifact zipOpenLibertyAll
+            artifact zipOpenLibertyDev
         }
         if (isAutomatedBuild) {
+            openLibertyAll(MavenPublication) {
+                artifactId 'openliberty-all'
+                version project.version
+                artifact zipOpenLibertyAll
+            }
             openLiberty(MavenPublication) {
                 groupId 'io.openliberty'
                 artifactId 'openliberty-runtime'

--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -167,6 +167,7 @@ task createGradleBootstrap {
 
         File dependenciesFile = new File(project.buildDir, 'dependencies.gradle')
         dependenciesFile.createNewFile()
+
         dependenciesFile.text = """dependencies {
 ${depsList.sort().join('\n')}
 }"""

--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -167,7 +167,6 @@ task createGradleBootstrap {
 
         File dependenciesFile = new File(project.buildDir, 'dependencies.gradle')
         dependenciesFile.createNewFile()
-
         dependenciesFile.text = """dependencies {
 ${depsList.sort().join('\n')}
 }"""


### PR DESCRIPTION
Instead of zipping all of `wlp`, use minify with `./bin/productInfo featureInfo` as the input features. I'm also adding the set of EE6 features built in OpenLiberty to the excludedFeatures list that we missed.
```
'jaxb-2.2',
'jaxws-2.2',
'wasJmsServer-1.0',
'wasJmsSecurity-1.0'
```

Startup shows the output:
```
Launching packageOpenLiberty (Open Liberty 20.0.0.1/wlp-1.0.36.202001081658) on Eclipse OpenJ9 VM, version 11.0.4+11 (en_US)
[AUDIT   ] CWWKE0001I: The server packageOpenLiberty has been launched.
[ERROR   ] CWWKF0001E: A feature definition could not be found for com.ibm.websphere.appserver.jsonp-1.0
[ERROR   ] CWWKF0001E: A feature definition could not be found for com.ibm.websphere.appserver.jaxws-2.2
[ERROR   ] CWWKF0001E: A feature definition could not be found for com.ibm.websphere.appserver.jaxb-2.2
[ERROR   ] CWWKF0001E: A feature definition could not be found for com.ibm.websphere.appserver.servlet-3.1
[ERROR   ] CWWKF0001E: A feature definition could not be found for com.ibm.websphere.appserver.servlet-3.0
[ERROR   ] CWWKF0001E: A feature definition could not be found for com.ibm.websphere.appserver.wasJmsSecurity-1.0
[ERROR   ] CWWKF0001E: A feature definition could not be found for com.ibm.websphere.appserver.wasJmsServer-1.0
[ERROR   ] CWWKF0001E: A feature definition could not be found for com.ibm.websphere.appserver.cdi-1.2
[ERROR   ] CWWKF0001E: A feature definition could not be found for com.ibm.websphere.appserver.jaxrs-2.0
[WARNING ] CWWKF0024W: The feature com.ibm.websphere.appserver.kernel-1.0 referenced a resource com.ibm.ws.config.utility/[1.0.0,1.0.100) that was unable to be located during a packaging query. 
[AUDIT   ] CWWKF0012I: The server installed the following features: [appClientSupport-1.0, appSecurity-1.0, appSecurity-2.0, appSecurity-3.0, appSecurityClient-1.0, arquillian-support-1.0, audit-1.0, batch-1.0, batchManagement-1.0, beanValidation-1.1, beanValidation-2.0, bells-1.0, cdi-2.0, cloudant-1.0, componenttest-1.0, concurrent-1.0, constrainedDelegation-1.0, couchdb-1.0, distributedMap-1.0, ejb-3.2, ejbHome-3.2, ejbLite-3.2, ejbPersistentTimer-3.2, ejbRemote-3.2, el-3.0, eventLogging-1.0, featureverifier-1.0, federatedRegistry-1.0, http2clienttest-1.0, j2eeManagement-1.1, jacc-1.5, jakartaee-8.0, jaspic-1.1, javaMail-1.5, javaMail-1.6, javaee-7.0, javaee-8.0, javaeeClient-7.0, javaeeClient-8.0, jaxb-2.3, jaxrs-2.1, jaxrsClient-2.1, jaxws-2.3, jca-1.7, jcaInboundSecurity-1.0, jcacheContainer-1.1, jdbc-4.2, jdbc-4.3, jms-2.0, jmsMdb-3.2, jndi-1.0, jpa-2.1, jpa-2.2, jpaContainer-2.1, jpaContainer-2.2, jsf-2.2, jsf-2.3, jsfContainer-2.2, jsfContainer-2.3, json-1.0, jsonb-1.0, jsonbContainer-1.0, jsonp-1.1, jsonpContainer-1.1, jsp-2.2, jsp-2.3, jwt-1.0, jwtSso-1.0, ldapRegistry-3.0, localConnector-1.0, logstashCollector-1.0, managedBeans-1.0, mdb-3.2, microProfile-1.0, microProfile-1.2, microProfile-1.3, microProfile-1.4, microProfile-2.0, microProfile-2.1, microProfile-2.2, microProfile-3.0, microProfile-3.2, microProfile-3.3, mongodb-2.0, monitor-1.0, mpConfig-1.1, mpConfig-1.2, mpConfig-1.3, mpConfig-1.4, mpContextPropagation-1.0, mpContextPropagation-1.1, mpFaultTolerance-1.0, mpFaultTolerance-1.1, mpFaultTolerance-2.0, mpFaultTolerance-2.1, mpGraphQL-1.0, mpHealth-1.0, mpHealth-2.0, mpHealth-2.1, mpJwt-1.0, mpJwt-1.1, mpMetrics-1.0, mpMetrics-1.1, mpMetrics-2.0, mpMetrics-2.2, mpOpenAPI-1.0, mpOpenAPI-1.1, mpOpenTracing-1.0, mpOpenTracing-1.1, mpOpenTracing-1.2, mpOpenTracing-1.3, mpReactiveMessaging-1.0, mpReactiveStreams-1.0, mpRestClient-1.0, mpRestClient-1.1, mpRestClient-1.2, mpRestClient-1.3, oauth-2.0, openapi-3.1, openid-2.0, openidConnectClient-1.0, openidConnectServer-1.0, opentracing-1.0, opentracing-1.1, opentracing-1.2, opentracing-1.3, osgiConsole-1.0, passwordUtilities-1.0, persistentExecutor-1.0, requestTiming-1.0, restConnector-2.0, samlWeb-2.0, scim-2.0, servlet-4.0, sessionCache-1.0, sessionDatabase-1.0, sipServlet-1.1, socialLogin-1.0, spnego-1.0, springBoot-1.5, springBoot-2.0, ssl-1.0, timedexit-1.0, transportSecurity-1.0, txtest-1.0, wasJmsClient-2.0, webCache-1.0, webProfile-7.0, webProfile-8.0, websocket-1.0, websocket-1.1, wsAtomicTransaction-1.2, wsSecurity-1.1, wsSecuritySaml-1.1].
```