### PR TITLE
Enable postgres and sqlserver tests where able

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/DataSourceTest.java
+++ b/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/DataSourceTest.java
@@ -24,7 +24,6 @@ import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.JdbcDatabaseContainer;
@@ -57,7 +56,6 @@ public class DataSourceTest extends FATServletClient {
     private static final String dsdfat = "dsdfat";
     private static final String dsdfat_global_lib = "dsdfat_global_lib";
 
-    @ClassRule
     public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
 
     //Server used for ConfigTest.java and DataSourceTest.java
@@ -66,6 +64,13 @@ public class DataSourceTest extends FATServletClient {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        // Need to set the default number of prepared transactions if working with Postgres
+        if (DatabaseContainerType.valueOf(testContainer) == DatabaseContainerType.Postgres) {
+            testContainer.withCommand("postgres -c max_prepared_transactions=5");
+        }
+
+        testContainer.start(); // Start the test container
+
         // Delete the Derby database that might be left over from last run
         Machine machine = server.getMachine();
         String installRoot = server.getInstallRoot();
@@ -110,6 +115,7 @@ public class DataSourceTest extends FATServletClient {
                           "WTRN0062E", //expected by testEnableSharingForDirectLookupsFalse
                           "J2CA0030E", //expected by testEnableSharingForDirectLookupsFalse
                           "CWWKE0701E"); //expected by testReapTimeUnsupportedValue
+        testContainer.stop(); // Stop the test container
     }
 
     /**
@@ -185,10 +191,9 @@ public class DataSourceTest extends FATServletClient {
     }
 
     @Test
-    @SkipIfSysProp({
-                     DB_Postgres, //TODO figure out why test fails with Postgres
-                     DB_SQLServer //TODO figure out why test stalls using SQLServer
-    })
+    @SkipIfSysProp({ DB_SQLServer }) // TODO
+    // This test does not work for SQLServer yet.  It might be a problem with the Docker version of SQLServer
+    // So we have opened up an issue with Microsoft to investigate further -> https://github.com/microsoft/mssql-docker/issues/554
     public void testLastParticipant() throws Exception {
         runTest();
     }
@@ -282,10 +287,9 @@ public class DataSourceTest extends FATServletClient {
     }
 
     @Test
-    @SkipIfSysProp({
-                     DB_Postgres, //TODO figure out why test fails with Postgres
-                     DB_SQLServer //TODO figure out why test stalls using SQLServer
-    })
+    @SkipIfSysProp({ DB_SQLServer }) //TODO figure out why test stalls using SQLServer
+    // This test does not work for SQLServer yet.  It might be a problem with the Docker version of SQLServer
+    // So we have opened up an issue with Microsoft to investigate further -> https://github.com/microsoft/mssql-docker/issues/554
     public void testTwoPhaseCommit() throws Exception {
         runTest();
     }
@@ -322,7 +326,7 @@ public class DataSourceTest extends FATServletClient {
     @AllowedFFDC({ "com.ibm.ws.rsadapter.exceptions.DataStoreAdapterException", "javax.transaction.xa.XAException" })
     @SkipIfSysProp({
                      DB_Oracle,
-                     DB_Postgres //TODO figure out why test fails with Postgres
+                     DB_Postgres //TODO Fails with Exception "Missing second entry in database." thrown from line 3154 in DataSourceTestServlet.testXARecovery:3154
     })
     public void testXARecovery() throws Exception {
         runTest();
@@ -335,7 +339,6 @@ public class DataSourceTest extends FATServletClient {
     }
 
     @Test
-    @SkipIfSysProp(DB_Postgres) //TODO figure out why test fails with Postgres
     public void testXAWithMultipleDatabases() throws Exception {
         runTest();
     }

--- a/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.fat/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.fat/server.xml
@@ -261,6 +261,10 @@
 	<javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers" />
 	<!-- Postgres and SQLServer permission to make a basic query-->
 	<javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
+
+	<!-- Postgres permission during commit cycle -->
+	<javaPermission className="org.osgi.framework.ServicePermission" name="*" actions="get"/>
+	<javaPermission className="javax.security.auth.PrivateCredentialPermission"  name='* * "*"' actions="read" />
 	
     <variable name="onError" value="FAIL"/>
 </server>

--- a/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.jaas.fat/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.jaas.fat/server.xml
@@ -247,9 +247,11 @@
     
     <!-- Postgres JDBC test requirement -->
     <javaPermission className="java.util.PropertyPermission" name="org.postgresql.forceBinary" actions="read"/>
+    <javaPermission className="javax.security.auth.PrivateCredentialPermission"  name='* * "*"' actions="read" />
     
     <!-- SQLServer JDBC test requirement -->
     <javaPermission className="java.util.PropertyPermission" name="java.specification.version" actions="read"/>
+    <javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
     
     <variable name="onError" value="FAIL"/>
 </server>


### PR DESCRIPTION
All the Postgres tests work now, with the exception of one (DataSourceTest:testXARecovery), which Kyle will be fixing after I get this branch checked in.