### PR TITLE
Fixing config change test for auth data

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/ConfigTest.java
+++ b/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/ConfigTest.java
@@ -244,26 +244,29 @@ public class ConfigTest extends FATServletClient {
         String method = "testConfigChangeAuthData";
         Log.info(c, method, "Executing " + method);
 
-        String originalUserName = testContainer.getUsername();
+        // First use the authData with its current value
+        runTest(basicfat, "testConfigChangeAuthDataOriginalValue");
 
-        // First check that authData matches with what was provided by the TestContainer
-        runTestWithResponse(server, basicfat, "testConfigChangeAuthDataOriginalValue&originalUsername=" + originalUserName);
-
-        // Update the authData's user
+        // Find the derbyAuth1 element
         ServerConfiguration config = server.getServerConfiguration();
         AuthData derbyAuth1 = null;
         for (AuthData authData : config.getAuthDataElements())
             if ("derbyAuth1".equals(authData.getId()))
                 derbyAuth1 = authData;
+        // Fail if we cannot find it
         if (derbyAuth1 == null) {
             System.out.println("Failure during " + method + " with the following config:");
             System.out.println(config);
             fail("Did not find authData with id=derbyAuth1");
         }
+        // Save the original username
+        String originalUserName = derbyAuth1.getUser();
 
+        // Update to a new username
         derbyAuth1.setUser("updatedUserName");
 
         try {
+            // Update and use the authData with its new value
             updateServerConfig(config, EMPTY_EXPR_LIST);
             runTest(basicfat, "testConfigChangeAuthData");
         } catch (Throwable x) {
@@ -276,8 +279,9 @@ public class ConfigTest extends FATServletClient {
         derbyAuth1.setUser(originalUserName);
 
         try {
+            // Update and use the authData with its restored value
             updateServerConfig(config, EMPTY_EXPR_LIST);
-            runTestWithResponse(server, basicfat, "testConfigChangeAuthDataOriginalValue&originalUsername=" + originalUserName);
+            runTest(basicfat, "testConfigChangeAuthDataOriginalValue");
         } catch (Throwable x) {
             System.out.println("Failure during " + method + " with the following config:");
             System.out.println(config);

--- a/dev/com.ibm.ws.jdbc_fat/test-applications/basicfat/src/basicfat/DataSourceTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat/test-applications/basicfat/src/basicfat/DataSourceTestServlet.java
@@ -51,8 +51,6 @@ import javax.management.ObjectInstance;
 import javax.management.ObjectName;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 import javax.transaction.HeuristicMixedException;
 import javax.transaction.UserTransaction;
@@ -163,8 +161,10 @@ public class DataSourceTestServlet extends FATServlet {
     @Resource(name = "jdbc/dsfat6ref", lookup = "java:comp/env/jdbc/dsfat6")
     DataSource ds6; // one-phase, Derby only, see @DataSourceDefinition above
 
+    // one-phase, Derby only, see @DataSourceDefinition above
+    // ibm-web-ext.xml overrides isolation to 1, ibm-web-bnd.xml sets authentication-alias to derbyAuth1
     @Resource(name = "jdbc/dsfat6ref1", lookup = "java:comp/env/jdbc/dsfat6")
-    DataSource ds6_1; // one-phase, Derby only, isolation=1, see @DataSourceDefinition above
+    DataSource ds6_1;
 
     @Resource(name = "jdbc/dsfat7ref", lookup = "java:module/env/jdbc/dsfat7")
     DataSource ds7; // one-phase, Derby only
@@ -370,7 +370,7 @@ public class DataSourceTestServlet extends FATServlet {
             DatabaseMetaData metadata = con.getMetaData();
             String user = metadata.getUserName();
             if (!"updatedUserName".equalsIgnoreCase(user))
-                throw new Exception("User name from authData ID:derbyAuth1 was not honored. Expected:updatedUserName Instead:" + user);
+                throw new Exception("User name from authData ID:derbyAuth1 was not honored. Expected: updatedUserName Instead: " + user);
         } finally {
             con.close();
         }
@@ -379,19 +379,14 @@ public class DataSourceTestServlet extends FATServlet {
     /**
      * Verify that a config change that sets authData derbyAuth1 back its original value.
      */
-    public void testConfigChangeAuthDataOriginalValue(HttpServletRequest request, HttpServletResponse response) throws Throwable {
-        String origUser = request.getParameter("originalUsername");
-
-        if (origUser == null) {
-            throw new Exception("Test suite called test without providing an original username.");
-        }
+    public void testConfigChangeAuthDataOriginalValue() throws Throwable {
 
         Connection con = ds6_1.getConnection();
         try {
             DatabaseMetaData metadata = con.getMetaData();
             String user = metadata.getUserName();
-            if (!origUser.equalsIgnoreCase(user))
-                throw new Exception("User name from authData ID:derbyAuth1 was not honored. Expected:" + origUser + " Instead:" + user);
+            if (!"dbuser1".equalsIgnoreCase(user))
+                throw new Exception("User name from authData ID:derbyAuth1 was not honored. Expected: dbuser1 Instead: " + user);
         } finally {
             con.close();
         }


### PR DESCRIPTION
A previous change that had been made to this test case changed the original call to use the Test Containers username.  However, this test should only be running against derby.  I have switched it back to ignore test containers and to make sure we are using a derby only datasource. 

Another (minor) issue with this test case is that on the server side we are using dsfat6 to get a connection between config changes.  However, dsfat6 is defined using `@DatasourceDefinition`, but we do not document anywhere on the client side code that the authentication configuration is being overridden by ibm-web-bnd.xml.  So it looks like the test is changing authdata and using a datasource to confirm the change that doesn't itself use that authdata.    