### PR TITLE
Fix jaxrs.2.0_fat to build in eclipse again.

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/.classpath
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/.classpath
@@ -2,7 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/restmetrics/src"/>
-	<classpathentry kind="src" path="test-applications/metrics/src"/>
 	<classpathentry kind="src" path="test-applications/linkheader/src"/>
 	<classpathentry kind="src" path="test-applications/annotationscan/src"/>
 	<classpathentry kind="src" path="test-applications/beanvalidation/src"/>


### PR DESCRIPTION
- Remove reference to non existent metrics directory.