### PR TITLE
messages when marked for rollback only

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/resources/com/ibm/ws/concurrent/persistent/resources/CWWKCMessages.nlsprops
+++ b/dev/com.ibm.ws.concurrent.persistent/resources/com/ibm/ws/concurrent/persistent/resources/CWWKCMessages.nlsprops
@@ -43,6 +43,18 @@ CWWKC1503.task.failure=CWWKC1503W: Persistent executor {0} rolled back task {1} 
 CWWKC1503.task.failure.explanation=Task execution failed and rolled back.
 CWWKC1503.task.failure.useraction=Correct the cause of the failure, if the failure is unexpected, and reschedule the task.
 
+CWWKC1504.tx.timeout.rollback=CWWKC1504E: Transaction is marked to roll back because the task execution time, {0} seconds, exceeded the transaction timeout, {1} seconds.
+CWWKC1504.tx.timeout.rollback.explanation=The task took too long to run, so the transaction is being rolled back.
+CWWKC1504.tx.timeout.rollback.useraction=A larger transaction timeout might be needed, or the task might need to be made shorter.
+
+CWWKC1505.mtt.timeout.rollback=CWWKC1505E: Transaction is marked to roll back because the task execution time, {0} seconds, exceeded the missedTaskThreshold, {1} seconds.
+CWWKC1505.mtt.timeout.rollback.explanation=The task took too long to run, so the transaction is being rolled back.
+CWWKC1505.mtt.timeout.rollback.useraction=A larger missedTaskThreshold might be needed, or the task might need to be made shorter.
+
+CWWKC1506.marked.rollback.only=CWWKC1506E: Transaction is marked to roll back.
+CWWKC1506.marked.rollback.only.explanation=The application might have marked the transaction to roll back using setRollbackOnly, or it could be due to an error or timeout.
+CWWKC1506.marked.rollback.only.useraction=If the rollback is unexpected, check the logs and the application.
+
 CWWKC1510.retry.limit.reached.rollback=CWWKC1510W: Persistent executor {0} aborted task {1} because it rolled back or failed {2} consecutive times.
 CWWKC1510.retry.limit.reached.rollback.explanation=The task has reached the limit of consecutive retries and will not be attempted again.
 CWWKC1510.retry.limit.reached.rollback.useraction=If the rollbacks or failures are unexpected, determine the cause and reschedule the task. If the rollbacks and failures are intermittent, consider increasing the retry limit. 

--- a/dev/com.ibm.ws.concurrent.persistent/resources/com/ibm/ws/concurrent/persistent/resources/CWWKCMessages.nlsprops
+++ b/dev/com.ibm.ws.concurrent.persistent/resources/com/ibm/ws/concurrent/persistent/resources/CWWKCMessages.nlsprops
@@ -52,7 +52,7 @@ CWWKC1505.mtt.timeout.rollback.explanation=The task took too long to run, so the
 CWWKC1505.mtt.timeout.rollback.useraction=A larger missedTaskThreshold might be needed, or the task might need to be made shorter.
 
 CWWKC1506.marked.rollback.only=CWWKC1506E: Transaction is marked to roll back.
-CWWKC1506.marked.rollback.only.explanation=The application might have marked the transaction to roll back using setRollbackOnly, or it could be due to an error or timeout.
+CWWKC1506.marked.rollback.only.explanation=The application marked the transaction to roll back with setRollbackOnly, or an error or timeout caused the rollback.
 CWWKC1506.marked.rollback.only.useraction=If the rollback is unexpected, check the logs and the application.
 
 CWWKC1510.retry.limit.reached.rollback=CWWKC1510W: Persistent executor {0} aborted task {1} because it rolled back or failed {2} consecutive times.

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/InvokerTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/InvokerTask.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.enterprise.concurrent.LastExecution;
 import javax.enterprise.concurrent.Trigger;
+import javax.transaction.RollbackException;
 import javax.transaction.Status;
 import javax.transaction.Synchronization;
 import javax.transaction.Transaction;
@@ -184,15 +185,19 @@ public class InvokerTask implements Runnable, Synchronization {
                         retry = consecutiveFailureCount != -1;
 
                         if (retry) {
-                            String seconds = consecutiveFailureCount == 1 || config.retryInterval == 0L ? "0" : NumberFormat.getInstance().format(config.retryInterval / 1000.0);
+                            String seconds = consecutiveFailureCount == 1 && config.missedTaskThreshold == -1 || config.retryInterval == 0L //
+                                            ? "0" //
+                                            : NumberFormat.getInstance().format(config.retryInterval / 1000.0);
                             if (failure == null)
                                 Tr.warning(tc, "CWWKC1500.task.rollback.retry", persistentExecutor.name, taskName, seconds);
                             else
                                 Tr.warning(tc, "CWWKC1501.task.failure.retry", persistentExecutor.name, taskName, failure, seconds);
-                        } else if (failure == null)
-                            Tr.warning(tc, "CWWKC1502.task.rollback", persistentExecutor.name, taskName);
-                        else
-                            Tr.warning(tc, "CWWKC1503.task.failure", persistentExecutor.name, taskName, failure);
+                        } else {
+                            if (failure == null)
+                                Tr.warning(tc, "CWWKC1502.task.rollback", persistentExecutor.name, taskName);
+                            else
+                                Tr.warning(tc, "CWWKC1503.task.failure", persistentExecutor.name, taskName, failure);
+                        }
                     }
                 } catch (Throwable x) {
                     failed = x;
@@ -289,6 +294,7 @@ public class InvokerTask implements Runnable, Synchronization {
             }
 
             tranMgr.begin();
+            long tranBeginNS = System.nanoTime();
             TaskRecord taskRecord;
 
             // Execution property TRANSACTION=SUSPEND indicates the task should not run in the persistent executor transaction.
@@ -488,7 +494,25 @@ public class InvokerTask implements Runnable, Synchronization {
 
             short autoPurgeBit = failure == null ? TaskRecord.Flags.AUTO_PURGE_ON_SUCCESS.bit : TaskRecord.Flags.AUTO_PURGE_ALWAYS.bit;
 
-            if ((nextExecTime == null || !skipped && nextFailureCount > 0) && (binaryFlags & autoPurgeBit) != 0) {
+            if (tranMgr.getStatus() == Status.STATUS_MARKED_ROLLBACK) {
+                // discontinue if already marked to roll back
+                long durationMS = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - tranBeginNS);
+                if (durationMS >= timeout * 1000l) {
+                    // The transaction was probably marked for roll back due to the the transaction timing out,
+                    // although it could have been marked to roll back even prior to that.
+                    String elapsedTime = NumberFormat.getInstance().format(durationMS / 1000.0);
+                    if (config.missedTaskThreshold == timeout)
+                        throw new RollbackException(Tr.formatMessage(tc, "CWWKC1505.mtt.timeout.rollback", elapsedTime, timeout));
+                    else
+                        throw new RollbackException(Tr.formatMessage(tc, "CWWKC1504.tx.timeout.rollback", elapsedTime, timeout));
+                } else {
+                    // The transaction timeout detection above is approximate.
+                    // When this code block is reached, it usually means that the transaction was marked to roll back
+                    // independently of the transaction timing out. But due to the imprecision, this code path might
+                    // some times be reached on the transaction timeout path as well.
+                    throw new RollbackException(Tr.formatMessage(tc, "CWWKC1506.marked.rollback.only"));
+                }
+            } else if ((nextExecTime == null || !skipped && nextFailureCount > 0) && (binaryFlags & autoPurgeBit) != 0) {
                 // Autopurge the completed task unless it is known that the task removed/canceled itself during execution
                 if (runningTaskRemovalState[1] != InvokerTask.REMOVED_BY_SELF) {
                     taskStore.remove(taskId, null, false);

--- a/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/PersistentExecutorTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/PersistentExecutorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -79,8 +79,10 @@ public class PersistentExecutorTest extends FATServletClient {
             runTest(server, APP_NAME, "verifyNoTasksRunning");
         } finally {
             if (server != null && server.isStarted())
-                server.stopServer("CWWKC1500W", //Persistent Executor Rollback
-                                  "CWWKC1510W", //Persistent Executor Rollback and Failed
+                server.stopServer("CWWKC1500W", //Task rolled back
+                                  "CWWKC1501W", //Task rolled back due to failure ...
+                                  "CWWKC1510W", //Task rolled back and aborted
+                                  "CWWKC1511W", //Task rolled back and aborted. Failure is ...
                                   "DSRA0174W"); //Generic Datasource Helper
         }
     }

--- a/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/PersistentExecutorWithFailoverEnabledTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/fat/src/com/ibm/ws/concurrent/persistent/fat/PersistentExecutorWithFailoverEnabledTest.java
@@ -95,9 +95,11 @@ public class PersistentExecutorWithFailoverEnabledTest extends FATServletClient 
             if (server != null)
                 try {
                     if (server.isStarted())
-                    server.stopServer("CWWKC1500W", //Persistent Executor Rollback
-                                      "CWWKC1510W", //Persistent Executor Rollback and Failed
-                                      "DSRA0174W"); //Generic Datasource Helper
+                        server.stopServer("CWWKC1500W", //Task rolled back
+                                          "CWWKC1501W", //Task rolled back due to failure ...
+                                          "CWWKC1510W", //Task rolled back and aborted
+                                          "CWWKC1511W", //Task rolled back and aborted. Failure is ...
+                                          "DSRA0174W"); //Generic Datasource Helper
                 } finally {
                     if (originalConfig != null)
                         server.updateServerConfiguration(originalConfig);

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/fat/src/com/ibm/ws/concurrent/persistent/fat/errorpaths/PersistentExecutorErrorPathsTestWithFailoverEnabledNoPolling.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/fat/src/com/ibm/ws/concurrent/persistent/fat/errorpaths/PersistentExecutorErrorPathsTestWithFailoverEnabledNoPolling.java
@@ -228,6 +228,11 @@ public class PersistentExecutorErrorPathsTestWithFailoverEnabledNoPolling {
     }
 
     @Test
+    public void testRollbackWhenMissedTaskThresholdExceeded() throws Exception {
+        runInServlet("testRollbackWhenMissedTaskThresholdExceeded");
+    }
+
+    @Test
     public void testShutDownDerbyBeforeTaskExecutionFENoPolling() throws Exception {
         runInServlet("testShutDownDerbyBeforeTaskExecution");
     }

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/PersistentErrorTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/PersistentErrorTestServlet.java
@@ -41,6 +41,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
+import javax.transaction.RollbackException;
 import javax.transaction.UserTransaction;
 
 import com.ibm.websphere.concurrent.persistent.AutoPurge;
@@ -888,7 +889,11 @@ public class PersistentErrorTestServlet extends HttpServlet {
             Integer result = status.get();
             throw new Exception("Should not be able to get a result from a task that always rolls back: " + result);
         } catch (AbortedException x) {
-            if (x.getMessage() == null || !x.getMessage().startsWith("CWWKC1555E"))
+            if (x.getMessage() == null || !x.getMessage().startsWith("CWWKC1555E")
+                    || !(x.getCause() instanceof RollbackException)
+                    || x.getCause().getMessage() == null
+                    || !x.getCause().getMessage().startsWith("CWWKC1505E")
+                    || !x.getCause().getMessage().contains(" 4 ")) // value of missedTaskThreshold in seconds
                 throw x;
         }
     }

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/WaitForRollbackTask.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/test-applications/persistenterrtest/src/web/WaitForRollbackTask.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package web;
+
+import java.io.Serializable;
+import java.util.concurrent.Callable;
+
+import javax.naming.InitialContext;
+import javax.transaction.Status;
+import javax.transaction.UserTransaction;
+
+import com.ibm.websphere.concurrent.persistent.TaskIdAccessor;
+
+/**
+ * Task that waits until it is rolled back. This is done to test transaction timeout.
+ */
+public class WaitForRollbackTask implements Callable<Integer>, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    // PersistentErrorTestServlet.init sets this value, because this task is run without context
+    // and otherwise has no way of looking up UserTransaction.
+    static UserTransaction tran;
+
+    @Override
+    public Integer call() throws Exception {
+        long taskId = TaskIdAccessor.get();
+        System.out.println("Started task " + taskId);
+
+        do Thread.sleep(200);
+        while (tran.getStatus() != Status.STATUS_MARKED_ROLLBACK);
+
+        System.out.println("Completed task " + taskId);
+        return tran.getStatus();
+    }
+}

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/fat/src/com/ibm/ws/concurrent/persistent/fat/failovertimers/FailoverTimersTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/fat/src/com/ibm/ws/concurrent/persistent/fat/failovertimers/FailoverTimersTest.java
@@ -210,8 +210,8 @@ public class FailoverTimersTest extends FATServletClient {
         // Also restart the server. This allows us to process any expected warning messages that are logged in response
         // to the intentionally failed task.
         serverA.stopServer(
-                "CWWKC1500W.*StatelessProgrammaticTimersBean", // Persistent executor defaultEJBPersistentTimerExecutor rolled back task ... The task is scheduled to retry after ...
-                "CWWKC1502W.*StatelessProgrammaticTimersBean"  // Persistent executor defaultEJBPersistentTimerExecutor rolled back task ... [no retry]
+                "CWWKC1501W.*StatelessProgrammaticTimersBean", // Persistent executor defaultEJBPersistentTimerExecutor rolled back task due to failure ... The task is scheduled to retry after ...
+                "CWWKC1503W.*StatelessProgrammaticTimersBean"  // Persistent executor defaultEJBPersistentTimerExecutor rolled back task due to failure ... [no retry]
                 );
     }
 

--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/PersistentTimerCoreTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/PersistentTimerCoreTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2019 IBM Corporation and others.
+ * Copyright (c) 2009, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -88,7 +88,7 @@ public class PersistentTimerCoreTest extends FATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         if (server != null && server.isStarted()) {
-            server.stopServer("CNTR0333W", "CWWKC1500W");
+            server.stopServer("CNTR0333W", "CWWKC1500W", "CWWKC1501W", "CWWKC1506E");
         }
     }
 


### PR DESCRIPTION
Add useful translatable messages to help identify when a task execution is being rolled back because it was marked for rollback only, possibly due to a timeout.