### PR TITLE
Upgrade MicroProfile OpenTracing 1.0 & 1.1 TCK

### DIFF
--- a/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
     <name>MicroProfile Opentracing TCK Runner TCK Module</name>
 
     <properties>
-        <microprofile.opentracing.version>1.1</microprofile.opentracing.version>
+        <microprofile.opentracing.version>1.1.1</microprofile.opentracing.version>
         <arquillian.version>1.1.13.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->

--- a/dev/com.ibm.ws.microprofile.opentracing_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
     <name>MicroProfile Opentracing TCK Runner TCK Module</name>
 
     <properties>
-        <microprofile.opentracing.version>1.0.1</microprofile.opentracing.version>
+        <microprofile.opentracing.version>1.0.2</microprofile.opentracing.version>
         <arquillian.version>1.1.13.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->


### PR DESCRIPTION
Maven Central does not allow to use HTTP to download starting on 1/15/2020. MicroProfile OpenTracing has released a bug fix to address this issue.

Fixes #10489