### PR TITLE
10582: Ensure app ExceptionMappers are invoked instead of OT mappers

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/provider/ProviderFactory.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/provider/ProviderFactory.java
@@ -1453,8 +1453,10 @@ public abstract class ProviderFactory {
         if (realClass1.isAssignableFrom(realClass2)) {
             // subclass should go first
             return 1;
+        } else if (realClass2.isAssignableFrom(realClass1)) { //Liberty change
+            return -1;
         }
-        return -1;
+        return 0; // Liberty change
     }
 
     //Liberty code change start

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/.classpath
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/.classpath
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
-	<classpathentry kind="src" path="test-applications/restmetrics/src"/>
-	<classpathentry kind="src" path="test-applications/linkheader/src"/>
 	<classpathentry kind="src" path="test-applications/annotationscan/src"/>
+	<classpathentry kind="src" path="test-applications/beanparam/src"/>
 	<classpathentry kind="src" path="test-applications/beanvalidation/src"/>
 	<classpathentry kind="src" path="test-applications/bookcontinuationstore/src"/>
 	<classpathentry kind="src" path="test-applications/bookstore/src"/>
@@ -12,6 +11,7 @@
 	<classpathentry kind="src" path="test-applications/client/src"/>
 	<classpathentry kind="src" path="test-applications/context/src"/>
 	<classpathentry kind="src" path="test-applications/contextresolver/src"/>
+	<classpathentry kind="src" path="test-applications/exceptionMappingWithOT/src"/>
 	<classpathentry kind="src" path="test-applications/extraproviders/src"/>
 	<classpathentry kind="src" path="test-applications/getCgetS/src"/>
 	<classpathentry kind="src" path="test-applications/helloworld/src"/>
@@ -19,14 +19,18 @@
 	<classpathentry kind="src" path="test-applications/jackson/src"/>
 	<classpathentry kind="src" path="test-applications/jacksonJsonIgnore/src"/>
 	<classpathentry kind="src" path="test-applications/json/src"/>
+	<classpathentry kind="src" path="test-applications/linkheader/src"/>
 	<classpathentry kind="src" path="test-applications/paramconverter/src"/>
 	<classpathentry kind="src" path="test-applications/params/src"/>
 	<classpathentry kind="src" path="test-applications/providerAndResource/src"/>
 	<classpathentry kind="src" path="test-applications/providerCache/src"/>
 	<classpathentry kind="src" path="test-applications/providers/src"/>
 	<classpathentry kind="src" path="test-applications/resourcealgorithm/src"/>
+	<classpathentry kind="src" path="test-applications/resourcepkg/src"/>
 	<classpathentry kind="src" path="test-applications/responseAPI/src"/>
+	<classpathentry kind="src" path="test-applications/restmetrics/src"/>
 	<classpathentry kind="src" path="test-applications/security/src"/>
+	<classpathentry kind="src" path="test-applications/servicescope/src"/>
 	<classpathentry kind="src" path="test-applications/servletcoexist1/src"/>
 	<classpathentry kind="src" path="test-applications/servletcoexist2/src"/>
 	<classpathentry kind="src" path="test-applications/servletcoexist3/src"/>
@@ -36,9 +40,6 @@
 	<classpathentry kind="src" path="test-applications/validation/src"/>
 	<classpathentry kind="src" path="test-applications/wadl/src"/>
 	<classpathentry kind="src" path="test-applications/webcontainer/src"/>
-	<classpathentry kind="src" path="test-applications/servicescope/src"/>
-	<classpathentry kind="src" path="test-applications/resourcepkg/src"/>
-	<classpathentry kind="src" path="test-applications/beanparam/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/bnd.bnd
@@ -23,6 +23,7 @@ src: \
   test-applications/client/src,\
   test-applications/context/src,\
   test-applications/contextresolver/src,\
+  test-applications/exceptionMappingWithOT/src,\
   test-applications/extraproviders/src,\
   test-applications/getCgetS/src,\
   test-applications/helloworld/src,\

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/FATSuite.java
@@ -29,6 +29,7 @@ import com.ibm.ws.jaxrs20.fat.client.ClientTest;
 import com.ibm.ws.jaxrs20.fat.context.ContextTest;
 import com.ibm.ws.jaxrs20.fat.contextresolver.DepartmentTest;
 import com.ibm.ws.jaxrs20.fat.exceptionmappers.ExceptionMappersTest;
+import com.ibm.ws.jaxrs20.fat.exceptionmappingWithOT.ExceptionMappingWithOTTest;
 import com.ibm.ws.jaxrs20.fat.extraproviders.ExtraProvidersTest;
 import com.ibm.ws.jaxrs20.fat.getClasses_getSingletons.SameClassInGetClassesAndGetSingletonsTest;
 import com.ibm.ws.jaxrs20.fat.helloworld.HelloWorldTest;
@@ -73,6 +74,7 @@ import componenttest.rules.repeater.RepeatTests;
                 ContextTest.class,
                 DepartmentTest.class,
                 ExceptionMappersTest.class,
+                ExceptionMappingWithOTTest.class,
                 ExceptionsSubresourcesTest.class,
                 ExtraProvidersTest.class,
                 HelloWorldTest.class,

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/exceptionmappingWithOT/ExceptionMappingWithOTTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/exceptionmappingWithOT/ExceptionMappingWithOTTest.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs20.fat.exceptionmappingWithOT;
+
+import static com.ibm.ws.jaxrs20.fat.TestUtils.getPort;
+import static org.junit.Assert.assertEquals;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+
+/*
+ * MP OpenTracing adds an ExceptionMapper<Throwable> in order to track all unhandled exceptions from
+ * JAX-RS resources/providers.  This can conflict with ExceptionMappers that are registered by the
+ * application.  This test ensures that application-provided ExceptionMappers are invoked, and not
+ * the MP OT mapper.
+ */
+@RunWith(FATRunner.class)
+public class ExceptionMappingWithOTTest {
+
+    @Server("com.ibm.ws.jaxrs.fat.exceptionMappingWithOT")
+    public static LibertyServer server;
+
+    private static HttpClient client;
+    private static final String testWar = "exceptionMappingWithOT";
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultDropinApp(server, testWar, "com.ibm.ws.jaxrs.fat.exceptionMappingWithOT");
+
+        // Make sure we don't fail because we try to start an
+        // already started server
+        try {
+            server.startServer(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (server != null) {
+            server.stopServer("CWWKW1002W", "CWMOT0008E", "CWWKS9582E", "CWMOT0010W");
+        }
+    }
+
+    @Before
+    public void getHttpClient() {
+        client = new DefaultHttpClient();
+    }
+
+    @After
+    public void resetHttpClient() {
+        client.getConnectionManager().shutdown();
+    }
+
+    private String getBaseTestUri() {
+        return "http://localhost:" + getPort() + "/" + testWar;
+    }
+
+    /**
+     * Tests that exception mapping works with MP OpenTracing enabled.
+     */
+    @Test
+    public void testExceptionIsMappedWithOpenTracingEnabled() throws Exception {
+        HttpGet getMethod = new HttpGet(getBaseTestUri() + "/exceptionMappingWithOT");
+        HttpResponse resp = client.execute(getMethod);
+        assertEquals(410, resp.getStatusLine().getStatusCode());
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.exceptionMappingWithOT/.gitignore
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.exceptionMappingWithOT/.gitignore
@@ -1,0 +1,2 @@
+/apps
+/dropins

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.exceptionMappingWithOT/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.exceptionMappingWithOT/bootstrap.properties
@@ -1,0 +1,4 @@
+com.ibm.ws.logging.trace.specification=*=info
+com.ibm.ws.logging.max.file.size=0
+
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.exceptionMappingWithOT/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.exceptionMappingWithOT/server.xml
@@ -1,0 +1,9 @@
+<server>
+    <featureManager>
+        <feature>componenttest-1.0</feature>
+        <feature>javaee-7.0</feature>
+        <feature>microprofile-1.3</feature>
+    </featureManager>
+
+  	<include location="../fatTestPorts.xml"/>
+</server>

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/exceptionMappingWithOT/src/com/ibm/ws/jaxrs/fat/exceptionMappingWithOT/MyAppAndResource.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/exceptionMappingWithOT/src/com/ibm/ws/jaxrs/fat/exceptionMappingWithOT/MyAppAndResource.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.exceptionMappingWithOT;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+
+@ApplicationPath("/")
+@Path("/exceptionMappingWithOT")
+@Produces(MediaType.TEXT_PLAIN)
+public class MyAppAndResource extends Application {
+
+    @GET
+    public String get() throws Exception {
+        System.out.println("MyAppAndResource.get()");
+        throw new Exception("Expected Exception");
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/exceptionMappingWithOT/src/com/ibm/ws/jaxrs/fat/exceptionMappingWithOT/MyExceptionHandler.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/exceptionMappingWithOT/src/com/ibm/ws/jaxrs/fat/exceptionMappingWithOT/MyExceptionHandler.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.fat.exceptionMappingWithOT;
+
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import javax.ws.rs.core.MediaType;
+
+@Provider
+public class MyExceptionHandler implements ExceptionMapper<Exception> {
+
+        @Override
+        public Response toResponse(Exception e) {
+            System.out.println("MyExceptionHandler.toResponse()");
+            return Response.status(Response.Status.GONE)
+                           .entity("Exception was mapped!")
+                           .type(MediaType.TEXT_PLAIN)
+                           .build();
+        }
+
+}


### PR DESCRIPTION
The change is to ProviderFactory.compareClasses - this change is in JAX-RS 2.1 and just needs to be back ported.  This ensures that the ExceptionMapper sorting algorithm finds the mapper that handles the exception type that is closest to the thrown exception.

The other changes are for testing.