### PR TITLE
Upload retranslated files

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/nls/de/messages.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/accountManager/nls/de/messages.js
@@ -23,7 +23,7 @@ var messages = {
     "FALSE": "False",
     "GENERATE": "Generieren",
     "LOADING": "Wird geladen",
-    "LOGOUT": "Anmelden",
+    "LOGOUT": "Abmelden",
     "NEXT_PAGE": "Nächste Seite",
     "NO_RESULTS_FOUND": "Keine Ergebnisse gefunden",
     "PAGES": "{0} von {1} Seiten",   // {0} - current page number; {1} - total pages

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/clientAdmin/nls/de/messages.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/clientAdmin/nls/de/messages.js
@@ -24,7 +24,7 @@ var messages = {
     "FALSE": "False",
     "GENERATE": "Generieren",
     "LOADING": "Wird geladen",
-    "LOGOUT": "Anmelden",
+    "LOGOUT": "Abmelden",
     "NEXT_PAGE": "Nächste Seite",
     "NO_RESULTS_FOUND": "Keine Ergebnisse gefunden",
     "PAGES": "{0} von {1} Seiten",   // {0} - current page number; {1} - total pages

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/tokenManager/nls/de/messages.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/tokenManager/nls/de/messages.js
@@ -24,7 +24,7 @@ var messages = {
     "FALSE": "False",
     "GENERATE": "Generieren",
     "LOADING": "Wird geladen",
-    "LOGOUT": "Anmelden",
+    "LOGOUT": "Abmelden",
     "NEXT_PAGE": "Nächste Seite",
     "NO_RESULTS_FOUND": "Keine Ergebnisse gefunden",
     "PAGES": "{0} von {1} Seiten",   // {0} - current page number; {1} - total pages


### PR DESCRIPTION
Update the German (de) message files for the OIDC applications to have the correct translation for 'Logout'.

fixes #10867 