### PR TITLE
AsyncResponseImpl.initContinuation() throws NPE when Continuation is null

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/impl/AsyncResponseImpl.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/jaxrs/impl/AsyncResponseImpl.java
@@ -354,6 +354,9 @@ public class AsyncResponseImpl implements AsyncResponse, ContinuationCallback {
     private void initContinuation() {
         ContinuationProvider provider =
             (ContinuationProvider)inMessage.get(ContinuationProvider.class.getName());
+        if (provider == null) {
+            throw new IllegalArgumentException("Continuation not supported. Please ensure that all servlets and servlet filters support async operations");
+        }
         cont = provider.getContinuation();
         initialSuspend = true;
     }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/impl/AsyncResponseImpl.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/impl/AsyncResponseImpl.java
@@ -348,6 +348,9 @@ public class AsyncResponseImpl implements AsyncResponse, ContinuationCallback {
     private void initContinuation() {
         ContinuationProvider provider =
             (ContinuationProvider)inMessage.get(ContinuationProvider.class.getName());
+        if (provider == null) {
+            throw new IllegalArgumentException("Continuation not supported. Please ensure that all servlets and servlet filters support async operations");
+        }
         cont = provider.getContinuation();
         initialSuspend = true;
     }


### PR DESCRIPTION
Throw an IllegalArgumentException in AsyncResponseImpl.initContinuation() instead of an NPE when user includes a servlet or servlet filter that does not support async.

https://github.com/OpenLiberty/open-liberty/issues/10712