### PR TITLE
renames to align with dual use of partition column

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/db/DatabaseTaskStore.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/db/DatabaseTaskStore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -442,7 +442,7 @@ public class DatabaseTaskStore implements TaskStore {
             taskRecord.setId(taskId);
             taskRecord.setIdentifierOfClassLoader((String) result[0]);
             taskRecord.setIdentifierOfOwner((String) result[1]);
-            taskRecord.setIdentifierOfPartition((Long) result[2]);
+            taskRecord.setClaimExpiryOrPartition((Long) result[2]);
             taskRecord.setMiscBinaryFlags((Short) result[3]);
             taskRecord.setName((String) result[4]);
             taskRecord.setNextExecutionTime((Long) result[5]);
@@ -1099,7 +1099,7 @@ public class DatabaseTaskStore implements TaskStore {
                 update.append("t.LOADER=:c2,");
             if (updates.hasIdentifierOfOwner())
                 update.append("t.OWNR=:o2,");
-            if (updates.hasIdentifierOfPartition())
+            if (updates.hasClaimExpiryOrPartition())
                 update.append("t.PARTN=:p2,");
             if (updates.hasMiscBinaryFlags())
                 update.append("t.MBITS=:m2,");
@@ -1135,7 +1135,7 @@ public class DatabaseTaskStore implements TaskStore {
             update.append(" AND t.LOADER=:c1");
         if (expected.hasIdentifierOfOwner())
             update.append(" AND t.OWNR=:o1");
-        if (expected.hasIdentifierOfPartition())
+        if (expected.hasClaimExpiryOrPartition())
             update.append(" AND t.PARTN=:p1");
         if (expected.hasMiscBinaryFlags())
             update.append(" AND t.MBITS=:m1");
@@ -1179,8 +1179,8 @@ public class DatabaseTaskStore implements TaskStore {
                     query.setParameter("c2", updates.getIdentifierOfClassLoader());
                 if (updates.hasIdentifierOfOwner())
                     query.setParameter("o2", updates.getIdentifierOfOwner());
-                if (updates.hasIdentifierOfPartition())
-                    query.setParameter("p2", updates.getIdentifierOfPartition());
+                if (updates.hasClaimExpiryOrPartition())
+                    query.setParameter("p2", updates.getClaimExpiryOrPartition());
                 if (updates.hasMiscBinaryFlags())
                     query.setParameter("m2", updates.getMiscBinaryFlags());
                 if (updates.hasName())
@@ -1215,8 +1215,8 @@ public class DatabaseTaskStore implements TaskStore {
                 query.setParameter("c1", expected.getIdentifierOfClassLoader());
             if (expected.hasIdentifierOfOwner())
                 query.setParameter("o1", expected.getIdentifierOfOwner());
-            if (expected.hasIdentifierOfPartition())
-                query.setParameter("p1", expected.getIdentifierOfPartition());
+            if (expected.hasClaimExpiryOrPartition())
+                query.setParameter("p1", expected.getClaimExpiryOrPartition());
             if (expected.hasMiscBinaryFlags())
                 query.setParameter("m1", expected.getMiscBinaryFlags());
             if (expected.hasName())

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/db/Task.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/db/Task.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -84,7 +84,8 @@ public class Task {
     @Column(nullable = false)
     public int VERSION;
 
-    public Task() {}
+    public Task() {
+    }
 
     Task(TaskRecord taskRecord) {
         if (taskRecord.hasId())
@@ -96,8 +97,8 @@ public class Task {
         if (taskRecord.hasIdentifierOfOwner())
             OWNR = taskRecord.getIdentifierOfOwner();
 
-        if (taskRecord.hasIdentifierOfPartition())
-            PARTN = taskRecord.getIdentifierOfPartition();
+        if (taskRecord.hasClaimExpiryOrPartition())
+            PARTN = taskRecord.getClaimExpiryOrPartition();
 
         if (taskRecord.hasMiscBinaryFlags())
             MBITS = taskRecord.getMiscBinaryFlags();

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/InvokerTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/InvokerTask.java
@@ -545,10 +545,10 @@ public class InvokerTask implements Runnable, Synchronization {
                     if (config.enableTaskExecution
                         && nextExecTime != null
                         && (config.pollInterval < 0 || nextExecTime <= System.currentTimeMillis() + config.pollInterval)) {
-                        updates.setIdentifierOfPartition(nextExecTime + config.missedTaskThreshold * 1000);
+                        updates.setClaimExpiryOrPartition(nextExecTime + config.missedTaskThreshold * 1000);
                         claimNextExecution = true;
                     } else {
-                        updates.setIdentifierOfPartition(-1);
+                        updates.setClaimExpiryOrPartition(-1);
                     }
 
                 TaskRecord expected = new TaskRecord(false);

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1202,7 +1202,7 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
             claimFirstExecution = true;
         }
 
-        record.setIdentifierOfPartition(taskAssignmentInfo); // TODO rename the methods on TaskRecord to reflect repurposed usage
+        record.setClaimExpiryOrPartition(taskAssignmentInfo);
 
         TransactionController tranController = new TransactionController();
         try {

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskRecord.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskRecord.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -79,7 +79,7 @@ public final class TaskRecord {
     private static final int ID = 0x1,
                     ID_OF_CLASSLOADER = 0x2,
                     ID_OF_OWNER = 0x4,
-                    ID_OF_PARTITION = 0x8,
+                    CLAIM_EXPIRY_OR_PARTITION = 0x8,
                     MISC_BINARY_FLAGS = 0x10,
                     NAME = 0x20,
                     NEXT_EXEC_TIME = 0x40,
@@ -123,9 +123,9 @@ public final class TaskRecord {
     private String idOfOwner;
 
     /**
-     * Identifier for the partition that this task belongs in.
+     * The expiry of the current claim on task execution (if fail over is enabled), or otherwise the partition to which the task is assigned.
      */
-    private long idOfPartition;
+    private long claimExpiryOrPartition;
 
     /**
      * Value that represents a combination of miscellaneous boolean flags.
@@ -223,7 +223,7 @@ public final class TaskRecord {
                    && ((attrs & ID) == 0 || id == other.id)
                    && ((attrs & ID_OF_CLASSLOADER) == 0 || match(idOfClassLoader, other.idOfClassLoader))
                    && ((attrs & ID_OF_OWNER) == 0 || match(idOfOwner, other.idOfOwner))
-                   && ((attrs & ID_OF_PARTITION) == 0 || idOfPartition == other.idOfPartition)
+                   && ((attrs & CLAIM_EXPIRY_OR_PARTITION) == 0 || claimExpiryOrPartition == other.claimExpiryOrPartition)
                    && ((attrs & MISC_BINARY_FLAGS) == 0 || miscBinaryFlags == other.miscBinaryFlags)
                    && ((attrs & NAME) == 0 || match(name, other.name))
                    && ((attrs & NEXT_EXEC_TIME) == 0 || nextExecTime == other.nextExecTime)
@@ -292,15 +292,16 @@ public final class TaskRecord {
     }
 
     /**
-     * Returns the identifier for the partition that this task belongs in.
+     * Returns the expiry of the current claim on task execution (if fail over is enabled),
+     * or otherwise the partition to which the task is assigned.
      *
-     * @return identifier for the partition that this task belongs in.
+     * @return claim expiry or partition id value.
      */
-    public final long getIdentifierOfPartition() {
-        if ((attrs & ID_OF_PARTITION) == 0)
+    public final long getClaimExpiryOrPartition() {
+        if ((attrs & CLAIM_EXPIRY_OR_PARTITION) == 0)
             throw new IllegalStateException();
         else
-            return idOfPartition;
+            return claimExpiryOrPartition;
     }
 
     /**
@@ -518,12 +519,12 @@ public final class TaskRecord {
     }
 
     /**
-     * Returns true if the IdentifierOfPartition attribute is set. Otherwise false.
+     * Returns true if the ClaimExpiryOrPartition attribute is set. Otherwise false.
      *
      * @return true if the attribute is set. Otherwise false.
      */
-    public final boolean hasIdentifierOfPartition() {
-        return (attrs & ID_OF_PARTITION) != 0;
+    public final boolean hasClaimExpiryOrPartition() {
+        return (attrs & CLAIM_EXPIRY_OR_PARTITION) != 0;
     }
 
     /**
@@ -704,13 +705,14 @@ public final class TaskRecord {
     }
 
     /**
-     * Sets the identifier for the partition that this task belongs in.
+     * Sets the expiry of the current claim on task execution (if fail over is enabled),
+     * or otherwise the partition to which the task is assigned.
      *
-     * @param partitionId identifier for the partition that this task belongs in.
+     * @param value the new value to use.
      */
-    public final void setIdentifierOfPartition(long partitionId) {
-        this.idOfPartition = partitionId;
-        attrs |= ID_OF_PARTITION;
+    public final void setClaimExpiryOrPartition(long value) {
+        this.claimExpiryOrPartition = value;
+        attrs |= CLAIM_EXPIRY_OR_PARTITION;
     }
 
     /**
@@ -872,11 +874,11 @@ public final class TaskRecord {
             output.append(EOLN).append("FLAGS=").append(Integer.toBinaryString(miscBinaryFlags));
         if ((attrs & NAME) != 0)
             output.append(EOLN).append("NAME=").append(name);
-        if ((attrs & ID_OF_PARTITION) != 0)
-            if (idOfPartition > 1500000000000l)
-                Utils.appendDate(output.append(EOLN).append("CLAIMTIL="), idOfPartition);
+        if ((attrs & CLAIM_EXPIRY_OR_PARTITION) != 0)
+            if (claimExpiryOrPartition > 1500000000000l)
+                Utils.appendDate(output.append(EOLN).append("CLAIMTIL="), claimExpiryOrPartition);
             else
-                output.append(EOLN).append("PARTITION=").append(idOfPartition);
+                output.append(EOLN).append("PARTITION=").append(claimExpiryOrPartition);
         if ((attrs & NEXT_EXEC_TIME) != 0)
             Utils.appendDate(output.append(EOLN).append("NEXTEXEC="), nextExecTime);
         if ((attrs & ORIG_SUBMIT_TIME) != 0)
@@ -960,10 +962,10 @@ public final class TaskRecord {
     }
 
     /**
-     * Unsets the IdentifierOfPartition attribute.
+     * Unsets the ClaimExpiryOrPartition attribute.
      */
-    public final void unsetIdentifierOfPartition() {
-        attrs &= ~ID_OF_PARTITION;
+    public final void unsetClaimExpiryOrPartition() {
+        attrs &= ~CLAIM_EXPIRY_OR_PARTITION;
     }
 
     /**


### PR DESCRIPTION
Refactoring/renames of fields/methods/constants within the code to be consistent with the repurposed partition column, which is used to store the expiry timestamps for task executions when fail over is enabled.