### PR TITLE
Issue 10277: Autonomical algorithm for calculating pollInterval.

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/db/DatabaseTaskStore.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/db/DatabaseTaskStore.java
@@ -593,7 +593,7 @@ public class DatabaseTaskStore implements TaskStore {
                 // Initialize to already-expired and eligible for any server to claim.
                 // Use a fractional second to help avoid accessing the database around the same time as scheduled tasks
                 // which might be scheduled to run on the hour or minute.
-                partition.EXPIRY = (System.currentTimeMillis() / 1000 - 1) * 1000 + 600;
+                partition.EXPIRY = System.currentTimeMillis() / 1000 * 1000 + 600;
                 partition.STATES = partition.EXPIRY; // used as a last-updated timestamp
                 partition.LSERVER = ".pollinfo";
                 partition.EXECUTOR = ""; // unused, cannot be null


### PR DESCRIPTION
We store two values in the partition table.
(1) last time we pulled
(2) time when the last poll slot reserved will trigger

We will assign the current poll to use value (2) plus a global poll value to determine when it will poll for tasks next.
Value (1) is used to detect if any poll intervals have been missed.

OpenLiberty Pull Requester,

ATTENTION, READ THIS: Updated 4/11/2018 - Read and understand this completely,
then delete this entire template. If a reviewer or merger sees this template,
they should fail the review or merge.

If this code change is fixing a user-visible bug in previously released code, it MUST
have an associated issue mentioned in the PR text or description. That Issue also
MUST be labelled “release bug”

This directs automation to scrape this fix for inclusion in the next release's
list of bugs fixed.

If this code is NOT for fixing a released bug, for example new function, fixing
a bug in unreleased function, or other improvements that do not affect the
user-space, no label is needed. An issue could or could not be used based
on the developer’s discretion, but do still delete this text block.

For full details, please see this wiki page:

https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions

