### PR TITLE
Make sure that MP 3.3 features use up-to-date MP dependencies

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpFaultTolerance-metrics2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpFaultTolerance-metrics2.0.feature
@@ -3,7 +3,7 @@ symbolicName=com.ibm.websphere.appserver.mpFaultTolerance-metrics2.0
 singleton=true
 IBM-Provision-Capability: \
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpFaultTolerance-1.1)(osgi.identity=com.ibm.websphere.appserver.mpFaultTolerance-2.0)(osgi.identity=com.ibm.websphere.appserver.mpFaultTolerance-2.1)))", \
- osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpMetrics-2.0)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-2.2)))"
+ osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpMetrics-2.0)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-2.2)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-2.3)))"
 IBM-Install-Policy: when-satisfied
 -bundles=com.ibm.ws.microprofile.faulttolerance.metrics,com.ibm.ws.microprofile.faulttolerance.metrics.2.0
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-3.3/com.ibm.websphere.appserver.microProfile-3.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-3.3/com.ibm.websphere.appserver.microProfile-3.3.feature
@@ -19,11 +19,11 @@ Subsystem-Name: MicroProfile 3.3
   com.ibm.websphere.appserver.mpFaultTolerance-2.1, \
   com.ibm.websphere.appserver.mpHealth-2.2, \
   com.ibm.websphere.appserver.mpJwt-1.1, \
-  com.ibm.websphere.appserver.mpMetrics-2.2, \
+  com.ibm.websphere.appserver.mpMetrics-2.3, \
   com.ibm.websphere.appserver.mpOpenAPI-1.1, \
   com.ibm.websphere.appserver.mpOpenTracing-1.3, \
   com.ibm.websphere.appserver.mpRestClient-1.3
 -bundles=\
   com.ibm.ws.require.java8
-kind=noship
-edition=full
+kind=beta
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpConfig-1.4/com.ibm.websphere.appserver.mpConfig-1.4.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpConfig-1.4/com.ibm.websphere.appserver.mpConfig-1.4.feature
@@ -11,8 +11,8 @@ IBM-API-Package: \
 IBM-ShortName: mpConfig-1.4
 Subsystem-Name: MicroProfile Config 1.4
 -features=com.ibm.websphere.appserver.org.eclipse.microprofile.config-1.4, \
- com.ibm.websphere.appserver.javax.cdi-1.2; ibm.tolerates:=2.0, \
- com.ibm.websphere.appserver.javax.annotation-1.2; ibm.tolerates:=1.3, \
+ com.ibm.websphere.appserver.javax.cdi-2.0; ibm.tolerates:=1.2, \
+ com.ibm.websphere.appserver.javax.annotation-1.3; ibm.tolerates:=1.2, \
  com.ibm.websphere.appserver.containerServices-1.0, \
  com.ibm.websphere.appserver.appmanager-1.0
 -bundles=com.ibm.ws.require.java8, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpFaultTolerance-2.1/com.ibm.websphere.appserver.mpFaultTolerance-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpFaultTolerance-2.1/com.ibm.websphere.appserver.mpFaultTolerance-2.1.feature
@@ -11,7 +11,7 @@ Subsystem-Name: MicroProfile Fault Tolerance 2.1
 -features=com.ibm.websphere.appserver.org.eclipse.microprofile.faulttolerance-2.1, \
  com.ibm.websphere.appserver.cdi-2.0, \
  com.ibm.websphere.appserver.concurrent-1.0, \
- com.ibm.websphere.appserver.mpConfig-1.1; ibm.tolerates:="1.2, 1.3, 1.4"
+ com.ibm.websphere.appserver.mpConfig-1.4; ibm.tolerates:="1.1, 1.2, 1.3"
 -bundles=com.ibm.ws.microprofile.faulttolerance; apiJar=false; location:="lib/", \
  com.ibm.ws.microprofile.faulttolerance.2.0; apiJar=false; location:="lib/", \
  com.ibm.ws.microprofile.faulttolerance.spi; apiJar=false; location:="lib/", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpHealth-2.2/com.ibm.websphere.appserver.mpHealth-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpHealth-2.2/com.ibm.websphere.appserver.mpHealth-2.2.feature
@@ -10,12 +10,12 @@ IBM-API-Package: \
 IBM-ShortName: mpHealth-2.2
 Subsystem-Name: MicroProfile Health 2.2
 -features=com.ibm.websphere.appserver.org.eclipse.microprofile.health-2.2, \
- com.ibm.websphere.appserver.cdi-1.2; ibm.tolerates:=2.0, \
+ com.ibm.websphere.appserver.cdi-2.0; ibm.tolerates:=1.2, \
  com.ibm.websphere.appserver.classloaderContext-1.0, \
  com.ibm.websphere.appserver.contextService-1.0, \
  com.ibm.websphere.appserver.jndi-1.0, \
  com.ibm.websphere.appserver.json-1.0, \
- com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:=4.0, \
+ com.ibm.websphere.appserver.servlet-4.0; ibm.tolerates:=3.1, \
  com.ibm.wsspi.appserver.webBundle-1.0 
 -bundles=com.ibm.ws.require.java8, \
  com.ibm.websphere.org.eclipse.microprofile.health.2.2; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.health:microprofile-health-api:2.2", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-2.3/com.ibm.websphere.appserver.mpMetrics-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-2.3/com.ibm.websphere.appserver.mpMetrics-2.3.feature
@@ -7,12 +7,12 @@ IBM-API-Package: org.eclipse.microprofile.metrics.annotation;  type="stable", \
 IBM-ShortName: mpMetrics-2.3
 Subsystem-Name: MicroProfile Metrics 2.3
 -features=com.ibm.websphere.appserver.org.eclipse.microprofile.metrics-2.3, \
- com.ibm.websphere.appserver.cdi-1.2; ibm.tolerates:=2.0,\
- com.ibm.websphere.appserver.javax.annotation-1.2; ibm.tolerates:=1.3, \
+ com.ibm.websphere.appserver.cdi-2.0; ibm.tolerates:=1.2,\
+ com.ibm.websphere.appserver.javax.annotation-1.3; ibm.tolerates:=1.2, \
  com.ibm.websphere.appserver.restHandler-1.0, \
  com.ibm.websphere.appserver.monitor-1.0, \
- com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:=4.0,\
- com.ibm.websphere.appserver.mpConfig-1.3; ibm.tolerates:=1.4
+ com.ibm.websphere.appserver.servlet-4.0; ibm.tolerates:=3.1,\
+ com.ibm.websphere.appserver.mpConfig-1.4; ibm.tolerates:=1.3
 -bundles=com.ibm.ws.require.java8, \
  com.ibm.ws.microprofile.metrics.common, \
  com.ibm.ws.microprofile.metrics.2.3, \

--- a/dev/com.ibm.ws.microprofile.config.1.1.cdi/resources/com/ibm/ws/microprofile/config/cdi/resources/ConfigCDI.nlsprops
+++ b/dev/com.ibm.ws.microprofile.config.1.1.cdi/resources/com/ibm/ws/microprofile/config/cdi/resources/ConfigCDI.nlsprops
@@ -53,6 +53,11 @@ unable.to.resolve.observer.injection.point.CWMCG5005E=CWMCG5005E: The InjectionP
 unable.to.resolve.observer.injection.point.CWMCG5005E.explanation=An injected ConfigProperty did not resolve. Either the named property was not able to be found or a Converter for the required type did not resolve. 
 unable.to.resolve.observer.injection.point.CWMCG5005E.useraction=Check the server message and FFDC logs to determine the cause. Ensure that the property exists in one of the ConfigSources and that the required Converters were configured.
 
+The InjectionPoint dependency was not resolved for the Observer bean: {0}.
+unable.to.process.observer.injection.point.CWMCG5006E=CWMCG5006E: The InjectionPoint dependency was not processed for the Observer bean: {0}.
+unable.to.process.observer.injection.point.CWMCG5006E.explanation=An unknown error occurred. It was not possible to properly process an Observer method.
+unable.to.process.observer.injection.point.CWMCG5006E.useraction=Check the server message and FFDC logs to determine the cause.
+
 
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Config error message

--- a/dev/com.ibm.ws.microprofile.config.1.4.cdi/src/com/ibm/ws/microprofile/config14/cdi/Config14CDIExtension.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4.cdi/src/com/ibm/ws/microprofile/config14/cdi/Config14CDIExtension.java
@@ -52,26 +52,30 @@ public class Config14CDIExtension extends Config12CDIExtension implements Extens
         abd.addBean(converterBean);
     }
 
-    <T, X> void processObserverMethod(@Observes ProcessObserverMethod<T, X> pot) {
+    public <T, X> void processObserverMethod(@Observes ProcessObserverMethod<T, X> pot) {
         AnnotatedMethod<X> annotatedMethod = pot.getAnnotatedMethod();
-        List<AnnotatedParameter<X>> parameters = annotatedMethod.getParameters();
-        for (AnnotatedParameter<X> parameter : parameters) {
-            Type type = parameter.getBaseType();
-            Set<Annotation> annotations = parameter.getAnnotations();
-            for (Annotation annotation : annotations) {
-                if (ConfigProperty.class.isAssignableFrom(annotation.annotationType())) {
-                    ConfigProperty configProperty = (ConfigProperty) annotation;
-                    String propertyName = configProperty.name();
-                    String defaultValue = configProperty.defaultValue();
+        if (annotatedMethod != null) {
+            List<AnnotatedParameter<X>> parameters = annotatedMethod.getParameters();
+            for (AnnotatedParameter<X> parameter : parameters) {
+                Type type = parameter.getBaseType();
+                Set<Annotation> annotations = parameter.getAnnotations();
+                for (Annotation annotation : annotations) {
+                    if (ConfigProperty.class.isAssignableFrom(annotation.annotationType())) {
+                        ConfigProperty configProperty = (ConfigProperty) annotation;
+                        String propertyName = configProperty.name();
+                        String defaultValue = configProperty.defaultValue();
 
-                    ClassLoader classLoader = annotatedMethod.getDeclaringType().getJavaClass().getClassLoader();
+                        ClassLoader classLoader = annotatedMethod.getDeclaringType().getJavaClass().getClassLoader();
 
-                    Throwable configException = validateConfigProperty(type, propertyName, defaultValue, classLoader);
-                    if (configException != null) {
-                        Tr.error(tc, "unable.to.resolve.observer.injection.point.CWMCG5005E", annotatedMethod.getJavaMember(), configException);
+                        Throwable configException = validateConfigProperty(type, propertyName, defaultValue, classLoader);
+                        if (configException != null) {
+                            Tr.error(tc, "unable.to.resolve.observer.injection.point.CWMCG5005E", annotatedMethod.getJavaMember(), configException);
+                        }
                     }
                 }
             }
+        } else {
+            Tr.error(tc, "unable.to.process.observer.injection.point.CWMCG5006E", pot.getObserverMethod().getBeanClass());
         }
     }
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/publish/servers/FaultTolerance21TCKServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/publish/servers/FaultTolerance21TCKServer/server.xml
@@ -14,8 +14,8 @@
         <feature>mpFaultTolerance-2.1</feature>
         <feature>cdi-2.0</feature>
         <feature>servlet-4.0</feature>
-        <feature>mpConfig-1.3</feature>
-        <feature>mpMetrics-2.2</feature>
+        <feature>mpConfig-1.4</feature>
+        <feature>mpMetrics-2.3</feature>
         <feature>localConnector-1.0</feature>
         <feature>arquillian-support-1.0</feature>
    </featureManager>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/bnd.bnd
@@ -30,7 +30,8 @@ tested.features: mpfaulttolerance-1.0,\
                  el-3.0,\
                  mpmetrics-1.0,\
                  mpMetrics-1.1,\
-                 mpMetrics-2.0
+                 mpMetrics-2.0,\
+                 mpMetrics-2.3
 
 -buildpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.microprofile.faulttolerance_repeat_tests/src/com/ibm/ws/microprofile/faulttolerance/fat/repeat/RepeatFaultTolerance.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_repeat_tests/src/com/ibm/ws/microprofile/faulttolerance/fat/repeat/RepeatFaultTolerance.java
@@ -46,7 +46,7 @@ public class RepeatFaultTolerance {
     static final Set<String> MP32_FEATURE_SET = new HashSet<>(Arrays.asList(MP32_FEATURES_ARRAY));
     public static final String MP32_FEATURES_ID = "MICROPROFILE32";
 
-    static final String[] MP33_FEATURES_ARRAY = { "mpConfig-1.3", "mpFaultTolerance-2.1", "servlet-4.0", "cdi-2.0", "appSecurity-3.0", "mpMetrics-2.2" };
+    static final String[] MP33_FEATURES_ARRAY = { "mpConfig-1.4", "mpFaultTolerance-2.1", "servlet-4.0", "cdi-2.0", "appSecurity-3.0", "mpMetrics-2.3" };
     static final Set<String> MP33_FEATURE_SET = new HashSet<>(Arrays.asList(MP33_FEATURES_ARRAY));
     public static final String MP33_FEATURES_ID = "MICROPROFILE33";
 

--- a/dev/com.ibm.ws.microprofile.metrics.2.3_fat_tck/publish/servers/MetricsTCKServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.3_fat_tck/publish/servers/MetricsTCKServer/server.xml
@@ -2,13 +2,13 @@
     <featureManager>
     	<feature>mpMetrics-2.3</feature>
 	    <feature>jaxrsMonitor-1.0</feature>
-        <feature>servlet-3.1</feature>
+        <feature>servlet-4.0</feature>
         <feature>componenttest-1.0</feature>
-        <feature>webProfile-7.0</feature>
+        <feature>webProfile-8.0</feature>
         <feature>localConnector-1.0</feature>
-        <feature>cdi-1.2</feature>
+        <feature>cdi-2.0</feature>
         <feature>jsp-2.3</feature>
-        <feature>appSecurity-2.0</feature>
+        <feature>appSecurity-3.0</feature>
         <feature>arquillian-support-1.0</feature>
     </featureManager>
 

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/servers/FATServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/servers/FATServer/server.xml
@@ -12,7 +12,7 @@
         <feature>localConnector-1.0</feature>
         <feature>cdi-2.0</feature>
         <feature>jaxrsClient-2.1</feature>
-        <feature>mpConfig-1.3</feature>
+        <feature>mpConfig-1.4</feature>
         <feature>mpRestClient-1.4</feature>
         <feature>arquillian-support-1.0</feature>
     </featureManager>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicCdiInEE8Test.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicCdiInEE8Test.java
@@ -20,7 +20,6 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -54,9 +54,14 @@ public class FATSuite {
                         .withID("mpRestClient-" + version)
                         .forServers(serverName);
         if ("1.0".equals(version) || "1.1".equals(version)) {
-            return use(action, "mpConfig", "1.1", "1.3");
+            return use(action, "mpConfig", "1.1", "1.3", "1.4");
         }
-        return use(action, "mpConfig", "1.3", "1.1");
+        else if ("1.2".equals(version) || "1.3".equals(version)) {
+            return use(action, "mpConfig", "1.3", "1.1", "1.4");
+        }
+        else {
+            return use(action, "mpConfig", "1.4", "1.1", "1.3");
+        }
     }
 
     private static FeatureReplacementAction use(FeatureReplacementAction action, String featureName, String version) {

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.basic.cdi/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.basic.cdi/bootstrap.properties
@@ -7,4 +7,5 @@ bootstrap.include=../testports.properties
 mpRestClient10.basicCdi.BasicServiceClient/mp-rest/url=http://localhost:${bvt.prop.HTTP_secondary}/basicRemoteApp/basic
 
 org.jboss.weld.probe.allowRemoteAddress=.*
-org.jboss.weld.development=true
+#if set to true, there is an issue with MP Config 1.4
+org.jboss.weld.development=false

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.basic.ejb/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.basic.ejb/bootstrap.properties
@@ -7,4 +7,5 @@ bootstrap.include=../testports.properties
 mpRestClient10.basicEJB.BasicServiceClient/mp-rest/url=http://localhost:${bvt.prop.HTTP_secondary}/basicRemoteApp/basic
 
 org.jboss.weld.probe.allowRemoteAddress=.*
-org.jboss.weld.development=true
+#if set to true, there is an issue with MP Config 1.4
+org.jboss.weld.development=false

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.multi.client.cdi/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.multi.client.cdi/bootstrap.properties
@@ -8,4 +8,5 @@ mpRestClient10.multiClientCdi.ClientA/mp-rest/url=http://localhost:8080/filtered
 mpRestClient10.multiClientCdi.ClientB/mp-rest/url=http://localhost:8080/filteredApp
 
 org.jboss.weld.probe.allowRemoteAddress=.*
-org.jboss.weld.development=true
+#if set to true, there is an issue with MP Config 1.4
+org.jboss.weld.development=false

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.tolerateEE8/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.tolerateEE8/bootstrap.properties
@@ -7,4 +7,5 @@ bootstrap.include=../testports.properties
 mpRestClient10.basicCdi.BasicServiceClient/mp-rest/url=http://localhost:${bvt.prop.HTTP_secondary}/basicRemoteApp/basic
 
 org.jboss.weld.probe.allowRemoteAddress=.*
+#if set to true, there is an issue with MP Config 1.4
 org.jboss.weld.development=false

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.tolerateEE8/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.tolerateEE8/bootstrap.properties
@@ -7,4 +7,4 @@ bootstrap.include=../testports.properties
 mpRestClient10.basicCdi.BasicServiceClient/mp-rest/url=http://localhost:${bvt.prop.HTTP_secondary}/basicRemoteApp/basic
 
 org.jboss.weld.probe.allowRemoteAddress=.*
-org.jboss.weld.development=true
+org.jboss.weld.development=false

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.cdiPropsAndProviders/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.cdiPropsAndProviders/bootstrap.properties
@@ -7,4 +7,5 @@ bootstrap.include=../testports.properties
 mpRestClient11.cdiPropsAndProviders.CdiPropsAndProvidersClient/mp-rest/url=http://localhost:${bvt.prop.HTTP_secondary}/basicRemoteApp/basic
 
 org.jboss.weld.probe.allowRemoteAddress=.*
-org.jboss.weld.development=true
+#if set to true, there is an issue with MP Config 1.4
+org.jboss.weld.development=false


### PR DESCRIPTION
MP 3.3 features should use up to date versions of other MP features. They may still tolerate older versions in some cases.
