### PR TITLE
Adding programmatic timer

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/fat/src/com/ibm/ws/concurrent/persistent/fat/demo/timers/DemoTimerTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/fat/src/com/ibm/ws/concurrent/persistent/fat/demo/timers/DemoTimerTest.java
@@ -56,6 +56,15 @@ public class DemoTimerTest extends FATServletClient {
         //Get driver name
         server.addEnvVar("DB_DRIVER", DatabaseContainerType.valueOf(testContainer).getDriverName());
 
+        if (DatabaseContainerType.valueOf(testContainer) == DatabaseContainerType.Oracle) {
+            //Type=javax.sql.ConnectionPoolDataSource to avoid
+            //  ORA-02089: COMMIT is not allowed in a subordinate session
+            //  when application tries to create a new table using oracle.
+            server.addEnvVar("DS_TYPE", "javax.sql.ConnectionPoolDataSource");
+        } else {
+            server.addEnvVar("DS_TYPE", "javax.sql.XADataSource");
+        }
+
         //Setup server DataSource properties
         DatabaseContainerUtil.setupDataSourceProperties(server, testContainer);
 

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/publish/servers/com.ibm.ws.concurrent.persistent.fat.demo.timers/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/publish/servers/com.ibm.ws.concurrent.persistent.fat.demo.timers/server.xml
@@ -16,8 +16,11 @@
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>
-
-  <dataSource id="DefaultDataSource" fat.modify="true">
+  
+  <!-- Edit persistentExecutor defaults with attribute missedTaskThreshold to enable failover -->
+  <persistentExecutor id="defaultEJBPersistentTimerExecutor" missedTaskThreshold="3s"/>
+  
+  <dataSource id="DefaultDataSource" type="${env.DS_TYPE}" fat.modify="true">
     <jdbcDriver libraryRef="AnonymousJDBCLib"/>
     <!-- Properties modified by fat for database rotation -->
     <properties.derby.embedded  createDatabase="create" databaseName="memory:persistenttimersdemo"/>
@@ -27,10 +30,19 @@
     <fileset dir="${shared.resource.dir}/jdbc" includes="${env.DB_DRIVER}"/>
   </library>
   
+  <!-- JDBC driver -->
   <javaPermission codebase="${shared.resource.dir}/jdbc/${env.DB_DRIVER}" className="java.security.AllPermission"/>
+  
+  <!-- Permission needed for SQLServer driver -->
+  <javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
+  
+  <!-- File read write permissions -->
+  <javaPermission className="java.util.PropertyPermission" name="user.dir" actions="read"/>
   <javaPermission className="java.io.FilePermission" name="files/timertestoutput.txt" actions="read,write"/>
   <javaPermission className="java.io.FilePermission" name="files" actions="write"/>
-  <javaPermission className="java.util.PropertyPermission" name="user.dir" actions="read"/>
+  
+  
+  
 
   <variable name="onError" value="FAIL"/>
 </server>

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/publish/servers/com.ibm.ws.concurrent.persistent.fat.demo.timers/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/publish/servers/com.ibm.ws.concurrent.persistent.fat.demo.timers/server.xml
@@ -18,7 +18,7 @@
   <include location="../fatTestPorts.xml"/>
   
   <!-- Edit persistentExecutor defaults with attribute missedTaskThreshold to enable failover -->
-  <persistentExecutor id="defaultEJBPersistentTimerExecutor" missedTaskThreshold="3s"/>
+  <persistentExecutor id="defaultEJBPersistentTimerExecutor" missedTaskThreshold="120s"/>
   
   <dataSource id="DefaultDataSource" type="${env.DS_TYPE}" fat.modify="true">
     <jdbcDriver libraryRef="AnonymousJDBCLib"/>

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticDatabase.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticDatabase.java
@@ -85,6 +85,7 @@ public class AutomaticDatabase {
             try (PreparedStatement pstmt = conn.prepareStatement(createTable)) {
                 pstmt.executeUpdate();
             }
+
             isTableCreated = true;
         } catch (SQLException e) {
             e.printStackTrace();

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticScheduler.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticScheduler.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package ejb.timers;
+
+import javax.annotation.Resource;
+import javax.ejb.EJB;
+import javax.ejb.Schedule;
+import javax.ejb.SessionContext;
+import javax.ejb.Singleton;
+import javax.ejb.Timer;
+
+/**
+ * This class uses the @Schedule annotation.
+ * Using this annotation will start the timer immediately on start and will run every hour.
+ */
+@Singleton
+public class AutomaticScheduler {
+    @Resource
+    private SessionContext sessionContext; //Used to get information about timer
+
+    @EJB
+    private ProgrammaticTimer programmaticTimer;
+
+    private int count;
+
+    /**
+     * Cancels timer execution
+     */
+    public void cancel() {
+        for (Timer timer : sessionContext.getTimerService().getTimers())
+            timer.cancel();
+    }
+
+    /**
+     * Get the value of count.
+     */
+    public int getRunCount() {
+        return count;
+    }
+
+    /**
+     * Runs once an hour. Automatically starts when application starts.
+     * When run will spawn a programmaticTimer.
+     */
+    @Schedule(info = "Scheduling Programmatic Timers", hour = "*", minute = "0", second = "0", persistent = true)
+    public void run(Timer timer) {
+        System.out.println("Running execution " + (++count) + " of timer " + timer.getInfo());
+
+        Timer spawnedTimer = programmaticTimer.setTimer();
+
+        System.out.println("Spawned New Timer: " + spawnedTimer.getInfo());
+    }
+
+}

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/PersistentDemoTimersServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/PersistentDemoTimersServlet.java
@@ -89,8 +89,6 @@ public class PersistentDemoTimersServlet extends FATServlet {
     public void testRepeatingAutomaticPersistentTimerIO() throws Exception {
         final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(4);
 
-        Thread.sleep(TimeUnit.MINUTES.toMillis(1));
-
         int count = autoTimerIO.getRunCount();
         for (long start = System.nanoTime(); count < 3 && System.nanoTime() - start < TIMEOUT_NS; Thread.sleep(POLL_INTERVAL)) {
             count = autoTimerIO.getRunCount();

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/ProgrammaticTimer.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/ProgrammaticTimer.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package ejb.timers;
+
+import javax.annotation.Resource;
+import javax.ejb.ScheduleExpression;
+import javax.ejb.Stateless;
+import javax.ejb.Timeout;
+import javax.ejb.Timer;
+import javax.ejb.TimerConfig;
+import javax.ejb.TimerService;
+
+/**
+ * This class uses the @Timeout annotation.
+ * The method decorated with @Timeout will be run each iteration of
+ * the timer. The timer is scheduled programmatically by calling the setTimer() method.
+ */
+@Stateless
+public class ProgrammaticTimer {
+
+    @Resource
+    TimerService timerService;
+
+    private int count;
+
+    /**
+     * Creates a timer that runs every 5 minutes,
+     * and then cancel's itself after 6 runs (30 minutes).
+     */
+    public Timer setTimer() {
+        final TimerConfig config = new TimerConfig();
+        config.setInfo("Created Programmaticlly and Running Every 5 minute(s)");
+        config.setPersistent(true);
+        ScheduleExpression exp = new ScheduleExpression().hour("*").minute("*/5").second("0");
+        return timerService.createCalendarTimer(exp, config);
+    }
+
+    @Timeout
+    public void run(Timer timer) {
+        System.out.println("Running execution " + (++count) + " of timer " + timer.getInfo());
+
+        if (count >= 6) //30 minutes
+            timer.cancel();
+    }
+}


### PR DESCRIPTION
Enable application to create a programmatic timer.  This timer is being created by an automatic timer that runs once an hour.  The programmatic timer that is created runs every 5 minutes for a half an hour. 

This is to simulate the customer case where their app responds to some user action (button click, or http request) which starts a timer action. 

