### PR TITLE
Add test to check result of hitting Readiness endpoint as server is starting

### DIFF
--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/fat/src/com/ibm/ws/microprofile/health20/fat/DelayAppStartupHealthCheckTest.java
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/fat/src/com/ibm/ws/microprofile/health20/fat/DelayAppStartupHealthCheckTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/fat/src/com/ibm/ws/microprofile/health20/fat/DelayAppStartupHealthCheckTest.java
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/fat/src/com/ibm/ws/microprofile/health20/fat/DelayAppStartupHealthCheckTest.java
@@ -41,7 +41,7 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+//@Mode(TestMode.FULL)  Comment out temporarily so that build will run this more than once
 public class DelayAppStartupHealthCheckTest {
 
     public static final String APP_NAME = "DelayedHealthCheckApp";

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/test-applications/DelayedHealthCheckApp/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/test-applications/DelayedHealthCheckApp/resources/WEB-INF/web.xml
@@ -13,5 +13,6 @@
   
   <servlet-mapping>
     <servlet-name>DelayedServlet</servlet-name>
+    <url-pattern>/DelayedServlet</url-pattern>
   </servlet-mapping>
 </web-app>

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/test-applications/DelayedHealthCheckApp/src/com/ibm/ws/microprofile/health20/delayed/health/check/app/DelayedServlet.java
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/test-applications/DelayedHealthCheckApp/src/com/ibm/ws/microprofile/health20/delayed/health/check/app/DelayedServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/test-applications/DelayedHealthCheckApp/src/com/ibm/ws/microprofile/health20/delayed/health/check/app/DelayedServlet.java
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/test-applications/DelayedHealthCheckApp/src/com/ibm/ws/microprofile/health20/delayed/health/check/app/DelayedServlet.java
@@ -49,6 +49,8 @@ public class DelayedServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         // TODO Auto-generated method stub
+        response.setContentType("text/plain");
+        response.setCharacterEncoding("UTF-8");
         response.getWriter().append("Served at: ").append(request.getContextPath()).append("\n");
         response.getWriter().println("Testing Delayed Servlet initialization.");
     }


### PR DESCRIPTION
In relation to https://github.com/OpenLiberty/open-liberty/issues/10495
Fixes #9609 