### PR TITLE
update cxf projects to fix eclipse builds on java 11+

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.api.2.6.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.api.2.6.2/bnd.bnd
@@ -26,6 +26,7 @@ Include-Resource:\
   org/apache/cxf=${bin}/org/apache/cxf
 
 -buildpath: org.apache.cxf:cxf-api;strategy=exact;version=${cxfVersion}, \
+  javax.activation:activation;version=1.1, \
   com.ibm.websphere.javaee.mail.1.5;version=latest, \
   com.ibm.websphere.javaee.wsdl4j.1.2;version=latest, \
   com.ibm.ws.logging.core, \

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.bnd
@@ -21,6 +21,7 @@ javac.target: 1.8
 instrument.classesExcludes: org/apache/cxf/common/jaxb/*.class
 
 -buildpath: \
+  javax.activation:activation;version=1.1,\
   com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
   org.apache.cxf:cxf-core;version=3.3.3.20190529,\
   com.ibm.ws.logging.core,\


### PR DESCRIPTION
updated the bundles to include `com.ibm.websphere.javaee.activation.1.1` to fix the eclipse builds