### PR TITLE
Allow radio buttons to behave correctly

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/clientAdmin/js/clientInputDialog.js
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/clientAdmin/js/clientInputDialog.js
@@ -359,7 +359,7 @@ var clientInputDialog = (function() {
                             return;
                         }
                     } 
-                    // Something else happed with the request.  Put up an error message...
+                    // Something else happened with the request.  Put up an error message...
                     var errTitle = messages.GENERIC_UPDATE_FAIL;
                     var errDescription = "";
                     if (errResponse.responseJSON && errResponse.responseJSON.error_description) {
@@ -545,8 +545,8 @@ var clientInputDialog = (function() {
             var optionId = 'rb_' + option.value.replace(/\s/g, '__');
             var defaultValue = option.value === fldDefault;
             field +=
+                "       <input id='" + optionId + "' class='tool_modal_radio_button' type='radio' role='radio' aria-checked='false' name='" + fldId + "' value='" + option.value + "' data-default=" + defaultValue + ">" +
                 "       <label for='" + optionId + "' class='tool_modal_radio_button_label'>" +
-                "           <input id='" + optionId + "' class='tool_modal_radio_button' type='radio' role='radio' aria-checked='false' name='" + fldId + "' value='" + option.value + "' data-default=" + defaultValue + ">" +
                 "           <span class='tool_modal_radio_button_appearance'></span>" + 
                 "           " + option.value + 
                 "       </label>";
@@ -592,16 +592,16 @@ var clientInputDialog = (function() {
             "       <legend class='tool_modal_body_field_label'>" + fldName + "</legend>" +
             "       <div class='tool_modal_body_field_helper_text'>" + fldDescription + "</div>" +
             "       <div class='tool_modal_radio_button_horizontal_wrapper'>" +
-            "           <label for='" + fldId + "-true' class='tool_modal_radio_button_label'>" +
-            "               <input id='" + fldId + "-true' class='tool_modal_radio_button' type='radio' role='radio' aria-checked='false' name='" + fldId + "' value='true'";
+            "           <input id='" + fldId + "-true' class='tool_modal_radio_button' type='radio' role='radio' aria-checked='false' name='" + fldId + "' value='true'";
         field += fldDefault === 'true' ? " data-default='true'" : " data-default='false'";
         field += ">" +
+            "           <label for='" + fldId + "-true' class='tool_modal_radio_button_label'>" +
             "               <span class='tool_modal_radio_button_appearance'></span>" + messages.TRUE + 
             "           </label>" +
+            "           <input id='" + fldId + "-false' class='tool_modal_radio_button' type='radio' role='radio' aria-checked='false' name='" + fldId + "' value='false'";
+        field += fldDefault === 'false' ? " data-default='true'" : " data-default='false'";
+        field += ">" +
             "           <label for='" + fldId + "-false' class='tool_modal_radio_button_label'>" +
-            "               <input id='" + fldId + "-false' class='tool_modal_radio_button' type='radio' role='radio' aria-checked='false' name='" + fldId + "' value='false'";
-            field += fldDefault === 'false' ? " data-default='true'" : " data-default='false'";
-            field += ">" +
             "               <span class='tool_modal_radio_button_appearance'></span>" + messages.FALSE +
             "           </label>" +
             "       </div>" +

--- a/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/common/css/tool.css
+++ b/dev/com.ibm.ws.security.openidconnect.server/resources/WEB-CONTENT/common/css/tool.css
@@ -451,7 +451,6 @@ th.table_sort_column:hover {      /* ....except for the button in the sortable c
     animation-timing-function: cubic-bezier(0,0,.3,1.6);
     border-top: 4px solid #3D70B2;
     box-shadow: 0 12px 24px 0 rgba(0,0,0,0.10);
-    overflow: hidden;
 }
 
 /* Small dialog centered on the page */


### PR DESCRIPTION
Radio button on the OIDC client admin's **Register New OAUTH Client** dialog appeared to not be selected when clicked.

Also, in chrome, selecting one of the radio buttons would cause the dialog to go blank.