### PR TITLE
Revert "Updated RepeatFaultTolerance to test FT 2.1"

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/suite/RepeatFaultTolerance.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/suite/RepeatFaultTolerance.java
@@ -121,7 +121,7 @@ public class RepeatFaultTolerance {
      */
     public static RepeatTests repeatDefault(String server) {
         return RepeatTests.with(mp20Features(server).fullFATOnly())
-                        .andWith(mp33Features(server));
+                        .andWith(mp30Features(server));
     }
 
     /**
@@ -136,9 +136,7 @@ public class RepeatFaultTolerance {
         return RepeatTests.with(mp13Features(server))
                         .andWith(mp20Features(server))
                         .andWith(ft20metrics11Features(server))
-                        .andWith(mp30Features(server))
-                        .andWith(mp32Features(server))
-                        .andWith(mp33Features(server));
+                        .andWith(mp30Features(server));
     }
 
     public static RepeatTests repeat20AndAbove(String server) {


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#10608 which appears to be the cause of https://wasrtc.hursley.ibm.com:9443/jazz/resource/itemName/com.ibm.team.workitem.WorkItem/271856