### PR TITLE
EJB Fat wait for security

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.async_fat/fat/src/com/ibm/ws/ejbcontainer/async/fat/tests/AsyncConfigTests.java
+++ b/dev/com.ibm.ws.ejbcontainer.async_fat/fat/src/com/ibm/ws/ejbcontainer/async/fat/tests/AsyncConfigTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.ejbcontainer.async.fat.tests;
+
+import static junit.framework.Assert.assertNotNull;
 
 import java.util.Collections;
 import java.util.logging.Logger;
@@ -74,6 +76,10 @@ public class AsyncConfigTests extends AbstractTest {
 
         // Finally, start server
         server.startServer();
+
+        // verify the appSecurity-2.0 feature is ready
+        assertNotNull("Security service did not report it was ready", server.waitForStringInLogUsingMark("CWWKS0008I"));
+        assertNotNull("LTPA configuration did not report it was ready", server.waitForStringInLogUsingMark("CWWKS4105I"));
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.ejbcontainer.async_fat/fat/src/com/ibm/ws/ejbcontainer/async/fat/tests/AsyncSecureTests.java
+++ b/dev/com.ibm.ws.ejbcontainer.async_fat/fat/src/com/ibm/ws/ejbcontainer/async/fat/tests/AsyncSecureTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -72,8 +72,9 @@ public class AsyncSecureTests extends AbstractTest {
         // Finally, start server
         server.startServer();
 
-        assertNotNull("Security service did not report it was ready", server.waitForStringInLog("CWWKS0008I"));
-        assertNotNull("LTPA configuration should report it is ready", server.waitForStringInLog("CWWKS4105I"));
+        // verify the appSecurity-2.0 feature is ready
+        assertNotNull("Security service did not report it was ready", server.waitForStringInLogUsingMark("CWWKS0008I"));
+        assertNotNull("LTPA configuration did not report it was ready", server.waitForStringInLogUsingMark("CWWKS4105I"));
     }
 
     @AfterClass


### PR DESCRIPTION
Updated EJB fat servers that use appSecurity-2.0 to wait for
security and LTPA to start before running tests.
