### PR TITLE
update to add project as the group after service account token introspection

### DIFF
--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/utils/OpenShiftUserApiUtils.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/utils/OpenShiftUserApiUtils.java
@@ -249,7 +249,6 @@ public class OpenShiftUserApiUtils {
         JsonObject userMetadata = getJsonObjectValueFromJson(jsonResponse, "metadata");
         JsonObject result = modifyUsername(userMetadata);
         result = addProjectNameAsGroup(result);
-        //result = addGroupsToResult(result, jsonResponse);
         return result.toString();
     }
 

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/utils/OpenShiftUserApiUtils.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/utils/OpenShiftUserApiUtils.java
@@ -248,7 +248,8 @@ public class OpenShiftUserApiUtils {
         JsonObject jsonResponse = readResponseAsJsonObject(response);
         JsonObject userMetadata = getJsonObjectValueFromJson(jsonResponse, "metadata");
         JsonObject result = modifyUsername(userMetadata);
-        result = addGroupsToResult(result, jsonResponse);
+        result = addProjectNameAsGroup(result);
+        //result = addGroupsToResult(result, jsonResponse);
         return result.toString();
     }
 
@@ -303,15 +304,25 @@ public class OpenShiftUserApiUtils {
         }
         return result;
     }
-
-    JsonObject addGroupsToResult(JsonObject metadataEntry, JsonObject rawJsonResponse) {
+    
+    JsonObject addProjectNameAsGroup(JsonObject metadataEntry) throws SocialLoginException {
         JsonObject result = metadataEntry;
-        String groupNameAttribute = config.getGroupNameAttribute();
-        if (groupNameAttribute != null && rawJsonResponse.containsKey(groupNameAttribute)) {
-            JsonObjectBuilder resultBuilder = copyJsonObject(metadataEntry);
-            resultBuilder.add(groupNameAttribute, rawJsonResponse.get(groupNameAttribute));
-            result = resultBuilder.build();
+        String userNameAttribute = config.getUserNameAttribute();
+        String username = getStringValueFromJson(metadataEntry, userNameAttribute);
+        int index = username.indexOf(":");        
+        if (index >= 0) {
+            String group = null;
+            group = username.substring(0,index);
+            if (group != null && !group.isEmpty()) {
+                String groupNameAttribute = config.getGroupNameAttribute();
+                if (groupNameAttribute != null) {
+                    JsonObjectBuilder resultBuilder = copyJsonObject(metadataEntry);
+                    resultBuilder.add(groupNameAttribute, group);
+                    result = resultBuilder.build();
+                }
+            }
         }
+        
         return result;
     }
 


### PR DESCRIPTION
Use the project name (which is part of the user name) as the group name. Ignore the "groups" in the response from the user Validation endpoint.