### PR TITLE
Only run test with Java EE 8 features for full fat mode.

### DIFF
--- a/dev/com.ibm.ws.wsat_fat/fat/src/com/ibm/ws/wsat/fat/FATSuite.java
+++ b/dev/com.ibm.ws.wsat_fat/fat/src/com/ibm/ws/wsat/fat/FATSuite.java
@@ -50,5 +50,5 @@ public class FATSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE8_FEATURES());
+                    .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly());
 }


### PR DESCRIPTION
- If tests are run with Java EE 8 features in lite mode, it goes over
the 1 hour time limit.
