### PR TITLE
disabled tests of login modules loaded from webapp and library within EAR

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
@@ -49,6 +49,7 @@ public class JDBCLoadFromAppTest extends FATServletClient {
     public static void setUp() throws Exception {
         WebArchive derbyApp = ShrinkWrap.create(WebArchive.class, "derbyApp.war")
                         .addPackage("web.derby") //
+                        .addAsWebInfResource(new File("test-applications/derbyapp/resources/WEB-INF/ibm-web-bnd.xml"))
                         .addAsLibrary(new File("publish/shared/resources/derby/derby.jar")) //
                         .addPackage("jdbc.driver.proxy"); // delegates to the Derby JDBC driver
         ShrinkHelper.exportAppToServer(server, derbyApp);
@@ -67,16 +68,22 @@ public class JDBCLoadFromAppTest extends FATServletClient {
         JavaArchive ejb2JAR = ShrinkWrap.create(JavaArchive.class, "ejb2.jar")
                         .addPackage("ejb.second");
 
+        JavaArchive lmJAR = ShrinkWrap.create(JavaArchive.class, "top-level-login-modules.jar")
+                        .addPackage("loginmod");
+
         EnterpriseArchive otherApp = ShrinkWrap.create(EnterpriseArchive.class, "otherApp.ear")
                         .addAsModule(otherWAR)
                         .addAsModule(ejb1JAR)
-                        .addAsModule(ejb2JAR);
+                        .addAsModule(ejb2JAR)
+                        .addAsLibrary(lmJAR);
 
         ShrinkHelper.exportAppToServer(server, otherApp);
 
         // TODO remove this
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "tempLoginModule.jar");
+        jar.addPackage("web.derby");
         jar.addPackage("web.other");
+        jar.addPackage("loginmod");
         ShrinkHelper.exportToServer(server, "/", jar);
 
         server.addInstalledAppForValidation("derbyApp");

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/server.xml
@@ -64,6 +64,14 @@
     </library>
     <javaPermission codebase="${server.config.dir}/tempLoginModule.jar" className="javax.security.auth.AuthPermission" name="modifyPrivateCredentials"/>
 
+    <jaasLoginContextEntry id="app1loginEntry" name="app1login">
+      <loginModule className="loginmod.LoadFromAppLoginModule" libraryRef="temp"/> <!-- TODO use classProviderRef once implemented -->
+    </jaasLoginContextEntry>
+
+    <jaasLoginContextEntry id="webapploginEntry" name="webapplogin">
+      <loginModule className="web.derby.LoadFromWebAppLoginModule" libraryRef="temp"/> <!-- TODO use classProviderRef once implemented -->
+    </jaasLoginContextEntry>
+
     <jaasLoginContextEntry id="web1loginEntry" name="web1login">
       <loginModule className="web.other.LoadFromWebModLoginModule" libraryRef="temp"/> <!-- TODO use classProviderRef once implemented -->
     </jaasLoginContextEntry>

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/resources/WEB-INF/ibm-web-bnd.xml
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/resources/WEB-INF/ibm-web-bnd.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<web-bnd xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-bnd_1_0.xsd" version="1.0">
+
+  <resource-ref name="java:module/env/jdbc/sldsLoginModuleFromWebApp">
+    <custom-login-configuration name="webapplogin">
+      <property name="shape" value="pentagon"/>
+      <property name="sides" value="5"/>
+      <property name="sumOfAngles" value="540"/>
+    </custom-login-configuration>
+  </resource-ref>
+
+</web-bnd>

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/src/web/derby/DerbyLoadFromAppServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/src/web/derby/DerbyLoadFromAppServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,6 +30,9 @@ import componenttest.app.FATDatabaseServlet;
 public class DerbyLoadFromAppServlet extends FATDatabaseServlet {
     @Resource
     private DataSource defaultDataSource;
+
+    @Resource(name = "java:module/env/jdbc/sldsLoginModuleFromWebApp", lookup = "jdbc/sharedLibDataSource")
+    private DataSource sldsLoginModuleFromWebApp;
 
     // Use a data source with generic properties element where the dataSource's jdbcDriver
     // specifies a data source class name, but is configured without any library,
@@ -63,6 +66,18 @@ public class DerbyLoadFromAppServlet extends FATDatabaseServlet {
     @Test
     public void testLoadDerbyClass() throws Exception {
         Class.forName("org.apache.derby.jdbc.EmbeddedDataSource");
+    }
+
+    /**
+     * testLoginModuleFromWebApp - verify that a login module that is packaged within the web application is used to authenticate
+     * to a data source when its resource reference specifies to use that login module.
+     */
+    @Test
+    public void testLoginModuleFromWebApp() throws Exception {
+        try (Connection con = sldsLoginModuleFromWebApp.getConnection()) {
+            DatabaseMetaData metadata = con.getMetaData();
+            assertEquals("webappuser", metadata.getUserName());
+        }
     }
 
     // Obtain a connection with a user/password that is unique to this method and a corresponding method

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/src/web/derby/LoadFromWebAppLoginModule.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/src/web/derby/LoadFromWebAppLoginModule.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package web.derby;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Map;
+
+import javax.resource.spi.security.PasswordCredential;
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+
+import com.ibm.wsspi.security.auth.callback.WSManagedConnectionFactoryCallback;
+import com.ibm.wsspi.security.auth.callback.WSMappingPropertiesCallback;
+
+/**
+ * This login module always assigns the same user/password, which tests can check for.
+ */
+public class LoadFromWebAppLoginModule implements LoginModule {
+    private CallbackHandler callbackHandler;
+    private Subject subject;
+
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        this.callbackHandler = callbackHandler;
+        this.subject = subject;
+    }
+
+    @Override
+    public boolean login() throws LoginException {
+        try {
+            final WSManagedConnectionFactoryCallback mcfCallback = new WSManagedConnectionFactoryCallback("Target ManagedConnectionFactory: ");
+            WSMappingPropertiesCallback mpropsCallback = new WSMappingPropertiesCallback("Mapping Properties (HashMap): ");
+            callbackHandler.handle(new Callback[] { mcfCallback, mpropsCallback });
+
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+                @Override
+                public Void run() {
+                    PasswordCredential passwordCredential = new PasswordCredential("webappuser", "webapppwd".toCharArray());
+                    passwordCredential.setManagedConnectionFactory(mcfCallback.getManagedConnectionFacotry());
+                    subject.getPrivateCredentials().add(passwordCredential);
+                    return null;
+                }
+            });
+        } catch (Exception x) {
+            throw (LoginException) new LoginException(x.getMessage()).initCause(x);
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean abort() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean commit() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean logout() throws LoginException {
+        return true;
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/resources/WEB-INF/ibm-web-bnd.xml
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/resources/WEB-INF/ibm-web-bnd.xml
@@ -20,7 +20,15 @@
     </custom-login-configuration>
   </resource-ref>
 
-  <resource-ref name="java:app/env/jdbc/slLoadFromAppWithWebModLoginModule">
+  <resource-ref name="java:app/env/jdbc/sldsLoginModuleFromTopLevelJarInApp">
+    <custom-login-configuration name="app1login">
+      <property name="shape" value="octagon"/>
+      <property name="sides" value="8"/>
+      <property name="sumOfAngles" value="1080"/>
+    </custom-login-configuration>
+  </resource-ref>
+
+  <resource-ref name="java:app/env/jdbc/sldsLoginModuleFromWebModuleInApp">
     <custom-login-configuration name="web1login">
       <property name="shape" value="triangle"/>
       <property name="sides" value="3"/>

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/ejb/first/FirstBean.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/ejb/first/FirstBean.java
@@ -10,24 +10,19 @@
  *******************************************************************************/
 package ejb.first;
 
-import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
 
 import javax.annotation.Resource;
 import javax.ejb.Stateless;
 import javax.sql.DataSource;
 
 @Stateless
-public class FirstBean implements Callable<String> {
+public class FirstBean implements Executor {
     @Resource(name = "java:comp/env/jdbc/dsref", lookup = "jdbc/sharedLibDataSource")
     DataSource ds;
 
     @Override
-    public String call() throws Exception {
-        try (Connection con = ds.getConnection()) {
-            DatabaseMetaData mdata = con.getMetaData();
-            return mdata.getUserName();
-        }
+    public void execute(Runnable runnable) {
+        runnable.run();
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/ejb/second/SecondBean.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/ejb/second/SecondBean.java
@@ -10,24 +10,19 @@
  *******************************************************************************/
 package ejb.second;
 
-import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
 
 import javax.annotation.Resource;
 import javax.ejb.Stateless;
 import javax.sql.DataSource;
 
 @Stateless
-public class SecondBean implements Callable<String> {
+public class SecondBean implements Executor {
     @Resource(name = "java:comp/env/jdbc/dsref", lookup = "jdbc/sharedLibDataSource")
     DataSource ds;
 
     @Override
-    public String call() throws Exception {
-        try (Connection con = ds.getConnection()) {
-            DatabaseMetaData mdata = con.getMetaData();
-            return mdata.getUserName();
-        }
+    public void execute(Runnable runnable) {
+        runnable.run();
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/loginmod/LoadFromAppLoginModule.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/loginmod/LoadFromAppLoginModule.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package loginmod;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Map;
+
+import javax.resource.spi.security.PasswordCredential;
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+
+import com.ibm.wsspi.security.auth.callback.WSManagedConnectionFactoryCallback;
+import com.ibm.wsspi.security.auth.callback.WSMappingPropertiesCallback;
+
+/**
+ * This login module always assigns the same user/password, which tests can check for.
+ */
+public class LoadFromAppLoginModule implements LoginModule {
+    private CallbackHandler callbackHandler;
+    private Subject subject;
+
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        this.callbackHandler = callbackHandler;
+        this.subject = subject;
+    }
+
+    @Override
+    public boolean login() throws LoginException {
+        try {
+            final WSManagedConnectionFactoryCallback mcfCallback = new WSManagedConnectionFactoryCallback("Target ManagedConnectionFactory: ");
+            WSMappingPropertiesCallback mpropsCallback = new WSMappingPropertiesCallback("Mapping Properties (HashMap): ");
+            callbackHandler.handle(new Callback[] { mcfCallback, mpropsCallback });
+
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+                @Override
+                public Void run() {
+                    PasswordCredential passwordCredential = new PasswordCredential("appuser", "apppwd".toCharArray());
+                    passwordCredential.setManagedConnectionFactory(mcfCallback.getManagedConnectionFacotry());
+                    subject.getPrivateCredentials().add(passwordCredential);
+                    return null;
+                }
+            });
+        } catch (Exception x) {
+            throw (LoginException) new LoginException(x.getMessage()).initCause(x);
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean abort() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean commit() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean logout() throws LoginException {
+        return true;
+    }
+}


### PR DESCRIPTION
Package a login module within a web application, associate it with a data source via a resource reference, attempt to access the data source from the web application and verify that the user name is chosen by the login module.  This test is disabled for now (by also including the login module within a separate library) and can be enabled once the necessary function is added.

Package a login module within a library at the top level within an EAR, associate it with a data source via a resource reference, attempt to access the data source from the web module and EJB modules and verify that the user name is chosen by the login module.  This test is disabled for now (by also including the login module within a separate library) and can be enabled once the necessary function is added.