### PR TITLE
Fixed DataSourceJaasTest Java 2 security issues

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/DataSourceJaasTest.java
+++ b/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/DataSourceJaasTest.java
@@ -82,7 +82,7 @@ public class DataSourceJaasTest extends FATServletClient {
                           "CWWKE0701E"); //TODO investigate why this warning is being logged
     }
 
-    //@Test TODO why does this test fail?
+    @Test
     public void testDataSourceMappingConfigAlias() throws Exception {
         runTest(server, basicfat, testName);
     }

--- a/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.jaas.fat/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.jaas.fat/server.xml
@@ -242,5 +242,14 @@
     <javaPermission className="javax.security.auth.PrivateCredentialPermission" signedBy="java.util.Hashtable" principalType="*" principalName="*" actions="read"/>
     <javaPermission className="javax.security.auth.AuthPermission" name="modifyPrivateCredentials"/>
     
+    <!-- Oracle JDBC test requirement -->
+    <javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+    
+    <!-- Postgres JDBC test requirement -->
+    <javaPermission className="java.util.PropertyPermission" name="org.postgresql.forceBinary" actions="read"/>
+    
+    <!-- SQLServer JDBC test requirement -->
+    <javaPermission className="java.util.PropertyPermission" name="java.specification.version" actions="read"/>
+    
     <variable name="onError" value="FAIL"/>
 </server>


### PR DESCRIPTION
There were a couple of Java 2 security permissions that needed to be granted to get the testDataSourceMappingConfigAlias FAT test working.