### PR TITLE
disabled test of login module loaded from the application

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -28,5 +28,8 @@ fat.project: true
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
-	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
-	com.ibm.websphere.javaee.transaction.1.1;version=latest
+	com.ibm.websphere.javaee.connector.1.7;version=latest,\
+	com.ibm.websphere.javaee.ejb.3.2;version=latest,\
+	com.ibm.websphere.javaee.servlet.4.0;version=latest,\
+	com.ibm.websphere.javaee.transaction.1.2;version=latest,\
+	com.ibm.ws.security.jaas.common;version=latest

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/server.xml
@@ -1,9 +1,22 @@
+<!--
+    Copyright (c) 2018,2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
 <server>
     <featureManager>
+      <feature>appSecurity-2.0</feature>
       <feature>componenttest-1.0</feature>
+      <feature>ejbLite-3.2</feature>
+      <feature>jca-1.7</feature>
       <feature>jdbc-4.2</feature>
       <feature>jndi-1.0</feature>
-      <feature>servlet-3.1</feature>
+      <feature>servlet-4.0</feature>
     </featureManager>
     
 
@@ -11,7 +24,7 @@
 
     <application location="derbyApp.war"/>
 
-    <application location="otherApp.war"/>
+    <application location="otherApp.ear"/>
 
     <dataSource id="DefaultDataSource" ibm.internal.nonship.function="true">
       <jdbcDriver javax.sql.DataSource="jdbc.driver.proxy.ProxyDataSource" libraryRef="ibm.internal.simulate.no.library.do.not.ship" ibm.internal.nonship.function="true"/> <!-- TODO remove libraryRef -->
@@ -21,6 +34,16 @@
     <dataSource id="DerbyDataSource" jndiName="jdbc/derby" ibm.internal.nonship.function="true">
       <jdbcDriver libraryRef="ibm.internal.simulate.no.library.do.not.ship" ibm.internal.nonship.function="true"/> <!-- TODO eventually remove jdbcDriver completely -->
       <properties.derby.embedded databaseName="memory:ds1" createDatabase="create"/>
+    </dataSource>
+
+    <dataSource id="sharedLibDataSource" jndiName="jdbc/sharedLibDataSource">
+      <!-- loads its JDBC driver from a shared library, NOT from the app like the other data sources in this server -->
+      <jdbcDriver>
+        <library>
+          <file name="${shared.resource.dir}/derby/derby.jar"/>
+        </library>
+      </jdbcDriver>
+      <properties.derby.embedded databaseName="memory:sharedLibDB" createDatabase="create"/>
     </dataSource>
 
     <dataSource id="MiniDataSource" jndiName="jdbc/miniDataSource" ibm.internal.nonship.function="true">
@@ -35,19 +58,41 @@
 
     <library id="ibm.internal.simulate.no.library.do.not.ship"/>
 
-    <!-- permissions for Derby -->
+    <!-- TODO replace with classProviderRef once implemented -->
+    <library id="temp">
+      <file name="${server.config.dir}/tempLoginModule.jar"/>
+    </library>
+    <javaPermission codebase="${server.config.dir}/tempLoginModule.jar" className="javax.security.auth.AuthPermission" name="modifyPrivateCredentials"/>
+
+    <jaasLoginContextEntry id="web1loginEntry" name="web1login">
+      <loginModule className="web.other.LoadFromWebModLoginModule" libraryRef="temp"/> <!-- TODO use classProviderRef once implemented -->
+    </jaasLoginContextEntry>
+
+    <!-- permissions for Derby in the app -->
     <javaPermission codeBase="${server.config.dir}apps/derbyApp.war" className="java.io.FilePermission" name="derby.log" actions="read,write"/>
     <javaPermission codeBase="${server.config.dir}apps/derbyApp.war" className="java.io.FilePermission" name="derby.properties" actions="read"/>
     <javaPermission codeBase="${server.config.dir}apps/derbyApp.war" className="java.lang.RuntimePermission" name="getClassLoader"/>
     <javaPermission codeBase="${server.config.dir}apps/derbyApp.war" className="java.lang.RuntimePermission" name="getProtectionDomain"/>
     <javaPermission codeBase="${server.config.dir}apps/derbyApp.war" className="java.lang.RuntimePermission" name="setContextClassLoader"/>
     <javaPermission codeBase="${server.config.dir}apps/derbyApp.war" className="java.util.PropertyPermission" name="*" actions="read"/>
-    <javaPermission codeBase="${server.config.dir}apps/derbyApp.war" className="javax.management.MBeanPermission" name="*" actions="registerMBean"/>
+    <javaPermission codeBase="${server.config.dir}apps/derbyApp.war" className="javax.management.MBeanPermission" name="*" actions="registerMBean,unregisterMBean"/>
     <javaPermission codeBase="${server.config.dir}apps/derbyApp.war" className="javax.management.MBeanServerPermission" name="createMBeanServer"/>
     <javaPermission codeBase="${server.config.dir}apps/derbyApp.war" className="javax.management.MBeanTrustPermission" name="register"/>
 
+    <!-- permissions for Derby in the shared library -->
+    <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="java.io.FilePermission" name="derby.log" actions="read,write"/>
+    <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="java.io.FilePermission" name="derby.properties" actions="read"/>
+    <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="java.lang.RuntimePermission" name="getProtectionDomain"/>
+    <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="java.lang.RuntimePermission" name="setContextClassLoader"/>
+    <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="java.sql.SQLPermission" name="deregisterDriver"/>
+    <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="java.util.PropertyPermission" name="*" actions="read"/>
+    <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="javax.management.MBeanPermission" name="*" actions="registerMBean,unregisterMBean"/>
+    <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="javax.management.MBeanServerPermission" name="createMBeanServer"/>
+    <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="javax.management.MBeanTrustPermission" name="register"/>
+
     <!-- permissions for Mini driver to utilize dynamic proxy -->
-    <javaPermission codeBase="${server.config.dir}apps/otherApp.war" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codeBase="${server.config.dir}apps/otherApp.ear" className="java.lang.RuntimePermission" name="getClassLoader"/>
 
     <variable name="onError" value="FAIL"/>
 </server>

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/resources/WEB-INF/ibm-web-bnd.xml
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/resources/WEB-INF/ibm-web-bnd.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<web-bnd xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-bnd_1_0.xsd" version="1.0">
+
+  <resource-ref name="java:app/env/jdbc/ddsLoadFromAppWithWebModLoginModule">
+    <custom-login-configuration name="web1login">
+      <property name="shape" value="rhombus"/>
+      <property name="sides" value="4"/>
+      <property name="sumOfAngles" value="360"/>
+    </custom-login-configuration>
+  </resource-ref>
+
+  <resource-ref name="java:app/env/jdbc/slLoadFromAppWithWebModLoginModule">
+    <custom-login-configuration name="web1login">
+      <property name="shape" value="triangle"/>
+      <property name="sides" value="3"/>
+      <property name="sumOfAngles" value="180"/>
+    </custom-login-configuration>
+  </resource-ref>
+
+</web-bnd>

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/ejb/first/FirstBean.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/ejb/first/FirstBean.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package ejb.first;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.util.concurrent.Callable;
+
+import javax.annotation.Resource;
+import javax.ejb.Stateless;
+import javax.sql.DataSource;
+
+@Stateless
+public class FirstBean implements Callable<String> {
+    @Resource(name = "java:comp/env/jdbc/dsref", lookup = "jdbc/sharedLibDataSource")
+    DataSource ds;
+
+    @Override
+    public String call() throws Exception {
+        try (Connection con = ds.getConnection()) {
+            DatabaseMetaData mdata = con.getMetaData();
+            return mdata.getUserName();
+        }
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/ejb/first/FirstEJBModLoginModule.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/ejb/first/FirstEJBModLoginModule.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package ejb.first;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Map;
+
+import javax.resource.spi.security.PasswordCredential;
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+
+import com.ibm.wsspi.security.auth.callback.WSManagedConnectionFactoryCallback;
+import com.ibm.wsspi.security.auth.callback.WSMappingPropertiesCallback;
+
+/**
+ * This login module always assigns the same user/password, which tests can check for.
+ */
+public class FirstEJBModLoginModule implements LoginModule {
+    private CallbackHandler callbackHandler;
+    private Subject subject;
+
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        this.callbackHandler = callbackHandler;
+        this.subject = subject;
+    }
+
+    @Override
+    public boolean login() throws LoginException {
+        try {
+            final WSManagedConnectionFactoryCallback mcfCallback = new WSManagedConnectionFactoryCallback("Target ManagedConnectionFactory: ");
+            WSMappingPropertiesCallback mpropsCallback = new WSMappingPropertiesCallback("Mapping Properties (HashMap): ");
+            callbackHandler.handle(new Callback[] { mcfCallback, mpropsCallback });
+
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+                @Override
+                public Void run() {
+                    PasswordCredential passwordCredential = new PasswordCredential("ejb1user", "ejb1pwd".toCharArray());
+                    passwordCredential.setManagedConnectionFactory(mcfCallback.getManagedConnectionFacotry());
+                    subject.getPrivateCredentials().add(passwordCredential);
+                    return null;
+                }
+            });
+        } catch (Exception x) {
+            throw (LoginException) new LoginException(x.getMessage()).initCause(x);
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean abort() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean commit() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean logout() throws LoginException {
+        return true;
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/ejb/second/SecondBean.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/ejb/second/SecondBean.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package ejb.second;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.util.concurrent.Callable;
+
+import javax.annotation.Resource;
+import javax.ejb.Stateless;
+import javax.sql.DataSource;
+
+@Stateless
+public class SecondBean implements Callable<String> {
+    @Resource(name = "java:comp/env/jdbc/dsref", lookup = "jdbc/sharedLibDataSource")
+    DataSource ds;
+
+    @Override
+    public String call() throws Exception {
+        try (Connection con = ds.getConnection()) {
+            DatabaseMetaData mdata = con.getMetaData();
+            return mdata.getUserName();
+        }
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/ejb/second/SecondEJBModLoginModule.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/ejb/second/SecondEJBModLoginModule.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package ejb.second;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Map;
+
+import javax.resource.spi.security.PasswordCredential;
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+
+import com.ibm.wsspi.security.auth.callback.WSManagedConnectionFactoryCallback;
+import com.ibm.wsspi.security.auth.callback.WSMappingPropertiesCallback;
+
+/**
+ * This login module always assigns the same user/password, which tests can check for.
+ */
+public class SecondEJBModLoginModule implements LoginModule {
+    private CallbackHandler callbackHandler;
+    private Subject subject;
+
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        this.callbackHandler = callbackHandler;
+        this.subject = subject;
+    }
+
+    @Override
+    public boolean login() throws LoginException {
+        try {
+            final WSManagedConnectionFactoryCallback mcfCallback = new WSManagedConnectionFactoryCallback("Target ManagedConnectionFactory: ");
+            WSMappingPropertiesCallback mpropsCallback = new WSMappingPropertiesCallback("Mapping Properties (HashMap): ");
+            callbackHandler.handle(new Callback[] { mcfCallback, mpropsCallback });
+
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+                @Override
+                public Void run() {
+                    PasswordCredential passwordCredential = new PasswordCredential("ejb2user", "ejb2pwd".toCharArray());
+                    passwordCredential.setManagedConnectionFactory(mcfCallback.getManagedConnectionFacotry());
+                    subject.getPrivateCredentials().add(passwordCredential);
+                    return null;
+                }
+            });
+        } catch (Exception x) {
+            throw (LoginException) new LoginException(x.getMessage()).initCause(x);
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean abort() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean commit() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean logout() throws LoginException {
+        return true;
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/web/other/LoadFromWebModLoginModule.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/web/other/LoadFromWebModLoginModule.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package web.other;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Map;
+
+import javax.resource.spi.security.PasswordCredential;
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+
+import com.ibm.wsspi.security.auth.callback.WSManagedConnectionFactoryCallback;
+import com.ibm.wsspi.security.auth.callback.WSMappingPropertiesCallback;
+
+/**
+ * This login module always assigns the same user/password, which tests can check for.
+ */
+public class LoadFromWebModLoginModule implements LoginModule {
+    private CallbackHandler callbackHandler;
+    private Subject subject;
+
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        this.callbackHandler = callbackHandler;
+        this.subject = subject;
+    }
+
+    @Override
+    public boolean login() throws LoginException {
+        try {
+            final WSManagedConnectionFactoryCallback mcfCallback = new WSManagedConnectionFactoryCallback("Target ManagedConnectionFactory: ");
+            WSMappingPropertiesCallback mpropsCallback = new WSMappingPropertiesCallback("Mapping Properties (HashMap): ");
+            callbackHandler.handle(new Callback[] { mcfCallback, mpropsCallback });
+
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+                @Override
+                public Void run() {
+                    PasswordCredential passwordCredential = new PasswordCredential("webuser", "webpwd".toCharArray());
+                    passwordCredential.setManagedConnectionFactory(mcfCallback.getManagedConnectionFacotry());
+                    subject.getPrivateCredentials().add(passwordCredential);
+                    return null;
+                }
+            });
+        } catch (Exception x) {
+            throw (LoginException) new LoginException(x.getMessage()).initCause(x);
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean abort() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean commit() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean logout() throws LoginException {
+        return true;
+    }
+}


### PR DESCRIPTION
Write a test (currently disabled until the function can be added) of a login module that is packaged within a web module within an application.  For now, we have the test configured to access the login module out of a separate JAR and can switch it over later.  Also, this has some login modules packaged within EJB modules for future experimentation.