### PR TITLE
PR for Issue 11075: Performance regression in JWK handling

### DIFF
--- a/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JwKRetriever.java
+++ b/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JwKRetriever.java
@@ -436,7 +436,8 @@ public class JwKRetriever {
         for (JWK aJwk : jwks) {
             if (isPEM(keyText)) {
                 jwkSet.addPemKey(location, keyText, jwk);
-            } else if (location != null) {
+            }
+            if (location != null) {
                 jwkSet.add(location, aJwk);
             } else {
                 jwkSet.add(keyText, aJwk);


### PR DESCRIPTION
Resolves #11075

When MP Config is used to set the `mp.jwt.verify.publickey.location` property, that value is initially used as the key location for the `JwKRetriever` class (represented by the `locationUsed` class member). The public key text itself isn’t known. In the case where the `mp.jwt.verify.publickey.location property` is set to a non-URL location, Liberty will attempt to read the key from the respective file (`JwKRetriever.getPublicKeyFromFile()`).

The first time through we obviously won't have the key in any cache, so we have to read the file and create the public key from the file contents. What’s interesting is that when the `JwKRetriever.getInputStream()` method succeeds in reading the file, it changes the value of the `locationUsed` class member to be the classloader value:

```Java
locationUsed = classLoadingSelector;
if (tc.isDebugEnabled()) {
    Tr.debug(tc, "input stream obtained from classloader and  locationUsed set to: " + locationUsed);
}
```

Back in `JwKRetriever.getPublicKeyFromFile()` we have:

```Java
if (publicKey == null) { // cache miss, read the jwk if we can,  &  update locationUsed
    InputStream is = getInputStream(jwkFile, fileSystemCacheSelector, location, classLoadingCacheSelector);
    if (is != null) {
        keyString = getKeyAsString(is);
        parseJwk(keyString, null, jwkSet, sigAlg); // also adds entry to cache.
        publicKey = getJwkFromJWKSet(locationUsed, kid, x5t, use, keyString);
    }
}
```

Once `getInputStream()` returns with the stream for the file contents, `locationUsed`  is set to the classloader location, not the `mp.jwt.verify.publickey.location` property. In the subsequent call to `parseJwk()`, Liberty makes a call to `parseKeyText()` with the classloader as the new location. My PR https://github.com/OpenLiberty/open-liberty/pull/9597 changed this method’s behavior to add PEM-type keys to a separate cache object (the regression was found with a PEM key):

```Java
if (isPEM(keyText)) {
    jwkSet.addPemKey(location, keyText, jwk);
} else if (location != null) {
    jwkSet.add(location, aJwk);
} else {
    jwkSet.add(keyText, aJwk);
}
```

PEM keys are tracked by a separate collection within `JWKSet` than all other keys (`pemJwksBySetId` for PEMs vs. `jwksBySetId` for all others). That’s important because on subsequent protected resource requests that include a JWT, we’ll check to see if the key to verify the JWT is cached. We don’t have a `kid`, `x5t`, or `use` value for the key, nor do we have the key text itself. Without any of those values, our code will only look in the `jwksBySetId` collection and use the key location as the "set ID" to look in. However because of my fix under #9597, the original key we looked up was cached under a completely different collection that isn’t being checked against. The key obviously can’t be found, which means we end up having to read the file all over again.