### PR TITLE
Disable Timer and Meter tests for Windows platforms due to anomolous java behaviour

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -198,5 +198,44 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
+                        <configuration>
+                            <systemProperties>
+                                <property>
+                                    <name>java.util.logging.config.file</name>
+                                    <value>${project.basedir}/../../../../../../fat/resources/logging.properties</value>
+                                </property>
+                            </systemProperties>
+                            <systemPropertyVariables>
+                                <wlp>${wlp}</wlp>
+                                <tck_server>${tck_server}</tck_server>
+                                <tck_port>${tck_port}</tck_port>
+                                <sun.rmi.transport.tcp.responseTimeout>${sun.rmi.transport.tcp.responseTimeout}</sun.rmi.transport.tcp.responseTimeout>
+                            </systemPropertyVariables>
+                            <dependenciesToScan>
+                                <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-rest-tck</dependency>
+                                <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-api-tck</dependency>
+                            </dependenciesToScan>
+                            <excludes>
+                                <exclude>**/TimerTest.java</exclude>
+                                <exclude>**/MeterTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/dev/com.ibm.ws.microprofile.metrics.2.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -198,5 +198,44 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
+                        <configuration>
+                            <systemProperties>
+                                <property>
+                                    <name>java.util.logging.config.file</name>
+                                    <value>${project.basedir}/../../../../../../fat/resources/logging.properties</value>
+                                </property>
+                            </systemProperties>
+                            <systemPropertyVariables>
+                                <wlp>${wlp}</wlp>
+                                <tck_server>${tck_server}</tck_server>
+                                <tck_port>${tck_port}</tck_port>
+                                <sun.rmi.transport.tcp.responseTimeout>${sun.rmi.transport.tcp.responseTimeout}</sun.rmi.transport.tcp.responseTimeout>
+                            </systemPropertyVariables>
+                            <dependenciesToScan>
+                                <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-rest-tck</dependency>
+                                <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-api-tck</dependency>
+                            </dependenciesToScan>
+                            <excludes>
+                                <exclude>**/TimerTest.java</exclude>
+                                <exclude>**/MeterTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/dev/com.ibm.ws.microprofile.metrics.2.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -198,5 +198,44 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
+                        <configuration>
+                            <systemProperties>
+                                <property>
+                                    <name>java.util.logging.config.file</name>
+                                    <value>${project.basedir}/../../../../../../fat/resources/logging.properties</value>
+                                </property>
+                            </systemProperties>
+                            <systemPropertyVariables>
+                                <wlp>${wlp}</wlp>
+                                <tck_server>${tck_server}</tck_server>
+                                <tck_port>${tck_port}</tck_port>
+                                <sun.rmi.transport.tcp.responseTimeout>${sun.rmi.transport.tcp.responseTimeout}</sun.rmi.transport.tcp.responseTimeout>
+                            </systemPropertyVariables>
+                            <dependenciesToScan>
+                                <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-rest-tck</dependency>
+                                <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-api-tck</dependency>
+                            </dependenciesToScan>
+                            <excludes>
+                                <exclude>**/TimerTest.java</exclude>
+                                <exclude>**/MeterTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
#build 
fixes #6400

The problem in #6400 affects Windows platforms only.
This is due to anomalous java behavior (dependent on java version) based on @kabicin research.