### PR TITLE
Sleep for 600ms so that Windows boxes will report sleep was >= 500.

### DIFF
--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/MyGraphQLEndpoint.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/MyGraphQLEndpoint.java
@@ -37,7 +37,8 @@ public class MyGraphQLEndpoint {
     public List<Widget> getTimeWidget() {
         long startTime = System.nanoTime();
         try {
-            Thread.sleep(500);
+            Thread.sleep(600); // really should only sleep 500 ms, but some JVMs end up sleeping under
+                               // that (or nanoTime() reports it is under)
         } catch (InterruptedException iex) {
             iex.printStackTrace();
         }


### PR DESCRIPTION
Working around a bug in Windows JDKs where Thread.sleep(500) sleeps for less than 500 milliseconds (or that System.nanoTime() called before and after the sleep reports less than 500ms elapsed).