### PR TITLE
Ensure OL tests run properly in DB Rotation

### DIFF
--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -39,28 +39,25 @@
 				<property name="ascii.file.encoding" value="ISO8859_1" />
 			</else>
 		</iff>
-		
+
 		<!-- If we are running an automated build, figuring out the test bucket name is -->
 		<!-- not necessary because it will be passed down by the calling ant script -->
 		<iff if="is.running.automated.build">
 			<else>
-	        <condition property="filesToFind" value="FATSuiteLite.class;FATSuite.class;FATTest.class" else="FATSuite.class;FATTest.class">
-	            <or>
-	                <not>
-	                    <isset property="fat.test.mode" />
-	                </not>
-	                <equals arg1="${fat.test.mode}" arg2="lite" casesensitive="false" trim="true" />
-	            </or>
-	        </condition>
-	        
-	        <!-- Works out what tests to run for the autoFVT.zip-->
-	        <scanJars entry="entry.point" filesToFind="${filesToFind}">
-	            <fileset dir="${basedir}/build/lib" includes="**.jar" />
-	        </scanJars>
-	        <echo message="entry point: ${entry.point}" />
-	
-	        <property name="test.bucket.class" value="${entry.point}" />
-	        <property name="test.bucket.name" value="${test.bucket.class}" />
+				<condition property="filesToFind" value="FATSuiteLite.class;FATSuite.class;FATTest.class" else="FATSuite.class;FATTest.class">
+					<or>
+						<not>
+							<isset property="fat.test.mode" />
+						</not>
+						<equals arg1="${fat.test.mode}" arg2="lite" casesensitive="false" trim="true" />
+					</or>
+				</condition>
+
+				<!-- Works out what tests to run for the autoFVT.zip-->
+				<scanJars entry="entry.point" filesToFind="${filesToFind}">
+					<fileset dir="${basedir}/build/lib" includes="**.jar" />
+				</scanJars>
+				<echo message="entry point: ${entry.point}" />
 			</else>
 		</iff>
 	</target>
@@ -90,23 +87,68 @@
 			<entry key="preferJIIWSWsAdmin" value="${simplicity.preferJIIWSWsAdmin}" />
 		</propertyfile>
 		
-		<!-- Work out the actual entry point based on the current java level -->
+		<echo>Initializing the classpath for ${test.bucket.name}</echo>
+		<property file="${bootstrapping.properties}" />
+
+		<!-- Work out the actual entry point based on the current java level and database properties -->
 		<echo message="Checking min java level for project based on bootstrapping.properties file..." />
-		            
-        <!-- If this test is compiled with a java level higher than the one we're currently running, -->
-        <!-- bypass the tests by invoking the always passes test instead of real FAT tests -->
-        <property file="${basedir}/fat.bnd.properties" />
-		<script language="javascript"> <![CDATA[
-			var testBucketClassForLowJava = "componenttest.custom.junit.runner.AlwaysPassesTest";
+
+		<!-- Get fat.test.databases and fat.minimum.java.level properties-->
+		<property file="${basedir}/fat.bnd.properties" />
+		<property file="${basedir}/fat.sys.properties" />
+		
+		<!-- Enforce fat.minimum.java.level rule. If this test is compiled with a java level 
+           higher than the one we're currently running we should skip these tests. -->
+		<script language="javascript">
+			<![CDATA[
 			var minTestJava = project.getProperty("fat.minimum.java.level");
 			var javaVersion = parseFloat(project.getProperty("java.specification.version"));
 			if(minTestJava != null && javaVersion < parseFloat(minTestJava))
-			  project.setProperty("test.bucket.class", testBucketClassForLowJava);
-        ]]></script>
-        <echo message="fat.minimum.java.level=${fat.minimum.java.level}"/>
-        <echo message="java.specification.version=${java.specification.version}"/>
-        <echo message="FAT entry point will be: ${test.bucket.class}"/>
-		<echo message="micro.version=${micro.version}"/>
+				project.setProperty("skip.java.level", true);
+        ]]>
+		</script>
+		
+		<!-- Output java level info -->
+		<echo message="fat.minimum.java.level=${fat.minimum.java.level}" />
+		<echo message="java.specification.version=${java.specification.version}" />
+		<echo message="micro.version=${micro.version}" />
+
+		<!-- Enforce fat.test.databases.only rule.  If bucket is not enlisted in database rotation skip it -->
+		<condition property="skip.no.db.tests" value="true">
+			<and>
+				<istrue value="${fat.test.databases.only}" />
+				<not>
+					<isTrue value="${fat.test.databases}" />
+				</not>
+			</and>
+		</condition>
+
+		<!-- Determine if we are going to skip testing or not -->
+		<!-- Bypass the tests by invoking the always passes test instead of real FAT tests -->
+		<iff>
+			<or>
+				<istrue value="${skip.no.db.tests}" />
+				<istrue value="${skip.java.level}" />
+			</or>
+			<then>
+				<var name="test.bucket.class" unset="true" />
+				<var name="test.bucket.name" unset="true" />
+				<property name="test.bucket.class" value="componenttest.custom.junit.runner.AlwaysPassesTest" />
+				<property name="test.bucket.name" value="${test.bucket.class}" />
+
+				<echo message="FAT bucket WILL NOT run tests, due to the following properties:" />
+				<echo message="     Only run database rotation buckets:  ${fat.test.databases.only}" />
+				<echo message="     This bucket uses database rotation:  ${fat.test.databases}" />
+				<echo message="     This bucket uses java level:         ${fat.minimum.java.level}" />
+			</then>
+			<else>
+				<property name="test.bucket.class" value="${entry.point}" />
+			</else>
+		</iff>
+
+		<!-- What will our entry point be? -->
+		<echo message="FAT entry point will be: ${test.bucket.class}" />
+
 	</target>
 
 	<!-- Properties used: test.bucket.name, dir.log, dir.log.xml, dir.log.tmp, local.properties, logging.properties, acute.properties, test.bucket.path, test.bucket.class -->
@@ -125,13 +167,13 @@
 		<condition property="is.zos.platform" else="false">
 			<os family="z/os" />
 		</condition>
-		
+
 		<condition property="is.windows.platform" else="false">
 			<os family="windows" />
 		</condition>
-		
+
 		<!-- boolean for Java9+ -->
-	    <script language="javascript">
+		<script language="javascript">
 			var curJava = project.getProperty("java.specification.version");
 			project.setProperty("is.java9", (curJava > 8));
 	    </script>
@@ -148,16 +190,13 @@
 			</then>
 		</iff>
 
-		<echo>Initializing the classpath for ${test.bucket.name}</echo>
-		<property file="${bootstrapping.properties}" />
-
 		<!-- Set fattest.timeout to 3 hours if full test is requested, else set it to 1 hour -->
 		<condition property="fattest.timeout" value="10800000" else="3600000">
 			<or>
 				<not>
-					<equals arg1 = "${fat.test.mode}" arg2 = "lite"/>
+					<equals arg1="${fat.test.mode}" arg2="lite" />
 				</not>
-				<contains string="${spawn.fullfat.buckets}"  substring="${test.bucket.name}" casesensitive="false"/>
+				<contains string="${spawn.fullfat.buckets}" substring="${test.bucket.name}" casesensitive="false" />
 			</or>
 		</condition>
 
@@ -165,8 +204,8 @@
 		<mkdir dir="${basedir}/output" />
 
 		<!-- by default, only add spec API to the test classpath -->
-		<property name="test.classpath.wlp.include" value="api/spec/*.jar"/>
-		
+		<property name="test.classpath.wlp.include" value="api/spec/*.jar" />
+
 		<path id="test.bucket.path">
 			<!-- Our tests themselves -->
 			<fileset dir="${basedir}/build/lib">
@@ -179,63 +218,63 @@
 			</fileset>
 
 			<!-- shared libraries from bootstrapping.properties -->
-            <fileset dir="${local.sharedLib}" erroronmissingdir="false">
- 				<include name="**/*.jar" />
- 			</fileset>
-			
+			<fileset dir="${local.sharedLib}" erroronmissingdir="false">
+				<include name="**/*.jar" />
+			</fileset>
+
 			<!-- java libraries for secure SSH authentication -->
 			<fileset dir="${local.java}/lib/" erroronmissingdir="false">
 				<include name="*.jar" />
-			</fileset> 
-			
+			</fileset>
+
 			<!-- The maven dependencies of fattest.simplicity -->
 			<fileset dir="${local.java}/build/libs/lib" erroronmissingdir="false">
-				<include name="*.jar"/>
+				<include name="*.jar" />
 			</fileset>
 
 			<fileset dir="${ant.home}/lib/" includes="ant-junit*.jar, ant.jar" />
 			<!-- junit.jar contains hamcrest classes, so include updated hamcrest JAR first -->
 			<fileset dir="${shared.resources}" includes="*hamcrest*.jar" />
 			<fileset dir="${shared.resources}">
-				<include name="junit/old/junit.jar"/>
-				<include name="jmock/2.6.0/jmock-junit4.jar"/>
+				<include name="junit/old/junit.jar" />
+				<include name="jmock/2.6.0/jmock-junit4.jar" />
 			</fileset>
-			
+
 			<!-- libs that were added to publish/ folder -->
-			<fileset dir="${basedir}" includes="publish/**/*.jar"/>
-			
+			<fileset dir="${basedir}" includes="publish/**/*.jar" />
+
 			<!-- add any libs that may have been added to the server -->
-			<fileset dir="${install.location}" includes="publish/servers/**/*.jar"/>
-			
+			<fileset dir="${install.location}" includes="publish/servers/**/*.jar" />
+
 			<!-- libs that were added to publish/files/ folder -->
-			<fileset dir="${basedir}" includes="publish/files/**/*.jar"/>
-			
-			<!-- Give an opportunity to add API/SPI from the liberty image --> 
-			<fileset dir="${liberty.location}/dev/" includes="${test.classpath.wlp.include}"/>
+			<fileset dir="${basedir}" includes="publish/files/**/*.jar" />
+
+			<!-- Give an opportunity to add API/SPI from the liberty image -->
+			<fileset dir="${liberty.location}/dev/" includes="${test.classpath.wlp.include}" />
 		</path>
 
-		<echo message="test.bucket.path including junit: ${toString:test.bucket.path}"/>
+		<echo message="test.bucket.path including junit: ${toString:test.bucket.path}" />
 
 		<iff>
-			<istrue value="${is.windows.platform}"/>
+			<istrue value="${is.windows.platform}" />
 			<then>
 				<echo>generating classpath jar file.</echo>
-				<property name="classpath.jar.name" value="${basedir}/build/lib/cp.jar"/>
+				<property name="classpath.jar.name" value="${basedir}/build/lib/cp.jar" />
 				<manifestclasspath property="classpath.list" maxParentLevels="20" jarfile="${classpath.jar.name}">
-				    <classpath refid="test.bucket.path"/>
+					<classpath refid="test.bucket.path" />
 				</manifestclasspath>
-				<jar jarfile="${classpath.jar.name}" >
-				    <manifest>
-				        <attribute name="Class-Path" value="${classpath.list}"/>
-				    </manifest>
+				<jar jarfile="${classpath.jar.name}">
+					<manifest>
+						<attribute name="Class-Path" value="${classpath.list}" />
+					</manifest>
 				</jar>
 				<path id="test.bucket.path">
-					<fileset file="${classpath.jar.name}"/>
-			    </path>
-				<echo message="modified test.bucket.path : ${toString:test.bucket.path}"/>
+					<fileset file="${classpath.jar.name}" />
+				</path>
+				<echo message="modified test.bucket.path : ${toString:test.bucket.path}" />
 			</then>
 		</iff>
-		
+
 		<echo>Initializing JRE logging</echo>
 		<delete dir="${dir.log}" quiet="true" />
 		<mkdir dir="${dir.log.xml}" />
@@ -246,10 +285,10 @@
 		</propertyfile>
 
 		<property name="dir.test.current.directory" value="${basedir}" />
-		
+
 		<!-- Load all env vars into env.* properties -->
-		<property environment="env"/>
-		
+		<property environment="env" />
+
 		<tstamp>
 			<format property="today.day" pattern="EEEE" />
 		</tstamp>
@@ -314,20 +353,20 @@
 		<!-- Server log validation should be done by default -->
 		<!-- Individual buckets must opt-out if they don't want to have logs checked -->
 		<property name="enable.server.log.validation" value="false" />
-		
-		<property name="extra.vmargs" value=""/>
-	    <echo message="Launching FAT with extra vmargs: ${extra.vmargs}"/>
-					
+
+		<property name="extra.vmargs" value="" />
+		<echo message="Launching FAT with extra vmargs: ${extra.vmargs}" />
+
 		<iff if="zos.environment">
 			<then>
-				<echo message="Setting zos.extra.vmargs because we are running on zos"/>
+				<echo message="Setting zos.extra.vmargs because we are running on zos" />
 				<property name="zos.extra.vmargs" value="-Dcom.ibm.jsse2.overrideDefaultTLS=true -Dcom.ibm.team.repository.transport.client.protocol=TLSv1.2" />
 			</then>
-		    <else>
+			<else>
 				<property name="zos.extra.vmargs" value="" />
 			</else>
 		</iff>
-		<echo message="Launching FAT with zos extra vmargs: ${zos.extra.vmargs}"/>	
+		<echo message="Launching FAT with zos extra vmargs: ${zos.extra.vmargs}" />
 
 		<!-- START coverage properties -->
 		<property name="exec.data.file" location="${dir.log.coverage}/jacoco.exec" />
@@ -342,7 +381,7 @@
 		<echo>jacocoagent.file: ${jacocoagent.file}</echo>
 
 		<mkdir dir="${build.tmp.dir}" />
-		
+
 		<!-- Note that users can override framework.maxheap from personal build -->
 		<property name="framework.maxheap" value="-Xmx1024m" />
 		<echo>framework.maxheap=${framework.maxheap}</echo>
@@ -370,14 +409,14 @@
 					<!-- Add the server.origin property -->
 					<sysproperty key="server.origin" value="${server.origin}" />
 					<!-- Pass select env vars in as system properties  -->
-                    <syspropertyset>
-                        <propertyref prefix="env.bvt.prop." />
-                        <propertyref prefix="env.global." />
-                        <propertyref prefix="env.fat.test." />
-                        <propertyref prefix="env.fat.bucket." />
-                        <propertyref prefix="env.ldap." />
-                        <mapper type="glob" from="env.*" to="*" />
-                    </syspropertyset>
+					<syspropertyset>
+						<propertyref prefix="env.bvt.prop." />
+						<propertyref prefix="env.global." />
+						<propertyref prefix="env.fat.test." />
+						<propertyref prefix="env.fat.bucket." />
+						<propertyref prefix="env.ldap." />
+						<mapper type="glob" from="env.*" to="*" />
+					</syspropertyset>
 					<syspropertyset>
 						<propertyref prefix="bvt.prop." />
 						<mapper type="glob" from="bvt.prop.*" to="*" />
@@ -389,7 +428,7 @@
 					<!-- copy any fat.test.* properties into the FAT running framework -->
 					<syspropertyset>
 						<propertyref prefix="fat.test." />
-						<propertyref prefix="fat.bucket."/>
+						<propertyref prefix="fat.bucket." />
 					</syspropertyset>
 					<!-- copy all ldap ports properties -->
 					<syspropertyset>
@@ -411,7 +450,7 @@
 					<!-- if LibertyServer.stopServer() should check messages.log for unexpected errors/warnings -->
 					<sysproperty key="enable.server.log.validation" value="${enable.server.log.validation}" />
 					<!-- Pass bundle micro version -->
-					<sysproperty key="micro.version" value="${micro.version}"/>
+					<sysproperty key="micro.version" value="${micro.version}" />
 					<!-- show junit where the test case is located-->
 					<classpath refid="test.bucket.path" />
 					<!-- report will be generated as xml -->
@@ -433,9 +472,9 @@
 					<sysproperty key="fat.on.mac" value="${test.run.on.mac.sysprop.value}" />
 					<jvmarg value="${framework.maxheap}" />
 					<!-- embedded trace conditionals -->
-					<jvmarg value="${framework.debug.embed.jvmarg1}" /> 
-					<jvmarg line="${extra.vmargs}"/>
-					<jvmarg line="${zos.extra.vmargs}"/>
+					<jvmarg value="${framework.debug.embed.jvmarg1}" />
+					<jvmarg line="${extra.vmargs}" />
+					<jvmarg line="${zos.extra.vmargs}" />
 				</junit>
 			</sequential>
 			<finally>
@@ -443,7 +482,7 @@
 				<fileset dir="${basedir}/output" includes="*.mrk" id="markfiles" />
 				<foreach param="serverFile" in="markfiles">
 					<echo>Failure running ${test.bucket.name}, attempting to copy logs from servers that did not stop properly : ${serverFile}</echo>
-					<local name="serverDir"/>
+					<local name="serverDir" />
 					<basename property="serverDir" file="${serverFile}" suffix=".mrk" />
 					<tstamp>
 						<format property="copyTime" pattern="dd-MM-yyyy-HH-mm-ss" />
@@ -461,12 +500,12 @@
 		</try>
 		<echo>Finished running ${test.bucket.name}</echo>
 		<echo>XML report is available at ${dir.log.xml}</echo>
-        <iff if="is.running.automated.build">
-        	<then>
-        		<!-- Restore the keys so nothing is broken -->
-        		<restoreSSHKeys />
-        	</then>
-        </iff>
+		<iff if="is.running.automated.build">
+			<then>
+				<!-- Restore the keys so nothing is broken -->
+				<restoreSSHKeys />
+			</then>
+		</iff>
 
 
 		<iff if="test.failure">
@@ -725,7 +764,7 @@
 		</loadresource>
 
 		<path id="project.under.test.bundles">
-			<fileset dir="${libertyInstallPath}/lib" >
+			<fileset dir="${libertyInstallPath}/lib">
 				<include name="${project.under.test}*.jar" />
 				<exclude name="com.ibm.ws.jaxrs.2.0.common*.jar" />
 			</fileset>
@@ -791,7 +830,7 @@
 			<!--  the class files and optional source files ...  -->
 			<structure name="FAT coverage report for ${project.under.test}">
 				<classfiles>
-					<fileset dir="${libertyInstallPath}/lib" >
+					<fileset dir="${libertyInstallPath}/lib">
 						<include name="${project.under.test}*.jar" />
 						<exclude name="com.ibm.ws.jaxrs.2.0.common*.jar" />
 					</fileset>
@@ -816,7 +855,7 @@
 			<!--  the class files and optional source files ...  -->
 			<structure name="FAT coverage report for ${project.under.test}">
 				<classfiles>
-					<fileset dir="${libertyInstallPath}/lib" >
+					<fileset dir="${libertyInstallPath}/lib">
 						<include name="${project.under.test}*.jar" />
 						<exclude name="com.ibm.ws.jaxrs.2.0.common*.jar" />
 					</fileset>
@@ -849,7 +888,7 @@
 	     status is desired from a single pass.
 	  -->
 	<target name="failIfTestFailures">
-		<echo message="haltOnFailure is '${haltOnFailure}'"/>
+		<echo message="haltOnFailure is '${haltOnFailure}'" />
 		<iff>
 			<and>
 				<not>
@@ -859,9 +898,9 @@
 				<!-- and the halt flag is either not set or set true-ish -->
 				<or>
 					<not>
-						<isset property="haltOnFailure"/>
+						<isset property="haltOnFailure" />
 					</not>
-					<istrue value="haltOnFailure"/>
+					<istrue value="haltOnFailure" />
 				</or>
 			</and>
 			<then>

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -381,7 +381,6 @@ task runfat(type: Exec) {
   dependsOn cleanBeforeRun
   mustRunAfter buildfat
   mustRunAfter cleanBeforeRun
-  System.setProperty("fat.test.localrun", "true");
   environment System.getProperties()
   if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
     executable "cmd"
@@ -390,7 +389,12 @@ task runfat(type: Exec) {
     executable "ant"
     args "-f", new File(autoFvtDir, 'TestBuild.xml')
   }
+
   doLast {
+    //This should be set during the execution phase and not the configuration stage
+    //Only set this property to true if the runfat task is called (which should only happen when calling buildandrun)
+    System.setProperty("fat.test.localrun", "true");
+    
     // We can have this here because this task only ever runs locally, and thus is OK to unconditionally fail
     // the build. If we ever run FATs in remote builds, we should also gate this on a property like 
     // 'is.running.remote.build' so we don't fail the entire build whenever a testcase fails
@@ -446,9 +450,10 @@ ext.gitClone = { proj, branch = 'NOT_SET', folder = '', site = 'git@github.com',
   //Staging area parent folder to enable copying all subfolders.
   File gitReposDir = new File(project.buildDir, 'gitRepos')
 
-  // If running locally use git directly
-  if( System.properties['fat.test.localrun'] ){
-
+  // Intended Behavior: If running locally use git directly
+  // TODO add conditional here once EBC cloning is implemented.
+  // Suggestion: !isAutomatedBuild - do not use [fat.test.localrun] as this is only know at runtime and not build time. 
+  if( true ) { 
     File repoDir = new File(gitReposDir, folder)
     String into = repoDir.getAbsolutePath()
      
@@ -463,7 +468,7 @@ ext.gitClone = { proj, branch = 'NOT_SET', folder = '', site = 'git@github.com',
     proc.err.eachLine { line -> println cmd + ':\n' + line }
     proc.waitFor()
     
-  } else {
+  } else { // TODO Non-local cloning is not implemented for now 
     // Make use of the EBC clone mechanism
     project.logger.lifecycle('ebc clone')
     ebcClone(url) 
@@ -476,11 +481,10 @@ ext.gitClone = { proj, branch = 'NOT_SET', folder = '', site = 'git@github.com',
       into gitReposDir
     }
   }
-  
 }
 
 def ebcClone(String url, String branch, String repoPath){
-  // Non-local cloning is not implemented for now  
+  // TODO Non-local cloning is not implemented for now  
 }
 
 build {

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -205,7 +205,7 @@ task autoFVT {
     // Create a fat.bnd.properties file that contains metadata about the FAT
     def bndProps = new Properties()
     
-    // By default, load up all properties with certain prefixes
+    // By default, load up all properties with certain prefixes from bndWorkspace
     bndWorkspace.getProject(project.getProjectDir()).getProperties().each { k, v ->
       if(k.startsWith("test.") || k.startsWith("fat."))
         bndProps.setProperty(k, v);
@@ -216,14 +216,31 @@ task autoFVT {
     bndProps.setProperty('fat.minimum.java.level', minJavaLevel)
     bndProps.setProperty('micro.version', bnd('libertyBundleMicroVersion'))
     
-    File propsFile = new File(autoFvtDir, 'fat.bnd.properties')
-    def writer = new FileWriter(propsFile)
+    File bndPropsFile = new File(autoFvtDir, 'fat.bnd.properties')
+    def bndWriter = new FileWriter(bndPropsFile)
     try {
-    	bndProps.store(writer, null)
+    	bndProps.store(bndWriter, null)
     } finally {
-      writer.close()
+      bndWriter.close()
     }
     
+    // Create a fat.sys.properties file that contains metadata about the FAT
+    def sysProps = new Properties()
+    
+    // By default, load up all properties with certain prefixes from System
+    System.getProperties().each { k, v ->
+      if(k.startsWith("test.") || k.startsWith("fat."))
+        sysProps.setProperty(k, v);
+    }
+    
+    File sysPropsFile = new File(autoFvtDir, 'fat.sys.properties')
+    def sysWriter = new FileWriter(sysPropsFile)
+    try {
+    	sysProps.store(sysWriter, null)
+    } finally {
+      sysWriter.close()
+    }
+
     // Copy the component test libs
     // TODO: It looks like the componenttest.app.jar got combined into something else, so this is now way more source in the jar than was there before. This might need changing then.
     copy {


### PR DESCRIPTION
Fixes #9970 
Part of epic #9260 

This is to ensure that database rotation rules are followed in OL when run locally and on our test systems. The three properties that control is are `fat.test.databases.only` to indicate that we should only run database tests, `fat.bucket.db.type` to indicate which database we should be testing against, and `fat.test.databases` to indicate if THIS test bucket can run against supported databases.  

These properties will be saved off to `fat.bnd.properties`, and control of whether or not the test bucket will run.  The `fat.bnd.properties` will be consumed in launch.xml and the determination made. 