### PR TITLE
Trace improvements

### DIFF
--- a/dev/com.ibm.tx.core/src/com/ibm/tx/jta/impl/RegisteredResources.java
+++ b/dev/com.ibm.tx.core/src/com/ibm/tx/jta/impl/RegisteredResources.java
@@ -1,7 +1,7 @@
 package com.ibm.tx.jta.impl;
 
 /*******************************************************************************
- * Copyright (c) 1997, 2013 IBM Corporation and others.
+ * Copyright (c) 1997, 2013, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -255,7 +255,7 @@ public class RegisteredResources implements Comparator<JTAResource> {
                                "as the recovery log was not available at transaction start";
             final IllegalStateException ise = new IllegalStateException(msg);
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "enlistResource (SPI)", ise);
+                Tr.exit(tc, "enlistResource", new Object[] {"(SPI)", ise});
             throw ise;
         }
 
@@ -276,7 +276,7 @@ public class RegisteredResources implements Comparator<JTAResource> {
                 final IllegalStateException ise = new IllegalStateException(msg);
                 // FFDC in TransactionImpl
                 if (tc.isEntryEnabled())
-                    Tr.exit(tc, "enlistResource (SPI)", ise);
+                    Tr.exit(tc, "enlistResource", new Object[] {"(SPI)", ise});
                 throw ise;
             }
         }
@@ -458,13 +458,13 @@ public class RegisteredResources implements Comparator<JTAResource> {
         {
             FFDCFilter.processException(ise, "com.ibm.tx.jta.impl.RegisteredResources.enlistResource", "483", this);
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "enlistResource (SPI)", ise);
+                Tr.exit(tc, "enlistResource", new Object[] {"(SPI)", ise});
             throw ise;
         } catch (Exception e) {
             FFDCFilter.processException(e, "com.ibm.tx.jta.impl.RegisteredResources.enlistResource", "489", this);
             final Throwable toThrow = new SystemException(e.getLocalizedMessage()).initCause(e);
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "enlistResource (SPI)", toThrow);
+                Tr.exit(tc, "enlistResource", new Object[] {"(SPI)", toThrow});
             throw (SystemException) toThrow;
         }
 

--- a/dev/com.ibm.tx.core/src/com/ibm/tx/jta/impl/TranManagerImpl.java
+++ b/dev/com.ibm.tx.core/src/com/ibm/tx/jta/impl/TranManagerImpl.java
@@ -1,7 +1,7 @@
 package com.ibm.tx.jta.impl;
 
 /*******************************************************************************
- * Copyright (c) 2002, 2013 IBM Corporation and others.
+ * Copyright (c) 2002, 2013, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -73,7 +73,7 @@ public class TranManagerImpl
     public void begin(int timeout) throws NotSupportedException, SystemException /* @512190C */
     {
         if (tc.isEntryEnabled())
-            Tr.entry(tc, "begin (SPI)");
+            Tr.entry(tc, "begin", "(SPI)");
 
         if (tx == null) {
             tx = createNewTransaction(timeout);
@@ -82,14 +82,14 @@ public class TranManagerImpl
             final NotSupportedException nse = new NotSupportedException("Nested transactions are not supported.");
             FFDCFilter.processException(nse, "com.ibm.tx.jta.impl.TranManagerImpl.begin", "135", this);
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "begin (SPI)", nse);
+                Tr.exit(tc, "begin", new Object[] {"(SPI)", nse});
             throw nse;
         }
 
         invokeEventListener(tx, UOWEventListener.POST_BEGIN, null);
 
         if (tc.isEntryEnabled())
-            Tr.exit(tc, "begin (SPI)");
+            Tr.exit(tc, "begin", "(SPI)");
     }
 
     //-------------------------------------------------------------------------
@@ -145,7 +145,7 @@ public class TranManagerImpl
                     SecurityException, IllegalStateException, SystemException
     {
         if (tc.isEntryEnabled())
-            Tr.entry(tc, "commit (SPI)");
+            Tr.entry(tc, "commit", "(SPI)");
 
         if (tx == null)
         {
@@ -153,7 +153,7 @@ public class TranManagerImpl
             final IllegalStateException ise = new IllegalStateException(msg);
             FFDCFilter.processException(ise, "com.ibm.tx.jta.impl.TranManagerImpl.commit", "167", this);
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "commit (SPI)", ise);
+                Tr.exit(tc, "commit", new Object[] {"(SPI)", ise});
             throw ise;
         }
 
@@ -168,14 +168,14 @@ public class TranManagerImpl
             invokeEventListener(completingTx, UOWEventListener.POST_END, null);
 
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "commit (SPI)");
+                Tr.exit(tc, "commit", "(SPI)");
         }
     }
 
     public void rollback() throws IllegalStateException, SecurityException, SystemException
     {
         if (tc.isEntryEnabled())
-            Tr.entry(tc, "rollback (SPI)");
+            Tr.entry(tc, "rollback", "(SPI)");
 
         if (tx == null)
         {
@@ -183,7 +183,7 @@ public class TranManagerImpl
             final IllegalStateException ise = new IllegalStateException(msg);
             FFDCFilter.processException(ise, "com.ibm.tx.jta.impl.TranManagerImpl.rollback", "193", this);
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "rollback (SPI)", ise);
+                Tr.exit(tc, "rollback", new Object[] {"(SPI)", ise});
             throw ise;
         }
 
@@ -198,14 +198,14 @@ public class TranManagerImpl
             invokeEventListener(completingTx, UOWEventListener.POST_END, null);
 
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "rollback (SPI)");
+                Tr.exit(tc, "rollback", "(SPI)");
         }
     }
 
     public Transaction suspend()
     {
         if (tc.isEntryEnabled())
-            Tr.entry(tc, "suspend (SPI)", this);
+            Tr.entry(tc, "suspend", new Object[] {"(SPI)", this});
 
         TransactionImpl suspended = null;
 
@@ -226,14 +226,14 @@ public class TranManagerImpl
         }
 
         if (tc.isEntryEnabled())
-            Tr.exit(tc, "suspend (SPI)", suspended);
+            Tr.exit(tc, "suspend", new Object[] {"(SPI)", suspended});
         return suspended;
     }
 
     public void resume(Transaction t) throws InvalidTransactionException, IllegalStateException
     {
         if (tc.isEntryEnabled())
-            Tr.entry(tc, "resume (SPI)", t);
+            Tr.entry(tc, "resume", new Object[] {"(SPI)", t});
 
         if (tx != null)
         {
@@ -241,7 +241,7 @@ public class TranManagerImpl
             final IllegalStateException ise = new IllegalStateException(msg);
             FFDCFilter.processException(ise, "com.ibm.tx.jta.impl.TranManagerImpl.resume", "249", this);
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "resume (SPI)", ise);
+                Tr.exit(tc, "resume", new Object[] {"(SPI)", ise});
             throw ise;
         }
 
@@ -279,7 +279,7 @@ public class TranManagerImpl
             if (tc.isDebugEnabled())
                 Tr.debug(tc, "Exception caught checking transaction state", e);
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "resume (SPI)");
+                Tr.exit(tc, "resume", "(SPI)");
 
             throw new InvalidTransactionException();
         }
@@ -292,13 +292,13 @@ public class TranManagerImpl
         }
 
         if (tc.isEntryEnabled())
-            Tr.exit(tc, "resume (SPI)");
+            Tr.exit(tc, "resume", "(SPI)");
     }
 
     public void setRollbackOnly() throws IllegalStateException
     {
         if (tc.isEntryEnabled())
-            Tr.entry(tc, "setRollbackOnly (SPI)");
+            Tr.entry(tc, "setRollbackOnly", "(SPI)");
 
         if (tx == null)
         {
@@ -306,7 +306,7 @@ public class TranManagerImpl
             final IllegalStateException ise = new IllegalStateException(msg);
             FFDCFilter.processException(ise, "com.ibm.tx.jta.impl.TranManagerImpl.setRollbackOnly", "303", this);
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "setRollbackOnly (SPI)", ise);
+                Tr.exit(tc, "setRollbackOnly", new Object[] {"(SPI)", ise});
             throw ise;
         }
 
@@ -316,14 +316,14 @@ public class TranManagerImpl
         } finally
         {
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "setRollbackOnly (SPI)");
+                Tr.exit(tc, "setRollbackOnly", "(SPI)");
         }
     }
 
     public void setTransactionTimeout(int timeout) throws SystemException
     {
         if (tc.isEntryEnabled())
-            Tr.entry(tc, "setTransactionTimeout (SPI)", timeout);
+            Tr.entry(tc, "setTransactionTimeout", new Object[] {"(SPI)", timeout});
 
         if (timeout > 0)
         {
@@ -350,13 +350,13 @@ public class TranManagerImpl
             final SystemException se = new SystemException("Transaction timeout value must be >= 0");
             FFDCFilter.processException(se, "com.ibm.tx.jta.impl.TranManagerImpl.setTransactionTimeout", "206", this);
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "setTransactionTimeout (SPI)", se);
+                Tr.exit(tc, "setTransactionTimeout", new Object[] {"(SPI)", se});
             throw se;
         }
         // Note: TransactionImpl will later check against maximumTransactionTimeout - its is done there as it is common for CMT/BMT
 
         if (tc.isEntryEnabled())
-            Tr.exit(tc, "setTransactionTimeout (SPI)", txTimeout);
+            Tr.exit(tc, "setTransactionTimeout", new Object[] {"(SPI)", txTimeout});
     }
 
     public int getStatus()

--- a/dev/com.ibm.tx.core/src/com/ibm/tx/jta/impl/TransactionImpl.java
+++ b/dev/com.ibm.tx.core/src/com/ibm/tx/jta/impl/TransactionImpl.java
@@ -1,7 +1,7 @@
 package com.ibm.tx.jta.impl;
 
 /*******************************************************************************
- * Copyright (c) 2002, 2019 IBM Corporation and others.
+ * Copyright (c) 2002, 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -705,7 +705,7 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
     @Override
     public void commit() throws RollbackException, HeuristicMixedException, HeuristicRollbackException, SecurityException, IllegalStateException, SystemException {
         if (tc.isEntryEnabled())
-            Tr.entry(tc, "commit (SPI)");
+            Tr.entry(tc, "commit", "(SPI)");
 
         try {
             processCommit();
@@ -715,11 +715,11 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
             final HeuristicMixedException hme = new HeuristicMixedException(hhe.getLocalizedMessage());
             hme.initCause(hhe.getCause()); //Set the cause to be the cause of the HeuristicHazardException
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "commit", hme);
+                Tr.exit(tc, "commit", new Object[] {"(SPI)", hme});
             throw hme;
         } finally {
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "commit (SPI)");
+                Tr.exit(tc, "commit", "(SPI)");
         }
     }
 
@@ -1037,7 +1037,7 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
     @Override
     public void rollback() throws IllegalStateException, SystemException {
         if (tc.isEntryEnabled())
-            Tr.entry(tc, "rollback (SPI)");
+            Tr.entry(tc, "rollback", "(SPI)");
 
         final int state = _status.getState();
 
@@ -1057,7 +1057,7 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
                 if (tc.isDebugEnabled())
                     Tr.debug(tc, "Exception caught setting state to ROLLING_BACK!", se);
                 if (tc.isEntryEnabled())
-                    Tr.exit(tc, "rollback (SPI)");
+                    Tr.exit(tc, "rollback", "(SPI)");
                 throw se;
             }
 
@@ -1089,14 +1089,14 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
                 if (tc.isEventEnabled())
                     Tr.event(tc, "SystemException caught during rollback", se);
                 if (tc.isEntryEnabled())
-                    Tr.exit(tc, "rollback (SPI)");
+                    Tr.exit(tc, "rollback", "(SPI)");
                 throw se;
             } catch (Throwable ex) {
                 FFDCFilter.processException(ex, "com.ibm.tx.jta.TransactionImpl.rollback", "1633", this);
                 if (tc.isEventEnabled())
                     Tr.event(tc, "Exception caught during rollback", ex);
                 if (tc.isEntryEnabled())
-                    Tr.exit(tc, "rollback (SPI)");
+                    Tr.exit(tc, "rollback", "(SPI)");
                 throw new SystemException(ex.getLocalizedMessage());
             } finally {
                 notifyCompletion();
@@ -1112,18 +1112,18 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
             if (tc.isEventEnabled())
                 Tr.event(tc, "No transaction available!");
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "rollback (SPI)");
+                Tr.exit(tc, "rollback", "(SPI)");
             throw new IllegalStateException();
         } else {
             if (tc.isEventEnabled())
                 Tr.event(tc, "Invalid transaction state:" + state);
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "rollback (SPI)");
+                Tr.exit(tc, "rollback", "(SPI)");
             throw new SystemException();
         }
 
         if (tc.isEntryEnabled())
-            Tr.exit(tc, "rollback (SPI)");
+            Tr.exit(tc, "rollback", "(SPI)");
     }
 
     public int internalPrepare() throws HeuristicMixedException, HeuristicHazardException, HeuristicRollbackException, IllegalStateException, SystemException {
@@ -1901,7 +1901,7 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
     @Override
     public void setRollbackOnly() throws IllegalStateException {
         if (tc.isEntryEnabled())
-            Tr.entry(tc, "setRollbackOnly (SPI)");
+            Tr.entry(tc, "setRollbackOnly", "(SPI)");
 
         final int state = _status.getState();
 
@@ -1909,13 +1909,13 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
             state == TransactionState.STATE_COMMITTED ||
             state == TransactionState.STATE_ROLLED_BACK) {
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "setRollbackOnly (SPI)");
+                Tr.exit(tc, "setRollbackOnly", "(SPI)");
             throw new IllegalStateException("No transaction available");
         }
         setRBO();
 
         if (tc.isEntryEnabled())
-            Tr.exit(tc, "setRollbackOnly (SPI)");
+            Tr.exit(tc, "setRollbackOnly", "(SPI)");
     }
 
     /**
@@ -1948,7 +1948,7 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
     @Override
     public boolean enlistResource(XAResource xaRes) throws RollbackException, IllegalStateException, SystemException {
         if (tc.isEntryEnabled())
-            Tr.entry(tc, "enlistResource (SPI)", xaRes);
+            Tr.entry(tc, "enlistResource", new Object[] {"(SPI)", xaRes});
 
         //
         // Check the transaction is in a valid state to allow a new resource to be enlisted.
@@ -1964,7 +1964,7 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
                 RollbackException rbe = new RollbackException("Transaction rolled back");
                 FFDCFilter.processException(rbe, "com.ibm.tx.jta.TransactionImpl.enlistResource", "1760", this);
                 if (tc.isEntryEnabled())
-                    Tr.exit(tc, "enlistResource (SPI)", rbe);
+                    Tr.exit(tc, "enlistResource", new Object[] {"(SPI)", rbe});
                 throw rbe;
             }
             default: {
@@ -1974,7 +1974,7 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
                 final IllegalStateException ise = new IllegalStateException("Transaction is inactive or prepared");
                 FFDCFilter.processException(ise, "com.ibm.tx.jta.TransactionImpl.enlistResource", "1769", this);
                 if (tc.isEntryEnabled())
-                    Tr.exit(tc, "enlistResource (SPI)", ise);
+                    Tr.exit(tc, "enlistResource", new Object[] {"(SPI)", ise});
                 throw ise;
             }
         }
@@ -1982,7 +1982,7 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
         if (xaRes == null) {
             final IllegalStateException ise = new IllegalStateException("Cannot enlist a null resource");
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "enlistResource", ise);
+                Tr.exit(tc, "enlistResource", new Object[] {"(SPI)",ise});
             throw ise;
         }
 
@@ -1997,7 +1997,7 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
         } catch (IllegalStateException ise) {
             FFDCFilter.processException(ise, "com.ibm.tx.jta.TransactionImpl.enlistResource", "1858", this);
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "enlistResource (SPI)", ise);
+                Tr.exit(tc, "enlistResource", new Object[] {"(SPI)", ise});
             throw ise;
         } catch (Throwable t) {
             FFDCFilter.processException(t, "com.ibm.tx.jta.TransactionImpl.enlistResource", "1868", this);
@@ -2005,12 +2005,12 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
             final RollbackException rbe = new RollbackException(t.getMessage());
             rbe.initCause(t);
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "enlistResource (SPI)", rbe);
+                Tr.exit(tc, "enlistResource", new Object[] {"(SPI)", rbe});
             throw rbe;
         }
 
         if (tc.isEntryEnabled())
-            Tr.exit(tc, "enlistResource (SPI)", Boolean.TRUE);
+            Tr.exit(tc, "enlistResource", new Object[] {"(SPI)", Boolean.TRUE});
         return true;
     }
 
@@ -2039,7 +2039,7 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
 
     public boolean enlistResource(XAResource xaRes, int recoveryIndex, int branchCoupling) throws RollbackException, IllegalStateException, SystemException {
         if (tc.isEntryEnabled())
-            Tr.entry(tc, "enlistResource (SPI)", new Object[] { xaRes, recoveryIndex, branchCoupling });
+            Tr.entry(tc, "enlistResource", new Object[] {"(SPI)",xaRes, recoveryIndex, branchCoupling});
 
         //
         // Check the transaction is in a valid state to allow a new resource to be enlisted.
@@ -2054,7 +2054,7 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
                 final RollbackException rbe = new RollbackException("Transaction rolled back");
                 FFDCFilter.processException(rbe, "com.ibm.tx.jta.TransactionImpl.enlistResource", "1895", this);
                 if (tc.isEntryEnabled())
-                    Tr.exit(tc, "enlistResource (SPI)", rbe);
+                    Tr.exit(tc, "enlistResource", new Object[] {"(SPI)", rbe});
                 throw rbe;
             default:
                 //
@@ -2063,7 +2063,7 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
                 final IllegalStateException ise = new IllegalStateException("Transaction is inactive or prepared");
                 FFDCFilter.processException(ise, "com.ibm.tx.jta.TransactionImpl.enlistResource", "1904", this);
                 if (tc.isEntryEnabled())
-                    Tr.exit(tc, "enlistResource (SPI)", ise);
+                    Tr.exit(tc, "enlistResource", new Object[] {"(SPI)", ise});
                 throw ise;
         }
 
@@ -2073,7 +2073,7 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
             final IllegalStateException ise = new IllegalStateException(msg);
             FFDCFilter.processException(ise, "com.ibm.tx.jta.TransactionImpl.enlistResource", "1914", this);
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "enlistResource (SPI)", ise);
+                Tr.exit(tc, "enlistResource", new Object[] {"(SPI)", ise});
             throw ise;
         }
 
@@ -2084,7 +2084,7 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
             final IllegalStateException ise = new IllegalStateException(msg);
             FFDCFilter.processException(ise, "com.ibm.tx.jta.TransactionImpl.enlistResource", "1934", this);
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "enlistResource (SPI)", ise);
+                Tr.exit(tc, "enlistResource", new Object[]{"(SPI)", ise});
             throw ise;
         }
 
@@ -2103,20 +2103,20 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
                 FFDCFilter.processException(rbe, "com.ibm.tx.jta.TransactionImpl.enlistResource", "2035", this);
                 this.setRollbackOnly();
                 if (tc.isEntryEnabled())
-                    Tr.exit(tc, "enlistResource (SPI)", rbe);
+                    Tr.exit(tc, "enlistResource", new Object[] {"(SPI)", rbe});
                 throw rbe;
             } catch (SystemException se) {
                 FFDCFilter.processException(se, "com.ibm.tx.jta.TransactionImpl.enlistResource", "2042", this);
                 this.setRollbackOnly();
                 if (tc.isEntryEnabled())
-                    Tr.exit(tc, "enlistResource (SPI)", se);
+                    Tr.exit(tc, "enlistResource", new Object[] {"(SPI)", se});
                 throw se;
             } catch (Throwable t) {
                 FFDCFilter.processException(t, "com.ibm.tx.jta.TransactionImpl.enlistResource", "2049", this);
                 this.setRollbackOnly();
                 final SystemException se = new SystemException(t.getLocalizedMessage());
                 if (tc.isEntryEnabled())
-                    Tr.exit(tc, "enlistResource (SPI)", t);
+                    Tr.exit(tc, "enlistResource", new Object[] {"(SPI)", t});
                 throw se;
             }
         } else {
@@ -2124,12 +2124,12 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
             final SystemException se = new SystemException(msg);
             FFDCFilter.processException(se, "com.ibm.tx.jta.TransactionImpl.enlistResource", "1955", this);
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "enlistResource (SPI)", se);
+                Tr.exit(tc, "enlistResource", new Object[] {"(SPI)", se});
             throw se;
         }
 
         if (tc.isEntryEnabled())
-            Tr.exit(tc, "enlistResource (SPI)", Boolean.TRUE);
+            Tr.exit(tc, "enlistResource", new Object[] {"(SPI)", Boolean.TRUE});
         return true;
     }
 
@@ -2142,12 +2142,12 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
      */
     public void enlistResource(JTAResource remoteRes) {
         if (tc.isEntryEnabled())
-            Tr.entry(tc, "enlistResource (SPI): args: ", remoteRes);
+            Tr.entry(tc, "enlistResource", new Object[] {"(SPI): args: ", remoteRes});
 
         getResources().addRes(remoteRes);
 
         if (tc.isEntryEnabled())
-            Tr.exit(tc, "enlistResource (SPI)");
+            Tr.exit(tc, "enlistResource", "(SPI)");
     }
 
     /**
@@ -2221,7 +2221,7 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
     @Override
     public boolean delistResource(XAResource xaRes, int flag) throws IllegalStateException, SystemException {
         if (tc.isEntryEnabled())
-            Tr.event(tc, "delistResource (SPI)", new Object[] { xaRes, Util.printFlag(flag) });
+            Tr.event(tc, "delistResource", new Object[] {"(SPI)",xaRes, Util.printFlag(flag)});
 
         //
         // Check the transaction is in a valid state to allow a resource to be delisted.
@@ -2231,7 +2231,7 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
             final IllegalStateException ise = new IllegalStateException(msg);
             FFDCFilter.processException(ise, "com.ibm.tx.jta.TransactionImpl.delistResource", "2212", this);
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "delistResource (SPI)", ise);
+                Tr.exit(tc, "delistResource", new Object[] {"(SPI)", ise});
             throw ise;
         }
 
@@ -2241,7 +2241,7 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
             final IllegalStateException ise = new IllegalStateException(msg);
             FFDCFilter.processException(ise, "com.ibm.tx.jta.TransactionImpl.delistResource", "2224", this);
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "delistResource (SPI)", ise);
+                Tr.exit(tc, "delistResource", new Object[] {"(SPI)", ise});
             throw ise;
         }
 
@@ -2268,8 +2268,7 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
     public void registerSynchronization(javax.transaction.Synchronization sync,
                                         int tier) throws RollbackException, IllegalStateException {
         if (tc.isEntryEnabled())
-            Tr.entry(tc, "registerSynchronization (SPI)", new Object[] { this,
-                                                                         sync, tier });
+            Tr.entry(tc, "registerSynchronization", new Object[] {"(SPI)",this, sync, tier});
 
         //
         // Check the transaction is in a valid state to allow a new
@@ -2285,7 +2284,7 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
                 final RollbackException rbe = new RollbackException("Transaction rolled back");
                 FFDCFilter.processException(rbe, "com.ibm.tx.jta.TransactionImpl.registerSynchronization", "2289", this);
                 if (tc.isEntryEnabled())
-                    Tr.exit(tc, "registerSynchronization (SPI)", rbe);
+                    Tr.exit(tc, "registerSynchronization", new Object[] {"(SPI)", rbe});
                 throw rbe;
             default:
                 //
@@ -2294,14 +2293,14 @@ public class TransactionImpl implements Transaction, ResourceCallback, UOWScopeL
                 final IllegalStateException ise = new IllegalStateException("Transaction is inactive or prepared");
                 FFDCFilter.processException(ise, "com.ibm.tx.jta.TransactionImpl.registerSynchronization", "2297", this);
                 if (tc.isEntryEnabled())
-                    Tr.exit(tc, "registerSynchronization (SPI)", ise);
+                    Tr.exit(tc, "registerSynchronization", new Object[] {"(SPI)", ise});
                 throw ise;
         }
 
         getSyncs().add(sync, tier);
 
         if (tc.isEntryEnabled())
-            Tr.exit(tc, "registerSynchronization (SPI)");
+            Tr.exit(tc, "registerSynchronization", "(SPI)");
     }
 
     /**

--- a/dev/com.ibm.tx.core/src/com/ibm/tx/jta/util/TxTMHelper.java
+++ b/dev/com.ibm.tx.core/src/com/ibm/tx/jta/util/TxTMHelper.java
@@ -1,7 +1,7 @@
 package com.ibm.tx.jta.util;
 
 /*******************************************************************************
- * Copyright (c) 2002, 2018 IBM Corporation and others.
+ * Copyright (c) 2002, 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -156,7 +156,7 @@ public class TxTMHelper implements TMService, UOWScopeCallbackAgent {
      */
     protected void setXaResourceFactory(ServiceReference<ResourceFactory> ref) {
         if (tc.isEntryEnabled())
-            Tr.entry(tc, "setXaResourceFactory, ref " + ref);
+            Tr.entry(tc, "setXaResourceFactory", "ref " + ref);
 
         _xaResourceFactoryReady = true;
 

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/tcpchannel/internal/NBAccept.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/tcpchannel/internal/NBAccept.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2007 IBM Corporation and others.
+ * Copyright (c) 2005, 2007, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -66,7 +66,7 @@ public class NBAccept {
      */
     public void registerPort(TCPPort endPoint) throws IOException {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
-            Tr.entry(tc, "registerPort: " + endPoint.getServerSocket());
+            Tr.entry(tc, "registerPort", endPoint.getServerSocket());
         }
 
         synchronized (this) {
@@ -147,7 +147,7 @@ public class NBAccept {
      */
     public void removePort(TCPPort endPoint) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
-            Tr.entry(tc, "removePort: " + endPoint.getServerSocket());
+            Tr.entry(tc, "removePort", endPoint.getServerSocket());
         }
 
         synchronized (this) {
@@ -168,7 +168,7 @@ public class NBAccept {
 
                 synchronized (workSync) {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                        Tr.event(this, tc, "Passing remove to selector; " + endPoint.getServerSocket());
+                        Tr.event(this, tc, "Passing remove to selector: " + endPoint.getServerSocket());
                     }
                     accept.addWork(work);
 

--- a/dev/com.ibm.ws.injection.core/src/com/ibm/ws/injectionengine/AbstractInjectionEngine.java
+++ b/dev/com.ibm.ws.injection.core/src/com/ibm/ws/injectionengine/AbstractInjectionEngine.java
@@ -389,7 +389,7 @@ public abstract class AbstractInjectionEngine implements InternalInjectionEngine
                                          ComponentNameSpaceConfiguration compNSConfig) throws InjectionException {
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
         if (isTraceOn && tc.isEntryEnabled())
-            Tr.entry(tc, "processInjectionMetaData (targets)");
+            Tr.entry(tc, "processInjectionMetaData", "(targets)");
 
         InjectionProcessorContextImpl context = createInjectionProcessorContext();
         // F743-31682 - Always bind in the client container code flow.
@@ -413,7 +413,7 @@ public abstract class AbstractInjectionEngine implements InternalInjectionEngine
         notifyInjectionMetaDataListeners(null, compNSConfig);
 
         if (isTraceOn && tc.isEntryEnabled())
-            Tr.exit(tc, "processInjectionMetaData: " + injectionTargetMap);
+            Tr.exit(tc, "processInjectionMetaData", injectionTargetMap);
     }
 
     /**

--- a/dev/com.ibm.ws.injection.core/src/com/ibm/wsspi/injectionengine/MethodMap.java
+++ b/dev/com.ibm.ws.injection.core/src/com/ibm/wsspi/injectionengine/MethodMap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2013 IBM Corporation and others.
+ * Copyright (c) 2007, 2013, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -110,7 +110,7 @@ public class MethodMap extends HashMap<String, List<Method>>
     {
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
         if (isTraceOn && tc.isEntryEnabled())
-            Tr.entry(tc, "getAllDeclaredMethods : " + clazz);
+            Tr.entry(tc, "getAllDeclaredMethods", clazz);
 
         // Not expecting null or an interface, but have ignored them in
         // the past, so continue to ignore them now.                       d658626

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/J2CGlobalConfigProperties.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/J2CGlobalConfigProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2017 IBM Corporation and others.
+ * Copyright (c) 1997, 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -386,8 +386,8 @@ public final class J2CGlobalConfigProperties implements PropertyChangeListener, 
                 this.cfName = _xpathId.substring(0, cmIndex);
         }
 
-        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
-            Tr.entry(tc, "xpath = " + XpathId + "  jndi = " + jndiName + "cfName = " + cfName);
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "xpath = " + XpathId + "  jndi = " + jndiName + "cfName = " + cfName);
         }
 
         dynamicEnlistmentSupported = false; // Will become true later if managed connection implements LazyEnlistableManagedConnection

--- a/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/impl/TransmissionData.java
+++ b/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/impl/TransmissionData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2006 IBM Corporation and others.
+ * Copyright (c) 2004, 2006, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -424,7 +424,7 @@ public class TransmissionData
          transmissionBuilt = false;
       exhausedXmitBuffer = false;
       
-      if (tc.isEntryEnabled()) SibTr.entry(this, tc, "buildTransmission", ""+retValue);
+      if (tc.isEntryEnabled()) SibTr.exit(this, tc, "buildTransmission", ""+retValue);
       return retValue;
    }
 

--- a/dev/com.ibm.ws.messaging.comms.server/src/com/ibm/ws/jfap/inbound/channel/CommsServerServiceFacade.java
+++ b/dev/com.ibm.ws.messaging.comms.server/src/com/ibm/ws/jfap/inbound/channel/CommsServerServiceFacade.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2013 IBM Corporation and others.
+ * Copyright (c) 2011, 2013, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -137,7 +137,7 @@ public class CommsServerServiceFacade {
     protected void modified(ComponentContext context,
                             Map<String, Object> properties) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
-            SibTr.entry(tc, "modified ", properties);
+            SibTr.entry(tc, "modified", properties);
 
         iswasJmsEndpointEnabled = MetatypeUtils.parseBoolean(Inbound_ConfigAlias, "enabled",
                                                              properties.get("enabled"),
@@ -174,7 +174,7 @@ public class CommsServerServiceFacade {
         }
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
-            SibTr.exit(tc, "modified ");
+            SibTr.exit(tc, "modified");
     }
 
     // Four Runnable actions (i.e stopBasicChain,stopSecureChain,updateBasicChain and updateSecureChain). However all these run() are called in-line ( not from other thread) in SCR action thread
@@ -377,7 +377,7 @@ public class CommsServerServiceFacade {
     @Trivial
     protected void setSslOptions(ServiceReference<ChannelConfiguration> service) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-            Tr.event(this, tc, "set tcp options " + service.getProperty("id"));
+            Tr.event(this, tc, "set ssl options " + service.getProperty("id"));
         }
         _sslOptionsRef.setReference(service);
 

--- a/dev/com.ibm.ws.messaging.msgstore/src/com/ibm/ws/sib/msgstore/deliverydelay/DeliveryDelayManager.java
+++ b/dev/com.ibm.ws.messaging.msgstore/src/com/ibm/ws/sib/msgstore/deliverydelay/DeliveryDelayManager.java
@@ -1,7 +1,7 @@
 package com.ibm.ws.sib.msgstore.deliverydelay;
 
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -776,7 +776,7 @@ public class DeliveryDelayManager implements AlarmListener, XmlConstants
     private void scheduleAlarm(long timeOut)
     {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
-            SibTr.entry(this, tc, "scheduleAlarm timeOut=" + timeOut);
+            SibTr.entry(this, tc, "scheduleAlarm", "timeOut=" + timeOut);
 
         // NB PM27294 implementation now means you cannot decrease the the timeOut if an alarm is already scheduled.
         // This is OK for the DeliveryDelayManager as the timeout does not change once DeliveryDelayManager is started.

--- a/dev/com.ibm.ws.messaging.msgstore/src/com/ibm/ws/sib/msgstore/expiry/CacheLoader.java
+++ b/dev/com.ibm.ws.messaging.msgstore/src/com/ibm/ws/sib/msgstore/expiry/CacheLoader.java
@@ -1,6 +1,6 @@
 package com.ibm.ws.sib.msgstore.expiry;
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -362,7 +362,7 @@ public class CacheLoader implements AlarmListener, XmlConstants
      */
     private Alarm scheduleAlarm(long timeOut)
     {
-        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) SibTr.entry(this, tc, "scheduleAlarm timeOut=" + timeOut);
+        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) SibTr.entry(this, tc, "scheduleAlarm", "timeOut=" + timeOut);
 
         Alarm alarm = AlarmManager.createNonDeferrable(timeOut, this);
 

--- a/dev/com.ibm.ws.messaging.msgstore/src/com/ibm/ws/sib/msgstore/expiry/Expirer.java
+++ b/dev/com.ibm.ws.messaging.msgstore/src/com/ibm/ws/sib/msgstore/expiry/Expirer.java
@@ -1,6 +1,6 @@
 package com.ibm.ws.sib.msgstore.expiry;
 /*******************************************************************************
- * Copyright (c) 2012, 2013 IBM Corporation and others.
+ * Copyright (c) 2012, 2013, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -634,7 +634,7 @@ public class Expirer implements AlarmListener,  XmlConstants
      */
     private void scheduleAlarm(long timeOut)
     {
-        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) SibTr.entry(this, tc, "scheduleAlarm timeOut=" + timeOut);
+        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) SibTr.entry(this, tc, "scheduleAlarm", "timeOut=" + timeOut);
         
         // NB PM27294 implementation now means you cannot decrease the the timeOut if an alarm is already scheduled.
         // This is OK for the expirer as the timeout does not change once Expirer is started.

--- a/dev/com.ibm.ws.messaging.security.common/src/com/ibm/ws/messaging/security/Authentication.java
+++ b/dev/com.ibm.ws.messaging.security.common/src/com/ibm/ws/messaging/security/Authentication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -40,7 +40,7 @@ public class Authentication {
 			MSTraceConstants.MESSAGING_SECURITY_RESOURCE_BUNDLE);
 
 	// Absolute class name along with the package used for tracing
-	private static final String CLASS_NAME = "com.ibm.ws.messaging.security.Authentication";
+	private static final String CLASS_NAME = "com.ibm.ws.messaging.security.Authentication.";
 
 	/* Authentication Service for messaging, exists only if security for
 	   messaging is enabled */

--- a/dev/com.ibm.ws.messaging.security.common/src/com/ibm/ws/messaging/security/Authorization.java
+++ b/dev/com.ibm.ws.messaging.security.common/src/com/ibm/ws/messaging/security/Authorization.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2013 IBM Corporation and others.
+ * Copyright (c) 2012, 2013, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -37,7 +37,7 @@ public class Authorization {
                                                       MSTraceConstants.MESSAGING_SECURITY_RESOURCE_BUNDLE);
 
     // Absolute class name along with the package used for tracing
-    private static final String CLASS_NAME = "com.ibm.ws.messaging.security.Authorization";
+    private static final String CLASS_NAME = "com.ibm.ws.messaging.security.Authorization.";
 
     /*
      * Authorization Service for Messaging, it will exists when messaging

--- a/dev/com.ibm.ws.messaging.security.common/src/com/ibm/ws/messaging/security/RuntimeSecurityService.java
+++ b/dev/com.ibm.ws.messaging.security.common/src/com/ibm/ws/messaging/security/RuntimeSecurityService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -40,7 +40,7 @@ public enum RuntimeSecurityService {
                                                       MSTraceConstants.MESSAGING_SECURITY_RESOURCE_BUNDLE);
 
     // Absolute class name along with the package used for tracing
-    private static final String CLASS_NAME = "com.ibm.ws.messaging.security.RuntimeSecurityService";
+    private static final String CLASS_NAME = "com.ibm.ws.messaging.security.RuntimeSecurityService.";
 
     // MessagingSecurityService variable which is null when Messaging Security 
     // is disabled, it will be initialized only when Messaging Security is enabled

--- a/dev/com.ibm.ws.messaging.security/src/com/ibm/ws/messaging/security/authentication/internal/MessagingAuthenticationServiceImpl.java
+++ b/dev/com.ibm.ws.messaging.security/src/com/ibm/ws/messaging/security/authentication/internal/MessagingAuthenticationServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -55,7 +55,7 @@ public class MessagingAuthenticationServiceImpl implements
                                                       MSTraceConstants.MESSAGING_SECURITY_RESOURCE_BUNDLE);
 
     // Absolute class name along with the package name, used for tracing
-    private static final String CLASS_NAME = "com.ibm.ws.messaging.security.authentication.internal.MessagingAuthenticationServiceImpl";
+    private static final String CLASS_NAME = "com.ibm.ws.messaging.security.authentication.internal.MessagingAuthenticationServiceImpl.";
 
     private MessagingSecurityServiceImpl _messagingSecurityService = null;
 

--- a/dev/com.ibm.ws.messaging.security/src/com/ibm/ws/messaging/security/internal/MessagingSecurityServiceImpl.java
+++ b/dev/com.ibm.ws.messaging.security/src/com/ibm/ws/messaging/security/internal/MessagingSecurityServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2013 IBM Corporation and others.
+ * Copyright (c) 2012, 2013, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -76,7 +76,7 @@ public class MessagingSecurityServiceImpl implements MessagingSecurityService, C
                                                             MSTraceConstants.MESSAGING_SECURITY_RESOURCE_BUNDLE);
 
     // Absolute class name along with the package name, used for tracing
-    private static final String CLASS_NAME = "com.ibm.ws.messaging.security.internal.MessagingSecurityServiceImpl";
+    private static final String CLASS_NAME = "com.ibm.ws.messaging.security.internal.MessagingSecurityServiceImpl.";
 
     // Liberty Security Service
     private SecurityService securityService = null;
@@ -172,7 +172,7 @@ public class MessagingSecurityServiceImpl implements MessagingSecurityService, C
 
     /*
      * Delay this service from starting until LTPAConfiguration is available.
-     * See RTC 269100: Ltpa2 key generation may on occasion take some time; if not available when e.g. an MDB runs an exception
+     * See RTC 269685: Ltpa2 key generation may on occasion take some time; if not available when e.g. an MDB runs an exception
      * is raised during authentication resulting in an FFDC dump.
      * This function is a "dummy" that will influence OSGi's running of this bundle, delaying until the service can be resolved.
      */

--- a/dev/com.ibm.ws.messaging.security/src/com/ibm/ws/messaging/security/utility/MessagingSecurityUtility.java
+++ b/dev/com.ibm.ws.messaging.security/src/com/ibm/ws/messaging/security/utility/MessagingSecurityUtility.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2013 IBM Corporation and others.
+ * Copyright (c) 2012, 2013, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -51,7 +51,7 @@ public class MessagingSecurityUtility implements MessagingSecurityConstants {
                                                       MSTraceConstants.MESSAGING_SECURITY_RESOURCE_BUNDLE);
 
     // Absolute class name along with the package name, used for tracing
-    private static final String CLASS_NAME = "com.ibm.ws.messaging.security.utility.MessagingSecurityUtility";
+    private static final String CLASS_NAME = "com.ibm.ws.messaging.security.utility.MessagingSecurityUtility.";
 
     private static SubjectHelper subjectHelper = new SubjectHelper();
 

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/KeyStoreManager.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/KeyStoreManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2019 IBM Corporation and others.
+ * Copyright (c) 2005, 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -115,7 +115,7 @@ public class KeyStoreManager {
      ***/
     public void addKeyStoreToMap(String keyStoreName, WSKeyStore ks) throws Exception {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
-            Tr.entry(tc, "addKeyStoreToMap: " + keyStoreName + ", ks=" + ks);
+            Tr.entry(tc, "addKeyStoreToMap", "name=" + keyStoreName + ", ks=" + ks);
 
         if (keyStoreMap.containsKey(keyStoreName))
             keyStoreMap.remove(keyStoreName);

--- a/dev/com.ibm.ws.tx.embeddable/src/com/ibm/tx/jta/embeddable/impl/EmbeddableTranManagerImpl.java
+++ b/dev/com.ibm.ws.tx.embeddable/src/com/ibm/tx/jta/embeddable/impl/EmbeddableTranManagerImpl.java
@@ -33,7 +33,7 @@ public class EmbeddableTranManagerImpl extends TranManagerImpl {
         final boolean traceOn = TraceComponent.isAnyTracingEnabled();
 
         if (traceOn && tc.isEntryEnabled())
-            Tr.entry(tc, "begin (SPI)");
+            Tr.entry(tc, "begin", "(SPI)");
 
         if (tx != null) {
             if (tx.getTxType() != UOWCoordinator.TXTYPE_NONINTEROP_GLOBAL) {
@@ -42,7 +42,7 @@ public class EmbeddableTranManagerImpl extends TranManagerImpl {
 
                 FFDCFilter.processException(nse, "com.ibm.tx.jta.embeddable.impl.EmbeddableTranManagerImpl.begin", "63", this);
                 if (traceOn && tc.isEntryEnabled())
-                    Tr.exit(tc, "begin (SPI)", nse);
+                    Tr.exit(tc, "begin", new Object[] {"(SPI)", nse});
                 throw nse;
             } else {
                 if (tc.isDebugEnabled())
@@ -65,7 +65,7 @@ public class EmbeddableTranManagerImpl extends TranManagerImpl {
         invokeEventListener(tx, UOWEventListener.POST_BEGIN, null);
 
         if (traceOn && tc.isEntryEnabled())
-            Tr.exit(tc, "begin (SPI)");
+            Tr.exit(tc, "begin", "(SPI)");
     }
 
     @Override

--- a/dev/com.ibm.ws.tx.embeddable/src/com/ibm/tx/jta/embeddable/impl/EmbeddableTransactionImpl.java
+++ b/dev/com.ibm.ws.tx.embeddable/src/com/ibm/tx/jta/embeddable/impl/EmbeddableTransactionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2019 IBM Corporation and others.
+ * Copyright (c) 2009, 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -603,14 +603,14 @@ public class EmbeddableTransactionImpl extends com.ibm.tx.jta.impl.TransactionIm
     public void enlistAsyncResource(String xaResFactoryFilter, Serializable xaResInfo, Xid xid) throws SystemException // @LIDB1922-5C
     {
         if (tc.isEntryEnabled())
-            Tr.entry(tc, "enlistAsyncResource (SPI): args: ", new Object[] { xaResFactoryFilter, xaResInfo, xid });
+            Tr.entry(tc, "enlistAsyncResource", new Object[] { "(SPI): args: ", xaResFactoryFilter, xaResInfo, xid });
         try {
             final WSATAsyncResource res = new WSATAsyncResource(xaResFactoryFilter, xaResInfo, xid);
             final WSATParticipantWrapper wrapper = new WSATParticipantWrapper(res);
             getResources().addAsyncResource(wrapper);
         } finally {
             if (tc.isEntryEnabled())
-                Tr.exit(tc, "enlistAsyncResource (SPI)");
+                Tr.exit(tc, "enlistAsyncResource", "(SPI)");
         }
     }
 


### PR DESCRIPTION
fixes #11121 

The improvements largely centre around keeping the traced function name to be just that - the function name without "additions".  Additional information is moved to the "extra info" argument of the trace entry/exit call.  Further, there are some changes around ensuring entry/exit pairs exist.

(Keeping the traced function name unaltered helps with any trace processing as additional weird and wacky syntaxes don't have to be accounted for.)