### PR TITLE
Enable kafka client trace

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/SimpleRxMessagingServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/publish/servers/SimpleRxMessagingServer/bootstrap.properties
@@ -10,7 +10,7 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 osgi.console=5471
-com.ibm.ws.logging.trace.specification = *=info:logservice=detail:REACTIVEMESSAGE=all:com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.impl.*=FINEST
+com.ibm.ws.logging.trace.specification = *=info:logservice=detail:REACTIVEMESSAGE=all:com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.impl.*=FINEST:org.apache.kafka.*=all
 
 # This is an override to force the new beta-level code to be used in these FAT tests. It should be removed before GA.
 use.kafka.producer.record=true


### PR DESCRIPTION
Turn on tracing for the kafka client library to try to track down the
cause of an occasional test failure.