### PR TITLE
tests of loading login modules from ejb modules

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
@@ -49,6 +49,7 @@ public class JDBCLoadFromAppTest extends FATServletClient {
     public static void setUp() throws Exception {
         WebArchive derbyApp = ShrinkWrap.create(WebArchive.class, "derbyApp.war")
                         .addPackage("web.derby") //
+                        .addAsWebInfResource(new File("test-applications/derbyapp/resources/WEB-INF/ibm-ejb-jar-bnd.xml"))
                         .addAsWebInfResource(new File("test-applications/derbyapp/resources/WEB-INF/ibm-web-bnd.xml"))
                         .addAsLibrary(new File("publish/shared/resources/derby/derby.jar")) //
                         .addPackage("jdbc.driver.proxy"); // delegates to the Derby JDBC driver
@@ -63,9 +64,11 @@ public class JDBCLoadFromAppTest extends FATServletClient {
                         .addPackage("jdbc.driver.proxy"); // delegates to the "mini" JDBC driver
 
         JavaArchive ejb1JAR = ShrinkWrap.create(JavaArchive.class, "ejb1.jar")
+                        .addAsManifestResource(new File("test-applications/otherapp/resources/ejb.first/META-INF/ibm-ejb-jar-bnd.xml"))
                         .addPackage("ejb.first");
 
         JavaArchive ejb2JAR = ShrinkWrap.create(JavaArchive.class, "ejb2.jar")
+                        .addAsManifestResource(new File("test-applications/otherapp/resources/ejb.second/META-INF/ibm-ejb-jar-bnd.xml"))
                         .addPackage("ejb.second");
 
         JavaArchive lmJAR = ShrinkWrap.create(JavaArchive.class, "top-level-login-modules.jar")

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
@@ -92,8 +92,7 @@ public class JDBCLoadFromAppTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer("CWWKE0701E.*JAASLoginModuleConfigImpl", // TODO remove this if we enable loading login modules from web applications
-                          "SRVE9967W.*derbyLocale" // ignore missing Derby locales
+        server.stopServer("SRVE9967W.*derbyLocale" // ignore missing Derby locales
         );
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/bootstrap.properties
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=info=enabled:RRA=all:WAS.j2c=all
+com.ibm.ws.logging.trace.specification=*=info=enabled:RRA=all:WAS.j2c=all:com.ibm.ws.security.jaas.common.*=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 ds.loglevel=debug

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/server.xml
@@ -10,7 +10,7 @@
  -->
 <server>
     <featureManager>
-      <feature>appSecurity-2.0</feature>
+      <feature>appSecurity-3.0</feature>
       <feature>componenttest-1.0</feature>
       <feature>ejbLite-3.2</feature>
       <feature>jca-1.7</feature>
@@ -73,6 +73,14 @@
 
     <jaasLoginContextEntry id="web1loginEntry" name="web1login">
       <loginModule className="web.other.LoadFromWebModLoginModule" classProviderRef="otherApp" libraryRef="ignore"/> <!-- TODO remove libraryRef once made optional -->
+    </jaasLoginContextEntry>
+
+    <jaasLoginContextEntry id="ejb1loginEntry" name="ejb1login">
+      <loginModule className="ejb.first.FirstEJBModLoginModule" classProviderRef="otherApp" libraryRef="ignore"/> <!-- TODO remove libraryRef once made optional -->
+    </jaasLoginContextEntry>
+
+    <jaasLoginContextEntry id="ejb2loginEntry" name="ejb2login">
+      <loginModule className="ejb.second.SecondEJBModLoginModule" classProviderRef="otherApp" libraryRef="ignore"/> <!-- TODO remove libraryRef once made optional -->
     </jaasLoginContextEntry>
 
     <!-- permissions for Derby in the app -->

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/resources/WEB-INF/ibm-ejb-jar-bnd.xml
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/resources/WEB-INF/ibm-ejb-jar-bnd.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<ejb-jar-bnd
+        xmlns="http://websphere.ibm.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-ejb-jar-bnd_1_1.xsd"
+        version="1.1">
+
+  <session name="BeanInWebApp">
+    <resource-ref name="jdbc/dsref">
+      <custom-login-configuration name="webapplogin">
+        <property name="shape" value="heptagon"/>
+        <property name="sides" value="7"/>
+        <property name="sumOfAngles" value="900"/>
+      </custom-login-configuration>
+    </resource-ref>
+  </session>
+    
+</ejb-jar-bnd>

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/src/web/derby/BeanInWebApp.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/src/web/derby/BeanInWebApp.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package web.derby;
+
+import java.util.concurrent.Executor;
+
+import javax.annotation.Resource;
+import javax.ejb.Stateless;
+import javax.sql.DataSource;
+
+@Stateless
+public class BeanInWebApp implements Executor {
+    @Resource(name = "java:comp/env/jdbc/dsref", lookup = "jdbc/sharedLibDataSource")
+    DataSource ds;
+
+    @Override
+    public void execute(Runnable runnable) {
+        runnable.run();
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/src/web/derby/DerbyLoadFromAppServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/src/web/derby/DerbyLoadFromAppServlet.java
@@ -12,7 +12,6 @@ package web.derby;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -26,7 +25,6 @@ import javax.sql.DataSource;
 
 import org.junit.Test;
 
-import componenttest.annotation.AllowedFFDC;
 import componenttest.app.FATDatabaseServlet;
 
 @SuppressWarnings("serial")
@@ -88,17 +86,14 @@ public class DerbyLoadFromAppServlet extends FATDatabaseServlet {
     }
 
     /**
-     * testLoginModuleFromWebApp - verify that a login module that is packaged within the web application CANNOT be used to authenticate
+     * testLoginModuleFromWebApp - verify that a login module that is packaged within the web application can be used to authenticate
      * to a data source when its resource reference specifies to use that login module.
      */
-    @AllowedFFDC({ "javax.security.auth.login.LoginException", "javax.resource.ResourceException" }) // TODO remove if we decide to enable this scenario
     @Test
     public void testLoginModuleFromWebApp() throws Exception {
         try (Connection con = sldsLoginModuleFromWebApp.getConnection()) {
             DatabaseMetaData metadata = con.getMetaData();
-            fail("authenticated as user " + metadata.getUserName());
-            // TODO if we decide to enable this path, then switch to the following assert and remove the catch block
-            // assertEquals("webappuser", metadata.getUserName());
+            assertEquals("webappuser", metadata.getUserName());
         } catch (SQLException x) {
             Throwable cause = x;
             while (cause != null && !(cause instanceof LoginException))

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/resources/ejb.first/META-INF/ibm-ejb-jar-bnd.xml
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/resources/ejb.first/META-INF/ibm-ejb-jar-bnd.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<ejb-jar-bnd
+        xmlns="http://websphere.ibm.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-ejb-jar-bnd_1_1.xsd"
+        version="1.1">
+
+  <session name="FirstBean">
+    <resource-ref name="jdbc/dsref">
+      <custom-login-configuration name="ejb1login">
+        <property name="shape" value="nonagon"/>
+        <property name="sides" value="9"/>
+        <property name="sumOfAngles" value="1260"/>
+      </custom-login-configuration>
+    </resource-ref>
+  </session>
+    
+</ejb-jar-bnd>

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/resources/ejb.second/META-INF/ibm-ejb-jar-bnd.xml
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/resources/ejb.second/META-INF/ibm-ejb-jar-bnd.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<ejb-jar-bnd
+        xmlns="http://websphere.ibm.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-ejb-jar-bnd_1_1.xsd"
+        version="1.1">
+
+  <session name="SecondBean">
+    <resource-ref name="jdbc/dsref">
+      <custom-login-configuration name="ejb2login">
+        <property name="shape" value="decagon"/>
+        <property name="sides" value="10"/>
+        <property name="sumOfAngles" value="1440"/>
+      </custom-login-configuration>
+    </resource-ref>
+  </session>
+    
+</ejb-jar-bnd>

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/web/other/LoadFromAppServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/web/other/LoadFromAppServlet.java
@@ -119,21 +119,20 @@ public class LoadFromAppServlet extends FATDatabaseServlet {
         }
     }
 
-    // TODO determine expectations around loading login modules from EJBs.
-    // Currently not expecting to load login modules from EJB modules, but what about being able to load login modules
-    // that are packaged elsewhere within the application when on an EJB code path?
-
+    /**
+     * testLoginModuleFromEJBModule1 - verify that a login module that is packaged within an EJB module
+     * is used to authenticate to a data source when its resource reference specifies to use that login module.
+     */
     @Test
     public void testLoginModuleFromEJBModule1() throws Exception {
         Executor bean = InitialContext.doLookup("java:global/otherApp/ejb1/FirstBean!java.util.concurrent.Executor");
         bean.execute(() -> {
             try {
-                System.out.println("EJB1 loads: " + Class.forName("loginmod.LoadFromAppLoginModule"));
                 DataSource ds = (DataSource) InitialContext.doLookup("java:comp/env/jdbc/dsref");
                 try (Connection con = ds.getConnection()) {
                     DatabaseMetaData mdata = con.getMetaData();
                     String userName = mdata.getUserName();
-                    assertEquals("APP", userName); // this will start failing if login module gets used. "APP" is the default Derby user, not a user from a login module
+                    assertEquals("ejb1user", userName);
                 }
             } catch (RuntimeException x) {
                 throw x;
@@ -143,17 +142,20 @@ public class LoadFromAppServlet extends FATDatabaseServlet {
         });
     }
 
+    /**
+     * testLoginModuleFromEJBModule2 - verify that a login module that is packaged within an EJB module
+     * is used to authenticate to a data source when its resource reference specifies to use that login module.
+     */
     @Test
     public void testLoginModuleFromEJBModule2() throws Exception {
         Executor bean = InitialContext.doLookup("java:global/otherApp/ejb2/SecondBean!java.util.concurrent.Executor");
         bean.execute(() -> {
             try {
-                System.out.println("EJB2 loads: " + Class.forName("loginmod.LoadFromAppLoginModule"));
                 DataSource ds = (DataSource) InitialContext.doLookup("java:comp/env/jdbc/dsref");
                 try (Connection con = ds.getConnection()) {
                     DatabaseMetaData mdata = con.getMetaData();
                     String userName = mdata.getUserName();
-                    assertEquals("APP", userName); // this will start failing if login module gets used. "APP" is the default Derby user, not a user from a login module
+                    assertEquals("ejb2user", userName);
                 }
             } catch (RuntimeException x) {
                 throw x;

--- a/dev/com.ibm.ws.security.client/bnd.bnd
+++ b/dev/com.ibm.ws.security.client/bnd.bnd
@@ -51,6 +51,7 @@ instrument.classesExcludes: com/ibm/ws/security/client/internal/resources/*.clas
 	com.ibm.ws.security.authentication;version=latest,\
 	com.ibm.ws.security.credentials;version=latest,\
 	com.ibm.ws.security.jaas.common;version=latest,\
+	com.ibm.ws.adaptable.module;version=latest,\
 	com.ibm.ws.classloading;version=latest,\
 	com.ibm.ws.clientcontainer;version=latest,\
 	com.ibm.ws.logging;version=latest, \

--- a/dev/com.ibm.ws.security.jaas.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.jaas.common/bnd.bnd
@@ -74,6 +74,7 @@ instrument.classesExcludes: com/ibm/ws/security/jaas/common/internal/resources/*
 	com.ibm.websphere.security;version=latest,\
 	com.ibm.ws.security.authentication;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
+	com.ibm.ws.adaptable.module;version=latest,\
 	com.ibm.ws.common.encoder,\
 	com.ibm.ws.bnd.annotations;version=latest,\
 	com.ibm.ws.classloading;version=latest,\

--- a/dev/com.ibm.ws.security.jaas.common_test/bnd.bnd
+++ b/dev/com.ibm.ws.security.jaas.common_test/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -27,6 +27,7 @@ test.project: true
 	com.ibm.ws.security.authentication;version=latest,\
 	com.ibm.ws.security.authentication.builtin;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
+	com.ibm.ws.adaptable.module;version=latest,\
 	com.ibm.ws.common.encoder,\
 	com.ibm.ws.bnd.annotations;version=latest,\
 	com.ibm.ws.classloading;version=latest,\


### PR DESCRIPTION
Include JAAS custom login module classes within EJB modules, and in one case where the JAAS custom login module is in a WAR module of a web application that has EJBs in the WAR module.  Define resource reference bindings that indicate to use the JAAS custom login module. 