### PR TITLE
Disable shared classes cache on server client commands

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -602,13 +602,13 @@ serverEnvDefaults()
     fi
   esac
 
-  # Add -Xquickstart -Xnoaot for client JVMs only.  AOT is ineffective if JVMs have conflicting
-  # options, and it's more important that the server JVMs be able to use AOT.
+  # Add -Xquickstart -Xshareclasses:none for client JVMs only.  We don't want 
+  # shared classes cache created for client operations.
   # Add -Dcom.ibm.tools.attach.enable=yes to allow self-attach on z/OS
   
-  IBM_JAVA_OPTIONS="-Xquickstart -Xnoaot -Dcom.ibm.tools.attach.enable=yes ${SPECIFIED_JAVA_OPTIONS}"
+  IBM_JAVA_OPTIONS="-Xquickstart -Dcom.ibm.tools.attach.enable=yes ${SPECIFIED_JAVA_OPTIONS} -Xshareclasses:none"
   export IBM_JAVA_OPTIONS
-  OPENJ9_JAVA_OPTIONS="-Xquickstart -Xnoaot -Dcom.ibm.tools.attach.enable=yes ${SPECIFIED_JAVA_OPTIONS}"
+  OPENJ9_JAVA_OPTIONS="-Xquickstart -Dcom.ibm.tools.attach.enable=yes ${SPECIFIED_JAVA_OPTIONS} -Xshareclasses:none"
   export OPENJ9_JAVA_OPTIONS
 
   # Set a default file encoding if needed

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
@@ -529,11 +529,10 @@ goto:eof
     set SERVER_IBM_JAVA_OPTIONS=!SPECIFIED_JAVA_OPTIONS!
   )
 
-  @REM Add -Xquickstart -Xnoaot for client JVMs only.  AOT is ineffective if
-  @REM JVMs have conflicting options, and it's more important that server JVMs
-  @REM be able to use AOT.
-  set IBM_JAVA_OPTIONS=-Xquickstart -Xnoaot !IBM_JAVA_OPTIONS!
-  set OPENJ9_JAVA_OPTIONS=-Xquickstart -Xnoaot !OPENJ9_JAVA_OPTIONS!
+  @REM Add -Xquickstart -Xshareclasses:none for client JVMs only.  We don't want 
+  @REM shared classes cache created for client operations.
+  set IBM_JAVA_OPTIONS=-Xquickstart !IBM_JAVA_OPTIONS! -Xshareclasses:none
+  set OPENJ9_JAVA_OPTIONS=-Xquickstart !OPENJ9_JAVA_OPTIONS! -Xshareclasses:none
 goto:eof
 
 @REM


### PR DESCRIPTION
- For commands like stop we do not want a shared classes cache created.
Only the server start command should create a shared classes cache.
