### PR TITLE
Update copyright header

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/metadata/Utils.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/metadata/Utils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 IBM Corporation and others.
+ * Copyright (c) 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
com.ibm.ws.jaxws.metadata.Utils.java has 2010 as its copyright year. Should be 2019 to reflect when it was added to Open-Liberty