### PR TITLE
FIXIT - Correct test assertions

### DIFF
--- a/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/JSF23FaceletVDLTests.java
+++ b/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/JSF23FaceletVDLTests.java
@@ -186,8 +186,8 @@ public class JSF23FaceletVDLTests {
         String result2 = jsf23Server.waitForStringInLogUsingMark(".*No context init parameter 'javax\\.faces\\.STATE_SAVING_METHOD' found, using default value 'server'*");
 
         // Verify that the correct values of the context parameters were found.
-        assertNotNull("The correct value of the javax.faces.FACELETS_REFRESH_PERIOD context parameter was not found", result != null);
-        assertNotNull("The correct value of the javax.faces.STATE_SAVING_METHOD context parameter was not found", result2 != null);
+        assertNotNull("The correct value of the javax.faces.FACELETS_REFRESH_PERIOD context parameter was not found", result);
+        assertNotNull("The correct value of the javax.faces.STATE_SAVING_METHOD context parameter was not found", result2);
 
         // Drive a request to the context root and ensure it contains the correct text
         try (WebClient webClient = new WebClient()) {

--- a/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/JSF23WebSocketTests.java
+++ b/dev/com.ibm.ws.jsf.2.3_fat/fat/src/com/ibm/ws/jsf23/fat/tests/JSF23WebSocketTests.java
@@ -101,7 +101,7 @@ public class JSF23WebSocketTests {
             String result1 = jsf23CDIWSOCServer.waitForStringInLogUsingMark("Channel myChannel was opened successfully!");
 
             // Verify that the correct message is found in the logs
-            assertNotNull("Message not found. Channel was not opened succesfully.", result1 != null);
+            assertNotNull("Message not found. Channel was not opened succesfully.", result1);
 
             // Get the form that we are dealing with
             HtmlForm form = testPushWebSocketPage.getFormByName("form1");
@@ -124,7 +124,7 @@ public class JSF23WebSocketTests {
             String result2 = jsf23CDIWSOCServer.waitForStringInLogUsingMark("Channel myChannel was closed successfully!");
 
             // Verify that the correct message is found in the logs
-            assertNotNull("Message not found. Channel was not closed succesfully.", result2 != null);
+            assertNotNull("Message not found. Channel was not closed succesfully.", result2);
         }
     }
 
@@ -170,7 +170,7 @@ public class JSF23WebSocketTests {
             String result1 = jsf23CDIWSOCServer.waitForStringInLogUsingMark("Channel myChannel was opened successfully!");
 
             // Verify that the correct message is found in the logs
-            assertNotNull("Message not found. Channel was not opened succesfully.", result1 != null);
+            assertNotNull("Message not found. Channel was not opened succesfully.", result1);
 
             // Now click the close button and get the resulted page.
             HtmlPage closePage = closeButton.click();
@@ -181,7 +181,7 @@ public class JSF23WebSocketTests {
             String result2 = jsf23CDIWSOCServer.waitForStringInLogUsingMark("Channel myChannel was closed successfully!");
 
             // Verify that the correct message is found in the logs
-            assertNotNull("Message not found. Channel was not closed succesfully.", result2 != null);
+            assertNotNull("Message not found. Channel was not closed succesfully.", result2);
         }
     }
 }

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/tests/JSF23WebSocketTests.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/tests/JSF23WebSocketTests.java
@@ -108,7 +108,7 @@ public class JSF23WebSocketTests extends FATServletClient {
             String result1 = jsf23CDIWSOCServer.waitForStringInLogUsingMark("Channel myChannel was opened successfully!");
 
             // Verify that the correct message is found in the logs
-            assertNotNull("Message not found. Channel was not opened succesfully.", result1 != null);
+            assertNotNull("Message not found. Channel was not opened succesfully.", result1);
 
             // Get the form that we are dealing with
             HtmlForm form = testPushWebSocketPage.getFormByName("form1");
@@ -131,7 +131,7 @@ public class JSF23WebSocketTests extends FATServletClient {
             String result2 = jsf23CDIWSOCServer.waitForStringInLogUsingMark("Channel myChannel was closed successfully!");
 
             // Verify that the correct message is found in the logs
-            assertNotNull("Message not found. Channel was not closed succesfully.", result2 != null);
+            assertNotNull("Message not found. Channel was not closed succesfully.", result2);
         }
     }
 
@@ -177,7 +177,7 @@ public class JSF23WebSocketTests extends FATServletClient {
             String result1 = jsf23CDIWSOCServer.waitForStringInLogUsingMark("Channel myChannel was opened successfully!");
 
             // Verify that the correct message is found in the logs
-            assertNotNull("Message not found. Channel was not opened succesfully.", result1 != null);
+            assertNotNull("Message not found. Channel was not opened succesfully.", result1);
 
             // Now click the close button and get the resulted page.
             HtmlPage closePage = closeButton.click();
@@ -188,7 +188,7 @@ public class JSF23WebSocketTests extends FATServletClient {
             String result2 = jsf23CDIWSOCServer.waitForStringInLogUsingMark("Channel myChannel was closed successfully!");
 
             // Verify that the correct message is found in the logs
-            assertNotNull("Message not found. Channel was not closed succesfully.", result2 != null);
+            assertNotNull("Message not found. Channel was not closed succesfully.", result2);
         }
     }
 


### PR DESCRIPTION
Correct the tests that asserted a `boolean` condition was not `null`.