### PR TITLE
Issue #10816 - Update Equinox to solve LinkageError

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -28,7 +28,7 @@ com.ibm.ws.org.eclipse.microprofile.context-propagation:microprofile-context-pro
 com.ibm.ws.org.eclipse.platform:org.eclipse.equinox.coordinator:1.3.600.v20180827-1235
 com.ibm.ws.org.eclipse.platform:org.eclipse.equinox.metatype:1.5.200.v20191008-0645
 com.ibm.ws.org.eclipse.platform:org.eclipse.equinox.region:1.4.600.v20190911-1340
-com.ibm.ws.org.eclipse.platform:org.eclipse.osgi:3.15.200.v20200113-1015
+com.ibm.ws.org.eclipse.platform:org.eclipse.osgi:3.15.200.v20200214-1600
 com.ibm.ws.org.apache.aries.jndi:org.apache.aries.jndi.core:1.0.3.ibm.s20180216.1834
 com.ibm.ws.org.apache.bval:org.apache.bval.bundle:1.1.2
 com.ibm.ws.org.apache.commons:commons-compress:1.16.1

--- a/dev/org.eclipse.osgi/bnd.bnd
+++ b/dev/org.eclipse.osgi/bnd.bnd
@@ -8,12 +8,12 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
--include= jar:${fileuri;${repo;com.ibm.ws.org.eclipse.platform:org.eclipse.osgi;3.15.200.v20200113-1015}}!/META-INF/MANIFEST.MF,bnd.overrides
+-include= jar:${fileuri;${repo;com.ibm.ws.org.eclipse.platform:org.eclipse.osgi;3.15.200.v20200214-1600}}!/META-INF/MANIFEST.MF,bnd.overrides
 -nouses: true
 -nodefaultversion: true
 
 -includeresource: \
-   @${repo;com.ibm.ws.org.eclipse.platform:org.eclipse.osgi;3.15.200.v20200113-1015}
+   @${repo;com.ibm.ws.org.eclipse.platform:org.eclipse.osgi;3.15.200.v20200214-1600}
 
 -buildpath: \
-	com.ibm.ws.org.eclipse.platform:org.eclipse.osgi;version=3.15.200.v20200113-1015
+	com.ibm.ws.org.eclipse.platform:org.eclipse.osgi;version=3.15.200.v20200214-1600


### PR DESCRIPTION
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=559926

Need to update Equinox to solve a LinkageError that
can occur after a dynamic import wire has been established
in a package which has a class already defined
