### PR TITLE
Add ibm:beta to metatype annotations

### DIFF
--- a/dev/com.ibm.ws.bnd.annotations/src/com/ibm/ws/bnd/metatype/annotation/Ext.java
+++ b/dev/com.ibm.ws.bnd.annotations/src/com/ibm/ws/bnd/metatype/annotation/Ext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015-2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,6 +23,15 @@ public interface Ext {
 	String INTERNAL_DESC = "internal use only";
 	String LOCALIZATION = "OSGI-INF/l10n/metatype";
 
+	/**
+	 * Sets ibm:beta on an OCD or AD
+	 */
+	@XMLAttribute(namespace = "http://www.ibm.com/xmlns/appservers/osgi/metatype/v1.0.0", prefix = "ibm", mapping="value=beta")
+	@Retention(RetentionPolicy.CLASS)
+	@Target({ElementType.TYPE, ElementType.METHOD})
+	public @interface Beta {
+		boolean value() default true;
+	}
 	/**
 	 * Sets the alias for the OCD.
 	 */


### PR DESCRIPTION
PR to add the ability to specify ibm:beta as a metatype annotation