### PR TITLE
disabled test for two embedded resource adapters with login modules

### DIFF
--- a/dev/com.ibm.ws.jca_fat_enterpriseApp/fat/src/com/ibm/ws/jca/fat/enterpriseApp/EnterpriseAppTest.java
+++ b/dev/com.ibm.ws.jca_fat_enterpriseApp/fat/src/com/ibm/ws/jca/fat/enterpriseApp/EnterpriseAppTest.java
@@ -61,6 +61,7 @@ public class EnterpriseAppTest extends FATServletClient {
         WebArchive war = ShrinkWrap.create(WebArchive.class, warFile + ".war");
         war.addPackage("web");
         war.addPackage("web.mdb");
+        war.addAsWebInfResource(new File("test-applications/fvtweb/resources/WEB-INF/ibm-web-bnd.xml")); // includes login properties
 
         ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "enterpriseRA.rar");
         rar.as(JavaArchive.class).addPackage("com.ibm.test.jca.enterprisera");
@@ -80,6 +81,7 @@ public class EnterpriseAppTest extends FATServletClient {
 
         // TODO remove this
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "tempLoginModule.jar");
+        jar.addPackage("com.ibm.test.jca.enterprisera");
         jar.addPackage("com.ibm.test.jca.loginmodra");
         ShrinkHelper.exportToServer(server, "/", jar);
 
@@ -180,6 +182,11 @@ public class EnterpriseAppTest extends FATServletClient {
 
     @Test
     public void testDataSourceLookup() throws Exception {
+        runInServlet(testName.getMethodName());
+    }
+
+    @Test
+    public void testDataSourceUsingLoginModule() throws Exception {
         runInServlet(testName.getMethodName());
     }
 

--- a/dev/com.ibm.ws.jca_fat_enterpriseApp/publish/servers/com.ibm.ws.jca.fat.enterpriseApp/server.xml
+++ b/dev/com.ibm.ws.jca_fat_enterpriseApp/publish/servers/com.ibm.ws.jca.fat.enterpriseApp/server.xml
@@ -45,7 +45,11 @@
       <containerAuthData user="DS1USER" password="{xor}GwxuDwgb"/>
       <properties.enterpriseApp.enterpriseRA />
     </connectionFactory>
-    
+
+    <jaasLoginContextEntry id="ds1LoginContextEntry" name="ds1login">
+      <loginModule className="com.ibm.test.jca.enterprisera.EALoginModule" libraryRef="temp"/> <!-- TODO replace with classProviderRef once implemented -->
+    </jaasLoginContextEntry>
+
     <activationSpec id="enterpriseApp/fvtweb/JCAEnterpriseAppMDB">
       <properties.enterpriseApp.enterpriseRA />
     </activationSpec>

--- a/dev/com.ibm.ws.jca_fat_enterpriseApp/test-applications/fvtweb/resources/WEB-INF/ibm-web-bnd.xml
+++ b/dev/com.ibm.ws.jca_fat_enterpriseApp/test-applications/fvtweb/resources/WEB-INF/ibm-web-bnd.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<web-bnd xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-bnd_1_0.xsd" version="1.0">
+
+  <resource-ref name="java:app/env/eis/ds1refWithLoginModule">
+    <custom-login-configuration name="ds1login">
+      <property name="loginName" value="LOGIN1"/>
+    </custom-login-configuration>
+  </resource-ref>
+
+</web-bnd>

--- a/dev/com.ibm.ws.jca_fat_enterpriseApp/test-applications/fvtweb/src/web/JCAEnterpriseAppTestServlet.java
+++ b/dev/com.ibm.ws.jca_fat_enterpriseApp/test-applications/fvtweb/src/web/JCAEnterpriseAppTestServlet.java
@@ -45,6 +45,9 @@ public class JCAEnterpriseAppTestServlet extends HttpServlet {
     @Resource(name = "eis/ds1")
     DataSource ds1;
 
+    @Resource(name = "java:app/env/eis/ds1refWithLoginModule", lookup = "eis/ds1")
+    DataSource ds1refWithLoginModule;
+
     @Resource(name = "eis/map1")
     Map<String, String> map1;
 
@@ -176,6 +179,21 @@ public class JCAEnterpriseAppTestServlet extends HttpServlet {
         } finally {
             if (conn != null)
                 conn.close();
+        }
+    }
+
+    /**
+     * Verify that the user computed by the login module is used by the JCA data source when the resource reference indicates to use the login module.
+     */
+    public void testDataSourceUsingLoginModule(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        Connection conn = ds1refWithLoginModule.getConnection();
+        try {
+            String user = conn.getMetaData().getUserName();
+            if (!"LOGIN1USER".equals(user)) {
+                throw new Exception("Unexpected user name " + user + ". Was the login module used?");
+            }
+        } finally {
+            conn.close();
         }
     }
 

--- a/dev/com.ibm.ws.jca_fat_enterpriseApp/test-resourceadapters/enterpriseAppRA/src/com/ibm/test/jca/enterprisera/EALoginModule.java
+++ b/dev/com.ibm.ws.jca_fat_enterpriseApp/test-resourceadapters/enterpriseAppRA/src/com/ibm/test/jca/enterprisera/EALoginModule.java
@@ -46,7 +46,6 @@ public class EALoginModule implements LoginModule {
 
             Map<?, ?> properties = mpropsCallback.getProperties();
             final String loginName = (String) properties.get("loginName");
-            System.out.println("### LOGINMODULE PROP " + loginName);
 
             AccessController.doPrivileged(new PrivilegedAction<Void>() {
                 @Override

--- a/dev/com.ibm.ws.jca_fat_enterpriseApp/test-resourceadapters/enterpriseAppRA/src/com/ibm/test/jca/enterprisera/EALoginModule.java
+++ b/dev/com.ibm.ws.jca_fat_enterpriseApp/test-resourceadapters/enterpriseAppRA/src/com/ibm/test/jca/enterprisera/EALoginModule.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.test.jca.enterprisera;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Map;
+
+import javax.resource.spi.security.PasswordCredential;
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+
+import com.ibm.wsspi.security.auth.callback.WSManagedConnectionFactoryCallback;
+import com.ibm.wsspi.security.auth.callback.WSMappingPropertiesCallback;
+
+/**
+ * This login module always assigns the user name based on a login property called "loginName".
+ */
+public class EALoginModule implements LoginModule {
+    private CallbackHandler callbackHandler;
+    private Subject subject;
+
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        this.callbackHandler = callbackHandler;
+        this.subject = subject;
+    }
+
+    @Override
+    public boolean login() throws LoginException {
+        try {
+            final WSManagedConnectionFactoryCallback mcfCallback = new WSManagedConnectionFactoryCallback("Target ManagedConnectionFactory: ");
+            WSMappingPropertiesCallback mpropsCallback = new WSMappingPropertiesCallback("Mapping Properties (HashMap): ");
+            callbackHandler.handle(new Callback[] { mcfCallback, mpropsCallback });
+
+            Map<?, ?> properties = mpropsCallback.getProperties();
+            final String loginName = (String) properties.get("loginName");
+            System.out.println("### LOGINMODULE PROP " + loginName);
+
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+                @Override
+                public Void run() {
+                    PasswordCredential passwordCredential = new PasswordCredential(loginName + "USER", (loginName + "PWD").toCharArray());
+                    passwordCredential.setManagedConnectionFactory(mcfCallback.getManagedConnectionFacotry());
+                    subject.getPrivateCredentials().add(passwordCredential);
+                    return null;
+                }
+            });
+        } catch (Exception x) {
+            throw (LoginException) new LoginException(x.getMessage()).initCause(x);
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean abort() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean commit() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean logout() throws LoginException {
+        return true;
+    }
+}


### PR DESCRIPTION
Enhance the tests for embedded resource adapters with login modules to add a login module into the second embedded RAR so that both have login modules.  This will help that we are able to load the right one even if there are multiple.  But we cannot enable the test until the function is added, so for now, it will also package the login modules in a separate library, which we can remove when the real function is ready to test.