### PR TITLE
Logout translated incorrectly in German

### DIFF
--- a/dev/com.ibm.ws.security.oauth/resources/OSGI-INF/l10n/metatype_de.properties
+++ b/dev/com.ibm.ws.security.oauth/resources/OSGI-INF/l10n/metatype_de.properties
@@ -102,7 +102,7 @@ databaseStore.password=Kennwort
 databaseStore.password.desc=Das f\u00fcr den Zugriff auf die Datenbank verwendete Kennwort.
 
 databaseStore.schema=Schema
-databaseStore.schema.desc=Der Datenbankschemaname.
+databaseStore.schema.desc=Der Name des Datenbankschemas.
 
 customStore=Angepasster OAuthStore
 customStore.desc=Clients werden definiert und Token und Einwilligungen werden in einer angepassten OAuthStore-Implementierung zwischengespeichert.
@@ -111,19 +111,19 @@ storeId=Angepasste OAuthStore-ID
 storeId.desc=Gibt die OAuthStore-ID an, die f\u00fcr einen angepassten Speicher verwendet werden soll. Der Wert muss mit dem Wert der Eigenschaft oauth.store.id property \u00fcbereinstimmen, der f\u00fcr die OAuthStore-Implementierung angegeben ist.
 
 authorizationGrantLifetime=Laufzeit des Berechtigungsgrants
-authorizationGrantLifetime.desc=Die Laufzeit des Berechtigungsgrants (in Sekunden). Der entsprechende Providerparameter im vollst\u00e4ndigen Anwendungsserverprofil ist oauth20.max.authorization.grant.lifetime.seconds.
+authorizationGrantLifetime.desc=Die Laufzeit des Berechtigungsgrants (in Sekunden). 
 authorizationCodeLifetime=Laufzeit des Berechtigungscodes
-authorizationCodeLifetime.desc=Die Laufzeit des Berechtigungscodes (in Sekunden). Der entsprechende Providerparameter im vollst\u00e4ndigen Anwendungsserverprofil ist oauth20.code.lifetime.seconds.
+authorizationCodeLifetime.desc=Die Laufzeit des Berechtigungscodes (in Sekunden). 
 authorizationCodeLength=L\u00e4nge des Autorisierungscodes
-authorizationCodeLength.desc=Die L\u00e4nge des generierten Berechtigungscodes. Der entsprechende Providerparameter im vollst\u00e4ndigen Anwendungsserverprofil ist oauth20.code.length.
+authorizationCodeLength.desc=Die L\u00e4nge des generierten Berechtigungscodes. 
 accessTokenLifetime=Laufzeit des Zugriffstokens
-accessTokenLifetime.desc=Die G\u00fcltigkeitsdauer des Zugriffstokens (in Sekunden). Der entsprechende Providerparameter im vollst\u00e4ndigen Anwendungsserverprofil ist oauth20.token.lifetime.seconds.
+accessTokenLifetime.desc=Die G\u00fcltigkeitsdauer des Zugriffstokens (in Sekunden). 
 accessTokenLength=L\u00e4nge des Zugriffstokens
-accessTokenLength.desc=Die L\u00e4nge des generierten OAuth-Zugriffstokens. Der entsprechende Providerparameter im vollst\u00e4ndigen Anwendungsserverprofil ist oauth20.access.token.length.
+accessTokenLength.desc=Die L\u00e4nge des generierten OAuth-Zugriffstokens. 
 issueRefreshToken=Flag f\u00fcr Verwendung von Aktualisierungstoken
-issueRefreshToken.desc=Der Wert false inaktiviert die Generierung und die Verwendung von Aktualisierungstoken. Der entsprechende Providerparameter im vollst\u00e4ndigen Anwendungsserverprofil ist oauth20.issue.refresh.token.
+issueRefreshToken.desc=Der Wert false inaktiviert die Generierung und die Verwendung von Aktualisierungstoken. 
 refreshTokenLength=Tokenl\u00e4nge aktualisieren
-refreshTokenLength.desc=Die L\u00e4nge des generierten Aktualisierungstokens. Der entsprechende Providerparameter im vollst\u00e4ndigen Anwendungsserverprofil ist oauth20.refresh.token.length.
+refreshTokenLength.desc=Die L\u00e4nge des generierten Aktualisierungstokens. 
 revokeAccessTokensWithRefreshTokens=Zugriffstokens beim Widerrufen des Aktualisierungstokens widerrufen
 revokeAccessTokensWithRefreshTokens.desc=Der Wert 'false' inaktiviert den Widerruf zugeh\u00f6riger Zugriffstokens, wenn ein Aktualisierungstoken widerrufen wird. Der Standardwert ist true.
 
@@ -132,29 +132,29 @@ libraryRef$Ref=Referenz auf gemeinsam genutzte Bibliothek
 libraryRef.desc=Eine Referenz auf die gemeinsam genutzte Bibliothek, die die Mediator-Plug-in-Klasse enth\u00e4lt.
 
 mediatorClassname=Name der Mediatorklasse
-mediatorClassname.desc=Der Name der Mediator-Plug-in-Klasse. Der entsprechende Providerparameter im vollst\u00e4ndigen Anwendungsserverprofil ist oauth20.mediator.classnames.
+mediatorClassname.desc=Der Name der Mediator-Plug-in-Klasse. 
 allowPublicClients=\u00d6ffentlichen Clients den Zugriff auf den OAuth-Provider erlauben
-allowPublicClients.desc=Der Wert false inaktiviert den Zugriff \u00f6ffentlicher Clients gem\u00e4\u00df der OAuth-Spezifikation. Der entsprechende Providerparameter im vollst\u00e4ndigen Anwendungsserverprofil ist oauth20.allow.public.clients.
+allowPublicClients.desc=Der Wert false inaktiviert den Zugriff \u00f6ffentlicher Clients gem\u00e4\u00df der OAuth-Spezifikation. 
 grantType=OAuth-Granttyp
 grantType.desc=Ein OAuth 2.0-Granttyp, gem\u00e4\u00df OAuth 2.0-Spezifikation, der f\u00fcr den Provider zul\u00e4ssig ist. Standardm\u00e4\u00dfig sind alle Granttypen zul\u00e4ssig. Zu den unterst\u00fctzten Werten geh\u00f6ren authorization_code, client_credentials, refresh_token, password, implicit und urn:ietf:params:oauth:grant-type:jwt-bearer.
 
 authorizationFormTemplate=Angepasstes Formular f\u00fcr Berechtigungen
-authorizationFormTemplate.desc=Der URL einer angepassten Seitenvorlage f\u00fcr Berechtigungen. Der entsprechende Providerparameter im vollst\u00e4ndigen Anwendungsserverprofil ist oauth20.authorization.form.template.
+authorizationFormTemplate.desc=Der URL einer angepassten Seitenvorlage f\u00fcr Berechtigungen. 
 authorizationErrorTemplate=Angepasstes Formular f\u00fcr Berechtigungsfehler
-authorizationErrorTemplate.desc=Der URL einer angepassten Seitenvorlage f\u00fcr Berechtigungsfehler. Der entsprechende Providerparameter im vollst\u00e4ndigen Anwendungsserverprofil ist oauth20.authorization.error.template.
+authorizationErrorTemplate.desc=Der URL einer angepassten Seitenvorlage f\u00fcr Berechtigungsfehler. 
 customLoginURL=Angepasstes Anmeldeformular
-customLoginURL.desc=Der URL einer angepassten Formularseite. Der entsprechende Providerparameter im vollst\u00e4ndigen Anwendungsserverprofil ist oauth20.authorization.loginURL.
+customLoginURL.desc=Der URL einer angepassten Formularseite. 
 autoAuthorizeParam=Parameter f\u00fcr automatische Berechtigung
-autoAuthorizeParam.desc=Wenn Sie die automatische Berechtigung verwenden, f\u00fcgen Sie den Parameter autoAuthorize mit dem Wert true an Anforderungen an. Der entsprechende Providerparameter im vollst\u00e4ndigen Anwendungsserverprofil ist oauth20.autoauthorize.param.
+autoAuthorizeParam.desc=Wenn Sie die automatische Berechtigung verwenden, f\u00fcgen Sie den Parameter autoAuthorize mit dem Wert true an Anforderungen an. 
 autoAuthorize=Automatische Berechtigung
 autoAuthorize.desc=Wenn diese Option auf true gesetzt ist, wird die automatische Berechtigung verwendet. Der Standardwert ist false.
 
 autoAuthorizeClient=Client f\u00fcr automatische Berechtigung
-autoAuthorizeClient.desc=Der Name eines Clients, der die automatische Berechtigung verwenden darf. Der entsprechende Providerparameter im vollst\u00e4ndigen Anwendungsserverprofil ist oauth20.autoauthorize.clients.
+autoAuthorizeClient.desc=Der Name eines Clients, der die automatische Berechtigung verwenden darf. 
 clientURISubstitutions=Substitution des Client-URI
-clientURISubstitutions.desc=Ein optionaler Wert f\u00fcr die Ersetzung von Client-URI-Zeichenfolgen f\u00fcr dynamische Hostnamen. Der entsprechende Providerparameter im vollst\u00e4ndigen Anwendungsserverprofil ist oauth20.client.uri.substitutions.
+clientURISubstitutions.desc=Ein optionaler Wert f\u00fcr die Ersetzung von Client-URI-Zeichenfolgen f\u00fcr dynamische Hostnamen.
 
-clientTokenCacheSize=Gr\u00f6\u00dfe des Client-Token-Caches
+clientTokenCacheSize=Gr\u00f6\u00dfe des Client-Token-Cache
 clientTokenCacheSize.desc=Die maximal zul\u00e4ssige Anzahl an Eintr\u00e4gen im Client-Token-Cache. 
 userClientTokenLimit=Tokengrenzwert f\u00fcr Benutzerclients
 userClientTokenLimit.desc=Der Tokengrenzwert f\u00fcr jede Benutzer/Client-Kombination.
@@ -169,13 +169,13 @@ publicClient=\u00d6ffentlicher OAuth-Client
 publicClient.desc=Gibt an, ob der OAuth-Client \u00f6ffentlich ist.
 
 filter=Anforderungsfilter
-filter.desc=Der URI-Filter w\u00e4hlt Anforderungen aus, die von diesem Provider berechtigt werden sollen. Der funktional entsprechende Parameter im vollst\u00e4ndigen Anwendungsserverprofil ist Filter.
+filter.desc=Der URI-Filter w\u00e4hlt Anforderungen aus, die von diesem Provider berechtigt werden sollen. 
 characterEncoding=Zeichencodierung
-characterEncoding.desc=Setzt die Codierung von Anforderungszeichen auf diesen Wert. Der funktional entsprechende Parameter im vollst\u00e4ndigen Anwendungsserverprofil ist im characterEncoding.
+characterEncoding.desc=Setzt die Codierung von Anforderungszeichen auf diesen Wert. 
 oauthOnly=Authentifizierungsfehler ausgeben, wenn OAuth-Zugriffstoken fehlt
-oauthOnly.desc=Wenn Sie diese Option ausw\u00e4hlen, m\u00fcssen Anforderungen, die dem Filter entsprechen, ein Zugriffstoken haben, ansonsten gelten sie als fehlgeschlagen. Wenn Sie diese Option nicht ausw\u00e4hlen, wird gepr\u00fcft, ob \u00fcbereinstimmende Anforderungen andere Authentifizierungsdaten enthalten, falls kein Zugriffstoken vorhanden ist. Der funktional entsprechende Parameter im vollst\u00e4ndigen Anwendungsserverprofil ist im oauthOnly. 
+oauthOnly.desc=Wenn Sie diese Option ausw\u00e4hlen, m\u00fcssen Anforderungen, die dem Filter entsprechen, ein Zugriffstoken haben, ansonsten gelten sie als fehlgeschlagen. Wenn Sie diese Option nicht ausw\u00e4hlen, wird gepr\u00fcft, ob \u00fcbereinstimmende Anforderungen andere Authentifizierungsdaten enthalten, falls kein Zugriffstoken vorhanden ist. 
 includeTokenInSubject=OAuth-Token in Subjekt einschlie\u00dfen
-includeTokenInSubject.desc=Wenn Sie diese Option auf den Wert true setzen, wird com.ibm.wsspi.security.oauth20.token.WSOAuth20Token als privater Berechtigungsnachweis hinzugef\u00fcgt. Der funktional entsprechende Parameter im vollst\u00e4ndigen Anwendungsserverprofil ist im includeToken.
+includeTokenInSubject.desc=Wenn Sie diese Option auf den Wert true setzen, wird com.ibm.wsspi.security.oauth20.token.WSOAuth20Token als privater Berechtigungsnachweis hinzugef\u00fcgt. 
 consentCacheEntryLifetime=Eintragslebensdauer im Zustimmungscache
 consentCacheEntryLifetime.desc=G\u00fcltigkeitsdauer (Sekunden) eines Eintrags im Zustimmungscache.
 
@@ -196,8 +196,8 @@ allowSpnegoAuthentication.desc=Erm\u00f6glicht die Authentifizierung eines SPNEG
 
 coverageMapSessionMaxAge=Maximale G\u00fcltigkeitsdauer von Coverage-Map-Sitzungen
 coverageMapSessionMaxAge.desc=Der max-age-Wert (Sekunden) f\u00fcr den cache-control-Header des Coverage-Map-Service.
-skipResourceOwnerValidation=Ressourceneignervalidierung \u00fcberspringen
-skipResourceOwnerValidation.desc=Wenn der Wert true ist, wird die Validierung des Ressourceneigners \u00fcbersprungen.
+skipResourceOwnerValidation=Validierung des Ressourceneigners \u00fcberspringen
+skipResourceOwnerValidation.desc=Wenn diese Einstellung ausgew\u00e4hlt (true) ist, wird die Validierung des Ressourceneigners \u00fcbersprungen.
 
 # new attribute for JWT GrantType
 jwtGrantType=JWT-Grant-Typ
@@ -215,12 +215,12 @@ iatRequired=iat-Anspruch in JWT-Token erforderlich
 iatRequired.desc=Gibt an, dass der iat-Anspruch in einem JWT-Token erforderlich ist.
 
 jwtAccessToken=Zugriffstoken ist JWT
-jwtAccessToken.desc=Generieren Sie das JSON-Web-Token, serialisieren Sie es als Zeichenfolge und ersetzen Sie das Zugriffstoken durch diese Zeichenfolge.
+jwtAccessToken.desc=Generiert das JSON Web Token (JWT), serialisiert es als Zeichenfolge und ersetzt das Zugriffstoken damit.
 
 resourceIds=Ressourcen-IDs
-resourceIds.desc=Die Ressourcen-IDs, die die Zielgruppen des JSON-Web-Tokens sind.
+resourceIds.desc=Die Ressourcen-IDs, die die Zielgruppen f\u00fcr das JSON Web Token (JWT) sind.
 
-logoutRedirectURL=Nach der Anmeldung verwendete URL
+logoutRedirectURL=Nach der Abmeldung verwendete URL
 logoutRedirectURL.desc=Optionale URL, an die der Client nach erfolgreichem Aufruf des Abmeldeendpunkts umgeleitet wird. Wenn keine URL angegeben wird, wird eine minimale Standardabmeldeseite verwendet. 
 appPasswordAllowed=Anwendungskennwort zul\u00e4ssig
 appPasswordAllowed.desc=Wenn der Wert auf true gesetzt ist, darf der OAuth-Client Anwendungskennw\u00f6rter anfordern.
@@ -245,7 +245,7 @@ passwordGrantRequiresAppPassword.desc=Wenn der Wert auf true gesetzt ist, m\u00f
 #	Additional metatype properties to support OIDC Client Registration
 # -------------------------------------------------------------------------------------------------
 tokenEndpointAuthMethod=Authentifizierungsmethode f\u00fcr Tokenendpunkt
-tokenEndpointAuthMethod.desc=Die angeforderte Authentifizierungsmethode f\u00fcr den Tokenendpunkt des Clients. 
+tokenEndpointAuthMethod.desc=Die angeforderte Authentifizierungsmethode f\u00fcr den Tokenendpunkt des Clients.
 tokenEndpointAuthMethod.none=Keine.
 tokenEndpointAuthMethod.clientSecretPost=client_secret_post
 tokenEndpointAuthMethod.clientSecretBasic=client_secret_basic
@@ -253,8 +253,8 @@ tokenEndpointAuthMethod.clientSecretBasic=client_secret_basic
 scope=Geltungsbereich
 scope.desc=Geben Sie eine durch Leerzeichen begrenzte Liste mit Geltungsbereichen f\u00fcr den Client an.
 
-grantTypes=Grant-Typen
-grantTypes.desc=Die Grant-Typen, die der Client verwenden kann.
+grantTypes=Granttypen
+grantTypes.desc=Die Granttypen, die der Client verwenden kann.
 grantTypes.authorizationCode=authorization_code
 grantTypes.implicit=implicit
 grantTypes.refreshToken=refresh_token
@@ -297,7 +297,7 @@ functionalUserGroupIds.desc=Eine Liste mit Gruppen-IDs, die Zugriffstoken zugeor
 
 
 tokenFormat=Typ des ausgestellten JWT
-tokenFormat.desc=Der Typ des zu erzeugenden Token. Die g\u00fcltigen Werte sind opaque, jwt und mpjwt. Mpjwt ist das Standardformat f\u00fcr Mikroprofile. Die Standardeinstellung ist opaque.  
+tokenFormat.desc=Der Typ des zu erzeugenden Token. Die g\u00fcltigen Werte sind opaque, jwt und mpjwt. Mpjwt ist das Standardformat f\u00fcr Mikroprofile. Die Standardeinstellung ist opaque.
 tokenFormat.opaque=opaque
 tokenFormat.jwt=jwt
 tokenFormat.mpjwt=mpjwt

--- a/dev/com.ibm.ws.security.oauth/resources/com/ibm/ws/security/oauth20/internal/resources/OAuthMessages_de.nlsprops
+++ b/dev/com.ibm.ws.security.oauth/resources/com/ibm/ws/security/oauth20/internal/resources/OAuthMessages_de.nlsprops
@@ -21,12 +21,12 @@ OAUTH_PROVIDER_CONFIG_INVALID=CWWKS1400E: Die Konfiguration des OAuth-Providers 
 OAUTH_PROVIDER_CONFIG_INVALID.explanation=Die angegebene Oauth-Provider-Konfiguration kann nicht abgerufen werden.
 OAUTH_PROVIDER_CONFIG_INVALID.useraction=Geben Sie eine g\u00fcltige Oauth-Provider-Konfiguration an.
 
-OAUTH_PROVIDER_CONFIG_NO_LIBRARYREF=CWWKS1401W: F\u00fcr den OAuth-Provider {0} ist eine Mediatorklasse angegeben, aber libraryRef ist nicht angegeben, oder die Bibliothek ist nicht aktiviert.
-OAUTH_PROVIDER_CONFIG_NO_LIBRARYREF.explanation=F\u00fcr den OAuth-Provider ist eine Mediatorklasse angegeben, aber libraryRef ist nicht angegeben, oder die Bibliothek ist nicht aktiviert. Dies kann ein Konfigurationsfehler sein, oder die Bibliothek wurde nach der Aktivierung des Providers aktiviert.
+OAUTH_PROVIDER_CONFIG_NO_LIBRARYREF=CWWKS1401W: F\u00fcr den OAuth-Provider {0} ist eine Mediatorklasse angegeben, aber libraryRef ist nicht angegeben oder die Bibliothek ist nicht aktiviert.
+OAUTH_PROVIDER_CONFIG_NO_LIBRARYREF.explanation=F\u00fcr den OAuth-Provider ist eine Mediatorklasse angegeben, aber libraryRef ist nicht angegeben oder die Bibliothek ist nicht aktiviert. Dies kann ein Konfigurationsfehler sein oder die Bibliothek wurde nach der Aktivierung des Providers aktiviert.
 OAUTH_PROVIDER_CONFIG_NO_LIBRARYREF.useraction=Stellen Sie sicher, dass libraryRef f\u00fcr den OAuth-Provider ordnungsgem\u00e4\u00df definiert ist.
 
 OAUTH_PROVIDER_CONFIG_MEDIATOR_LIBRARYREF_ACTIVE=CWWKS1402I: Die libraryRef des OAuth-Providers {0} wurde f\u00fcr die Mediatorklasse {1} aktiviert.
-OAUTH_PROVIDER_CONFIG_MEDIATOR_LIBRARYREF_ACTIVE.explanation=F\u00fcr den OAuth-Provider wurde eine Mediatorklasse angegeben, und libraryRef ist aktiviert.
+OAUTH_PROVIDER_CONFIG_MEDIATOR_LIBRARYREF_ACTIVE.explanation=F\u00fcr den OAuth-Provider wurde eine Mediatorklasse angegeben und libraryRef ist aktiviert.
 OAUTH_PROVIDER_CONFIG_MEDIATOR_LIBRARYREF_ACTIVE.useraction=Keine.
 
 OAUTH_PROVIDER_CONFIG_PROCESSED=CWWKS1403I: Die Konfiguration des OAuth-Providers {0} wurde ordnungsgem\u00e4\u00df verarbeitet.
@@ -42,7 +42,7 @@ OAUTH_INTROSPECT_NO_TOKEN.explanation=Die Selbst\u00fcberwachungsanforderung mus
 OAUTH_INTROSPECT_NO_TOKEN.useraction=Rufen Sie die Anforderung erneut mit einem Tokenparameter auf, der ein g\u00fcltiges Zugriffstoken angibt.
 
 OAUTH_INVALID_CLIENT=CWWKS1406E: Die Anforderung {0} enth\u00e4lt einen ung\u00fcltigen Clientberechtigungsnachweis. Die Anforderungs-URI ist {1}.
-OAUTH_INVALID_CLIENT.explanation=Die angegebene Anforderung muss eine g\u00fcltige Client-ID und ein g\u00fcltiges Kennwort enthalten, und die Client-ID muss mit der Client-ID \u00fcbereinstimmen, die das Zugriffstoken erstellt hat.
+OAUTH_INVALID_CLIENT.explanation=Die angegebene Anforderung muss eine g\u00fcltige Client-ID und ein g\u00fcltiges Kennwort enthalten und die Client-ID muss mit der Client-ID \u00fcbereinstimmen, die das Zugriffstoken erstellt hat.
 OAUTH_INVALID_CLIENT.useraction=Rufen Sie die Anforderung erneut mit einem g\u00fcltigen Clientberechtigungsnachweis auf.
 
 CUSTOMIZED_FACTORY_INSTANTIATE_ERROR=CWWKS1407E: Der Klassenname {0} des angepassten Grant-Handlers kann nicht instanziiert werden: {1}
@@ -122,11 +122,11 @@ OAUTH_CLIENT_REGISTRATION_CLIENTID_NOT_FOUND.explanation=Die Anforderung enthiel
 OAUTH_CLIENT_REGISTRATION_CLIENTID_NOT_FOUND.useraction=Wiederholen Sie die Anforderung mit einer g\u00fcltigen Client-ID.
 
 OAUTH_CLIENT_REGISTRATION_INVALID_REQUEST_PATH=CWWKS1425E: Es wurde eine Registrierungsanforderung an eine falsche URI abgesetzt.
-OAUTH_CLIENT_REGISTRATION_INVALID_REQUEST_PATH.explanation=Clients k\u00f6nnen nur mit einer POST-Anforderugn an die URI des Registrierungsendpunkts erstellt werden. 
+OAUTH_CLIENT_REGISTRATION_INVALID_REQUEST_PATH.explanation=Clients k\u00f6nnen nur mit einer POST-Anforderung an die URI des Registrierungsendpunkts erstellt werden. 
 OAUTH_CLIENT_REGISTRATION_INVALID_REQUEST_PATH.useraction=Sehen Sie sich die API-Dokumentation f\u00fcr diesen Service an und wiederholen Sie die Anforderung an die URI des Registrierungsendpunkts.
 
 OAUTH_CLIENT_REGISTRATION_MISSING_CLIENTID=CWWKS1426E: Die Operation {0} ist fehlgeschlagen, weil die Anforderung den Parameter {1} nicht enth\u00e4lt.
-OAUTH_CLIENT_REGISTRATION_MISSING_CLIENTID.explanation=Clients k\u00f6nnen nur mit einer POST-Anforderugn an die URI des Registrierungsendpunkts erstellt werden. 
+OAUTH_CLIENT_REGISTRATION_MISSING_CLIENTID.explanation=Clients k\u00f6nnen nur mit einer POST-Anforderung an die URI des Registrierungsendpunkts erstellt werden. 
 OAUTH_CLIENT_REGISTRATION_MISSING_CLIENTID.useraction=Sehen Sie sich die API-Dokumentation f\u00fcr diesen Service an und wiederholen Sie die Anforderung an die URI des Registrierungsendpunkts.
 
 OAUTH_CLIENT_REGISTRATION_INVALID_CLIENTID=CWWKS1427E: Die Operation {0} ist fehlgeschlagen, weil die Anforderung den ung\u00fcltigen {1}-Parameter {2} enth\u00e4lt.
@@ -190,7 +190,7 @@ OAUATH_CLIENT_CERT_AUTH_FAIL.explanation=Da das Attribut certAuthentication in d
 OAUATH_CLIENT_CERT_AUTH_FAIL.useraction=Stellen Sie sicher, dass das w\u00e4hrend des SSL-Handshakes in der Anforderung bereitgestellte Clientzertifikat einen g\u00fcltigen Benutzer enth\u00e4lt und dass der Benutzer beim OpenID Connect-Provider registriert ist.
 
 OAUTH_CLIENT_REGISTRATION_VALUE_NOT_SUPPORTED=CWWKS1442E: Der Wert {0} ist kein unterst\u00fctzter Wert f\u00fcr das Feld mit den Metadaten der Clientregistrierung, {1}.
-OAUTH_CLIENT_REGISTRATION_VALUE_NOT_SUPPORTED.explanation=Diese Clienteigenschaft ist auf genehmigte Werte beschr\u00e4nkt, und der angegebene Wert ist nicht genehmigt.
+OAUTH_CLIENT_REGISTRATION_VALUE_NOT_SUPPORTED.explanation=Diese Clienteigenschaft ist auf genehmigte Werte beschr\u00e4nkt und der angegebene Wert ist nicht genehmigt.
 OAUTH_CLIENT_REGISTRATION_VALUE_NOT_SUPPORTED.useraction=Sehen Sie sich die API-Dokumentation f\u00fcr diesen Service an und wiederholen Sie dann die Anforderung mit einem genehmigten Wert.
 
 OAUTH_CLIENT_REGISTRATION_VALUE_DUPE=CWWKS1443E: Der Wert {0} ist ein Duplikat f\u00fcr das Feld mit den Metadaten der Clientregistrierung, {1}.
@@ -221,11 +221,11 @@ OAUTH_PROVIDER_DATABASESTORE_INVALID_ATTRIBUTE=CWWKS1449E: Im OAuth-Provider {0}
 OAUTH_PROVIDER_DATABASESTORE_INVALID_ATTRIBUTE.explanation=Im OAuth-Provider ist ein Element databaseStore angegeben, aber das Attribut ist entweder nicht angegeben oder ung\u00fcltig. Dies kann auf einen Konfigurationsfehler zur\u00fcckzuf\u00fchren sein.
 OAUTH_PROVIDER_DATABASESTORE_INVALID_ATTRIBUTE.useraction=Stellen Sie sicher, dass das Attribut des Elements databaseStore im OAuth-Provider ordnungsgem\u00e4\u00df definiert ist.
 
-OIDC_SERVER_MULTI_OIDC_TO_ONE_OAUTH=CWWKS1450E: Ein Konfigurationsfehler ist aufgetreten. Der OpenID Connect-Provider {0} und {1} haben denselben OAuth-Provider {2}. Beide OpenID Connect-Provider werden inaktiviert.
+OIDC_SERVER_MULTI_OIDC_TO_ONE_OAUTH=CWWKS1450E: Ein Konfigurationsfehler ist aufgetreten. Die OpenID Connect-Provider {0} und {1} haben denselben OAuth-Provider {2}. Beide OpenID Connect-Provider wurden inaktiviert.
 OIDC_SERVER_MULTI_OIDC_TO_ONE_OAUTH.explanation=F\u00fcr jeden OpenID Connect-Provider muss ein eindeutiger OAuth-Provider in der Datei server.xml angegeben sein. Andernfalls werden die doppelten OpenID Connect-Provider inaktiviert. 
 OIDC_SERVER_MULTI_OIDC_TO_ONE_OAUTH.useraction=Stellen Sie sicher, dass f\u00fcr jeden OpenID Connect-Provider ein eindeutiger OAuth-Provider in der Datei server.xml angegeben ist.
 
-OAUTH_PROVIDER_DATABASESTORE_INVALID_DATASOURCEFACTORY=CWWKS1451E: Im OAuth-Provider {0} ist ein Element databaseStore angegeben, aber die dataSourceFactory f\u00fcr die angegebene dataSource ist nicht aktiviert.
+OAUTH_PROVIDER_DATABASESTORE_INVALID_DATASOURCEFACTORY=CWWKS1451E: Im OAuth-Provider {0} ist ein Element databaseStore angegeben, aber das Attribut dataSourceFactory f\u00fcr die angegebene Datenquelle ist nicht aktiviert.
 OAUTH_PROVIDER_DATABASESTORE_INVALID_DATASOURCEFACTORY.explanation=Im OAuth-Provider ist ein Element databaseStore angegeben, aber das Attribut dataSourceFactory f\u00fcr die angegebene Datenquelle ist nicht aktiviert. Dies kann auf einen Konfigurationsfehler mit der Datenquelle zur\u00fcckzuf\u00fchren sein.
 OAUTH_PROVIDER_DATABASESTORE_INVALID_DATASOURCEFACTORY.useraction=Stellen Sie sicher, dass das Attribut dataSourceRef des Elements databaseStore im OAuth-Provider ordnungsgem\u00e4\u00df mit einer g\u00fcltigen Datenquelle definiert ist.
 
@@ -458,11 +458,11 @@ WRONG_TOKEN_GRANTTYPE.explanation=Das Token ist nicht g\u00fcltig, weil der zuge
 WRONG_TOKEN_GRANTTYPE.useraction=Verwenden Sie ein Token mit einem zul\u00e4ssigen Granttypen.
 
 # html title of logout page
-LOGOUT_PAGE_TITLE=Anmelden
+LOGOUT_PAGE_TITLE=Abmelden
 # html body of logout page
 LOGOUT_PAGE_BODY=Die Abmeldung war erfolgreich.
 
 # html title of logout error page
-LOGOUT_ERROR_PAGE_TITLE=Anmelden
+LOGOUT_ERROR_PAGE_TITLE=Abmelden
 # html body of logout error page
 LOGOUT_ERROR_PAGE_BODY=W\u00e4hrend der Abmeldung ist eine Ausnahme eingetreten. Es wird empfohlen, den Web-Browser zu schlie\u00dfen, um die Abmeldung abzuschlie\u00dfen.

--- a/dev/com.ibm.ws.security.saml.sso/resources/OSGI-INF/l10n/metatype_de.properties
+++ b/dev/com.ibm.ws.security.saml.sso/resources/OSGI-INF/l10n/metatype_de.properties
@@ -188,5 +188,5 @@ useRelayStateForTarget.desc=Wenn Sie IdP-initiiertes SSO ausf\u00fchren, gibt di
 spLogout=Automatische SAML-Abmeldung
 spLogout.desc=F\u00fchrt eine SAML-Abmeldung durch, wenn Sie die Methode HttpServletRequest.logout oder die ibm_security_logout-URL aufrufen.
 
-postLogoutRedirectUrl=Nach der Anmeldung verwendete URL
+postLogoutRedirectUrl=Nach der Abmeldung verwendete URL
 postLogoutRedirectUrl.desc=Der Client wird an diese optionale URL umgeleitet, wenn der Client den SAML-Abmeldeendpunkt aufruft und die Abmeldung abgeschlossen ist.

--- a/dev/com.ibm.ws.security.saml.sso/resources/com/ibm/ws/security/saml/sso20/internal/resources/SamlSso20Messages_de.nlsprops
+++ b/dev/com.ibm.ws.security.saml.sso/resources/com/ibm/ws/security/saml/sso20/internal/resources/SamlSso20Messages_de.nlsprops
@@ -86,7 +86,7 @@ RS_EMPTY_SAML_ASSERTION.useraction=Stellen Sie sicher, dass die rsSaml-Konfigura
 # 0=URL specified in the config, 1=Name of configuration attribute, 2=ID of the SAML configuration element
 SAML20_POST_LOGOUT_URL_NOT_VALID=CWWKS5014W: Die URL [{0}], die im Attribut [{1}] in der Konfiguration [{2}] angegeben ist, ist nicht g\u00fcltig. Es wird die Standardseite nach der Abmeldung verwendet.
 SAML20_POST_LOGOUT_URL_NOT_VALID.explanation=Der angepasste URL-Wert f\u00fcr die Seite nach der Abmeldung ist nicht g\u00fcltig und deshalb kann die Seite nicht angezeigt werden. Der Wert enth\u00e4lt wahrscheinlich Zeichen, die f\u00fcr URI-Pfade nicht g\u00fcltig sind, wie z. B. Leerzeichen oder Fragmentzeichen.
-SAML20_POST_LOGOUT_URL_NOT_VALID.useraction=Stellen Sie sicher, dass der angepasste URL-Wert f\u00fcr die Seite nach der Anmeldung nur Zeichen enth\u00e4lt, die in URI-Pfaden verwendet werden k\u00f6nnen.
+SAML20_POST_LOGOUT_URL_NOT_VALID.useraction=Stellen Sie sicher, dass der angepasste URL-Wert f\u00fcr die Seite nach der Abmeldung nur Zeichen enth\u00e4lt, die in URI-Pfaden verwendet werden k\u00f6nnen.
 
 SAML20_CONFIG_DEACTIVATED=CWWKS5016I: Die SAML Web SSO Version 2.0-Konfiguration [{0}] wurde erfolgreich inaktiviert.
 SAML20_CONFIG_DEACTIVATED.explanation=Die SAML Web SSO Version 2.0-Konfiguration wurde erfolgreich inaktiviert.
@@ -319,7 +319,7 @@ LOGOUT_REQUEST_MISSING_SSO_REQUEST.explanation=Zur Verarbeitung der Abmeldeanfor
 LOGOUT_REQUEST_MISSING_SSO_REQUEST.useraction=Stellen Sie sicher, dass mindestens ein SAML-Provider (SP) konfiguriert ist, oder dass mindestens ein SP f\u00fcr die Verarbeitung dieser Anforderung konfiguriert ist.
 
 POST_LOGOUT_PAGE_MISSING_MESSAGE_CONTEXT=CWWKS5213E: Der SAML-SLO-Service (Single Logout) kann die Seite nach Abschluss der Abmeldung nicht anzeigen, weil SAML-Nachrichteninformationen fehlen.
-POST_LOGOUT_PAGE_MISSING_MESSAGE_CONTEXT.explanation=M\u00f6glicherweise ist im SAML-SSO (Single Sign-On) bei der \u00dcbergabe der SAML-Abmeldeanforderung oder bei der Verarbeitung der SAML-Anmeldeantwort ein Fehler aufgetreten.
+POST_LOGOUT_PAGE_MISSING_MESSAGE_CONTEXT.explanation=M\u00f6glicherweise ist im SAML-SSO (Single Sign-On) bei der \u00dcbergabe der SAML-Abmeldeanforderung oder bei der Verarbeitung der SAML-Abmeldeantwort ein Fehler aufgetreten.
 POST_LOGOUT_PAGE_MISSING_MESSAGE_CONTEXT.useraction=Suchen Sie in den Serverprotokollen nach zus\u00e4tzlichen Fehlernachrichten. Stellen Sie sicher, dass im SAML-SSO-Service keine anderen Fehler aufgetreten sind.
 
 # do not translate HTTP-POST, SingleLogoutService
@@ -329,8 +329,8 @@ SAML20_SLOENDPOINT_NOT_IN_METADATA.useraction=Vergewissern Sie sich, dass die Id
 
 LOGOUT_CANNOT_PERFORM_SLO=CWWKS5215E: Der Abmeldeservice kann die SAML Single Logout-Anforderung nicht ausf\u00fchren, weil er keinen eindeutigen Service-Provider findet. Die Benutzersicherheitssitzung in Service-Providern werden gel\u00f6scht. Die verf\u00fcgbaren Service-Provider sind [{0}].
 LOGOUT_CANNOT_PERFORM_SLO.explanation=Es sind mehrere Service-Provider-Instanzen im Liberty-Server konfiguriert. Der Liberty-Server hat keinen eindeutigen Service-Provider f\u00fcr die Einleitung des SAML Single Logout-Prozesses gefunden. Es wird nur die Benutzersicherheitssitzung in den Service-Providern gel\u00f6scht.
-LOGOUT_CANNOT_PERFORM_SLO.useraction=Stellen Sie sicher, dass die Anmeldeanwendung nur einem einzigen Service-Provider zugeordnet ist.
+LOGOUT_CANNOT_PERFORM_SLO.useraction=Stellen Sie sicher, dass die Abmeldeanwendung nur einem einzigen Service-Provider zugeordnet ist.
 
 LOGOUT_CANNOT_FIND_SAMLTOKEN=CWWKS5218E: Der Abmeldeservice kann die SAML Single Logout-Anforderung nicht ausf\u00fchren, weil er die Benutzersicherheitssitzung nicht findet.
 LOGOUT_CANNOT_FIND_SAMLTOKEN.explanation=Der Service-Provider findet die Benutzersicherheitssitzung f\u00fcr die Erstellung der SAML Single Logout-Anforderungsnachricht nicht. Der Benutzer wurde vom Service-Provider angemeldet, hat aber unter Umst\u00e4nden noch eine aktive Sicherheitssitzung beim Identit\u00e4tsprovider (IdP).
-LOGOUT_CANNOT_FIND_SAMLTOKEN.useraction=Sie k\u00f6nnen die vom Identit\u00e4tsprovider (IdP) eingeleitete Anmeldung implementieren und den Benutzer f\u00fcr die Abmeldung an den Identit\u00e4tsprovider (IdP) umleiten. Dies gilt insbesondere, wenn die Service-Provider-Anmeldung fehlschl\u00e4gt oder nicht abgeschlossen wird. 
+LOGOUT_CANNOT_FIND_SAMLTOKEN.useraction=Sie k\u00f6nnen die vom Identit\u00e4tsprovider (IdP) eingeleitete Abmeldung implementieren und den Benutzer f\u00fcr die Abmeldung an den Identit\u00e4tsprovider (IdP) umleiten. Dies gilt insbesondere, wenn die Service-Provider-Abmeldung fehlschl\u00e4gt oder nicht abgeschlossen wird. 


### PR DESCRIPTION
Update the German (de) message files for the OIDC applications to have the correct translation for 'Logout'.

fixes #10867