### PR TITLE
Avoid setting status/headers when response is already committed

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
@@ -657,12 +657,14 @@ public abstract class AbstractHTTPDestination
                 return null;
             }
         }
-        response.setStatus(responseCode);
         //Liberty code change start
-        if (headers == null) {
-            headers = new Headers(outMessage);
+        if (!response.isCommitted()) {
+            response.setStatus(responseCode); //Original CXF line
+            if (headers == null) {
+                headers = new Headers(outMessage);
+            }
+            headers.copyToResponse(response);
         }
-        headers.copyToResponse(response);
         //Liberty code change end
 
         outMessage.put(RESPONSE_HEADERS_COPIED, "true");

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
@@ -659,12 +659,14 @@ public abstract class AbstractHTTPDestination
                 return null;
             }
         }
-        response.setStatus(responseCode);
         //Liberty code change start
-        if (headers == null) {
-            headers = new Headers(outMessage);
+        if (!response.isCommitted()) {
+            response.setStatus(responseCode); //Original CXF line
+            if (headers == null) {
+                headers = new Headers(outMessage);
+            }
+            headers.copyToResponse(response);
         }
-        headers.copyToResponse(response);
         //Liberty code change end
 
         outMessage.put(RESPONSE_HEADERS_COPIED, "true");


### PR DESCRIPTION
Test fix for issue #10988 - many thanks to @wtlucy for suggesting this change.  This should avoid calling setStatus or copying headers to the response output stream when the response has already been committed.  This should prevent warning errors like those mentioned in issue #10988.  