### PR TITLE
Ensure duplicate key exception is avoided

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/ProgrammaticTimer.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/ProgrammaticTimer.java
@@ -37,7 +37,7 @@ public class ProgrammaticTimer {
      */
     public Timer setTimer() {
         final TimerConfig config = new TimerConfig();
-        config.setInfo("Created Programmaticlly and Running Every 5 minute(s)");
+        config.setInfo("Created Programmatically and Running Every 5 minute(s)");
         config.setPersistent(true);
         ScheduleExpression exp = new ScheduleExpression().hour("*").minute("*/5").second("0");
         return timerService.createCalendarTimer(exp, config);


### PR DESCRIPTION
We were running into issues on our test systems where each time the AutomaticDatabase timer ran it would attempt to create the row where we are trying to keep track of executions.  This resulted in a duplicate key exception being thrown by the database. Likely due to a timing issue.

Here I have changed the test to ensure that the row is created before the timer, and there is only one attempt to create the row.  I did this by inserting the down during the `PostConstruct` method, after table creation. 

