### PR TITLE
Issue #11046: EJB Timer ExpectedException

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/test-applications/RestartMissedTimerActionEJB.jar/src/com/ibm/ws/ejbcontainer/timer/persistent/restart/missed/ejb/RestartMissedTimerActionBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/test-applications/RestartMissedTimerActionEJB.jar/src/com/ibm/ws/ejbcontainer/timer/persistent/restart/missed/ejb/RestartMissedTimerActionBean.java
@@ -28,6 +28,7 @@ import javax.annotation.PostConstruct;
 import javax.annotation.Resource;
 import javax.ejb.ConcurrencyManagement;
 import javax.ejb.EJBException;
+import javax.ejb.NoSuchObjectLocalException;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
 import javax.ejb.Timeout;
@@ -139,15 +140,27 @@ public class RestartMissedTimerActionBean implements RestartMissedTimerAction {
 
     @Timeout
     public void timeout(Timer timer) {
+        Date nextTimeout = null;
+        long timeRemaining = 0;
+        try {
+            nextTimeout = timer.getNextTimeout();
+            timeRemaining = timer.getTimeRemaining();
+        } catch (NoSuchObjectLocalException ex) {
+            // NoSuchObjectLocalException can occur if timer is running when cancelled
+            // by a concurrent thread. Possible when using bean managed transactions as
+            // persistent executor will not hold lock on timer in DB.
+            logger.info("RestartMissedTimerActionBean.timeout allowed ex : " + ex);
+        }
+
         CountDownLatch latch = timerLatch;
         if (latch != null && latch.getCount() > 0) {
-            nextTimeouts.add(timer.getNextTimeout());
-            timeRemains.add(timer.getTimeRemaining());
-            logger.info("RestartMissedTimerActionBean.timeout : " + timer.getNextTimeout() + ", " + timer.getTimeRemaining());
+            nextTimeouts.add(nextTimeout);
+            timeRemains.add(timeRemaining);
+            logger.info("RestartMissedTimerActionBean.timeout : " + nextTimeout + ", " + timeRemaining);
             timerLatch.countDown();
             firstTimeoutLatch.countDown();
         } else {
-            logger.info("RestartMissedTimerActionBean.timeout : " + timer.getNextTimeout() + ", " + timer.getTimeRemaining());
+            logger.info("RestartMissedTimerActionBean.timeout : " + nextTimeout + ", " + timeRemaining);
         }
     }
 


### PR DESCRIPTION
Test has a timing problem during shutdown where a timer may be running when it is cancelled,
resulting in various errors, including NoSuchObjectLocalException.

Change to handle this expected exception.

fixes #11046 