### PR TITLE
Issue #10357: Handle OSGi Concurrency in InjectionEngine

### DIFF
--- a/dev/com.ibm.ws.injection.core/src/com/ibm/ws/injectionengine/AbstractInjectionEngine.java
+++ b/dev/com.ibm.ws.injection.core/src/com/ibm/ws/injectionengine/AbstractInjectionEngine.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2015 IBM Corporation and others.
+ * Copyright (c) 2010, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -78,16 +78,12 @@ import com.ibm.wsspi.injectionengine.factory.ResRefReferenceFactory;
  * The implementation of the InjectionEngine interface that is shared by all
  * runtime environments.
  */
-public abstract class AbstractInjectionEngine
-                implements InternalInjectionEngine, Formattable
-{
-    private static final TraceComponent tc = Tr.register
-                    (AbstractInjectionEngine.class,
-                     InjectionConfigConstants.traceString,
-                     InjectionConfigConstants.messageFile);
+public abstract class AbstractInjectionEngine implements InternalInjectionEngine, Formattable {
+    private static final TraceComponent tc = Tr.register(AbstractInjectionEngine.class,
+                                                         InjectionConfigConstants.traceString,
+                                                         InjectionConfigConstants.messageFile);
 
-    private static final ThreadContextAccessor svThreadContextAccessor =
-                    ThreadContextAccessor.getThreadContextAccessor(); // F54050
+    private static final ThreadContextAccessor svThreadContextAccessor = ThreadContextAccessor.getThreadContextAccessor(); // F54050
 
     private static final InjectionTarget[] EMPTY_INJECTION_TARGETS = new InjectionTarget[0];
 
@@ -170,8 +166,7 @@ public abstract class AbstractInjectionEngine
      * The set of class loaders that have been checked for overridden annotation
      * classes.
      */
-    private final Set<ClassLoader> ivCheckedAnnotationClassLoaders =
-                    Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<ClassLoader, Boolean>())); // d676633
+    private final Set<ClassLoader> ivCheckedAnnotationClassLoaders = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<ClassLoader, Boolean>())); // d676633
 
     /**
      * A mapping from class loaders to the set of annotation classes that they
@@ -236,8 +231,7 @@ public abstract class AbstractInjectionEngine
      */
     public abstract ResourceFactoryBuilder getResourceFactoryBuilder(String type) throws InjectionException;
 
-    public void initialize() // F743-27658.1
-    {
+    public void initialize() {
         InternalInjectionEngineAccessor.setInjectionEngine(this); // F46994.2
 
         InjectionDiagnosticModule dm = InjectionDiagnosticModule.instance();
@@ -247,12 +241,10 @@ public abstract class AbstractInjectionEngine
         // set the flag to true
         ivIsInitialized = true;
 
-        try
-        {
+        try {
             registerInjectionProcessorProvider(new ResourceProcessorProvider()); // RTC115266
             registerInjectionProcessorProvider(new DataSourceDefinitionProcessorProvider()); // F743-21590, RTC115266
-        } catch (InjectionException ex)
-        {
+        } catch (InjectionException ex) {
             throw new IllegalStateException(ex);
         }
     }
@@ -260,8 +252,7 @@ public abstract class AbstractInjectionEngine
     /**
      * Set the initialized flag to false so that others may not NOT register in their start method.
      */
-    public void stop()
-    {
+    public void stop() {
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
         if (isTraceOn && tc.isEntryEnabled())
             Tr.entry(tc, "stop");
@@ -276,18 +267,14 @@ public abstract class AbstractInjectionEngine
      * If a processor was already registered with the specified annotation, that class will be returned
      * otherwise a null will be returned.
      *
-     * @param processor The processor class to be registered
+     * @param processor  The processor class to be registered
      * @param annotation The annotation class the processor is associated.
      * @throws InjectionException if the provider is already registered
      */
     @Override
-    public <A extends Annotation, AS extends Annotation> void registerInjectionProcessor
-                    (Class<? extends InjectionProcessor<A, AS>> processor,
-                     Class<A> annotation)
-                                    throws InjectionException
-    {
-        if (OverrideInjectionProcessor.class.isAssignableFrom(processor)) // RTC114863
-        {
+    public <A extends Annotation, AS extends Annotation> void registerInjectionProcessor(Class<? extends InjectionProcessor<A, AS>> processor,
+                                                                                         Class<A> annotation) throws InjectionException {
+        if (OverrideInjectionProcessor.class.isAssignableFrom(processor)) {
             throw new IllegalArgumentException("OverrideInjectionProcessor must be registered with an InjectionProcessorProvider");
         }
 
@@ -295,62 +282,62 @@ public abstract class AbstractInjectionEngine
     }
 
     @Override
-    public synchronized void registerInjectionProcessorProvider(InjectionProcessorProvider<?, ?> provider)
-                    throws InjectionException
-    {
+    public synchronized void registerInjectionProcessorProvider(InjectionProcessorProvider<?, ?> provider) throws InjectionException {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
             Tr.debug(tc, "registerInjectionProcessor: " +
                          provider.getAnnotationClass() + " = " + provider);
 
-        if (!ivIsInitialized)
-        {
+        if (!ivIsInitialized) {
             Tr.error(tc, "INJECTION_ENGINE_SERVICE_NOT_INITIALIZED_CWNEN0006E");
             throw new InjectionException("injection engine is not initialized");
         }
 
         Class<?> annotationClass = provider.getAnnotationClass();
 
-        if (ivProcessorProviders.get(annotationClass) != null)
-        {
-            throw new InjectionException("provider already registered for " + annotationClass.getName());
-        }
+        // Since OSGi doesn't force an order for register/unregister when a service restarts,
+        // allowing either order, so the last register call will override any prior register.
 
-        ivProcessorProviders.put(annotationClass, provider);
+        InjectionProcessorProvider<?, ?> previousProvider = ivProcessorProviders.put(annotationClass, provider);
+
+        if (previousProvider != null) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
+                Tr.debug(tc, "registerInjectionProcessor: provider already registered for " + annotationClass.getName() + ", previous = " + previousProvider);
+        }
     }
 
     @Override
-    public synchronized void unregisterInjectionProcessorProvider(InjectionProcessorProvider<?, ?> provider)
-                    throws InjectionException
-    {
+    public synchronized void unregisterInjectionProcessorProvider(InjectionProcessorProvider<?, ?> provider) throws InjectionException {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
             Tr.debug(tc, "unregisterInjectionProcessorProvider: " +
                          provider.getAnnotationClass() + " = " + provider);
 
-        if (!ivIsInitialized)
-        {
+        if (!ivIsInitialized) {
             Tr.error(tc, "INJECTION_ENGINE_SERVICE_NOT_INITIALIZED_CWNEN0006E");
             throw new InjectionException("injection engine is not initialized");
         }
 
         Class<?> annotationClass = provider.getAnnotationClass();
 
-        if (ivProcessorProviders.get(annotationClass) != provider)
-        {
-            throw new InjectionException("provider not registered for " + annotationClass.getName());
-        }
+        // Since OSGi doesn't force an order for register/unregister when a service restarts,
+        // allowing either order, so the last register call will override any prior register.
 
-        ivProcessorProviders.remove(annotationClass);
+        InjectionProcessorProvider<?, ?> currentProvider = ivProcessorProviders.get(annotationClass);
+
+        if (currentProvider == provider) {
+            ivProcessorProviders.remove(annotationClass);
+        } else {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
+                Tr.debug(tc, "unregisterInjectionProcessorProvider: provider not registered for " + annotationClass.getName() + ", current = " + currentProvider);
+        }
     }
 
-    InjectionProcessorContextImpl createInjectionProcessorContext() // F743-33811.1
-    {
+    InjectionProcessorContextImpl createInjectionProcessorContext() {
         InjectionProcessorContextImpl context = new InjectionProcessorContextImpl();
 
         // Copy the map instance variables into the processor context, and
         // indicate they must be copied if a call is made to modify them, since
         // the current copies are in use.                                  PM79779
-        synchronized (this)
-        {
+        synchronized (this) {
             context.ivObjectFactoryMap = ivObjectFactoryMap;
             ivObjectFactoryMapCopyOnWrite = true;
 
@@ -367,22 +354,18 @@ public abstract class AbstractInjectionEngine
     ComponentNameSpaceConfiguration createNonCompNameSpaceConfig(InjectionScope scope,
                                                                  J2EEName j2eeName,
                                                                  Context javaColonContext,
-                                                                 InjectionProcessorContextImpl context)
-    {
+                                                                 InjectionProcessorContextImpl context) {
         String displayName = j2eeName != null ? j2eeName.getComponent() : null; // d696076
-        if (displayName == null)
-        {
+        if (displayName == null) {
             displayName = scope.qualifiedName();
         }
 
         ComponentNameSpaceConfiguration compNSConfig = new ComponentNameSpaceConfiguration(displayName, j2eeName);
 
-        if (compNSConfig.getModuleName() == null)
-        {
+        if (compNSConfig.getModuleName() == null) {
             compNSConfig.setModuleDisplayName(scope.qualifiedName()); // d696076
         }
-        if (compNSConfig.getApplicationName() == null)
-        {
+        if (compNSConfig.getApplicationName() == null) {
             compNSConfig.setApplicationDisplayName(scope.qualifiedName()); // d696076
         }
 
@@ -397,16 +380,13 @@ public abstract class AbstractInjectionEngine
      * Populates the empty cookie map with cookies to be injections.
      *
      * @param injectionTargetMap An empty map to be populated with the injection targets from
-     *            the merged xml and annotations.
-     * @param compNSConfig The component configuration information provided by the container.
+     *                               the merged xml and annotations.
+     * @param compNSConfig       The component configuration information provided by the container.
      * @throws InjectionException if an error occurs processing the injection metadata
      */
     @Override
-    public void processInjectionMetaData
-                    (HashMap<Class<?>, InjectionTarget[]> injectionTargetMap,
-                     ComponentNameSpaceConfiguration compNSConfig)
-                                    throws InjectionException
-    {
+    public void processInjectionMetaData(HashMap<Class<?>, InjectionTarget[]> injectionTargetMap,
+                                         ComponentNameSpaceConfiguration compNSConfig) throws InjectionException {
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
         if (isTraceOn && tc.isEntryEnabled())
             Tr.entry(tc, "processInjectionMetaData (targets)");
@@ -419,16 +399,12 @@ public abstract class AbstractInjectionEngine
         processInjectionMetaData(compNSConfig, null);
 
         List<Class<?>> injectionClasses = compNSConfig.getInjectionClasses();
-        if (injectionClasses != null && !injectionClasses.isEmpty()) // d721619
-        {
-            Map<Class<?>, List<InjectionTarget>> declaredTargets =
-                            getDeclaredInjectionTargets(context.ivProcessedInjectionBindings);
+        if (injectionClasses != null && !injectionClasses.isEmpty()) {
+            Map<Class<?>, List<InjectionTarget>> declaredTargets = getDeclaredInjectionTargets(context.ivProcessedInjectionBindings);
 
             boolean checkAppConfig = compNSConfig.isCheckApplicationConfiguration();
-            for (Class<?> injectionClass : injectionClasses)
-            {
-                InjectionTarget[] injectionTargets =
-                                getInjectionTargets(declaredTargets, injectionClass, checkAppConfig);
+            for (Class<?> injectionClass : injectionClasses) {
+                InjectionTarget[] injectionTargets = getInjectionTargets(declaredTargets, injectionClass, checkAppConfig);
                 injectionTargetMap.put(injectionClass, injectionTargets);
             }
         }
@@ -444,15 +420,13 @@ public abstract class AbstractInjectionEngine
      * Processes injection metadata using the specified configuration with
      * InjectionProcessorContext already set.
      *
-     * @param compNSConfig the component configuration with
-     *            InjectionProcessorContext already set
+     * @param compNSConfig     the component configuration with
+     *                             InjectionProcessorContext already set
      * @param annotatedClasses the list of classes that should be processed for
-     *            annotations, or <tt>null</tt> if the list should be determined from {@link ComponentNameSpaceConfiguration#getInjectionClasses}
+     *                             annotations, or <tt>null</tt> if the list should be determined from {@link ComponentNameSpaceConfiguration#getInjectionClasses}
      */
     protected void processInjectionMetaData(ComponentNameSpaceConfiguration compNSConfig,
-                                            List<Class<?>> annotatedClasses)
-                    throws InjectionException
-    {
+                                            List<Class<?>> annotatedClasses) throws InjectionException {
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
         if (isTraceOn && tc.isEntryEnabled())
             Tr.entry(tc, "processInjectionMetaData: " + compNSConfig.toDumpString());
@@ -478,8 +452,7 @@ public abstract class AbstractInjectionEngine
         InjectionProcessorContextImpl context = InjectionProcessorContextImpl.get(compNSConfig);
         context.ivJavaNameSpaceContext = compNSConfig.getJavaColonContext(); // d682474
 
-        List<InjectionProcessorProvider<?, ?>> providers =
-                        new ArrayList<InjectionProcessorProvider<?, ?>>(ivProcessorProviders.values());
+        List<InjectionProcessorProvider<?, ?>> providers = new ArrayList<InjectionProcessorProvider<?, ?>>(ivProcessorProviders.values());
         InjectionProcessorManager processorManager = new InjectionProcessorManager(this, compNSConfig, context, providers);
 
         // Extract all the persistence related specification from the deployment
@@ -488,28 +461,22 @@ public abstract class AbstractInjectionEngine
 
         // Populate the injectionTargetMap with the  the annotation information
         // using the registered processors and instance classes
-        if (annotatedClasses == null) // F743-33811.1
-        {
-            if (!compNSConfig.isMetaDataComplete())
-            {
+        if (annotatedClasses == null) {
+            if (!compNSConfig.isMetaDataComplete()) {
                 annotatedClasses = compNSConfig.getInjectionClasses();
             }
-            if (annotatedClasses == null)
-            {
+            if (annotatedClasses == null) {
                 annotatedClasses = Collections.emptyList();
             }
         }
 
-        if (!annotatedClasses.isEmpty())
-        {
+        if (!annotatedClasses.isEmpty()) {
             ClassLoader loader = compNSConfig.getClassLoader();
-            if (loader != null)
-            {
+            if (loader != null) {
                 checkAnnotationClasses(loader); // d676633
             }
 
-            for (Class<?> annotatedClass : annotatedClasses)
-            {
+            for (Class<?> annotatedClass : annotatedClasses) {
                 processorManager.processAnnotations(annotatedClass);
             }
         }
@@ -519,8 +486,7 @@ public abstract class AbstractInjectionEngine
         // For federated client modules, collect all the client injection targets
         // and make them available to client processes.
         if (compNSConfig.getOwningFlow() == ComponentNameSpaceConfiguration.ReferenceFlowKind.CLIENT &&
-            compNSConfig.getClassLoader() == null)
-        {
+            compNSConfig.getClassLoader() == null) {
             processClientInjections(compNSConfig, context); // F743-33811.1
         }
 
@@ -532,50 +498,41 @@ public abstract class AbstractInjectionEngine
      * Check the specified class loader to check if it has overridden any
      * annotation classes processed by the injection engine.
      */
-    private void checkAnnotationClasses(ClassLoader loader) // d676633
-    {
+    private void checkAnnotationClasses(ClassLoader loader) {
         boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
         if (isTraceOn && tc.isDebugEnabled())
             Tr.entry(tc, "checkAnnotationClasses: " + loader);
 
         // All EJBs in an application share the same class loader.  Only check
         // a given class loader once.
-        if (ivCheckedAnnotationClassLoaders.add(loader))
-        {
-            for (Class<?> processorClass : ivProcessorProviders.keySet())
-            {
+        if (ivCheckedAnnotationClassLoaders.add(loader)) {
+            for (Class<?> processorClass : ivProcessorProviders.keySet()) {
                 String className = processorClass.getName();
 
                 Class<?> loaderClass;
-                try
-                {
+                try {
                     loaderClass = loader.loadClass(className);
-                } catch (ClassNotFoundException ex)
-                {
+                } catch (ClassNotFoundException ex) {
                     // At least it hasn't been overridden, so ignore per WAB.  F53641
                     if (isTraceOn && tc.isDebugEnabled())
                         Tr.debug(tc, "ignoring " + className + " : " + ex);
                     continue;
                 }
 
-                if (loaderClass != processorClass)
-                {
+                if (loaderClass != processorClass) {
                     Set<String> warnedAnnotations = null;
                     ClassLoader loaderClassLoader = loaderClass.getClassLoader();
 
                     if (isTraceOn && tc.isDebugEnabled())
                         Tr.debug(tc, "loaded " + loaderClass + " from application class loader " + loaderClassLoader);
 
-                    synchronized (this)
-                    {
-                        if (ivWarnedClassLoaderAnnotations == null)
-                        {
+                    synchronized (this) {
+                        if (ivWarnedClassLoaderAnnotations == null) {
                             ivWarnedClassLoaderAnnotations = new WeakHashMap<ClassLoader, Set<String>>();
                         }
 
                         warnedAnnotations = ivWarnedClassLoaderAnnotations.get(loaderClassLoader);
-                        if (warnedAnnotations == null)
-                        {
+                        if (warnedAnnotations == null) {
                             warnedAnnotations = Collections.synchronizedSet(new HashSet<String>());
                             ivWarnedClassLoaderAnnotations.put(loaderClassLoader, warnedAnnotations);
                         }
@@ -585,8 +542,7 @@ public abstract class AbstractInjectionEngine
                     // particular annotation class.  We do not want a PARENT_LAST
                     // application to generate warnings for every child WAR class
                     // loader.  Similarly for application server class loaders.
-                    if (warnedAnnotations == null || warnedAnnotations.add(className))
-                    {
+                    if (warnedAnnotations == null || warnedAnnotations.add(className)) {
                         CodeSource codeSource = loaderClass.getProtectionDomain().getCodeSource();
                         String codeSourceLocation = codeSource == null ? null : String.valueOf(codeSource.getLocation());
 
@@ -602,8 +558,7 @@ public abstract class AbstractInjectionEngine
     }
 
     protected abstract void processClientInjections(ComponentNameSpaceConfiguration compNSConfig,
-                                                    InjectionProcessorContextImpl context)
-                    throws InjectionException;
+                                                    InjectionProcessorContextImpl context) throws InjectionException;
 
     /**
      * Creates a map of class to injection targets for fields and methods
@@ -614,21 +569,16 @@ public abstract class AbstractInjectionEngine
      * @see #getInjectionTargets
      */
     // d719917
-    Map<Class<?>, List<InjectionTarget>> getDeclaredInjectionTargets
-                    (List<InjectionBinding<?>> resolvedInjectionBindings)
-    {
+    Map<Class<?>, List<InjectionTarget>> getDeclaredInjectionTargets(List<InjectionBinding<?>> resolvedInjectionBindings) {
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
         if (isTraceOn && tc.isEntryEnabled())
             Tr.entry(tc, "getDeclaredInjectionTargets");
 
-        Map<Class<?>, List<InjectionTarget>> declaredTargets =
-                        new HashMap<Class<?>, List<InjectionTarget>>();
+        Map<Class<?>, List<InjectionTarget>> declaredTargets = new HashMap<Class<?>, List<InjectionTarget>>();
 
         // First, collect declared injection targets on a per-class basis.
-        for (InjectionBinding<?> injectionBinding : resolvedInjectionBindings)
-        {
-            if (!injectionBinding.isResolved())
-            {
+        for (InjectionBinding<?> injectionBinding : resolvedInjectionBindings) {
+            if (!injectionBinding.isResolved()) {
                 if (isTraceOn && tc.isDebugEnabled())
                     Tr.debug(tc, "skipping unresolved " + injectionBinding);
                 continue;
@@ -639,10 +589,8 @@ public abstract class AbstractInjectionEngine
                              Util.identity(injectionBinding) + '[' + injectionBinding.getDisplayName() + ']');
 
             List<InjectionTarget> injectionTargets = InjectionProcessorContextImpl.getInjectionTargets(injectionBinding);
-            if (injectionTargets != null)
-            {
-                for (InjectionTarget target : injectionTargets)
-                {
+            if (injectionTargets != null) {
+                for (InjectionTarget target : injectionTargets) {
                     Member member = target.getMember();
                     Class<?> memberClass = member.getDeclaringClass();
 
@@ -650,8 +598,7 @@ public abstract class AbstractInjectionEngine
                         Tr.debug(tc, "adding " + member);
 
                     List<InjectionTarget> classTargets = declaredTargets.get(memberClass);
-                    if (classTargets == null)
-                    {
+                    if (classTargets == null) {
                         if (isTraceOn && tc.isDebugEnabled())
                             Tr.debug(tc, "creating list for " + memberClass + "/" + AccessController.doPrivileged(new GetClassLoaderPrivileged(memberClass)));
 
@@ -674,17 +621,15 @@ public abstract class AbstractInjectionEngine
      * from a map of declared injection targets.
      *
      * @param declaredTargets the result of {@link #getDeclaredInjectionTargets}
-     * @param instanceClass the class to which injection targets should apply
-     * @param checkAppConfig true if application configuration should be checked
+     * @param instanceClass   the class to which injection targets should apply
+     * @param checkAppConfig  true if application configuration should be checked
      * @return the applicable injection targets
      * @throws InjectionException
      */
     // F50309.4
     InjectionTarget[] getInjectionTargets(Map<Class<?>, List<InjectionTarget>> declaredTargets,
                                           Class<?> instanceClass,
-                                          boolean checkAppConfig)
-                    throws InjectionException
-    {
+                                          boolean checkAppConfig) throws InjectionException {
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
         if (isTraceOn && tc.isEntryEnabled())
             Tr.entry(tc, "getInjectionTargets: " + instanceClass + "/" + AccessController.doPrivileged(new GetClassLoaderPrivileged(instanceClass)));
@@ -705,38 +650,32 @@ public abstract class AbstractInjectionEngine
         // before subclass methods.                                        d719917
         List<Class<?>> classHierarchy = new ArrayList<Class<?>>();
         for (Class<?> superclass = instanceClass; superclass != null && superclass != Object.class; // d721081
-        superclass = superclass.getSuperclass())
-        {
+                        superclass = superclass.getSuperclass()) {
             classHierarchy.add(superclass);
         }
         Collections.reverse(classHierarchy);
 
         // Fields must be injected before methods, so we make two passes over
         // the injection targets: first fields, then methods.
-        for (int memberRound = 0; memberRound < 2; memberRound++)
-        {
+        for (int memberRound = 0; memberRound < 2; memberRound++) {
             boolean wantFields = memberRound == 0;
 
             if (isTraceOn && tc.isDebugEnabled())
                 Tr.debug(tc, wantFields ? "collecting fields" : "collecting methods");
 
-            for (Class<?> superclass : classHierarchy)
-            {
+            for (Class<?> superclass : classHierarchy) {
                 List<InjectionTarget> classTargets = declaredTargets.get(superclass);
-                if (classTargets == null)
-                {
+                if (classTargets == null) {
                     if (isTraceOn && tc.isDebugEnabled())
                         Tr.debug(tc, "no members for " + superclass + "/" + AccessController.doPrivileged(new GetClassLoaderPrivileged(superclass)));
                     continue;
                 }
 
-                for (InjectionTarget injectionTarget : classTargets)
-                {
+                for (InjectionTarget injectionTarget : classTargets) {
                     Member member = injectionTarget.getMember();
 
                     boolean isField = member instanceof Field;
-                    if (wantFields != isField)
-                    {
+                    if (wantFields != isField) {
                         continue;
                     }
 
@@ -745,21 +684,17 @@ public abstract class AbstractInjectionEngine
                     // overridden.                                            d719917
                     if (!isField &&
                         !Modifier.isPrivate(member.getModifiers()) &&
-                        member.getDeclaringClass() != instanceClass)
-                    {
-                        if (nonPrivateMethods == null)
-                        {
+                        member.getDeclaringClass() != instanceClass) {
+                        if (nonPrivateMethods == null) {
                             // Compute the set of "overriding" non-private methods in
                             // the hierarchy.
                             nonPrivateMethods = new HashSet<Method>();
-                            for (MethodMap.MethodInfo methodInfo : MethodMap.getAllNonPrivateMethods(instanceClass))
-                            {
+                            for (MethodMap.MethodInfo methodInfo : MethodMap.getAllNonPrivateMethods(instanceClass)) {
                                 nonPrivateMethods.add(methodInfo.getMethod());
                             }
                         }
 
-                        if (!nonPrivateMethods.contains(member))
-                        {
+                        if (!nonPrivateMethods.contains(member)) {
                             // The method was overridden.
                             if (isTraceOn && tc.isDebugEnabled())
                                 Tr.debug(tc, "skipping overridden " + member + " for " +
@@ -769,8 +704,7 @@ public abstract class AbstractInjectionEngine
                         }
                     }
 
-                    if (injectionTargets == null)
-                    {
+                    if (injectionTargets == null) {
                         injectionTargets = new LinkedHashMap<Member, InjectionTarget>();
                     }
 
@@ -781,12 +715,10 @@ public abstract class AbstractInjectionEngine
 
                     InjectionTarget previousTarget = injectionTargets.put(member, injectionTarget);
 
-                    if (previousTarget != null)
-                    {
+                    if (previousTarget != null) {
                         String memberName = member.getDeclaringClass().getName() + "." + member.getName();
                         Tr.warning(tc, "DUPLICATE_INJECTION_TARGETS_SPECIFIED_CWNEN0040W", memberName); //d447011
-                        if (isValidationFailable(checkAppConfig)) // F50309.6
-                        {
+                        if (isValidationFailable(checkAppConfig)) {
                             memberName += isField ? " field" : " method";
                             String curRefName = injectionTarget.getInjectionBinding().getDisplayName();
                             String preRefName = previousTarget.getInjectionBinding().getDisplayName();
@@ -800,12 +732,9 @@ public abstract class AbstractInjectionEngine
         }
 
         InjectionTarget[] result;
-        if (injectionTargets == null)
-        {
+        if (injectionTargets == null) {
             result = EMPTY_INJECTION_TARGETS;
-        }
-        else
-        {
+        } else {
             result = new InjectionTarget[injectionTargets.size()];
             injectionTargets.values().toArray(result);
         }
@@ -821,9 +750,7 @@ public abstract class AbstractInjectionEngine
      */
     @Override
     public void inject(Object objectToInject,
-                       InjectionTarget injectionTarget)
-                    throws InjectionException
-    {
+                       InjectionTarget injectionTarget) throws InjectionException {
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
         if (isTraceOn && tc.isEntryEnabled())
             Tr.entry(tc, "inject", objectToInject, injectionTarget);
@@ -840,9 +767,7 @@ public abstract class AbstractInjectionEngine
     @Override
     public void inject(Object objectToInject,
                        InjectionTarget target,
-                       InjectionTargetContext targetContext)
-                    throws InjectionException
-    {
+                       InjectionTargetContext targetContext) throws InjectionException {
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
         if (isTraceOn && tc.isEntryEnabled())
             Tr.entry(tc, "inject " + "(" + Util.identity(objectToInject) +
@@ -860,17 +785,14 @@ public abstract class AbstractInjectionEngine
      */
     @Override
     public void notifyInjectionMetaDataListeners(ReferenceContext referenceContext,
-                                                 ComponentNameSpaceConfiguration compNSpaceConfiguration)
-                    throws InjectionException
-    {
+                                                 ComponentNameSpaceConfiguration compNSpaceConfiguration) throws InjectionException {
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
         if (isTraceOn && tc.isEntryEnabled())
             Tr.entry(tc, "notifyInjectionMetaDataListeners");
 
         InjectionMetaData injectionMetaData = new InjectionMetaDataImpl(this, compNSpaceConfiguration, referenceContext); // F48603
 
-        for (InjectionMetaDataListener metaDataListener : metaDataListeners)
-        {
+        for (InjectionMetaDataListener metaDataListener : metaDataListeners) {
             if (isTraceOn && tc.isDebugEnabled())
                 Tr.debug(tc, "invoking InjectionMetaDataListener: " + metaDataListener);
             metaDataListener.injectionMetaDataCreated(injectionMetaData);
@@ -885,8 +807,7 @@ public abstract class AbstractInjectionEngine
      * engine instance.
      */
     @Override
-    public void registerInjectionMetaDataListener(InjectionMetaDataListener metaDataListener)
-    {
+    public void registerInjectionMetaDataListener(InjectionMetaDataListener metaDataListener) {
         if (metaDataListener == null) {
             throw new IllegalArgumentException("A null InjectionMetaDataListener cannot be registered " +
                                                "with the injection engine.");
@@ -901,8 +822,7 @@ public abstract class AbstractInjectionEngine
      * engine instance.
      */
     @Override
-    public void unregisterInjectionMetaDataListener(InjectionMetaDataListener metaDataListener)
-    {
+    public void unregisterInjectionMetaDataListener(InjectionMetaDataListener metaDataListener) {
         if (metaDataListener == null) {
             throw new IllegalArgumentException("A null InjectionMetaDataListener cannot be unregistered " +
                                                "from the injection engine.");
@@ -917,9 +837,7 @@ public abstract class AbstractInjectionEngine
     public void registerObjectFactory(Class<? extends Annotation> annotation,
                                       Class<?> type,
                                       Class<? extends ObjectFactory> objectFactory,
-                                      boolean allowOverride) // F623-841.1
-    throws InjectionException
-    {
+                                      boolean allowOverride) throws InjectionException {
         registerObjectFactory(annotation, type, objectFactory, allowOverride, null, true);
     }
 
@@ -930,17 +848,12 @@ public abstract class AbstractInjectionEngine
                                       Class<? extends ObjectFactory> objectFactory,
                                       boolean allowOverride,
                                       Set<String> allowedAttributes,
-                                      boolean refAddrNeeded)
-                    throws InjectionException
-    {
-        registerObjectFactoryInfo(new ObjectFactoryInfoImpl(annotation, type, objectFactory, allowOverride,
-                        allowedAttributes, refAddrNeeded));
+                                      boolean refAddrNeeded) throws InjectionException {
+        registerObjectFactoryInfo(new ObjectFactoryInfoImpl(annotation, type, objectFactory, allowOverride, allowedAttributes, refAddrNeeded));
     }
 
     @Override
-    public void registerObjectFactoryInfo(ObjectFactoryInfo info)
-                    throws InjectionException
-    {
+    public void registerObjectFactoryInfo(ObjectFactoryInfo info) throws InjectionException {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "registerObjectFactoryInfo: " +
                          info.getAnnotationClass() + " : " + info.getType() +
@@ -950,9 +863,7 @@ public abstract class AbstractInjectionEngine
     }
 
     @Override
-    public void unregisterObjectFactoryInfo(ObjectFactoryInfo info)
-                    throws InjectionException
-    {
+    public void unregisterObjectFactoryInfo(ObjectFactoryInfo info) throws InjectionException {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "unregisterObjectFactoryInfo: " +
                          info.getAnnotationClass() + " : " + info.getType() +
@@ -961,11 +872,8 @@ public abstract class AbstractInjectionEngine
         updateObjectFactoryInfo(info, false);
     }
 
-    private void updateObjectFactoryInfo(ObjectFactoryInfo info, boolean register)
-                    throws InjectionException
-    {
-        if (!ivIsInitialized)
-        {
+    private void updateObjectFactoryInfo(ObjectFactoryInfo info, boolean register) throws InjectionException {
+        if (!ivIsInitialized) {
             Tr.error(tc, "INJECTION_ENGINE_SERVICE_NOT_INITIALIZED_CWNEN0006E");
             throw new InjectionException("injection engine is not initialized");
         }
@@ -976,8 +884,7 @@ public abstract class AbstractInjectionEngine
 
         if (annotation == null ||
             type == null ||
-            objectFactory == null)
-        {
+            objectFactory == null) {
             throw new IllegalArgumentException("Null arguments are not allowed: " +
                                                annotation + ", " + type + ", " + objectFactory);
         }
@@ -988,19 +895,13 @@ public abstract class AbstractInjectionEngine
         boolean allowOverride = info.isOverrideAllowed();
 
         // Now add the new ObjectFactory to the map, per annotation and data type.
-        synchronized (this)
-        {
-            Map<Class<? extends Annotation>, Map<Class<?>, ObjectFactoryInfo>> objectFactoryMap =
-                            allowOverride ? ivObjectFactoryMap : ivNoOverrideObjectFactoryMap;
+        synchronized (this) {
+            Map<Class<? extends Annotation>, Map<Class<?>, ObjectFactoryInfo>> objectFactoryMap = allowOverride ? ivObjectFactoryMap : ivNoOverrideObjectFactoryMap;
 
-            boolean copyOnWrite = allowOverride ? ivObjectFactoryMapCopyOnWrite
-                            : ivNoOverrideObjectFactoryMapCopyOnWrite;
-            if (copyOnWrite) // PM79779 F743-32696
-            {
-                Map<Class<? extends Annotation>, Map<Class<?>, ObjectFactoryInfo>> newMap =
-                                new HashMap<Class<? extends Annotation>, Map<Class<?>, ObjectFactoryInfo>>();
-                for (Map.Entry<Class<? extends Annotation>, Map<Class<?>, ObjectFactoryInfo>> entry : objectFactoryMap.entrySet())
-                {
+            boolean copyOnWrite = allowOverride ? ivObjectFactoryMapCopyOnWrite : ivNoOverrideObjectFactoryMapCopyOnWrite;
+            if (copyOnWrite) {
+                Map<Class<? extends Annotation>, Map<Class<?>, ObjectFactoryInfo>> newMap = new HashMap<Class<? extends Annotation>, Map<Class<?>, ObjectFactoryInfo>>();
+                for (Map.Entry<Class<? extends Annotation>, Map<Class<?>, ObjectFactoryInfo>> entry : objectFactoryMap.entrySet()) {
                     newMap.put(entry.getKey(), new HashMap<Class<?>, ObjectFactoryInfo>(entry.getValue()));
                 }
 
@@ -1009,17 +910,14 @@ public abstract class AbstractInjectionEngine
 
             Map<Class<?>, ObjectFactoryInfo> factories = objectFactoryMap.get(annotation);
 
-            if (factories == null)
-            {
-                if (!register)
-                {
+            if (factories == null) {
+                if (!register) {
                     throw new InjectionException("Object factory " + objectFactory.getName() +
                                                  " not registered for the " + annotation.getName() +
                                                  " annotation and the " + type.getName() + " type.");
                 }
 
-                if (!ivProcessorProviders.containsKey(annotation))
-                {
+                if (!ivProcessorProviders.containsKey(annotation)) {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                         Tr.debug(tc, "registerObjectFactory: An injection processor " +
                                      "does not exist for the specified annotation: " +
@@ -1032,14 +930,10 @@ public abstract class AbstractInjectionEngine
                 objectFactoryMap.put(annotation, factories);
             }
 
-            if (register)
-            {
+            if (register) {
                 factories.put(type, info); // d675976
-            }
-            else
-            {
-                if (factories.get(type) != info)
-                {
+            } else {
+                if (factories.get(type) != info) {
                     throw new InjectionException("Object factory " + objectFactory.getName() +
                                                  " not registered for the " + annotation.getName() +
                                                  " annotation and the " + type.getName() + " type.");
@@ -1048,16 +942,12 @@ public abstract class AbstractInjectionEngine
                 factories.remove(type);
             }
 
-            if (copyOnWrite) // PM79779 F743-32696
-            {
+            if (copyOnWrite) {
                 // Replace exiting map after all updates have been made.
-                if (allowOverride)
-                {
+                if (allowOverride) {
                     ivObjectFactoryMap = objectFactoryMap;
                     ivObjectFactoryMapCopyOnWrite = false; // PM79779
-                }
-                else
-                {
+                } else {
                     ivNoOverrideObjectFactoryMap = objectFactoryMap;
                     ivNoOverrideObjectFactoryMapCopyOnWrite = false; // PM79779
                 }
@@ -1081,40 +971,33 @@ public abstract class AbstractInjectionEngine
      * will be performed as if the override reference factory did not exist. <p>
      *
      * @param annotation the type of annotation processor the factory is to
-     *            be registered with.
-     * @param factory thread safe instance of an override reference factory.
+     *                       be registered with.
+     * @param factory    thread safe instance of an override reference factory.
      *
-     * @throws InjectionException if an injection processor has not been
-     *             registered for the specified annotation.
+     * @throws InjectionException       if an injection processor has not been
+     *                                      registered for the specified annotation.
      * @throws IllegalArgumentException if any of the parameters are null.
      **/
     // F1339-9050
     @Override
     public <A extends Annotation> void registerOverrideReferenceFactory(Class<A> annotation,
-                                                                        OverrideReferenceFactory<A> factory)
-                    throws InjectionException
-    {
+                                                                        OverrideReferenceFactory<A> factory) throws InjectionException {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "registerOverrideReferenceFactory", annotation, factory);
 
         if (annotation == null ||
-            factory == null)
-        {
+            factory == null) {
             throw new IllegalArgumentException("Null arguments are not allowed: " +
                                                annotation + ", " + factory);
         }
 
         // Now add the new factory to the map, per annotation.
-        synchronized (this)
-        {
+        synchronized (this) {
             HashMap<Class<? extends Annotation>, OverrideReferenceFactory<?>[]> map = ivOverrideReferenceFactoryMap;
 
-            if (ivOverrideReferenceFactoryMapCopyOnWrite) // PM79779 F743-32696
-            {
-                HashMap<Class<? extends Annotation>, OverrideReferenceFactory<?>[]> newMap =
-                                new HashMap<Class<? extends Annotation>, OverrideReferenceFactory<?>[]>();
-                for (Map.Entry<Class<? extends Annotation>, OverrideReferenceFactory<?>[]> entry : map.entrySet())
-                {
+            if (ivOverrideReferenceFactoryMapCopyOnWrite) {
+                HashMap<Class<? extends Annotation>, OverrideReferenceFactory<?>[]> newMap = new HashMap<Class<? extends Annotation>, OverrideReferenceFactory<?>[]>();
+                for (Map.Entry<Class<? extends Annotation>, OverrideReferenceFactory<?>[]> entry : map.entrySet()) {
                     OverrideReferenceFactory<?>[] value = entry.getValue();
                     OverrideReferenceFactory<?>[] newValue = new OverrideReferenceFactory[value.length];
                     System.arraycopy(value, 0, newValue, 0, value.length);
@@ -1126,10 +1009,8 @@ public abstract class AbstractInjectionEngine
 
             OverrideReferenceFactory<?>[] factories = map.get(annotation);
 
-            if (factories == null)
-            {
-                if (!ivProcessorProviders.containsKey(annotation))
-                {
+            if (factories == null) {
+                if (!ivProcessorProviders.containsKey(annotation)) {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                         Tr.debug(tc, "registerOverrideReferenceFactory: An injection " +
                                      "processor does not exist for the specified annotation: " +
@@ -1142,9 +1023,7 @@ public abstract class AbstractInjectionEngine
                 factories[0] = factory;
 
                 map.put(annotation, factories);
-            }
-            else
-            {
+            } else {
                 OverrideReferenceFactory<?>[] newFactories = new OverrideReferenceFactory[factories.length + 1];
                 System.arraycopy(factories, 0, newFactories, 0, factories.length);
                 newFactories[factories.length] = factory;
@@ -1152,8 +1031,7 @@ public abstract class AbstractInjectionEngine
                 map.put(annotation, newFactories);
             }
 
-            if (ivOverrideReferenceFactoryMapCopyOnWrite) // PM79779 F743-32696
-            {
+            if (ivOverrideReferenceFactoryMapCopyOnWrite) {
                 // Replace exiting map after all updates have been made.
                 ivOverrideReferenceFactoryMap = map;
                 ivOverrideReferenceFactoryMapCopyOnWrite = false;
@@ -1169,28 +1047,22 @@ public abstract class AbstractInjectionEngine
      */
     @Override
     @SuppressWarnings("unchecked")
-    public synchronized <A extends Annotation> OverrideReferenceFactory<A>[] getOverrideReferenceFactories(Class<A> klass) // F743-32443
-    {
+    public synchronized <A extends Annotation> OverrideReferenceFactory<A>[] getOverrideReferenceFactories(Class<A> klass) {
         ivOverrideReferenceFactoryMapCopyOnWrite = true; // PM79779
         return (OverrideReferenceFactory<A>[]) ivOverrideReferenceFactoryMap.get(klass);
     }
 
     @Override
     public ObjectFactory getObjectFactory(String objectFactoryClassName,
-                                          Class<? extends ObjectFactory> objectFactoryClass) // F54050
-    throws InjectionException
-    {
-        try
-        {
-            if (objectFactoryClass == null)
-            {
+                                          Class<? extends ObjectFactory> objectFactoryClass) throws InjectionException {
+        try {
+            if (objectFactoryClass == null) {
                 ClassLoader classLoader = svThreadContextAccessor.getContextClassLoaderForUnprivileged(Thread.currentThread());
                 objectFactoryClass = classLoader.loadClass(objectFactoryClassName).asSubclass(ObjectFactory.class);
             }
 
             return objectFactoryClass.newInstance();
-        } catch (Throwable ex)
-        {
+        } catch (Throwable ex) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(tc, "getInjectionObjectInstance", ex);
             Tr.error(tc, "OBJECT_FACTORY_CLASS_FAILED_TO_LOAD_CWNEN0024E", objectFactoryClassName);
@@ -1210,8 +1082,7 @@ public abstract class AbstractInjectionEngine
      **/
     // d698540.1
     @Override
-    public MBLinkReferenceFactory registerManagedBeanReferenceFactory(MBLinkReferenceFactory mbLinkRefFactory)
-    {
+    public MBLinkReferenceFactory registerManagedBeanReferenceFactory(MBLinkReferenceFactory mbLinkRefFactory) {
         MBLinkReferenceFactory rtnFactory = DEFAULT_MBLinkRefFactory;
         ivMBLinkRefFactory = mbLinkRefFactory; // d703474
         return rtnFactory;
@@ -1226,8 +1097,7 @@ public abstract class AbstractInjectionEngine
      * <code>ReferenceContext</code> to the <code>DeployedModule</code>.
      */
     @Override
-    public ReferenceContext createReferenceContext()
-    {
+    public ReferenceContext createReferenceContext() {
         return new ReferenceContextImpl(this); // F743-33811.1
     }
 
@@ -1239,8 +1109,7 @@ public abstract class AbstractInjectionEngine
      */
     // F49213
     @Override
-    public void formatTo(IncidentStream is)
-    {
+    public void formatTo(IncidentStream is) {
         is.writeLine("", "");
 
         // -----------------------------------------------------------------------
@@ -1264,8 +1133,7 @@ public abstract class AbstractInjectionEngine
 
         is.writeLine("", "");
         is.writeLine("", "   Registered Processors : ");
-        for (Map.Entry<Class<?>, ?> entry : ivProcessorProviders.entrySet())
-        {
+        for (Map.Entry<Class<?>, ?> entry : ivProcessorProviders.entrySet()) {
             is.writeLine("", "      " + entry.getKey().getName() +
                              " : " + entry.getValue());
         }
@@ -1274,39 +1142,32 @@ public abstract class AbstractInjectionEngine
         // while their state is being logged, but the CopyOnWrite flags don't
         // need to be set since the maps, nor any of their state will be
         // referenced beyond this synchronized block.                      PM79779
-        synchronized (this)
-        {
+        synchronized (this) {
             is.writeLine("", "");
             is.writeLine("", "   Registered Object Factories : ");
-            for (Map.Entry<Class<? extends Annotation>, Map<Class<?>, ObjectFactoryInfo>> entry : ivObjectFactoryMap.entrySet())
-            {
+            for (Map.Entry<Class<? extends Annotation>, Map<Class<?>, ObjectFactoryInfo>> entry : ivObjectFactoryMap.entrySet()) {
                 is.writeLine("", "      " + entry.getKey().getName());
                 Map<Class<?>, ObjectFactoryInfo> factories = entry.getValue();
-                for (Map.Entry<Class<?>, ObjectFactoryInfo> factoryEntry : factories.entrySet())
-                {
+                for (Map.Entry<Class<?>, ObjectFactoryInfo> factoryEntry : factories.entrySet()) {
                     is.writeLine("", "         " + factoryEntry.getKey().getName() + " : " + factoryEntry.getValue());
                 }
             }
 
             is.writeLine("", "");
             is.writeLine("", "   Registered No-Override Object Factories : ");
-            for (Map.Entry<Class<? extends Annotation>, Map<Class<?>, ObjectFactoryInfo>> entry : ivNoOverrideObjectFactoryMap.entrySet())
-            {
+            for (Map.Entry<Class<? extends Annotation>, Map<Class<?>, ObjectFactoryInfo>> entry : ivNoOverrideObjectFactoryMap.entrySet()) {
                 is.writeLine("", "      " + entry.getKey().getName());
                 Map<Class<?>, ObjectFactoryInfo> factories = entry.getValue();
-                for (Map.Entry<Class<?>, ObjectFactoryInfo> factoryEntry : factories.entrySet())
-                {
+                for (Map.Entry<Class<?>, ObjectFactoryInfo> factoryEntry : factories.entrySet()) {
                     is.writeLine("", "         " + factoryEntry.getKey().getName() + " : " + factoryEntry.getValue());
                 }
             }
 
             is.writeLine("", "");
             is.writeLine("", "   Registered Override Reference Factories : ");
-            for (Map.Entry<Class<? extends Annotation>, OverrideReferenceFactory<?>[]> entry : ivOverrideReferenceFactoryMap.entrySet())
-            {
+            for (Map.Entry<Class<? extends Annotation>, OverrideReferenceFactory<?>[]> entry : ivOverrideReferenceFactoryMap.entrySet()) {
                 is.writeLine("", "      " + entry.getKey().getName());
-                for (OverrideReferenceFactory<?> factory : entry.getValue())
-                {
+                for (OverrideReferenceFactory<?> factory : entry.getValue()) {
                     is.writeLine("", "         " + Util.identity(factory));
                 }
             }
@@ -1314,8 +1175,7 @@ public abstract class AbstractInjectionEngine
 
         is.writeLine("", "");
         is.writeLine("", "   Registered MetaDataListeners : ");
-        for (InjectionMetaDataListener listener : metaDataListeners)
-        {
+        for (InjectionMetaDataListener listener : metaDataListeners) {
             is.writeLine("", "      " + Util.identity(listener));
         }
         is.writeLine("", "");


### PR DESCRIPTION
Since OSGi doesn't force an order for register/unregister when a service restarts,
allowing either order, so the last register call will override any prior register.

fixes #10357 