### PR TITLE
Handle Charsets in JsonBProvider

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/.classpath
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/.classpath
@@ -5,6 +5,7 @@
 	<classpathentry kind="src" path="test-applications/classSubResApp/src"/>
 	<classpathentry kind="src" path="test-applications/formApp/src"/>
 	<classpathentry kind="src" path="test-applications/jsonbapp/src"/>
+	<classpathentry kind="src" path="test-applications/jsonbCharsetApp/src"/>
 	<classpathentry kind="src" path="test-applications/jsonbContextResolverApp/src"/>
 	<classpathentry kind="src" path="test-applications/mutableHeadersApp/src"/>
 	<classpathentry kind="src" path="test-applications/patchapp/src"/>

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/bnd.bnd
@@ -17,6 +17,7 @@ src: \
   test-applications/classSubResApp/src,\
   test-applications/formApp/src,\
   test-applications/jsonbapp/src,\
+  test-applications/jsonbCharsetApp/src,\
   test-applications/jsonbContextResolverApp/src,\
   test-applications/mutableHeadersApp/src,\
   test-applications/patchapp/src,\

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/FATSuite.java
@@ -19,6 +19,7 @@ import org.junit.runners.Suite.SuiteClasses;
                 
                 CDITest.class,
                 ClassSubResTest.class,
+                JsonbCharsetTest.class,
                 JsonbContextResolverTest.class,
                 FormBehaviorTest.class,
                 MutableHeadersTest.class,

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/JsonbCharsetTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/JsonbCharsetTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs21.fat.extended;
+
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import jaxrs21.fat.jsonbcharset.JsonbCharsetTestServlet;
+
+@RunWith(FATRunner.class)
+public class JsonbCharsetTest extends FATServletClient {
+
+    private static final String appName = "jsonbCharsetApp";
+
+    @Server("jaxrs21.fat.jsonbCharset")
+    @TestServlet(servlet = JsonbCharsetTestServlet.class, contextRoot = appName)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        WebArchive app = ShrinkHelper.buildDefaultApp(appName, "jaxrs21.fat.jsonbcharset");
+        ShrinkHelper.exportDropinAppToServer(server, app);
+        server.addInstalledAppForValidation(appName);
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        server.stopServer();
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.jsonbCharset/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.jsonbCharset/bootstrap.properties
@@ -1,0 +1,5 @@
+com.ibm.ws.logging.trace.specification=*=info:LogService=all
+com.ibm.ws.logging.max.file.size=0
+osgi.console=5678
+ds.loglevel=debug
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.jsonbCharset/jvm.options
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.jsonbCharset/jvm.options
@@ -1,0 +1,1 @@
+-Dfile.encoding=US-ASCII

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.jsonbCharset/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/servers/jaxrs21.fat.jsonbCharset/server.xml
@@ -1,0 +1,10 @@
+<server>
+  <featureManager>
+    <feature>componenttest-1.0</feature>
+    <feature>jaxrs-2.1</feature>
+    <feature>jsonb-1.0</feature>
+  </featureManager>
+
+  <include location="../fatTestPorts.xml"/>
+
+</server>

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/jsonbCharsetApp/src/jaxrs21/fat/jsonbcharset/JsonbCharsetTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/jsonbCharsetApp/src/jaxrs21/fat/jsonbcharset/JsonbCharsetTestServlet.java
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jaxrs21.fat.jsonbcharset;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.StringReader;
+import java.util.regex.Pattern;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.stream.JsonParsingException;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/JsonbCharsetTestServlet")
+public class JsonbCharsetTestServlet extends FATServlet {
+
+    private Client client;
+
+    @Override
+    public void init() throws ServletException {
+        client = ClientBuilder.newBuilder().build();
+    }
+
+    @Override
+    public void destroy() {
+        client.close();
+    }
+
+    @Test
+    public void testUS_ASCII(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        String pattern = "{\"name\":\"Bob Smith\",\"age\":34}";
+        Response response = target(req, "person").request().header("Accept-Charset", "US-ASCII").get();
+        assertEquals(200, response.getStatus());
+        compareJSON(pattern, response.readEntity(String.class));
+    }
+
+    @Test
+    public void testISO_8859_1(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        String pattern = "{\"name\":\"Bob Smith\",\"age\":34}";
+        Response response = target(req, "person").request().header("Accept-Charset", "ISO-8859-1").get();
+        assertEquals(200, response.getStatus());
+        compareJSON(pattern, response.readEntity(String.class));
+    }
+
+    @Test
+    public void testUTF8(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        String pattern = "{\"name\":\"Bŏb Smitй\",\"age\":34}";
+        Response response = target(req, "person").request().header("Accept-Charset", "UTF-8").get();
+        assertEquals(200, response.getStatus());
+        compareJSON(pattern, response.readEntity(String.class));
+    }
+
+    @Test
+    public void testUTF16(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        String pattern = "{\"name\":\"Bŏb Smitй\",\"age\":34}";
+        Response response = target(req, "person").request().header("Accept-Charset", "UTF-16").get();
+        assertEquals(200, response.getStatus());
+        compareJSON(pattern, response.readEntity(String.class));
+    }
+
+    @Test
+    public void testUTF32(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        String pattern = "{\"name\":\"Bŏb Smitй\",\"age\":34}";
+        Response response = target(req, "person").request().header("Accept-Charset", "UTF-32").get();
+        assertEquals(200, response.getStatus());
+        compareJSON(pattern, response.readEntity(String.class));
+    }
+
+    @Test
+    public void testUS_ASCII_ServerReturnsUniqueChar(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        Response response = target(req, "personUniqueChar").request().header("Accept-Charset", "US-ASCII").get();
+        assertEquals(200, response.getStatus());
+        Person p = response.readEntity(Person.class);
+        assertTrue("Bŏb Smitй".equals(p.getName()));
+    }
+
+    @Test
+    public void testISO_8859_1_ServerReturnsUniqueChar(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        Response response = target(req, "personUniqueChar").request().header("Accept-Charset", "ISO-8859-1").get();
+        assertEquals(200, response.getStatus());
+        Person p = response.readEntity(Person.class);
+        assertTrue("Bŏb Smitй".equals(p.getName()));
+    }
+
+    @Test
+    public void testUnspecified(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        String pattern = "{\"name\":\"Bob Smith\",\"age\":34}";
+        Response response = target(req, "person").request().get();
+        assertEquals(200, response.getStatus());
+        compareJSON(pattern, response.readEntity(String.class));
+    }
+
+    @Test
+    public void testUnspecified_ServerReturnsUniqueChar(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        String pattern = "{\"name\":\"Bŏb Smitй\",\"age\":34}";
+        Response response = target(req, "personUniqueChar").request().get();
+        assertEquals(200, response.getStatus());
+        compareJSON(pattern, response.readEntity(String.class));
+    }
+
+    private void compareJSON(String expected, String actual) throws Exception {
+        System.out.println("compareJSON\n\texpected = " + expected + "\n\tactual = " + actual);
+        try {
+            JsonReader jsonReader = Json.createReader(new StringReader(expected));
+            JsonObject exp = jsonReader.readObject();
+            jsonReader = Json.createReader(new StringReader(actual));
+            JsonObject act = jsonReader.readObject();
+            assertTrue("expected=" + expected + ", actual=" + actual, exp.equals(act));
+        } catch (JsonParsingException e) {
+            // Json failed to parse as an object, try array
+            JsonReader jsonReader = Json.createReader(new StringReader(expected));
+            JsonArray exp = jsonReader.readArray();
+            jsonReader = Json.createReader(new StringReader(actual));
+            JsonArray act = jsonReader.readArray();
+            assertTrue("expected=" + expected + ", actual=" + actual, exp.equals(act));
+        }
+    }
+
+    private WebTarget target(HttpServletRequest request, String path) {
+        String base = "http://" + request.getServerName() + ':' + request.getServerPort()
+            + "/jsonbCharsetApp/rest/person/";
+        return client.target(base + path);
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/jsonbCharsetApp/src/jaxrs21/fat/jsonbcharset/Person.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/jsonbCharsetApp/src/jaxrs21/fat/jsonbcharset/Person.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jaxrs21.fat.jsonbcharset;
+
+public class Person {
+
+    private String name;
+    private int age;
+
+    public Person() {
+        
+    }
+
+    public Person(String name, int age) {
+        this.name = name;
+        this.age = age;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/jsonbCharsetApp/src/jaxrs21/fat/jsonbcharset/Resource.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/jsonbCharsetApp/src/jaxrs21/fat/jsonbcharset/Resource.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jaxrs21.fat.jsonbcharset;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.HttpHeaders;
+
+@ApplicationPath("/rest")
+@Path("/person")
+@Produces("application/json")
+public class Resource extends Application {
+
+    @GET
+    @Path("person")
+    public Person getPerson(@HeaderParam(HttpHeaders.ACCEPT_CHARSET) String charset) {
+        System.out.println("getPerson - charset = " + charset);
+        Person p = null;
+        if (charset == null || charset.equals("US-ASCII") || charset.equals("ISO-8859-1")) {
+            p = new Person("Bob Smith", 34);
+        } else if (charset.startsWith("UTF-")) {
+            p = getPersonUniqueChar(charset);
+        }
+        return p;
+    }
+
+    @GET
+    @Path("personUniqueChar")
+    public Person getPersonUniqueChar(@HeaderParam(HttpHeaders.ACCEPT_CHARSET) String charset) {
+        return new Person("Bŏb Smitй", 34);
+    }
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs21/providers/json/JsonBProvider.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs21/providers/json/JsonBProvider.java
@@ -243,6 +243,9 @@ public class JsonBProvider implements MessageBodyWriter<Object>, MessageBodyRead
     }
 
     private static Charset charset(MultivaluedMap<String, Object> httpHeaders) {
+        if (httpHeaders == null) {
+            return DEFAULT_CHARSET;
+        }
         List<?> charsets = httpHeaders.get(HttpHeaders.ACCEPT_CHARSET);
         return JAXRSUtils.sortCharsets(charsets)
                          .stream()

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs21/providers/json/JsonBProvider.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs21/providers/json/JsonBProvider.java
@@ -16,10 +16,14 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Iterator;
+import java.util.List;
 import java.util.ServiceLoader;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicReference;
@@ -30,6 +34,7 @@ import javax.json.bind.spi.JsonbProvider;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.ContextResolver;
@@ -38,9 +43,11 @@ import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
 
 import org.apache.cxf.jaxrs.model.ProviderInfo;
+import org.apache.cxf.jaxrs.utils.JAXRSUtils;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 @Produces({ "*/*" })
 @Consumes({ "*/*" })
@@ -48,9 +55,33 @@ import com.ibm.websphere.ras.TraceComponent;
 public class JsonBProvider implements MessageBodyWriter<Object>, MessageBodyReader<Object>, UnaryOperator<Jsonb> {
 
     private final static TraceComponent tc = Tr.register(JsonBProvider.class);
+    private final static Charset DEFAULT_CHARSET = getDefaultCharset();
     private final JsonbProvider jsonbProvider;
     private final AtomicReference<Jsonb> jsonb = new AtomicReference<>();
     private final Iterable<ProviderInfo<ContextResolver<?>>> contextResolvers;
+    
+    @FFDCIgnore(Exception.class)
+    private static Charset getDefaultCharset() {
+        Charset cs = null;
+        String csStr = null;
+        try {
+            csStr = AccessController.doPrivileged((PrivilegedAction<String>)() -> {
+                return System.getProperty("com.ibm.ws.jaxrs.jsonbprovider.defaultCharset");
+            });
+            if (csStr != null) {
+                cs = Charset.forName(csStr);
+            }
+        } catch (Exception ex) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Could not load specified default charset: " + csStr);
+            }
+        }
+        if (cs == null) {
+            cs = StandardCharsets.UTF_8;
+        }
+        return cs;
+    }
+    
 
     public JsonBProvider(JsonbProvider jsonbProvider, Iterable<ProviderInfo<ContextResolver<?>>> contextResolvers) {
         this.contextResolvers = contextResolvers;
@@ -169,7 +200,7 @@ public class JsonBProvider implements MessageBodyWriter<Object>, MessageBodyRead
     public void writeTo(Object obj, Class<?> type, Type genericType, Annotation[] annotations,
                         MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
         String json = getJsonb().toJson(obj);
-        entityStream.write(json.getBytes()); // do not close
+        entityStream.write(json.getBytes(charset(httpHeaders))); // do not close entityStream
 
         if (tc.isDebugEnabled()) {
             Tr.debug(tc, "object=" + obj);
@@ -209,5 +240,19 @@ public class JsonBProvider implements MessageBodyWriter<Object>, MessageBodyRead
             return t;
         }
         return jsonbProvider.create().build();
+    }
+
+    private static Charset charset(MultivaluedMap<String, Object> httpHeaders) {
+        List<?> charsets = httpHeaders.get(HttpHeaders.ACCEPT_CHARSET);
+        return JAXRSUtils.sortCharsets(charsets)
+                         .stream()
+                         .findFirst()
+                         .orElseGet(() -> {
+                             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                                 Tr.debug(tc, "No matching charsets, using " + DEFAULT_CHARSET.name() + 
+                                              ", client requested " + charsets);
+                             }
+                             return DEFAULT_CHARSET;
+                         });
     }
 }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/test/com/ibm/ws/jaxrs/utils/test/JAXRSUtilsTest.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/test/com/ibm/ws/jaxrs/utils/test/JAXRSUtilsTest.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs.utils.test;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.cxf.jaxrs.utils.JAXRSUtils;
+import org.junit.Test;
+
+
+public class JAXRSUtilsTest {
+
+
+    @Test
+    public void testSortCharsets_nullAndEmpty() throws Exception {
+        assertEquals(Collections.EMPTY_LIST, JAXRSUtils.sortCharsets(null));
+        assertEquals(Collections.EMPTY_LIST, JAXRSUtils.sortCharsets(new ArrayList<Object>()));
+    }
+
+    @Test
+    public void testSortCharsets_singleEntryNoQ() throws Exception {
+        String cs = "UTF-16";
+        List<Charset> sortedCharsets = JAXRSUtils.sortCharsets(Collections.singletonList(cs));
+        assertNotNull(sortedCharsets);
+        assertEquals(1, sortedCharsets.size());
+        assertEquals(Charset.forName(cs), sortedCharsets.get(0));
+    }
+
+    @Test
+    public void testSortCharsets_singleEntryWithQ() throws Exception {
+        String cs = "UTF-16;q=0.5";
+        List<Charset> sortedCharsets = JAXRSUtils.sortCharsets(Collections.singletonList(cs));
+        assertNotNull(sortedCharsets);
+        assertEquals(1, sortedCharsets.size());
+        assertEquals(Charset.forName("UTF-16"), sortedCharsets.get(0));
+
+        cs = "UTF-16;q=.005";
+        sortedCharsets = JAXRSUtils.sortCharsets(Collections.singletonList(cs));
+        assertNotNull(sortedCharsets);
+        assertEquals(1, sortedCharsets.size());
+        assertEquals(Charset.forName("UTF-16"), sortedCharsets.get(0));
+        
+        cs = "UTF-16;q=0"; // 0 == disabled
+        sortedCharsets = JAXRSUtils.sortCharsets(Collections.singletonList(cs));
+        assertNotNull(sortedCharsets);
+        assertEquals(0, sortedCharsets.size());
+
+        cs = "UTF-16;q=1";
+        sortedCharsets = JAXRSUtils.sortCharsets(Collections.singletonList(cs));
+        assertNotNull(sortedCharsets);
+        assertEquals(1, sortedCharsets.size());
+        assertEquals(Charset.forName("UTF-16"), sortedCharsets.get(0));
+    }
+
+    @Test
+    public void testSortCharsets_multipleEntries() throws Exception {
+        List<String> charsetHeaderValues = Arrays.asList("UTF-8;q=0.3", "UTF-16BE;q=0.5", "UTF-16LE;Q=.6",
+                                                         "UTF-16;q=.4", "US-ASCII;q=15.7", "ISO-8859-1;Q=-20");
+        List<Charset> sortedCharsets = JAXRSUtils.sortCharsets(charsetHeaderValues);
+        assertNotNull(sortedCharsets);
+        assertEquals(5, sortedCharsets.size());
+        assertEquals(Charset.forName("US-ASCII"), sortedCharsets.get(0));
+        assertEquals(Charset.forName("UTF-16LE"), sortedCharsets.get(1));
+        assertEquals(Charset.forName("UTF-16BE"), sortedCharsets.get(2));
+        assertEquals(Charset.forName("UTF-16"), sortedCharsets.get(3));
+        assertEquals(Charset.forName("UTF-8"), sortedCharsets.get(4));
+
+        charsetHeaderValues = Arrays.asList("UTF-8;q=0.999", "UTF-16BE", "UTF-16LE;Q=0");
+        sortedCharsets = JAXRSUtils.sortCharsets(charsetHeaderValues);
+        assertNotNull(sortedCharsets);
+        assertEquals(2, sortedCharsets.size());
+        assertEquals(Charset.forName("UTF-16BE"), sortedCharsets.get(0));
+        assertEquals(Charset.forName("UTF-8"), sortedCharsets.get(1));
+    }
+
+    @Test
+    public void testSortCharsets_invalidWeightEntries() throws Exception {
+        assertEquals(Collections.EMPTY_LIST, JAXRSUtils.sortCharsets(Collections.singletonList("UTF-16;q=ALOT")));
+        assertEquals(Collections.EMPTY_LIST, JAXRSUtils.sortCharsets(Collections.singletonList("UTF-16;q= ")));
+        assertEquals(Collections.EMPTY_LIST, JAXRSUtils.sortCharsets(Collections.singletonList("UTF-16;q=MILLIONS")));
+        assertEquals(Collections.EMPTY_LIST, JAXRSUtils.sortCharsets(Collections.singletonList("UTF-16;q=%20")));
+        assertEquals(Collections.EMPTY_LIST, JAXRSUtils.sortCharsets(Collections.singletonList("UTF-16 ; q = 0.5")));
+        assertEquals(Collections.EMPTY_LIST, JAXRSUtils.sortCharsets(Collections.singletonList("UTF-16;q==0.3")));
+    }
+}


### PR DESCRIPTION
Should resolve issue #10604.  This change allows users to specify the default charset for Liberty's built-in JSONB provider by setting "com.ibm.ws.jaxrs.jsonbprovider.defaultCharset=<someCharset>" - the default (per spec section 4.2.4) is UTF-8.

Clients may also specify a charset by using the `Accept-Charset` HTTP header.  