### PR TITLE
Issue 10362: Follow up to initial service account logic

### DIFF
--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/AuthUtils.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/AuthUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,33 +14,33 @@ import javax.servlet.http.HttpServletRequest;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Sensitive;
 
 public class AuthUtils {
 
     public static final TraceComponent tc = Tr.register(AuthUtils.class);
 
+    @Sensitive
     public String getBearerTokenFromHeader(HttpServletRequest req) {
         return getBearerTokenFromHeader(req, "Authorization");
     }
 
+    @Sensitive
     public String getBearerTokenFromHeader(HttpServletRequest req, String... headersToCheck) {
         if (headersToCheck == null) {
             return null;
         }
         for (String headerName : headersToCheck) {
             String hdrValue = req.getHeader(headerName);
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, headerName + " header=", hdrValue);
-            }
             //if we are looking at custom header, then just return the value
-            if (!isAuthorizationHeader(headerName)) { 
+            if (!isAuthorizationHeader(headerName)) {
                 return hdrValue;
             } else {
                 String bearerAuthzMethod = "Bearer ";
                 if (hdrValue != null && hdrValue.startsWith(bearerAuthzMethod)) {
                     return hdrValue.substring(bearerAuthzMethod.length());
                 }
-            }   
+            }
         }
         return null;
     }

--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/HttpUtils.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/http/HttpUtils.java
@@ -308,7 +308,7 @@ public class HttpUtils {
         return responseStream;
     }
 
-    public HttpURLConnection setHeaders(HttpURLConnection con, Map<String, String> headers) {
+    public HttpURLConnection setHeaders(HttpURLConnection con, @Sensitive Map<String, String> headers) {
         if (headers == null) {
             return con;
         }

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/utils/OpenShiftUserApiUtils.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/utils/OpenShiftUserApiUtils.java
@@ -17,6 +17,7 @@ import java.io.StringReader;
 import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -59,13 +60,17 @@ public class OpenShiftUserApiUtils {
         return response;
     }
 
-    public String getUserApiResponseForServiceAccountToken(String serviceAccountToken, SSLSocketFactory sslSocketFactory) throws SocialLoginException {
+    public String getUserApiResponseForServiceAccountToken(@Sensitive String serviceAccountToken, SSLSocketFactory sslSocketFactory) throws SocialLoginException {
         String response = null;
         try {
             HttpURLConnection connection = sendServiceAccountIntrospectRequest(serviceAccountToken, sslSocketFactory);
             response = readServiceAccountIntrospectResponse(connection);
         } catch (Exception e) {
             throw new SocialLoginException("ERROR_INTROSPECTING_SERVICE_ACCOUNT", e, new Object[] { e });
+            //# 0=Exception message
+            //ERROR_INTROSPECTING_SERVICE_ACCOUNT=CWWKS53xxE: The response from the service account user API cannot be processed: {0}
+            //ERROR_INTROSPECTING_SERVICE_ACCOUNT.explanation=Information about the service account cannot be obtained because another error occurred.
+            //ERROR_INTROSPECTING_SERVICE_ACCOUNT.useraction=If the message contains another error message, see the user action for that message. Otherwise, check the server logs for more error messages that might indicate where the other error occurred.
         }
         return response;
     }
@@ -86,8 +91,8 @@ public class OpenShiftUserApiUtils {
         return connection;
     }
 
-    HttpURLConnection sendServiceAccountIntrospectRequest(String serviceAccountToken, SSLSocketFactory sslSocketFactory) throws IOException {
-        HttpURLConnection connection = httpUtils.createConnection(HttpUtils.RequestMethod.POST, config.getUserApi(), sslSocketFactory);
+    HttpURLConnection sendServiceAccountIntrospectRequest(@Sensitive String serviceAccountToken, SSLSocketFactory sslSocketFactory) throws IOException {
+        HttpURLConnection connection = httpUtils.createConnection(HttpUtils.RequestMethod.GET, config.getUserApi(), sslSocketFactory);
         connection = httpUtils.setHeaders(connection, getServiceAccountIntrospectRequestHeaders(serviceAccountToken));
         connection.connect();
         return connection;
@@ -135,8 +140,12 @@ public class OpenShiftUserApiUtils {
         String response = httpUtils.readConnectionResponse(connection);
         if (responseCode != HttpServletResponse.SC_OK) {
             throw new SocialLoginException("SERVICE_ACCOUNT_USER_API_BAD_STATUS", null, new Object[] { responseCode, response });
+            //# 0=HTTP response code, 1=Response body
+            //SERVICE_ACCOUNT_USER_API_BAD_STATUS=CWWKS5383E: The service account user API returned an unexpected [{0}] response code. Verify that the request to the API contains all of the required information and that the service account token is valid. The response from the API is [{1}].
+            //SERVICE_ACCOUNT_USER_API_BAD_STATUS.explanation=The service account user API did not return the expected status code.
+            //SERVICE_ACCOUNT_USER_API_BAD_STATUS.useraction=Check the API response that is in the error message for more information. Verify that the request to the API contains all of the required information. Ensure that the service account token is valid.
         }
-        return response;
+        return processServiceAccountIntrospectResponse(response);
     }
 
     String modifyExistingResponseToJSON(String response) throws SocialLoginException {
@@ -242,6 +251,65 @@ public class OpenShiftUserApiUtils {
             throw new SocialLoginException("KUBERNETES_USER_API_RESPONSE_MISSING_KEY", null, new Object[] { "status", currentResponse });
         }
 
+    }
+
+    String processServiceAccountIntrospectResponse(String response) throws SocialLoginException {
+        JsonObject jsonResponse = readResponseAsJsonObject(response);
+        JsonObject userMetadata = getJsonObjectValueFromJson(jsonResponse, "metadata");
+        JsonObject result = addGroupsToResult(jsonResponse, userMetadata);
+        return result.toString();
+    }
+
+    JsonObject readResponseAsJsonObject(String response) throws SocialLoginException {
+        if (response == null || response.isEmpty()) {
+            return null;
+        }
+        JsonObject jsonResponse;
+        try {
+            jsonResponse = Json.createReader(new StringReader(response)).readObject();
+        } catch (JsonParsingException e) {
+            throw new SocialLoginException("RESPONSE_NOT_JSON", null, new Object[] { response, e });
+            //RESPONSE_NOT_JSON=CWWKS53xxE: The content of the response is not a valid JSON object. The full response is {0}. {1}
+            //RESPONSE_NOT_JSON.explanation=The response is expected to be a valid JSON object.
+            //RESPONSE_NOT_JSON.useraction=Verify that request was sent to the expected target. Ensure that the intended target of the request is capable of returning JSON data. Check the response to see whether more information is included.
+        }
+        return jsonResponse;
+    }
+
+    JsonObject getJsonObjectValueFromJson(JsonObject json, String key) throws SocialLoginException {
+        if (!json.containsKey(key)) {
+            throw new SocialLoginException("JSON_MISSING_KEY", null, new Object[] { key, json });
+            //JSON_MISSING_KEY=CWWKS53xxE: The JSON object that is provided is missing an expected key: [{0}]. The full JSON object is [{1}].
+            //JSON_MISSING_KEY.explanation=The key that is specified in the message is expected to be within the JSON data. The key might be missing, or it might be in an unexpected location.
+            //JSON_MISSING_KEY.useraction=Check the JSON data to determine whether the key is missing.
+        }
+        JsonValue rawValue = json.get(key);
+        if (rawValue.getValueType() != ValueType.OBJECT) {
+            throw new SocialLoginException("JSON_ENTRY_WRONG_JSON_TYPE", null, new Object[] { key, ValueType.OBJECT, rawValue.getValueType(), json });
+            //JSON_ENTRY_WRONG_JSON_TYPE=CWWKS53xxE: The value for the key [{0}] in the JSON data is expected to be of type {1}, but the value is of type {2}. The JSON data is [{3}].
+            //JSON_ENTRY_WRONG_JSON_TYPE.explanation=The value for the specified key did not have the correct type. The JSON data might be malformed or might have an unexpected structure.
+            //JSON_ENTRY_WRONG_JSON_TYPE.useraction=Check the structure of the JSON data. Check the JSON data to see whether an error occurred.
+        }
+        return json.getJsonObject(key);
+    }
+
+    JsonObject addGroupsToResult(JsonObject rawJsonResponse, JsonObject metadataEntry) {
+        JsonObject result = metadataEntry;
+        String groupNameAttribute = config.getGroupNameAttribute();
+        if (groupNameAttribute != null && rawJsonResponse.containsKey(groupNameAttribute)) {
+            JsonObjectBuilder resultBuilder = copyJsonObject(metadataEntry);
+            resultBuilder.add(groupNameAttribute, rawJsonResponse.get(groupNameAttribute));
+            result = resultBuilder.build();
+        }
+        return result;
+    }
+
+    private JsonObjectBuilder copyJsonObject(JsonObject original) {
+        JsonObjectBuilder result = Json.createObjectBuilder();
+        for (Entry<String, JsonValue> entry : original.entrySet()) {
+            result.add(entry.getKey(), entry.getValue());
+        }
+        return result;
     }
 
 }

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/AuthorizationCodeAuthenticator.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/AuthorizationCodeAuthenticator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.websphere.security.jwt.JwtToken;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.common.jwk.utils.JsonUtils;
@@ -39,6 +40,7 @@ public class AuthorizationCodeAuthenticator {
     SSLSocketFactory sslSocketFactory = null;
 
     private Map<String, Object> tokens = new HashMap<String, Object>();
+    @Sensitive
     private String accessToken = null;
     private String userApiResponse = null;
     private JwtToken jwt = null;
@@ -62,14 +64,15 @@ public class AuthorizationCodeAuthenticator {
         this.tokens = tokens;
         this.accessToken = getAccessTokenFromTokens();
     }
-    
-    public AuthorizationCodeAuthenticator(HttpServletRequest req, HttpServletResponse res, SocialLoginConfig socialConfig, String accessToken, boolean openShift) {
+
+    public AuthorizationCodeAuthenticator(HttpServletRequest req, HttpServletResponse res, SocialLoginConfig socialConfig, @Sensitive String accessToken, boolean openShift) {
         this.request = req;
-        this.response = res; 
+        this.response = res;
         this.socialConfig = socialConfig;
         this.tokens.put(ClientConstants.ACCESS_TOKEN, accessToken);
     }
 
+    @Sensitive
     public Map<String, Object> getTokens() {
         return tokens;
     }
@@ -78,6 +81,7 @@ public class AuthorizationCodeAuthenticator {
         return userApiResponse;
     }
 
+    @Sensitive
     public String getAccessToken() {
         return accessToken;
     }
@@ -95,7 +99,7 @@ public class AuthorizationCodeAuthenticator {
         getTokensFromTokenEndpoint();
         createJwtUserApiResponseAndIssuedJwtWithAppropriateToken();
     }
-    
+
     public void generateJwtAndTokensFromAccessOrServiceAccountToken() throws SocialLoginException {
         createSslSocketFactory();
         createJwtUserApiResponseAndIssuedJwtWithAppropriateToken();
@@ -153,6 +157,7 @@ public class AuthorizationCodeAuthenticator {
         return (String) tokens.get(ClientConstants.ID_TOKEN);
     }
 
+    @Sensitive
     String getAccessTokenFromTokens() {
         return (String) tokens.get(ClientConstants.ACCESS_TOKEN);
     }

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/OAuthLoginFlow.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/OAuthLoginFlow.java
@@ -20,6 +20,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.websphere.security.WebTrustAssociationFailedException;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.social.Constants;
@@ -90,7 +91,7 @@ public class OAuthLoginFlow {
         return result;
     }
 
-    private boolean isAccessTokenNullOrEmpty(String tokenFromRequest) {
+    private boolean isAccessTokenNullOrEmpty(@Sensitive String tokenFromRequest) {
         if (tokenFromRequest == null || tokenFromRequest.isEmpty()) {
             return true;
         }
@@ -98,7 +99,7 @@ public class OAuthLoginFlow {
     }
 
     @FFDCIgnore(SocialLoginException.class)
-    private TAIResult handleAccessToken(String tokenFromRequest, HttpServletRequest request, HttpServletResponse response, SocialLoginConfig clientConfig) throws WebTrustAssociationFailedException {
+    private TAIResult handleAccessToken(@Sensitive String tokenFromRequest, HttpServletRequest request, HttpServletResponse response, SocialLoginConfig clientConfig) throws WebTrustAssociationFailedException {
         AuthorizationCodeAuthenticator authzCodeAuthenticator = new AuthorizationCodeAuthenticator(request, response, clientConfig, tokenFromRequest, true);
         try {
             authzCodeAuthenticator.generateJwtAndTokensFromAccessOrServiceAccountToken();

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/TAIWebUtils.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/TAIWebUtils.java
@@ -16,6 +16,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.common.http.AuthUtils;
 import com.ibm.ws.security.common.web.WebUtils;
@@ -145,6 +146,7 @@ public class TAIWebUtils {
         return hostAndPort;
     }
 
+    @Sensitive
     public String getBearerAccessToken(HttpServletRequest req, SocialLoginConfig clientConfig) {
         String headerName = clientConfig.getAccessTokenHeaderName();
         if (headerName != null) {
@@ -158,12 +160,13 @@ public class TAIWebUtils {
         }
     }
 
+    @Sensitive
     String getBearerTokenFromCustomHeader(HttpServletRequest req, String headerName) {
         String hdrValue = authUtils.getBearerTokenFromHeader(req, headerName);
-        if (tc.isDebugEnabled()) {
-            Tr.debug(tc, headerName + " content=", hdrValue);
-        }
         if (hdrValue != null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Header value is not null");
+            }
             return hdrValue.trim();
         } else {
             return getBearerTokenFromCustomHeaderSegments(req, headerName);
@@ -171,6 +174,7 @@ public class TAIWebUtils {
     }
 
     @FFDCIgnore(Exception.class)
+    @Sensitive
     String getBearerTokenFromCustomHeaderSegments(HttpServletRequest req, String headerName) {
         String headerSegments = req.getHeader(headerName + JWT_SEGMENTS);
         if (headerSegments == null) {
@@ -191,6 +195,7 @@ public class TAIWebUtils {
         return hdrValue;
     }
 
+    @Sensitive
     String buildBearerTokenFromCustomHeaderSegments(HttpServletRequest req, String headerName, int numberOfSegments) {
         StringBuffer tokenStringBuilder = new StringBuffer();
         for (int i = 1; i < numberOfSegments + 1; i++) {
@@ -202,11 +207,9 @@ public class TAIWebUtils {
         return tokenStringBuilder.toString();
     }
 
+    @Sensitive
     String getBearerTokenFromAuthzHeaderOrRequestBody(HttpServletRequest req) {
         String hdrValue = authUtils.getBearerTokenFromHeader(req);
-        if (tc.isDebugEnabled()) {
-            Tr.debug(tc, "Authorization header=", hdrValue);
-        }
         if (hdrValue == null) {
             String reqMethod = req.getMethod();
             if (ClientConstants.REQ_METHOD_POST.equalsIgnoreCase(reqMethod)) {


### PR DESCRIPTION
Adds logic to appropriately parse and handle the response from OpenShift's user API being used for the service account token. Also adds some `@Sensitive` annotations where we're logging the service account token