### PR TITLE
Revert "Revert "Splitting deps for every 100 prereqs""

### DIFF
--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -167,9 +167,17 @@ task createGradleBootstrap {
 
         File dependenciesFile = new File(project.buildDir, 'dependencies.gradle')
         dependenciesFile.createNewFile()
+        def deps = ""
+        def sortedDeps = depsList.sort()
+        for(def i=0;i<sortedDeps.size;i++){
+          deps+=sortedDeps.get(i)+"\n"
+          if(i%100==0){
+            deps+="}\ndependencies {"
+          }
+        }
         dependenciesFile.text = """dependencies {
-${depsList.sort().join('\n')}
-}"""
+           ${deps}
+        }"""
     }
 }
 


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#10407
As discussed in defect 271379 (sorry internal) that defect appears to have been attributed to https://github.ibm.com/was-liberty/rtc-build-launcher/pull/37 and https://github.com/OpenLiberty/open-liberty/pull/10372 .

They were delivered on 13th at 12:50 UTC.

LAOS Continuous Build - EBC 20200113-1343 failed with this error
LAOS Continuous Build - EBC 20200113-1702 was ok aside from some test failures 
LAOS Continuous Build - EBC 20200113-2022 pushed 
LAOS Continuous Build - EBC 20200113-2342 did not hit this (it progressed 5 hours beyond this issue)

then on 14th at ~01:04 UTC https://github.ibm.com/was-liberty/rtc-build-launcher/pull/37 and https://github.com/OpenLiberty/open-liberty/pull/10372 were reverted.

So the first build after the above changes hit  issue - but the next 3 didn't so I'm pretty confident that #37 and #10372 are not the cause and should be redelivered.