### PR TITLE
Issue #11052: Basic Registry throws PatternSyntaxException when brace…

### DIFF
--- a/dev/com.ibm.ws.security.registry.basic/src/com/ibm/ws/security/registry/basic/internal/BasicRegistry.java
+++ b/dev/com.ibm.ws.security.registry.basic/src/com/ibm/ws/security/registry/basic/internal/BasicRegistry.java
@@ -463,6 +463,8 @@ public class BasicRegistry implements UserRegistry {
      * <li>? -> .</li>
      * <li>( -> \(</li>
      * <li>) -> \)</li>
+     * <li>{ -> \{</li>
+     * <li>} -> \}</li>
      * </ul>
      *
      * @param pattern
@@ -479,10 +481,12 @@ public class BasicRegistry implements UserRegistry {
         }
 
         /*
-         * Replace any * with .* and escape any parentheses that might be interpreted as a
-         * group capture.
+         * Replace any * with .* and escape any characters that might have special meaning
+         * in a regular expression.
          */
-        pattern = pattern.replace("*", ".*").replace("(", "\\(").replace(")", "\\)");
+        pattern = pattern.replace("*", ".*");
+        pattern = pattern.replace("(", "\\(").replace(")", "\\)");
+        pattern = pattern.replace("{", "\\{").replace("}", "\\}");
 
         /*
          * Add the ignore case control back on if we removed it.

--- a/dev/com.ibm.ws.security.registry.basic_fat/fat/src/com/ibm/ws/security/registry/basic/fat/FATTest.java
+++ b/dev/com.ibm.ws.security.registry.basic_fat/fat/src/com/ibm/ws/security/registry/basic/fat/FATTest.java
@@ -18,15 +18,18 @@ import static org.junit.Assert.assertNull;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.registry.SearchResult;
 import com.ibm.ws.security.registry.test.UserRegistryServletConnection;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.vulnerability.LeakedPasswordChecker;
 
+@RunWith(FATRunner.class)
 public class FATTest {
     private static final String DEFAULT_CONFIG_FILE = "basic.server.xml.orig";
     private static final String ALTERNATE_BASIC_REGISTRY_CONFIG = "alternateBasicRegistry.xml";
@@ -250,5 +253,43 @@ public class FATTest {
 
         result = servlet.getGroups("*tractors)*", 0);
         assertEquals(1, result.getList().size());
+    }
+
+    /**
+     * Validate fix for OLGH11052, where a PatternSyntaxException (illegal repetition near index N)
+     * was thrown when a brace was present in a search filter.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void getUsersWithBraces() throws Exception {
+        Log.info(c, "getUsersWithBraces", "Check getUsers with braces");
+
+        setServerConfiguration(server, DEFAULT_CONFIG_FILE);
+
+        SearchResult result = servlet.getUsers("*{*", 0);
+        assertEquals("Expected 1 user with '{'.", 1, result.getList().size());
+
+        result = servlet.getUsers("*}*", 0);
+        assertEquals("Expected 1 user with '}'.", 1, result.getList().size());
+    }
+
+    /**
+     * Validate fix for OLGH11052, where a PatternSyntaxException (illegal repetition near index N)
+     * was thrown when a brace was present in a search filter.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void getGroupsWithBraces() throws Exception {
+        Log.info(c, "getGroupsWithBraces", "Check getGroups with braces");
+
+        setServerConfiguration(server, DEFAULT_CONFIG_FILE);
+
+        SearchResult result = servlet.getGroups("*{*", 0);
+        assertEquals("Expected 1 group with '{'.", 1, result.getList().size());
+
+        result = servlet.getGroups("*}*", 0);
+        assertEquals("Expected 1 group with '}'.", 1, result.getList().size());
     }
 }

--- a/dev/com.ibm.ws.security.registry.basic_fat/fat/src/com/ibm/ws/security/registry/basic/fat/FATTestFederated.java
+++ b/dev/com.ibm.ws.security.registry.basic_fat/fat/src/com/ibm/ws/security/registry/basic/fat/FATTestFederated.java
@@ -18,10 +18,12 @@ import static org.junit.Assert.assertNull;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.registry.test.UserRegistryServletConnection;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.vulnerability.LeakedPasswordChecker;
@@ -29,6 +31,7 @@ import componenttest.vulnerability.LeakedPasswordChecker;
 /**
  * Test the basic registry federation.
  */
+@RunWith(FATRunner.class)
 public class FATTestFederated {
     private static final String DEFAULT_CONFIG_FILE = "basic.server.xml.orig";
     private static final String ALTERNATE_BASIC_REGISTRY_CONFIG = "alternateBasicRegistry.xml";

--- a/dev/com.ibm.ws.security.registry.basic_fat/fat/src/com/ibm/ws/security/registry/basic/fat/FATTestIgnoreCase.java
+++ b/dev/com.ibm.ws.security.registry.basic_fat/fat/src/com/ibm/ws/security/registry/basic/fat/FATTestIgnoreCase.java
@@ -17,14 +17,17 @@ import static org.junit.Assert.assertNull;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.registry.test.UserRegistryServletConnection;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.vulnerability.LeakedPasswordChecker;
 
+@RunWith(FATRunner.class)
 public class FATTestIgnoreCase {
     private static final String DEFAULT_CONFIG_FILE = "basic.ignore.server.xml.orig";
     private static final String ALTERNATE_BASIC_REGISTRY_CONFIG_IGNORE_CASE_TRUE = "alternateIgnoreCaseTrueBasicRegistry.xml";

--- a/dev/com.ibm.ws.security.registry.basic_fat/publish/files/basic.server.xml.orig
+++ b/dev/com.ibm.ws.security.registry.basic_fat/publish/files/basic.server.xml.orig
@@ -23,6 +23,7 @@
         <user name="user1" password="password123" />
         <user name="user2" password="{xor}Lz4sLCgwLTtubWw=" />
         <user name="bob (contractor)" password="bobspassword" />
+        <user name="henry {contractor}" password="henryspassword" />
         <group name="memberlessGroup" />
         <group name="adminGroup">
             <member name="admin"/>
@@ -33,6 +34,9 @@
         </group>
         <group name="group1 (contractors)">
             <member name="bob (contractor)" />
+        </group>
+        <group name="group2 {contractors}">
+            <member name="henry {contractor}" />
         </group>
     </basicRegistry>
 


### PR DESCRIPTION
…s are included in search pattern for getUsers and getGroups.

fixes #11052 