### PR TITLE
catch IO exception due to bundle uninstallation in generateXML

### DIFF
--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
@@ -147,6 +147,7 @@ public class PluginGenerator {
 
     private final PluginConfigData pcd;
     private final BundleContext context;
+    private final Bundle bundle;
 
     // distinguish between implicit generation (when endpoints change) and explicit generation (user mbean request)
     private boolean utilityRequest = true;
@@ -191,7 +192,9 @@ public class PluginGenerator {
         pcd = newPcd;
         appServerName = locSvc.getServerName();
 
-        cachedFile = context.getBundle().getDataFile("cached-PluginCfg.xml");
+        bundle = context.getBundle();
+        cachedFile = bundle.getDataFile("cached-PluginCfg.xml");
+
         if (cachedFile.exists()) {
             try {
                 
@@ -206,6 +209,10 @@ public class PluginGenerator {
     /** Wrapped method for getting the bundle context: required for test */
     protected BundleContext getBundleContext() {
         return FrameworkUtil.getBundle(PluginGenerator.class).getBundleContext();
+    }
+
+    private boolean isBundleUninstalled() {
+        return bundle.getState() == Bundle.UNINSTALLED;
     }
 
     /**
@@ -775,6 +782,7 @@ public class PluginGenerator {
 
             // Only write out to file if we have new or changed configuration information, or if this is an explicit request
             if (writeFile || !utilityRequest || !fileExists) {
+                // The bundle must not be uninstalled in order to write the file
                 // If writeFile is true write to the cachedFile and copy from there
                 // If writeFile is false and the cachedFile doesn't exist write to the cache file and copy from there
                 // If writeFile is false and cachedFile exists copy from there
@@ -799,6 +807,11 @@ public class PluginGenerator {
                         serializer.setOutputProperties(oprops);
                         serializer.transform(new DOMSource(output), new StreamResult(pluginCfgWriter));
                     }
+                } catch(IOException e){
+                    //path to the cachedFile is broken when bundle was uninstalled 
+                    if(!this.isBundleUninstalled()){ 
+                        throw e; // Missing for some other reason 
+                    }
                 } finally {
                     if (pluginCfgWriter != null) {
                         pluginCfgWriter.flush();
@@ -806,17 +819,14 @@ public class PluginGenerator {
                         fOutputStream.getFD().sync();
                         pluginCfgWriter.close();
                     }
-
                     try {
                         copyFile(cachedFile, outFile.asFile());
                     } catch (IOException e){
-                        //File no longer exists if the bundle was deactivated 
-                        Bundle bundle = FrameworkUtil.getBundle(PluginGenerator.class);
-                        if(bundle.getState() != bundle.UNINSTALLED){
+                        //cachedFile no longer exists if the bundle was uninstalled 
+                        if(!this.isBundleUninstalled()){
                             throw e; // Missing for some other reason 
                         }
-                    }
-                        
+                    }    
                 }
             } else {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {


### PR DESCRIPTION
In the rare case the bundle is uninstalled just before 

 fOutputStream = new FileOutputStream(cachedFile);

Then an IO exception will be thrown since the path to the cached file is broken. 

Just catching the exception as before in PR #10613 

