### PR TITLE
Close the original input stream in `copyAndGetEntityStream`

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
@@ -1932,10 +1932,15 @@ public final class JAXRSUtils {
     // copy the input stream so that it is not inadvertently closed
     private static InputStream copyAndGetEntityStream(Message m) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        InputStream origInputStream = m.getContent(InputStream.class);
         try {
-            IOUtils.copy(m.getContent(InputStream.class), baos);
+            IOUtils.copy(origInputStream, baos);
         } catch (IOException e) {
             throw ExceptionUtils.toInternalServerErrorException(e, null);
+        } finally {
+            try {
+                origInputStream.close();
+            } catch (Throwable t) { /* AutoFFDC */ }
         }
         final byte[] copiedBytes = baos.toByteArray();
         m.setContent(InputStream.class, new ByteArrayInputStream(copiedBytes));

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
@@ -1925,10 +1925,15 @@ public final class JAXRSUtils {
     // copy the input stream so that it is not inadvertently closed
     private static InputStream copyAndGetEntityStream(Message m) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        InputStream origInputStream = m.getContent(InputStream.class);
         try {
-            IOUtils.copy(m.getContent(InputStream.class), baos);
+            IOUtils.copy(origInputStream, baos);
         } catch (IOException e) {
             throw ExceptionUtils.toInternalServerErrorException(e, null);
+        } finally {
+            try {
+                origInputStream.close();
+            } catch (Throwable t) { /* AutoFFDC */ }
         }
         final byte[] copiedBytes = baos.toByteArray();
         m.setContent(InputStream.class, new ByteArrayInputStream(copiedBytes));


### PR DESCRIPTION
Suggestion proposed by the CXF community to close the copied input stream.