### PR TITLE
disabled test for login module in standalone resource adapter

### DIFF
--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/FATSuite.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,8 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
 @SuiteClasses({
                 AlwaysPassesTest.class,
                 DerbyResourceAdapterTest.class,
-                DerbyResourceAdapterSecurityTest.class
+                DerbyResourceAdapterSecurityTest.class,
+                LoginModuleInStandaloneResourceAdapterTest.class
 })
-public class FATSuite {}
+public class FATSuite {
+}

--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/LoginModuleInStandaloneResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/LoginModuleInStandaloneResourceAdapterTest.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jca.fat.derbyra;
+
+import java.io.File;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+@RunWith(FATRunner.class)
+public class LoginModuleInStandaloneResourceAdapterTest extends FATServletClient {
+
+    private static final String APP = "derbyRAApp";
+    private static final String WAR_NAME = "fvtweb";
+    private static final String DerbyRAServlet = "fvtweb/DerbyRAServlet";
+    private static final String DerbyRAAnnoServlet = "fvtweb/DerbyRAAnnoServlet";
+
+    @Server("com.ibm.ws.jca.fat.derbyra.loginModuleInRA")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        WebArchive war = ShrinkWrap.create(WebArchive.class, WAR_NAME + ".war");
+        war.addPackage("web");
+        war.addAsWebInfResource(new File("test-applications/fvtweb/resources/WEB-INF/ibm-web-bnd.xml"));
+        war.addAsWebInfResource(new File("test-applications/fvtweb/resources/WEB-INF/web.xml"));
+
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, APP + ".ear");
+        ear.addAsModule(war);
+        ShrinkHelper.addDirectory(ear, "lib/LibertyFATTestFiles/derbyRAApp");
+        ShrinkHelper.exportToServer(server, "apps", ear);
+
+        ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "DerbyLMRA.rar");
+        rar.as(JavaArchive.class).addPackage("fat.derbyra.resourceadapter");
+        rar.addAsManifestResource(new File("test-resourceadapters/fvt-resourceadapter/resources/META-INF/ra.xml"));
+        rar.addAsManifestResource(new File("test-resourceadapters/fvt-resourceadapter/resources/META-INF/permissions.xml"));
+
+        rar.addAsLibrary(new File("publish/shared/resources/derby/derby.jar"));
+
+        rar.as(JavaArchive.class).addPackage("com.ibm.ws.jca.fat.security.login");
+        // TODO switch to JAR within resource adapter once implemented to properly read from the rar
+        //JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "loginModule.jar");
+        //jar.addPackage("com.ibm.ws.jca.fat.security.login");
+        //rar.addAsLibraries(jar);
+
+        ShrinkHelper.exportToServer(server, "connectors", rar);
+
+        server.addInstalledAppForValidation(APP);
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer("SRVE9967W"); // The manifest class path derbyLocale_cs.jar can not be found in jar file wsjar:file:/C:/Users/IBM_ADMIN/Documents/workspace/build.image/wlp/usr/servers/com.ibm.ws.jca.fat.derbyra/connectors/DerbyRA.rar!/derby.jar or its parent.
+                                        // This may just be because we don't care about including manifest files in our test buckets, if that's the case, we can ignore this.
+    }
+
+    @Test
+    public void testJCADataSourceResourceRefLoginModuleInRAR() throws Exception {
+        FATServletClient.runTest(server, DerbyRAServlet, "testJCADataSourceResourceRefSecurity");
+    }
+
+    @Test
+    public void testCustomLoginModuleInRARCF() throws Exception {
+        FATServletClient.runTest(server, DerbyRAAnnoServlet, "testCustomLoginModuleCF");
+    }
+
+}

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.loginModuleInRA/bootstrap.properties
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.loginModuleInRA/bootstrap.properties
@@ -1,0 +1,6 @@
+com.ibm.ws.logging.trace.specification=*=event=enabled:logservice=all:rarInstall=all:WAS.j2c=all:test=all:web.*=all:com.ibm.ws.security.jca.*=all
+com.ibm.ws.logging.max.file.size=0
+osgi.console=5678
+
+bootstrap.include=../testports.properties
+ds.lock.timeout.milliseconds=30000

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.loginModuleInRA/server.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.loginModuleInRA/server.xml
@@ -1,0 +1,72 @@
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+    <featureManager>
+      <feature>appSecurity-2.0</feature>
+      <feature>componenttest-1.0</feature>
+      <feature>concurrent-1.0</feature>
+      <feature>jca-1.7</feature>
+      <feature>jndi-1.0</feature>
+      <feature>servlet-4.0</feature>
+    </featureManager>
+
+    <include optional="true" location="../fatTestPorts.xml"/>
+
+    <variable name="onError" value="FAIL"/>
+
+    <application location="derbyRAApp.ear"/>
+
+    <resourceAdapter id="DerbyLMRA" location="${server.config.dir}/connectors/DerbyLMRA.rar"/>
+
+    <!-- injected into application, but otherwise not used by tests -->
+    <adminObject jndiName="eis/bootstrapContext">
+      <properties.DerbyLMRA.BootstrapContext/>
+    </adminObject>
+
+    <!-- injected into application, but otherwise not used by tests -->
+    <adminObject jndiName="eis/map1">
+      <properties.DerbyLMRA.Map tableName="MAP1"/>
+    </adminObject>
+
+    <connectionFactory jndiName="eis/ds1">
+      <containerAuthData user="DS1USER" password="{xor}GwxuDwgb"/>
+      <properties.DerbyLMRA/>
+    </connectionFactory>    
+
+    <jaasLoginContextEntry id="myJAASLoginEntry" name="myJAASLoginEntryName">
+      <!-- TODO replace with classProviderRef="DerbyLMRA" once implemented -->
+      <loginModule className="com.ibm.ws.jca.fat.security.login.TestLoginModule" libraryRef="temp"/>
+    </jaasLoginContextEntry>
+
+    <!-- TODO remove this -->
+    <library id="temp">
+      <file name="${server.config.dir}/connectors/DerbyLMRA.rar"/>
+    </library>
+
+    <!-- "APP" is the default schema for Derby -->
+    <authData id="APP" user="APP" password="{aes}APb9ZaYzUL+JsfFD/OOBGaPM0evjmx5AnvmzbaKgffyX"/>
+
+    <!-- TODO go through these copied permissions once we are properly loading the login module from the resource adapter -->
+    <!-- 
+    NOTE: for this bucket to run cleanly with j2sec enabled with IBM JDK, the following permission must 
+    be manually granted in the java.policy file at $JAVA_HOME/jre/lib/security/java.policy: 
+    permission java.lang.RuntimePermission "accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect";
+    -->
+    <javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
+    <javaPermission codebase="${server.config.dir}/connectors/DerbyLMRA.rar" className="javax.security.auth.AuthPermission" name="modifyPrivateCredentials"/>
+    <javaPermission className="javax.security.auth.AuthPermission" name="createLoginContext.myJAASLoginEntryName"/>
+    <javaPermission className="javax.security.auth.PrivateCredentialPermission" signedBy="javax.resource.spi.security.PasswordCredential" principalType="*" principalName="*" actions="read"/>
+    <javaPermission className="javax.security.auth.PrivateCredentialPermission" signedBy="java.util.HashMap" principalType="*" principalName="*" actions="read"/>
+    <javaPermission className="java.lang.RuntimePermission" name="modifyThread"/>
+    <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission className="javax.management.MBeanPermission" name="*" actions="*"/>
+    <javaPermission className="javax.management.MBeanServerPermission" name="createMBeanServer"/>
+</server>


### PR DESCRIPTION
Copy the existing tests for JAAS login module loaded from a library into a test that will, when implementation is ready, be switched over to loading the JAAS login module from a standalone resource adapter.  In order to confirm the tests are otherwise correct, I have temporarily pointed a libraryRef at the RAR file.  This can switch to classProviderRef when that feature is implemented.