### PR TITLE
use proxy to redirect from app pid to class provider

### DIFF
--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/LoginModuleInStandaloneResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/LoginModuleInStandaloneResourceAdapterTest.java
@@ -60,11 +60,9 @@ public class LoginModuleInStandaloneResourceAdapterTest extends FATServletClient
 
         rar.addAsLibrary(new File("publish/shared/resources/derby/derby.jar"));
 
-        rar.as(JavaArchive.class).addPackage("com.ibm.ws.jca.fat.security.login");
-        // TODO switch to JAR within resource adapter once implemented to properly read from the rar
-        //JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "loginModule.jar");
-        //jar.addPackage("com.ibm.ws.jca.fat.security.login");
-        //rar.addAsLibraries(jar);
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "loginModule.jar");
+        jar.addPackage("com.ibm.ws.jca.fat.security.login");
+        rar.addAsLibraries(jar);
 
         ShrinkHelper.exportToServer(server, "connectors", rar);
 

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.loginModuleInRA/server.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.loginModuleInRA/server.xml
@@ -42,13 +42,14 @@
     </connectionFactory>    
 
     <jaasLoginContextEntry id="myJAASLoginEntry" name="myJAASLoginEntryName">
-      <!-- TODO replace with classProviderRef="DerbyLMRA" once implemented -->
-      <loginModule className="com.ibm.ws.jca.fat.security.login.TestLoginModule" libraryRef="temp"/>
+      <!-- TODO remove libraryRef once enforcement is added to config. For now, while still being experimented with, classProviderRef takes precedence -->
+      <loginModule className="com.ibm.ws.jca.fat.security.login.TestLoginModule" libraryRef="temp" classProviderRef="DerbyLMRA"/>
     </jaasLoginContextEntry>
 
     <!-- TODO remove this -->
     <library id="temp">
-      <file name="${server.config.dir}/connectors/DerbyLMRA.rar"/>
+      <!-- no login modules found here - this library is only temporarily present to satisfy the mandatory libraryRef requirement that we will later take away -->
+      <file name="${server.config.dir}/apps/derbyRAApp.ear"/>
     </library>
 
     <!-- "APP" is the default schema for Derby -->

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/DerbyRAServlet.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/DerbyRAServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -334,7 +334,7 @@ public class DerbyRAServlet extends FATServlet {
                 throw new Exception("User name doesn't match configured value on containerAuthData. Instead: " + userName);
 
             if (con.toString().contains("WSPrincipal:") == false) {
-                throw new Exception("The subject does not contain a principal.");
+                throw new Exception("The subject does not contain a principal. " + con.toString());
             }
         } finally {
             con.close();

--- a/dev/com.ibm.ws.security.client/bnd.bnd
+++ b/dev/com.ibm.ws.security.client/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -51,6 +51,7 @@ instrument.classesExcludes: com/ibm/ws/security/client/internal/resources/*.clas
 	com.ibm.ws.security.authentication;version=latest,\
 	com.ibm.ws.security.credentials;version=latest,\
 	com.ibm.ws.security.jaas.common;version=latest,\
+	com.ibm.ws.classloading;version=latest,\
 	com.ibm.ws.clientcontainer;version=latest,\
 	com.ibm.ws.logging;version=latest, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest

--- a/dev/com.ibm.ws.security.jaas.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.jaas.common/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -56,6 +56,7 @@ Service-Component: \
 
 -dsannotations: \
   com.ibm.ws.security.jaas.common.JAASConfigurationFactory, \
+  com.ibm.ws.security.jaas.common.internal.ClassProviderCoordinator, \
   com.ibm.ws.security.jaas.common.internal.JAASLoginContextEntryImpl, \
   com.ibm.ws.security.jaas.common.internal.JAASLoginModuleConfigImpl, \
   com.ibm.ws.security.jaas.config.internal.JAASLoginConfigImpl
@@ -70,6 +71,7 @@ instrument.classesExcludes: com/ibm/ws/security/jaas/common/internal/resources/*
 	com.ibm.websphere.security;version=latest,\
 	com.ibm.ws.security.authentication;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
+	com.ibm.ws.app.manager;version=latest,\
 	com.ibm.ws.common.encoder,\
 	com.ibm.ws.bnd.annotations;version=latest,\
 	com.ibm.ws.classloading;version=latest,\
@@ -82,7 +84,7 @@ instrument.classesExcludes: com/ibm/ws/security/jaas/common/internal/resources/*
 	com.ibm.websphere.org.osgi.core,\
 	com.ibm.websphere.org.osgi.service.component,\
 	com.ibm.wsspi.org.osgi.service.component.annotations,\
-	com.ibm.wsspi.org.osgi.service.metatype.annotations, \
+	com.ibm.wsspi.org.osgi.service.metatype.annotations,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.ws.org.apache.commons.codec.1.4;version=latest
 	

--- a/dev/com.ibm.ws.security.jaas.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.jaas.common/bnd.bnd
@@ -27,7 +27,11 @@ Export-Package: \
   com.ibm.wsspi.security.auth.callback;provide:=true;thread-context=true  
   
 Import-Package: \
-  com.ibm.ws.common.internal.encoder, !*.internal.*, !javax.resource.spi.*, *
+  com.ibm.ws.common.internal.encoder, \
+  !*.internal.*, \
+  !javax.resource.spi.*, \
+  !com.ibm.wsspi.application.*, \
+  *
 
 DynamicImport-Package: \
   javax.resource.spi.*
@@ -52,11 +56,19 @@ Service-Component: \
     optional:='changeListener'; \
     multiple:='changeListener'; \
     dynamic:='changeListener'; \
-    properties:='service.vendor=IBM'
+    properties:='service.vendor=IBM',\
+  com.ibm.ws.security.jaas.common.internal.ClassProviderCoordinator; \
+    implementation:=com.ibm.ws.security.jaas.common.internal.ClassProviderCoordinator; \
+    configuration-policy:=ignore; \
+    immediate:=true; \
+    classProvider=com.ibm.wsspi.application.Application; \
+    dynamic:='classProvider'; \
+    greedy:='classProvider'; \
+    multiple:='classProvider'; \
+    optional:='classProvider'
 
 -dsannotations: \
   com.ibm.ws.security.jaas.common.JAASConfigurationFactory, \
-  com.ibm.ws.security.jaas.common.internal.ClassProviderCoordinator, \
   com.ibm.ws.security.jaas.common.internal.JAASLoginContextEntryImpl, \
   com.ibm.ws.security.jaas.common.internal.JAASLoginModuleConfigImpl, \
   com.ibm.ws.security.jaas.config.internal.JAASLoginConfigImpl
@@ -71,7 +83,6 @@ instrument.classesExcludes: com/ibm/ws/security/jaas/common/internal/resources/*
 	com.ibm.websphere.security;version=latest,\
 	com.ibm.ws.security.authentication;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
-	com.ibm.ws.app.manager;version=latest,\
 	com.ibm.ws.common.encoder,\
 	com.ibm.ws.bnd.annotations;version=latest,\
 	com.ibm.ws.classloading;version=latest,\

--- a/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/common/internal/ClassProviderCoordinator.java
+++ b/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/common/internal/ClassProviderCoordinator.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.jaas.common.internal;
+
+import java.security.AccessController;
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import com.ibm.ws.classloading.ClassProvider;
+import com.ibm.ws.kernel.service.util.SecureAction;
+import com.ibm.wsspi.application.Application;
+import com.ibm.wsspi.kernel.service.utils.FilterUtils;
+
+/**
+ * This class collects references to com.ibm.ws.app.manager pids, which are what classProviderRef can refer to.
+ * It republishes intermediate forms of ClassProvider, with dependencies on the remaining services that
+ * are necessary for them to be usable for loading classes.
+ *
+ * The need to do this is a result of security eagerly loading everything. If that ever changes, consider
+ * replacing the mechanism that is provided by this class.
+ */
+@Component(configurationPolicy = ConfigurationPolicy.IGNORE, immediate = true)
+public class ClassProviderCoordinator {
+    static final SecureAction secureAction = AccessController.doPrivileged(SecureAction.get());
+
+    private final ConcurrentHashMap<ServiceReference<Application>, ClassProviderProxy> proxyClassProvidersForResourceAdapters = //
+                    new ConcurrentHashMap<ServiceReference<Application>, ClassProviderProxy>();
+
+    @Reference(service = Application.class, cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
+    protected void setClassProvider(ServiceReference<Application> ref) throws InvalidSyntaxException {
+        String classProviderId = (String) ref.getProperty("id");
+        String extendsFactoryPid = (String) ref.getProperty("ibm.extends.source.factoryPid");
+        if ("com.ibm.ws.jca.resourceAdapter".equals(extendsFactoryPid)) {
+            String filter = "(&"
+                            + FilterUtils.createPropertyFilter("objectClass", ClassProvider.class.getName())
+                            + FilterUtils.createPropertyFilter("id", classProviderId)
+                            + ")";
+
+            String appMgrPid = (String) ref.getProperty("service.pid");
+            ClassProviderProxy proxy = new ClassProviderProxy(appMgrPid);
+            BundleContext bundleContext = FrameworkUtil.getBundle(ClassProviderCoordinator.class).getBundleContext();
+            bundleContext.addServiceListener(proxy, filter);
+
+            // If the above was registered just as we were adding the ServiceListener
+            // and so the ServiceListener didn't get notified, then we need to register manually,
+            Collection<ServiceReference<ClassProvider>> refs = bundleContext.getServiceReferences(ClassProvider.class, filter);
+            if (!refs.isEmpty())
+                proxy.register(refs.iterator().next());
+
+            ClassProviderProxy previous = proxyClassProvidersForResourceAdapters.put(ref, proxy);
+            if (previous != null) {
+                bundleContext.removeServiceListener(proxy);
+                previous.unregister();
+            }
+        }
+
+        System.out.println("*** Class provider found " + ref);
+    }
+
+    protected void unsetClassProvider(ServiceReference<Application> ref) {
+        ClassProviderProxy proxy = proxyClassProvidersForResourceAdapters.remove(ref);
+        if (proxy != null) {
+            BundleContext bundleContext = FrameworkUtil.getBundle(ClassProviderCoordinator.class).getBundleContext();
+            bundleContext.removeServiceListener(proxy);
+            proxy.unregister();
+        }
+    }
+}

--- a/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/common/internal/ClassProviderCoordinator.java
+++ b/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/common/internal/ClassProviderCoordinator.java
@@ -18,16 +18,9 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import com.ibm.ws.classloading.ClassProvider;
 import com.ibm.ws.kernel.service.util.SecureAction;
-import com.ibm.wsspi.application.Application;
 import com.ibm.wsspi.kernel.service.utils.FilterUtils;
 
 /**
@@ -38,15 +31,13 @@ import com.ibm.wsspi.kernel.service.utils.FilterUtils;
  * The need to do this is a result of security eagerly loading everything. If that ever changes, consider
  * replacing the mechanism that is provided by this class.
  */
-@Component(configurationPolicy = ConfigurationPolicy.IGNORE, immediate = true)
 public class ClassProviderCoordinator {
     static final SecureAction secureAction = AccessController.doPrivileged(SecureAction.get());
 
-    private final ConcurrentHashMap<ServiceReference<Application>, ClassProviderProxy> proxyClassProvidersForResourceAdapters = //
-                    new ConcurrentHashMap<ServiceReference<Application>, ClassProviderProxy>();
+    private final ConcurrentHashMap<ServiceReference<?>, ClassProviderProxy> proxyClassProvidersForResourceAdapters = //
+                    new ConcurrentHashMap<ServiceReference<?>, ClassProviderProxy>();
 
-    @Reference(service = Application.class, cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
-    protected void setClassProvider(ServiceReference<Application> ref) throws InvalidSyntaxException {
+    protected void setClassProvider(ServiceReference<?> ref) throws InvalidSyntaxException {
         String classProviderId = (String) ref.getProperty("id");
         String extendsFactoryPid = (String) ref.getProperty("ibm.extends.source.factoryPid");
         if ("com.ibm.ws.jca.resourceAdapter".equals(extendsFactoryPid)) {
@@ -72,11 +63,9 @@ public class ClassProviderCoordinator {
                 previous.unregister();
             }
         }
-
-        System.out.println("*** Class provider found " + ref);
     }
 
-    protected void unsetClassProvider(ServiceReference<Application> ref) {
+    protected void unsetClassProvider(ServiceReference<?> ref) {
         ClassProviderProxy proxy = proxyClassProvidersForResourceAdapters.remove(ref);
         if (proxy != null) {
             BundleContext bundleContext = FrameworkUtil.getBundle(ClassProviderCoordinator.class).getBundleContext();

--- a/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/common/internal/ClassProviderProxy.java
+++ b/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/common/internal/ClassProviderProxy.java
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.jaas.common.internal;
+
+import java.util.Hashtable;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.framework.ServiceListener;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
+
+import com.ibm.ws.classloading.ClassProvider;
+import com.ibm.ws.classloading.LibertyClassLoader;
+
+/**
+ * This proxy class provider delegates to another class provider that wasn't available
+ * at the time of registration.
+ */
+class ClassProviderProxy implements ServiceListener {
+    /**
+     * com.ibm.ws.app.manager_# service.pid that is resolved by the classProviderRef
+     */
+    private final String appMgrPid;
+
+    /**
+     * Proxied class provider instance. This is lazily initialized after it becomes available.
+     */
+    private ClassProvider classProvider;
+
+    /**
+     * Service reference to the proxied class provider instance. This is supplied once it becomes available.
+     */
+    private ServiceReference<ClassProvider> classProviderRef;
+
+    /**
+     * Lock for accessing all of the fields of this class.
+     */
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    /**
+     * Registration of this instance, which is a prerequisite of activating a JAASLoginModuleConfigImpl that has a classProviderRef.
+     */
+    private ServiceRegistration<ClassProviderProxy> registration;
+
+    ClassProviderProxy(String appMgrPid) {
+        this.appMgrPid = appMgrPid;
+    }
+
+    LibertyClassLoader getDelegateLoader() {
+        lock.readLock().lock();
+        try {
+            if (classProvider == null) {
+                // Switch to write lock for initialization
+                lock.readLock().unlock();
+                lock.writeLock().lock();
+                try {
+                    if (classProvider == null) {
+                        BundleContext bundleContext = FrameworkUtil.getBundle(ClassProviderProxy.class).getBundleContext();
+                        classProvider = bundleContext.getService(classProviderRef);
+                    }
+                } finally {
+                    // Downgrade to read lock for rest of method
+                    lock.readLock().lock();
+                    lock.writeLock().unlock();
+                }
+            }
+
+            return classProvider.getDelegateLoader();
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Register this proxy class provider to load from a resource adapter's class provider, which is now available.
+     *
+     * @param classProviderRef reference to the proxied ClassProvider that is now available.
+     */
+    void register(ServiceReference<ClassProvider> classProviderRef) {
+        BundleContext bundleContext = FrameworkUtil.getBundle(ClassProviderProxy.class).getBundleContext();
+
+        Hashtable<String, Object> props = new Hashtable<String, Object>();
+        props.put("provides.classes.for.pid", appMgrPid);
+
+        lock.writeLock().lock();
+        try {
+            if (registration == null) {
+                this.classProviderRef = classProviderRef;
+                registration = bundleContext.registerService(ClassProviderProxy.class, this, props);
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void serviceChanged(ServiceEvent event) {
+        switch (event.getType()) {
+            case ServiceEvent.REGISTERED:
+                register((ServiceReference<ClassProvider>) event.getServiceReference());
+                break;
+            case ServiceEvent.UNREGISTERING:
+            case ServiceEvent.MODIFIED_ENDMATCH:
+                unregister();
+                break;
+            case ServiceEvent.MODIFIED:
+                lock.writeLock().lock();
+                classProvider = null;
+                classProviderRef = (ServiceReference<ClassProvider>) event.getServiceReference();
+                lock.writeLock().unlock();
+                break;
+            default:
+                throw new IllegalStateException(event.toString()); // should be unreachable
+        }
+    }
+
+    /**
+     * Unregister this proxy class provider.
+     */
+    void unregister() {
+        lock.writeLock().lock();
+        try {
+            if (registration != null) {
+                registration.unregister();
+                registration = null;
+                classProvider = null;
+                classProviderRef = null;
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+}

--- a/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/common/internal/ModuleConfig.java
+++ b/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/common/internal/ModuleConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,19 @@ public @interface ModuleConfig {
 
     @AttributeDefinition(name = "%className", description = "%className.desc")
     String className();
+
+    // TODO translatable name, description, and make into ibm:beta="true" before GA?
+    @AttributeDefinition(name = Ext.INTERNAL, description = Ext.INTERNAL_DESC, required = false)
+    @Ext.ReferencePid("com.ibm.ws.app.manager")
+    String classProviderRef();
+
+    @AttributeDefinition(name = Ext.INTERNAL, description = Ext.INTERNAL_DESC, defaultValue = "${count(classProviderRef)}")
+    @Ext.Final
+    String ClassProvider_cardinality_minimum();
+
+    @AttributeDefinition(name = Ext.INTERNAL, description = Ext.INTERNAL_DESC, defaultValue = "(provides.classes.for.pid=${classProviderRef})")
+    @Ext.Final
+    String ClassProvider_target();
 
     @AttributeDefinition(name = "%controlFlag", description = "%controlFlag.desc", defaultValue = "REQUIRED",
                     options = { @Option(value = "REQUIRED", label = "%controlFlag.REQUIRED"),

--- a/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/config/internal/JAASLoginConfigImpl.java
+++ b/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/config/internal/JAASLoginConfigImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -189,7 +189,7 @@ public class JAASLoginConfigImpl extends Parser implements JAASLoginConfig
 
         for (AppConfigurationEntry appConfigurationEntry : appConfigurationEntries) {
             Map<String, Object> options = (Map<String, Object>) appConfigurationEntry.getOptions();
-            options = JAASLoginModuleConfigImpl.processDelegateOptions(options, appConfigurationEntry.getLoginModuleName(), classLoadingService, sharedLibrary, true);
+            options = JAASLoginModuleConfigImpl.processDelegateOptions(options, appConfigurationEntry.getLoginModuleName(), null, classLoadingService, sharedLibrary, true);
             LoginModuleControlFlag controlFlag = appConfigurationEntry.getControlFlag();
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "loginModuleClassName: " + JAASLoginModuleConfig.LOGIN_MODULE_PROXY + " options: " + options.toString() + " controlFlag: " + controlFlag.toString());

--- a/dev/com.ibm.ws.security.jaas.common_test/test/com/ibm/ws/security/jaas/common/internal/JAASLoginModuleConfigImplTestWithMock.java
+++ b/dev/com.ibm.ws.security.jaas.common_test/test/com/ibm/ws/security/jaas/common/internal/JAASLoginModuleConfigImplTestWithMock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -110,6 +110,21 @@ public class JAASLoginModuleConfigImplTestWithMock {
             @Override
             public String className() {
                 return delegateClassName;
+            }
+
+            @Override
+            public String classProviderRef() {
+                return null;
+            }
+
+            @Override
+            public String ClassProvider_cardinality_minimum() {
+                return "0";
+            }
+
+            @Override
+            public String ClassProvider_target() {
+                return "(provides.classes.for.pid=${classProviderRef})";
             }
 
             @Override


### PR DESCRIPTION
This pull covers the approach of enforcing a declarative services dependency on the appmanager pid that is specified as the classProviderRef.  However, because the app instance becomes available in the service registry long before the corresponding resource adapter and its class loader, if we are to use this approach, we need an intermediate proxy that becomes registered in response to the real ClassProvider becoming available and which redirects to it.