### PR TITLE
Avoid calling `toString()` when tracing Java dynamic proxies

### DIFF
--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/util/BlockingList.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/util/BlockingList.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.Traceable;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
@@ -60,7 +61,7 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
  * @param <E> the type of the elements
  */
 
-public class BlockingList<K, E> extends AbstractList<E> implements List<E> {
+public class BlockingList<K, E> extends AbstractList<E> implements List<E>, Traceable {
     static final TraceComponent tc = Tr.register(BlockingList.class);
 
     @com.ibm.websphere.ras.annotation.Trivial
@@ -649,6 +650,11 @@ public class BlockingList<K, E> extends AbstractList<E> implements List<E> {
         } finally {
             stateLock.readLock().unlock();
         }
+    }
+
+    @Override
+    public String toTraceString() {
+        return toString();
     }
 
     /**

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectorProperties.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectorProperties.java
@@ -26,11 +26,12 @@ import java.util.Vector;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.Traceable;
 
-public final class ConnectorProperties extends Vector<Object> implements Serializable {
+public final class ConnectorProperties extends Vector<Object> implements Serializable, Traceable {
 
     private static final long serialVersionUID = -248509787807561932L;
-    private static final TraceComponent tc = Tr.register(ConnectorProperties.class, J2CConstants.traceSpec, J2CConstants.messageFile); 
+    private static final TraceComponent tc = Tr.register(ConnectorProperties.class, J2CConstants.traceSpec, J2CConstants.messageFile);
     public static final String nl = String.format("%n");
 
     // override the Vector add method to not add duplicate entries.  That is, entries with the same name.
@@ -47,14 +48,14 @@ public final class ConnectorProperties extends Vector<Object> implements Seriali
             connectorProperty = (ConnectorProperty) e.nextElement();
             name = connectorProperty.getName();
             if (name.equals(nameToAdd)) {
-                if (tc.isDebugEnabled()) { 
-                    String value = (String) connectorPropertyToAdd.getValue(); 
-                    if (!value.equals("")) { 
-                        if (name.equals("UserName") || name.equals("Password")) { 
+                if (tc.isDebugEnabled()) {
+                    String value = (String) connectorPropertyToAdd.getValue();
+                    if (!value.equals("")) {
+                        if (name.equals("UserName") || name.equals("Password")) {
                             Tr.debug(tc, "DUPLICATE_USERNAME_PASSWORD_CONNECTOR_PROPERTY_J2CA0103", new Object[] { (ConnectorProperty) o });
                         } else {
                             Tr.warning(tc, "DUPLICATE_CONNECTOR_PROPERTY_J2CA0308", new Object[] { (ConnectorProperty) o });
-                        } 
+                        }
                     }
                 }
                 return true;
@@ -65,13 +66,13 @@ public final class ConnectorProperties extends Vector<Object> implements Seriali
         return super.add(o);
 
     }
-    
+
     /**
      * Given this ConnectorProperties Vector, find the String identified by the
      * input desiredPropertyName. If not found, return the defaultValue.
-     * 
+     *
      * @param desiredPropertyName Name of com.ibm.ejs.j2c.ConnectorProperty entry to look for.
-     * @param defaultValue value to return if the desiredPropertyName is not found, or its value is invalid.
+     * @param defaultValue        value to return if the desiredPropertyName is not found, or its value is invalid.
      * @return String
      */
     public String findConnectorPropertyString(String desiredPropertyName, String defaultValue) {
@@ -104,7 +105,7 @@ public final class ConnectorProperties extends Vector<Object> implements Seriali
     public String toString() {
         StringBuffer buf = new StringBuffer(100);
         ConnectorProperty prop;
-        String propName = null; 
+        String propName = null;
 
         buf.append("[Deployed Resource Adapter Properties]" + nl);
 
@@ -131,8 +132,13 @@ public final class ConnectorProperties extends Vector<Object> implements Seriali
                 buf.append(prop.getValue());
                 buf.append(nl);
             }
-        } 
+        }
 
         return buf.toString();
+    }
+
+    @Override
+    public String toTraceString() {
+        return toString();
     }
 }

--- a/dev/com.ibm.ws.jca.utils/src/com/ibm/ws/jca/utils/metagen/MetatypeGenerator.java
+++ b/dev/com.ibm.ws.jca.utils/src/com/ibm/ws/jca/utils/metagen/MetatypeGenerator.java
@@ -511,8 +511,8 @@ public class MetatypeGenerator {
             //   The ConnectionDefinition and ConnectionDefinitions annotations are
             //   applied to the JavaBean class and are restricted to be applied only on JavaBean
             //   classes that implement the ManagedConnectionFactory interface (see
-            //   Section 5.3.2, “ManagedConnectionFactory JavaBean and Outbound
-            //   Communication” on page 5-8).
+            //   Section 5.3.2, "ManagedConnectionFactory JavaBean and Outbound
+            //   Communication" on page 5-8).
 
             //   The element managedconnectionfactory-class specifies
             //   the fully qualified name of the Java class that
@@ -1424,7 +1424,7 @@ public class MetatypeGenerator {
     }
 
     private ModuleAnnotations getModuleAnnotations() throws UnableToAdaptException {
-        return AnnotationsBetaHelper.getModuleAnnotations( config.getRarContainer() );
+        return AnnotationsBetaHelper.getModuleAnnotations(config.getRarContainer());
     }
 
     /**

--- a/dev/com.ibm.ws.logging_test/test/com/ibm/ws/logging/internal/impl/BaseTraceFormatterTest.java
+++ b/dev/com.ibm.ws.logging_test/test/com/ibm/ws/logging/internal/impl/BaseTraceFormatterTest.java
@@ -788,7 +788,7 @@ public class BaseTraceFormatterTest {
                                               new Class<?>[] { MyProxyInterface.class },
                                               new ProxyHandler(123));
         String formatted = formatter.formatObj(proxy);
-        assertEquals("Proxy for " + proxy.getClass().getName(), formatted.trim());
+        assertTrue(formatted.trim().startsWith("Proxy for " + proxy.getClass().getName() + "@"));
     }
 
     @Test
@@ -816,15 +816,12 @@ public class BaseTraceFormatterTest {
         formatted = formatted.replace('\n', ',');
 
         assertEquals("Unexpected output: " + formatted,
-                     "[Proxy for " + proxy1.getClass().getName() + ", " +
-                                                        "ProxiedTraceable.toTraceString(), " +
-                                                        "foo]",
+                     "[" + proxyName(proxy1) + ", ProxiedTraceable.toTraceString(), foo]",
                      formatted.trim());
+    }
 
-//        assertTrue("Unexpected output: " + formatted,
-//                   Pattern.matches("\\[Proxy for " + proxy1.getClass().getName() + ".*" +
-//                                   "ProxiedTraceable.toTraceString().*" +
-//                                   "foo\\]", formatted));
+    private String proxyName(Object proxyObj) {
+        return "Proxy for " + proxyObj.getClass().getName() + "@" + Integer.toHexString(System.identityHashCode(proxyObj));
     }
 
     @Test
@@ -933,7 +930,7 @@ public class BaseTraceFormatterTest {
             if ("equals".equals(method.getName())) {
                 return proxy == args[0];
             }
-            if ("iterator".contentEquals(method.getName())) {
+            if ("toArray".contentEquals(method.getName())) {
                 throw new UnsupportedOperationException("expected");
             }
             assertFalse("toString method invoked on proxy object", method.getName().equals("toString"));

--- a/dev/com.ibm.ws.logging_test/test/com/ibm/ws/logging/internal/impl/BaseTraceFormatterTest.java
+++ b/dev/com.ibm.ws.logging_test/test/com/ibm/ws/logging/internal/impl/BaseTraceFormatterTest.java
@@ -16,8 +16,15 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.ListResourceBundle;
 import java.util.Random;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
@@ -41,7 +48,8 @@ import test.common.SharedOutputManager;
  */
 public class BaseTraceFormatterTest {
     static SharedOutputManager outputMgr;
-    static final Object idObj = new Object() {};
+    static final Object idObj = new Object() {
+    };
     static final Object idHash = DataFormatHelper.padHexString(System.identityHashCode(idObj), 8);
 
     static final String id = " id=        ";
@@ -773,6 +781,96 @@ public class BaseTraceFormatterTest {
         }
     }
 
+    @Test
+    public void testProxyObject() {
+        BaseTraceFormatter formatter = new BaseTraceFormatter(TraceFormat.BASIC);
+        Object proxy = Proxy.newProxyInstance(this.getClass().getClassLoader(),
+                                              new Class<?>[] { MyProxyInterface.class },
+                                              new ProxyHandler(123));
+        String formatted = formatter.formatObj(proxy);
+        assertEquals("Proxy for " + proxy.getClass().getName(), formatted.trim());
+    }
+
+    @Test
+    public void testProxyObjectThatImplementsTraceable() {
+        BaseTraceFormatter formatter = new BaseTraceFormatter(TraceFormat.BASIC);
+        Object proxy = Proxy.newProxyInstance(this.getClass().getClassLoader(),
+                                              new Class<?>[] { MyProxyInterface2.class },
+                                              new ProxyHandler(456));
+
+        String formatted = formatter.formatObj(proxy);
+        assertEquals("ProxiedTraceable.toTraceString()", formatted.trim());
+    }
+
+    @Test
+    public void testListIncludingProxies() {
+        BaseTraceFormatter formatter = new BaseTraceFormatter(TraceFormat.BASIC);
+        Object proxy1 = Proxy.newProxyInstance(this.getClass().getClassLoader(),
+                                               new Class<?>[] { MyProxyInterface.class },
+                                               new ProxyHandler(789));
+        Object proxy2 = Proxy.newProxyInstance(this.getClass().getClassLoader(),
+                                               new Class<?>[] { MyProxyInterface2.class },
+                                               new ProxyHandler(987));
+        Object nonProxy = new String("foo");
+        String formatted = formatter.formatObj(Arrays.asList(proxy1, proxy2, nonProxy)).trim();
+        formatted = formatted.replace('\n', ',');
+
+        assertEquals("Unexpected output: " + formatted,
+                     "[Proxy for " + proxy1.getClass().getName() + ", " +
+                                                        "ProxiedTraceable.toTraceString(), " +
+                                                        "foo]",
+                     formatted.trim());
+
+//        assertTrue("Unexpected output: " + formatted,
+//                   Pattern.matches("\\[Proxy for " + proxy1.getClass().getName() + ".*" +
+//                                   "ProxiedTraceable.toTraceString().*" +
+//                                   "foo\\]", formatted));
+    }
+
+    @Test
+    public void testSetIncludingProxies() {
+        BaseTraceFormatter formatter = new BaseTraceFormatter(TraceFormat.BASIC);
+        Set<Object> set = new HashSet<>();
+        Object proxy = Proxy.newProxyInstance(this.getClass().getClassLoader(),
+                                              new Class<?>[] { MyProxyInterface.class },
+                                              new ProxyHandler(234));
+        set.add(proxy);
+        set.add(Proxy.newProxyInstance(this.getClass().getClassLoader(),
+                                       new Class<?>[] { MyProxyInterface2.class },
+                                       new ProxyHandler(567)));
+        set.add(new String("foo"));
+
+        String formatted = formatter.formatObj(set).trim();
+        formatted = formatted.replace('\n', ',');
+        assertTrue("Unexpected output: " + formatted, formatted.startsWith("["));
+        assertTrue("Unexpected output: " + formatted, formatted.endsWith("]"));
+        assertTrue("Unexpected output: " + formatted, formatted.contains("Proxy for " + proxy.getClass().getName()));
+        assertTrue("Unexpected output: " + formatted, formatted.contains("ProxiedTraceable.toTraceString()"));
+        assertTrue("Unexpected output: " + formatted, formatted.contains("foo"));
+    }
+
+    @Test
+    public void testCollectionThatThrowsException() {
+        BaseTraceFormatter formatter = new BaseTraceFormatter(TraceFormat.BASIC);
+        Object proxy = Proxy.newProxyInstance(this.getClass().getClassLoader(),
+                                              new Class<?>[] { Collection.class },
+                                              new ProxyHandler(3827));
+        String formatted = formatter.formatObj(proxy).trim();
+        assertTrue("Unexpected output: " + formatted, formatted.startsWith("["));
+        assertTrue("Unexpected output: " + formatted, formatted.endsWith("]"));
+        assertTrue("Unexpected output: " + formatted, formatted.contains("UnsupportedOperationException"));
+        assertTrue("Unexpected output: " + formatted, formatted.contains("Caught"));
+        assertTrue("Unexpected output: " + formatted, formatted.contains("while logging collection type"));
+    }
+
+    @Test
+    public void testNullObject() {
+        BaseTraceFormatter formatter = new BaseTraceFormatter(TraceFormat.BASIC);
+        Object o = null;
+        String formatted = formatter.formatObj(o);
+        assertEquals("null", formatted.trim());
+    }
+
     // ----------------------------------------------------------------------------------
     // supporting classes
     // ----------------------------------------------------------------------------------
@@ -809,5 +907,39 @@ public class BaseTraceFormatterTest {
             else
                 return "LookAtMeIMTraceable";
         }
+    }
+
+    public static interface MyProxyInterface {
+        int doSomething();
+    }
+
+    public static interface MyProxyInterface2 extends Traceable {
+        int doSomethingElse();
+    }
+
+    public static class ProxyHandler implements InvocationHandler {
+
+        final int hashCode;
+
+        ProxyHandler(int hashCode) {
+            this.hashCode = hashCode;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            if ("hashCode".equals(method.getName())) {
+                return hashCode;
+            }
+            if ("equals".equals(method.getName())) {
+                return proxy == args[0];
+            }
+            if ("iterator".contentEquals(method.getName())) {
+                throw new UnsupportedOperationException("expected");
+            }
+            assertFalse("toString method invoked on proxy object", method.getName().equals("toString"));
+            assertTrue(String.class.equals(method.getReturnType()) && method.getName().equals("toTraceString"));
+            return "ProxiedTraceable.toTraceString()";
+        }
+
     }
 }

--- a/dev/com.ibm.ws.messaging.common/src/com/ibm/ws/sib/mfp/impl/SchemaSet.java
+++ b/dev/com.ibm.ws.messaging.common/src/com/ibm/ws/sib/mfp/impl/SchemaSet.java
@@ -20,6 +20,7 @@ import com.ibm.ws.sib.mfp.util.ArrayUtil;
 import com.ibm.ws.sib.mfp.util.HexUtil;
 import com.ibm.ws.sib.utils.ras.SibTr;
 
+import com.ibm.websphere.ras.Traceable;
 import com.ibm.websphere.ras.TraceComponent;
 
 /*
@@ -43,7 +44,7 @@ import com.ibm.websphere.ras.TraceComponent;
  * This class only officially supports SchemaIds. However, as a SchemaId is a
  * Long, it will cater for any Long in reality..
  */
-public final class SchemaSet implements ConnectionSchemaSet, Set {
+public final class SchemaSet implements ConnectionSchemaSet, Set, Traceable {
 
   private static TraceComponent tc = SibTr.register(SchemaSet.class, MfpConstants.MSG_GROUP, MfpConstants.MSG_BUNDLE);
  
@@ -362,6 +363,10 @@ public final class SchemaSet implements ConnectionSchemaSet, Set {
     return buf.toString();
   }
 
+  @Override
+  public String toTraceString() {
+      return toString();
+  }
 
   /**
    * Write a Schema Id out as a hex string.

--- a/dev/com.ibm.ws.messaging.common/src/com/ibm/ws/sib/mfp/jmf/impl/JSMessageData.java
+++ b/dev/com.ibm.ws.messaging.common/src/com/ibm/ws/sib/mfp/jmf/impl/JSMessageData.java
@@ -16,6 +16,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 
+import com.ibm.websphere.ras.Traceable;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.FFDCSelfIntrospectable;
 import com.ibm.ws.sib.mfp.jmf.JMFEncapsulation;
@@ -125,7 +126,7 @@ import com.ibm.ws.sib.mfp.util.ArrayUtil;
  * very difficult, even with the locking that is in place.
  * 
  */
-public abstract class JSMessageData extends AbstractList implements JMFMessageData, FFDCSelfIntrospectable {
+public abstract class JSMessageData extends AbstractList implements JMFMessageData, FFDCSelfIntrospectable, Traceable {
     private static TraceComponent tc = JmfTr.register(JSMessageData.class, JmfConstants.MSG_GROUP, JmfConstants.MSG_BUNDLE);
 
     // Subclasses must implement the following methods
@@ -1813,6 +1814,11 @@ public abstract class JSMessageData extends AbstractList implements JMFMessageDa
     public String toString() {
         String result = getClass().getName() + '@' + Integer.toHexString(System.identityHashCode(this));
         return result;
+    }
+
+    @Override
+    public String toTraceString() {
+        return toString();
     }
 
     /*

--- a/dev/com.ibm.ws.repository.parsers/bnd.bnd
+++ b/dev/com.ibm.ws.repository.parsers/bnd.bnd
@@ -31,6 +31,7 @@ Private-Package: \
 	com.ibm.ws.repository;version=latest,\
 	com.ibm.ws.kernel.feature.core;version=latest,\
 	com.ibm.ws.kernel.boot.core;version=latest,\
+	com.ibm.ws.logging.core;version=latest,\
 	com.ibm.ws.product.utility;version=latest,\
 	com.ibm.ws.org.apache.aries.util;version=latest,\
 	com.ibm.ws.org.apache.ant;version=latest,\

--- a/dev/com.ibm.ws.repository.parsers/src/com/ibm/ws/repository/parsers/internal/ManifestHeaderProcessor.java
+++ b/dev/com.ibm.ws.repository.parsers/src/com/ibm/ws/repository/parsers/internal/ManifestHeaderProcessor.java
@@ -37,6 +37,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.ibm.websphere.ras.Traceable;
+
 import org.apache.aries.util.ManifestHeaderUtils;
 import org.apache.aries.util.VersionRange;
 import org.osgi.framework.Constants;
@@ -191,7 +193,7 @@ public class ManifestHeaderProcessor
     /**
      * List of Name/Value
      */
-    public static class NameValueList extends ArrayList<NameValuePair> implements NameValueCollection, List<NameValuePair> {
+    public static class NameValueList extends ArrayList<NameValuePair> implements NameValueCollection, List<NameValuePair>, Traceable {
         private static final long serialVersionUID = 1808636823825029983L;
 
         @Override
@@ -212,6 +214,11 @@ public class ManifestHeaderProcessor
             }
             sb.append("}");
             return sb.toString();
+        }
+
+        @Override
+        public String toTraceString() {
+            return toString();
         }
     }
 

--- a/dev/com.ibm.ws.security.authorization/src/com/ibm/ws/security/authorization/RoleSet.java
+++ b/dev/com.ibm.ws.security.authorization/src/com/ibm/ws/security/authorization/RoleSet.java
@@ -16,16 +16,18 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
+import com.ibm.websphere.ras.Traceable;
+
 /**
  * A RoleSet is an immutable Set of role names (Strings) for use by the
  * AuthorizationTableService.
  * <p>
  * The Set is immutable in order to enforce read-only access to the
  * AuthorizationTableService by other services.
- * 
+ *
  * @see AuthorizationTableService
  */
-public class RoleSet implements Set<String> {
+public class RoleSet implements Set<String>, Traceable {
     /**
      * A RoleSet containing no roles.
      */
@@ -36,7 +38,7 @@ public class RoleSet implements Set<String> {
 
     /**
      * Construct the immutable RoleSet based on the provided Set.
-     * 
+     *
      * @param set
      */
     public RoleSet(Set<String> set) {
@@ -46,7 +48,7 @@ public class RoleSet implements Set<String> {
     /**
      * Construct the immutable RoleSet by combining another Set of roles
      * with an existing RoleSet.
-     * 
+     *
      * @param roleSet existing roleSet, must not be null
      * @param another (optional) Set of roles
      */
@@ -82,7 +84,8 @@ public class RoleSet implements Set<String> {
      * This method intentionally does not alter the map contents.
      */
     @Override
-    public void clear() {}
+    public void clear() {
+    }
 
     /** {@inheritDoc} */
     @Override
@@ -168,4 +171,9 @@ public class RoleSet implements Set<String> {
         return set.toString();
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public String toTraceString() {
+        return set.toString();
+    }
 }


### PR DESCRIPTION
This change will check if a parameter or object type is a proxy before tracing it.  If so, it will log "Proxy for <className>" instead of invoking the `toString()` method - which could lead to unwanted behaviors in the associated invocation handler.

If the proxy instance implements other RAS-related interfaces, like `Traceable`, it will be traced according to those interfaces rather than as a proxy.

This change includes unit test changes.