### PR TITLE
Ensure SSL passwords are not logged in oracle connection properties

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/JDBCDriverService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 IBM Corporation and others.
+ * Copyright (c) 2011, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1084,35 +1084,26 @@ public class JDBCDriverService extends Observable implements LibraryChangeListen
      * @ connProp an Oracle connectionProperties string which may contain encoded passwords
      * @return a connectionProperties string with the passwords decoded
      */
-    public static String decodeOracleConnectionPropertiesPwds(String connProp)
-                    throws InvalidPasswordDecodingException, UnsupportedCryptoAlgorithmException {
-        final String pattern1 = "javax\\.net\\.ssl\\.keyStorePassword\\s*=\\s*(.*?)\\s*(;|$)";
-        final String pattern2 = "javax\\.net\\.ssl\\.trustStorePassword\\s*=\\s*(.*?)\\s*(;|$)";
-        connProp = decodeEmbeddedPassword(connProp, pattern1, 1);
-        return decodeEmbeddedPassword(connProp, pattern2, 1);
-    }
-    /**
-     * Given a string which potentially contains a key value pair where the value is a password encoded using
-     * one of the supported methods, use the supplied regex pattern to locate the key value pair and
-     * replace the value portion of the string with the decoded password.  For example,
-     * given the following value of an Oracle database connectionProperties string:
-     * "oracle.net.ssl_version=1.2;javax.net.ssl.keyStorePassword={aes}AIEJn6kmbn878lbUd8jJGWKMDYPm9FD1EoiL4JFNXO7f;javax.net.ssl.keyStore= path-to-keystore/keystore.p12"
-     * return this string:
-     * "oracle.net.ssl_version=1.2;javax.net.ssl.keyStorePassword=foobar;javax.net.ssl.keyStore= path-to-keystore/keystore.p12"
-     * 
-     * @param input A string potentially containing an encoded password
-     * @param pattern A regex pattern which attempts to match the password portion in the group specified in groupNumber
-     * @param groupNumber The group of the regex that contains the password to be decoded
-     * @return
-     */
-    private static String decodeEmbeddedPassword(String input, String pattern, int groupNumber)
-                    throws InvalidPasswordDecodingException, UnsupportedCryptoAlgorithmException {
-        Matcher matcher = Pattern.compile(pattern).matcher(input);
-        if (!matcher.find()) return input; // pattern not found
-        String password = matcher.group(groupNumber);
-        // decode password if encoded                   
-        password = PasswordUtil.getCryptoAlgorithm(password) == null ? password : PasswordUtil.decode(password);
-        return new StringBuilder(input).replace(matcher.start(groupNumber), matcher.end(groupNumber), password).toString();
-    }
+    public static String decodeOracleConnectionPropertiesPwds(String connProp) throws InvalidPasswordDecodingException, UnsupportedCryptoAlgorithmException {
+        final String regex = "Password\\s*=\\s*(.*?)\\s*(;|$)";
+        
+        StringBuffer sb = new StringBuffer();
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(connProp);
 
+        while (matcher.find()) {
+            //group(0) = "Password = {xor}abcd;" group(1) = "{xor}abcd" group(2) = ";"
+            String password = matcher.group(1);
+            password = PasswordUtil.getCryptoAlgorithm(password) == null ? password : PasswordUtil.decode(matcher.group(1));
+            
+            //This appends a replacement for group(0), so we want to just replace group(1) with [decoded password]
+            matcher.appendReplacement(sb, matcher.group(0).replace(matcher.group(1), password));
+        }
+        
+        //Append any trailing characters after matches
+        //If there were no matches this will just append props
+        matcher.appendTail(sb);
+        
+        return sb.toString(); 
+    }
 }

--- a/dev/com.ibm.ws.jdbc/test/com/ibm/ws/jdbc/internal/InternalTest.java
+++ b/dev/com.ibm.ws.jdbc/test/com/ibm/ws/jdbc/internal/InternalTest.java
@@ -216,6 +216,25 @@ public class InternalTest {
                                   "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=password16;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=password16",
                                   "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=password17;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=password17"
     };
+    static String[] expectedObfuscatedConnProps = {
+                                 "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=*****;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=*****",
+                                 "javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStorePassword =*****;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=*****",
+                                 "javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStorePassword= *****;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=*****",
+                                 "oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword = *****;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=*****",
+                                 "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=*****;",
+                                 "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStorePassword =*****",
+                                 "javax.net.ssl.keyStorePassword= *****",
+                                 "javax.net.ssl.keyStorePassword =*****;",
+                                 "javax.net.ssl.keyStorePassword = *****;;",
+                                 "oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword = *****;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=*****",
+                                 "javax.net.ssl.keyStorePassword= *****",
+                                 "javax.net.ssl.keyStorePassword =*****;;",
+                                 "oracle.net.ssl_version=1.2;javax.net.ssl.keyStorePassword = *****;oracle.net.authentication_services=(TCPS);",
+                                 "javax.net.ssl.keyStorePassword = *****  ;oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);",
+                                 "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=*****;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=*****",
+                                 "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=*****;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=*****",
+                                 "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=*****;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=*****"
+   };
     static String[] connProps = {
                                   "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=unencPassword1;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=password",
                                   "javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStorePassword ={xor}KjE6MTwPPiwsKDAtO20=;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=password",
@@ -247,6 +266,22 @@ public class InternalTest {
             }            
         } catch (Throwable t) {
             outputMgr.failWithThrowable(testName, t);
+        }
+    }
+    
+    @Test
+    public void testOracleConnPropsPwdObfuscating() {
+        String message;
+        // compare expected connProp after substitution
+        try {
+            for (int i = 0; i < connProps.length; i++ ) {
+                message = System.lineSeparator() + "input: " + connProps[i] + System.lineSeparator() + "expected: " + expectedObfuscatedConnProps[i];
+                String result = PropertyService.filterConnectionProperties(connProps[i]);
+                message += System.lineSeparator() + "output: " + result;
+                assertEquals(message, expectedObfuscatedConnProps[i], result );
+            }            
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable("testOracleConnPropsPwdObfuscating", t);
         }
     }
 }

--- a/dev/com.ibm.ws.jdbc/test/com/ibm/ws/jdbc/internal/InternalTest.java
+++ b/dev/com.ibm.ws.jdbc/test/com/ibm/ws/jdbc/internal/InternalTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -214,7 +214,8 @@ public class InternalTest {
                                   "javax.net.ssl.keyStorePassword = password14  ;oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);",
                                   "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=password15;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=password15",
                                   "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=password16;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=password16",
-                                  "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=password17;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=password17"
+                                  "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=password17;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=password17",
+                                  "oracle.net.ssl_version=1.2;"
     };
     static String[] expectedObfuscatedConnProps = {
                                  "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=*****;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=*****",
@@ -233,7 +234,8 @@ public class InternalTest {
                                  "javax.net.ssl.keyStorePassword = *****  ;oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);",
                                  "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=*****;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=*****",
                                  "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=*****;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=*****",
-                                 "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=*****;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=*****"
+                                 "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=*****;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=*****",
+                                 "oracle.net.ssl_version=1.2;"
    };
     static String[] connProps = {
                                   "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=unencPassword1;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=password",
@@ -252,7 +254,8 @@ public class InternalTest {
                                   "javax.net.ssl.keyStorePassword = {aes}AJsqh5c/+TrDO8Qw+9V12zBh8osrL3+01Nz//lctzD+u  ;oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);",
                                   "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword={xor}Lz4sLCgwLTtuag==;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword={xor}Lz4sLCgwLTtuag==",
                                   "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword={xor}Lz4sLCgwLTtuaQ==;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=password16",
-                                  "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=password17;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword={aes}AAu/gbr1pTHWM6fMJVxR79MgjNp4bs2ZKBw97EWi5M23"
+                                  "oracle.net.ssl_version=1.2;oracle.net.authentication_services=(TCPS);javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStoreType=PKCS12;javax.net.ssl.keyStorePassword=password17;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword={aes}AAu/gbr1pTHWM6fMJVxR79MgjNp4bs2ZKBw97EWi5M23",
+                                  "oracle.net.ssl_version=1.2;"
     };
     
     @Test


### PR DESCRIPTION
Fixes #8547 

Filters out SSL passwords in oracle connection properties when traced.

```
Input:
javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStorePassword= {aes}AGSgzua84RvVKvqP/N1FhMMbhdoFoht03A+T02KrDZ4QAJngbba3jDbVUVnhGTZ0Ig==;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=password"

Output:
javax.net.ssl.keyStore=path-to-keystore/keystore.p12;javax.net.ssl.keyStorePassword= *****;javax.net.ssl.trustStore= path-to-keystore/keystore.p12;javax.net.ssl.trustStoreType=PKCS12;javax.net.ssl.trustStorePassword=*****"
```
