### PR TITLE
com.ibm.ws.cxf.cxf.bindings.soap.3.2 is missing resources

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/bnd.bnd
@@ -16,6 +16,8 @@ javac.target: 1.8
 cxfVersion=3.3.3
 
 -includeresource: \
+   @${repo;org.apache.cxf:cxf-rt-bindings-soap;3.3.3}!/!META-INF/*,\
+   org/apache/cxf=${bin}/org/apache/cxf,\
    META-INF=resources/META-INF
 
 -buildpath: org.apache.cxf:cxf-rt-bindings-soap;strategy=exact;version=${cxfVersion},\


### PR DESCRIPTION
Fix missing resources by including them in bnd file. 