### PR TITLE
make oauth scope optional, to match reality

### DIFF
--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/Oauth2LoginConfigImpl.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/Oauth2LoginConfigImpl.java
@@ -258,7 +258,7 @@ public class Oauth2LoginConfigImpl implements SocialLoginConfig {
             getRequiredConfigAttribute(props, KEY_clientId);
             getRequiredSerializableProtectedStringConfigAttribute(props, KEY_clientSecret);
             getRequiredConfigAttribute(props, KEY_authorizationEndpoint);
-            getRequiredConfigAttribute(props, KEY_scope);
+            //getRequiredConfigAttribute(props, KEY_scope);  // removing as not all providers require it. 
         }
     }
 

--- a/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/internal/Oauth2LoginConfigImplTest.java
+++ b/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/internal/Oauth2LoginConfigImplTest.java
@@ -1208,7 +1208,7 @@ public class Oauth2LoginConfigImplTest extends CommonConfigTestClass {
     protected Map<String, Object> getRequiredConfigProps() {
         Map<String, Object> props = new HashMap<String, Object>();
         props.put(Oauth2LoginConfigImpl.KEY_authorizationEndpoint, authzEndpoint);
-        props.put(Oauth2LoginConfigImpl.KEY_scope, scope);
+        //props.put(Oauth2LoginConfigImpl.KEY_scope, scope);
         props.put(Oauth2LoginConfigImpl.KEY_clientId, clientId);
         props.put(Oauth2LoginConfigImpl.KEY_clientSecret, clientSecretPS);
         return props;


### PR DESCRIPTION
remove config checking that oauth scope must be specified, many providers have a default no matter what the client sends them