### PR TITLE
move long running tests in errorpaths bucket to full mode

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/fat/src/com/ibm/ws/concurrent/persistent/fat/errorpaths/PersistentExecutorErrorPathsTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/fat/src/com/ibm/ws/concurrent/persistent/fat/errorpaths/PersistentExecutorErrorPathsTest.java
@@ -32,6 +32,8 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 
 /**
@@ -134,7 +136,7 @@ public class PersistentExecutorErrorPathsTest {
     /**
      * Verify that pending/active task ids, plus other helpful information, appears in the server dump output.
      */
-    // TODO switch to full mode after we are further along
+    @Mode(TestMode.FULL)
     @Test
     public void testIntrospectorWithFailOverDisabled() throws Exception {
         // schedule some tasks that will remain active while the introspector output is recorded
@@ -366,11 +368,13 @@ public class PersistentExecutorErrorPathsTest {
         runInServlet("testTaskFailsToSerialize");
     }
 
+    @Mode(TestMode.FULL)
     @Test
     public void testTransactionTimeout() throws Exception {
         runInServlet("testTransactionTimeout");
     }
 
+    @Mode(TestMode.FULL)
     @Test
     public void testTransactionTimeoutSuspendedTransaction() throws Exception {
         runInServlet("testTransactionTimeoutSuspendedTransaction");

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/fat/src/com/ibm/ws/concurrent/persistent/fat/errorpaths/PersistentExecutorErrorPathsTestWithFailoverAndPollingEnabled.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/fat/src/com/ibm/ws/concurrent/persistent/fat/errorpaths/PersistentExecutorErrorPathsTestWithFailoverAndPollingEnabled.java
@@ -34,6 +34,8 @@ import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 
 /**
@@ -195,7 +197,7 @@ public class PersistentExecutorErrorPathsTestWithFailoverAndPollingEnabled {
     /**
      * Verify that pending/active task ids, plus other helpful information, appears in the server dump output.
      */
-    // TODO switch to full mode after we are further along
+    @Mode(TestMode.FULL)
     @Test
     public void testIntrospectorWithFailOverEnabled() throws Exception {
         // schedule some tasks that will remain active while the introspector output is recorded
@@ -452,6 +454,7 @@ public class PersistentExecutorErrorPathsTestWithFailoverAndPollingEnabled {
             throw new Exception("Problem with substitution parameters in message " + errorMessage);
     }
 
+    @Mode(TestMode.FULL)
     @Test
     public void testShutDownDerbyBeforeTaskExecutionFEWithPolling() throws Exception {
         runInServlet("testShutDownDerbyBeforeTaskExecution");
@@ -492,11 +495,13 @@ public class PersistentExecutorErrorPathsTestWithFailoverAndPollingEnabled {
         runInServlet("testSkipRunFailsOnOnlyExecutionAttemptNoAutoPurge");
     }
 
+    @Mode(TestMode.FULL)
     @Test
     public void testTransactionTimeoutFEWithPolling() throws Exception {
         runInServlet("testTransactionTimeout");
     }
 
+    @Mode(TestMode.FULL)
     @Test
     public void testTransactionTimeoutSuspendedTransactionFEWithPolling() throws Exception {
         runInServlet("testTransactionTimeoutSuspendedTransaction");

--- a/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/fat/src/com/ibm/ws/concurrent/persistent/fat/errorpaths/PersistentExecutorErrorPathsTestWithFailoverEnabledNoPolling.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_errorpaths/fat/src/com/ibm/ws/concurrent/persistent/fat/errorpaths/PersistentExecutorErrorPathsTestWithFailoverEnabledNoPolling.java
@@ -32,6 +32,8 @@ import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 
 /**
@@ -232,6 +234,7 @@ public class PersistentExecutorErrorPathsTestWithFailoverEnabledNoPolling {
         runInServlet("testRollbackWhenMissedTaskThresholdExceeded");
     }
 
+    @Mode(TestMode.FULL)
     @Test
     public void testShutDownDerbyBeforeTaskExecutionFENoPolling() throws Exception {
         runInServlet("testShutDownDerbyBeforeTaskExecution");
@@ -277,11 +280,13 @@ public class PersistentExecutorErrorPathsTestWithFailoverEnabledNoPolling {
         runInServlet("testTaskFailsToSerialize");
     }
 
+    @Mode(TestMode.FULL)
     @Test
     public void testTransactionTimeoutFENoPolling() throws Exception {
         runInServlet("testTransactionTimeout");
     }
 
+    @Mode(TestMode.FULL)
     @Test
     public void testTransactionTimeoutSuspendedTransactionFENoPolling() throws Exception {
         runInServlet("testTransactionTimeoutSuspendedTransaction");


### PR DESCRIPTION
There are a handful of tests in the errorpaths test bucket, such as the tests that capture a dump of the server and test the introspector output, that take a long time to run, and therefore belong under full mode instead of lite.