### PR TITLE
Issue #10453: Auto-link EJB ref in java global with ejb-link

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.injection_fat/test-applications/InjectionMiscBean.jar/resources/META-INF/ibm-ejb-jar-bnd.xml
+++ b/dev/com.ibm.ws.ejbcontainer.injection_fat/test-applications/InjectionMiscBean.jar/resources/META-INF/ibm-ejb-jar-bnd.xml
@@ -16,8 +16,4 @@
     <resource-ref name="resourceRefMethodName" binding-name="jdbc/TestDataSource"/>
   </session>
 
-  <session name="ClientBean">
-    <ejb-ref name="java:global/env/ejb/ClientBeanRef" binding-name="java:global/InjectionMiscTestApp/InjectionMiscBean/ClientBean"/>
-  </session>
-
 </ejb-jar-bnd>


### PR DESCRIPTION
Relax the checking in EJBProcessor to allow ejb references
in java:global to use auto-link when the application name
is known and ejb-link has been specified (i.e. ejb-link or beanName).

This will allow EJB references in java:global to auto-link to
an EJB specified by ejb-link that exists in the same application.

If the EJB is in a different application, a binding will still be
required.

Also removed a binding from a test that was previously added to
demonstrate the current behavior. The test will now properly link
to the EJB without the need for a binding.

Please excuse the reformatting.... the only changes were the additions
of lines 233-235 in the new version of EJBProcessor.

fixes #10453 