### PR TITLE
Handle defunct processes

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/PSProcessStatusImpl.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/PSProcessStatusImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -62,13 +62,16 @@ public class PSProcessStatusImpl implements ProcessStatus {
             Process p = pb.start();
             in = p.getInputStream();
 
+            boolean defunct = false;
             reader = new BufferedReader(new InputStreamReader(in));
             for (String line; (line = reader.readLine()) != null;) {
                 Debug.println(line);
+                if (line.contains("<defunct>"))
+                    defunct = true;
             }
 
             p.waitFor();
-            if (p.exitValue() == 0)
+            if (p.exitValue() == 0 && !defunct)
                 return State.YES;
             else
                 return State.NO;


### PR DESCRIPTION
When we check to see if a server is possibly still running we need to take `<defunct>` processes into consideration. 