### PR TITLE
Issue #11076: Remove Hardcoded Client Port

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.remote.client_fat/publish/clients/com.ibm.ws.ejbcontainer.remote.client.fat.clientInjection/bootstrap.properties
+++ b/dev/com.ibm.ws.ejbcontainer.remote.client_fat/publish/clients/com.ibm.ws.ejbcontainer.remote.client.fat.clientInjection/bootstrap.properties
@@ -8,6 +8,7 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
+bootstrap.include=../../servers/testports.properties
 com.ibm.ws.timedexit.timetolive=120000
 #bvt.prop.IIOP=28090
 #bvt.prop.IIOP.secure=28100

--- a/dev/com.ibm.ws.ejbcontainer.remote.client_fat/publish/clients/com.ibm.ws.ejbcontainer.remote.client.fat.clientInjection/client.xml
+++ b/dev/com.ibm.ws.ejbcontainer.remote.client_fat/publish/clients/com.ibm.ws.ejbcontainer.remote.client.fat.clientInjection/client.xml
@@ -19,7 +19,7 @@
     <sslDefault sslRef="supportedClientAuthenticationSSLConfig"/>
     <ssl id="supportedClientAuthenticationSSLConfig" keyStoreRef="defaultKeyStore" clientAuthenticationSupported="true"/>
     
-    <orb id="defaultOrb">-
+    <orb id="defaultOrb"  nameService="corbaloc::localhost:${bvt.prop.IIOP}/NameService">
         <clientPolicy.clientContainerCsiv2>
             <layers>
                 <authenticationLayer password="mypwd" realm="BasicRealm" user="bob" establishTrustInClient="Supported" mechanisms="GSSUP"/>


### PR DESCRIPTION
Test client is using a hard coded port for the ORB name service, which will
vary on the test systems.  Need to use the same environment variable that
is used by the test server.

fixes #11076 