### PR TITLE
initial dbtaskstore methods to create, read, and update the partition entry for polling

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/Config.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/Config.java
@@ -53,6 +53,11 @@ class Config {
     final long missedTaskThreshold;
 
     /**
+     * Experimental attribute that causes a single poll interval to be coordinated across multiple instances when fail over is also enabled.
+     */
+    final boolean pollingCoordination;
+
+    /**
      * Interval between polling for tasks to run. A value of -1 means auto-compute a poll interval.
      * When fail over is disabled, the -1 value disables all polling after the initial poll.
      */
@@ -88,6 +93,7 @@ class Config {
         initialPollDelay = (Long) properties.get("initialPollDelay");
         missedTaskThreshold = (Long) properties.get("missedTaskThreshold");
         Long pollIntrvl = enableTaskExecution ? (Long) properties.get("pollInterval") : null;
+        pollingCoordination = missedTaskThreshold > 0 && Boolean.parseBoolean((String) properties.get("pollingCoordination.for.test.use.only")); // NOT SUPPORTED for production use
         pollSize = enableTaskExecution ? (Integer) properties.get("pollSize") : null;
         Long retryIntrvl = (Long) properties.get("retryInterval");
         retryLimit = (Short) properties.get("retryLimit");

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
@@ -2294,9 +2294,10 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
                 tranMgr.begin();
                 try {
                     // TODO implement this method. For now, we invoke some basic db operations to demonstrate that what we have so far is working
-                    Object result = taskStore.findPollInfoForUpdate(pollPartitionId);
-                    taskStore.updatePollInfo(pollPartitionId, System.currentTimeMillis() + config.pollInterval,
-                                             "TODO: compute with the previous parameter and do something with " + result);
+                    Object[] expiryAndLastUpdated = taskStore.findPollInfoForUpdate(pollPartitionId);
+                    long expiry = (Long) expiryAndLastUpdated[0];
+                    long lastUpdated = (Long) expiryAndLastUpdated[1];
+                    taskStore.updatePollInfo(pollPartitionId, System.currentTimeMillis() + config.pollInterval);
                     delay = config.pollInterval;
                     successful = true;
                 } finally {

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskStore.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskStore.java
@@ -163,10 +163,10 @@ public interface TaskStore {
      * Reads information from the partition entry for polling coordination and obtains a write lock on it.
      *
      * @param partitionId unique identifier of the partition entry for polling coordination.
-     * @return TODO specify precise type for return value and document here
+     * @return size 2 array where the first element is the expiry (type <code>long</code>) and the second is the last-updated timestamp (type <code>long</code>).
      * @throws Exception if an error occurs accessing the persistent store.
      */
-    Object findPollInfoForUpdate(long partitionId) throws Exception;
+    Object[] findPollInfoForUpdate(long partitionId) throws Exception;
 
     /**
      * Find all task IDs for tasks that match the specified name pattern and the presence or absence
@@ -390,13 +390,12 @@ public interface TaskStore {
     int transfer(Long maxTaskId, long oldPartitionId, long newPartitionId) throws Exception;
 
     /**
-     * Reads information from the partition entry for polling coordination.
+     * Writes a new expiry and last-updated timestamp to the partition entry for polling coordination.
      *
      * @param partitionId unique identifier of the partition entry for polling coordination.
      * @param newExpiry   the new expiry value to use.
-     * @param otherStuff  TODO what we need will depend on the algorithm that is chosen
      * @return true if the partition entry for polling was updated. Otherwise false.
      * @throws Exception if an error occurs accessing the persistent store.
      */
-    boolean updatePollInfo(long partitionId, long newExpiry, String otherStuff) throws Exception;
+    boolean updatePollInfo(long partitionId, long newExpiry) throws Exception;
 }

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskStore.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/wsspi/concurrent/persistent/TaskStore.java
@@ -151,6 +151,24 @@ public interface TaskStore {
     long findOrCreate(PartitionRecord record) throws Exception;
 
     /**
+     * Creates a dedicated partition record to be used for partitioning out poll attempts across multiple instances.
+     * Only use this when missedTaskTheshold is enabled and pollInterval is unspecified, which means Liberty determines it automatically.
+     *
+     * @return unique identifier for the partition record to be used for coordination of automatically determined polling.
+     * @throws Exception if an error occurs when attempting to access the persistent task store.
+     */
+    long findOrCreatePollPartition() throws Exception;
+
+    /**
+     * Reads information from the partition entry for polling coordination and obtains a write lock on it.
+     *
+     * @param partitionId unique identifier of the partition entry for polling coordination.
+     * @return TODO specify precise type for return value and document here
+     * @throws Exception if an error occurs accessing the persistent store.
+     */
+    Object findPollInfoForUpdate(long partitionId) throws Exception;
+
+    /**
      * Find all task IDs for tasks that match the specified name pattern and the presence or absence
      * (as determined by the inState attribute) of the specified state.
      * For example, to find taskIDs for the first 100 tasks belonging to app1 in partition 12 that have not completed all executions
@@ -370,4 +388,15 @@ public interface TaskStore {
      * @throws Exception if an error occurs when attempting to update the persistent task store.
      */
     int transfer(Long maxTaskId, long oldPartitionId, long newPartitionId) throws Exception;
+
+    /**
+     * Reads information from the partition entry for polling coordination.
+     *
+     * @param partitionId unique identifier of the partition entry for polling coordination.
+     * @param newExpiry   the new expiry value to use.
+     * @param otherStuff  TODO what we need will depend on the algorithm that is chosen
+     * @return true if the partition entry for polling was updated. Otherwise false.
+     * @throws Exception if an error occurs accessing the persistent store.
+     */
+    boolean updatePollInfo(long partitionId, long newExpiry, String otherStuff) throws Exception;
 }


### PR DESCRIPTION
Put the basic infrastructure in place to initialize a partition entry to be used for coordination of polling.  Fit this in so that it can start computing the delay until the next poll, once implemented.  For now, the function is guarded with a hidden property to be used only by tests.