### PR TITLE
enable tests of loading login module from top level jar of app

### DIFF
--- a/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/ConnectionManagerMBeanTest.java
+++ b/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/ConnectionManagerMBeanTest.java
@@ -144,10 +144,9 @@ public class ConnectionManagerMBeanTest {
         ShrinkHelper.addDirectory(fvtapp_ear, "lib/LibertyFATTestFiles/fvtapp");
         ShrinkHelper.exportToServer(server, "apps", fvtapp_ear);
 
-        // TODO remove this temporary jar when login modules can be accessed from the resource adapter
-        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "tempLoginModule.jar");
-        jar.addPackage("fat.jca.resourceadapter.jar1");
-        jar.addPackage("fat.jca.resourceadapter.jar2");
+        // TODO remove this temporary jar once libraryRef is made optional
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "ignoreThisUselessLibrary.jar");
+        jar.addPackage("web.mdb.bindings"); // no login modules here
         ShrinkHelper.exportToServer(server, "/", jar);
 
         originalServerConfig = server.getServerConfiguration().clone();

--- a/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/DependantApplicationTest.java
+++ b/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/DependantApplicationTest.java
@@ -156,10 +156,9 @@ public class DependantApplicationTest {
         ShrinkHelper.addDirectory(fvtapp_ear, "lib/LibertyFATTestFiles/fvtapp");
         ShrinkHelper.exportToServer(server, "apps", fvtapp_ear);
 
-        // TODO remove this temporary jar when login modules can be accessed from the resource adapter
-        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "tempLoginModule.jar");
-        jar.addPackage("fat.jca.resourceadapter.jar1");
-        jar.addPackage("fat.jca.resourceadapter.jar2");
+        // TODO remove this temporary jar once libraryRef is made optional
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "ignoreThisUselessLibrary.jar");
+        jar.addPackage("web.mdb.bindings"); // no login modules here
         ShrinkHelper.exportToServer(server, "/", jar);
 
         originalServerConfig = server.getServerConfiguration().clone();

--- a/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/JCATest.java
+++ b/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/JCATest.java
@@ -119,10 +119,9 @@ public class JCATest extends FATServletClient {
         ShrinkHelper.addDirectory(fvtapp_ear, "lib/LibertyFATTestFiles/fvtapp");
         ShrinkHelper.exportToServer(server, "apps", fvtapp_ear);
 
-        // TODO remove this temporary jar when login modules can be accessed from the resource adapter
-        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "tempLoginModule.jar");
-        jar.addPackage("fat.jca.resourceadapter.jar1");
-        jar.addPackage("fat.jca.resourceadapter.jar2");
+        // TODO remove this temporary jar once libraryRef is made optional
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "ignoreThisUselessLibrary.jar");
+        jar.addPackage("web.mdb.bindings"); // no login modules here
         ShrinkHelper.exportToServer(server, "/", jar);
 
         server.addInstalledAppForValidation(fvtapp);

--- a/dev/com.ibm.ws.jca_fat/publish/servers/com.ibm.ws.jca.fat/server.xml
+++ b/dev/com.ibm.ws.jca_fat/publish/servers/com.ibm.ws.jca.fat/server.xml
@@ -68,17 +68,16 @@
     <application type="ear" id="fvtapp" name="fvtapp" location="fvtapp.ear">
     </application>
 
-    <library id="temp">
-      <file name="${server.config.dir}/tempLoginModule.jar"/>
+    <library id="ignore">
+      <file name="${server.config.dir}/ignoreThisUselessLibrary.jar"/>
     </library>
-    <javaPermission codebase="${server.config.dir}/tempLoginModule.jar" className="javax.security.auth.AuthPermission" name="modifyPrivateCredentials"/>
 
     <jaasLoginContextEntry id="jar1LoginContextEntry" name="jar1login">
-      <loginModule className="fat.jca.resourceadapter.jar1.JAR1LoginModule" libraryRef="temp"/> <!-- TODO replace with classProviderRef once implemented -->
+      <loginModule className="fat.jca.resourceadapter.jar1.JAR1LoginModule" classProviderRef="FAT1" libraryRef="ignore"/> <!-- TODO remove libraryRef once made optional -->
     </jaasLoginContextEntry>
 
     <jaasLoginContextEntry id="jar2LoginContextEntry" name="jar2login">
-      <loginModule className="fat.jca.resourceadapter.jar2.JAR2LoginModule" libraryRef="temp"/> <!-- TODO replace with classProviderRef once implemented -->
+      <loginModule className="fat.jca.resourceadapter.jar2.JAR2LoginModule" classProviderRef="FAT1" libraryRef="ignore"/> <!-- TODO remove libraryRef once made optional -->
     </jaasLoginContextEntry>
 
     <!-- 
@@ -96,6 +95,7 @@
                     name="javax.resource.spi.security.PasswordCredential * &quot;*&quot;" actions="read"/>
 
     <!-- TODO switch to resource adapter (should be covered above) once it replaces the temporary login module jar -->
-    <javaPermission codebase="${server.config.dir}/tempLoginModule.jar" className="javax.security.auth.PrivateCredentialPermission"
+    <javaPermission codebase="${server.config.dir}/connectors/JCAFAT1.rar" className="javax.security.auth.PrivateCredentialPermission"
                     signedBy="javax.resource.spi.security.PasswordCredential" principalType="*" principalName="*" actions="read"/>
+    <javaPermission codebase="${server.config.dir}/connectors/JCAFAT1.rar" className="javax.security.auth.AuthPermission" name="modifyPrivateCredentials"/>
 </server>

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
@@ -79,11 +79,9 @@ public class JDBCLoadFromAppTest extends FATServletClient {
 
         ShrinkHelper.exportAppToServer(server, otherApp);
 
-        // TODO remove this
-        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "tempLoginModule.jar");
-        jar.addPackage("web.derby");
-        jar.addPackage("web.other");
-        jar.addPackage("loginmod");
+        // TODO remove this once libraryRef is made optional
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "ignoreThisUselessLibrary.jar");
+        jar.addPackage("com.ibm.ws.jdbc.fat.loadfromapp"); // no login modules here
         ShrinkHelper.exportToServer(server, "/", jar);
 
         server.addInstalledAppForValidation("derbyApp");
@@ -94,6 +92,8 @@ public class JDBCLoadFromAppTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer("SRVE9967W.*derbyLocale"); // ignore missing Derby locales
+        server.stopServer("CWWKE0701E.*JAASLoginModuleConfigImpl", // TODO remove this if we enable loading login modules from web applications
+                          "SRVE9967W.*derbyLocale" // ignore missing Derby locales
+        );
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/server.xml
@@ -22,9 +22,9 @@
 
     <include location="../fatTestPorts.xml"/>
 
-    <application location="derbyApp.war"/>
+    <application id="derbyApp" location="derbyApp.war"/>
 
-    <application location="otherApp.ear"/>
+    <application id="otherApp" location="otherApp.ear"/>
 
     <dataSource id="DefaultDataSource" ibm.internal.nonship.function="true">
       <jdbcDriver javax.sql.DataSource="jdbc.driver.proxy.ProxyDataSource" libraryRef="ibm.internal.simulate.no.library.do.not.ship" ibm.internal.nonship.function="true"/> <!-- TODO remove libraryRef -->
@@ -59,21 +59,20 @@
     <library id="ibm.internal.simulate.no.library.do.not.ship"/>
 
     <!-- TODO replace with classProviderRef once implemented -->
-    <library id="temp">
-      <file name="${server.config.dir}/tempLoginModule.jar"/>
+    <library id="ignore">
+      <file name="${server.config.dir}/ignoreThisUselessLibrary.jar"/>
     </library>
-    <javaPermission codebase="${server.config.dir}/tempLoginModule.jar" className="javax.security.auth.AuthPermission" name="modifyPrivateCredentials"/>
 
     <jaasLoginContextEntry id="app1loginEntry" name="app1login">
-      <loginModule className="loginmod.LoadFromAppLoginModule" libraryRef="temp"/> <!-- TODO use classProviderRef once implemented -->
+      <loginModule className="loginmod.LoadFromAppLoginModule" classProviderRef="otherApp" libraryRef="ignore"/> <!-- TODO remove libraryRef once made optional -->
     </jaasLoginContextEntry>
 
     <jaasLoginContextEntry id="webapploginEntry" name="webapplogin">
-      <loginModule className="web.derby.LoadFromWebAppLoginModule" libraryRef="temp"/> <!-- TODO use classProviderRef once implemented -->
+      <loginModule className="web.derby.LoadFromWebAppLoginModule" classProviderRef="derbyApp" libraryRef="ignore"/> <!-- TODO remove libraryRef once made optional -->
     </jaasLoginContextEntry>
 
     <jaasLoginContextEntry id="web1loginEntry" name="web1login">
-      <loginModule className="web.other.LoadFromWebModLoginModule" libraryRef="temp"/> <!-- TODO use classProviderRef once implemented -->
+      <loginModule className="web.other.LoadFromWebModLoginModule" classProviderRef="otherApp" libraryRef="ignore"/> <!-- TODO remove libraryRef once made optional -->
     </jaasLoginContextEntry>
 
     <!-- permissions for Derby in the app -->
@@ -101,6 +100,9 @@
 
     <!-- permissions for Mini driver to utilize dynamic proxy -->
     <javaPermission codeBase="${server.config.dir}apps/otherApp.ear" className="java.lang.RuntimePermission" name="getClassLoader"/>
+
+    <!-- permissions for login modules -->
+    <javaPermission codebase="${server.config.dir}/apps/otherApp.ear" className="javax.security.auth.AuthPermission" name="modifyPrivateCredentials"/>
 
     <variable name="onError" value="FAIL"/>
 </server>

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/resources/WEB-INF/ibm-web-bnd.xml
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/resources/WEB-INF/ibm-web-bnd.xml
@@ -12,6 +12,14 @@
 <web-bnd xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://websphere.ibm.com/xml/ns/javaee"
     xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-bnd_1_0.xsd" version="1.0">
 
+  <resource-ref name="java:module/env/jdbc/sldsLoginModuleFromOtherApp">
+    <custom-login-configuration name="app1login">
+      <property name="shape" value="hexagon"/>
+      <property name="sides" value="6"/>
+      <property name="sumOfAngles" value="720"/>
+    </custom-login-configuration>
+  </resource-ref>
+
   <resource-ref name="java:module/env/jdbc/sldsLoginModuleFromWebApp">
     <custom-login-configuration name="webapplogin">
       <property name="shape" value="pentagon"/>

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/src/web/derby/DerbyLoadFromAppServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/src/web/derby/DerbyLoadFromAppServlet.java
@@ -12,17 +12,21 @@ package web.derby;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
 
 import javax.annotation.Resource;
 import javax.naming.InitialContext;
+import javax.security.auth.login.LoginException;
 import javax.servlet.annotation.WebServlet;
 import javax.sql.DataSource;
 
 import org.junit.Test;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.app.FATDatabaseServlet;
 
 @SuppressWarnings("serial")
@@ -30,6 +34,9 @@ import componenttest.app.FATDatabaseServlet;
 public class DerbyLoadFromAppServlet extends FATDatabaseServlet {
     @Resource
     private DataSource defaultDataSource;
+
+    @Resource(name = "java:module/env/jdbc/sldsLoginModuleFromOtherApp", lookup = "jdbc/sharedLibDataSource")
+    private DataSource sldsLoginModuleFromOtherApp;
 
     @Resource(name = "java:module/env/jdbc/sldsLoginModuleFromWebApp", lookup = "jdbc/sharedLibDataSource")
     private DataSource sldsLoginModuleFromWebApp;
@@ -69,14 +76,35 @@ public class DerbyLoadFromAppServlet extends FATDatabaseServlet {
     }
 
     /**
-     * testLoginModuleFromWebApp - verify that a login module that is packaged within the web application is used to authenticate
+     * testLoginModuleFromOtherApp - verify that a login module that is packaged within another application can be used to authenticate
+     * a data source that is defined in the current web application, where its resource reference specifies to use that login module.
+     */
+    @Test
+    public void testLoginModuleFromOtherApp() throws Exception {
+        try (Connection con = sldsLoginModuleFromOtherApp.getConnection()) {
+            DatabaseMetaData metadata = con.getMetaData();
+            assertEquals("appuser", metadata.getUserName());
+        }
+    }
+
+    /**
+     * testLoginModuleFromWebApp - verify that a login module that is packaged within the web application CANNOT be used to authenticate
      * to a data source when its resource reference specifies to use that login module.
      */
+    @AllowedFFDC({ "javax.security.auth.login.LoginException", "javax.resource.ResourceException" }) // TODO remove if we decide to enable this scenario
     @Test
     public void testLoginModuleFromWebApp() throws Exception {
         try (Connection con = sldsLoginModuleFromWebApp.getConnection()) {
             DatabaseMetaData metadata = con.getMetaData();
-            assertEquals("webappuser", metadata.getUserName());
+            fail("authenticated as user " + metadata.getUserName());
+            // TODO if we decide to enable this path, then switch to the following assert and remove the catch block
+            // assertEquals("webappuser", metadata.getUserName());
+        } catch (SQLException x) {
+            Throwable cause = x;
+            while (cause != null && !(cause instanceof LoginException))
+                cause = cause.getCause();
+            if (!(cause instanceof LoginException))
+                throw x;
         }
     }
 


### PR DESCRIPTION
Enable tests that load a login module class from a top level JAR within a specified application.
These test verify that a data source which relies on the login module can be used from within the application's web module and EJB modules.  Also add a test to verify that the login module can be used by a data source within a completely different application.  For now, the tests will enforce that login modules are not loaded from other locations within the app (besides resource adapters which are tested elsewhere).  We can update those tests if later adding that function.

Also, this enables some additional tests for login module in a standalone RAR that were already working.