### PR TITLE
Shortened feature description to a single sentence

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/audit-1.0/resources/l10n/com.ibm.websphere.appserver.audit-1.0.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/audit-1.0/resources/l10n/com.ibm.websphere.appserver.audit-1.0.properties
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/audit-1.0/resources/l10n/com.ibm.websphere.appserver.audit-1.0.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/audit-1.0/resources/l10n/com.ibm.websphere.appserver.audit-1.0.properties
@@ -15,4 +15,5 @@
 #NLS_MESSAGEFORMAT_NONE
 #
 
-description=The Audit feature is used to report and track auditable events to ensure the integrity of your system.
+description=The Audit feature is used to report and track auditable events to ensure the integrity \
+ of your system.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/audit-1.0/resources/l10n/com.ibm.websphere.appserver.audit-1.0.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/audit-1.0/resources/l10n/com.ibm.websphere.appserver.audit-1.0.properties
@@ -15,33 +15,4 @@
 #NLS_MESSAGEFORMAT_NONE
 #
 
-description=The Liberty Audit feature is used to report and track auditable events to ensure the integrity of your system. \n\
-The Liberty Audit feature introduces an infrastructure which serves two purposes: \n\n\
- - Confirming the effectiveness and integrity of the existing configuration \n\
- - Identifying areas where improvement to the configuration may be needed  \n\n\
-The Liberty Audit feature has the ability to capture the following auditable events: \n\n\
- - Basic authentication \n\
- - Start and stop of the Audit service \n\
- - Form login authentication \n\
- - Client certificate authentication \n\
- - Servlet runAs delegation \n\
- - Failover to basic authentication \n\
- - Unprotected servlet authorization \n\
- - Servlet 3.0 APIs: login/logout/authenticate \n\
- - JACC web authorization \n\
- - Form logout \n\
- - JACC EJB authorization \n\
- - EJB delegation \n\
- - SCIM operations/member management \n\
- - Dynamic audit feature handling \n\
- - EJB authorization \n\
- - JMX MBean operations \n\
- - JMX Notifications \n\
- - JMX MBean registration \n\
- - JMX MBean attribute operations \n\
- - JMS Authentication \n\
- - JMS Authorization \n\
- - OAuth application password and token management \n\
- - SAF authorization \n\n\
-The Liberty Audit feature supports the Cloud Auditing Data Federation (CADF) event model.  The CADF model describes a data model and associated schema definitions for an audit event. \n\n\
-The feature provides a default implementation, the AuditFileHandler, which emits human-readable audit records to a file-based log.   Each audit record is emitted in JSON format.
+description=The Audit feature is used to report and track auditable events to ensure the integrity of your system.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/socialLogin-1.0/resources/l10n/com.ibm.websphere.appserver.socialLogin-1.0.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/socialLogin-1.0/resources/l10n/com.ibm.websphere.appserver.socialLogin-1.0.properties
@@ -15,5 +15,4 @@
 #
 
 description=Social login is a form of single sign-on (SSO) that enables users to sign in to a \
-secured website by using their existing social media account instead of creating an account \
-specifically for the website.
+secured website by using their existing social media account.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/socialLogin-1.0/resources/l10n/com.ibm.websphere.appserver.socialLogin-1.0.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/socialLogin-1.0/resources/l10n/com.ibm.websphere.appserver.socialLogin-1.0.properties
@@ -14,5 +14,5 @@
 #NLS_MESSAGEFORMAT_NONE
 #
 
-description=Social login is a form of single sign-on (SSO) that enables users to sign in to a \
-secured website by using their existing social media account.
+description=Social Media Login feature provides a form of single sign-on (SSO) that enables users \
+ to sign in to a secured website by using their existing social media account.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/socialLogin-1.0/resources/l10n/com.ibm.websphere.appserver.socialLogin-1.0.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/socialLogin-1.0/resources/l10n/com.ibm.websphere.appserver.socialLogin-1.0.properties
@@ -16,8 +16,4 @@
 
 description=Social login is a form of single sign-on (SSO) that enables users to sign in to a \
 secured website by using their existing social media account instead of creating an account \
-specifically for the website. For example, you can configure social login so that users \
-can log in to your website with their Facebook or Twitter accounts. \
-You can enable social login for any social media platform that uses \
-the OAuth 2.0 or OpenID Connect 1.0 standard for authorization. \
-It can be used instead of, or in addition to, the configured user registry.
+specifically for the website.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/socialLogin-1.0/resources/l10n/com.ibm.websphere.appserver.socialLogin-1.0.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/socialLogin-1.0/resources/l10n/com.ibm.websphere.appserver.socialLogin-1.0.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2019 IBM Corporation and others.
+# Copyright (c) 2016, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at


### PR DESCRIPTION
 Shortened to a single sentence for consistency across features. Moved extended description out to docs (instead of part of generated feature doc which is also displayed in Eclipse Tools).