### PR TITLE
Eclipse settings updates

### DIFF
--- a/dev/com.ibm.websphere.org.eclipse.microprofile.health.2.2/.classpath
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.health.2.2/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>	
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.websphere.org.eclipse.microprofile.metrics.2.3/.classpath
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.metrics.2.3/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.microprofile.metrics.2.3/.classpath
+++ b/dev/com.ibm.ws.microprofile.metrics.2.3/.classpath
@@ -4,7 +4,5 @@
 	<classpathentry kind="src" path="resources"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.ws.microprofile.metrics.2.0"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.websphere.org.eclipse.microprofile.metrics.2.3"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
- Remove non existent src directories from .classpath
- Remove project references in .classpath and only rely on bnd to get
project dependencies.
