### PR TITLE
Issue 10500: Adjust referenced features on acmeCA feature

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/acmeCA-2.0/com.ibm.websphere.appserver.acmeCA-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/acmeCA-2.0/com.ibm.websphere.appserver.acmeCA-2.0.feature
@@ -6,9 +6,9 @@ IBM-ShortName: acmeCA-2.0
 Subsystem-Version: 2.0
 Subsystem-Name: Automatic Certificate Management Environment (ACME) Support 2.0
 -features=\
-  com.ibm.wsspi.appserver.webBundle-1.0,\
-  com.ibm.websphere.appserver.appSecurity-3.0, \
   com.ibm.websphere.appserver.servlet-4.0, \
+  com.ibm.websphere.appserver.internal.slf4j-1.7.7, \
+  com.ibm.websphere.appserver.transportSecurity-1.0
 
 -bundles=\
   com.ibm.ws.security.acme; start-phase:=APPLICATION_EARLY


### PR DESCRIPTION
Fixes #10500

The appSecurity featuer was too wide of an umbrella. Adjust down to features we really need.