### PR TITLE
Refactor JPA 2.1 Spec CDI FAT

### DIFF
--- a/dev/com.ibm.ws.jpa_spec21_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
+++ b/dev/com.ibm.ws.jpa_spec21_fat/fat/src/com/ibm/ws/jpa/FATSuite.java
@@ -27,8 +27,8 @@ import componenttest.rules.repeater.RepeatTests;
                 TestOLGH8820_Web.class,
                 TestTXSynchronization.class,
                 TestTXDDSynchronization.class,
-                TestCDI.class,
-                TestCDILib.class,
+                TestCDI_WEB.class,
+                TestCDI_EJB.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
 public class FATSuite {

--- a/dev/com.ibm.ws.jpa_spec21_fat/fat/src/com/ibm/ws/jpa/TestCDI_EJB.java
+++ b/dev/com.ibm.ws.jpa_spec21_fat/fat/src/com/ibm/ws/jpa/TestCDI_EJB.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jpa_spec21_fat/fat/src/com/ibm/ws/jpa/TestCDI_WEB.java
+++ b/dev/com.ibm.ws.jpa_spec21_fat/fat/src/com/ibm/ws/jpa/TestCDI_WEB.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -42,8 +42,6 @@ public class TestCDI_WEB extends JPAFATServletClient {
     private final static String CONTEXT_ROOT_JPALIB = "TestCDIWithJPALib";
     private final static String RESOURCE_ROOT = "test-applications/CDI/";
     private final static String appFolder = "apps";
-//    private final static String appName = "TestCDISimple";
-//    private final static String appNameEar = appName + ".ear";
 
     private final static Set<String> dropSet = new HashSet<String>();
     private final static Set<String> createSet = new HashSet<String>();

--- a/dev/com.ibm.ws.jpa_spec21_fat/test-applications/CDI/apps/TestCDIWithJPALibEJB.ear/lib/jpamodel.jar/META-INF/beans.xml
+++ b/dev/com.ibm.ws.jpa_spec21_fat/test-applications/CDI/apps/TestCDIWithJPALibEJB.ear/lib/jpamodel.jar/META-INF/beans.xml
@@ -1,0 +1,4 @@
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+
+</beans>

--- a/dev/com.ibm.ws.jpa_spec21_fat/test-applications/CDI/apps/TestCDIWithJPALibEJB.ear/lib/jpamodel.jar/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa_spec21_fat/test-applications/CDI/apps/TestCDIWithJPALibEJB.ear/lib/jpamodel.jar/META-INF/persistence.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jpa_spec21_fat/test-applications/CDI/apps/TestCDIWithJPALibEJB.ear/lib/jpamodel.jar/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa_spec21_fat/test-applications/CDI/apps/TestCDIWithJPALibEJB.ear/lib/jpamodel.jar/META-INF/persistence.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<persistence 
+    xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
+    version="2.1">
+
+    <persistence-unit name="TestCDIJPALib">
+        <jta-data-source>jdbc/JPA_DS</jta-data-source>
+        <class>com.ibm.ws.jpa.fvt.cdi.jpalib.model.Widget</class>
+        <exclude-unlisted-classes>true</exclude-unlisted-classes>
+    </persistence-unit>
+
+    <persistence-unit name="TestCDIJPALib_RL" transaction-type="RESOURCE_LOCAL">
+        <non-jta-data-source>jdbc/JPA_NJTADS</non-jta-data-source>
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
Refactor the bucket, separating the test grouping into EJB and Web groups, to differentiate the names enough so that there is no confusion recognizing names waiting for apps to start.