### PR TITLE
Fix hide password logic for connProps

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/PropertyService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/internal/PropertyService.java
@@ -171,7 +171,7 @@ public class PropertyService extends Properties {
                 entry.setValue("******");
             else if(entry.getKey() instanceof String && entry.getValue() instanceof String && ((String) entry.getKey()).toLowerCase().contains("url"))
                 entry.setValue(filterURL((String) entry.getValue()));
-            else if (entry.getKey() instanceof String && entry.getKey() instanceof String && ((String) entry.getKey()).toLowerCase().contains("connectionproperties"))
+            else if (entry.getKey() instanceof String && entry.getValue() instanceof String && ((String) entry.getKey()).toLowerCase().contains("connectionproperties"))
                 entry.setValue(filterConnectionProperties((String) entry.getValue()));
         return map;
     }

--- a/dev/fattest.databases/src/componenttest/topology/database/container/DatabaseContainerUtil.java
+++ b/dev/fattest.databases/src/componenttest/topology/database/container/DatabaseContainerUtil.java
@@ -131,6 +131,7 @@ public final class DatabaseContainerUtil {
         	Class<?> clazz = type.getContainerClass();
         	Method getSid = clazz.getMethod("getSid");
         	props.setDatabaseName((String) getSid.invoke(cont));
+        	props.setExtraAttribute("driverType", "thin");
         }
     	
     	for(DataSource ds : datasources) {


### PR DESCRIPTION
Updated hide password logic, was accidentally checking the same property twice.  
Also added in the driver type to generic properties when connecting to oracle.  This was causing errors during our DB rotation testing.  