### PR TITLE
Ensure LTPA Keys are created before hitting https endpoint

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.2.0.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -80,7 +80,7 @@ public class TestEnableDisableFeaturesTest {
     
     private static LibertyServer currentServ;
     
-    
+    private static boolean serverEDF6FirstUse = true;
     
     @BeforeClass
     public static void setUp() throws Exception {
@@ -157,8 +157,8 @@ public class TestEnableDisableFeaturesTest {
         Log.info(c, testName, "------- No monitor-1.0: no vendor metrics should be available ------");
         serverEDF1.setServerConfigurationFile("server_mpMetric20.xml");
         serverEDF1.startServer();
-        Assert.assertNotNull("Web application /metrics not loaded", serverEDF1.waitForStringInLog("CWWKT0016I: Web application available \\(default_host\\): http:\\/\\/.*:.*\\/metrics\\/"));
-        Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF1.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+        waitForSecurityPrerequisites(serverEDF1, 60000);
+        Assert.assertNotNull("Web application /metrics not loaded", serverEDF1.waitForStringInLog("CWWKT0016I.*http:\\/\\/.*:.*\\/metrics\\/"));
         Assert.assertNotNull("SRVE9103I NOT FOUND",serverEDF1.waitForStringInLogUsingMark("SRVE9103I"));
         Log.info(c, testName, "------- server started -----");
         checkStrings(getHttpsServlet("/metrics", serverEDF1), 
@@ -172,7 +172,7 @@ public class TestEnableDisableFeaturesTest {
     	String testName = "testEDF2";
     	Log.info(c, testName, "------- Enable mpMetrics-2.0 and monitor-1.0: threadpool metrics should be available ------");
     	serverEDF2.startServer();
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF2.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	waitForSecurityPrerequisites(serverEDF2, 60000);
     	serverEDF2.setServerConfigurationFile("server_monitor2.xml");
     	// CWMPI2003I is for mpMetrics-2.0 and monitor-1.0; CWMPI2001I is for mpMetrics-1.x and monitor-1.0
         String logMsg = serverEDF2.waitForStringInLogUsingMark("CWPMI2003I");
@@ -196,7 +196,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF3;
     	String testName = "testEDF3";
     	serverEDF3.startServer();
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF3.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	waitForSecurityPrerequisites(serverEDF3, 60000);
     	Log.info(c, testName, "------- Add session application and run session servlet ------");
        	ShrinkHelper.defaultDropinApp(serverEDF3, "testSessionApp", "com.ibm.ws.microprofile.metrics.monitor_fat.session.servlet");
        	Log.info(c, testName, "------- added testSessionApp to dropins -----");
@@ -217,7 +217,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF4;
     	String testName = "testEDF4";
     	serverEDF4.startServer();
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF4.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	waitForSecurityPrerequisites(serverEDF4, 60000);
     	Log.info(c, testName, "------- Add session application ------");
        	ShrinkHelper.defaultDropinApp(serverEDF4, "testSessionApp", "com.ibm.ws.microprofile.metrics.monitor_fat.session.servlet");
        	Log.info(c, testName, "------- added testSessionApp to dropins -----");
@@ -255,11 +255,11 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF5;
     	String testName = "testEDF5";
     	serverEDF5.startServer();
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF5.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	waitForSecurityPrerequisites(serverEDF5, 60000);
     	Log.info(c, testName, "------- Add jax-ws endpoint application and run jax-ws client servlet ------");
        	ShrinkHelper.defaultDropinApp(serverEDF5, "testJaxWsApp", "com.ibm.ws.microprofile.metrics.monitor_fat.jaxws","com.ibm.ws.microprofile.metrics.monitor_fat.jaxws.client");
        	Log.info(c, testName, "------- added testJaxWsApp to dropins -----");
-        Assert.assertNotNull("Application testJaxWsApp started",serverEDF5.waitForStringInLogUsingMark("Application testJaxWsApp started"));
+       	Assert.assertNotNull("Application testJaxWsApp not started",serverEDF5.waitForStringInLogUsingMark("CWWKZ0001I.*testJaxWsApp.*"));
       	checkStrings(getHttpServlet("/testJaxWsApp/SimpleStubClientServlet",serverEDF5),
        		new String[] { "Pass" }, new String[] {});
        	Log.info(c, testName, "------- jax-ws metrics should be available ------");
@@ -284,7 +284,15 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF6;
     	String testName = "testEDF6";
     	serverEDF6.startServer();
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF6.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	
+    	if (serverEDF6FirstUse) {
+    		// We only need to wait for LTPA keys if this is the first time using this server
+    		waitForSecurityPrerequisites(serverEDF6, 60000);
+    	} else {
+    		Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",serverEDF6.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl",60000));
+    	}
+    	serverEDF6FirstUse = false;
+    	
     	Log.info(c, testName, "------- Monitor filter ThreadPool and WebContainer  ------");
     	serverEDF6.setServerConfigurationFile("server_monitorFilter1.xml");
         Assert.assertNotNull("CWWKG0017I NOT FOUND",serverEDF6.waitForStringInLogUsingMark("CWWKG0017I"));
@@ -301,7 +309,15 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF6;
     	String testName = "testEDF7";
     	serverEDF6.startServer();
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF6.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	
+    	if (serverEDF6FirstUse) {
+    		// We only need to wait for LTPA keys if this is the first time using this server
+    		waitForSecurityPrerequisites(serverEDF6, 60000);
+    	} else {
+    		Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",serverEDF6.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl",60000));
+    	}
+    	serverEDF6FirstUse = false;
+    	
     	Log.info(c, testName, "------- Monitor filter WebContainer and Session ------");
        	serverEDF6.setMarkToEndOfLog();
        	serverEDF6.setServerConfigurationFile("server_monitorFilter2.xml");
@@ -319,7 +335,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF8;
     	String testName = "testEDF8";
     	serverEDF8.startServer();
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF8.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	waitForSecurityPrerequisites(serverEDF8, 60000);
     	checkStrings(getHttpServlet("/testJDBCApp/testJDBCServlet?operation=create", serverEDF8), 
           		new String[] { "sql: create table cities" }, new String[] {});
     	Log.info(c, testName, "------- Monitor filter Session and ConnectionPool ------");
@@ -338,7 +354,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF9;
     	String testName = "testEDF9";
     	serverEDF9.startServer();
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF9.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	waitForSecurityPrerequisites(serverEDF9, 60000);
     	checkStrings(getHttpServlet("/testJDBCApp/testJDBCServlet?operation=create", serverEDF9), 
           		new String[] { "sql: create table cities" }, new String[] {});
     	Log.info(c, testName, "------- Monitor filter ThreadPool, WebContainer, Session and ConnectionPool ------");
@@ -349,8 +365,8 @@ public class TestEnableDisableFeaturesTest {
  	    		new String[] { "Session id:" }, new String[] {});
  	    checkStrings(getHttpServlet("/testJDBCApp/testJDBCServlet?operation=select&city=city1&id=id1",serverEDF9), 
  			    new String[] { "sql: select" }, new String[] {});
- 	     Log.info(c, testName, "------- all four vendor metrics should be available ------");
- 	     checkStrings(getHttpsServlet("/metrics/vendor",serverEDF9), 
+ 	    Log.info(c, testName, "------- all four vendor metrics should be available ------");
+ 	    checkStrings(getHttpsServlet("/metrics/vendor",serverEDF9), 
  		        new String[] {"vendor_threadpool", "vendor_servlet", "vendor_session", "vendor_connectionpool" }, 
  		        new String[] {});
     }
@@ -360,16 +376,16 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF10;
     	String testName = "testEDF10";
     	serverEDF10.startServer();
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF10.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	waitForSecurityPrerequisites(serverEDF10, 60000);
     	Log.info(c, testName, "------- Remove JAX-WS application ------");
     	boolean rc1 = serverEDF10.removeAndStopDropinsApplications("testJaxWsApp.war");
     	Log.info(c, testName, "------- " + (rc1 ? "successfully removed" : "failed to remove") + " JAX-WS application ------");
-    	Assert.assertNotNull("CWWKT0017I NOT FOUND",serverEDF10.waitForStringInLogUsingMark(".*CWWKT0017I.*testJaxWsApp.*"));
+    	Assert.assertNotNull("CWWKT0017I NOT FOUND",serverEDF10.waitForStringInLogUsingMark("CWWKT0017I.*testJaxWsApp.*"));
     	serverEDF10.setMarkToEndOfLog();
     	serverEDF10.setServerConfigurationFile("server_noJaxWs.xml");
     	Assert.assertNotNull("CWWKF0008I NOT FOUND",serverEDF10.waitForStringInLogUsingMark("CWWKF0008I"));
-    	Assert.assertNotNull("testJDBCApp not loaded", serverEDF10.waitForStringInLog("CWWKT0016I: Web application available .*testJDBCApp.*"));
-        Assert.assertNotNull("testSessionApp not loaded", serverEDF10.waitForStringInLog("CWWKT0016I: Web application available .*testSessionApp.*"));
+    	Assert.assertNotNull("testJDBCApp not loaded", serverEDF10.waitForStringInLog("CWWKT0016I.*testJDBCApp.*"));
+        Assert.assertNotNull("testSessionApp not loaded", serverEDF10.waitForStringInLog("CWWKT0016I.*testSessionApp.*"));
     	Log.info(c, testName, "------- jax-ws metrics should not be available ------");
     	checkStrings(getHttpsServlet("/metrics/vendor",serverEDF10), 
     		new String[] { "vendor_" }, 
@@ -381,7 +397,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF11;
     	String testName = "testEDF11";
     	serverEDF11.startServer();
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF11.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	waitForSecurityPrerequisites(serverEDF11, 60000);
     	Log.info(c, testName, "------- Remove JDBC application ------");
     	boolean rc2 = serverEDF11.removeAndStopDropinsApplications("testJDBCApp.war");
     	Log.info(c, testName, "------- " + (rc2 ? "successfully removed" : "failed to remove") + " JDBC application ------");
@@ -399,7 +415,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF12;
     	String testName = "testEDF12";
     	serverEDF12.startServer();
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF12.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	waitForSecurityPrerequisites(serverEDF12, 60000);
     	Assert.assertNotNull("CWWKF0011I NOT FOUND",serverEDF12.waitForStringInLogUsingMark("CWWKF0011I"));
     	Log.info(c, testName, "------- Remove monitor-1.0 ------");
     	serverEDF12.setMarkToEndOfLog();
@@ -409,6 +425,15 @@ public class TestEnableDisableFeaturesTest {
     	checkStrings(getHttpsServlet("/metrics",serverEDF12), 
     		new String[] {}, 
     		new String[] { "vendor_" });
+    }
+    
+    private void waitForSecurityPrerequisites(LibertyServer server, int timeout) {
+    	// Need to ensure LTPA keys and configuration are created before hitting a secure endpoint
+        Assert.assertNotNull("LTPA keys are not created within timeout period of " + timeout + "ms.", server.waitForStringInLog("CWWKS4104A",timeout));
+        Assert.assertNotNull("LTPA configuration is not ready within timeout period of " + timeout + "ms.", server.waitForStringInLog("CWWKS4105I",timeout));
+
+        // Ensure defaultHttpEndpoint-ssl TCP Channel is started
+        Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",server.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl",timeout));
     }
     
     private String getHttpServlet(String servletPath, LibertyServer server) throws Exception {

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -157,8 +157,8 @@ public class TestEnableDisableFeaturesTest {
         Log.info(c, testName, "------- No monitor-1.0: no vendor metrics should be available ------");
         serverEDF1.setServerConfigurationFile("server_mpMetric11.xml");
         serverEDF1.startServer();
-        Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF1.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
-        Assert.assertNotNull("Web application /metrics not loaded", serverEDF1.waitForStringInLog("CWWKT0016I: Web application available \\(default_host\\): http:\\/\\/.*:.*\\/metrics\\/"));
+        waitForSecurityPrerequisites(serverEDF1, 60000);
+        Assert.assertNotNull("Web application /metrics not loaded", serverEDF1.waitForStringInLog("CWWKT0016I.*http:\\/\\/.*:.*\\/metrics\\/"));
         Assert.assertNotNull("SRVE9103I NOT FOUND",serverEDF1.waitForStringInLogUsingMark("SRVE9103I"));
         Log.info(c, testName, "------- server started -----");
         checkStrings(getHttpsServlet("/metrics", serverEDF1), 
@@ -172,7 +172,7 @@ public class TestEnableDisableFeaturesTest {
     	String testName = "testEDF2";
     	Log.info(c, testName, "------- Enable mpMetrics-1.1 and monitor-1.0: threadpool metrics should be available ------");
     	serverEDF2.startServer();
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF2.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	waitForSecurityPrerequisites(serverEDF2, 60000);
     	serverEDF2.setServerConfigurationFile("server_monitor.xml");
         String logMsg = serverEDF2.waitForStringInLogUsingMark("CWPMI2001I");
         Log.info(c, testName, logMsg);
@@ -194,7 +194,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF3;
     	String testName = "testEDF3";
     	serverEDF3.startServer();
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF3.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	waitForSecurityPrerequisites(serverEDF3, 60000);
     	Log.info(c, testName, "------- Add session application and run session servlet ------");
        	ShrinkHelper.defaultDropinApp(serverEDF3, "testSessionApp", "com.ibm.ws.microprofile.metrics.monitor_fat.session.servlet");
        	Log.info(c, testName, "------- added testSessionApp to dropins -----");
@@ -215,7 +215,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF4;
     	String testName = "testEDF4";
     	serverEDF4.startServer();
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF4.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	waitForSecurityPrerequisites(serverEDF4, 60000);
     	Log.info(c, testName, "------- Add session application ------");
        	ShrinkHelper.defaultDropinApp(serverEDF4, "testSessionApp", "com.ibm.ws.microprofile.metrics.monitor_fat.session.servlet");
        	Log.info(c, testName, "------- added testSessionApp to dropins -----");
@@ -253,11 +253,11 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF5;
     	String testName = "testEDF5";
     	serverEDF5.startServer();
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF5.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	waitForSecurityPrerequisites(serverEDF5, 60000);
     	Log.info(c, testName, "------- Add jax-ws endpoint application and run jax-ws client servlet ------");
        	ShrinkHelper.defaultDropinApp(serverEDF5, "testJaxWsApp", "com.ibm.ws.microprofile.metrics.monitor_fat.jaxws","com.ibm.ws.microprofile.metrics.monitor_fat.jaxws.client");
        	Log.info(c, testName, "------- added testJaxWsApp to dropins -----");
-        Assert.assertNotNull("Application testJaxWsApp started",serverEDF5.waitForStringInLogUsingMark("Application testJaxWsApp started"));
+        Assert.assertNotNull("Application testJaxWsApp not started",serverEDF5.waitForStringInLogUsingMark("CWWKZ0001I.*testJaxWsApp.*"));
       	checkStrings(getHttpServlet("/testJaxWsApp/SimpleStubClientServlet",serverEDF5),
        		new String[] { "Pass" }, new String[] {});
        	Log.info(c, testName, "------- jax-ws metrics should be available ------");
@@ -282,7 +282,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF6;
     	String testName = "testEDF6";
     	serverEDF6.startServer();
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF6.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	waitForSecurityPrerequisites(serverEDF6, 60000);
     	Log.info(c, testName, "------- Monitor filter ThreadPool and WebContainer  ------");
     	serverEDF6.setServerConfigurationFile("server_monitorFilter1.xml");
         Assert.assertNotNull("CWWKG0017I NOT FOUND",serverEDF6.waitForStringInLogUsingMark("CWWKG0017I"));
@@ -299,7 +299,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF6;
     	String testName = "testEDF7";
     	serverEDF6.startServer();
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF6.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",serverEDF6.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- Monitor filter WebContainer and Session ------");
        	serverEDF6.setMarkToEndOfLog();
        	serverEDF6.setServerConfigurationFile("server_monitorFilter2.xml");
@@ -317,7 +317,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF8;
     	String testName = "testEDF8";
     	serverEDF8.startServer();
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF8.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	waitForSecurityPrerequisites(serverEDF8, 60000);
     	checkStrings(getHttpServlet("/testJDBCApp/testJDBCServlet?operation=create", serverEDF8), 
           		new String[] { "sql: create table cities" }, new String[] {});
     	Log.info(c, testName, "------- Monitor filter Session and ConnectionPool ------");
@@ -336,7 +336,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF9;
     	String testName = "testEDF9";
     	serverEDF9.startServer();
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF9.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	waitForSecurityPrerequisites(serverEDF9, 60000);
     	checkStrings(getHttpServlet("/testJDBCApp/testJDBCServlet?operation=create", serverEDF9), 
           		new String[] { "sql: create table cities" }, new String[] {});
     	Log.info(c, testName, "------- Monitor filter ThreadPool, WebContainer, Session and ConnectionPool ------");
@@ -347,8 +347,8 @@ public class TestEnableDisableFeaturesTest {
  	    		new String[] { "Session id:" }, new String[] {});
  	    checkStrings(getHttpServlet("/testJDBCApp/testJDBCServlet?operation=select&city=city1&id=id1",serverEDF9), 
  			    new String[] { "sql: select" }, new String[] {});
- 	     Log.info(c, testName, "------- all four vendor metrics should be available ------");
- 	     checkStrings(getHttpsServlet("/metrics/vendor",serverEDF9), 
+ 	    Log.info(c, testName, "------- all four vendor metrics should be available ------");
+ 	    checkStrings(getHttpsServlet("/metrics/vendor",serverEDF9), 
  		        new String[] {"vendor:threadpool", "vendor:servlet", "vendor:session", "vendor:connectionpool" }, 
  		        new String[] {});
     }
@@ -358,16 +358,16 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF10;
     	String testName = "testEDF10";
     	serverEDF10.startServer();
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF10.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	waitForSecurityPrerequisites(serverEDF10, 60000);
     	Log.info(c, testName, "------- Remove JAX-WS application ------");
     	boolean rc1 = serverEDF10.removeAndStopDropinsApplications("testJaxWsApp.war");
     	Log.info(c, testName, "------- " + (rc1 ? "successfully removed" : "failed to remove") + " JAX-WS application ------");
-    	Assert.assertNotNull("CWWKT0017I NOT FOUND",serverEDF10.waitForStringInLogUsingMark(".*CWWKT0017I.*testJaxWsApp.*"));
+    	Assert.assertNotNull("CWWKT0017I NOT FOUND",serverEDF10.waitForStringInLogUsingMark("CWWKT0017I.*testJaxWsApp.*"));
     	serverEDF10.setMarkToEndOfLog();
     	serverEDF10.setServerConfigurationFile("server_noJaxWs.xml");
     	Assert.assertNotNull("CWWKF0008I NOT FOUND",serverEDF10.waitForStringInLogUsingMark("CWWKF0008I"));
-    	Assert.assertNotNull("testJDBCApp not loaded", serverEDF10.waitForStringInLog("CWWKT0016I: Web application available .*testJDBCApp.*"));
-        Assert.assertNotNull("testSessionApp not loaded", serverEDF10.waitForStringInLog("CWWKT0016I: Web application available .*testSessionApp.*"));
+    	Assert.assertNotNull("testJDBCApp not loaded", serverEDF10.waitForStringInLog("CWWKT0016I.*testJDBCApp.*"));
+        Assert.assertNotNull("testSessionApp not loaded", serverEDF10.waitForStringInLog("CWWKT0016I.*testSessionApp.*"));
     	Log.info(c, testName, "------- jax-ws metrics should not be available ------");
     	checkStrings(getHttpsServlet("/metrics/vendor",serverEDF10), 
     		new String[] { "vendor:" }, 
@@ -379,7 +379,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF11;
     	String testName = "testEDF11";
     	serverEDF11.startServer();
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF11.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	waitForSecurityPrerequisites(serverEDF11, 60000);
     	Log.info(c, testName, "------- Remove JDBC application ------");
     	boolean rc2 = serverEDF11.removeAndStopDropinsApplications("testJDBCApp.war");
     	Log.info(c, testName, "------- " + (rc2 ? "successfully removed" : "failed to remove") + " JDBC application ------");
@@ -397,7 +397,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF12;
     	String testName = "testEDF12";
     	serverEDF12.startServer();
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",serverEDF12.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+    	waitForSecurityPrerequisites(serverEDF12, 60000);
     	Assert.assertNotNull("CWWKF0011I NOT FOUND",serverEDF12.waitForStringInLogUsingMark("CWWKF0011I"));
     	Log.info(c, testName, "------- Remove monitor-1.0 ------");
     	serverEDF12.setMarkToEndOfLog();
@@ -407,6 +407,15 @@ public class TestEnableDisableFeaturesTest {
     	checkStrings(getHttpsServlet("/metrics",serverEDF12), 
     		new String[] {}, 
     		new String[] { "vendor:" });
+    }
+    
+    private void waitForSecurityPrerequisites(LibertyServer server, int timeout) {
+    	// Need to ensure LTPA keys and configuration are created before hitting a secure endpoint
+        Assert.assertNotNull("LTPA keys are not created within timeout period of " + timeout + "ms.", server.waitForStringInLog("CWWKS4104A",timeout));
+        Assert.assertNotNull("LTPA configuration is not ready within timeout period of " + timeout + "ms.", server.waitForStringInLog("CWWKS4105I",timeout));
+        
+        // Ensure defaultHttpEndpoint-ssl TCP Channel is started
+        Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",server.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl",timeout));
     }
     
     private String getHttpServlet(String servletPath, LibertyServer server) throws Exception {

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -80,7 +80,7 @@ public class TestEnableDisableFeaturesTest {
     
     private static LibertyServer currentServ;
     
-    
+    private static boolean serverEDF6FirstUse = true;
     
     @BeforeClass
     public static void setUp() throws Exception {
@@ -282,7 +282,15 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF6;
     	String testName = "testEDF6";
     	serverEDF6.startServer();
-    	waitForSecurityPrerequisites(serverEDF6, 60000);
+    	
+    	if (serverEDF6FirstUse) {
+    		// We only need to wait for LTPA keys if this is the first time using this server
+    		waitForSecurityPrerequisites(serverEDF6, 60000);
+    	} else {
+    		Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",serverEDF6.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl",60000));
+    	}
+    	serverEDF6FirstUse = false;
+    	
     	Log.info(c, testName, "------- Monitor filter ThreadPool and WebContainer  ------");
     	serverEDF6.setServerConfigurationFile("server_monitorFilter1.xml");
         Assert.assertNotNull("CWWKG0017I NOT FOUND",serverEDF6.waitForStringInLogUsingMark("CWWKG0017I"));
@@ -299,9 +307,17 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF6;
     	String testName = "testEDF7";
     	serverEDF6.startServer();
-    	Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",serverEDF6.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl",60000));
+    	
+    	if (serverEDF6FirstUse) {
+    		// We only need to wait for LTPA keys if this is the first time using this server
+    		waitForSecurityPrerequisites(serverEDF6, 60000);
+    	} else {
+    		Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",serverEDF6.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl",60000));
+    	}
+    	serverEDF6FirstUse = false;
+    	
     	Log.info(c, testName, "------- Monitor filter WebContainer and Session ------");
-       	serverEDF6.setMarkToEndOfLog();
+    	serverEDF6.setMarkToEndOfLog();
        	serverEDF6.setServerConfigurationFile("server_monitorFilter2.xml");
        	Assert.assertNotNull("CWWKG0017I NOT FOUND",serverEDF6.waitForStringInLogUsingMark("CWWKG0017I"));
     	checkStrings(getHttpServlet("/testSessionApp/testSessionServlet", serverEDF6), 


### PR DESCRIPTION
In relation to https://github.com/OpenLiberty/open-liberty/issues/10675


This PR is meant to fix #10675.

The test failure is caused by attempting to hit a secure endpoint before the LTPA keys are created and LTPA is configured. This meant that the test received a 401 response code and thus failed as that is not the expected response.

The fix is to simply add a wait statement in the test code to hold off hitting any secure endpoints until after the LTPA keys are created and LTPA is configured. This fix is applied to all test cases under
TestEnableDisableFeaturesTest.

In addition to the fix, a bunch of other changes were made to the strings/regexps that the test code was waiting for throughout the tests. The strings/regexps should not contain any English phrases such as "Web application available". The corresponding message codes were used instead.

For more information about LTPA refer to https://www.ibm.com/support/knowledgecenter/SSFS6T/com.ibm.apic.apionprem.doc/task_apionprem_ltpa_new.html