### PR TITLE
Only set transaction context if we are actually going to do something.

### DIFF
--- a/dev/com.ibm.ws.session/src/com/ibm/ws/session/store/memory/MemoryStore.java
+++ b/dev/com.ibm.ws.session/src/com/ibm/ws/session/store/memory/MemoryStore.java
@@ -415,8 +415,15 @@ public class MemoryStore implements IStore {
          * runApplicationStoreInvalidation();
          * } else {
          */
+        Set keySet = _sessions.keySet();
+        if (keySet.size() == 0) {
+            if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && LoggingUtil.SESSION_LOGGER_CORE.isLoggable(Level.FINE)) {
+                LoggingUtil.SESSION_LOGGER_CORE.exiting(methodClassName, methodNames[RUN_INVALIDATION], "no sessions in memory store - " + appNameForLogging);
+            }
+            return;
+        }
         long nowTime = System.currentTimeMillis();
-        Iterator iter = _sessions.keySet().iterator();
+        Iterator iter = keySet.iterator();
         try {
             //setThreadContext threw a NPE because we were trying to get the config from within getModuleMetaData and it was returning null
             //this only happens after the app has been shutdown.  There was a small timing window where this was possible.

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebApp.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebApp.java
@@ -2384,15 +2384,17 @@ public abstract class WebApp extends BaseContainer implements ServletContext, IS
             logger.logp(Level.FINE, CLASS_NAME, "notifyServletContextCreated", "ENTRY"); //PI26908
 
         TxCollaboratorConfig txConfig = null;
+        final boolean hasListeners = !servletContextListeners.isEmpty();
+
         try {
-            webAppNameSpaceCollab.preInvoke(getModuleMetaData().getCollaboratorComponentMetaData());
+            if (hasListeners) {
+                webAppNameSpaceCollab.preInvoke(getModuleMetaData().getCollaboratorComponentMetaData());
 
-            txConfig = txCollab.preInvoke(null, this.isServlet23);
-            if (txConfig != null)
-                txConfig.setDispatchContext(null);
+                txConfig = txCollab.preInvoke(null, this.isServlet23);
+                if (txConfig != null)
+                    txConfig.setDispatchContext(null);
 
-            if (!servletContextListeners.isEmpty()) {
-				if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE))
+                if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE))
                     logger.logp(Level.FINE, CLASS_NAME, "notifyServletContextCreated", "stopAppStartupOnListenerException = " + WCCustomProperties.STOP_APP_STARTUP_ON_LISTENER_EXCEPTION);
 
                 Iterator i = servletContextListeners.iterator();
@@ -2443,13 +2445,15 @@ public abstract class WebApp extends BaseContainer implements ServletContext, IS
             logger.logp(Level.SEVERE, CLASS_NAME, "notifyServletContextCreated", "exception.caught.in.notifyServletContextCreated", new Object[] { e } ); // PK27660
         } finally {
             canAddServletContextListener = true;
-            try {
-                txCollab.postInvoke(null, txConfig, this.isServlet23);
-            } catch (Exception e) {
-                com.ibm.wsspi.webcontainer.util.FFDCWrapper.processException(e, CLASS_NAME + ".notifyServletContextCreated", "1327", this);
+            if (hasListeners) {
+                try {
+                    txCollab.postInvoke(null, txConfig, this.isServlet23);
+                } catch (Exception e) {
+                    com.ibm.wsspi.webcontainer.util.FFDCWrapper.processException(e, CLASS_NAME + ".notifyServletContextCreated", "1327", this);
 
+                }
+                webAppNameSpaceCollab.postInvoke();
             }
-            webAppNameSpaceCollab.postInvoke();
         }
     }
     


### PR DESCRIPTION
- When calling contextInitialized listeners, don't set the transaction
context if there are no listeners
- When doing session invalidation, if there are no session in the
current store, do not set transaction context.