### PR TITLE
Issue #10328: Use triggerDump and request exclusive access for J9 system dumps

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/JavaDumper.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/commands/JavaDumper.java
@@ -33,8 +33,8 @@ public abstract class JavaDumper {
                 Class<?>[] paramTypes = new Class<?>[] { String.class };
                 Method javaDumpToFileMethod = dumpClass.getMethod("javaDumpToFile", paramTypes);
                 Method heapDumpToFileMethod = dumpClass.getMethod("heapDumpToFile", paramTypes);
-                Method systemDumpToFileMethod = dumpClass.getMethod("systemDumpToFile", paramTypes);
-                return new IBMJavaDumperImpl(javaDumpToFileMethod, heapDumpToFileMethod, systemDumpToFileMethod);
+                Method triggerDumpMethod = dumpClass.getMethod("triggerDump", paramTypes);
+                return new IBMJavaDumperImpl(javaDumpToFileMethod, heapDumpToFileMethod, triggerDumpMethod);
             } catch (NoSuchMethodException e) {
                 return new IBMLegacyJavaDumperImpl(dumpClass);
             }
@@ -70,8 +70,8 @@ public abstract class JavaDumper {
 
     /**
      * Generate a java dump of the current process.
-     * 
-     * @param action the dump action
+     *
+     * @param action    the dump action
      * @param outputDir the server output directory
      * @return the file containing the dump, or null if the action is not supported by this JVM
      * @throws RuntimeException if an error occurs while dumping


### PR DESCRIPTION
For details, see Issue #10328.

Validated this fix shows the `J9RAS_DUMP_DO_EXCLUSIVE_VM_ACCESS` bit flag:

```
$ bin/server javadump play --include=system
[...]
Server play dump complete in /opt/ibm/wlp/output/play/core.20200108.175308.13395.0002.dmp.
$ jdmpview -core /opt/ibm/wlp/output/play/core.20200108.175308.13395.0002.dmp
[...]
> !findcallsite dmpagent.c:1713
[...]
 !j9x 0x00002AD018012C30,0x0000000000000078	dmpagent.c:1713
Call site count = 9
> !J9RASdumpAgent 0x00002AD018012C30
[...]
	0x60: UDATA requestMask = 0x000000000000000D (13)
```