### PR TITLE
disabled test of login module in JARs within RAR

### DIFF
--- a/dev/com.ibm.ws.jca_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jca_fat/bnd.bnd
@@ -28,4 +28,5 @@ fat.project: true
 	com.ibm.websphere.javaee.jms.1.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
-	com.ibm.ws.logging
+	com.ibm.ws.logging,\
+	com.ibm.ws.security.jaas.common;version=latest

--- a/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/JCATest.java
+++ b/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/JCATest.java
@@ -119,6 +119,12 @@ public class JCATest extends FATServletClient {
         ShrinkHelper.addDirectory(fvtapp_ear, "lib/LibertyFATTestFiles/fvtapp");
         ShrinkHelper.exportToServer(server, "apps", fvtapp_ear);
 
+        // TODO remove this temporary jar when login modules can be accessed from the resource adapter
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "tempLoginModule.jar");
+        jar.addPackage("fat.jca.resourceadapter.jar1");
+        jar.addPackage("fat.jca.resourceadapter.jar2");
+        ShrinkHelper.exportToServer(server, "/", jar);
+
         server.addInstalledAppForValidation(fvtapp);
         server.startServer();
     }
@@ -145,6 +151,16 @@ public class JCATest extends FATServletClient {
     @Test
     public void testDestinations() throws Exception {
         runInServlet("testDestinations", fvtweb);
+    }
+
+    @Test
+    public void testLoginModuleInJarInJarInRar() throws Exception {
+        runInServlet("testLoginModuleInJarInJarInRar", fvtweb);
+    }
+
+    @Test
+    public void testLoginModuleInJarInRar() throws Exception {
+        runInServlet("testLoginModuleInJarInRar", fvtweb);
     }
 
     /**

--- a/dev/com.ibm.ws.jca_fat/publish/servers/com.ibm.ws.jca.fat/server.xml
+++ b/dev/com.ibm.ws.jca_fat/publish/servers/com.ibm.ws.jca.fat/server.xml
@@ -10,6 +10,7 @@
  -->
 <server>
     <featureManager>
+      <feature>appSecurity-2.0</feature>
       <feature>servlet-4.0</feature>
       <feature>localConnector-1.0</feature>
       <feature>jmsMdb-3.2</feature>
@@ -67,6 +68,19 @@
     <application type="ear" id="fvtapp" name="fvtapp" location="fvtapp.ear">
     </application>
 
+    <library id="temp">
+      <file name="${server.config.dir}/tempLoginModule.jar"/>
+    </library>
+    <javaPermission codebase="${server.config.dir}/tempLoginModule.jar" className="javax.security.auth.AuthPermission" name="modifyPrivateCredentials"/>
+
+    <jaasLoginContextEntry id="jar1LoginContextEntry" name="jar1login">
+      <loginModule className="fat.jca.resourceadapter.jar1.JAR1LoginModule" libraryRef="temp"/> <!-- TODO replace with classProviderRef once implemented -->
+    </jaasLoginContextEntry>
+
+    <jaasLoginContextEntry id="jar2LoginContextEntry" name="jar2login">
+      <loginModule className="fat.jca.resourceadapter.jar2.JAR2LoginModule" libraryRef="temp"/> <!-- TODO replace with classProviderRef once implemented -->
+    </jaasLoginContextEntry>
+
     <!-- 
     NOTE: for this bucket to run cleanly with j2sec enabled, the following permission must be manually
     granted in the java.policy file at $JAVA_HOME/jre/lib/security/java.policy: 
@@ -81,4 +95,7 @@
     <javaPermission codebase="${server.config.dir}/connectors/JCAFAT1.rar" className="javax.security.auth.PrivateCredentialPermission"
                     name="javax.resource.spi.security.PasswordCredential * &quot;*&quot;" actions="read"/>
 
+    <!-- TODO switch to resource adapter (should be covered above) once it replaces the temporary login module jar -->
+    <javaPermission codebase="${server.config.dir}/tempLoginModule.jar" className="javax.security.auth.PrivateCredentialPermission"
+                    signedBy="javax.resource.spi.security.PasswordCredential" principalType="*" principalName="*" actions="read"/>
 </server>

--- a/dev/com.ibm.ws.jca_fat/test-applications/fvtweb/resources/WEB-INF/ibm-web-bnd.xml
+++ b/dev/com.ibm.ws.jca_fat/test-applications/fvtweb/resources/WEB-INF/ibm-web-bnd.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011,2016 IBM Corporation and others.
+    Copyright (c) 2011,2020 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -11,6 +11,15 @@
  -->
 <web-bnd xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://websphere.ibm.com/xml/ns/javaee"
     xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-bnd_1_0.xsd" version="1.0">
+
+  <resource-ref name="java:module/env/jms/jar1loginref">
+    <custom-login-configuration name="jar1login"/>
+  </resource-ref>
+
+  <resource-ref name="java:global/env/jms/jar2loginref">
+    <custom-login-configuration name="jar2login"/>
+  </resource-ref>
+
 
   <resource-ref name="jms/destination1" binding-name="jms/queue1">
   </resource-ref>

--- a/dev/com.ibm.ws.jca_fat/test-applications/fvtweb/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jca_fat/test-applications/fvtweb/resources/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011,2016 IBM Corporation and others.
+    Copyright (c) 2011,2020 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -37,11 +37,23 @@
     <res-type>javax.jms.ConnectionFactory</res-type>
     <lookup-name>jms/cf1</lookup-name>
   </resource-ref>
-  
+
   <resource-ref>
     <res-ref-name>jms/cf1-unshareable</res-ref-name>
     <res-type>javax.jms.ConnectionFactory</res-type>
     <res-sharing-scope>Unshareable</res-sharing-scope>
+    <lookup-name>jms/cf1</lookup-name>
+  </resource-ref>
+
+  <resource-ref>
+    <res-ref-name>java:module/env/jms/jar1loginref</res-ref-name>
+    <res-type>javax.jms.ConnectionFactory</res-type>
+    <lookup-name>jms/cf1</lookup-name>
+  </resource-ref>
+
+  <resource-ref>
+    <res-ref-name>java:global/env/jms/jar2loginref</res-ref-name>
+    <res-type>javax.jms.ConnectionFactory</res-type>
     <lookup-name>jms/cf1</lookup-name>
   </resource-ref>
 

--- a/dev/com.ibm.ws.jca_fat/test-resourceadapters/fvt-resourceadapter/src/fat/jca/resourceadapter/FVTConnection.java
+++ b/dev/com.ibm.ws.jca_fat/test-resourceadapters/fvt-resourceadapter/src/fat/jca/resourceadapter/FVTConnection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -69,7 +69,7 @@ public class FVTConnection implements Connection {
 
     @Override
     public ConnectionMetaData getMetaData() throws JMSException {
-        throw new UnsupportedOperationException();
+        return new FVTConnectionMetaData(mc);
     }
 
     @Override
@@ -83,8 +83,10 @@ public class FVTConnection implements Connection {
     }
 
     @Override
-    public void start() throws JMSException {}
+    public void start() throws JMSException {
+    }
 
     @Override
-    public void stop() throws JMSException {}
+    public void stop() throws JMSException {
+    }
 }

--- a/dev/com.ibm.ws.jca_fat/test-resourceadapters/fvt-resourceadapter/src/fat/jca/resourceadapter/FVTConnectionMetaData.java
+++ b/dev/com.ibm.ws.jca_fat/test-resourceadapters/fvt-resourceadapter/src/fat/jca/resourceadapter/FVTConnectionMetaData.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package fat.jca.resourceadapter;
+
+import java.util.Collections;
+import java.util.Enumeration;
+
+import javax.jms.ConnectionMetaData;
+import javax.jms.JMSException;
+
+public class FVTConnectionMetaData implements ConnectionMetaData {
+    FVTManagedConnection mc;
+
+    FVTConnectionMetaData(FVTManagedConnection mc) {
+        this.mc = mc;
+    }
+
+    @Override
+    public int getJMSMajorVersion() throws JMSException {
+        return 2;
+    }
+
+    @Override
+    public int getJMSMinorVersion() throws JMSException {
+        return 0;
+    }
+
+    @Override
+    public String getJMSProviderName() throws JMSException {
+        // (ab)using this method as a convenient way to externalize the user name to the application
+        if (mc == null || mc.user == null)
+            return "Fake JMS Provider for Tests";
+        else
+            return "Fake JMS Provider for Tests, created for " + mc.user;
+    }
+
+    @Override
+    public String getJMSVersion() throws JMSException {
+        return "2.0";
+    }
+
+    @Override
+    public Enumeration<?> getJMSXPropertyNames() throws JMSException {
+        return Collections.emptyEnumeration();
+    }
+
+    @Override
+    public int getProviderMajorVersion() throws JMSException {
+        return 96;
+    }
+
+    @Override
+    public int getProviderMinorVersion() throws JMSException {
+        return 247;
+    }
+
+    @Override
+    public String getProviderVersion() throws JMSException {
+        return "96.247.265";
+    }
+}

--- a/dev/com.ibm.ws.jca_fat/test-resourceadapters/fvt-resourceadapter/src/fat/jca/resourceadapter/FVTManagedConnection.java
+++ b/dev/com.ibm.ws.jca_fat/test-resourceadapters/fvt-resourceadapter/src/fat/jca/resourceadapter/FVTManagedConnection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -39,6 +39,7 @@ public class FVTManagedConnection implements LazyEnlistableManagedConnection, Lo
     private final ConcurrentLinkedQueue<ConnectionEventListener> listeners = new ConcurrentLinkedQueue<ConnectionEventListener>();
     final FVTManagedConnectionFactory mcf;
     final Subject subject;
+    final String user;
     private final XAConnection xacon;
 
     FVTManagedConnection(final FVTManagedConnectionFactory mcf, FVTConnectionRequestInfo cri, Subject subj) throws ResourceException {
@@ -70,6 +71,8 @@ public class FVTManagedConnection implements LazyEnlistableManagedConnection, Lo
         } catch (SQLException x) {
             throw new ResourceAllocationException(x);
         }
+
+        this.user = userPwd == null ? null : userPwd[0];
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.ws.jca_fat/test-resourceadapters/fvt-resourceadapter/src/fat/jca/resourceadapter/FVTManagedConnectionFactory.java
+++ b/dev/com.ibm.ws.jca_fat/test-resourceadapters/fvt-resourceadapter/src/fat/jca/resourceadapter/FVTManagedConnectionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,8 @@
 package fat.jca.resourceadapter;
 
 import java.io.PrintWriter;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -117,10 +119,19 @@ public class FVTManagedConnectionFactory implements ManagedConnectionFactory, Re
         for (Object o : set)
             if (o instanceof FVTManagedConnection) {
                 FVTManagedConnection m = (FVTManagedConnection) o;
-                if (match(m.cri, cri) && match(m.subject, subject))
+                if (match(m.cri, cri) && matchSubjects(m.subject, subject))
                     return m;
             }
         return null;
+    }
+
+    private static final boolean matchSubjects(final Subject s1, final Subject s2) {
+        return AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+            @Override
+            public Boolean run() {
+                return match(s1, s2);
+            }
+        });
     }
 
     public void setClientID(String clientID) {

--- a/dev/com.ibm.ws.jca_fat/test-resourceadapters/fvt-resourceadapter/src/fat/jca/resourceadapter/jar1/JAR1LoginModule.java
+++ b/dev/com.ibm.ws.jca_fat/test-resourceadapters/fvt-resourceadapter/src/fat/jca/resourceadapter/jar1/JAR1LoginModule.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package fat.jca.resourceadapter.jar1;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Map;
+
+import javax.resource.spi.security.PasswordCredential;
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+
+import com.ibm.wsspi.security.auth.callback.WSManagedConnectionFactoryCallback;
+import com.ibm.wsspi.security.auth.callback.WSMappingPropertiesCallback;
+
+/**
+ * This login module always assigns the same user/password, which tests can check for.
+ */
+public class JAR1LoginModule implements LoginModule {
+    private CallbackHandler callbackHandler;
+    private Subject subject;
+
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        this.callbackHandler = callbackHandler;
+        this.subject = subject;
+    }
+
+    @Override
+    public boolean login() throws LoginException {
+        try {
+            final WSManagedConnectionFactoryCallback mcfCallback = new WSManagedConnectionFactoryCallback("Target ManagedConnectionFactory: ");
+            WSMappingPropertiesCallback mpropsCallback = new WSMappingPropertiesCallback("Mapping Properties (HashMap): ");
+            callbackHandler.handle(new Callback[] { mcfCallback, mpropsCallback });
+
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+                @Override
+                public Void run() {
+                    PasswordCredential passwordCredential = new PasswordCredential("jar1user", "jar1pwd".toCharArray());
+                    passwordCredential.setManagedConnectionFactory(mcfCallback.getManagedConnectionFacotry());
+                    subject.getPrivateCredentials().add(passwordCredential);
+                    return null;
+                }
+            });
+        } catch (Exception x) {
+            throw (LoginException) new LoginException(x.getMessage()).initCause(x);
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean abort() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean commit() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean logout() throws LoginException {
+        return true;
+    }
+}

--- a/dev/com.ibm.ws.jca_fat/test-resourceadapters/fvt-resourceadapter/src/fat/jca/resourceadapter/jar2/JAR2LoginModule.java
+++ b/dev/com.ibm.ws.jca_fat/test-resourceadapters/fvt-resourceadapter/src/fat/jca/resourceadapter/jar2/JAR2LoginModule.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package fat.jca.resourceadapter.jar2;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Map;
+
+import javax.resource.spi.security.PasswordCredential;
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+
+import com.ibm.wsspi.security.auth.callback.WSManagedConnectionFactoryCallback;
+import com.ibm.wsspi.security.auth.callback.WSMappingPropertiesCallback;
+
+/**
+ * This login module always assigns the same user/password, which tests can check for.
+ */
+public class JAR2LoginModule implements LoginModule {
+    private CallbackHandler callbackHandler;
+    private Subject subject;
+
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        this.callbackHandler = callbackHandler;
+        this.subject = subject;
+    }
+
+    @Override
+    public boolean login() throws LoginException {
+        try {
+            final WSManagedConnectionFactoryCallback mcfCallback = new WSManagedConnectionFactoryCallback("Target ManagedConnectionFactory: ");
+            WSMappingPropertiesCallback mpropsCallback = new WSMappingPropertiesCallback("Mapping Properties (HashMap): ");
+            callbackHandler.handle(new Callback[] { mcfCallback, mpropsCallback });
+
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+                @Override
+                public Void run() {
+                    PasswordCredential passwordCredential = new PasswordCredential("jar2user", "jar2pwd".toCharArray());
+                    passwordCredential.setManagedConnectionFactory(mcfCallback.getManagedConnectionFacotry());
+                    subject.getPrivateCredentials().add(passwordCredential);
+                    return null;
+                }
+            });
+        } catch (Exception x) {
+            throw (LoginException) new LoginException(x.getMessage()).initCause(x);
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean abort() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean commit() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean logout() throws LoginException {
+        return true;
+    }
+}


### PR DESCRIPTION
Add login modules to JAR files that are inside of a resource adapter RAR at various levels.  This will be the basis for a test JAAS login context entries can be defined in server config pointing to login modules within a RAR which are not at top level.  The test will be disabled now, (by pointing at at standalone JAR instead) given that the necessary function has not been added.  The tests can be turned on to verify later when it is added.