### PR TITLE
Add trace to delayexec fat

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_delayexec/publish/servers/com.ibm.ws.concurrent.persistent.delayexec.fat/.options
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_delayexec/publish/servers/com.ibm.ws.concurrent.persistent.delayexec.fat/.options
@@ -1,0 +1,7 @@
+#OSGI debug options to resolve weird case where the bundle metatype is not found
+org.eclipse.osgi/debug=true
+org.eclipse.osgi/debug/bundleFile=true
+org.eclipse.osgi/debug/cachedmanifest=true
+
+
+

--- a/dev/com.ibm.ws.concurrent.persistent_fat_delayexec/publish/servers/com.ibm.ws.concurrent.persistent.delayexec.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_delayexec/publish/servers/com.ibm.ws.concurrent.persistent.delayexec.fat/bootstrap.properties
@@ -13,8 +13,12 @@ bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
 logservice=all:\
 persistentExecutor=all:\
-com.ibm.ws.concurrent.persistent*=all
+com.ibm.ws.concurrent.persistent*=all:\
+com.ibm.ws.org.eclipse.equinox.metatype=debug:\
+com.ibm.ws.config.xml.internal.BundleProcessor=all
 
 ds.loglevel=DEBUG
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
+osgi.debug=
+


### PR DESCRIPTION
PR to add osgi trace to the com.ibm.ws.concurrent.persistent.delayexec FAT