### PR TITLE
Changed tck_suite.xml DOCKTYPE certificates to use http rather than https

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/tck-suite-10-subset.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/tck-suite-10-subset.xml
@@ -5,7 +5,7 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
     the specific language governing permissions and limitations under the License. -->
-<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
 <suite name="microprofile-faulttolerance-1.1-TCK" verbose="2"
     configfailurepolicy="continue">

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/tck-suite-11-subset.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/tck-suite-11-subset.xml
@@ -5,7 +5,7 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
     the specific language governing permissions and limitations under the License. -->
-<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
 <suite name="microprofile-faulttolerance-1.1-TCK" verbose="2"
     configfailurepolicy="continue">

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/tck-suite-lite.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/tck-suite-lite.xml
@@ -5,7 +5,7 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
     the specific language governing permissions and limitations under the License. -->
-<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
 <suite name="microprofile-faulttolerance-2.0-TCK" verbose="2"
     configfailurepolicy="continue">


### PR DESCRIPTION
Some tck-suite files referenced the DTD with an https URL which was causing issues in sun JVMs which don't accept the certificate.

