### PR TITLE
Allow postgres to engage in two phase commit transactions

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/fat/src/com/ibm/ws/concurrent/persistent/fat/demo/timers/DemoTimerTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/fat/src/com/ibm/ws/concurrent/persistent/fat/demo/timers/DemoTimerTest.java
@@ -19,7 +19,6 @@ import java.sql.SQLException;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
@@ -55,11 +54,20 @@ public class DemoTimerTest extends FATServletClient {
     @TestServlet(servlet = PersistentDemoTimersServlet.class, path = APP_NAME)
     public static LibertyServer server;
 
-    @ClassRule
+    // Not a ClassRule as Postgres needs to start with a specific command
     public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
 
     @BeforeClass
     public static void setUp() throws Exception {
+        // In order to use two phase commit Postgres needs explicit permission to prepare transactions
+        // See documentation here: https://www.postgresql.org/docs/current/sql-prepare-transaction.html
+        if (DatabaseContainerType.valueOf(testContainer) == DatabaseContainerType.Postgres) {
+            testContainer.withCommand("postgres -c max_prepared_transactions=2");
+        }
+
+        //Start Database
+        testContainer.start();
+
         //Get driver name
         server.addEnvVar("DB_DRIVER", DatabaseContainerType.valueOf(testContainer).getDriverName());
 
@@ -69,6 +77,7 @@ public class DemoTimerTest extends FATServletClient {
         //Install App
         ShrinkHelper.defaultDropinApp(server, APP_NAME, "ejb.timers");
 
+        //Start server
         server.startServer();
 
         //Application uses an XA datasource to perform database access.
@@ -93,5 +102,6 @@ public class DemoTimerTest extends FATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         server.stopServer("CWWKC1501W", "CWWKC1511W");
+        testContainer.stop();
     }
 }


### PR DESCRIPTION
Postgres was failing with the following error:

```
[01/20/2020 15:46:30:044 CST] 046 PostgreSQLContainer            output                         I ERROR:  prepared transactions are disabled
[01/20/2020 15:46:30:045 CST] 046 PostgreSQLContainer            output                         I HINT:  Set max_prepared_transactions to a nonzero value.
[01/20/2020 15:46:30:045 CST] 046 PostgreSQLContainer            output                         I STATEMENT:  PREPARE TRANSACTION '1463898948_AAABb8Tr3vIAAAABE64luOLe+k3znXUtazKvPrWOA7w3dYE9_AAABb8Tr3vIAAAABE64luOLe+k3znXUtazKvPrWOA7w3dYE9AAAAAQAAAAAAAAAAAAAAAAAC'
```

This is because by default Postgres is unable to prepare transactions. Therefore, by default cannot engage in a two phase commit.  I have set the max number of prepared transactions to 2 to allow Postgres to engage in two phase commits.  This number will likely need to be increased if this application is going to be run under heavier load. 
