### PR TITLE
update builder and consumer tests to wait for server initialization to complete

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/Constants.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/Constants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2019 IBM Corporation and others.
+ * Copyright (c) 2013, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -56,6 +56,8 @@ public class Constants {
 
     public static final String HEADER_SET_COOKIE = "Set-Cookie";
     public static final String TOKEN_TYPE_BEARER = "Bearer";
+    public static final String TOKEN_TYPE_TOKEN = "Token";
+    public static final String TOKEN_TYPE_MISC = "misc";
 
     public static final String J_SECURITY_CHECK = "j_security_check";
     public static final String J_USERNAME = "j_username";
@@ -73,6 +75,8 @@ public class Constants {
     public static final String APP_TESTMARKER = "testmarker";
 
     public static final String COMMON_CONFIG_DIR = "configs";
+
+    public static final String HELLOWORLD_APP = "helloworld";
 
     /* ***************** Http methods ******************* */
     public static final String GETMETHOD = "GET";

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/servers/ServerInstanceUtils.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/servers/ServerInstanceUtils.java
@@ -1,9 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package com.ibm.ws.security.fat.common.servers;
 
 import java.net.InetAddress;
+import java.util.List;
 
 import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.security.fat.common.MessageConstants;
 
+import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 
 public class ServerInstanceUtils {
@@ -28,4 +41,40 @@ public class ServerInstanceUtils {
             Log.info(thisClass, thisMethod, "Setup failed to add host info to bootstrap.properties");
         }
     }
+
+    // Special case SSL ready checker - for test classes that don't enable/use SSL from server
+    // startup.  This method will check entire message log for the ssl inited msg (instead of checking
+    // from the last mark)
+    public static void waitForSSLMsg(LibertyServer server) {
+
+        waitForSSLMsg(server, System.currentTimeMillis());
+    }
+
+    private static void waitForSSLMsg(LibertyServer server, long startTime) {
+
+        String methodName = "waitForSSLMsg";
+        try {
+
+            // wait for up to 2 minutes
+            if (System.currentTimeMillis() - startTime > (2 * 60 * 1000)) {
+                Log.info(thisClass, methodName, "Timed out searching for SSL ready message - test will probably fail");
+                return;
+            }
+            // if nothing is found, sleep and request another try
+            List<String> wasFound = LibertyFileManager.findStringsInFile(".*" + MessageConstants.CWWKO0219I_SSL_CHANNEL_READY + ".*", server.getDefaultLogFile());
+            if (wasFound == null || wasFound.isEmpty()) {
+                Thread.sleep(5 * 1000);
+                waitForSSLMsg(server, startTime);
+            } else {
+                for (String msg : wasFound) {
+                    Log.info(thisClass, "waitForSSLMsg", "Found SSL MSG: " + msg);
+                }
+                Log.info(thisClass, methodName, "Found SSL ready message");
+                return;
+            }
+        } catch (Exception e) {
+            Log.info(thisClass, "waitForSSLMsg", "Something went wrong while checking for the SSL ready msg: " + e.getMessage());
+        }
+    }
+
 }

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/utils/CommonWaitForAppChecks.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/utils/CommonWaitForAppChecks.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package com.ibm.ws.security.fat.common.utils;
 
 import java.util.ArrayList;
@@ -13,9 +23,23 @@ public class CommonWaitForAppChecks {
     }
 
     public static List<String> getSSLChannelReadyMsgs(List<String> waitForMessages) throws Exception {
-
         waitForMessages.add(MessageConstants.CWWKO0219I_SSL_CHANNEL_READY);
-
         return waitForMessages;
     }
+
+    public static List<String> getBasicSecurityReadyMsgs() throws Exception {
+        List<String> waitForMessages = new ArrayList<String>();
+        return getBasicSecurityReadyMsgs(waitForMessages);
+    }
+
+    public static List<String> getBasicSecurityReadyMsgs(List<String> waitForMessages) throws Exception {
+        waitForMessages.add(MessageConstants.CWWKS0008I_SECURITY_SERVICE_READY);
+        return waitForMessages;
+    }
+
+    public static List<String> getSecurityReadyMsgs() throws Exception {
+        List<String> waitForMessages = new ArrayList<String>();
+        return getBasicSecurityReadyMsgs(getSSLChannelReadyMsgs(waitForMessages));
+    }
+
 }

--- a/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwkEndpointValidationUrlTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwkEndpointValidationUrlTests.java
@@ -36,6 +36,7 @@ import com.ibm.ws.security.fat.common.jwt.JwtMessageConstants;
 import com.ibm.ws.security.fat.common.jwt.PayloadConstants;
 import com.ibm.ws.security.fat.common.servers.ServerInstanceUtils;
 import com.ibm.ws.security.fat.common.utils.CommonExpectations;
+import com.ibm.ws.security.fat.common.utils.CommonWaitForAppChecks;
 import com.ibm.ws.security.fat.common.utils.SecurityFatHttpUtils;
 import com.ibm.ws.security.fat.common.web.WebResponseUtils;
 import com.ibm.ws.security.jwt.fat.builder.actions.JwtBuilderActions;
@@ -64,7 +65,7 @@ public class JwkEndpointValidationUrlTests extends CommonSecurityFat {
     @Server("com.ibm.ws.security.jwt_fat.builder.rs")
     public static LibertyServer rsServer;
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification() ;
+    public static RepeatTests r = RepeatTests.withoutModification();
 
     private static final JwtBuilderActions actions = new JwtBuilderActions();
     public static final BuilderTestValidationUtils validationUtils = new BuilderTestValidationUtils();
@@ -80,7 +81,8 @@ public class JwkEndpointValidationUrlTests extends CommonSecurityFat {
     public static void setUp() throws Exception {
 
         serverTracker.addServer(builderServer);
-        builderServer.startServerUsingExpandedConfiguration("server_configTests.xml");
+        builderServer.addInstalledAppForValidation(JWTBuilderConstants.JWT_BUILDER_SERVLET);
+        builderServer.startServerUsingExpandedConfiguration("server_configTests.xml", CommonWaitForAppChecks.getSecurityReadyMsgs());
         SecurityFatHttpUtils.saveServerPorts(builderServer, JWTBuilderConstants.BVT_SERVER_1_PORT_NAME_ROOT);
 
         // the server's default config contains an invalid value (on purpose), tell the fat framework to ignore it!
@@ -89,7 +91,8 @@ public class JwkEndpointValidationUrlTests extends CommonSecurityFat {
         // start server to run protected app - make sure we can use the JWT Token that we produce
         serverTracker.addServer(rsServer);
         ServerInstanceUtils.addHostNameAndAddrToBootstrap(rsServer);
-        rsServer.startServerUsingExpandedConfiguration("rs_server_orig.xml");
+        rsServer.addInstalledAppForValidation(JWTBuilderConstants.HELLOWORLD_APP);
+        rsServer.startServerUsingExpandedConfiguration("rs_server_orig.xml", CommonWaitForAppChecks.getSecurityReadyMsgs());
         SecurityFatHttpUtils.saveServerPorts(rsServer, JWTBuilderConstants.BVT_SERVER_2_PORT_NAME_ROOT);
 
     }

--- a/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderAPIConfigAltKeyStoreTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderAPIConfigAltKeyStoreTests.java
@@ -24,6 +24,7 @@ import com.ibm.ws.security.fat.common.expectations.Expectations;
 import com.ibm.ws.security.fat.common.expectations.ServerMessageExpectation;
 import com.ibm.ws.security.fat.common.jwt.HeaderConstants;
 import com.ibm.ws.security.fat.common.jwt.JwtMessageConstants;
+import com.ibm.ws.security.fat.common.utils.CommonWaitForAppChecks;
 import com.ibm.ws.security.fat.common.utils.SecurityFatHttpUtils;
 import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
 import com.ibm.ws.security.jwt.fat.builder.actions.JwtBuilderActions;
@@ -52,7 +53,7 @@ public class JwtBuilderAPIConfigAltKeyStoreTests extends CommonSecurityFat {
     public static LibertyServer builderServer;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification() ;
+    public static RepeatTests r = RepeatTests.withoutModification();
 
     private static final JwtBuilderActions actions = new JwtBuilderActions();
     public static final TestValidationUtils validationUtils = new TestValidationUtils();
@@ -61,7 +62,8 @@ public class JwtBuilderAPIConfigAltKeyStoreTests extends CommonSecurityFat {
     public static void setUp() throws Exception {
 
         serverTracker.addServer(builderServer);
-        builderServer.startServerUsingExpandedConfiguration("server_configTests2.xml");
+        builderServer.addInstalledAppForValidation(JWTBuilderConstants.JWT_BUILDER_SERVLET);
+        builderServer.startServerUsingExpandedConfiguration("server_configTests2.xml", CommonWaitForAppChecks.getSecurityReadyMsgs());
         SecurityFatHttpUtils.saveServerPorts(builderServer, JWTBuilderConstants.BVT_SERVER_1_PORT_NAME_ROOT);
 
         // the server's default config contains an invalid value (on purpose), tell the fat framework to ignore it!

--- a/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderAPIConfigTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderAPIConfigTests.java
@@ -29,6 +29,7 @@ import com.ibm.ws.security.fat.common.jwt.JwtMessageConstants;
 import com.ibm.ws.security.fat.common.jwt.PayloadConstants;
 import com.ibm.ws.security.fat.common.jwt.expectations.JwtApiExpectation;
 import com.ibm.ws.security.fat.common.utils.CommonExpectations;
+import com.ibm.ws.security.fat.common.utils.CommonWaitForAppChecks;
 import com.ibm.ws.security.fat.common.utils.SecurityFatHttpUtils;
 import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
 import com.ibm.ws.security.jwt.fat.builder.actions.JwtBuilderActions;
@@ -56,7 +57,7 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
     public static LibertyServer builderServer;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification() ;
+    public static RepeatTests r = RepeatTests.withoutModification();
 
     private static final JwtBuilderActions actions = new JwtBuilderActions();
     public static final TestValidationUtils validationUtils = new TestValidationUtils();
@@ -65,7 +66,8 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
     public static void setUp() throws Exception {
 
         serverTracker.addServer(builderServer);
-        builderServer.startServerUsingExpandedConfiguration("server_configTests.xml");
+        builderServer.addInstalledAppForValidation(JWTBuilderConstants.JWT_BUILDER_SERVLET);
+        builderServer.startServerUsingExpandedConfiguration("server_configTests.xml", CommonWaitForAppChecks.getSecurityReadyMsgs());
         SecurityFatHttpUtils.saveServerPorts(builderServer, JWTBuilderConstants.BVT_SERVER_1_PORT_NAME_ROOT);
 
         // the server's default config contains an invalid value (on purpose), tell the fat framework to ignore it!

--- a/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderAPIMinimumConfigTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderAPIMinimumConfigTests.java
@@ -24,6 +24,7 @@ import com.ibm.ws.security.fat.common.expectations.Expectations;
 import com.ibm.ws.security.fat.common.jwt.HeaderConstants;
 import com.ibm.ws.security.fat.common.jwt.JwtMessageConstants;
 import com.ibm.ws.security.fat.common.jwt.PayloadConstants;
+import com.ibm.ws.security.fat.common.servers.ServerInstanceUtils;
 import com.ibm.ws.security.fat.common.utils.SecurityFatHttpUtils;
 import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
 import com.ibm.ws.security.jwt.fat.builder.actions.JwtBuilderActions;
@@ -55,11 +56,13 @@ import componenttest.topology.impl.LibertyServer;
 @AllowedFFDC({ "org.apache.http.NoHttpResponseException" })
 public class JwtBuilderAPIMinimumConfigTests extends CommonSecurityFat {
 
+    public final String AppStartMsg = ".*CWWKZ0001I.*" + JWTBuilderConstants.JWT_BUILDER_SERVLET + ".*";
+
     @Server("com.ibm.ws.security.jwt_fat.builder")
     public static LibertyServer builderServer;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification() ;
+    public static RepeatTests r = RepeatTests.withoutModification();
 
     private static final JwtBuilderActions actions = new JwtBuilderActions();
     public static final TestValidationUtils validationUtils = new TestValidationUtils();
@@ -94,7 +97,7 @@ public class JwtBuilderAPIMinimumConfigTests extends CommonSecurityFat {
     @Test
     public void JwtBuilderAPIMinimumConfigTests_minimumRunnableConfig() throws Exception {
 
-        builderServer.reconfigureServerUsingExpandedConfiguration(_testName, "server_minimumRunnableConfig.xml");
+        builderServer.reconfigureServerUsingExpandedConfiguration(_testName, "server_minimumRunnableConfig.xml", AppStartMsg);
 
         JSONObject expectationSettings = BuilderHelpers.setDefaultClaims(builderServer);
         expectationSettings.put(PayloadConstants.ISSUER, SecurityFatHttpUtils.getServerIpUrlBase(builderServer) + "jwt/defaultJWT");
@@ -113,8 +116,9 @@ public class JwtBuilderAPIMinimumConfigTests extends CommonSecurityFat {
     @Test
     public void JwtBuilderAPIMinimumConfigTests_minimumSSLConfig_global() throws Exception {
 
-        builderServer.reconfigureServerUsingExpandedConfiguration(_testName, "server_minimumSSLConfig1.xml");
+        builderServer.reconfigureServerUsingExpandedConfiguration(_testName, "server_minimumSSLConfig1.xml", AppStartMsg);
 
+        ServerInstanceUtils.waitForSSLMsg(builderServer);
         JSONObject expectationSettings = BuilderHelpers.setDefaultClaims(builderServer);
 
         Expectations expectations = BuilderHelpers.createGoodBuilderExpectations(JWTBuilderConstants.JWT_BUILDER_SETAPIS_ENDPOINT, expectationSettings, builderServer);
@@ -127,8 +131,9 @@ public class JwtBuilderAPIMinimumConfigTests extends CommonSecurityFat {
     @Test
     public void JwtBuilderAPIMinimumConfigTests_minimumSSLConfig_builder() throws Exception {
 
-        builderServer.reconfigureServerUsingExpandedConfiguration(_testName, "server_minimumSSLConfig2.xml");
+        builderServer.reconfigureServerUsingExpandedConfiguration(_testName, "server_minimumSSLConfig2.xml", AppStartMsg);
 
+        ServerInstanceUtils.waitForSSLMsg(builderServer);
         JSONObject expectationSettings = BuilderHelpers.setDefaultClaims(builderServer);
         expectationSettings.put(PayloadConstants.ISSUER, SecurityFatHttpUtils.getServerIpUrlBase(builderServer) + "jwt/defaultJWT");
 

--- a/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderAPIWithLDAPConfigTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderAPIWithLDAPConfigTests.java
@@ -22,6 +22,7 @@ import com.ibm.json.java.JSONObject;
 import com.ibm.ws.security.fat.common.expectations.Expectations;
 import com.ibm.ws.security.fat.common.jwt.JwtMessageConstants;
 import com.ibm.ws.security.fat.common.jwt.PayloadConstants;
+import com.ibm.ws.security.fat.common.utils.CommonWaitForAppChecks;
 import com.ibm.ws.security.fat.common.utils.SecurityFatHttpUtils;
 import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
 import com.ibm.ws.security.jwt.fat.builder.actions.JwtBuilderActions;
@@ -48,7 +49,7 @@ public class JwtBuilderAPIWithLDAPConfigTests extends JwtBuilderCommonLDAPFat {
     public static LibertyServer builderServer;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification() ;
+    public static RepeatTests r = RepeatTests.withoutModification();
 
     private static final JwtBuilderActions actions = new JwtBuilderActions();
     public static final TestValidationUtils validationUtils = new TestValidationUtils();
@@ -59,7 +60,8 @@ public class JwtBuilderAPIWithLDAPConfigTests extends JwtBuilderCommonLDAPFat {
         setupLdapServer(builderServer);
 
         serverTracker.addServer(builderServer);
-        builderServer.startServerUsingExpandedConfiguration("server_LDAPRegistry_configTests.xml");
+        builderServer.addInstalledAppForValidation(JWTBuilderConstants.JWT_BUILDER_SERVLET);
+        builderServer.startServerUsingExpandedConfiguration("server_LDAPRegistry_configTests.xml", CommonWaitForAppChecks.getSecurityReadyMsgs());
         SecurityFatHttpUtils.saveServerPorts(builderServer, JWTBuilderConstants.BVT_SERVER_1_PORT_NAME_ROOT);
 
         // the server's default config contains an invalid value (on purpose), tell the fat framework to ignore it!

--- a/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderApiBasicTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderApiBasicTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2109 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,6 +33,7 @@ import com.ibm.ws.security.fat.common.jwt.PayloadConstants;
 import com.ibm.ws.security.fat.common.jwt.expectations.JwtApiExpectation;
 import com.ibm.ws.security.fat.common.servers.ServerInstanceUtils;
 import com.ibm.ws.security.fat.common.utils.CommonExpectations;
+import com.ibm.ws.security.fat.common.utils.CommonWaitForAppChecks;
 import com.ibm.ws.security.fat.common.utils.SecurityFatHttpUtils;
 import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
 import com.ibm.ws.security.jwt.fat.builder.actions.JwtBuilderActions;
@@ -96,13 +97,15 @@ public class JwtBuilderApiBasicTests extends CommonSecurityFat {
 
         // Start server that will build the JWT Token
         serverTracker.addServer(builderServer);
-        builderServer.startServerUsingExpandedConfiguration("server_basicRegistry.xml");
+        builderServer.addInstalledAppForValidation(JWTBuilderConstants.JWT_BUILDER_SERVLET);
+        builderServer.startServerUsingExpandedConfiguration("server_basicRegistry.xml", CommonWaitForAppChecks.getSecurityReadyMsgs());
         SecurityFatHttpUtils.saveServerPorts(builderServer, JWTBuilderConstants.BVT_SERVER_1_PORT_NAME_ROOT);
 
         // start server to run protected app - make sure we can use the JWT Token that we produce
         serverTracker.addServer(rsServer);
         ServerInstanceUtils.addHostNameAndAddrToBootstrap(rsServer);
-        rsServer.startServerUsingExpandedConfiguration("rs_server_orig.xml");
+        rsServer.addInstalledAppForValidation(JWTBuilderConstants.HELLOWORLD_APP);
+        rsServer.startServerUsingExpandedConfiguration("rs_server_orig.xml", CommonWaitForAppChecks.getSecurityReadyMsgs());
         SecurityFatHttpUtils.saveServerPorts(rsServer, JWTBuilderConstants.BVT_SERVER_2_PORT_NAME_ROOT);
 
         protectedApp = SecurityFatHttpUtils.getServerUrlBase(rsServer) + "helloworld/rest/helloworld";

--- a/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderApiWithLDAPBasicTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderApiWithLDAPBasicTests.java
@@ -22,10 +22,10 @@ import com.ibm.ws.security.fat.common.expectations.Expectations;
 import com.ibm.ws.security.fat.common.jwt.JwtMessageConstants;
 import com.ibm.ws.security.fat.common.jwt.PayloadConstants;
 import com.ibm.ws.security.fat.common.servers.ServerBootstrapUtils;
+import com.ibm.ws.security.fat.common.utils.CommonWaitForAppChecks;
 import com.ibm.ws.security.fat.common.utils.SecurityFatHttpUtils;
 import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
 import com.ibm.ws.security.jwt.fat.builder.actions.JwtBuilderActions;
-import com.ibm.ws.security.jwt.fat.builder.actions.JwtBuilderClaimRepeatActions;
 import com.ibm.ws.security.jwt.fat.builder.utils.BuilderHelpers;
 
 import componenttest.annotation.Server;
@@ -53,7 +53,7 @@ public class JwtBuilderApiWithLDAPBasicTests extends JwtBuilderCommonLDAPFat {
     protected static ServerBootstrapUtils bootstrapUtils = new ServerBootstrapUtils();
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification() ;
+    public static RepeatTests r = RepeatTests.withoutModification();
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -61,7 +61,8 @@ public class JwtBuilderApiWithLDAPBasicTests extends JwtBuilderCommonLDAPFat {
         setupLdapServer(builderServer);
 
         serverTracker.addServer(builderServer);
-        builderServer.startServerUsingExpandedConfiguration("server_LDAPRegistry.xml");
+        builderServer.addInstalledAppForValidation(JWTBuilderConstants.JWT_BUILDER_SERVLET);
+        builderServer.startServerUsingExpandedConfiguration("server_LDAPRegistry.xml", CommonWaitForAppChecks.getSecurityReadyMsgs());
         SecurityFatHttpUtils.saveServerPorts(builderServer, JWTBuilderConstants.BVT_SERVER_1_PORT_NAME_ROOT);
 
     }

--- a/dev/com.ibm.ws.security.jwt_fat.builder/publish/servers/com.ibm.ws.security.jwt_fat.builder/configs/server_minimumConfig.xml
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/publish/servers/com.ibm.ws.security.jwt_fat.builder/configs/server_minimumConfig.xml
@@ -7,4 +7,9 @@
 
 	<include location="${shared.config.dir}/op_fatTestPorts.xml" />
 
+	<javaPermission className="java.util.PropertyPermission" actions="read" name="*"/>
+	<javaPermission className="javax.security.auth.AuthPermission" actions="wssecurity.getRunAsSubject" name="*"/>
+	<javaPermission className="javax.security.auth.AuthPermission" actions="wssecurity.getCallerSubject" name="*"/>
+	<javaPermission className="java.lang.RuntimePermission" actions="setFactory" name="*" />
+
 </server>

--- a/dev/com.ibm.ws.security.jwt_fat.builder/publish/shared/config/helloworldApplication.xml
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/publish/shared/config/helloworldApplication.xml
@@ -18,4 +18,10 @@
 			</security-role>
 		</application-bnd>
 	</application>
+	
+	<javaPermission className="java.util.PropertyPermission" actions="read" name="*"/>
+	<javaPermission className="javax.security.auth.AuthPermission" actions="wssecurity.getRunAsSubject" name="*"/>
+	<javaPermission className="javax.security.auth.AuthPermission" actions="wssecurity.getCallerSubject" name="*"/>
+	<javaPermission className="javax.security.auth.PrivateCredentialPermission" actions="read" name='* * "*"'/>
+
 </server>    

--- a/dev/com.ibm.ws.security.jwt_fat.builder/publish/shared/config/jwtBuilderClientApplication.xml
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/publish/shared/config/jwtBuilderClientApplication.xml
@@ -18,4 +18,10 @@
 			</security-role>
 		</application-bnd>
 	</application>
+	
+	<javaPermission className="java.util.PropertyPermission" actions="read" name="*"/>
+	<javaPermission className="javax.security.auth.AuthPermission" actions="wssecurity.getRunAsSubject" name="*"/>
+	<javaPermission className="javax.security.auth.AuthPermission" actions="wssecurity.getCallerSubject" name="*"/>
+	<javaPermission className="java.lang.RuntimePermission" actions="setFactory" name="*" />
+	
 </server>    

--- a/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/JwtConsumerAPIMinimumConfigTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/JwtConsumerAPIMinimumConfigTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import com.gargoylesoftware.htmlunit.Page;
 import com.ibm.ws.security.fat.common.CommonSecurityFat;
 import com.ibm.ws.security.fat.common.expectations.Expectations;
 import com.ibm.ws.security.fat.common.jwt.JWTTokenBuilder;
+import com.ibm.ws.security.fat.common.servers.ServerInstanceUtils;
 import com.ibm.ws.security.fat.common.utils.SecurityFatHttpUtils;
 import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
 import com.ibm.ws.security.jwt.fat.consumer.actions.JwtConsumerActions;
@@ -38,6 +39,8 @@ import componenttest.topology.impl.LibertyServer;
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
 public class JwtConsumerAPIMinimumConfigTests extends CommonSecurityFat {
+
+    public final String AppStartMsg = ".*CWWKZ0001I.*" + JwtConsumerConstants.JWT_CONSUMER_SERVLET + ".*";
 
     @Server("com.ibm.ws.security.jwt_fat.consumer")
     public static LibertyServer consumerServer;
@@ -90,7 +93,8 @@ public class JwtConsumerAPIMinimumConfigTests extends CommonSecurityFat {
     @Test
     public void JwtConsumerAPIMinimumConfigTests_minimumHSARunableConfig() throws Exception {
 
-        consumerServer.reconfigureServerUsingExpandedConfiguration(_testName, "server_minimumHS256Config.xml");
+        consumerServer.reconfigureServerUsingExpandedConfiguration(_testName, "server_minimumHS256Config.xml", AppStartMsg);
+        ServerInstanceUtils.waitForSSLMsg(consumerServer);
 
         createBuilderWithHSClaims();
         String jwtToken = builder.build();
@@ -113,7 +117,8 @@ public class JwtConsumerAPIMinimumConfigTests extends CommonSecurityFat {
     @Test
     public void JwtConsumerAPIMinimumConfigTests_minimumSSLConfig_global() throws Exception {
 
-        consumerServer.reconfigureServerUsingExpandedConfiguration(_testName, "server_minimumConfig_ServerWideSSL.xml");
+        consumerServer.reconfigureServerUsingExpandedConfiguration(_testName, "server_minimumConfig_ServerWideSSL.xml", AppStartMsg);
+        ServerInstanceUtils.waitForSSLMsg(consumerServer);
 
         createBuilderWithRSAClaims();
         String jwtToken = builder.build();
@@ -136,7 +141,8 @@ public class JwtConsumerAPIMinimumConfigTests extends CommonSecurityFat {
     @Test
     public void JwtConsumerAPIMinimumConfigTests_minimumSSLConfig_consumer() throws Exception {
 
-        consumerServer.reconfigureServerUsingExpandedConfiguration(_testName, "server_minimumConfig_SSLInConsumer.xml");
+        consumerServer.reconfigureServerUsingExpandedConfiguration(_testName, "server_minimumConfig_SSLInConsumer.xml", AppStartMsg);
+        ServerInstanceUtils.waitForSSLMsg(consumerServer);
 
         createBuilderWithRSAClaims();
         String jwtToken = builder.build();

--- a/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/JwtConsumerApiBasicTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/JwtConsumerApiBasicTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,6 +23,7 @@ import com.ibm.ws.security.fat.common.jwt.JwtMessageConstants;
 import com.ibm.ws.security.fat.common.jwt.expectations.JwtApiExpectation;
 import com.ibm.ws.security.fat.common.jwt.sharedTests.ConsumeMangledJWTTests;
 import com.ibm.ws.security.fat.common.utils.CommonExpectations;
+import com.ibm.ws.security.fat.common.utils.CommonWaitForAppChecks;
 import com.ibm.ws.security.fat.common.utils.SecurityFatHttpUtils;
 import com.ibm.ws.security.jwt.fat.consumer.actions.JwtConsumerActions;
 import com.ibm.ws.security.jwt.fat.consumer.utils.ConsumerHelpers;
@@ -61,7 +62,8 @@ public class JwtConsumerApiBasicTests extends ConsumeMangledJWTTests {
     public static void setUp() throws Exception {
 
         serverTracker.addServer(consumerServer);
-        consumerServer.startServerUsingExpandedConfiguration("server_jwtConsumer.xml");
+        consumerServer.addInstalledAppForValidation(JwtConsumerConstants.JWT_CONSUMER_SERVLET);
+        consumerServer.startServerUsingExpandedConfiguration("server_jwtConsumer.xml", CommonWaitForAppChecks.getSecurityReadyMsgs());
         SecurityFatHttpUtils.saveServerPorts(consumerServer, JwtConsumerConstants.BVT_SERVER_1_PORT_NAME_ROOT);
 
     }

--- a/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/JwtConsumerApiConfigTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/JwtConsumerApiConfigTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -63,9 +63,10 @@ public class JwtConsumerApiConfigTests extends CommonSecurityFat {
     public static void setUp() throws Exception {
 
         serverTracker.addServer(consumerServer);
+        consumerServer.addInstalledAppForValidation(JwtConsumerConstants.JWT_CONSUMER_SERVLET);
         consumerServer.startServerUsingExpandedConfiguration("server_configTests.xml");
         SecurityFatHttpUtils.saveServerPorts(consumerServer, JwtConsumerConstants.BVT_SERVER_1_PORT_NAME_ROOT);
-        // one of the JWT Consumer configs had an empty SignatureAlg value which results in a CWWKG0032W warning - mark this as "OK"
+        // one of the JWT Consumer configs has an empty SignatureAlg value which results in a CWWKG0032W warning - mark this as "OK"
         consumerServer.addIgnoredErrors(Arrays.asList(JwtMessageConstants.CWWKG0032W_CONFIG_INVALID_VALUE + ".+" + "signatureAlgorithm"));
 
         // set the default signing key for this test class (individual test cases can override if needed)

--- a/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/JwtConsumerApiConfigWithGlobalTrustTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/JwtConsumerApiConfigWithGlobalTrustTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import com.gargoylesoftware.htmlunit.Page;
 import com.ibm.ws.security.fat.common.CommonSecurityFat;
 import com.ibm.ws.security.fat.common.expectations.Expectations;
 import com.ibm.ws.security.fat.common.jwt.JWTTokenBuilder;
+import com.ibm.ws.security.fat.common.utils.CommonWaitForAppChecks;
 import com.ibm.ws.security.fat.common.utils.SecurityFatHttpUtils;
 import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
 import com.ibm.ws.security.jwt.fat.consumer.actions.JwtConsumerActions;
@@ -55,7 +56,8 @@ public class JwtConsumerApiConfigWithGlobalTrustTests extends CommonSecurityFat 
     public static void setUp() throws Exception {
 
         serverTracker.addServer(consumerServer);
-        consumerServer.startServerUsingExpandedConfiguration("server_configGlobalTrust.xml");
+        consumerServer.addInstalledAppForValidation(JwtConsumerConstants.JWT_CONSUMER_SERVLET);
+        consumerServer.startServerUsingExpandedConfiguration("server_configGlobalTrust.xml", CommonWaitForAppChecks.getSSLChannelReadyMsgs());
         SecurityFatHttpUtils.saveServerPorts(consumerServer, JwtConsumerConstants.BVT_SERVER_1_PORT_NAME_ROOT);
 
         createBuilderWithDefaultClaims();

--- a/dev/com.ibm.ws.security.jwt_fat.consumer/publish/servers/com.ibm.ws.security.jwt_fat.consumer/configs/server_minimumConfig.xml
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/publish/servers/com.ibm.ws.security.jwt_fat.consumer/configs/server_minimumConfig.xml
@@ -9,4 +9,6 @@
 
 	<include location="${shared.config.dir}/fatTestPorts.xml" />
 
+	<javaPermission className="java.util.PropertyPermission" actions="read" name="*"/>
+
 </server>

--- a/dev/com.ibm.ws.security.jwt_fat.consumer/publish/shared/config/jwtConsumerClientApplication.xml
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/publish/shared/config/jwtConsumerClientApplication.xml
@@ -18,4 +18,7 @@
 			</security-role>
 		</application-bnd>
 	</application>
+	
+	<javaPermission className="java.util.PropertyPermission" actions="read" name="*"/>
+	
 </server>    


### PR DESCRIPTION
Update the builder and consumer FAT tests to wait for server initialization to complete before trying to run any of the tests.
Adding waits for apps to initialize and in some cases, SSL init to complete.
