### PR TITLE
Avoid tracing connectionProperties components that contain passwords

### DIFF
--- a/dev/com.ibm.ws.jdbc/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.jdbc/resources/OSGI-INF/metatype/metatype.xml
@@ -1244,9 +1244,9 @@
   <AD id="databaseName"                       required="false" type="String"  name="%databaseName" description="%databaseName.desc"/>
   <AD id="serverName"                         required="false" type="String"  default="localhost" name="%serverName" description="%serverName.desc"/>
   <AD id="portNumber"                         required="false" type="Integer" default="1521" name="%portNumber" description="%portNumber.desc"/>
-  <AD id="URL"                                required="false" type="String"  name="%URL" description="%URL.oracle.desc"/>
+  <AD id="URL"                                required="false" type="String"  ibm:type="password" name="%URL" description="%URL.oracle.desc"/>
   <!-- Advanced properties for properties.oracle -->
-  <AD id="connectionProperties"               ibmui:group="Advanced" required="false" type="String"  name="%connectionProperties" description="%connectionProperties.desc"/>
+  <AD id="connectionProperties"               ibmui:group="Advanced" required="false" type="String"  ibm:type="password" name="%connectionProperties" description="%connectionProperties.desc"/>
   <AD id="loginTimeout"                       ibmui:group="Advanced" required="false" type="String"  ibm:type="duration(s)" min="0" name="%loginTimeout" description="%loginTimeout.desc"/>
   <AD id="networkProtocol"                    ibmui:group="Advanced" required="false" type="String"  name="%networkProtocol" description="%networkProtocol.desc"/>
   <AD id="ONSConfiguration"                   ibmui:group="Advanced" required="false" type="String"  name="%ONSConfiguration" description="%ONSConfiguration.desc"/>
@@ -1272,13 +1272,13 @@
   <AD id="databaseName"                       required="false" type="String"  name="%databaseName" description="%databaseName.desc"/>
   <AD id="serverName"                         required="false" type="String"  default="localhost" name="%serverName" description="%serverName.desc"/>
   <AD id="portNumber"                         required="false" type="Integer" default="1521" name="%portNumber" description="%portNumber.desc"/>
-  <AD id="URL"                                required="false" type="String"  name="%URL" description="%URL.oracle.desc"/>
+  <AD id="URL"                                required="false" type="String"  ibm:type="password" name="%URL" description="%URL.oracle.desc"/>
   <!-- Advanced properties for properties.oracle.ucp -->
   <AD id="abandonedConnectionTimeout"         ibmui:group="Advanced" required="false" type="String"  ibm:type="duration(s)" name="%abandonedConnectionTimeout" description="%abandonedConnectionTimeout.desc" />
   <AD id="connectionFactoryProperties"        ibmui:group="Advanced" required="false" type="String"  name="%connectionFactoryProperties" description="%connectionFactoryProperties.desc"/>
   <AD id="connectionHarvestMaxCount"          ibmui:group="Advanced" required="false" type="Integer" name="%connectionHarvestMaxCount" description="%connectionHarvestMaxCount.desc"/>
   <AD id="connectionHarvestTriggerCount"      ibmui:group="Advanced" required="false" type="Integer" name="%connectionHarvestTriggerCount" description="%connectionHarvestTriggerCount.desc"/>
-  <AD id="connectionProperties"               ibmui:group="Advanced" required="false" type="String"  name="%connectionProperties" description="%connectionProperties.desc"/>
+  <AD id="connectionProperties"               ibmui:group="Advanced" required="false" type="String"  ibm:type="password" name="%connectionProperties" description="%connectionProperties.desc"/>
   <AD id="connectionWaitTimeout"              ibmui:group="Advanced" required="false" type="String"  ibm:type="duration(s)" name="%connectionWaitTimeout" description="%connectionWaitTimeout.desc"/>
   <AD id="fastConnectionFailoverEnabled"      ibmui:group="Advanced" required="false" type="Boolean" name="%fastConnectionFailoverEnabled" description="%fastConnectionFailoverEnabled.desc"/>
   <AD id="initialPoolSize"                    ibmui:group="Advanced" required="false" type="Integer" name="%initialPoolSize" description="%initialPoolSize.desc"/>

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceResourceFactoryBuilder.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceResourceFactoryBuilder.java
@@ -124,7 +124,7 @@ public class DataSourceResourceFactoryBuilder implements ResourceFactoryBuilder 
     public ResourceFactory createResourceFactory(Map<String, Object> props) throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
-            Tr.entry(tc, "createResourceFactory", PropertyService.hidePasswords(props));
+            Tr.entry(tc, "createResourceFactory", props);
 
         Hashtable<String, Object> cmSvcProps = new Hashtable<String, Object>();
         Hashtable<String, Object> dsSvcProps = new Hashtable<String, Object>();
@@ -593,16 +593,16 @@ public class DataSourceResourceFactoryBuilder implements ResourceFactoryBuilder 
                                     try {
                                         if (driver.acceptsURL(url)) {
                                             if (trace && tc.isDebugEnabled())
-                                                Tr.debug(this, tc, driver + " accepts " + PropertyService.filterURL(url));
+                                                Tr.debug(this, tc, driver + " accepts " + url);
                                             className = driver.getClass().getName();
                                             break;
                                         } else {
                                             if (trace && tc.isDebugEnabled())
-                                                Tr.debug(this, tc, driver + " does not accept " + PropertyService.filterURL(url));
+                                                Tr.debug(this, tc, driver + " does not accept " + url);
                                         }
                                     } catch (SQLException x) {
                                         if (trace && tc.isDebugEnabled())
-                                            Tr.debug(this, tc, driver + " does not accept " + PropertyService.filterURL(url), x);
+                                            Tr.debug(this, tc, driver + " does not accept " + url, x);
                                     }
                                 }
                             } else {

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
@@ -236,7 +236,7 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
     protected void activate(ComponentContext context, Map<String, Object> properties) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
-            Tr.entry(this, tc, "activate", PropertyService.hidePasswords(properties));
+            Tr.entry(this, tc, "activate", properties);
 
         String jndiName = (String) properties.get(JNDI_NAME);
         id = (String) properties.get("config.displayId");
@@ -836,7 +836,7 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
                     } else if (trace && tc.isDebugEnabled()) {
                         if(key.toLowerCase().equals("url")) {
                             if(value instanceof String)
-                                Tr.debug(this, tc, "Found vendor property: " + key + '=' + PropertyService.filterURL((String) value));
+                                Tr.debug(this, tc, "Found vendor property: " + key + '=' + (String) value);
                         } else {
                             Tr.debug(this, tc, "Found vendor property: " + key + '=' + value);
                         }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
@@ -241,7 +241,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
 
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
-            Tr.entry(tc, "create", className, classloader, PropertyService.hidePasswords(props));
+            Tr.entry(tc, "create", className, classloader, props);
 
         //Add a value for connectionFactoryClassName when using UCP if one is not specified
         if (className.startsWith("oracle.ucp.jdbc") && !props.containsKey("connectionFactoryClassName")) {
@@ -306,10 +306,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                                     if (x instanceof InvocationTargetException)
                                         x = x.getCause();
                                     FFDCFilter.processException(x, getClass().getName(), "217", this, new Object[] { className, name, value });
-                                    boolean isURL = ("URL".equals(name) || "url".equals(name)) && value instanceof String;
-                                    SQLException failure = connectorSvc.ignoreWarnOrFail(tc, x, SQLException.class, "PROP_SET_ERROR", name,
-                                                                                                     "=" + (isPassword ? "******" : isURL ? PropertyService.filterURL((String) value) : value),
-                                                                                                     AdapterUtil.stackTraceToString(x));
+                                    SQLException failure = connectorSvc.ignoreWarnOrFail(tc, x, SQLException.class, "PROP_SET_ERROR", name, "=" + value, AdapterUtil.stackTraceToString(x));
                                     if (failure != null)
                                         throw failure;
                                 }
@@ -794,7 +791,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
     private Driver loadDriver(final String className, String url, final ClassLoader classloader, Properties props, String dataSourceID) throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isDebugEnabled())
-            Tr.entry(this, tc, "loadDriver", className, PropertyService.filterURL(url), classloader);
+            Tr.entry(this, tc, "loadDriver", className, url, classloader);
         int index = url.toLowerCase().indexOf("logintimeout");
         if(index != -1) {
             int length = url.length();
@@ -972,11 +969,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
         String propName = pd.getName();
 
         if (tc.isDebugEnabled()) {
-            if("URL".equals(propName) || "url".equals(propName)) {
-                Tr.debug(tc, "set " + propName + " = " + PropertyService.filterURL(value));
-            } else {
-                Tr.debug(tc, "set " + propName + " = " + (doTraceValue ? value : "******"));
-            }
+                Tr.debug(tc, "set " + propName + " = " + value);
         }
 
         java.lang.reflect.Method setter = pd.getWriteMethod();

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
@@ -21,7 +21,6 @@ import java.sql.Driver;
 import java.sql.SQLException;
 import java.sql.SQLNonTransientException;
 import java.util.AbstractMap.SimpleEntry;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -32,7 +31,6 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Observable;
 import java.util.Properties;
 import java.util.ServiceLoader;
@@ -270,7 +268,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                         @SuppressWarnings("unchecked")
                         Class<T> dsClass = (Class<T>) loader.loadClass(className);
                         introspectedClasses.add(dsClass);
-                        T ds = dsClass.newInstance();
+                        T ds = dsClass.getDeclaredConstructor().newInstance();
 
                         // Set all of the JDBC vendor properties
                         Hashtable<?, ?> p = (Hashtable<?, ?>) props.clone();
@@ -828,7 +826,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
                 public Driver run() throws Exception {
                     ClassLoader loader = classloader == null ? Thread.currentThread().getContextClassLoader() : classloader;
                     Class<Driver> driverClass = (Class<Driver>) loader.loadClass(className);
-                    return driverClass.newInstance();
+                    return driverClass.getDeclaredConstructor().newInstance();
                 }
             });
             drivers = Collections.singleton(driver);
@@ -1044,7 +1042,7 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
         if (embDerbyRefCount.remove(classloader) && !embDerbyRefCount.contains(classloader))
             try {
                 Class<?> EmbDS = AdapterUtil.forNameWithPriv("org.apache.derby.jdbc.EmbeddedDataSource40", true, classloader);
-                DataSource ds = (DataSource) EmbDS.newInstance();
+                DataSource ds = (DataSource) EmbDS.getDeclaredConstructor().newInstance();
                 EmbDS.getMethod("setShutdownDatabase", String.class).invoke(ds, "shutdown");
                 ds.getConnection().close();
                 if (trace && tc.isEntryEnabled())

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/PropertyService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/PropertyService.java
@@ -102,12 +102,12 @@ public class PropertyService extends Properties {
     private static final List<String> PASSWORD_PROPS = Arrays.asList(DataSourceDef.password.name(),
                                                                      "accessToken",
                                                                      "apiKey",
+                                                                     "connectionProperties",
+                                                                     "connectionFactoryProperties",
                                                                      "keyStoreSecret",
                                                                      "trustStorePassword",
                                                                      "sslTrustStorePassword",
-                                                                     "sslKeyStorePassword",
-                                                                     "connectionProperties",
-                                                                     "connectionFactoryProperties"
+                                                                     "sslKeyStorePassword"
                                                                      );
 
     /**
@@ -135,6 +135,15 @@ public class PropertyService extends Properties {
      */
     public String getFactoryPID() {
         return factoryPID;
+    }
+    
+    /**
+     * Factory pid for the nested vendor properties elements.
+     * 
+     * @param factoryPID factory pid for vendor properties element.
+     */
+    public void setFactoryPID(String factoryPID) {
+        this.factoryPID = factoryPID;
     }
 
     /**
@@ -279,21 +288,11 @@ public class PropertyService extends Properties {
      * @param vendorProps
      */
     public static final void parsePasswordProperties(Map<String, Object> vendorProps) {
-
         for (String propName : PASSWORD_PROPS) {
             String propValue = (String) vendorProps.remove(propName);
             if (propValue != null)
                 vendorProps.put(propName, new SerializableProtectedString(propValue.toCharArray()));
         }
-    }
-
-    /**
-     * Factory pid for the nested vendor properties elements.
-     * 
-     * @param factoryPID factory pid for vendor properties element.
-     */
-    public void setFactoryPID(String factoryPID) {
-        this.factoryPID = factoryPID;
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/DSConfig.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/DSConfig.java
@@ -334,7 +334,7 @@ public class DSConfig implements FFDCSelfIntrospectable {
         return new String[] {
                              toString(),
                              nameValuePairs.toString(),
-                             PropertyService.hidePasswords(vendorProps).toString() };
+                             vendorProps.toString() };
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2JCCHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2JCCHelper.java
@@ -643,7 +643,7 @@ public class DB2JCCHelper extends DB2Helper {
 
     public void reuseKerbrosConnection(Connection sqlConn, GSSCredential gssCred, Properties props) throws SQLException {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) 
-            Tr.debug(this, tc, "reuseKerbrosConnection", sqlConn, gssCred, PropertyService.hidePasswords(props));
+            Tr.debug(this, tc, "reuseKerbrosConnection", sqlConn, gssCred, props);
         invokeOnDB2Connection(sqlConn, reuseDB2Connection, "reuseDB2Connection", TYPES_GSSCredential_Properties, gssCred, props);
     }
 }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
@@ -870,7 +870,7 @@ public class WSManagedConnectionFactoryImpl extends WSManagedConnectionFactory i
                             if ("URL".equals(name) || "url".equals(name)) {
                                 url = str;
                                 if (isTraceOn && tc.isDebugEnabled())
-                                    Tr.debug(this, tc, name + '=' + PropertyService.filterURL(str));
+                                    Tr.debug(this, tc, name + '=' + str);
                             } else if ((user == null || !"user".equals(name)) && (pwd == null || !"password".equals(name))) {
                                 // Decode passwords
                                 if (PropertyService.isPassword(name)) {

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcTracer.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcTracer.java
@@ -157,7 +157,7 @@ public class WSJdbcTracer implements InvocationHandler
             if (tracer.getLevel() <= 1 /* LevelConstants.LEVEL_ALL */&& args != null)
                 for (int i = 0; i < args.length; i++) {
                     if(methName.equals("connect") && i == 0) {
-                        buffer.append(PropertyService.filterURL(toString(args[i])));
+                        buffer.append(toString(args[i]));
                         continue;
                     }
                     

--- a/dev/com.ibm.ws.jdbc/test/com/ibm/ws/jdbc/internal/InternalTest.java
+++ b/dev/com.ibm.ws.jdbc/test/com/ibm/ws/jdbc/internal/InternalTest.java
@@ -167,36 +167,6 @@ public class InternalTest {
         }
     }
     
-    @Test
-    public void testURLFiltering() {
-        //URL with descriptor beyond vendor
-        assertEquals("Test1", "jdbc:oracle:thin:****", 
-                     PropertyService.filterURL("jdbc:oracle:thin:username/pass123!@localhost:1521:oracle"));
-
-        //URL with no descriptor beyond vendor, no properties
-        assertEquals("Test2", "jdbc:vendor:****", 
-                     PropertyService.filterURL("jdbc:vendor:username/pass123!@localhost:1521:oracle"));
-
-        //Test with password in URL, with qualifier following, using semicolon
-        assertEquals("Test4", "jdbc:sqlserver:****", 
-                     PropertyService.filterURL("jdbc:sqlserver:!@pass://localhost;user=username;password=ab9&*&^*#(*;"));
-
-        //Test with password at very end of URL, using semicolon
-        assertEquals("Test5", "jdbc:sqlserver:****", 
-                     PropertyService.filterURL("jdbc:sqlserver://localhost/;user=username;password=ab9&*&^*#(*"));
-        
-        //Driver using mutliple tokens
-        assertEquals("Test15", "jdbc:driver:****", 
-                     PropertyService.filterURL("jdbc:driver:database5,host=localhost:user=bob,foo=bar,test=2"));
-        
-        //Uncompliant driver without property
-        assertEquals("Test16", "****", 
-                     PropertyService.filterURL("this_is_a_very_non_complient_jdbc_url"));
-        
-        //Uncompliant driver with property
-        assertEquals("Test17", "****", 
-                     PropertyService.filterURL("this_is_a_very_non_complient_jdbc_url;password=12jsadf")); 
-    }
     static String[] expectedConnProps = {
                                   "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=unencPassword1;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=password",
                                   "javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStorePassword =unencPassword2;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=password",

--- a/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/OracleTest.java
@@ -15,14 +15,12 @@ import static org.junit.Assert.fail;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.List;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.containers.output.OutputFrame;
@@ -83,14 +81,17 @@ public class OracleTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        if (server.isStarted())
+    	testSSLPasswordIsNotLogged();
+    	testURLPasswordIsNotLogged();
+    	
+        if (server.isStarted()) {
             server.stopServer();
+        }
     }
     
-    @Test
     //FIXME com.ibm.ws.jdbc.* does not log this password, but it is still being logged 
     //by OSGi Declaritive Service.  Enable this test once that is no longer the case. 
-    public void testSSLPasswordIsNotLogged() throws Exception {
+    private static void testSSLPasswordIsNotLogged() throws Exception {
     	if(server.isStarted()) {
     		//Allow in output.txt log as we use env variables to set SSL_PASSWORD and URL
     		int count = server.findStringsInTrace(Pattern.quote(SSL_PASSWORD)).size();
@@ -101,10 +102,9 @@ public class OracleTest extends FATServletClient {
     	}
     }
     
-    @Test
     //FIXME com.ibm.ws.jdbc.* does not log the URL with password, but it is still being logged 
     //by OSGi Declaritive Service.  Enable this test once that is no longer the case. 
-    public void testURLPasswordIsNotLogged() throws Exception {
+    private static void testURLPasswordIsNotLogged() throws Exception {
     	if(server.isStarted()) {
     		//Allow in output.txt log as we use env variables to set SSL_PASSWORD and URL
     		int count = server.findStringsInTrace(Pattern.quote(oracle.getJdbcUrl())).size();

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle/server.xml
@@ -57,6 +57,8 @@
     	<jdbcDriver libraryRef="DBLib"/>
     </dataSource>
     
+    <!-- Not actually interested in making a true SSL connection here.
+         Just making sure that SSL Trust/Key Store passwords are not being logged. -->
     <dataSource id="ssl-ds" jndiName="jdbc/ssl-ds">
     	<properties.oracle URL="${env.URL}" connectionProperties="oracle.net.ssl_version=1.2; oracle.net.authentication_services=(TCPS); javax.net.ssl.keyStore=${server.config.dir}/resources/security/key.p12; javax.net.ssl.keyStoreType=PKCS12; javax.net.ssl.keyStorePassword=${env.SSL_PASSWORD}; javax.net.ssl.trustStore=${server.config.dir}/resources/security/key.p12; javax.net.ssl.trustStoreType=PKCS14; javax.net.ssl.trustStorePassword=${env.SSL_PASSWORD}"/>
     	<jdbcDriver libraryRef="DBLib"/>

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle/server.xml
@@ -14,9 +14,12 @@
       <feature>jdbc-4.2</feature>
       <feature>jndi-1.0</feature>
       <feature>componenttest-1.0</feature>
+      <feature>transportSecurity-1.0</feature>
     </featureManager>
     
     <include location="../fatTestPorts.xml"/>
+    
+    <keyStore id="defaultKeyStore" password="${env.SSL_PASSWORD}" />
 
     <application location="oraclejdbcfat.war" >
         <classloader commonLibraryRef="DBLib"/>
@@ -51,6 +54,16 @@
     
     <dataSource id="inferred-ds" jndiName="jdbc/inferred-ds">
     	<properties databaseName="${env.DBNAME}" portNumber="${env.PORT}" serverName="${env.HOST}" user="${env.USER}" password="${env.PASSWORD}" driverType="thin"/>
+    	<jdbcDriver libraryRef="DBLib"/>
+    </dataSource>
+    
+    <dataSource id="ssl-ds" jndiName="jdbc/ssl-ds">
+    	<properties.oracle URL="${env.URL}" connectionProperties="oracle.net.ssl_version=1.2; oracle.net.authentication_services=(TCPS); javax.net.ssl.keyStore=${server.config.dir}/resources/security/key.p12; javax.net.ssl.keyStoreType=PKCS12; javax.net.ssl.keyStorePassword=${env.SSL_PASSWORD}; javax.net.ssl.trustStore=${server.config.dir}/resources/security/key.p12; javax.net.ssl.trustStoreType=PKCS14; javax.net.ssl.trustStorePassword=${env.SSL_PASSWORD}"/>
+    	<jdbcDriver libraryRef="DBLib"/>
+    </dataSource>
+    
+     <dataSource id="url-auth-ds" jndiName="jdbc/url-auth-ds">
+    	<properties.oracle URL="${env.URL}"/> <!-- Username and Password contained in URL -->
     	<jdbcDriver libraryRef="DBLib"/>
     </dataSource>
     

--- a/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oraclejdbcfat/src/web/OracleTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oraclejdbcfat/src/web/OracleTestServlet.java
@@ -21,7 +21,6 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 
@@ -57,6 +56,9 @@ public class OracleTestServlet extends FATServlet {
 
     @Resource(lookup = "jdbc/inferred-ds")
     private DataSource inferred_ds;
+    
+    @Resource(lookup = "jdbc/ssl-ds")
+    private DataSource ssl_ds;
 
     // Verify that connections are/are not castable to OracleConnection based on whether enableConnectionCasting=true/false.
     @Test
@@ -281,6 +283,23 @@ public class OracleTestServlet extends FATServlet {
             conn2.close();
         }
     }
+    
+    
+    @Test
+    public void testDSUsingSSL() throws Exception {
+        Connection conn = ssl_ds.getConnection();
+        
+        try {
+            PreparedStatement ps = conn.prepareStatement("INSERT INTO MYTABLE VALUES(?,?)");
+            ps.setInt(1, 21);
+            ps.setString(2, "twenty-one");
+            ps.executeUpdate();
+            ps.close();
+        } finally {
+            conn.close();
+        }
+    }
+
 
     //Test that the proper implementation classes are used for the various datasources configured in this test bucket
     //since the JDBC Driver used is named so as not to be recognized by the built-in logic


### PR DESCRIPTION
Fixes #8547
Made changes to JDBC tracing to hide SSL key/trust store passwords in connectionProperties string.  Wrote unit tests to ensure the function correctly replaces passwords with a dummy string "****".  Also wrote FAT tests to ensure that SSL passwords and URL embedded passwords are not traced anywhere in output/trace files.  These tests, however, currently fail since these passwords are being traced by OSGi Declarative Services  
