### PR TITLE
Properly handle removal of REST stat metrics when an application is unloaded

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.2.0/src/com/ibm/ws/microprofile/metrics/ApplicationListener.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0/src/com/ibm/ws/microprofile/metrics/ApplicationListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,24 +33,29 @@ public class ApplicationListener implements ApplicationStateListener {
 
     /** {@inheritDoc} */
     @Override
-    public void applicationStarting(ApplicationInfo appInfo) throws StateChangeException {}
+    public void applicationStarting(ApplicationInfo appInfo) throws StateChangeException {
+    }
 
     /** {@inheritDoc} */
     @Override
-    public void applicationStarted(ApplicationInfo appInfo) throws StateChangeException {}
+    public void applicationStarted(ApplicationInfo appInfo) throws StateChangeException {
+    }
 
     /** {@inheritDoc} */
     @Override
-    public void applicationStopping(ApplicationInfo appInfo) {}
+    public void applicationStopping(ApplicationInfo appInfo) {
+    }
 
     /** {@inheritDoc} */
     @Override
     public void applicationStopped(ApplicationInfo appInfo) {
-        MetricRegistry registry = sharedMetricRegistry.getOrCreate(MetricRegistry.Type.APPLICATION.getName());
-
-        if (MetricRegistryImpl.class.isInstance(registry)) {
-            MetricRegistryImpl impl = (MetricRegistryImpl) registry;
-            impl.unRegisterApplicationMetrics(appInfo.getDeploymentName());
+        MetricRegistry[] registryArray = new MetricRegistry[] { sharedMetricRegistry.getOrCreate(MetricRegistry.Type.APPLICATION.getName()),
+                                                                sharedMetricRegistry.getOrCreate(MetricRegistry.Type.BASE.getName()) };
+        for (MetricRegistry registry : registryArray) {
+            if (MetricRegistryImpl.class.isInstance(registry)) {
+                MetricRegistryImpl impl = (MetricRegistryImpl) registry;
+                impl.unRegisterApplicationMetrics(appInfo.getDeploymentName());
+            }
         }
     }
 

--- a/dev/com.ibm.ws.microprofile.metrics.2.0/src/com/ibm/ws/microprofile/metrics/impl/MetricRegistryImpl.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0/src/com/ibm/ws/microprofile/metrics/impl/MetricRegistryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 IBM Corporation and others.
+* Copyright (c) 2019, 2020 IBM Corporation and others.
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
@@ -269,6 +269,18 @@ public class MetricRegistryImpl extends MetricRegistry {
      */
     protected void addNameToApplicationMap(MetricID metricID) {
         String appName = getApplicationName();
+        addNameToApplicationMap(metricID, appName);
+    }
+
+    /**
+     * Adds the MetricID to an application map given the application name.
+     * This map is not a complete list of metrics owned by an application,
+     * produced metrics are managed in the MetricsExtension
+     *
+     * @param metricID metric ID of metric that was added
+     * @param appName  applicationName
+     */
+    public void addNameToApplicationMap(MetricID metricID, String appName) {
         // If it is a base metric, the name will be null
         if (appName == null)
             return;
@@ -280,7 +292,6 @@ public class MetricRegistryImpl extends MetricRegistry {
                 list = newList;
         }
         list.add(metricID);
-
     }
 
     public void unRegisterApplicationMetrics() {

--- a/dev/com.ibm.ws.microprofile.metrics.2.0/src/com/ibm/ws/microprofile/metrics/impl/SharedMetricRegistries.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0/src/com/ibm/ws/microprofile/metrics/impl/SharedMetricRegistries.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2017, 2019 IBM Corporation and others.
+* Copyright (c) 2017, 2020 IBM Corporation and others.
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
@@ -28,6 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -69,6 +70,14 @@ public class SharedMetricRegistries {
             return raced;
         }
         return existing;
+    }
+
+    public void associateMetricIDToApplication(MetricID metricID, String appName, MetricRegistry registry) {
+        if (MetricRegistryImpl.class.isInstance(registry)) {
+            MetricRegistryImpl metricRegistryImpl = (MetricRegistryImpl) registry;
+            metricRegistryImpl.addNameToApplicationMap(metricID, appName);
+        }
+
     }
 
     @Reference(service = ConfigProviderResolver.class, cardinality = ReferenceCardinality.MANDATORY)

--- a/dev/com.ibm.ws.microprofile.metrics.2.3.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetrics.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.3.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetrics.java
@@ -29,187 +29,213 @@ import com.ibm.ws.microprofile.metrics.impl.SharedMetricRegistries;
 public class MonitorMetrics {
 
 	private static final TraceComponent tc = Tr.register(MonitorMetrics.class);
-	
+
 	protected String objectName;
 	protected String mbeanStatsName;
 	protected MBeanServer mbs;
-	protected Set<MetricID> metricIDs;
+	protected Set<MetricID> vendorMetricIDs;
+	protected Set<MetricID> baseMetricIDs;
 
 	public MonitorMetrics(String objectName) {
 		this.mbs = ManagementFactory.getPlatformMBeanServer();
 		this.objectName = objectName;
-		this.metricIDs = new HashSet<MetricID>();
-		
+		this.vendorMetricIDs = new HashSet<MetricID>();
+		this.baseMetricIDs = new HashSet<MetricID>();
 	}
 
 	public void createMetrics(SharedMetricRegistries sharedMetricRegistry, String[][] data) {
-		
-        MetricRegistry vendorRegistry = sharedMetricRegistry.getOrCreate(MetricRegistry.Type.VENDOR.getName());
-        MetricRegistry baseRegistry = sharedMetricRegistry.getOrCreate(MetricRegistry.Type.BASE.getName());
-        MetricRegistry metricRegistry = null;
-        
-        for (String[] metricData : data) {
-        	
-            String metricName = metricData[MappingTable.METRIC_NAME];
-            String metricTagName = metricData[MappingTable.MBEAN_STATS_NAME];
-            
-            Tag metricTag = null;
-            if (metricTagName != null) {
-            	metricTag = new Tag(metricTagName, getMBeanStatsString());
-            }
-            MetricID metricID = new MetricID(metricName, metricTag);
-            MetricType type = MetricType.valueOf(metricData[MappingTable.METRIC_TYPE]);
-            
-            /*
-             * New for the REST metrics (which are registered under base)
-             * Will there be future optional base metrics?
-             */
-            metricRegistry = (metricData[MappingTable.METRIC_REGISTRY_TYPE].equalsIgnoreCase("vendor") ) ? vendorRegistry : baseRegistry;
-            
-            if (MetricType.COUNTER.equals(type)) {
-                MonitorCounter mc = metricData[MappingTable.MBEAN_SUBATTRIBUTE] == null ? 
-                        new MonitorCounter(mbs, objectName, metricData[MappingTable.MBEAN_ATTRIBUTE]) :
-                        new MonitorCounter(mbs, objectName, metricData[MappingTable.MBEAN_ATTRIBUTE], metricData[MappingTable.MBEAN_SUBATTRIBUTE]);
-                
-                        metricRegistry.register(
-        				Metadata.builder().withName(metricName).withDisplayName(metricData[MappingTable.METRIC_DISPLAYNAME]).withDescription(metricData[MappingTable.METRIC_DESCRIPTION]).withType(type).withUnit(metricData[MappingTable.METRIC_UNIT]).build(), 
-        			mc, metricTag);
-        		metricIDs.add(metricID);
-        		Tr.debug(tc, "Registered " + metricID.toString());
-        	} else if (MetricType.GAUGE.equals(type)) {
-            	MonitorGauge<Number> mg =  metricData[MappingTable.MBEAN_SUBATTRIBUTE] == null ?
-            		new MonitorGauge<Number>(mbs, objectName, metricData[MappingTable.MBEAN_ATTRIBUTE]) :
-            		new MonitorGauge<Number>(mbs, objectName, metricData[MappingTable.MBEAN_ATTRIBUTE], metricData[MappingTable.MBEAN_SUBATTRIBUTE]);
-            		metricRegistry.register(
-        				Metadata.builder().withName(metricName).withDisplayName(metricData[MappingTable.METRIC_DISPLAYNAME]).withDescription(metricData[MappingTable.METRIC_DESCRIPTION]).withType(type).withUnit(metricData[MappingTable.METRIC_UNIT]).build(),
-        			mg, metricTag);
-        		metricIDs.add(metricID);
-        		Tr.debug(tc, "Registered " + metricID.toString());
-        	} 
-        	// Only REST_Stats is using SIMPLETIMER at the moment
-            else if (MetricType.SIMPLE_TIMER.equals(type)) {
-	        		
-        		/*
-        		 * Since only REST Stats is the only one using SIMPLETIMER
-        		 * we're leveraging the sub-attribute at the moment as the second attribute to retreive
-        		 */
-        		
-        		MonitorSimpleTimer mst = new MonitorSimpleTimer(mbs, objectName, metricData[MappingTable.MBEAN_ATTRIBUTE], metricData[MappingTable.MBEAN_SUBATTRIBUTE], metricData[MappingTable.MBEAN_SECOND_ATTRIBUTE], metricData[MappingTable.MBEAN_SECOND_SUBATTRIBUTE]);
-        		String[] objName_rest = getRESTMBeanStatsTags();
-        		
-        		Tag classTag = new Tag("class" , objName_rest[1]);
-        		Tag methodTag= new Tag("method" , objName_rest[2]);
-        		
-        		metricRegistry.register(
-        				Metadata.builder().withName(metricName).withDisplayName(metricData[MappingTable.METRIC_DISPLAYNAME]).withDescription(metricData[MappingTable.METRIC_DESCRIPTION]).withType(type).withUnit(metricData[MappingTable.METRIC_UNIT]).build(),
-        			mst, classTag, methodTag);
-        		metricIDs.add(metricID);
-        		Tr.debug(tc, "Registered " + metricID.toString());
-            } else {
-            	Tr.debug(tc, "Falied to register " + metricName + " because of invalid type " + type);
-            }
-            
-            //reset
-            metricRegistry = null;
-        }		
+
+		MetricRegistry vendorRegistry = sharedMetricRegistry.getOrCreate(MetricRegistry.Type.VENDOR.getName());
+		MetricRegistry baseRegistry = sharedMetricRegistry.getOrCreate(MetricRegistry.Type.BASE.getName());
+		MetricRegistry metricRegistry = null;
+		Set<MetricID> metricIDSet = null;
+
+		for (String[] metricData : data) {
+
+			String metricName = metricData[MappingTable.METRIC_NAME];
+			String metricTagName = metricData[MappingTable.MBEAN_STATS_NAME];
+
+			Tag metricTag = null;
+			if (metricTagName != null) {
+				metricTag = new Tag(metricTagName, getMBeanStatsString());
+			}
+			MetricID metricID = new MetricID(metricName, metricTag);
+			MetricType type = MetricType.valueOf(metricData[MappingTable.METRIC_TYPE]);
+
+			/*
+			 * New for the REST metrics (which are registered under base) Will there be
+			 * future optional base metrics?
+			 */
+			metricRegistry = (metricData[MappingTable.METRIC_REGISTRY_TYPE].equalsIgnoreCase("vendor")) ? vendorRegistry
+					: baseRegistry;
+			metricIDSet = (metricData[MappingTable.METRIC_REGISTRY_TYPE].equalsIgnoreCase("vendor")) ? vendorMetricIDs
+					: baseMetricIDs;
+
+			if (MetricType.COUNTER.equals(type)) {
+				MonitorCounter mc = metricData[MappingTable.MBEAN_SUBATTRIBUTE] == null
+						? new MonitorCounter(mbs, objectName, metricData[MappingTable.MBEAN_ATTRIBUTE])
+						: new MonitorCounter(mbs, objectName, metricData[MappingTable.MBEAN_ATTRIBUTE],
+								metricData[MappingTable.MBEAN_SUBATTRIBUTE]);
+
+				metricRegistry.register(Metadata.builder().withName(metricName)
+						.withDisplayName(metricData[MappingTable.METRIC_DISPLAYNAME])
+						.withDescription(metricData[MappingTable.METRIC_DESCRIPTION]).withType(type)
+						.withUnit(metricData[MappingTable.METRIC_UNIT]).build(), mc, metricTag);
+				metricIDSet.add(metricID);
+				Tr.debug(tc, "Registered " + metricID.toString());
+			} else if (MetricType.GAUGE.equals(type)) {
+				MonitorGauge<Number> mg = metricData[MappingTable.MBEAN_SUBATTRIBUTE] == null
+						? new MonitorGauge<Number>(mbs, objectName, metricData[MappingTable.MBEAN_ATTRIBUTE])
+						: new MonitorGauge<Number>(mbs, objectName, metricData[MappingTable.MBEAN_ATTRIBUTE],
+								metricData[MappingTable.MBEAN_SUBATTRIBUTE]);
+				metricRegistry.register(Metadata.builder().withName(metricName)
+						.withDisplayName(metricData[MappingTable.METRIC_DISPLAYNAME])
+						.withDescription(metricData[MappingTable.METRIC_DESCRIPTION]).withType(type)
+						.withUnit(metricData[MappingTable.METRIC_UNIT]).build(), mg, metricTag);
+				metricIDSet.add(metricID);
+				Tr.debug(tc, "Registered " + metricID.toString());
+			}
+			// Only REST_Stats is using SIMPLETIMER at the moment
+			else if (MetricType.SIMPLE_TIMER.equals(type)) {
+
+				MonitorSimpleTimer mst = new MonitorSimpleTimer(mbs, objectName,
+						metricData[MappingTable.MBEAN_ATTRIBUTE], metricData[MappingTable.MBEAN_SUBATTRIBUTE],
+						metricData[MappingTable.MBEAN_SECOND_ATTRIBUTE],
+						metricData[MappingTable.MBEAN_SECOND_SUBATTRIBUTE]);
+				String[] objName_rest = getRESTMBeanStatsTags();
+
+				// Only REST STAT metric is using SIMPLE TIMER.. explicitly creating the tags
+				// necessary.
+				String appName = objName_rest[0];
+				Tag classTag = new Tag("class", objName_rest[1]);
+				Tag methodTag = new Tag("method", objName_rest[2]);
+
+				metricRegistry.register(Metadata.builder().withName(metricName)
+						.withDisplayName(metricData[MappingTable.METRIC_DISPLAYNAME])
+						.withDescription(metricData[MappingTable.METRIC_DESCRIPTION]).withType(type)
+						.withUnit(metricData[MappingTable.METRIC_UNIT]).build(), mst, classTag, methodTag);
+
+				metricID = new MetricID(metricName, classTag, methodTag);
+				metricIDSet.add(metricID);
+				sharedMetricRegistry.associateMetricIDToApplication(metricID, appName, metricRegistry);
+
+				Tr.debug(tc, "Registered " + metricID.toString());
+			} else {
+				Tr.debug(tc, "Failed to register " + metricName + " because of invalid type " + type);
+			}
+
+			// reset
+			metricRegistry = null;
+		}
 	}
 
 	protected String[] getRESTMBeanStatsTags() {
-		String[] Tags = new String[3];
+		String[] mbeanProperties = new String[3];
 		for (String subString : objectName.split(",")) {
 			subString = subString.trim();
-            if (subString.contains("name=")) {
-            	Tags = subString.split("/");
-            	//blank method
-            	Tags[2] = Tags[2].replaceAll("\\(\\)", "");
-            	//otherwise first bracket becomes underscores
-            	Tags[2] = Tags[2].replaceAll("\\(", "_");
-            	//second bracket is removed
-            	Tags[2] = Tags[2].replaceAll("\\)", "");
-            	break;
-            }
+
+			if (subString.contains("name=")) {
+				mbeanProperties = subString.split("/");
+
+				mbeanProperties[0] = mbeanProperties[0].substring(mbeanProperties[0].indexOf("=") + 1,
+						mbeanProperties[0].length());
+
+				// blank method
+				mbeanProperties[2] = mbeanProperties[2].replaceAll("\\(\\)", "");
+				// otherwise first bracket becomes underscores
+				mbeanProperties[2] = mbeanProperties[2].replaceAll("\\(", "_");
+				// second bracket is removed
+				mbeanProperties[2] = mbeanProperties[2].replaceAll("\\)", "");
+
+				break;
+			}
 		}
-		return Tags;
+		return mbeanProperties;
 	}
-	
-	
+
 	protected String getMBeanStatsString() {
-    	if (mbeanStatsName == null) {
-    		String serviceName = null;
-    		String serviceURL = null;
-    		String portName = null;
-    		String mbeanObjName = null;
-    		StringBuffer sb = new StringBuffer();
-            for (String subString : objectName.split(",")) {
-                subString = subString.trim();
-                if (subString.contains("service=")) {	
-                	serviceName = getMBeanStatsServiceName(subString);
-                	serviceURL = getMBeanStatsServiceURL(subString);
-                	continue;
-                }
-                if (subString.contains("port=")) {
-                	portName = getMBeanStatsPortName(subString);
-                	continue;
-                }
-                if (subString.contains("name=")) {
-                	mbeanObjName = getMBeanStatsName(subString);
-                	break;
-                }
-            }
-            if (serviceURL != null && serviceName != null && portName != null) {
-            	sb.append(serviceURL);
-            	sb.append(".");
-            	sb.append(serviceName);
-            	sb.append(".");
-            	sb.append(portName);
-            }
-            else if (mbeanObjName != null) {
-            	sb.append(mbeanObjName);
-            }
-            else {
-            	sb.append("unknown");
-            }
-            
-            mbeanStatsName = sb.toString();
-    	}
-        return mbeanStatsName;
+		if (mbeanStatsName == null) {
+			String serviceName = null;
+			String serviceURL = null;
+			String portName = null;
+			String mbeanObjName = null;
+			StringBuffer sb = new StringBuffer();
+			for (String subString : objectName.split(",")) {
+				subString = subString.trim();
+				if (subString.contains("service=")) {
+					serviceName = getMBeanStatsServiceName(subString);
+					serviceURL = getMBeanStatsServiceURL(subString);
+					continue;
+				}
+				if (subString.contains("port=")) {
+					portName = getMBeanStatsPortName(subString);
+					continue;
+				}
+				if (subString.contains("name=")) {
+					mbeanObjName = getMBeanStatsName(subString);
+					break;
+				}
+			}
+			if (serviceURL != null && serviceName != null && portName != null) {
+				sb.append(serviceURL);
+				sb.append(".");
+				sb.append(serviceName);
+				sb.append(".");
+				sb.append(portName);
+			} else if (mbeanObjName != null) {
+				sb.append(mbeanObjName);
+			} else {
+				sb.append("unknown");
+			}
+
+			mbeanStatsName = sb.toString();
+		}
+		return mbeanStatsName;
 	}
-	
+
 	private String getMBeanStatsName(String nameStr) {
 		String mbeanName = nameStr.split("=")[1];
-		mbeanName = mbeanName.replaceAll(" ", "_"); 
+		mbeanName = mbeanName.replaceAll(" ", "_");
 		mbeanName = mbeanName.replaceAll("/", "_");
 		mbeanName = mbeanName.replaceAll("[^a-zA-Z0-9_]", "_");
-    	return mbeanName;
+		return mbeanName;
 	}
-	
+
 	private String getMBeanStatsServiceName(String serviceStr) {
-    	serviceStr = serviceStr.split("=")[1];
-    	serviceStr = serviceStr.replaceAll("\"", "");
-    	String serviceName = serviceStr.substring(serviceStr.indexOf("}") + 1);
-    	return serviceName;
+		serviceStr = serviceStr.split("=")[1];
+		serviceStr = serviceStr.replaceAll("\"", "");
+		String serviceName = serviceStr.substring(serviceStr.indexOf("}") + 1);
+		return serviceName;
 	}
-	
+
 	private String getMBeanStatsServiceURL(String serviceStr) {
-    	serviceStr = serviceStr.split("=")[1];
-    	serviceStr = serviceStr.replaceAll("\"", "");
-    	String serviceURL = serviceStr.substring(serviceStr.indexOf("{") + 1, serviceStr.indexOf("}"));
-    	serviceURL = serviceURL.replace("http://", "").replace("https://", "").replace("/", ".");
-    	return serviceURL;
+		serviceStr = serviceStr.split("=")[1];
+		serviceStr = serviceStr.replaceAll("\"", "");
+		String serviceURL = serviceStr.substring(serviceStr.indexOf("{") + 1, serviceStr.indexOf("}"));
+		serviceURL = serviceURL.replace("http://", "").replace("https://", "").replace("/", ".");
+		return serviceURL;
 	}
-	
+
 	private String getMBeanStatsPortName(String portStr) {
 		portStr = portStr.split("=")[1];
-    	String portName = portStr.replaceAll("\"", "");	
-    	return portName;
+		String portName = portStr.replaceAll("\"", "");
+		return portName;
 	}
 
 	public void unregisterMetrics(SharedMetricRegistries sharedMetricRegistry) {
-		MetricRegistry registry = sharedMetricRegistry.getOrCreate(MetricRegistry.Type.VENDOR.getName());
-		for (MetricID metricID : metricIDs) {
-			boolean rc = registry.remove(metricID);
+		MetricRegistry vendorRegistry = sharedMetricRegistry.getOrCreate(MetricRegistry.Type.VENDOR.getName());
+		MetricRegistry baseRegistry = sharedMetricRegistry.getOrCreate(MetricRegistry.Type.BASE.getName());
+		
+		for (MetricID metricID : vendorMetricIDs) {
+			boolean rc = vendorRegistry.remove(metricID);
 			Tr.debug(tc, "Unregistered " + metricID.toString() + " " + (rc ? "successfully" : "unsuccessfully"));
 		}
-		metricIDs.clear();
+		
+		for (MetricID metricID : baseMetricIDs) {
+			boolean rc = baseRegistry.remove(metricID);
+			Tr.debug(tc, "Unregistered " + metricID.toString() + " " + (rc ? "successfully" : "unsuccessfully"));
+		}
+		vendorMetricIDs.clear();
+		baseMetricIDs.clear();
 	}
 }

--- a/dev/com.ibm.ws.microprofile.metrics.2.3.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetrics.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.3.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetrics.java
@@ -82,7 +82,9 @@ public class MonitorMetrics {
 						.withDescription(metricData[MappingTable.METRIC_DESCRIPTION]).withType(type)
 						.withUnit(metricData[MappingTable.METRIC_UNIT]).build(), mc, metricTag);
 				metricIDSet.add(metricID);
-				Tr.debug(tc, "Registered " + metricID.toString());
+				if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()){
+					Tr.debug(tc, "Registered " + metricID.toString());
+				}
 			} else if (MetricType.GAUGE.equals(type)) {
 				MonitorGauge<Number> mg = metricData[MappingTable.MBEAN_SUBATTRIBUTE] == null
 						? new MonitorGauge<Number>(mbs, objectName, metricData[MappingTable.MBEAN_ATTRIBUTE])
@@ -93,7 +95,9 @@ public class MonitorMetrics {
 						.withDescription(metricData[MappingTable.METRIC_DESCRIPTION]).withType(type)
 						.withUnit(metricData[MappingTable.METRIC_UNIT]).build(), mg, metricTag);
 				metricIDSet.add(metricID);
-				Tr.debug(tc, "Registered " + metricID.toString());
+				if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()){
+					Tr.debug(tc, "Registered " + metricID.toString());
+				}
 			}
 			// Only REST_Stats is using SIMPLETIMER at the moment
 			else if (MetricType.SIMPLE_TIMER.equals(type)) {
@@ -118,10 +122,14 @@ public class MonitorMetrics {
 				metricID = new MetricID(metricName, classTag, methodTag);
 				metricIDSet.add(metricID);
 				sharedMetricRegistry.associateMetricIDToApplication(metricID, appName, metricRegistry);
-
-				Tr.debug(tc, "Registered " + metricID.toString());
+				
+				if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()){
+					Tr.debug(tc, "Registered " + metricID.toString());
+				}
 			} else {
-				Tr.debug(tc, "Failed to register " + metricName + " because of invalid type " + type);
+				if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()){
+					Tr.debug(tc, "Failed to register " + metricName + " because of invalid type " + type);
+				}
 			}
 
 			// reset
@@ -225,15 +233,19 @@ public class MonitorMetrics {
 	public void unregisterMetrics(SharedMetricRegistries sharedMetricRegistry) {
 		MetricRegistry vendorRegistry = sharedMetricRegistry.getOrCreate(MetricRegistry.Type.VENDOR.getName());
 		MetricRegistry baseRegistry = sharedMetricRegistry.getOrCreate(MetricRegistry.Type.BASE.getName());
-		
+
 		for (MetricID metricID : vendorMetricIDs) {
 			boolean rc = vendorRegistry.remove(metricID);
-			Tr.debug(tc, "Unregistered " + metricID.toString() + " " + (rc ? "successfully" : "unsuccessfully"));
+			if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+				Tr.debug(tc, "Unregistered " + metricID.toString() + " " + (rc ? "successfully" : "unsuccessfully"));
+			}
 		}
-		
+
 		for (MetricID metricID : baseMetricIDs) {
 			boolean rc = baseRegistry.remove(metricID);
-			Tr.debug(tc, "Unregistered " + metricID.toString() + " " + (rc ? "successfully" : "unsuccessfully"));
+			if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+				Tr.debug(tc, "Unregistered " + metricID.toString() + " " + (rc ? "successfully" : "unsuccessfully"));
+			}
 		}
 		vendorMetricIDs.clear();
 		baseMetricIDs.clear();

--- a/dev/com.ibm.ws.microprofile.metrics.2.3.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetrics.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.3.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetrics.java
@@ -138,27 +138,28 @@ public class MonitorMetrics {
 	}
 
 	protected String[] getRESTMBeanStatsTags() {
-		String[] mbeanProperties = new String[3];
+		String[] mbeanNameProperty = new String[3];
 		for (String subString : objectName.split(",")) {
 			subString = subString.trim();
-
+			
+			//Example of expected Mbean property name=ApplicationName/fully.qualified.class.name/methodSignature(java.lang.String)
 			if (subString.contains("name=")) {
-				mbeanProperties = subString.split("/");
+				mbeanNameProperty = subString.split("/");
 
-				mbeanProperties[0] = mbeanProperties[0].substring(mbeanProperties[0].indexOf("=") + 1,
-						mbeanProperties[0].length());
+				mbeanNameProperty[0] = mbeanNameProperty[0].substring(mbeanNameProperty[0].indexOf("=") + 1,
+						mbeanNameProperty[0].length());
 
 				// blank method
-				mbeanProperties[2] = mbeanProperties[2].replaceAll("\\(\\)", "");
+				mbeanNameProperty[2] = mbeanNameProperty[2].replaceAll("\\(\\)", "");
 				// otherwise first bracket becomes underscores
-				mbeanProperties[2] = mbeanProperties[2].replaceAll("\\(", "_");
+				mbeanNameProperty[2] = mbeanNameProperty[2].replaceAll("\\(", "_");
 				// second bracket is removed
-				mbeanProperties[2] = mbeanProperties[2].replaceAll("\\)", "");
+				mbeanNameProperty[2] = mbeanNameProperty[2].replaceAll("\\)", "");
 
 				break;
 			}
 		}
-		return mbeanProperties;
+		return mbeanNameProperty;
 	}
 
 	protected String getMBeanStatsString() {


### PR DESCRIPTION
#build  
fixes #10942 

REST stat metrics are not properly removed when an application is unloaded/removed.
Uses the SharedMetricRegistry service component to piggy back a call to MetricRegistryImpl

Eclipse formatted the following file dev/com.ibm.ws.microprofile.metrics.2.3.monitor/src/com/ibm/ws/microprofile/metrics/monitor/MonitorMetrics.java

See the comments for listing of what files were changed.