### PR TITLE
Fixing XA Recovery issue with Postgres and optimized creating table

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/ConfigTest.java
+++ b/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/ConfigTest.java
@@ -173,7 +173,9 @@ public class ConfigTest extends FATServletClient {
 
     @After
     public void cleanUpPerTest() throws Exception {
+        server.setLogOnUpdate(false); //Reduce output that is not specific to the actual tests being run
         updateServerConfig(originalServerConfigUpdatedForJDBC, cleanUpExprs);
+        server.setLogOnUpdate(true);
         cleanUpExprs = EMPTY_EXPR_LIST;
     }
 

--- a/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/DataSourceTest.java
+++ b/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/DataSourceTest.java
@@ -12,7 +12,6 @@ package com.ibm.ws.jdbc.fat.tests;
 
 import static com.ibm.websphere.simplicity.config.DataSourceProperties.DERBY_EMBEDDED;
 import static componenttest.annotation.SkipIfSysProp.DB_Oracle;
-import static componenttest.annotation.SkipIfSysProp.DB_Postgres;
 import static componenttest.annotation.SkipIfSysProp.DB_SQLServer;
 import static org.junit.Assert.fail;
 
@@ -324,10 +323,7 @@ public class DataSourceTest extends FATServletClient {
 
     @Test
     @AllowedFFDC({ "com.ibm.ws.rsadapter.exceptions.DataStoreAdapterException", "javax.transaction.xa.XAException" })
-    @SkipIfSysProp({
-                     DB_Oracle,
-                     DB_Postgres //TODO Fails with Exception "Missing second entry in database." thrown from line 3154 in DataSourceTestServlet.testXARecovery:3154
-    })
+    @SkipIfSysProp(DB_Oracle)
     public void testXARecovery() throws Exception {
         runTest();
     }

--- a/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.fat/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.fat/server.xml
@@ -11,6 +11,10 @@
 <server>
 <!-- All datasources that have fat.modify="true" will be modified at test
 		run time to run against alternative databases. -->
+		
+<!-- Derby database has two save locations
+	${shared.resource.dir}/data/jdbcfat - for datasources enlisted in database rotation
+	${shared.resource.dir}/data/derbyfat - for datasources that always run against derby -->
 
     <featureManager>
       <feature>componenttest-1.0</feature>
@@ -149,8 +153,8 @@
     </dataSource>
     
     <!-- This is a Derby-only data source -->
-    <dataSource id="dsfat5derby" jndiName="jdbc/dsfat5" jdbcDriverRef="Derby" connectionManagerRef="conMgr5" containerAuthDataRef="derbyAuth1" queryTimeout="30s" syncQueryTimeoutWithTransactionTimeout="true">
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/derbyfat" createDatabase="create"/> 
+    <dataSource id="dsfat5derby" jndiName="jdbc/dsfat5" jdbcDriverRef="Derby" connectionManagerRef="conMgr5" queryTimeout="30s" syncQueryTimeoutWithTransactionTimeout="true">
+      <properties.derby.embedded databaseName="${shared.resource.dir}/data/derbyfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/> 
     </dataSource>
 	
 	<!-- ### dsfat6, dsfat7, dsfat8, dsfat9 are defined via @DataSourceDefinition in DataSourceTestServlet

--- a/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.jaas.fat/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.jaas.fat/server.xml
@@ -11,6 +11,10 @@
 <server>
 <!-- All datasources that have fat.modify="true" will be modified at test
 		run time to run against alternative databases. -->
+		
+<!-- Derby database has two save locations
+	${shared.resource.dir}/data/jdbcfat - for datasources enlisted in database rotation
+	${shared.resource.dir}/data/derbyfat - for datasources that always run against derby -->
 
     <featureManager>
       <feature>componenttest-1.0</feature>

--- a/dev/com.ibm.ws.jdbc_fat/test-applications/basicfat/resources/WEB-INF/ibm-web-bnd.xml
+++ b/dev/com.ibm.ws.jdbc_fat/test-applications/basicfat/resources/WEB-INF/ibm-web-bnd.xml
@@ -5,6 +5,10 @@
   <resource-ref name="jdbc/dsfat3" binding-name="jdbc/dsfat3">
     <authentication-alias name="auth1"/>
   </resource-ref>
+  
+  <resource-ref name="jdbc/dsfat5ref1" binding-name="jdbc/dsfat5">
+    <authentication-alias name="derbyAuth1"/>
+  </resource-ref>
 
   <resource-ref name="jdbc/dsfat6ref1" binding-name="java:comp/env/jdbc/dsfat6">
     <authentication-alias name="derbyAuth1"/>

--- a/dev/com.ibm.ws.jdbc_fat/test-applications/basicfat/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jdbc_fat/test-applications/basicfat/resources/WEB-INF/web.xml
@@ -21,6 +21,12 @@
   </servlet-mapping>
 
   <!-- RESOURCE REFERENCES -->
+    <resource-ref>
+    <res-ref-name>jdbc/dsfat5ref1</res-ref-name>
+    <res-type>javax.sql.DataSource</res-type>
+    <res-auth>Container</res-auth>
+  </resource-ref>
+  
   <resource-ref>
     <res-ref-name>jdbc/dsfat6ref1</res-ref-name>
     <res-type>javax.sql.DataSource</res-type>

--- a/dev/com.ibm.ws.jdbc_fat/test-applications/basicfat/src/basicfat/DataSourceTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat/test-applications/basicfat/src/basicfat/DataSourceTestServlet.java
@@ -33,8 +33,10 @@ import java.sql.SQLNonTransientException;
 import java.sql.SQLSyntaxErrorException;
 import java.sql.SQLTransientConnectionException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.List;
 import java.util.Set;
 import java.util.Stack;
 import java.util.concurrent.Callable;
@@ -51,6 +53,8 @@ import javax.management.ObjectInstance;
 import javax.management.ObjectName;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
 import javax.sql.DataSource;
 import javax.transaction.HeuristicMixedException;
 import javax.transaction.UserTransaction;
@@ -125,6 +129,7 @@ import componenttest.app.FATServlet;
 @SuppressWarnings("serial")
 public class DataSourceTestServlet extends FATServlet {
     private static final String className = "DataSourceTestServlet";
+
     @Resource(name = "jdbc/dsfat0")
     DataSource ds0; // one-phase, default isolation, MatchOriginalRequest
 
@@ -154,6 +159,9 @@ public class DataSourceTestServlet extends FATServlet {
 
     @Resource(lookup = "jdbc/dsfat5", shareable = false)
     DataSource ds5u; // one-phase, default isolation, unsharable, Derby only
+
+    @Resource(name = "jdbc/dsfat5ref1", lookup = "jdbc/dsfat5")
+    DataSource ds5_1; //one-phase, default isolation, Derby Only, derbyAuth1 set as authentication alias
 
     @Resource(lookup = "jdbc/dsfatmca", type = DataSource.class)
     DataSource dsmca; // one-phase, default isolation, MatchOriginalRequest, sharable, mapping config alias
@@ -197,11 +205,6 @@ public class DataSourceTestServlet extends FATServlet {
     private ExecutorService executor;
 
     /**
-     * Indicates if we have already created tables for this tests.
-     */
-    private static boolean initialized;
-
-    /**
      * Standard isolation level values.
      */
     private static final int[] ISOLATION_LEVELS = new int[] {
@@ -211,41 +214,26 @@ public class DataSourceTestServlet extends FATServlet {
                                                               Connection.TRANSACTION_READ_UNCOMMITTED
     };
 
-    /**
-     * Create the default table used by the tests.
-     */
-    private void createTable(DataSource ds) throws SQLException {
-        try (Connection con = ds.getConnection()) {
-            //See if cities table was already created
-            DatabaseMetaData md = con.getMetaData();
-            boolean tableFound = false;
-            ResultSet rs = md.getTables(null, null, "CITIES", null); // Some DB providers require the table name in all upper case
-            while (rs.next()) {
-                if (rs.getString("TABLE_NAME").equalsIgnoreCase("cities")) {
-                    tableFound = true;
-                }
-            }
-
-            if (!tableFound) {
-                rs = md.getTables(null, null, "cities", null); // Other DB providers require the table name in all lower case
-                while (rs.next()) {
-                    if (rs.getString("TABLE_NAME").equalsIgnoreCase("cities")) {
-                        tableFound = true;
-                    }
-                }
-            }
-
+    @Override
+    public void init(ServletConfig c) throws ServletException {
+        //Create table in database container
+        try (Connection con = ds1.getConnection()) {
             try (Statement st = con.createStatement()) {
-                if (tableFound) {
-                    st.executeUpdate("drop table cities");
-                }
-                String dbProductName = md.getDatabaseProductName().toUpperCase();
-                if (dbProductName.contains("IDS") || dbProductName.contains("INFORMIX")) // Informix JCC and JDBC
-                    st.executeUpdate("create table cities (name varchar(50) not null primary key, population int, county varchar(30)) LOCK MODE ROW");
-                else
-                    st.executeUpdate("create table cities (name varchar(50) not null primary key, population int, county varchar(30))");
+                st.executeUpdate("create table cities (name varchar(50) not null primary key, population int, county varchar(30))");
             }
+        } catch (SQLException e) {
+            //Ignore, server could have been restarted. Assume table is available.
         }
+
+        //Create table in derby database
+        try (Connection con = ds5u.getConnection()) {
+            try (Statement st = con.createStatement()) {
+                st.executeUpdate("create table cities (name varchar(50) not null primary key, population int, county varchar(30))");
+            }
+        } catch (SQLException e) {
+            //Ignore, server could have been restarted. Assume table is available.
+        }
+
     }
 
     /**
@@ -266,25 +254,15 @@ public class DataSourceTestServlet extends FATServlet {
     }
 
     /**
-     * Create tables used by the tests the first time a test is run.
-     * If not the first test run, then clear the tables.
+     * clears table of all data to ensure fresh start for this test.
      *
      * @param datasource the data source to clear the table for
      */
-    public void setUpTables(DataSource datasource) throws Exception {
-
-        if (!initialized) {
-            // Create a new table in EACH of the different databases
-            createTable(ds1);
-            createTable(ds5u);
-            initialized = true;
-        }
-
-        Connection con = datasource.getConnection();
-        try {
-            con.createStatement().executeUpdate("delete from cities");
-        } finally {
-            con.close();
+    public void clearTable(DataSource datasource) throws Exception {
+        try (Connection con = datasource.getConnection()) {
+            try (Statement stmt = con.createStatement()) {
+                stmt.executeUpdate("delete from cities");
+            }
         }
 
         // End the current LTC and get a new one, so that test methods start from the correct place
@@ -296,7 +274,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Run a basic query to the database.
      */
     public void testBasicQuery() throws Exception {
-        setUpTables(ds1);
+        clearTable(ds1);
         Connection con = ds1.getConnection();
         try {
             Statement stmt = con.createStatement();
@@ -327,7 +305,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Run batch updates.
      */
     public void testBatchUpdates() throws Exception {
-        setUpTables(ds1);
+        clearTable(ds1);
         Connection con = ds1.getConnection();
         try {
             DatabaseMetaData metadata = con.getMetaData();
@@ -381,7 +359,7 @@ public class DataSourceTestServlet extends FATServlet {
      */
     public void testConfigChangeAuthData() throws Throwable {
 
-        Connection con = ds6_1.getConnection();
+        Connection con = ds5_1.getConnection();
         try {
             DatabaseMetaData metadata = con.getMetaData();
             String user = metadata.getUserName();
@@ -397,7 +375,7 @@ public class DataSourceTestServlet extends FATServlet {
      */
     public void testConfigChangeAuthDataOriginalValue() throws Throwable {
 
-        Connection con = ds6_1.getConnection();
+        Connection con = ds5_1.getConnection();
         try {
             DatabaseMetaData metadata = con.getMetaData();
             String user = metadata.getUserName();
@@ -412,7 +390,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Verify commitOrRollbackOnCleanup=commit
      */
     public void testConfigChangeCommitOnCleanup() throws Throwable {
-        setUpTables(ds3);
+        clearTable(ds3);
 
         Connection con = ds3.getConnection();
         try {
@@ -680,7 +658,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Verify commitOrRollbackOnCleanup=rollback (or defaulted to rollback for transactional=false)
      */
     public void testConfigChangeRollbackOnCleanup() throws Throwable {
-        setUpTables(ds3);
+        clearTable(ds3);
 
         Connection con = ds3.getConnection();
         try {
@@ -711,7 +689,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Verify configuration change that top level config (transactional=false)
      */
     public void testConfigChangeTransactionalFalse() throws Throwable {
-        setUpTables(ds1u);
+        clearTable(ds1u);
         PreparedStatement pstmt;
         Connection con = ds1u.getConnection();
         con.setAutoCommit(false);
@@ -767,7 +745,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Verify configuration change that sets transactional=true
      */
     public void testConfigChangeTransactionalTrue() throws Throwable {
-        setUpTables(ds1u);
+        clearTable(ds1u);
         PreparedStatement pstmt;
         Connection con = ds1u.getConnection();
         con.setAutoCommit(false);
@@ -849,7 +827,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Use a data source defined with @DataSourceDefinition
      */
     public void testDataSourceDefinition() throws Throwable {
-        setUpTables(ds6);
+        clearTable(ds6);
 
         int loginTimeout = ds6.getLoginTimeout();
         if (loginTimeout != 600)
@@ -948,7 +926,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Use data sources defined with @DataSourceDefinitions
      */
     public void testDataSourceDefinitions() throws Throwable {
-        setUpTables(ds7);
+        clearTable(ds7);
 
         int loginTimeout;
 
@@ -1076,7 +1054,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Use a data source with a mappingConfigAlias
      */
     public void testDataSourceMappingConfigAlias() throws Throwable {
-        setUpTables(dsmca);
+        clearTable(dsmca);
 
         Connection con = dsmca.getConnection();
         try {
@@ -1144,7 +1122,7 @@ public class DataSourceTestServlet extends FATServlet {
      */
     public void testEnableSharingForDirectLookupsFalse() throws Exception {
         DataSource ds = (DataSource) new InitialContext().lookup("jdbc/dsfat1");
-        setUpTables(ds);
+        clearTable(ds);
         Connection con = null;
         Connection con2 = null;
         Statement stmt = null;
@@ -1172,7 +1150,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Verify that pooled connections are properly cleaned up.
      */
     public void testConnectionCleanup() throws Exception {
-        setUpTables(ds1);
+        clearTable(ds1);
         Connection con = ds1.getConnection();
         try {
             DatabaseMetaData metadata = con.getMetaData();
@@ -1207,7 +1185,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Child JDBC resources should be closed implicitly when connection is closed.
      */
     public void testImplicitlyCloseChildren() throws Exception {
-        setUpTables(ds1);
+        clearTable(ds1);
         Connection con = ds1.getConnection();
         try {
             PreparedStatement pstmt = con.prepareStatement("insert into cities values (?, ?, ?)");
@@ -1261,7 +1239,7 @@ public class DataSourceTestServlet extends FATServlet {
     public void testIsolatedSharedLibraries() throws Throwable {
         // ds9 (DataSourceDefinition) and ds5 (a <datasource> in server.xml)
         // both use the same database.
-        setUpTables(ds5u);
+        clearTable(ds5u);
 
         // Write the value with ds9
         Connection con = ds9.getConnection();
@@ -1301,7 +1279,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Enlist a single one-phase capable resource in a global transaction with a two-phase capable resource.
      */
     public void testLastParticipant() throws Throwable {
-        setUpTables(ds1);
+        clearTable(ds1);
         // Enlist both resources and commit changes
         tran.begin();
         try {
@@ -1376,7 +1354,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Share connections for which the current state matches.
      */
     public void testMatchCurrentState() throws Throwable {
-        setUpTables(ds1);
+        clearTable(ds1);
         Connection[] cons = new Connection[2];
         try {
             cons[0] = ds1.getConnection();
@@ -1450,7 +1428,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Share connections for which the original connection request matches.
      */
     public void testMatchOriginalRequest() throws Throwable {
-        setUpTables(ds0);
+        clearTable(ds0);
         int nonDefaultIsolation;
         Connection con = ds0.getConnection();
         try {
@@ -1552,7 +1530,7 @@ public class DataSourceTestServlet extends FATServlet {
      * After the agedTimeout, the pool size should drop to 0.
      */
     public void testMinPoolSize() throws Throwable {
-        setUpTables(ds5u);
+        clearTable(ds5u);
         ClassLoader loader;
         String databaseName;
         boolean testWasNotRun = false;
@@ -1736,7 +1714,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Use a non-transactional data source.
      */
     public void testNonTransactional() throws Throwable {
-        setUpTables(ds3);
+        clearTable(ds3);
         PreparedStatement pstmt;
         Connection con = ds3.getConnection();
         try {
@@ -1792,7 +1770,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Verify than unresolved database transactions are rolled back by default.
      */
     public void testNonTransactionalCleanup() throws Throwable {
-        setUpTables(ds3);
+        clearTable(ds3);
         Connection con = ds3.getConnection();
         try {
             con.setAutoCommit(false);
@@ -1826,7 +1804,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Use multiple connections from a non-transactional data source.
      */
     public void testNonTransactionalMultipleConnections() throws Throwable {
-        setUpTables(ds3);
+        clearTable(ds3);
         Connection[] cons = new Connection[2];
         try {
             tran.begin();
@@ -2053,7 +2031,7 @@ public class DataSourceTestServlet extends FATServlet {
      * The transaction manager can use the one-phase optimization (skip prepare) when we commit.
      */
     public void testOnePhaseOptimization() throws Throwable {
-        setUpTables(ds2);
+        clearTable(ds2);
         Connection con;
 
         tran.begin();
@@ -2128,7 +2106,7 @@ public class DataSourceTestServlet extends FATServlet {
      * ConfigTest contains the code to check the logs.
      */
     public void testOnErrorWARN() throws Exception {
-        setUpTables(ds5); // ensure the other data source (dsfat5) is used first
+        clearTable(ds5); // ensure the other data source (dsfat5) is used first
 
         tran.setTransactionTimeout(60);
         try {
@@ -2240,7 +2218,7 @@ public class DataSourceTestServlet extends FATServlet {
      * connection request with TRANSACTION_READ_UNCOMMITTED from the resource ref.
      */
     public void testResourceRefIsolationLevel() throws Throwable {
-        setUpTables(ds6);
+        clearTable(ds6);
 
         tran.begin();
         try {
@@ -2284,7 +2262,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Use ResultSetMetaData.
      */
     public void testResultSetMetaData() throws Exception {
-        setUpTables(ds2);
+        clearTable(ds2);
 
         Connection con = ds2.getConnection();
         try {
@@ -2323,7 +2301,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Run a test to check if DataSource de/serializes correctly.
      */
     public void testSerialization() throws Exception {
-        setUpTables(ds1);
+        clearTable(ds1);
 
         DataSource testSource = ds1;
         Connection con = testSource.getConnection();
@@ -2359,7 +2337,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Serial reuse of one-phase capable connection in a global transaction.
      */
     public void testSerialReuseInGlobalTran() throws Throwable {
-        setUpTables(ds0);
+        clearTable(ds0);
         tran.begin();
         try {
             Connection con = ds0.getConnection();
@@ -2392,7 +2370,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Serial reuse of shared connection in an LTC
      */
     public void testSerialReuseInLTC() throws Throwable {
-        setUpTables(ds1);
+        clearTable(ds1);
         Connection con = ds1.getConnection();
         try {
             con.setAutoCommit(false);
@@ -2440,7 +2418,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Verify that sharable handles are reassociated across transaction boundaries.
      */
     public void testSharableHandleReassociation() throws Throwable {
-        setUpTables(ds1);
+        clearTable(ds1);
         Connection[] cons = new Connection[2];
         try {
             cons[0] = ds1.getConnection();
@@ -2582,7 +2560,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Share a connection in a global transaction.
      */
     public void testSharingInGlobalTran() throws Throwable {
-        setUpTables(ds0);
+        clearTable(ds0);
         tran.begin();
         try {
             Connection con0 = ds0.getConnection();
@@ -2617,7 +2595,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Verify that cached statements are properly cleaned up.
      */
     public void testStatementCleanup() throws Exception {
-        setUpTables(ds1);
+        clearTable(ds1);
         Connection con = ds1.getConnection();
         try {
             PreparedStatement pstmt = con.prepareStatement("insert into cities values (?, ?, ?)");
@@ -2649,7 +2627,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Unsharable data source should allow statements to remain open across transactions.
      */
     public void testStatementsAcrossTranBoundaries() throws Throwable {
-        setUpTables(ds1u);
+        clearTable(ds1u);
         Connection con = ds1u.getConnection();
         try {
             Statement stmt = con.createStatement();
@@ -2780,7 +2758,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Use two-phase commit.
      */
     public void testTwoPhaseCommit() throws Throwable {
-        setUpTables(ds4);
+        clearTable(ds4);
         Connection con1, con2;
 
         // Commit some updates to the database
@@ -2859,7 +2837,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Roll one back and commit the other.
      */
     public void testTwoTransactions() throws Exception {
-        setUpTables(ds1);
+        clearTable(ds1);
         Connection[] cons = new Connection[2];
         try {
             cons[0] = ds1.getConnection();
@@ -2912,7 +2890,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Verify that sharable and unsharable connections don't share with eachother.
      */
     public void testUnsharable() throws Throwable {
-        setUpTables(ds1);
+        clearTable(ds1);
         Connection con = ds1.getConnection(); // sharable
         try {
             con.setAutoCommit(false);
@@ -2964,7 +2942,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Update a result set.
      */
     public void testUpdatableResult() throws Exception {
-        setUpTables(ds2);
+        clearTable(ds2);
         Connection con = ds2.getConnection();
         try {
             DatabaseMetaData metadata = con.getMetaData();
@@ -3039,7 +3017,7 @@ public class DataSourceTestServlet extends FATServlet {
      * The recoveryAuthData should be used for recovery.
      */
     public void testXARecovery() throws Throwable {
-        setUpTables(ds4u_2);
+        clearTable(ds4u_2);
         Connection[] cons = new Connection[3];
         tran.begin();
         try {
@@ -3119,6 +3097,7 @@ public class DataSourceTestServlet extends FATServlet {
 
         System.out.println("attempting to access data (only possible after recovery)");
         Connection con = ds4u_8.getConnection();
+
         String dbProductName = con.getMetaData().getDatabaseProductName().toUpperCase();
         if (dbProductName.contains("INFORMIX") || dbProductName.contains("IDS")) {
             // set lock mode to wait for 60 seconds
@@ -3134,22 +3113,41 @@ public class DataSourceTestServlet extends FATServlet {
             ResultSet result;
             PreparedStatement pstmt = con.prepareStatement("select name, population, county from cities where name = ?");
 
-            pstmt.setString(1, "Edina");
-            result = pstmt.executeQuery();
-            if (!result.next())
-                throw new Exception("Missing first entry in database.");
+            /*
+             * Poll for results once a second for 5 seconds.
+             * Most databases will have XA recovery done by this point
+             *
+             */
+            List<String> cities = new ArrayList<>();
+            for (int count = 0; cities.size() < 3 && count < 5; Thread.sleep(1000)) {
+                if (!cities.contains("Edina")) {
+                    pstmt.setString(1, "Edina");
+                    result = pstmt.executeQuery();
+                    if (result.next())
+                        cities.add(0, "Edina");
+                }
 
-            pstmt.setString(1, "St. Louis Park");
-            result = pstmt.executeQuery();
-            if (!result.next())
-                throw new Exception("Missing second entry in database.");
+                if (!cities.contains("St. Louis Park")) {
+                    pstmt.setString(1, "St. Louis Park");
+                    result = pstmt.executeQuery();
+                    if (result.next())
+                        cities.add(1, "St. Louis Park");
+                }
 
-            pstmt.setString(1, "Moorhead");
-            result = pstmt.executeQuery();
-            if (!result.next())
-                throw new Exception("Missing third entry in database.");
+                if (!cities.contains("Moorhead")) {
+                    pstmt.setString(1, "Moorhead");
+                    result = pstmt.executeQuery();
+                    if (result.next())
+                        cities.add(2, "Moorhead");
+                }
+                count++;
+                System.out.println("Attempt " + count + " to retrieve recovered XA data. Current status: " + cities);
+            }
 
-            System.out.println("successfully accessed the data");
+            if (cities.size() < 3)
+                throw new Exception("Missing entry in database. Results: " + cities);
+            else
+                System.out.println("successfully accessed the data");
         } finally {
             con.close();
         }
@@ -3282,7 +3280,7 @@ public class DataSourceTestServlet extends FATServlet {
      * Use multiple databases in an XA transaction.
      */
     public void testXAWithMultipleDatabases() throws Throwable {
-        setUpTables(ds5u);
+        clearTable(ds5u);
         Connection con1 = ds5u.getConnection();
         try {
             // Commit updates to the database

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 IBM Corporation and others.
+ * Copyright (c) 2011, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -292,6 +292,8 @@ public class LibertyServer implements LogMonitorClient {
 
     private boolean needsPostTestRecover = true;
 
+    private boolean logOnUpdate = true;
+
     protected boolean debuggingAllowed = true;
 
     /**
@@ -314,6 +316,14 @@ public class LibertyServer implements LogMonitorClient {
      */
     public void setDebuggingAllowed(boolean debuggingAllowed) {
         this.debuggingAllowed = debuggingAllowed;
+    }
+
+    public boolean isLogOnUpdate() {
+        return logOnUpdate;
+    }
+
+    public void setLogOnUpdate(boolean logOnUpdate) {
+        this.logOnUpdate = logOnUpdate;
     }
 
     /**
@@ -4185,7 +4195,7 @@ public class LibertyServer implements LogMonitorClient {
         // above. Even if the timestamp would not be changed, the size out be.
         LibertyFileManager.moveLibertyFile(newServerFile, file);
 
-        if (LOG.isLoggable(Level.INFO)) {
+        if (LOG.isLoggable(Level.INFO) && logOnUpdate) {
             LOG.info("Server configuration updated:");
             logServerConfiguration(Level.INFO, false);
         }


### PR DESCRIPTION
It was found that during XA recovery Postgres (even when using isolation level Serializable) will return results for any connections that were commited, while not returning results for those that are in-doubt (that is in recovery).  And that Postgres takes a little bit longer than other databases to perform recovery

Therefore, that test has been changed to poll that database once a second for 5 seconds.  This should give postgres enough time to perform XA recovery. 

Also suppressed logs of server config changes at the end of tests as this was bloating the output.txt file and not displaying anything useful. 

Finally, decided to create the database table during the `init` phase of the servlet so that we can guarantee the table will be available for the app.
