### PR TITLE
update retryInterval description per fail over

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/l10n/metatype.properties
@@ -50,7 +50,7 @@ pollSize=Poll size
 pollSize.desc=The maximum number of task entries to find when polling the persistent store for tasks to run. If unspecified, there is no limit.
 
 retryInterval=Retry interval
-retryInterval.desc=The amount of time that must pass between consecutive retries of a failed task. When fail over is enabled, the first retry occurs after the interval. When fail over is not enabled, the first retry occurs immediately. In the absence of a configured value, a default is used. If fail over is enabled, the default retry interval is computed from the poll interval and the missed task threshold. If fail over is not enabled, the default is 1 minute.
+retryInterval.desc=The amount of time that must pass between consecutive retries of a failed task. The retry interval applies only to the server on which the failure occurred. When fail over is enabled, servers that have not seen the failure will initially retry at their next poll. When fail over is not enabled, the first retry occurs immediately on the same server, and at the retry interval thereafter. In the absence of a configured value, a default is used. If fail over is enabled, the default retry interval is computed from the poll interval and the missed task threshold. If fail over is not enabled, the default is 1 minute.
 
 retryLimit=Retry limit
 retryLimit.desc=Limit of consecutive retries for a task that has failed or rolled back, after which the task is considered permanently failed and does not attempt further retries. A value of -1 allows for unlimited retries.

--- a/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/l10n/metatype.properties
@@ -50,7 +50,7 @@ pollSize=Poll size
 pollSize.desc=The maximum number of task entries to find when polling the persistent store for tasks to run. If unspecified, there is no limit.
 
 retryInterval=Retry interval
-retryInterval.desc=The amount of time that must pass between consecutive retries of a failed task. The retry interval applies only to the server on which the failure occurred. When fail over is enabled, servers that have not seen the failure will initially retry at their next poll. When fail over is not enabled, the first retry occurs immediately on the same server, and at the retry interval thereafter. In the absence of a configured value, a default is used. If fail over is enabled, the default retry interval is computed from the poll interval and the missed task threshold. If fail over is not enabled, the default is 1 minute.
+retryInterval.desc=The amount of time that must pass between consecutive retries of a failed task. The retry interval applies only to the server on which the failure occurred. When failover is enabled, servers that did not see the failure retry at their next poll. When failover is not enabled, the first retry occurs immediately on the same server, and at the retry interval thereafter. In the absence of a configured value, a default is used. If failover is enabled, the default retry interval is computed from the poll interval and the missed task threshold. If failover is not enabled, the default is 1 minute.
 
 retryLimit=Retry limit
 retryLimit.desc=Limit of consecutive retries for a task that has failed or rolled back, after which the task is considered permanently failed and does not attempt further retries. A value of -1 allows for unlimited retries.


### PR DESCRIPTION
retryInterval description needs an update because it only applies to the server where the failure happened.