### PR TITLE
Ensure duplicate key exception is avoided attempt 2

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/publish/servers/com.ibm.ws.concurrent.persistent.fat.demo.timers/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/publish/servers/com.ibm.ws.concurrent.persistent.fat.demo.timers/server.xml
@@ -36,13 +36,13 @@
   <!-- Permission needed for SQLServer driver -->
   <javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
   
+    <!-- Permission needed for Oracle driver -->
+  <javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers" />
+  
   <!-- File read write permissions -->
   <javaPermission className="java.util.PropertyPermission" name="user.dir" actions="read"/>
   <javaPermission className="java.io.FilePermission" name="files/timertestoutput.txt" actions="read,write"/>
   <javaPermission className="java.io.FilePermission" name="files" actions="write"/>
   
-  
-  
-
   <variable name="onError" value="FAIL"/>
 </server>

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticIO.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticIO.java
@@ -20,14 +20,14 @@ import java.io.IOException;
 import javax.annotation.Resource;
 import javax.ejb.Schedule;
 import javax.ejb.SessionContext;
-import javax.ejb.Singleton;
+import javax.ejb.Stateless;
 import javax.ejb.Timer;
 
 /**
  * This class uses the @Schedule annotation.
  * Using this annotation will start the timer immediately on start and will run every other minute.
  */
-@Singleton
+@Stateless
 public class AutomaticIO {
     private static final Class<AutomaticIO> c = AutomaticIO.class;
 
@@ -35,6 +35,7 @@ public class AutomaticIO {
     private SessionContext sessionContext; //Used to get information about timer
 
     private int count; //Incremented with each execution of timers
+
     private final File file = new File("files/timertestoutput.txt");
 
     /**

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticMemory.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticMemory.java
@@ -15,14 +15,14 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Resource;
 import javax.ejb.Schedule;
 import javax.ejb.SessionContext;
-import javax.ejb.Singleton;
+import javax.ejb.Stateless;
 import javax.ejb.Timer;
 
 /**
  * This class uses the @Schedule annotation.
  * Using this annotation will start the timer immediately on start and will run every other second.
  */
-@Singleton
+@Stateless
 public class AutomaticMemory {
     @Resource
     private SessionContext sessionContext; //Used to get information about timer


### PR DESCRIPTION
Continued from PR: #10522 
We have continued to see Duplicate Key exceptions popping up in our SOE builds from this test bucket.  Without JDBC trace I was unable to locate exactly when we are originally creating the row.  My best guess is that by having this timer bean as `@Stateless` has somehow resulted in more than one bean being created, and therefore more then one attempt to create the same row in the database.

I wasn't able to recreate this error locally.  But to ensure that this is not possible I have changed the AutomaticDatabase bean to be a `@Singleton`.  This should ensure that the PostConstruct method is only ever called once.  And added in an extra check to see if the row has previously been created. 
