### PR TITLE
Make rpm name consistent when building on different Linuxes

### DIFF
--- a/dev/build.image/packaging/openliberty.spec.template
+++ b/dev/build.image/packaging/openliberty.spec.template
@@ -10,7 +10,7 @@ Summary:        Open Liberty
 License:        EPL-1.0
 Name:           %{name}
 Version:        %{version}
-Release:        1%{?dist}
+Release:        1
 Source:         %{name}-%{version}.tar.gz
 BuildArch:      noarch
 URL:            https://openliberty.io


### PR DESCRIPTION
Modified rpm spec file to ensure generated rpm file name is consistent when built on different Linux machines.