### PR TITLE
make libraryRef optional and beta classProviderRef

### DIFF
--- a/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/ConnectionManagerMBeanTest.java
+++ b/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/ConnectionManagerMBeanTest.java
@@ -144,11 +144,6 @@ public class ConnectionManagerMBeanTest {
         ShrinkHelper.addDirectory(fvtapp_ear, "lib/LibertyFATTestFiles/fvtapp");
         ShrinkHelper.exportToServer(server, "apps", fvtapp_ear);
 
-        // TODO remove this temporary jar once libraryRef is made optional
-        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "ignoreThisUselessLibrary.jar");
-        jar.addPackage("web.mdb.bindings"); // no login modules here
-        ShrinkHelper.exportToServer(server, "/", jar);
-
         originalServerConfig = server.getServerConfiguration().clone();
         server.addInstalledAppForValidation(fvtapp);
         server.startServer();

--- a/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/DependantApplicationTest.java
+++ b/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/DependantApplicationTest.java
@@ -156,11 +156,6 @@ public class DependantApplicationTest {
         ShrinkHelper.addDirectory(fvtapp_ear, "lib/LibertyFATTestFiles/fvtapp");
         ShrinkHelper.exportToServer(server, "apps", fvtapp_ear);
 
-        // TODO remove this temporary jar once libraryRef is made optional
-        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "ignoreThisUselessLibrary.jar");
-        jar.addPackage("web.mdb.bindings"); // no login modules here
-        ShrinkHelper.exportToServer(server, "/", jar);
-
         originalServerConfig = server.getServerConfiguration().clone();
         server.addInstalledAppForValidation(fvtapp);
         server.startServer();

--- a/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/JCATest.java
+++ b/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/JCATest.java
@@ -119,11 +119,6 @@ public class JCATest extends FATServletClient {
         ShrinkHelper.addDirectory(fvtapp_ear, "lib/LibertyFATTestFiles/fvtapp");
         ShrinkHelper.exportToServer(server, "apps", fvtapp_ear);
 
-        // TODO remove this temporary jar once libraryRef is made optional
-        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "ignoreThisUselessLibrary.jar");
-        jar.addPackage("web.mdb.bindings"); // no login modules here
-        ShrinkHelper.exportToServer(server, "/", jar);
-
         server.addInstalledAppForValidation(fvtapp);
         server.startServer();
     }

--- a/dev/com.ibm.ws.jca_fat/publish/servers/com.ibm.ws.jca.fat/server.xml
+++ b/dev/com.ibm.ws.jca_fat/publish/servers/com.ibm.ws.jca.fat/server.xml
@@ -68,16 +68,12 @@
     <application type="ear" id="fvtapp" name="fvtapp" location="fvtapp.ear">
     </application>
 
-    <library id="ignore">
-      <file name="${server.config.dir}/ignoreThisUselessLibrary.jar"/>
-    </library>
-
     <jaasLoginContextEntry id="jar1LoginContextEntry" name="jar1login">
-      <loginModule className="fat.jca.resourceadapter.jar1.JAR1LoginModule" classProviderRef="FAT1" libraryRef="ignore"/> <!-- TODO remove libraryRef once made optional -->
+      <loginModule className="fat.jca.resourceadapter.jar1.JAR1LoginModule" classProviderRef="FAT1"/>
     </jaasLoginContextEntry>
 
     <jaasLoginContextEntry id="jar2LoginContextEntry" name="jar2login">
-      <loginModule className="fat.jca.resourceadapter.jar2.JAR2LoginModule" classProviderRef="FAT1" libraryRef="ignore"/> <!-- TODO remove libraryRef once made optional -->
+      <loginModule className="fat.jca.resourceadapter.jar2.JAR2LoginModule" classProviderRef="FAT1"/>
     </jaasLoginContextEntry>
 
     <!-- 

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.loginModuleInRA/server.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra.loginModuleInRA/server.xml
@@ -42,15 +42,8 @@
     </connectionFactory>    
 
     <jaasLoginContextEntry id="myJAASLoginEntry" name="myJAASLoginEntryName">
-      <!-- TODO remove libraryRef once enforcement is added to config. For now, while still being experimented with, classProviderRef takes precedence -->
-      <loginModule className="com.ibm.ws.jca.fat.security.login.TestLoginModule" libraryRef="temp" classProviderRef="DerbyLMRA"/>
+      <loginModule className="com.ibm.ws.jca.fat.security.login.TestLoginModule" classProviderRef="DerbyLMRA"/>
     </jaasLoginContextEntry>
-
-    <!-- TODO remove this -->
-    <library id="temp">
-      <!-- no login modules found here - this library is only temporarily present to satisfy the mandatory libraryRef requirement that we will later take away -->
-      <file name="${server.config.dir}/apps/derbyRAApp.ear"/>
-    </library>
 
     <!-- "APP" is the default schema for Derby -->
     <authData id="APP" user="APP" password="{aes}APb9ZaYzUL+JsfFD/OOBGaPM0evjmx5AnvmzbaKgffyX"/>

--- a/dev/com.ibm.ws.jca_fat_enterpriseApp/fat/src/com/ibm/ws/jca/fat/enterpriseApp/EnterpriseAppTest.java
+++ b/dev/com.ibm.ws.jca_fat_enterpriseApp/fat/src/com/ibm/ws/jca/fat/enterpriseApp/EnterpriseAppTest.java
@@ -79,11 +79,6 @@ public class EnterpriseAppTest extends FATServletClient {
         ShrinkHelper.addDirectory(ear, "lib/LibertyFATTestFiles/enterpriseApp");
         ShrinkHelper.exportToServer(server, "apps", ear);
 
-        // TODO remove this once libraryRef is made optional
-        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "ignoreThisUselessLibrary.jar");
-        jar.addPackage("web.mdb"); // no login modules here
-        ShrinkHelper.exportToServer(server, "/", jar);
-
         server.addInstalledAppForValidation(appName);
         server.startServer();
     }

--- a/dev/com.ibm.ws.jca_fat_enterpriseApp/publish/servers/com.ibm.ws.jca.fat.enterpriseApp/server.xml
+++ b/dev/com.ibm.ws.jca_fat_enterpriseApp/publish/servers/com.ibm.ws.jca.fat.enterpriseApp/server.xml
@@ -32,14 +32,9 @@
     <connectionFactory jndiName="eis/cf1">
       <properties.enterpriseApp.loginModRA />
       <jaasLoginContextEntry name="cf1login">
-        <loginModule className="com.ibm.test.jca.loginmodra.LMLoginModule" classProviderRef="enterpriseApp" libraryRef="ignore"/> <!-- TODO replace with classProviderRef once implemented -->
+        <loginModule className="com.ibm.test.jca.loginmodra.LMLoginModule" classProviderRef="enterpriseApp"/>
       </jaasLoginContextEntry>
     </connectionFactory>
-
-    <!-- TODO remove this library once libraryRef is made optional for login modules -->
-    <library id="ignore">
-      <file name="${server.config.dir}/ignoreThisUselessLibrary.jar"/>
-    </library>
 
     <connectionFactory jndiName="eis/ds1">
       <containerAuthData user="DS1USER" password="{xor}GwxuDwgb"/>
@@ -47,7 +42,7 @@
     </connectionFactory>
 
     <jaasLoginContextEntry id="ds1LoginContextEntry" name="ds1login">
-      <loginModule className="com.ibm.test.jca.enterprisera.EALoginModule" classProviderRef="enterpriseApp" libraryRef="ignore"/> <!-- TODO replace with classProviderRef once implemented -->
+      <loginModule className="com.ibm.test.jca.enterprisera.EALoginModule" classProviderRef="enterpriseApp"/>
     </jaasLoginContextEntry>
 
     <activationSpec id="enterpriseApp/fvtweb/JCAEnterpriseAppMDB">

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
@@ -82,11 +82,6 @@ public class JDBCLoadFromAppTest extends FATServletClient {
 
         ShrinkHelper.exportAppToServer(server, otherApp);
 
-        // TODO remove this once libraryRef is made optional
-        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "ignoreThisUselessLibrary.jar");
-        jar.addPackage("com.ibm.ws.jdbc.fat.loadfromapp"); // no login modules here
-        ShrinkHelper.exportToServer(server, "/", jar);
-
         server.addInstalledAppForValidation("derbyApp");
         server.addInstalledAppForValidation("otherApp");
 

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
@@ -49,6 +49,7 @@ public class JDBCLoadFromAppTest extends FATServletClient {
     public static void setUp() throws Exception {
         WebArchive derbyApp = ShrinkWrap.create(WebArchive.class, "derbyApp.war")
                         .addPackage("web.derby") //
+                        .addAsWebInfResource(new File("test-applications/derbyapp/resources/WEB-INF/ibm-ejb-jar-bnd.xml"))
                         .addAsWebInfResource(new File("test-applications/derbyapp/resources/WEB-INF/ibm-web-bnd.xml"))
                         .addAsLibrary(new File("publish/shared/resources/derby/derby.jar")) //
                         .addPackage("jdbc.driver.proxy"); // delegates to the Derby JDBC driver
@@ -63,9 +64,11 @@ public class JDBCLoadFromAppTest extends FATServletClient {
                         .addPackage("jdbc.driver.proxy"); // delegates to the "mini" JDBC driver
 
         JavaArchive ejb1JAR = ShrinkWrap.create(JavaArchive.class, "ejb1.jar")
+                        .addAsManifestResource(new File("test-applications/otherapp/resources/ejb.first/META-INF/ibm-ejb-jar-bnd.xml"))
                         .addPackage("ejb.first");
 
         JavaArchive ejb2JAR = ShrinkWrap.create(JavaArchive.class, "ejb2.jar")
+                        .addAsManifestResource(new File("test-applications/otherapp/resources/ejb.second/META-INF/ibm-ejb-jar-bnd.xml"))
                         .addPackage("ejb.second");
 
         JavaArchive lmJAR = ShrinkWrap.create(JavaArchive.class, "top-level-login-modules.jar")

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
@@ -92,8 +92,7 @@ public class JDBCLoadFromAppTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer("CWWKE0701E.*JAASLoginModuleConfigImpl", // TODO remove this if we enable loading login modules from web applications
-                          "SRVE9967W.*derbyLocale" // ignore missing Derby locales
+        server.stopServer("SRVE9967W.*derbyLocale" // ignore missing Derby locales
         );
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/bootstrap.properties
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/bootstrap.properties
@@ -1,4 +1,4 @@
-com.ibm.ws.logging.trace.specification=*=info=enabled:RRA=all:WAS.j2c=all
+com.ibm.ws.logging.trace.specification=*=info=enabled:RRA=all:WAS.j2c=all:com.ibm.ws.security.jaas.common.*=all
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 ds.loglevel=debug

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/server.xml
@@ -78,6 +78,11 @@
       <loginModule className="ejb.second.SecondEJBModLoginModule" classProviderRef="otherApp"/>
     </jaasLoginContextEntry>
 
+    <jaasLoginContextEntry id="system.WEB_INBOUND" name="system.WEB_INBOUND" loginModuleRef="webInboundLoginModule, hashtable"/>
+    <jaasLoginModule id="webInboundLoginModule" controlFlag="REQUIRED" className="loginmod.WebInboundLoginModule" classProviderRef="otherApp">
+      <options city="Rochester" state="MN" zip="55901"/>
+    </jaasLoginModule>
+
     <!-- permissions for Derby in the app -->
     <javaPermission codeBase="${server.config.dir}apps/derbyApp.war" className="java.io.FilePermission" name="derby.log" actions="read,write"/>
     <javaPermission codeBase="${server.config.dir}apps/derbyApp.war" className="java.io.FilePermission" name="derby.properties" actions="read"/>

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/server.xml
@@ -10,7 +10,7 @@
  -->
 <server>
     <featureManager>
-      <feature>appSecurity-2.0</feature>
+      <feature>appSecurity-3.0</feature>
       <feature>componenttest-1.0</feature>
       <feature>ejbLite-3.2</feature>
       <feature>jca-1.7</feature>
@@ -73,6 +73,14 @@
 
     <jaasLoginContextEntry id="web1loginEntry" name="web1login">
       <loginModule className="web.other.LoadFromWebModLoginModule" classProviderRef="otherApp" libraryRef="ignore"/> <!-- TODO remove libraryRef once made optional -->
+    </jaasLoginContextEntry>
+
+    <jaasLoginContextEntry id="ejb1loginEntry" name="ejb1login">
+      <loginModule className="ejb.first.FirstEJBModLoginModule" classProviderRef="otherApp" libraryRef="ignore"/> <!-- TODO remove libraryRef once made optional -->
+    </jaasLoginContextEntry>
+
+    <jaasLoginContextEntry id="ejb2loginEntry" name="ejb2login">
+      <loginModule className="ejb.second.SecondEJBModLoginModule" classProviderRef="otherApp" libraryRef="ignore"/> <!-- TODO remove libraryRef once made optional -->
     </jaasLoginContextEntry>
 
     <!-- permissions for Derby in the app -->

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/server.xml
@@ -58,29 +58,24 @@
 
     <library id="ibm.internal.simulate.no.library.do.not.ship"/>
 
-    <!-- TODO replace with classProviderRef once implemented -->
-    <library id="ignore">
-      <file name="${server.config.dir}/ignoreThisUselessLibrary.jar"/>
-    </library>
-
     <jaasLoginContextEntry id="app1loginEntry" name="app1login">
-      <loginModule className="loginmod.LoadFromAppLoginModule" classProviderRef="otherApp" libraryRef="ignore"/> <!-- TODO remove libraryRef once made optional -->
+      <loginModule className="loginmod.LoadFromAppLoginModule" classProviderRef="otherApp"/>
     </jaasLoginContextEntry>
 
     <jaasLoginContextEntry id="webapploginEntry" name="webapplogin">
-      <loginModule className="web.derby.LoadFromWebAppLoginModule" classProviderRef="derbyApp" libraryRef="ignore"/> <!-- TODO remove libraryRef once made optional -->
+      <loginModule className="web.derby.LoadFromWebAppLoginModule" classProviderRef="derbyApp"/>
     </jaasLoginContextEntry>
 
     <jaasLoginContextEntry id="web1loginEntry" name="web1login">
-      <loginModule className="web.other.LoadFromWebModLoginModule" classProviderRef="otherApp" libraryRef="ignore"/> <!-- TODO remove libraryRef once made optional -->
+      <loginModule className="web.other.LoadFromWebModLoginModule" classProviderRef="otherApp"/>
     </jaasLoginContextEntry>
 
     <jaasLoginContextEntry id="ejb1loginEntry" name="ejb1login">
-      <loginModule className="ejb.first.FirstEJBModLoginModule" classProviderRef="otherApp" libraryRef="ignore"/> <!-- TODO remove libraryRef once made optional -->
+      <loginModule className="ejb.first.FirstEJBModLoginModule" classProviderRef="otherApp"/>
     </jaasLoginContextEntry>
 
     <jaasLoginContextEntry id="ejb2loginEntry" name="ejb2login">
-      <loginModule className="ejb.second.SecondEJBModLoginModule" classProviderRef="otherApp" libraryRef="ignore"/> <!-- TODO remove libraryRef once made optional -->
+      <loginModule className="ejb.second.SecondEJBModLoginModule" classProviderRef="otherApp"/>
     </jaasLoginContextEntry>
 
     <!-- permissions for Derby in the app -->

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/resources/WEB-INF/ibm-ejb-jar-bnd.xml
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/resources/WEB-INF/ibm-ejb-jar-bnd.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<ejb-jar-bnd
+        xmlns="http://websphere.ibm.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-ejb-jar-bnd_1_1.xsd"
+        version="1.1">
+
+  <session name="BeanInWebApp">
+    <resource-ref name="jdbc/dsref">
+      <custom-login-configuration name="webapplogin">
+        <property name="shape" value="heptagon"/>
+        <property name="sides" value="7"/>
+        <property name="sumOfAngles" value="900"/>
+      </custom-login-configuration>
+    </resource-ref>
+  </session>
+    
+</ejb-jar-bnd>

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/src/web/derby/BeanInWebApp.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/src/web/derby/BeanInWebApp.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package web.derby;
+
+import java.util.concurrent.Executor;
+
+import javax.annotation.Resource;
+import javax.ejb.Stateless;
+import javax.sql.DataSource;
+
+@Stateless
+public class BeanInWebApp implements Executor {
+    @Resource(name = "java:comp/env/jdbc/dsref", lookup = "jdbc/sharedLibDataSource")
+    DataSource ds;
+
+    @Override
+    public void execute(Runnable runnable) {
+        runnable.run();
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/src/web/derby/DerbyLoadFromAppServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/src/web/derby/DerbyLoadFromAppServlet.java
@@ -12,7 +12,6 @@ package web.derby;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -26,7 +25,6 @@ import javax.sql.DataSource;
 
 import org.junit.Test;
 
-import componenttest.annotation.AllowedFFDC;
 import componenttest.app.FATDatabaseServlet;
 
 @SuppressWarnings("serial")
@@ -88,17 +86,14 @@ public class DerbyLoadFromAppServlet extends FATDatabaseServlet {
     }
 
     /**
-     * testLoginModuleFromWebApp - verify that a login module that is packaged within the web application CANNOT be used to authenticate
+     * testLoginModuleFromWebApp - verify that a login module that is packaged within the web application can be used to authenticate
      * to a data source when its resource reference specifies to use that login module.
      */
-    @AllowedFFDC({ "javax.security.auth.login.LoginException", "javax.resource.ResourceException" }) // TODO remove if we decide to enable this scenario
     @Test
     public void testLoginModuleFromWebApp() throws Exception {
         try (Connection con = sldsLoginModuleFromWebApp.getConnection()) {
             DatabaseMetaData metadata = con.getMetaData();
-            fail("authenticated as user " + metadata.getUserName());
-            // TODO if we decide to enable this path, then switch to the following assert and remove the catch block
-            // assertEquals("webappuser", metadata.getUserName());
+            assertEquals("webappuser", metadata.getUserName());
         } catch (SQLException x) {
             Throwable cause = x;
             while (cause != null && !(cause instanceof LoginException))

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/resources/ejb.first/META-INF/ibm-ejb-jar-bnd.xml
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/resources/ejb.first/META-INF/ibm-ejb-jar-bnd.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<ejb-jar-bnd
+        xmlns="http://websphere.ibm.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-ejb-jar-bnd_1_1.xsd"
+        version="1.1">
+
+  <session name="FirstBean">
+    <resource-ref name="jdbc/dsref">
+      <custom-login-configuration name="ejb1login">
+        <property name="shape" value="nonagon"/>
+        <property name="sides" value="9"/>
+        <property name="sumOfAngles" value="1260"/>
+      </custom-login-configuration>
+    </resource-ref>
+  </session>
+    
+</ejb-jar-bnd>

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/resources/ejb.second/META-INF/ibm-ejb-jar-bnd.xml
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/resources/ejb.second/META-INF/ibm-ejb-jar-bnd.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<ejb-jar-bnd
+        xmlns="http://websphere.ibm.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-ejb-jar-bnd_1_1.xsd"
+        version="1.1">
+
+  <session name="SecondBean">
+    <resource-ref name="jdbc/dsref">
+      <custom-login-configuration name="ejb2login">
+        <property name="shape" value="decagon"/>
+        <property name="sides" value="10"/>
+        <property name="sumOfAngles" value="1440"/>
+      </custom-login-configuration>
+    </resource-ref>
+  </session>
+    
+</ejb-jar-bnd>

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/loginmod/WebInboundLoginModule.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/loginmod/WebInboundLoginModule.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package loginmod;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Map;
+
+import javax.resource.spi.security.PasswordCredential;
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+
+import com.ibm.wsspi.security.auth.callback.WSManagedConnectionFactoryCallback;
+import com.ibm.wsspi.security.auth.callback.WSMappingPropertiesCallback;
+
+/**
+ * This login module always assigns the same user/password, which tests can check for.
+ */
+public class WebInboundLoginModule implements LoginModule {
+    private CallbackHandler callbackHandler;
+    private Subject subject;
+
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        this.callbackHandler = callbackHandler;
+        this.subject = subject;
+    }
+
+    @Override
+    public boolean login() throws LoginException {
+        try {
+            final WSManagedConnectionFactoryCallback mcfCallback = new WSManagedConnectionFactoryCallback("Target ManagedConnectionFactory: ");
+            WSMappingPropertiesCallback mpropsCallback = new WSMappingPropertiesCallback("Mapping Properties (HashMap): ");
+            if (callbackHandler != null)
+                callbackHandler.handle(new Callback[] { mcfCallback, mpropsCallback });
+
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+                @Override
+                public Void run() {
+                    PasswordCredential passwordCredential = new PasswordCredential("webInboundUser", "webInboundPwd".toCharArray());
+                    passwordCredential.setManagedConnectionFactory(mcfCallback.getManagedConnectionFacotry());
+                    subject.getPrivateCredentials().add(passwordCredential);
+                    return null;
+                }
+            });
+        } catch (Exception x) {
+            throw (LoginException) new LoginException(x.getMessage()).initCause(x);
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean abort() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean commit() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean logout() throws LoginException {
+        return true;
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/web/other/LoadFromAppServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/otherapp/src/web/other/LoadFromAppServlet.java
@@ -119,21 +119,20 @@ public class LoadFromAppServlet extends FATDatabaseServlet {
         }
     }
 
-    // TODO determine expectations around loading login modules from EJBs.
-    // Currently not expecting to load login modules from EJB modules, but what about being able to load login modules
-    // that are packaged elsewhere within the application when on an EJB code path?
-
+    /**
+     * testLoginModuleFromEJBModule1 - verify that a login module that is packaged within an EJB module
+     * is used to authenticate to a data source when its resource reference specifies to use that login module.
+     */
     @Test
     public void testLoginModuleFromEJBModule1() throws Exception {
         Executor bean = InitialContext.doLookup("java:global/otherApp/ejb1/FirstBean!java.util.concurrent.Executor");
         bean.execute(() -> {
             try {
-                System.out.println("EJB1 loads: " + Class.forName("loginmod.LoadFromAppLoginModule"));
                 DataSource ds = (DataSource) InitialContext.doLookup("java:comp/env/jdbc/dsref");
                 try (Connection con = ds.getConnection()) {
                     DatabaseMetaData mdata = con.getMetaData();
                     String userName = mdata.getUserName();
-                    assertEquals("APP", userName); // this will start failing if login module gets used. "APP" is the default Derby user, not a user from a login module
+                    assertEquals("ejb1user", userName);
                 }
             } catch (RuntimeException x) {
                 throw x;
@@ -143,17 +142,20 @@ public class LoadFromAppServlet extends FATDatabaseServlet {
         });
     }
 
+    /**
+     * testLoginModuleFromEJBModule2 - verify that a login module that is packaged within an EJB module
+     * is used to authenticate to a data source when its resource reference specifies to use that login module.
+     */
     @Test
     public void testLoginModuleFromEJBModule2() throws Exception {
         Executor bean = InitialContext.doLookup("java:global/otherApp/ejb2/SecondBean!java.util.concurrent.Executor");
         bean.execute(() -> {
             try {
-                System.out.println("EJB2 loads: " + Class.forName("loginmod.LoadFromAppLoginModule"));
                 DataSource ds = (DataSource) InitialContext.doLookup("java:comp/env/jdbc/dsref");
                 try (Connection con = ds.getConnection()) {
                     DatabaseMetaData mdata = con.getMetaData();
                     String userName = mdata.getUserName();
-                    assertEquals("APP", userName); // this will start failing if login module gets used. "APP" is the default Derby user, not a user from a login module
+                    assertEquals("ejb2user", userName);
                 }
             } catch (RuntimeException x) {
                 throw x;

--- a/dev/com.ibm.ws.security.client/bnd.bnd
+++ b/dev/com.ibm.ws.security.client/bnd.bnd
@@ -51,6 +51,7 @@ instrument.classesExcludes: com/ibm/ws/security/client/internal/resources/*.clas
 	com.ibm.ws.security.authentication;version=latest,\
 	com.ibm.ws.security.credentials;version=latest,\
 	com.ibm.ws.security.jaas.common;version=latest,\
+	com.ibm.ws.adaptable.module;version=latest,\
 	com.ibm.ws.classloading;version=latest,\
 	com.ibm.ws.clientcontainer;version=latest,\
 	com.ibm.ws.logging;version=latest, \

--- a/dev/com.ibm.ws.security.jaas.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.jaas.common/bnd.bnd
@@ -74,6 +74,7 @@ instrument.classesExcludes: com/ibm/ws/security/jaas/common/internal/resources/*
 	com.ibm.websphere.security;version=latest,\
 	com.ibm.ws.security.authentication;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
+	com.ibm.ws.adaptable.module;version=latest,\
 	com.ibm.ws.common.encoder,\
 	com.ibm.ws.bnd.annotations;version=latest,\
 	com.ibm.ws.classloading;version=latest,\

--- a/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/common/internal/JAASLoginModuleConfigImpl.java
+++ b/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/common/internal/JAASLoginModuleConfigImpl.java
@@ -114,6 +114,15 @@ public class JAASLoginModuleConfigImpl implements JAASLoginModuleConfig {
             Class<?> cl = getTargetClassForName(target);
             options.put(LoginModuleProxy.KERNEL_DELEGATE, cl);
         } else {
+            if (sharedLibrary == null && classProviderAppInfo == null) // nowhere to load the login module class from
+                throw new IllegalArgumentException(Tr.formatMessage(tc, "CWWKS1147_JAAS_CUSTOM_LOGIN_MODULE_CP_LIB_MISSING",
+                                                                    originalLoginModuleClassName,
+                                                                    props.get("config.displayId")));
+            else if (sharedLibrary != null && classProviderAppInfo != null) // conflicting locations to load from
+                throw new IllegalArgumentException(Tr.formatMessage(tc, "CWWKS1146_JAAS_CUSTOM_LOGIN_MODULE_CP_LIB_CONFLICT",
+                                                                    originalLoginModuleClassName,
+                                                                    props.get("config.displayId")));
+
             options = processDelegateOptions(options, originalLoginModuleClassName, classProviderAppInfo, classLoadingService, sharedLibrary, false);
         }
         this.options = options;
@@ -294,13 +303,14 @@ public class JAASLoginModuleConfigImpl implements JAASLoginModuleConfig {
         return options;
     }
 
+    /** Required if classProviderRef is configured, in which case it will be called before activate */
     @Reference(cardinality = ReferenceCardinality.OPTIONAL)
     protected void setClassProvider(ApplicationInfo classProviderAppInfo) {
         this.classProviderAppInfo = classProviderAppInfo;
     }
 
-    /** Set required service, will be called before activate */
-    @Reference
+    /** Required if libraryRef is configured, in which case it will be called before activate */
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL)
     protected void setSharedLib(Library svc) {
         sharedLibrary = svc;
     }

--- a/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/common/internal/ModuleConfig.java
+++ b/dev/com.ibm.ws.security.jaas.common/src/com/ibm/ws/security/jaas/common/internal/ModuleConfig.java
@@ -26,8 +26,8 @@ public @interface ModuleConfig {
     @AttributeDefinition(name = "%className", description = "%className.desc")
     String className();
 
-    // TODO translatable name, description, and make into ibm:beta="true" before GA?
-    @AttributeDefinition(name = Ext.INTERNAL, description = Ext.INTERNAL_DESC, required = false)
+    @AttributeDefinition(name = "%classProviderRef", description = "%classProviderRef.desc", required = false)
+    @Ext.Beta // TODO remove once it is time to GA this attribute
     @Ext.ReferencePid("com.ibm.ws.app.manager")
     String classProviderRef();
 
@@ -46,9 +46,13 @@ public @interface ModuleConfig {
                                @Option(value = "OPTIONAL", label = "%controlFlag.OPTIONAL") })
     String controlFlag();
 
-    @AttributeDefinition(name = "%libraryRef", description = "%libraryRef.desc")
+    @AttributeDefinition(name = "%libraryRef", description = "%libraryRef.desc", required = false)
     @Ext.ReferencePid("com.ibm.ws.classloading.sharedlibrary")
     String libraryRef();
+
+    @AttributeDefinition(name = Ext.INTERNAL, description = Ext.INTERNAL_DESC, defaultValue = "${count(libraryRef)}")
+    @Ext.Final
+    String SharedLib_cardinality_minimum();
 
     @AttributeDefinition(name = "internal", description = "internal use only", defaultValue = "(service.pid=${libraryRef})")
     String SharedLib_target();

--- a/dev/com.ibm.ws.security.jaas.common_test/bnd.bnd
+++ b/dev/com.ibm.ws.security.jaas.common_test/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -27,6 +27,7 @@ test.project: true
 	com.ibm.ws.security.authentication;version=latest,\
 	com.ibm.ws.security.authentication.builtin;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
+	com.ibm.ws.adaptable.module;version=latest,\
 	com.ibm.ws.common.encoder,\
 	com.ibm.ws.bnd.annotations;version=latest,\
 	com.ibm.ws.classloading;version=latest,\

--- a/dev/com.ibm.ws.security.jaas.common_test/test/com/ibm/ws/security/jaas/common/internal/JAASLoginModuleConfigImplTestWithMock.java
+++ b/dev/com.ibm.ws.security.jaas.common_test/test/com/ibm/ws/security/jaas/common/internal/JAASLoginModuleConfigImplTestWithMock.java
@@ -205,6 +205,7 @@ public class JAASLoginModuleConfigImplTestWithMock {
         ModuleConfig moduleConfig = moduleConfig();
 
         JAASLoginModuleConfigImpl jaasLoginModuleConfig = new JAASLoginModuleConfigImpl();
+        jaasLoginModuleConfig.setSharedLib(sharedLibrary);
         jaasLoginModuleConfig.activate(moduleConfig, orops);
 
         assertEquals("Should have two options", 2, jaasLoginModuleConfig.getOptions().size());

--- a/dev/com.ibm.ws.security.jaas.common_test/test/com/ibm/ws/security/jaas/common/internal/JAASLoginModuleConfigImplTestWithMock.java
+++ b/dev/com.ibm.ws.security.jaas.common_test/test/com/ibm/ws/security/jaas/common/internal/JAASLoginModuleConfigImplTestWithMock.java
@@ -137,6 +137,10 @@ public class JAASLoginModuleConfigImplTestWithMock {
                 return null;
             }
 
+            public String SharedLib_cardinality_minimum() {
+                return "1";
+            }
+
             @Override
             public String SharedLib_target() {
                 return null;


### PR DESCRIPTION
Updates to make libraryRef optional and beta the classProviderRef attribute.
Also, I've added a test that loads a system.WEB_INBOUND login module from the app and in which the login module is used independently of JCA/JDBC/JMS code paths.