### PR TITLE
Upgrade MicroProfile OpenTracing 1.2 & 1.3 TCK

### DIFF
--- a/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
     <name>MicroProfile Opentracing TCK Runner TCK Module</name>
 
     <properties>
-        <microprofile.opentracing.version>1.2.1</microprofile.opentracing.version>
+        <microprofile.opentracing.version>1.2.2</microprofile.opentracing.version>
         <arquillian.version>1.1.13.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->

--- a/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
     <name>MicroProfile Opentracing TCK Runner TCK Module</name>
 
     <properties>
-        <microprofile.opentracing.version>1.3.1</microprofile.opentracing.version>
+        <microprofile.opentracing.version>1.3.2</microprofile.opentracing.version>
         <arquillian.version>1.1.13.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->


### PR DESCRIPTION
Maven Central does not allow to use HTTP to download starting on 1/15/2020.  MicroProfile OpenTracing has released a bug fix to address this issue.

Relates #10489