### PR TITLE
Update eclipse settings for new jwt fat changes

### DIFF
--- a/dev/com.ibm.ws.security.fat.common.jwt/.classpath
+++ b/dev/com.ibm.ws.security.fat.common.jwt/.classpath
@@ -5,6 +5,6 @@
 	<classpathentry kind="src" path="test-applications/jwtbuilder/src"/>
 	<classpathentry kind="src" path="test-applications/helloworld/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.security.jwt_fat.builder/.classpath
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/.classpath
@@ -4,8 +4,6 @@
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/jwtbuilderclient/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.ws.security.fat.common"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.ws.security.fat.common.jwt"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.security.jwt_fat.builder/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_member=insert

--- a/dev/com.ibm.ws.security.jwt_fat.consumer/.classpath
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/.classpath
@@ -4,7 +4,6 @@
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/jwtconsumerclient/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
-	<classpathentry exported="true" kind="src" path="/com.ibm.websphere.javaee.servlet.3.1"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.security.jwt_fat.consumer/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_member=insert


### PR DESCRIPTION
- Update security.fat.common.jwt .classpath to have the right Java
version
- Remove classpath entries and only rely on bnd in
security.jwt_fat.builder|consumer components
- Add org.eclipse.jdt.core.prefs files to specify Java 8 as the java
source and target for security.jwt_fat.builder|consumer components.
