### PR TITLE
load login module from standalone resource adapter

### DIFF
--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/LoginModuleInStandaloneResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/LoginModuleInStandaloneResourceAdapterTest.java
@@ -60,11 +60,9 @@ public class LoginModuleInStandaloneResourceAdapterTest extends FATServletClient
 
         rar.addAsLibrary(new File("publish/shared/resources/derby/derby.jar"));
 
-        rar.as(JavaArchive.class).addPackage("com.ibm.ws.jca.fat.security.login");
-        // TODO switch to JAR within resource adapter once implemented to properly read from the rar
-        //JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "loginModule.jar");
-        //jar.addPackage("com.ibm.ws.jca.fat.security.login");
-        //rar.addAsLibraries(jar);
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "loginModule.jar");
+        jar.addPackage("com.ibm.ws.jca.fat.security.login");
+        rar.addAsLibraries(jar);
 
         ShrinkHelper.exportToServer(server, "connectors", rar);
 

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.loginModuleInRA/server.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.loginModuleInRA/server.xml
@@ -42,13 +42,14 @@
     </connectionFactory>    
 
     <jaasLoginContextEntry id="myJAASLoginEntry" name="myJAASLoginEntryName">
-      <!-- TODO replace with classProviderRef="DerbyLMRA" once implemented -->
-      <loginModule className="com.ibm.ws.jca.fat.security.login.TestLoginModule" libraryRef="temp"/>
+      <!-- TODO remove libraryRef once enforcement is added to config. For now, while still being experimented with, classProviderRef takes precedence -->
+      <loginModule className="com.ibm.ws.jca.fat.security.login.TestLoginModule" libraryRef="temp" classProviderRef="DerbyLMRA"/>
     </jaasLoginContextEntry>
 
     <!-- TODO remove this -->
     <library id="temp">
-      <file name="${server.config.dir}/connectors/DerbyLMRA.rar"/>
+      <!-- no login modules found here - this library is only temporarily present to satisfy the mandatory libraryRef requirement that we will later take away -->
+      <file name="${server.config.dir}/apps/derbyRAApp.ear"/>
     </library>
 
     <!-- "APP" is the default schema for Derby -->

--- a/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/common/internal/ModuleConfig.java
+++ b/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/common/internal/ModuleConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,21 +16,30 @@ import org.osgi.service.metatype.annotations.Option;
 
 import com.ibm.ws.bnd.metatype.annotation.Ext;
 
-@ObjectClassDefinition(factoryPid = "com.ibm.ws.security.authentication.internal.jaas.jaasLoginModuleConfig",
-                name = "%jaasLoginModule",
-                description = "%jaasLoginModule.desc",
-                localization = "OSGI-INF/l10n/metatype")
+@ObjectClassDefinition(factoryPid = "com.ibm.ws.security.authentication.internal.jaas.jaasLoginModuleConfig", name = "%jaasLoginModule", description = "%jaasLoginModule.desc", localization = "OSGI-INF/l10n/metatype")
 @Ext.Alias("jaasLoginModule")
 public @interface ModuleConfig {
 
     @AttributeDefinition(name = "%className", description = "%className.desc")
     String className();
 
-    @AttributeDefinition(name = "%controlFlag", description = "%controlFlag.desc", defaultValue = "REQUIRED",
-                    options = { @Option(value = "REQUIRED", label = "%controlFlag.REQUIRED"),
-                               @Option(value = "REQUISITE", label = "%controlFlag.REQUISITE"),
-                               @Option(value = "SUFFICIENT", label = "%controlFlag.SUFFICIENT"),
-                               @Option(value = "OPTIONAL", label = "%controlFlag.OPTIONAL") })
+    // TODO translatable name, description, and make into ibm:beta="true" before GA?
+    @AttributeDefinition(name = Ext.INTERNAL, description = Ext.INTERNAL_DESC, required = false)
+    @Ext.ReferencePid("com.ibm.ws.app.manager")
+    String classProviderRef();
+
+    @AttributeDefinition(name = Ext.INTERNAL, description = Ext.INTERNAL_DESC, defaultValue = "${count(classProviderRef)}")
+    @Ext.Final
+    String ClassProvider_cardinality_minimum();
+
+    @AttributeDefinition(name = Ext.INTERNAL, description = Ext.INTERNAL_DESC, defaultValue = "(service.pid=${classProviderRef})")
+    @Ext.Final
+    String ClassProvider_target();
+
+    @AttributeDefinition(name = "%controlFlag", description = "%controlFlag.desc", defaultValue = "REQUIRED", options = { @Option(value = "REQUIRED", label = "%controlFlag.REQUIRED"),
+                                                                                                                          @Option(value = "REQUISITE", label = "%controlFlag.REQUISITE"),
+                                                                                                                          @Option(value = "SUFFICIENT", label = "%controlFlag.SUFFICIENT"),
+                                                                                                                          @Option(value = "OPTIONAL", label = "%controlFlag.OPTIONAL") })
     String controlFlag();
 
     @AttributeDefinition(name = "%libraryRef", description = "%libraryRef.desc")

--- a/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/common/modules/WSLoginModuleProxy.java
+++ b/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/common/modules/WSLoginModuleProxy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,8 @@
 package com.ibm.ws.security.jaas.common.modules;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -21,11 +23,17 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.LoginException;
 import javax.security.auth.spi.LoginModule;
 
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.classloading.ClassProvider;
 import com.ibm.ws.kernel.boot.security.LoginModuleProxy;
-import com.ibm.ws.security.jaas.common.TraceConstants;
 import com.ibm.ws.security.jaas.common.internal.JAASLoginModuleConfigImpl;
+import com.ibm.wsspi.kernel.service.utils.FilterUtils;
 
 /**
  * <p>
@@ -77,10 +85,65 @@ public class WSLoginModuleProxy extends CommonLoginModule implements LoginModule
     @Override
     public void initialize(Subject subject, CallbackHandler callbackHandler,
                            Map<String, ?> sharedState, Map<String, ?> options) {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
 
         checkForNoOptions(options);
 
-        Class<?> target = (Class<?>) options.get(JAASLoginModuleConfigImpl.DELEGATE);
+        String delegateProviderPid = (String) options.get(JAASLoginModuleConfigImpl.DELEGATE_PROVIDER_PID);
+        Class<?> target = null;
+        if (delegateProviderPid == null) {
+            // loaded from shared library
+            target = (Class<?>) options.get(JAASLoginModuleConfigImpl.DELEGATE);
+        } else {
+            // load login module from resourceAdapter or application
+            String loginModuleClassName = (String) options.get(JAASLoginModuleConfigImpl.DELEGATE);
+            String classProviderFilter = FilterUtils.createPropertyFilter("service.pid", delegateProviderPid);
+            BundleContext bundleContext = FrameworkUtil.getBundle(WSLoginModuleProxy.class).getBundleContext();
+            ServiceReference<?>[] refs;
+            try {
+                refs = bundleContext.getServiceReferences("com.ibm.wsspi.application.Application", classProviderFilter);
+            } catch (InvalidSyntaxException x) {
+                throw new RuntimeException(classProviderFilter, x); // internal error - filter above must be bad
+            }
+            if (trace && tc.isDebugEnabled())
+                Tr.debug(this, tc, "found?", classProviderFilter, Arrays.toString(refs));
+            if (refs == null) {
+                // TODO better error message?
+                throw new IllegalStateException(classProviderFilter);
+            }
+            String classProviderId = (String) refs[0].getProperty("id");
+            String extendsFactoryPid = (String) refs[0].getProperty("ibm.extends.source.factoryPid");
+            if ("com.ibm.ws.jca.resourceAdapter".equals(extendsFactoryPid)) {
+                // load from resource adapter
+                classProviderFilter = FilterUtils.createPropertyFilter("id", classProviderId);
+                Collection<ServiceReference<ClassProvider>> classProviderRefs;
+                try {
+                    classProviderRefs = bundleContext.getServiceReferences(ClassProvider.class, classProviderFilter);
+                } catch (InvalidSyntaxException x) {
+                    throw new RuntimeException(classProviderFilter, x); // internal error - filter above must be bad
+                }
+                if (trace && tc.isDebugEnabled())
+                    Tr.debug(this, tc, "found resource adapter?", classProviderFilter, Arrays.toString(refs));
+                if (classProviderRefs.isEmpty()) {
+                    // TODO better error message?
+                    throw new IllegalStateException("resourceAdapter " + classProviderId);
+                }
+                ClassProvider classProvider = bundleContext.getService(classProviderRefs.iterator().next());
+                ClassLoader loader = classProvider.getDelegateLoader();
+                if (trace && tc.isDebugEnabled())
+                    Tr.debug(this, tc, "about to load " + loginModuleClassName + " with " + loader + " from " + classProvider);
+                try {
+                    target = loader.loadClass(loginModuleClassName);
+                } catch (ClassNotFoundException x) {
+                    // TODO better error message?
+                    throw new IllegalArgumentException(x);
+                }
+            } else {
+                // load from application
+                // TODO
+            }
+        }
+
         if (target == null) {
             throw new IllegalArgumentException(Tr.formatMessage(tc, "JAAS_WSLOGIN_MODULE_PROXY_DELEGATE_NOT_SET"));
 
@@ -121,6 +184,7 @@ public class WSLoginModuleProxy extends CommonLoginModule implements LoginModule
         Map<String, Object> cutomLoginModuleOptions = new HashMap<String, Object>();
         cutomLoginModuleOptions.putAll(options);
         cutomLoginModuleOptions.remove(JAASLoginModuleConfigImpl.DELEGATE);
+        cutomLoginModuleOptions.remove(JAASLoginModuleConfigImpl.DELEGATE_PROVIDER_PID);
         cutomLoginModuleOptions.remove(LoginModuleProxy.KERNEL_DELEGATE);
         cutomLoginModuleOptions.remove(JAASLoginModuleConfigImpl.WAS_LM_SHARED_LIB);
         return cutomLoginModuleOptions;

--- a/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/config/internal/JAASLoginConfigImpl.java
+++ b/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/config/internal/JAASLoginConfigImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -189,7 +189,7 @@ public class JAASLoginConfigImpl extends Parser implements JAASLoginConfig
 
         for (AppConfigurationEntry appConfigurationEntry : appConfigurationEntries) {
             Map<String, Object> options = (Map<String, Object>) appConfigurationEntry.getOptions();
-            options = JAASLoginModuleConfigImpl.processDelegateOptions(options, appConfigurationEntry.getLoginModuleName(), classLoadingService, sharedLibrary, true);
+            options = JAASLoginModuleConfigImpl.processDelegateOptions(options, appConfigurationEntry.getLoginModuleName(), null, classLoadingService, sharedLibrary, true);
             LoginModuleControlFlag controlFlag = appConfigurationEntry.getControlFlag();
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "loginModuleClassName: " + JAASLoginModuleConfig.LOGIN_MODULE_PROXY + " options: " + options.toString() + " controlFlag: " + controlFlag.toString());

--- a/dev/com.ibm.ws.security.jaas.common_test/test/com/ibm/ws/security/jaas/common/internal/JAASLoginModuleConfigImplTestWithMock.java
+++ b/dev/com.ibm.ws.security.jaas.common_test/test/com/ibm/ws/security/jaas/common/internal/JAASLoginModuleConfigImplTestWithMock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -110,6 +110,21 @@ public class JAASLoginModuleConfigImplTestWithMock {
             @Override
             public String className() {
                 return delegateClassName;
+            }
+
+            @Override
+            public String classProviderRef() {
+                return null;
+            }
+
+            @Override
+            public String ClassProvider_cardinality_minimum() {
+                return "0";
+            }
+
+            @Override
+            public String ClassProvider_target() {
+                return "(service.pid=${classProviderRef})";
             }
 
             @Override


### PR DESCRIPTION
Code updates to load a login module from resource adapter that is specified by a classProviderRef.  Declarative services isn't used to inject the service due to a lot of unfortunate eager initialization in the security code which would require the resource adapter to be available far earlier on than is possible.  Instead, we lazily locate it a later point where it is guaranteed that the resource adapter is already available (per spec, resource adapters must be started before applications).