### PR TITLE
Revert "Security SSO changes to leverage SameSite cookie code"

### DIFF
--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/web/JavaScriptUtils.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/web/JavaScriptUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -124,7 +124,7 @@ public class JavaScriptUtils {
         return wrapInJavascriptHtmlTags(javascript);
     }
 
-    public String createJavaScriptHtmlCookieString(String name, String value, Map<String, String> cookieProperties, boolean htmlEncodeNameAndValue) {
+    private String createJavaScriptHtmlCookieString(String name, String value, Map<String, String> cookieProperties, boolean htmlEncodeNameAndValue) {
         String result = "document.cookie=\"";
         if (htmlEncodeNameAndValue) {
             result += getHtmlCookieString(name, value, cookieProperties);
@@ -143,15 +143,11 @@ public class JavaScriptUtils {
             return "";
         }
         String cookieString = createHtmlCookiePropertyString(name, value, htmlEncodeNameAndValue);
-        if (cookieProperties == null) {
-            cookieProperties = new HashMap<String, String>();
-        }
-        cookieProperties.putAll(getWebAppSecurityConfigCookieProperties());
         cookieString += createHtmlCookiePropertiesString(cookieProperties);
         return cookieString;
     }
 
-    public String createHtmlCookiePropertiesString(Map<String, String> props) {
+    private String createHtmlCookiePropertiesString(Map<String, String> props) {
         String propertyString = "";
         if (props == null) {
             return propertyString;
@@ -196,49 +192,19 @@ public class JavaScriptUtils {
         if (cookieProperties == null) {
             result += createHtmlCookiePropertiesString(getDefaultCookieProperties());
         } else {
-            cookieProperties = addWebAppSecConfigPropsToCookieProperties(cookieProperties);
             result += createHtmlCookiePropertiesString(cookieProperties);
         }
         result += "\";";
         return result;
     }
 
-    public Map<String, String> getDefaultCookieProperties() {
+    private Map<String, String> getDefaultCookieProperties() {
         Map<String, String> cookieProperties = new HashMap<String, String>();
         cookieProperties.put("path", "/");
-        cookieProperties.putAll(getWebAppSecurityConfigCookieProperties());
-        return cookieProperties;
-    }
-
-    public Map<String, String> getWebAppSecurityConfigCookieProperties() {
-        return getWebAppSecurityConfigCookieProperties(getWebAppSecurityConfig());
-    }
-
-    public Map<String, String> getWebAppSecurityConfigCookieProperties(WebAppSecurityConfig webAppSecurityConfig) {
-        Map<String, String> cookieProperties = new HashMap<String, String>();
+        WebAppSecurityConfig webAppSecurityConfig = getWebAppSecurityConfig();
         if (webAppSecurityConfig != null) {
             if (webAppSecurityConfig.getSSORequiresSSL()) {
                 cookieProperties.put("secure", null);
-            }
-            String sameSite = webAppSecurityConfig.getSameSiteCookie();
-            if (sameSite != null) {
-                cookieProperties.put("SameSite", sameSite);
-                if ("None".equalsIgnoreCase(sameSite)) {
-                    cookieProperties.put("secure", null);
-                }
-            }
-        }
-        return cookieProperties;
-    }
-
-    private Map<String, String> addWebAppSecConfigPropsToCookieProperties(Map<String, String> cookieProperties) {
-        if (cookieProperties == null) {
-            cookieProperties = new HashMap<String, String>();
-        }
-        Map<String, String> webAppSecProps = getWebAppSecurityConfigCookieProperties();
-        for (Entry<String, String> entry : webAppSecProps.entrySet()) {
-            if (!cookieProperties.containsKey(entry.getKey())) {
-                cookieProperties.put(entry.getKey(), entry.getValue());
             }
         }
         return cookieProperties;

--- a/dev/com.ibm.ws.security.common/test/com/ibm/ws/security/common/web/JavaScriptUtilsTest.java
+++ b/dev/com.ibm.ws.security.common/test/com/ibm/ws/security/common/web/JavaScriptUtilsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -48,8 +48,6 @@ public class JavaScriptUtilsTest extends CommonTestClass {
     static final String WINDOW_LOCATION_REPLACE_START = "window.location.replace(\"";
     static final String WINDOW_LOCATION_REPLACE_END = "\");";
     static final String VALID_URL = "https://localhost:8010/myApp";
-    static final String SAME_SITE_ATTR_VALUE = "SameSiteValue";
-    static final String SAME_SITE_PROP = "SameSite=" + SAME_SITE_ATTR_VALUE + ";";
 
     final HttpServletRequest request = mockery.mock(HttpServletRequest.class);
     final HttpServletResponse response = mockery.mock(HttpServletResponse.class);
@@ -197,9 +195,7 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             String name = "some value";
             String value = "some value";
 
-            final String expectedCookieString = name + "=" + value + "; " + SAME_SITE_PROP;
-
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
+            final String expectedCookieString = name + "=" + value + ";";
 
             String result = utils.getJavaScriptHtmlCookieString(name, value);
 
@@ -223,9 +219,7 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             String value = "some value";
             Map<String, String> cookieProps = new HashMap<String, String>();
 
-            final String expectedCookieString = name + "=" + value + "; " + SAME_SITE_PROP;
-
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
+            final String expectedCookieString = name + "=" + value + ";";
 
             String result = utils.getJavaScriptHtmlCookieString(name, value, cookieProps);
 
@@ -251,14 +245,10 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             cookieProps.put("key1", "value1");
             cookieProps.put("key2", "value2");
 
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
-
             String result = utils.getJavaScriptHtmlCookieString(name, value, cookieProps);
 
             final String expectedCookieString = name + "=" + value + ";";
             verifyPattern(result, Pattern.quote(expectedCookieString), "Expected cookie name and value did not appear in the result.");
-
-            cookieProps.put("SameSite", SAME_SITE_ATTR_VALUE);
             verifyCookiePropertyStrings(result, cookieProps);
 
         } catch (Throwable t) {
@@ -327,11 +317,9 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             String name = "<cookie name\"'>";
             String value = null;
 
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
-
             String result = utils.getUnencodedJavaScriptHtmlCookieString(name, value);
 
-            String expectedCookieString = name + "; " + SAME_SITE_PROP;
+            String expectedCookieString = name + ";";
             verifyCaseInsensitiveQuotedPatternMatches(result, DOCUMENT_COOKIE_START + expectedCookieString + DOCUMENT_COOKIE_END, "Cookie string did not match expected pattern.");
 
         } catch (Throwable t) {
@@ -352,11 +340,9 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             String name = "<cookie name\"'>";
             String value = "";
 
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
-
             String result = utils.getUnencodedJavaScriptHtmlCookieString(name, value);
 
-            String expectedCookieString = name + "=; " + SAME_SITE_PROP;
+            String expectedCookieString = name + "=;";
             verifyCaseInsensitiveQuotedPatternMatches(result, DOCUMENT_COOKIE_START + expectedCookieString + DOCUMENT_COOKIE_END, "Cookie string did not match expected pattern.");
 
         } catch (Throwable t) {
@@ -377,11 +363,9 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             String name = "<cookie name\"'>";
             String value = ">cookie'<\" value ";
 
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
-
             String result = utils.getUnencodedJavaScriptHtmlCookieString(name, value);
 
-            String expectedCookieString = name + "=" + value + "; " + SAME_SITE_PROP;
+            String expectedCookieString = name + "=" + value + ";";
             verifyCaseInsensitiveQuotedPatternMatches(result, DOCUMENT_COOKIE_START + expectedCookieString + DOCUMENT_COOKIE_END, "Cookie string did not match expected pattern.");
 
         } catch (Throwable t) {
@@ -402,8 +386,6 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             String name = "<cookie name\"'>";
             String value = ">cookie'<\" value ";
             Map<String, String> cookieProps = new HashMap<String, String>();
-
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
 
             String result = utils.getUnencodedJavaScriptHtmlCookieString(name, value, cookieProps);
 
@@ -431,14 +413,10 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             cookieProps.put("key1", "value1");
             cookieProps.put("key2", "value2");
 
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
-
             String result = utils.getUnencodedJavaScriptHtmlCookieString(name, value, cookieProps);
 
             String expectedCookieString = DOCUMENT_COOKIE_START + name + "=" + value + ";";
             verifyPattern(result, Pattern.quote(expectedCookieString), "Expected cookie name and value did not appear in the result.");
-
-            cookieProps.put("SameSite", SAME_SITE_ATTR_VALUE);
             verifyCookiePropertyStrings(result, cookieProps);
 
         } catch (Throwable t) {
@@ -593,11 +571,9 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             String name = "some value";
             String value = null;
 
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
-
             String result = utils.getHtmlCookieString(name, value);
 
-            String expectedCookieString = name + "; " + SAME_SITE_PROP;
+            String expectedCookieString = name + ";";
             verifyCaseInsensitiveQuotedPatternMatches(result, expectedCookieString, "Cookie string did not match expected pattern.");
 
         } catch (Throwable t) {
@@ -618,11 +594,9 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             String name = "some value";
             String value = "";
 
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
-
             String result = utils.getHtmlCookieString(name, value);
 
-            String expectedCookieString = name + "=" + "; " + SAME_SITE_PROP;
+            String expectedCookieString = name + "=" + ";";
             verifyCaseInsensitiveQuotedPatternMatches(result, expectedCookieString, "Cookie string did not match expected pattern.");
 
         } catch (Throwable t) {
@@ -643,11 +617,9 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             String name = "some value";
             String value = "some value";
 
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
-
             String result = utils.getHtmlCookieString(name, value);
 
-            String expectedCookieString = name + "=" + value + "; " + SAME_SITE_PROP;
+            String expectedCookieString = name + "=" + value + ";";
             verifyCaseInsensitiveQuotedPatternMatches(result, expectedCookieString, "Cookie string did not match expected pattern.");
 
         } catch (Throwable t) {
@@ -668,13 +640,11 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             String name = ">\"name,";
             String value = "&value<";
 
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
-
             String result = utils.getHtmlCookieString(name, value);
 
             String htmlEncodedName = "&gt;&quot;name,";
             String htmlEncodedValue = "&amp;value&lt;";
-            String expectedCookieString = htmlEncodedName + "=" + htmlEncodedValue + "; " + SAME_SITE_PROP;
+            String expectedCookieString = htmlEncodedName + "=" + htmlEncodedValue + ";";
             verifyCaseInsensitiveQuotedPatternMatches(result, expectedCookieString, "Cookie string did not match expected pattern.");
 
         } catch (Throwable t) {
@@ -695,11 +665,9 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             String value = "a value";
             Map<String, String> cookieProps = new HashMap<String, String>();
 
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
-
             String result = utils.getHtmlCookieString(name, value, cookieProps);
 
-            String expectedCookieString = name + "=" + value + "; " + SAME_SITE_PROP;
+            String expectedCookieString = name + "=" + value + ";";
             verifyCaseInsensitiveQuotedPatternMatches(result, expectedCookieString, "Cookie string did not match expected pattern.");
 
         } catch (Throwable t) {
@@ -727,14 +695,10 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             cookieProps.put("NullValue", null);
             cookieProps.put("EmptyValue", "");
 
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
-
             String result = utils.getHtmlCookieString(name, value, cookieProps);
 
             String expectedCookieNameAndValue = name + "=" + value + ";";
             verifyPattern(result, Pattern.quote(expectedCookieNameAndValue), "Expected cookie name and value did not appear in the result.");
-
-            cookieProps.put("SameSite", SAME_SITE_ATTR_VALUE);
             verifyCookiePropertyStrings(result, cookieProps);
 
         } catch (Throwable t) {
@@ -801,11 +765,9 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             String name = "some value";
             String value = null;
 
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
-
             String result = utils.getUnencodedHtmlCookieString(name, value);
 
-            String expectedCookieString = name + "; " + SAME_SITE_PROP;
+            String expectedCookieString = name + ";";
             verifyCaseInsensitiveQuotedPatternMatches(result, expectedCookieString, "Cookie string did not match expected pattern.");
 
         } catch (Throwable t) {
@@ -826,11 +788,9 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             String name = "& some<\"name,";
             String value = "";
 
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
-
             String result = utils.getUnencodedHtmlCookieString(name, value);
 
-            String expectedCookieString = name + "=; " + SAME_SITE_PROP;
+            String expectedCookieString = name + "=;";
             verifyCaseInsensitiveQuotedPatternMatches(result, expectedCookieString, "Cookie string did not match expected pattern.");
 
         } catch (Throwable t) {
@@ -851,11 +811,9 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             String name = ">\"name,";
             String value = "&value<";
 
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
-
             String result = utils.getUnencodedHtmlCookieString(name, value);
 
-            String expectedCookieString = name + "=" + value + "; " + SAME_SITE_PROP;
+            String expectedCookieString = name + "=" + value + ";";
             verifyCaseInsensitiveQuotedPatternMatches(result, expectedCookieString, "Cookie string did not match expected pattern.");
 
         } catch (Throwable t) {
@@ -876,8 +834,6 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             String name = "<cookie name\"'>";
             String value = ">cookie'<\" value ";
             Map<String, String> cookieProps = new HashMap<String, String>();
-
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
 
             String result = utils.getUnencodedHtmlCookieString(name, value, cookieProps);
 
@@ -905,14 +861,10 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             cookieProps.put("key1", "value1");
             cookieProps.put("key2", "value2");
 
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
-
             String result = utils.getUnencodedHtmlCookieString(name, value, cookieProps);
 
             String expectedCookieString = name + "=" + value + ";";
             verifyPattern(result, Pattern.quote(expectedCookieString), "Expected cookie name and value did not appear in the result.");
-
-            cookieProps.put("SameSite", SAME_SITE_ATTR_VALUE);
             verifyCookiePropertyStrings(result, cookieProps);
 
         } catch (Throwable t) {
@@ -1054,7 +1006,12 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             String requestUrlCookieName = "some cookie name";
             String redirectUrl = VALID_URL;
 
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
+            mockery.checking(new Expectations() {
+                {
+                    one(webAppConfig).getSSORequiresSSL();
+                    will(returnValue(false));
+                }
+            });
 
             String result = utils.getJavaScriptForRedirect(requestUrlCookieName, redirectUrl);
 
@@ -1083,7 +1040,12 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             String requestUrlCookieName = "some cookie name";
             String redirectUrl = VALID_URL;
 
-            getWebAppSecurityConfigCookiePropertiesExpectations(true);
+            mockery.checking(new Expectations() {
+                {
+                    one(webAppConfig).getSSORequiresSSL();
+                    will(returnValue(true));
+                }
+            });
 
             String result = utils.getJavaScriptForRedirect(requestUrlCookieName, redirectUrl);
 
@@ -1111,7 +1073,12 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             String requestUrlCookieName = "some cookie name";
             String redirectUrl = VALID_URL + "?test=value";
 
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
+            mockery.checking(new Expectations() {
+                {
+                    one(webAppConfig).getSSORequiresSSL();
+                    will(returnValue(false));
+                }
+            });
 
             try {
                 String result = utils.getJavaScriptForRedirect(requestUrlCookieName, redirectUrl);
@@ -1140,7 +1107,12 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             String requestUrlCookieName = "a'cookie \"name<with> HTML&chars";
             String redirectUrl = VALID_URL;
 
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
+            mockery.checking(new Expectations() {
+                {
+                    one(webAppConfig).getSSORequiresSSL();
+                    will(returnValue(false));
+                }
+            });
 
             String result = utils.getJavaScriptForRedirect(requestUrlCookieName, redirectUrl);
 
@@ -1171,8 +1143,6 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             String redirectUrl = VALID_URL;
 
             Map<String, String> cookieProps = new HashMap<String, String>();
-
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
 
             String result = utils.getJavaScriptForRedirect(requestUrlCookieName, redirectUrl, cookieProps);
 
@@ -1208,11 +1178,8 @@ public class JavaScriptUtilsTest extends CommonTestClass {
             cookieProps.put("NullValue", null);
             cookieProps.put("EmptyValue", "");
 
-            getWebAppSecurityConfigCookiePropertiesExpectations(false);
-
             String result = utils.getJavaScriptForRedirect(requestUrlCookieName, redirectUrl, cookieProps);
 
-            cookieProps.put("SameSite", SAME_SITE_ATTR_VALUE);
             verifyValidJavaScriptForRedirectBlock(result, requestUrlCookieName, redirectUrl, cookieProps);
 
         } catch (Throwable t) {
@@ -1327,17 +1294,6 @@ public class JavaScriptUtilsTest extends CommonTestClass {
     private Pattern getExpectedCookieNameAndValuePattern(String cookieName) {
         String expectedCookieVal = Pattern.quote("\"+encodeURI(") + "[a-zA-Z0-9]+" + Pattern.quote(")+\"");
         return Pattern.compile(Pattern.quote(DOCUMENT_COOKIE_START + WebUtils.htmlEncode(cookieName) + "=") + expectedCookieVal + Pattern.quote(";"));
-    }
-
-    private void getWebAppSecurityConfigCookiePropertiesExpectations(final boolean ssoRequiresSsl) {
-        mockery.checking(new Expectations() {
-            {
-                one(webAppConfig).getSSORequiresSSL();
-                will(returnValue(ssoRequiresSsl));
-                one(webAppConfig).getSameSiteCookie();
-                will(returnValue(SAME_SITE_ATTR_VALUE));
-            }
-        });
     }
 
 }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,7 +35,6 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.common.internal.encoder.Base64Coder;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
-import com.ibm.ws.security.common.web.JavaScriptUtils;
 import com.ibm.ws.security.openidconnect.client.jose4j.util.Jose4jUtil;
 import com.ibm.ws.security.openidconnect.common.Constants;
 import com.ibm.ws.webcontainer.security.AuthResult;
@@ -594,9 +593,12 @@ public class OIDCClientAuthenticatorUtil {
                 .append("var loc=window.location.href;")
                 .append("document.cookie=\"").append(cookieName).append("=\"").append("+loc+").append("\";" + strDomain + " path=/;");
 
-        JavaScriptUtils jsUtils = new JavaScriptUtils();
-        String cookieProps = jsUtils.createHtmlCookiePropertiesString(jsUtils.getWebAppSecurityConfigCookieProperties());
-        sb.append(cookieProps);
+        WebAppSecurityConfig webAppSecurityConfig = WebAppSecurityCollaboratorImpl.getGlobalWebAppSecurityConfig();
+        if (webAppSecurityConfig != null) {
+            if (webAppSecurityConfig.getSSORequiresSSL()) {
+                sb.append(" secure;");
+            }
+        }
         sb.append("\"</script>");
 
         sb.append("<script type=\"text/javascript\" language=\"javascript\">")

--- a/dev/com.ibm.ws.security.saml.sso/src/com/ibm/ws/security/saml/sso20/internal/utils/ForwardRequestInfo.java
+++ b/dev/com.ibm.ws.security.saml.sso/src/com/ibm/ws/security/saml/sso20/internal/utils/ForwardRequestInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.security.common.web.JavaScriptUtils;
 import com.ibm.ws.security.saml.Constants;
 import com.ibm.ws.security.saml.error.SamlException;
 import com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl;
@@ -211,9 +210,12 @@ public class ForwardRequestInfo extends HttpRequestInfo implements Serializable 
         sb.append("\n<SCRIPT type=\"TEXT/JAVASCRIPT\" language=\"JavaScript\">\n");
         sb.append("document.cookie = '");
         sb.append(cookieName + "=' + encodeURIComponent(window.location.href) + '; Path=/;"); // session cookie
-        JavaScriptUtils jsUtils = new JavaScriptUtils();
-        String cookieProps = jsUtils.createHtmlCookiePropertiesString(jsUtils.getWebAppSecurityConfigCookieProperties());
-        sb.append(cookieProps);
+        WebAppSecurityConfig webAppSecurityConfig = WebAppSecurityCollaboratorImpl.getGlobalWebAppSecurityConfig();
+        if (webAppSecurityConfig != null) {
+            if (webAppSecurityConfig.getSSORequiresSSL()) {
+                sb.append(" secure;");
+            }
+        }
         sb.append("';\n");
         sb.append("</SCRIPT>\n");
 

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/web/SelectionPageGenerator.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/web/SelectionPageGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,9 +25,8 @@ import javax.servlet.http.HttpServletResponse;
 import com.ibm.json.java.JSONObject;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.security.common.lang.LocalesModifier;
-import com.ibm.ws.security.common.web.JavaScriptUtils;
 import com.ibm.ws.security.common.web.WebUtils;
+import com.ibm.ws.security.common.lang.LocalesModifier;
 import com.ibm.ws.security.social.SocialLoginConfig;
 import com.ibm.ws.security.social.SocialLoginWebappConfig;
 import com.ibm.ws.security.social.TraceConstants;
@@ -250,7 +249,7 @@ public class SelectionPageGenerator {
         }
         return "";
     }
-
+ 
     String createHtmlHead() {
         StringBuilder html = new StringBuilder();
         html.append("<head>\n");
@@ -271,21 +270,16 @@ public class SelectionPageGenerator {
         StringBuilder html = new StringBuilder();
         html.append("<script>\n");
         html.append("function " + createCookieFunctionName + "(value) {\n");
-        html.append("document.cookie = \"" + ClientConstants.LOGIN_HINT + "=\" + value + \";" + getJavaScriptCookiePropsString() + "\";\n");
+        html.append("document.cookie = \"" + ClientConstants.LOGIN_HINT + "=\" + value;\n");
         html.append("}\n");
         html.append("</script>\n");
         return html.toString();
     }
 
-    String getJavaScriptCookiePropsString() {
-        JavaScriptUtils jsUtils = new JavaScriptUtils();
-        return jsUtils.createHtmlCookiePropertiesString(jsUtils.getWebAppSecurityConfigCookieProperties());
-    }
-
     String getHtmlTitle() {
         return Tr.formatMessage(tc, LocalesModifier.getPrimaryLocale(request.getLocales()), "SELECTION_PAGE_TITLE");
     }
-
+    
     String createHtmlBody() {
         StringBuilder html = new StringBuilder();
         html.append("<body>\n");

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/web/utils/SocialWebUtils.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/web/utils/SocialWebUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,6 @@ import javax.servlet.http.HttpSession;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
-import com.ibm.ws.security.common.web.JavaScriptUtils;
 import com.ibm.ws.security.common.web.WebUtils;
 import com.ibm.ws.security.social.TraceConstants;
 import com.ibm.ws.security.social.error.SocialLoginException;
@@ -88,9 +87,12 @@ public class SocialWebUtils {
                 .append("var loc=window.location.href;")
                 .append("document.cookie=\"").append(reqUrlCookieName).append("=\"").append("+encodeURI(loc)+").append("\"; path=/;");
 
-        JavaScriptUtils jsUtils = new JavaScriptUtils();
-        String cookieProps = jsUtils.createHtmlCookiePropertiesString(jsUtils.getWebAppSecurityConfigCookieProperties());
-        sb.append(cookieProps);
+        WebAppSecurityConfig webAppSecurityConfig = getWebAppSecurityConfig();
+        if (webAppSecurityConfig != null) {
+            if (webAppSecurityConfig.getSSORequiresSSL()) {
+                sb.append(" secure;");
+            }
+        }
         sb.append("\"</script>");
 
         sb.append("<script type=\"text/javascript\" language=\"javascript\">")

--- a/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/twitter/TwitterTokenServicesTest.java
+++ b/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/twitter/TwitterTokenServicesTest.java
@@ -69,7 +69,6 @@ public class TwitterTokenServicesTest extends CommonTestClass {
     final String MSG_RESPONSE_FAILURE = "CWWKS5424E";
 
     static final String JSON_FAILURE_MSG = "JSON failure message. Something went wrong.";
-    static final String SAME_SITE_COOKIE_VALUE = "SameSiteValue";
 
     static Map<String, String> SUCCESSFUL_REQUEST_TOKEN_RESPONSE = new HashMap<String, String>();
     static Map<String, String> SUCCESSFUL_ACCESS_TOKEN_RESPONSE = new HashMap<String, String>();
@@ -837,8 +836,6 @@ public class TwitterTokenServicesTest extends CommonTestClass {
                 will(returnValue(false));
                 allowing(webAppSecConfig).getSSORequiresSSL();
                 will(returnValue(false));
-                allowing(webAppSecConfig).getSameSiteCookie();
-                will(returnValue(SAME_SITE_COOKIE_VALUE));
                 allowing(webAppSecConfig).createReferrerURLCookieHandler();
                 will(returnValue(new ReferrerURLCookieHandler(webAppSecConfig)));
                 allowing(webAppSecConfig).getSameSiteCookie();

--- a/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/web/SelectionPageGeneratorTest.java
+++ b/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/web/SelectionPageGeneratorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 IBM Corporation and others.
+ * Copyright (c) 2016, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -47,7 +47,6 @@ import com.ibm.ws.security.social.internal.utils.SocialTaiRequest;
 import com.ibm.ws.security.social.test.CommonTestClass;
 import com.ibm.ws.security.social.web.utils.ConfigInfoJsonBuilder;
 import com.ibm.ws.security.social.web.utils.SocialWebUtils;
-import com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl;
 
 import test.common.SharedOutputManager;
 
@@ -165,7 +164,6 @@ public class SelectionPageGeneratorTest extends CommonTestClass {
     public void before() {
         System.out.println("Entering test: " + testName.getMethodName());
         generator = new SelectionPageGenerator();
-        WebAppSecurityCollaboratorImpl.setGlobalWebAppSecurityConfig(webAppSecConfig);
     }
 
     @After
@@ -1172,10 +1170,6 @@ public class SelectionPageGeneratorTest extends CommonTestClass {
                     will(returnValue(HTML_PAGE_TITLE));
                     one(mockInterface).createCssContentString();
                     will(returnValue(""));
-                    one(webAppSecConfig).getSSORequiresSSL();
-                    will(returnValue(false));
-                    one(webAppSecConfig).getSameSiteCookie();
-                    will(returnValue("SameSiteValue"));
                 }
             });
 

--- a/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/web/utils/SocialWebUtilsTest.java
+++ b/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/web/utils/SocialWebUtilsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 IBM Corporation and others.
+ * Copyright (c) 2016, 2018 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -112,7 +112,6 @@ public class SocialWebUtilsTest extends CommonTestClass {
                 one(response).getWriter();
                 will(returnValue(writer));
                 one(webAppSecConfig).getSSORequiresSSL();
-                one(webAppSecConfig).getSameSiteCookie();
                 allowing(writer).println(with(any(String.class)));
                 allowing(response).setHeader(with(any(String.class)), with(any(String.class)));
                 one(response).setDateHeader("Expires", 0);
@@ -130,13 +129,12 @@ public class SocialWebUtilsTest extends CommonTestClass {
     public void createJavaScriptForRedirect() throws Exception {
         String scriptStart = "<script type=\"text/javascript\" language=\"javascript\">";
         String scriptEnd = "</script>";
-        String cookieRegex = scriptStart + ".*document\\.cookie=\"" + COOKIE_NAME + "=\"\\+encodeURI\\(loc\\)\\+\"; path=/;[^\"]*\".*" + scriptEnd;
+        String cookieRegex = scriptStart + ".*document\\.cookie=\"" + COOKIE_NAME + "=\"\\+encodeURI\\(loc\\)\\+\"; path=/;\".*" + scriptEnd;
         String windowReplaceRegex = scriptStart + ".*window\\.location\\.replace\\(\"" + LOGIN_URL + "\"\\).*" + scriptEnd;
 
         mockery.checking(new Expectations() {
             {
                 one(webAppSecConfig).getSSORequiresSSL();
-                one(webAppSecConfig).getSameSiteCookie();
             }
         });
 


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#10974

This is causing unit test failures in com.ibm.ws.security.saml.sso20.sp.SolicitedTest