### PR TITLE
Fix server script handling of java options variables

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -2,7 +2,7 @@
 ###############################################################################
 # WebSphere Application Server liberty launch script
 #
-# Copyright IBM Corp. 2011, 2019
+# Copyright IBM Corp. 2011, 2020
 # The source code for this program is not published or other-
 # wise divested of its trade secrets, irrespective of what has
 # been deposited with the U.S. Copyright Office.
@@ -576,31 +576,44 @@ serverEnvDefaults()
     fi
   fi
 
+# Prefer OPENJ9_JAVA_OPTIONS to deprecated IBM_JAVA_OPTIONS
+  if [ -z "${OPENJ9_JAVA_OPTIONS}" ]
+  then
+    SPECIFIED_JAVA_OPTIONS=${IBM_JAVA_OPTIONS}
+  else
+    SPECIFIED_JAVA_OPTIONS=${OPENJ9_JAVA_OPTIONS}
+  fi
+  
   # Command-line parsing of -Xshareclasses does not allow "," in cacheDir.
   case ${WLP_OUTPUT_DIR} in
   *,*)
-    SERVER_IBM_JAVA_OPTIONS=${OPENJ9_JAVA_OPTIONS}
+    SERVER_IBM_JAVA_OPTIONS=${SPECIFIED_JAVA_OPTIONS}
     ;;
   *)
-    if $shareclassesCacheDirPerm
-    then
-      SERVER_IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty-%u,nonfatal,cacheDir=\"${WLP_OUTPUT_DIR}/.classCache\",cacheDirPerm=1000 -XX:ShareClassesEnableBCI -Xscmx80m ${OPENJ9_JAVA_OPTIONS}"
+    if ( echo "${SPECIFIED_JAVA_OPTIONS}" | grep -q "Xshareclasses"); then
+      SERVER_IBM_JAVA_OPTIONS=${SPECIFIED_JAVA_OPTIONS}
     else
-      SERVER_IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty-%u,nonfatal,cacheDir=\"${WLP_OUTPUT_DIR}/.classCache\" -XX:ShareClassesEnableBCI -Xscmx80m ${OPENJ9_JAVA_OPTIONS}"
+      if $shareclassesCacheDirPerm
+      then
+        SERVER_IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty-%u,nonfatal,cacheDir=\"${WLP_OUTPUT_DIR}/.classCache\",cacheDirPerm=1000 -XX:ShareClassesEnableBCI -Xscmx80m ${SPECIFIED_JAVA_OPTIONS}"
+      else
+        SERVER_IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty-%u,nonfatal,cacheDir=\"${WLP_OUTPUT_DIR}/.classCache\" -XX:ShareClassesEnableBCI -Xscmx80m ${SPECIFIED_JAVA_OPTIONS}"
+      fi
     fi
   esac
 
   # Add -Xquickstart -Xnoaot for client JVMs only.  AOT is ineffective if JVMs have conflicting
   # options, and it's more important that the server JVMs be able to use AOT.
   # Add -Dcom.ibm.tools.attach.enable=yes to allow self-attach on z/OS
-  IBM_JAVA_OPTIONS="-Xquickstart -Xnoaot -Dcom.ibm.tools.attach.enable=yes ${OPENJ9_JAVA_OPTIONS}"
+  
+  IBM_JAVA_OPTIONS="-Xquickstart -Xnoaot -Dcom.ibm.tools.attach.enable=yes ${SPECIFIED_JAVA_OPTIONS}"
   export IBM_JAVA_OPTIONS
-  OPENJ9_JAVA_OPTIONS="-Xquickstart -Xnoaot -Dcom.ibm.tools.attach.enable=yes ${OPENJ9_JAVA_OPTIONS}"
+  OPENJ9_JAVA_OPTIONS="-Xquickstart -Xnoaot -Dcom.ibm.tools.attach.enable=yes ${SPECIFIED_JAVA_OPTIONS}"
   export OPENJ9_JAVA_OPTIONS
 
   # Set a default file encoding if needed
   if [ -n "$defaultFileEncoding" ]; then
-    if ! expr "${JVM_OPTIONS_QUOTED} ${JVM_ARGS} ${OPENJ9_JAVA_OPTIONS}" : '.*\(-Dfile\.encoding\=[^[:space:]]\)' > /dev/null; then
+    if ! expr "${JVM_OPTIONS_QUOTED} ${JVM_ARGS} ${SPECIFIED_JAVA_OPTIONS}" : '.*\(-Dfile\.encoding\=[^[:space:]]\)' > /dev/null; then
       JVM_ARGS="${JVM_ARGS} -Dfile.encoding=$defaultFileEncoding"
     fi
   fi
@@ -936,8 +949,10 @@ serverCmd()
 
   SAVE_JVM_OPTIONS_QUOTED=${JVM_OPTIONS_QUOTED}
   JVM_OPTIONS_QUOTED=${SERVER_JVM_OPTIONS_QUOTED}
-  SAVE_IBM_JAVA_OPTIONS=${OPENJ9_JAVA_OPTIONS}
+  
+  SAVE_IBM_JAVA_OPTIONS=${IBM_JAVA_OPTIONS}
   IBM_JAVA_OPTIONS=${SERVER_IBM_JAVA_OPTIONS}
+  SAVE_OPENJ9_JAVA_OPTIONS=${OPENJ9_JAVA_OPTIONS}
   OPENJ9_JAVA_OPTIONS=${SERVER_IBM_JAVA_OPTIONS}
 
   if $os400lib; then
@@ -946,7 +961,7 @@ serverCmd()
 
     JVM_OPTIONS_QUOTED=${SAVE_JVM_OPTIONS_QUOTED}
     IBM_JAVA_OPTIONS=${SAVE_IBM_JAVA_OPTIONS}
-    OPENJ9_JAVA_OPTIONS=${SAVE_IBM_JAVA_OPTIONS}
+    OPENJ9_JAVA_OPTIONS=${SAVE_OPENJ9_JAVA_OPTIONS}
 
     if [ -n "${SERVER_CMD_BACKGROUND_LOG}" ]; then
       PID=`cat "${X_PID_FILE}"`
@@ -968,7 +983,7 @@ serverCmd()
 
       JVM_OPTIONS_QUOTED=${SAVE_JVM_OPTIONS_QUOTED}
       IBM_JAVA_OPTIONS=${SAVE_IBM_JAVA_OPTIONS}
-      OPENJ9_JAVA_OPTIONS=${SAVE_IBM_JAVA_OPTIONS}
+      OPENJ9_JAVA_OPTIONS=${SAVE_OPENJ9_JAVA_OPTIONS}
 
       if [ $rc = 0 ]; then
         # Verify/wait for the process to start
@@ -1029,7 +1044,7 @@ serverCmd()
 
     JVM_OPTIONS_QUOTED=${SAVE_JVM_OPTIONS_QUOTED}
     IBM_JAVA_OPTIONS=${SAVE_IBM_JAVA_OPTIONS}
-    OPENJ9_JAVA_OPTIONS=${SAVE_IBM_JAVA_OPTIONS}
+    OPENJ9_JAVA_OPTIONS=${SAVE_OPENJ9_JAVA_OPTIONS}
 
     if [ -n "${SERVER_CMD_BACKGROUND_LOG}" ]; then
       # Verify/wait for the process to start


### PR DESCRIPTION
Users should be able to specify either IBM_JAVA_OPTIONS or OPENJ9_JAVA_OPTIONS (though the former is deprecated, so the latter is recommended.) We will prefer OPENJ9_JAVA_OPTIONS, but will set both so that older JDKs will still pick up the value. 

We also shouldn't add Xshareclasses if it is already specified. 