### PR TITLE
Issue #10563: MissedPersistentTimerAction

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent/src/com/ibm/ws/ejbcontainer/timer/persistent/osgi/internal/EJBPersistentTimerRuntimeImpl.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent/src/com/ibm/ws/ejbcontainer/timer/persistent/osgi/internal/EJBPersistentTimerRuntimeImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2017 IBM Corporation and others.
+ * Copyright (c) 2013, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -61,19 +61,31 @@ import com.ibm.ws.tx.embeddable.EmbeddableWebSphereTransactionManager;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 
 @Component(service = { EJBPersistentTimerRuntime.class, EJBPersistentTimerRuntimeImpl.class },
-           configurationPolicy = ConfigurationPolicy.IGNORE)
+           configurationPid = "com.ibm.ws.ejbcontainer.timer.runtime",
+           configurationPolicy = ConfigurationPolicy.OPTIONAL)
 public class EJBPersistentTimerRuntimeImpl implements EJBPersistentTimerRuntime {
 
     private static final TraceComponent tcContainer = Tr.register(EJBPersistentTimerRuntimeImpl.class, "EJBContainer", "com.ibm.ejs.container.container");
 
     private static final String REFERENCE_EJB_TIMER_RUNTIME = "ejbTimerRuntime";
     private static final String REFERENCE_DEFAULT_PERSISTENT_EXECUTOR = "defaultEJBPersistentTimerExecutor";
+    private static final String MISSED_TIMER_ACTION = "missedPersistentTimerAction";
+
+    /**
+     * Enumeration of the timerService.missedPersistentTimerAction configuration allowed options.
+     */
+    enum MissedTimerAction {
+        ALL, ONCE, NONE
+    }
 
     private final AtomicServiceReference<EJBTimerRuntime> ejbTimerRuntimeServiceRef = new AtomicServiceReference<EJBTimerRuntime>(REFERENCE_EJB_TIMER_RUNTIME);
     private final AtomicServiceReference<PersistentExecutor> defaultPersistentExecutorRef = new AtomicServiceReference<PersistentExecutor>(REFERENCE_DEFAULT_PERSISTENT_EXECUTOR);
 
     private boolean enabledDatabasePolling, hasSetupTimers;
     private volatile boolean serverStopping;
+
+    // Configured missedPersistentTimerAction; null if not explicitly declared
+    private MissedTimerAction missedTimerAction;
 
     /**
      * Map of Java EE Name -> allowCachedTimerData integer value; where J2EEName is either the
@@ -109,6 +121,7 @@ public class EJBPersistentTimerRuntimeImpl implements EJBPersistentTimerRuntime 
         ejbTimerRuntimeServiceRef.activate(cc);
         defaultPersistentExecutorRef.activate(cc);
         updateConfiguration(properties);
+        PersistentTimerTaskHandlerImpl.persistentTimerRuntime = this;
     }
 
     @Modified
@@ -117,6 +130,14 @@ public class EJBPersistentTimerRuntimeImpl implements EJBPersistentTimerRuntime 
     }
 
     private void updateConfiguration(Map<String, Object> properties) {
+
+        // Read the missedPersistentTimerAction configuration; do not set a default as
+        // that will vary based on whether the PersistentExecutor has failover enabled
+        String missedTimerActionProperty = (String) properties.get(MISSED_TIMER_ACTION);
+        missedTimerAction = (missedTimerActionProperty != null) ? MissedTimerAction.valueOf(missedTimerActionProperty) : null;
+
+        if (TraceComponent.isAnyTracingEnabled() && tcContainer.isDebugEnabled())
+            Tr.debug(tcContainer, "MissedTimerAction = " + missedTimerAction);
 
         // For quick access, regardless of whether an application is even installed,
         // build a map of Java EE name string to timer data cache setting; where the
@@ -525,5 +546,43 @@ public class EJBPersistentTimerRuntimeImpl implements EJBPersistentTimerRuntime 
         if (TraceComponent.isAnyTracingEnabled() && tcContainer.isDebugEnabled())
             Tr.debug(tcContainer, "isServiceConfigured : false : no persistent executor");
         return false;
+    }
+
+    /**
+     * Returns the configured missed timer action for persistent timers. When not
+     * explicitly configured, the missed timer action will default to ONCE when
+     * failover is enabled for the PersistentExecutor, otherwise ALL.
+     *
+     * @return missed timer action for persistent timers
+     */
+    @Trivial
+    MissedTimerAction getMissedTimerAction() {
+        // Explicitly configured for timerService
+        if (missedTimerAction != null) {
+            if (TraceComponent.isAnyTracingEnabled() && tcContainer.isDebugEnabled())
+                Tr.debug(tcContainer, "MissedTimerAction = " + missedTimerAction);
+            return missedTimerAction;
+        }
+
+        try {
+            // Default to ONCE if failover is enabled
+            if (getPersistentExecutor().isFailOverEnabled()) {
+                if (TraceComponent.isAnyTracingEnabled() && tcContainer.isDebugEnabled())
+                    Tr.debug(tcContainer, "MissedTimerAction = " + MissedTimerAction.ONCE);
+                return MissedTimerAction.ONCE;
+            }
+        } catch (Throwable ex) {
+            // Although unusual; obtaining the PersistentExecutor may fail if it has not
+            // been configured properly. Allow FFDC to be collected, but otherwise just
+            // fall through and return the default of ALL. The error will be reported
+            // later when another attempt is made to use the PersistentExecutor.
+            if (TraceComponent.isAnyTracingEnabled() && tcContainer.isDebugEnabled())
+                Tr.debug(tcContainer, "getMissedTimerAction : " + ex);
+        }
+
+        // Legacy default has been to run all expirations
+        if (TraceComponent.isAnyTracingEnabled() && tcContainer.isDebugEnabled())
+            Tr.debug(tcContainer, "MissedTimerAction = " + MissedTimerAction.ALL);
+        return MissedTimerAction.ALL;
     }
 }

--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/.classpath
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/.classpath
@@ -2,6 +2,8 @@
 <classpath>
     <classpathentry kind="src" path="fat/src"/>
     <classpathentry kind="src" path="test-applications/InitTxRecoveryLogEJB.jar/src"/>
+    <classpathentry kind="src" path="test-applications/MissedTimerActionEJB.jar/src"/>
+    <classpathentry kind="src" path="test-applications/MissedTimerActionWeb.war/src"/>
     <classpathentry kind="src" path="test-applications/NoDBNonPersistAutoTimerEJB.jar/src"/>
     <classpathentry kind="src" path="test-applications/NoDBNonPersistAutoTimerWeb.war/src"/>
     <classpathentry kind="src" path="test-applications/NoDBPersistAutoTimerEJB.jar/src"/>

--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -14,6 +14,8 @@ bVersion=1.0
 src: \
 	fat/src,\
 	test-applications/InitTxRecoveryLogEJB.jar/src, \
+	test-applications/MissedTimerActionEJB.jar/src, \
+	test-applications/MissedTimerActionWeb.war/src, \
 	test-applications/NoDBNonPersistAutoTimerEJB.jar/src, \
 	test-applications/NoDBNonPersistAutoTimerWeb.war/src, \
 	test-applications/NoDBPersistAutoTimerEJB.jar/src, \

--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/PersistentTimerCoreTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/PersistentTimerCoreTest.java
@@ -11,6 +11,7 @@
 
 package com.ibm.ws.ejbcontainer.timer.persistent.fat.tests;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -27,6 +28,7 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.EJBContainerElement;
 import com.ibm.websphere.simplicity.config.EJBTimerServiceElement;
+import com.ibm.websphere.simplicity.config.PersistentExecutor;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.ws.ejbcontainer.timer.persistent.core.web.TimerAccessOperationsServlet;
 import com.ibm.ws.ejbcontainer.timer.persistent.core.web.TimerSFOperationsServlet;
@@ -38,6 +40,7 @@ import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.RepeatTestFilter;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
@@ -47,12 +50,13 @@ import componenttest.topology.utils.FATServletClient;
 @MinimumJavaLevel(javaLevel = 8)
 public class PersistentTimerCoreTest extends FATServletClient {
 
-    public static final String WAR_NAME = "PersistentTimerCoreWeb";
+    public static final String CORE_WAR_NAME = "PersistentTimerCoreWeb";
+    public static final String MISSED_ACTION_WAR_NAME = "MissedTimerActionWeb";
 
     @Server("com.ibm.ws.ejbcontainer.timer.persistent.fat.PersistentTimerServer")
-    @TestServlets({ @TestServlet(servlet = TimerAccessOperationsServlet.class, contextRoot = WAR_NAME),
-                    @TestServlet(servlet = TimerSFOperationsServlet.class, contextRoot = WAR_NAME),
-                    @TestServlet(servlet = TimerSLOperationsServlet.class, contextRoot = WAR_NAME) })
+    @TestServlets({ @TestServlet(servlet = TimerAccessOperationsServlet.class, contextRoot = CORE_WAR_NAME),
+                    @TestServlet(servlet = TimerSFOperationsServlet.class, contextRoot = CORE_WAR_NAME),
+                    @TestServlet(servlet = TimerSLOperationsServlet.class, contextRoot = CORE_WAR_NAME) })
     public static LibertyServer server;
 
     @ClassRule
@@ -69,6 +73,15 @@ public class PersistentTimerCoreTest extends FATServletClient {
         InitTxRecoveryLogApp.addAsModule(InitTxRecoveryLogEJBJar);
 
         ShrinkHelper.exportDropinAppToServer(server, InitTxRecoveryLogApp);
+
+        //#################### MissedTimerActionApp.ear
+        JavaArchive MissedTimerActionEJB = ShrinkHelper.buildJavaArchive("MissedTimerActionEJB.jar", "com.ibm.ws.ejbcontainer.timer.persistent.missed.ejb.");
+        WebArchive MissedTimerActionWeb = ShrinkHelper.buildDefaultApp("MissedTimerActionWeb.war", "com.ibm.ws.ejbcontainer.timer.persistent.missed.web.");
+
+        EnterpriseArchive MissedTimerActionApp = ShrinkWrap.create(EnterpriseArchive.class, "MissedTimerActionApp.ear");
+        MissedTimerActionApp.addAsModule(MissedTimerActionEJB).addAsModule(MissedTimerActionWeb);
+
+        ShrinkHelper.exportDropinAppToServer(server, MissedTimerActionApp);
 
         //#################### PersistentTimerCoreApp.ear
         JavaArchive PersistentTimerCoreEJB = ShrinkHelper.buildJavaArchive("PersistentTimerCoreEJB.jar", "com.ibm.ws.ejbcontainer.timer.persistent.core.ejb.");
@@ -87,9 +100,31 @@ public class PersistentTimerCoreTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
+        // CNTR0333W  : test*LateTimer - Late Timer Warning
+        // CWWKC1501W : testSLTimerServiceEJBTimeoutSessionContextCMT - PersistentExecutor rolled back a task
+        // CWWKC1506E : testSLTimerServiceEJBTimeoutSessionContextCMT - Transaction is marked for rollback
+        // CWWKG0032W : testMissedTimerActionBadValueNoFailover - Unexpected value [Blah]
         if (server != null && server.isStarted()) {
-            server.stopServer("CNTR0333W", "CWWKC1500W", "CWWKC1501W", "CWWKC1506E");
+            server.stopServer("CNTR0333W", "CWWKC1500W", "CWWKC1501W", "CWWKC1506E", "CWWKG0032W.*Blah");
         }
+    }
+
+    /**
+     * Returns the test method name without the RepeatTests suffix.
+     *
+     * For example, when using RepeatTests with EE7_FEATURES, the suffix _EE7_FEATURES is added
+     * to provide unique test names for junit reporting purposes. The simple test method name
+     * dose not include the suffix.
+     *
+     * @return test method name without the RepeatTests suffix.
+     */
+    protected String getTestMethodSimpleName() {
+        String testMethodName = testName.getMethodName();
+        if (testMethodName.endsWith(RepeatTestFilter.CURRENT_REPEAT_ACTION)) {
+            testMethodName = testMethodName.substring(0, testMethodName.length() - (RepeatTestFilter.CURRENT_REPEAT_ACTION.length() + 1));
+        }
+
+        return testMethodName;
     }
 
     //-----------------------------------------------------
@@ -185,4 +220,214 @@ public class PersistentTimerCoreTest extends FATServletClient {
         }
     }
 
+    //-----------------------------------------------------
+    // --------------MissedTimerActionServlet--------------
+    //-----------------------------------------------------
+
+    /**
+     * Test Persistent Timer missed action default behavior when failover has not been enabled.
+     * The default behavior without failover should be ALL. <p>
+     *
+     * This test will confirm the following :
+     * <ol>
+     * <li> Interval timer will run all expirations despite a delay that causes several to be missed.
+     * <li> Timer.getNextTimeout() will return values in the past for missed expirations.
+     * </ol>
+     */
+    @Test
+    public void testMissedTimerActionDefaultNoFailover() throws Exception {
+        // Default when no failover is ALL
+        testMissedTimerAction(null, false);
+    }
+
+    /**
+     * Test Persistent Timer missed action default behavior when failover has been enabled.
+     * The default behavior with failover should be ONCE. <p>
+     *
+     * This test will confirm the following :
+     * <ol>
+     * <li> Interval timer will skip expirations missed because of a delay.
+     * <li> Timer.getNextTimeout() will return values in the future; skipping missed expirations.
+     * </ol>
+     */
+    @Test
+    public void testMissedTimerActionDefaultWithFailover() throws Exception {
+        // Default when failover is enabled is ONCE
+        testMissedTimerAction(null, true);
+    }
+
+    /**
+     * Test Persistent Timer missed action "ALL" behavior when failover has not been enabled. <p>
+     *
+     * This test will confirm the following :
+     * <ol>
+     * <li> Interval timer will run all expirations despite a delay that causes several to be missed.
+     * <li> Timer.getNextTimeout() will return values in the past for missed expirations.
+     * </ol>
+     */
+    @Test
+    @Mode(Mode.TestMode.FULL)
+    public void testMissedTimerActionAllNoFailover() throws Exception {
+        testMissedTimerAction("ALL", false);
+    }
+
+    /**
+     * Test Persistent Timer missed action "ALL" behavior when failover has been enabled. <p>
+     *
+     * This test will confirm the following :
+     * <ol>
+     * <li> Interval timer will run all expirations despite a delay that causes several to be missed.
+     * <li> Timer.getNextTimeout() will return values in the past for missed expirations.
+     * </ol>
+     */
+    @Test
+    public void testMissedTimerActionAllWithFailover() throws Exception {
+        testMissedTimerAction("ALL", true);
+    }
+
+    /**
+     * Test Persistent Timer missed action "ONCE" behavior when failover has not been enabled. <p>
+     *
+     * This test will confirm the following :
+     * <ol>
+     * <li> Interval timer will skip expirations missed because of a delay.
+     * <li> Timer.getNextTimeout() will return values in the future; skipping missed expirations.
+     * </ol>
+     */
+    @Test
+    public void testMissedTimerActionOnceNoFailover() throws Exception {
+        testMissedTimerAction("ONCE", false);
+    }
+
+    /**
+     * Test Persistent Timer missed action "ONCE" behavior when failover has been enabled. <p>
+     *
+     * This test will confirm the following :
+     * <ol>
+     * <li> Interval timer will skip expirations missed because of a delay.
+     * <li> Timer.getNextTimeout() will return values in the future; skipping missed expirations.
+     * </ol>
+     */
+    @Test
+    @Mode(Mode.TestMode.FULL)
+    public void testMissedTimerActionOnceWithFailover() throws Exception {
+        testMissedTimerAction("ONCE", true);
+    }
+
+    /**
+     * Test Persistent Timer missed action "ONCE" behavior when failover has not been enabled. <p>
+     *
+     * This test will confirm the following :
+     * <ol>
+     * <li> Interval timer will skip expirations missed because of a delay.
+     * <li> Timer.getNextTimeout() will return values in the future; skipping missed expirations.
+     * </ol>
+     */
+    @Test
+    public void testMissedTimerActionNoneNoFailover() throws Exception {
+        testMissedTimerAction("NONE", false);
+    }
+
+    /**
+     * Test Persistent Timer missed action "NONE" behavior when failover has been enabled. <p>
+     *
+     * This test will confirm the following :
+     * <ol>
+     * <li> Interval timer will skip expirations missed because of a delay.
+     * <li> Timer.getNextTimeout() will return values in the future; skipping missed expirations.
+     * </ol>
+     */
+    @Test
+    @Mode(Mode.TestMode.FULL)
+    public void testMissedTimerActionNoneWithFailover() throws Exception {
+        testMissedTimerAction("NONE", true);
+    }
+
+    /**
+     * Test Persistent Timer missed action "None" (mixed case) behavior when failover has not been enabled.
+     * The value is case insensitive and will be treated as "NONE". <p>
+     *
+     * This test will confirm the following :
+     * <ol>
+     * <li> Interval timer will skip expirations missed because of a delay.
+     * <li> Timer.getNextTimeout() will return values in the future; skipping missed expirations.
+     * </ol>
+     */
+    @Test
+    @Mode(Mode.TestMode.FULL)
+    public void testMissedTimerActionMixedCaseNoFailover() throws Exception {
+        testMissedTimerAction("None", false);
+    }
+
+    /**
+     * Test Persistent Timer missed action "Blah" (bad value) behavior when failover has not been enabled.
+     * A warning will be logged, and the value will be treated as unspecified, so default to "ALL". <p>
+     *
+     * This test will confirm the following :
+     * <ol>
+     * <li> Interval timer will run all expirations despite a delay that causes several to be missed.
+     * <li> Timer.getNextTimeout() will return values in the past for missed expirations.
+     * </ol>
+     */
+    @Test
+    @Mode(Mode.TestMode.FULL)
+    public void testMissedTimerActionBadValueNoFailover() throws Exception {
+        // Change to non-default configuration before setting bad configuration value.
+        setMissedPersistentTimerActionConfiguration("ONCE", false);
+        server.setMarkToEndOfLog();
+
+        // Change to bad value "Blah" configuration.
+        setMissedPersistentTimerActionConfiguration("Blah", false);
+        assertFalse("Expected CWWKG0032W message for Blah did not occur", server.findStringsInLogs("CWWKG0032W.*missedPersistentTimerAction.*Blah").isEmpty());
+        server.setMarkToEndOfLog();
+
+        // Run test and verify default, ALL, is used rather than prior value, "ONCE"
+        try {
+            String servlet = MISSED_ACTION_WAR_NAME + "/MissedTimerActionServlet";
+            FATServletClient.runTest(server, servlet, getTestMethodSimpleName());
+        } finally {
+            setMissedPersistentTimerActionConfiguration(null, false);
+        }
+    }
+
+    private void testMissedTimerAction(String missedTimerAction, boolean failover) throws Exception {
+        setMissedPersistentTimerActionConfiguration(missedTimerAction, failover);
+        server.setMarkToEndOfLog();
+
+        try {
+            String servlet = MISSED_ACTION_WAR_NAME + "/MissedTimerActionServlet";
+            FATServletClient.runTest(server, servlet, getTestMethodSimpleName());
+        } finally {
+            setMissedPersistentTimerActionConfiguration(null, false);
+        }
+    }
+
+    /**
+     * Change the setting of the timerService missedPersistentTimerAction to the specified value;
+     * and set persistentExecutor missedTaskThreshold to the minimum value if failover should
+     * be enabled.
+     *
+     * @param missedPersistentTimerAction missed persistent timer action or null
+     * @param failover true if failover should be enabled; otherwise false
+     */
+    private static void setMissedPersistentTimerActionConfiguration(String missedPersistentTimerAction, boolean failover) throws Exception {
+
+        ServerConfiguration config = server.getServerConfiguration();
+        EJBContainerElement ejbContainer = config.getEJBContainer();
+        EJBTimerServiceElement timerService = ejbContainer.getTimerService();
+        timerService.setMissedPersistentTimerAction(missedPersistentTimerAction);
+
+        PersistentExecutor persistentExecutor = config.getPersistentExecutors().getById("Howdy");
+        if (failover) {
+            persistentExecutor.setMissedTaskThreshold("100s");
+            persistentExecutor.setRetryInterval(null); // mutually exclusive with missedTaskThreshold
+        } else {
+            persistentExecutor.setMissedTaskThreshold(null);
+            persistentExecutor.setRetryInterval("300s");
+        }
+
+        server.setMarkToEndOfLog();
+        server.updateServerConfiguration(config);
+        assertNotNull(server.waitForConfigUpdateInLogUsingMark(null));
+    }
 }

--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/test-applications/MissedTimerActionEJB.jar/src/com/ibm/ws/ejbcontainer/timer/persistent/missed/ejb/MissedTimerAction.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/test-applications/MissedTimerActionEJB.jar/src/com/ibm/ws/ejbcontainer/timer/persistent/missed/ejb/MissedTimerAction.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.timer.persistent.missed.ejb;
+
+public interface MissedTimerAction {
+
+    public void createIntervalTimer();
+
+    public void verifyMissedTimerAction(String missedTimerAction);
+
+    public void cancelAllTimers();
+}

--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/test-applications/MissedTimerActionEJB.jar/src/com/ibm/ws/ejbcontainer/timer/persistent/missed/ejb/MissedTimerActionBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/test-applications/MissedTimerActionEJB.jar/src/com/ibm/ws/ejbcontainer/timer/persistent/missed/ejb/MissedTimerActionBean.java
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.timer.persistent.missed.ejb;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import javax.annotation.Resource;
+import javax.ejb.EJBException;
+import javax.ejb.NoSuchObjectLocalException;
+import javax.ejb.Stateless;
+import javax.ejb.Timeout;
+import javax.ejb.Timer;
+import javax.ejb.TimerService;
+
+import com.ibm.websphere.ejbcontainer.test.tools.FATHelper;
+
+@Stateless
+public class MissedTimerActionBean implements MissedTimerAction {
+    private static final Logger logger = Logger.getLogger(MissedTimerActionBean.class.getName());
+
+    private static final long INTERVAL = 1000; // 1 second
+    private static final int SKIPS = 10; // number of skipped expirations
+    private static final long DELAY = SKIPS * 1000; // 10 seconds
+
+    private static volatile CountDownLatch timerLatch;
+    private static volatile Date firstNextTimeout;
+    private static volatile Long firstTimeRemaining;
+    private static volatile ArrayList<Date> nextTimeouts;
+    private static volatile ArrayList<Long> timeRemains;
+
+    @Resource
+    private TimerService timerService;
+
+    @Override
+    public void createIntervalTimer() {
+        timerLatch = new CountDownLatch(SKIPS + 1);
+        nextTimeouts = new ArrayList<Date>();
+        timeRemains = new ArrayList<Long>();
+        Timer timer = timerService.createIntervalTimer(0, INTERVAL, null);
+        logger.info("MissedTimerActionBean.createIntervalTimer : " + timer);
+    }
+
+    @Override
+    public void cancelAllTimers() {
+        Collection<Timer> timers = timerService.getTimers();
+        logger.info("MissedTimerActionBean.cancelAllTimers : " + timers.size());
+        for (Timer timer : timers) {
+            try {
+                timer.cancel();
+            } catch (NoSuchObjectLocalException nso) {
+
+            } catch (Throwable ex) {
+                ex.printStackTrace(System.out);
+            }
+        }
+        timerLatch = null;
+        firstNextTimeout = null;
+        firstTimeRemaining = null;
+    }
+
+    @Override
+    public void verifyMissedTimerAction(String missedTimerAction) {
+        // Wait for the timer to run a few times after a delay
+        try {
+            logger.info("MissedTimerActionBean.verifyMissedTimerAction : waiting for latch...");
+            timerLatch.await(3, TimeUnit.MINUTES);
+            logger.info("MissedTimerActionBean.verifyMissedTimerAction : latch obtained");
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+            throw new EJBException("Timers failed to run in 3 minutes : e", e);
+        }
+
+        if ("ALL".equals(missedTimerAction)) {
+            long nextExpected = firstNextTimeout.getTime();
+            for (Date nextTimeout : nextTimeouts) {
+                assertNotNull("Unexpected null for getNextTimeout()", nextTimeout);
+                long interval = nextTimeout.getTime() - nextExpected;
+                assertEquals("getNextTimeout() interval not expected", INTERVAL, interval);
+                nextExpected = nextTimeout.getTime();
+            }
+        } else if ("ONCE".equals(missedTimerAction) || "NONE".equals(missedTimerAction)) {
+            long nextExpected = firstNextTimeout.getTime();
+            for (int index = 0; index < nextTimeouts.size(); index++) {
+                Date nextTimeout = nextTimeouts.get(index);
+                assertNotNull("Unexpected null for getNextTimeout() on result #" + index, nextTimeout);
+                long interval = nextTimeout.getTime() - nextExpected;
+                if (index == 0) {
+                    assertTrue("getNextTimeout() not >= DELAY : " + interval + " >= " + DELAY, interval >= DELAY);
+                } else {
+                    assertEquals("getNextTimeout() interval not expected on result #" + index, INTERVAL, interval);
+                }
+                nextExpected = nextTimeout.getTime();
+            }
+        } else {
+            fail("Unexpected missedPersistentTimerAction : " + missedTimerAction);
+        }
+    }
+
+    @Timeout
+    public void timeout(Timer timer) {
+        if (firstNextTimeout == null) {
+            firstNextTimeout = timer.getNextTimeout();
+            firstTimeRemaining = timer.getTimeRemaining();
+            logger.info("MissedTimerActionBean.timeout : delay for " + DELAY + " : " + firstNextTimeout + ", " + firstTimeRemaining);
+            FATHelper.sleep(DELAY);
+        } else {
+            CountDownLatch latch = timerLatch;
+            if (latch != null && latch.getCount() > 0) {
+                nextTimeouts.add(timer.getNextTimeout());
+                timeRemains.add(timer.getTimeRemaining());
+                logger.info("MissedTimerActionBean.timeout : " + timer.getNextTimeout() + ", " + timer.getTimeRemaining());
+                timerLatch.countDown();
+            }
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/test-applications/MissedTimerActionWeb.war/src/com/ibm/ws/ejbcontainer/timer/persistent/missed/web/MissedTimerActionServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/test-applications/MissedTimerActionWeb.war/src/com/ibm/ws/ejbcontainer/timer/persistent/missed/web/MissedTimerActionServlet.java
@@ -1,0 +1,188 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.ejbcontainer.timer.persistent.missed.web;
+
+import java.util.logging.Logger;
+
+import javax.ejb.EJB;
+import javax.ejb.EJBException;
+import javax.servlet.annotation.WebServlet;
+
+import com.ibm.ws.ejbcontainer.timer.persistent.missed.ejb.MissedTimerAction;
+
+import componenttest.app.FATServlet;
+
+@WebServlet("/MissedTimerActionServlet")
+@SuppressWarnings("serial")
+public class MissedTimerActionServlet extends FATServlet {
+
+    private static final Logger svLogger = Logger.getLogger(MissedTimerActionServlet.class.getName());
+
+    @EJB
+    MissedTimerAction timerBean;
+
+    /**
+     * Test Persistent Timer missed action default behavior when failover has not been enabled.
+     * The default behavior without failover should be ALL. <p>
+     *
+     * This test will confirm the following :
+     * <ol>
+     * <li> Interval timer will run all expirations despite a delay that causes several to be missed.
+     * <li> Timer.getNextTimeout() will return values in the past for missed expirations.
+     * </ol>
+     */
+    public void testMissedTimerActionDefaultNoFailover() throws Exception {
+        // Default when no failover is ALL
+        testMissedTimerAction("testMissedTimerActionDefaultNoFailover", "ALL");
+    }
+
+    /**
+     * Test Persistent Timer missed action default behavior when failover has been enabled.
+     * The default behavior with failover should be ONCE. <p>
+     *
+     * This test will confirm the following :
+     * <ol>
+     * <li> Interval timer will skip expirations missed because of a delay.
+     * <li> Timer.getNextTimeout() will return values in the future; skipping missed expirations.
+     * </ol>
+     */
+    public void testMissedTimerActionDefaultWithFailover() throws Exception {
+        // Default when failover is enabled is ONCE
+        testMissedTimerAction("testMissedTimerActionDefaultWithFailover", "ONCE");
+    }
+
+    /**
+     * Test Persistent Timer missed action "ALL" behavior when failover has not been enabled. <p>
+     *
+     * This test will confirm the following :
+     * <ol>
+     * <li> Interval timer will run all expirations despite a delay that causes several to be missed.
+     * <li> Timer.getNextTimeout() will return values in the past for missed expirations.
+     * </ol>
+     */
+    public void testMissedTimerActionAllNoFailover() throws Exception {
+        testMissedTimerAction("testMissedTimerActionAllNoFailover", "ALL");
+    }
+
+    /**
+     * Test Persistent Timer missed action "ALL" behavior when failover has been enabled. <p>
+     *
+     * This test will confirm the following :
+     * <ol>
+     * <li> Interval timer will run all expirations despite a delay that causes several to be missed.
+     * <li> Timer.getNextTimeout() will return values in the past for missed expirations.
+     * </ol>
+     */
+    public void testMissedTimerActionAllWithFailover() throws Exception {
+        testMissedTimerAction("testMissedTimerActionAllWithFailover", "ALL");
+    }
+
+    /**
+     * Test Persistent Timer missed action "ONCE" behavior when failover has not been enabled. <p>
+     *
+     * This test will confirm the following :
+     * <ol>
+     * <li> Interval timer will skip expirations missed because of a delay.
+     * <li> Timer.getNextTimeout() will return values in the future; skipping missed expirations.
+     * </ol>
+     */
+    public void testMissedTimerActionOnceNoFailover() throws Exception {
+        testMissedTimerAction("testMissedTimerActionOnceNoFailover", "ONCE");
+    }
+
+    /**
+     * Test Persistent Timer missed action "ONCE" behavior when failover has been enabled. <p>
+     *
+     * This test will confirm the following :
+     * <ol>
+     * <li> Interval timer will skip expirations missed because of a delay.
+     * <li> Timer.getNextTimeout() will return values in the future; skipping missed expirations.
+     * </ol>
+     */
+    public void testMissedTimerActionOnceWithFailover() throws Exception {
+        testMissedTimerAction("testMissedTimerActionOnceWithFailover", "ONCE");
+    }
+
+    /**
+     * Test Persistent Timer missed action "ONCE" behavior when failover has not been enabled. <p>
+     *
+     * This test will confirm the following :
+     * <ol>
+     * <li> Interval timer will skip expirations missed because of a delay.
+     * <li> Timer.getNextTimeout() will return values in the future; skipping missed expirations.
+     * </ol>
+     */
+    public void testMissedTimerActionNoneNoFailover() throws Exception {
+        testMissedTimerAction("testMissedTimerActionNoneNoFailover", "NONE");
+    }
+
+    /**
+     * Test Persistent Timer missed action "NONE" behavior when failover has been enabled. <p>
+     *
+     * This test will confirm the following :
+     * <ol>
+     * <li> Interval timer will skip expirations missed because of a delay.
+     * <li> Timer.getNextTimeout() will return values in the future; skipping missed expirations.
+     * </ol>
+     */
+    public void testMissedTimerActionNoneWithFailover() throws Exception {
+        testMissedTimerAction("testMissedTimerActionNoneWithFailover", "NONE");
+    }
+
+    /**
+     * Test Persistent Timer missed action "None" (mixed case) behavior when failover has not been enabled.
+     * The value is case insensitive and will be treated as "NONE". <p>
+     *
+     * This test will confirm the following :
+     * <ol>
+     * <li> Interval timer will skip expirations missed because of a delay.
+     * <li> Timer.getNextTimeout() will return values in the future; skipping missed expirations.
+     * </ol>
+     */
+    public void testMissedTimerActionMixedCaseNoFailover() throws Exception {
+        testMissedTimerAction("testMissedTimerActionMixedCaseNoFailover", "NONE");
+    }
+
+    /**
+     * Test Persistent Timer missed action "Blah" (bad value) behavior when failover has not been enabled.
+     * A warning will be logged, and the value will be treated as unspecified, so default to "ALL". <p>
+     *
+     * This test will confirm the following :
+     * <ol>
+     * <li> Interval timer will run all expirations despite a delay that causes several to be missed.
+     * <li> Timer.getNextTimeout() will return values in the past for missed expirations.
+     * </ol>
+     */
+    public void testMissedTimerActionBadValueNoFailover() throws Exception {
+        testMissedTimerAction("testMissedTimerActionBadValueNoFailover", "ALL");
+    }
+
+    private void testMissedTimerAction(String testName, String missedTimerAction) throws Exception {
+        svLogger.info(testName + ": creating interval timer");
+        timerBean.createIntervalTimer();
+
+        try {
+            svLogger.info(testName + ": verifying timer results");
+            timerBean.verifyMissedTimerAction(missedTimerAction);
+        } catch (EJBException ejbex) {
+            // Unwrap any junit assertion errors to make it clearer what failed.
+            Throwable rootex = ejbex.getCause();
+            if (rootex instanceof AssertionError) {
+                throw (AssertionError) rootex;
+            }
+            throw ejbex;
+        } finally {
+            timerBean.cancelAllTimers();
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.ejbcontainer.timer/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.ejbcontainer.timer/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2014, 2019 IBM Corporation and others.
+# Copyright (c) 2014, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -36,3 +36,9 @@ persistentExecutorRef.desc=Schedules and runs EJB persistent timer tasks.
 nonPersistentContextServiceRef=Non-persistent Timer Thread Context Propagation
 nonPersistentContextServiceRef$Ref=Thread context propagation reference
 nonPersistentContextServiceRef.desc=The context service is used to manage context propagation to non-persistent timer method threads.
+
+missedPersistentTimerAction=Missed persistent timer action
+missedPersistentTimerAction.desc=Specifies the action to perform when the expiration of an interval or schedule-based persistent timer is missed. One or more expirations of a persistent timer are classified as missed if the current expiration is scheduled before application server start or the next expiration is scheduled before the current time. The default action when failover of persistent timers is enabled is ONCE, otherwise the default action is ALL.
+missedPersistentTimerAction.ALL=The timeout method is invoked immediately for all missed expirations. When multiple expirations are missed for the same timer, each invocation occurs synchronously until all missed expirations are processed, then the timer resumes with the next future expiration. 
+missedPersistentTimerAction.ONCE=The timeout method is invoked once immediately. All other missed expirations are skipped and the timer resumes with the next future expiration. 
+missedPersistentTimerAction.NONE=No action is taken. All missed expirations that occurred before application server start are skipped and the timer resumes with the next future expiration. Missed expirations that occur after application server start are handled with the ONCE missed timer action.   

--- a/dev/com.ibm.ws.ejbcontainer.timer/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.ejbcontainer.timer/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 IBM Corporation and others.
+    Copyright (c) 2017, 2020 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -41,6 +41,13 @@
         <AD id="nonPersistentContextService.target" type="String"  ibm:final="true" required="false"
             default="(service.pid=${nonPersistentContextServiceRef})" 
             name="internal" description="internal use only"/>
+
+        <AD id="missedPersistentTimerAction" type="String" ibm:beta="true" required="false"
+            name="%missedPersistentTimerAction" description="%missedPersistentTimerAction.desc">
+            <Option value="ALL"  label="%missedPersistentTimerAction.ALL"/>
+            <Option value="ONCE" label="%missedPersistentTimerAction.ONCE"/>
+            <Option value="NONE" label="%missedPersistentTimerAction.NONE"/>
+        </AD>
     </OCD>
 
     <Designate factoryPid="com.ibm.ws.ejbcontainer.timer.runtime">

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/EJBTimerServiceElement.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/EJBTimerServiceElement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2015 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@ public class EJBTimerServiceElement extends ConfigElement {
     private Long lateTimerThreshold;
     private Long nonPersistentRetryInterval;
     private Integer nonPersistentMaxRetries;
+    private String missedPersistentTimerAction;
 
     public Long getLateTimerThreshold() {
         return lateTimerThreshold;
@@ -48,15 +49,30 @@ public class EJBTimerServiceElement extends ConfigElement {
         this.nonPersistentMaxRetries = nonPersistentMaxRetries;
     }
 
+    public String getMissedPersistentTimerAction() {
+        return missedPersistentTimerAction;
+    }
+
+    @XmlAttribute(name = "missedPersistentTimerAction")
+    public void setMissedPersistentTimerAction(String missedPersistentTimerAction) {
+        this.missedPersistentTimerAction = missedPersistentTimerAction;
+    }
+
     @Override
     public String toString() {
         StringBuffer buf = new StringBuffer("EJBTimerServiceElement {");
 
+        if (lateTimerThreshold != null) {
+            buf.append("lateTimerThreshold=\"" + lateTimerThreshold + "\" ");
+        }
         if (nonPersistentRetryInterval != null) {
             buf.append("nonPersistentRetryInterval=\"" + nonPersistentRetryInterval + "\" ");
         }
         if (nonPersistentMaxRetries != null) {
             buf.append("nonPersistentMaxRetries=\"" + nonPersistentMaxRetries + "\" ");
+        }
+        if (missedPersistentTimerAction != null) {
+            buf.append("missedPersistentTimerAction=\"" + missedPersistentTimerAction + "\" ");
         }
 
         buf.append("}");


### PR DESCRIPTION
Added support for skipping missed EJB persistent timer expirations

for #10563 