### PR TITLE
translatable classProviderRef

### DIFF
--- a/dev/com.ibm.ws.security.jaas.common/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.jaas.common/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011 IBM Corporation and others.
+# Copyright (c) 2011,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -34,6 +34,10 @@ jaasLoginModule.desc=A login module in the JAAS configuration.
 
 className=Class name
 className.desc=Fully-qualified package name of the JAAS login module class.
+
+classProviderRef=Class Provider
+classProviderRef.desc=A reference to the ID of the resource adapter or application that provides the JAAS login module class. Only specify this configuration attribute if you do not specify a shared library reference.
+classProviderRef$Ref=Class provider
 
 controlFlag=Login module control flag
 controlFlag.desc=The login module's control flag.  Valid values are REQUIRED, REQUISITE, SUFFICIENT, and OPTIONAL.

--- a/dev/com.ibm.ws.security.jaas.common/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.jaas.common/resources/OSGI-INF/l10n/metatype.properties
@@ -36,7 +36,7 @@ className=Class name
 className.desc=Fully-qualified package name of the JAAS login module class.
 
 classProviderRef=Class Provider
-classProviderRef.desc=A reference to the ID of the resource adapter or application that provides the JAAS login module class. Only specify this configuration attribute if you do not specify a shared library reference.
+classProviderRef.desc=A reference to the ID of the resource adapter or application that provides the JAAS login module class. Specify this configuration attribute only if you do not specify a shared library reference.
 classProviderRef$Ref=Class provider
 
 controlFlag=Login module control flag


### PR DESCRIPTION
Translatable name and description for classProviderRef.
This is kept separate from the other changes so it does not hold up delivery if we go back and forth several times on the language to be used.