### PR TITLE
Enable all databases to use xa datasources

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/publish/servers/com.ibm.ws.concurrent.persistent.fat.demo.timers/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/publish/servers/com.ibm.ws.concurrent.persistent.fat.demo.timers/server.xml
@@ -20,7 +20,7 @@
   <!-- Edit persistentExecutor defaults with attribute missedTaskThreshold to enable failover -->
   <persistentExecutor id="defaultEJBPersistentTimerExecutor" missedTaskThreshold="120s"/>
   
-  <dataSource id="DefaultDataSource" type="${env.DS_TYPE}" fat.modify="true">
+  <dataSource id="DefaultDataSource" fat.modify="true">
     <jdbcDriver libraryRef="AnonymousJDBCLib"/>
     <!-- Properties modified by fat for database rotation -->
     <properties.derby.embedded  createDatabase="create" databaseName="memory:persistenttimersdemo"/>

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticDatabase.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticDatabase.java
@@ -70,15 +70,16 @@ public class AutomaticDatabase {
     }
 
     private void initTable() {
-        final String createTable = "CREATE TABLE AutomaticDatabase (name VARCHAR(64) NOT NULL PRIMARY KEY, count INT)";
+        final String createTable = "CREATE TABLE AUTOMATICDATABASE (name VARCHAR(64) NOT NULL PRIMARY KEY, count INT)";
 
         try (Connection conn = ds.getConnection()) {
             //See if table was created by another server
             DatabaseMetaData md = conn.getMetaData();
-            ResultSet rs = md.getTables(null, null, "AutomaticDatabase", null);
+            ResultSet rs = md.getTables(null, null, "AUTOMATICDATABASE".toUpperCase(), null);
             while (rs.next()) {
-                isTableCreated = true;
-                return;
+                isTableCreated = rs.getString("TABLE_NAME").equalsIgnoreCase("AUTOMATICDATABASE");
+                if (isTableCreated)
+                    return;
             }
 
             //If not, create it.
@@ -94,7 +95,7 @@ public class AutomaticDatabase {
     }
 
     private void initCounter(Timer timer) {
-        final String createRow = "INSERT INTO AutomaticDatabase VALUES(?,?)";
+        final String createRow = "INSERT INTO AUTOMATICDATABASE VALUES(?,?)";
 
         //create count
         count = 1;
@@ -121,7 +122,7 @@ public class AutomaticDatabase {
             return count;
         }
 
-        final String modifyRow = "UPDATE AutomaticDatabase SET count = ? WHERE name = ?";
+        final String modifyRow = "UPDATE AUTOMATICDATABASE SET count = ? WHERE name = ?";
 
         try (Connection conn = ds.getConnection()) {
             try (PreparedStatement pstmt = conn.prepareStatement(modifyRow)) {

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/PersistentDemoTimersServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/PersistentDemoTimersServlet.java
@@ -12,10 +12,8 @@ package ejb.timers;
 
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.Resource;
 import javax.ejb.EJB;
 import javax.servlet.annotation.WebServlet;
-import javax.transaction.UserTransaction;
 
 import org.junit.Test;
 
@@ -39,9 +37,6 @@ public class PersistentDemoTimersServlet extends FATServlet {
 
     @EJB
     private AutomaticIO autoTimerIO;
-
-    @Resource
-    private UserTransaction tran;
 
     /**
      * Verify that an automatic persistent timer is running multiple times


### PR DESCRIPTION
Was previously changing datasource to not use an XA datasource when testing against oracle. This was due to a limitation in oracle JDBC driver to create a table when using an XA datasource.  

But, the DefaultDatasource is also used to persist timers, and we want all databases to use the same type of datasource.  Now, when testing against oracle I create the table prior to running the application.  The default datasource once again uses two phase commit for all databases. 
