### PR TITLE
Fix bug where metrics monitor is not properly removing ending brackets for REST metrics

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.2.3.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetrics.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.3.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetrics.java
@@ -125,7 +125,7 @@ public class MonitorMetrics {
             	//otherwise first bracket becomes underscores
             	Tags[2] = Tags[2].replaceAll("\\(", "_");
             	//second bracket is removed
-            	Tags[2] = Tags[2].replaceAll("\\(", "");
+            	Tags[2] = Tags[2].replaceAll("\\)", "");
             	break;
             }
 		}


### PR DESCRIPTION
Bug in metrics-23-monitor-1.0 code where it is not appropriately removing the ending bracket from the method signature retrieved from the REST stat JMX beans.

#build