### PR TITLE
Remove ZipFileReaper contention on open and close.

### DIFF
--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipFileData.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipFileData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.artifact.zip.cache.ZipCachingProperties;
-import com.ibm.wsspi.kernel.service.utils.FileUtils;
+import com.ibm.ws.artifact.zip.internal.FileUtils;
 
 /**
  * Data for tracking a single zip file.
@@ -668,22 +668,59 @@ ZipFile [Path]
 
             @SuppressWarnings("unused")
             ZipFile oldZipFile = closeZipFile();
+
             @SuppressWarnings("unused")
-            ZipFile newZipFile = openZipFile(newZipLength, newZipLastModified); // throws IOException, ZipException
+            ZipFile newZipFile = openZipFile(newZipLength, newZipLastModified);
+            // throws IOException, ZipException
         }
 
         return zipFile;
     }
 
-    private static final long UNKNOWN_ZIP_LENGTH = -1L;
-    private static final long UNUSED_ZIP_LAST_MODIFIED = -1L;
-
+    /**
+     * Open the zip file.  Set the zip file length and last modified values.
+     *
+     * @throws IOException Thrown if the zip file could not be opened, or if the
+     *     zip file length or last modified value could not be obtained.
+     * @throws ZipException Throw if the zip file could not be opened.
+     */
     @Trivial
     protected ZipFile openZipFile() throws IOException, ZipException {
         return openZipFile(ZipFileData.UNKNOWN_ZIP_LENGTH, ZipFileData.UNUSED_ZIP_LAST_MODIFIED);
         // throws IOException, ZipException
     }
 
+    /**
+     * Control parameter: The zip file length is not yet known and must
+     * be obtained from the file system.
+     * 
+     * See {@link #openZipFile(ZipFile, long, long)}.
+     */
+    private static final long UNKNOWN_ZIP_LENGTH = -1L;
+    
+    /**
+     * Control parameter: The zip file last modified value is not yet known and
+     * must be obtained from the file system.
+     * 
+     * See {@link #openZipFile(ZipFile, long, long)}.
+     */
+    private static final long UNUSED_ZIP_LAST_MODIFIED = -1L;
+
+    /**
+     * Open the zip file.  Set the zip file length and last modified values.
+     *
+     * @param useZipLength The length of the zip file.  If set to {@link #UNKNOWN_ZIP_LENGTH},
+     *     the zip file length will be obtained from the file system.
+     * @param useZipLastModified The last modified value of the zip file.  If set
+     *     to {@link #UNKNOWN_ZIP_LAST_MODIFIED}, the last modified value will be obtained
+     *     from the file system.
+     *
+     * @return the zip file which was just opened.
+     *
+     * @throws IOException Thrown if the zip file could not be opened, or if the
+     *     zip file length or last modified value could not be obtained.
+     * @throws ZipException Throw if the zip file could not be opened.
+     */
     @Trivial
     protected ZipFile openZipFile(long useZipLength, long useZipLastModified) throws IOException, ZipException {
         String methodName = "openZipFile";

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipFileReaper.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipFileReaper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,12 +12,19 @@ package com.ibm.ws.artifact.zip.cache.internal;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.HashMap;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 //import java.util.function.Consumer;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
@@ -130,23 +137,25 @@ public class ZipFileReaper {
     }
 
     @Trivial
-    private static String toRelSec(long baseNS, long actualNS) {
-        return ZipCachingProperties.toRelSec(baseNS, actualNS);
+    private static String toRelSec_s(long baseNS, long actualNS) {
+        return ZipCachingProperties.toRelSec(baseNS, actualNS) + " (s)";
     }
 
     @Trivial
-    private static String toAbsSec(long durationNS) {
-        return ZipCachingProperties.toAbsSec(durationNS);
+    private static String toAbsSec_s(long durationNS) {
+        return ZipCachingProperties.toAbsSec(durationNS) + " (s)";
     }
 
     //
 
     @Trivial
     public void validate() {
-        synchronized ( reaperLock ) {
+        synchronized (pendingStorageLock) {
             pendingQuickStorage.validate();
             pendingSlowStorage.validate();
-            if ( !debugState ) {
+        }
+        if ( !debugState ) {
+            synchronized (completedStorage) {
                 completedStorage.validate();
             }
         }
@@ -228,7 +237,7 @@ public class ZipFileReaper {
 
         //
 
-        protected final BlockingQueue<DeferredLogRecord> deferredLogQueue;
+        private final BlockingQueue<DeferredLogRecord> deferredLogQueue;
 
         public void post(String msgKey, Object... msgArgs) {
             try {
@@ -261,7 +270,7 @@ public class ZipFileReaper {
         logThread.start();
     }
 
-    protected static void asyncWarning(final String msgKey, final Object ... msgArgs) {
+    private static void asyncWarning(final String msgKey, final Object ... msgArgs) {
         logEmitter.post(msgKey, msgArgs);
     }
 
@@ -275,11 +284,6 @@ public class ZipFileReaper {
             // These are used only by 'run', but are stored at the
             // instance level to enable view by the introspector.
 
-            this.initialAt = -1;
-
-            this.isFinal = false;
-            this.finalAt = -1;
-
             this.didShutdownReap = false;
             this.shutdownReapAt = -1;
 
@@ -289,11 +293,6 @@ public class ZipFileReaper {
 
             this.startupLatch = new CountDownLatch(1);
         }
-
-        private long initialAt;
-
-        private boolean isFinal;
-        private long finalAt;
 
         private boolean didShutdownReap;
         private long shutdownReapAt;
@@ -305,35 +304,33 @@ public class ZipFileReaper {
 
         private final CountDownLatch startupLatch;
 
-        protected void waitForStartup() throws InterruptedException {
+        void waitForStartup() throws InterruptedException {
             startupLatch.await(); // throws InterruptedException
         }
 
-        protected void signalStartup() {
+        private void signalStartup() {
             startupLatch.countDown();
         }
 
         // Invoked by 'ZipFileReaper.introspect(PrintWriter)'
 
-        protected void introspect(PrintWriter output) {
+        void introspect(PrintWriter output) {
             output.println();
             output.println("  Runner [ " + this + " ]");
 
-            long reaperInitialAt = getReaper().getInitialAt();
-
-            output.println("    Initial       [ " + toRelSec(reaperInitialAt, initialAt) + " (s) ]");
-            if ( isFinal ) {
-                output.println("    Final         [ " + toRelSec(reaperInitialAt, initialAt) + " (s) ]");
+            output.println("    Initial    [ " + toAbsSec_s( reaper.getInitialAt() ) + " ]");
+            if ( reaper.getIsFinal() ) {
+                output.println("    Final      [ " + reaper.fromInitial_s( reaper.getFinalAt() ) + " ]");
             }
 
             if ( didShutdownReap ) {
-                output.println("    Shutdown Reap [ " + toRelSec(reaperInitialAt, shutdownReapAt) + " (s) ]");
+                output.println("    Shutdown   [ " + reaper.fromInitial_s(shutdownReapAt) + " ]");
             }
 
-            output.println("    Last Reap     [ " + toRelSec(reaperInitialAt, lastReapAt) + " (s) ]");
-            output.println("    Next Reap     [ " + toRelSec(reaperInitialAt, nextReapAt) + " (s) ]");
-            String delayText = ( (nextReapDelay < 0) ? "INDEFINITE" : toAbsSec(nextReapDelay) );
-            output.println("    Next Delay    [ " + delayText + " (s) ] (" + nextReapReason + ")");
+            output.println("    Last Reap  [ " + reaper.fromInitial_s(lastReapAt) + " ]");
+            output.println("    Next Reap  [ " + reaper.fromInitial_s(nextReapAt) + " ]");
+            String delayText = ( (nextReapDelay < 0) ? "INDEFINITE" : toAbsSec_s(nextReapDelay) );
+            output.println("    Next Delay [ " + delayText + " ] (" + nextReapReason + ")");
 
             output.println();
             output.println("  Logger [ " + logThread + " ]");
@@ -359,12 +356,12 @@ public class ZipFileReaper {
             String methodName = "run";
             boolean doDebug = ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() );
 
-            long startAt = SystemUtils.getNanoTime();
             if ( doDebug ) {
-                Tr.debug(tc, methodName + " Start [ " + toRelSec(startAt, startAt) + " (s) ]");
+                Tr.debug(tc, methodName + " Start [ " + toAbsSec_s( reaper.getInitialAt() ) + " ]");
             }
 
-            synchronized ( reaper.reaperLock ) {
+            reaper.reaperLock.acquireWriteLock();
+            try {
                 // Use this latch to ensure the reaper thread has started
                 // and has acquired the reaper lock before allowing zip file
                 // operations.  That prevents us from having to handle cases where
@@ -386,12 +383,11 @@ public class ZipFileReaper {
                 nextReapDelay = REAP_DELAY_INDEFINITE;
                 reaper.addWaitReason("indefinite (initial)");
 
-                nextReapAt = initialAt;
+                nextReapAt = reaper.getInitialAt();
                 nextReapReason = "indefinite (initial)";
 
                 while ( true ) {
-                    
-                    long lastReapAt = nextReapAt;
+                    lastReapAt = nextReapAt;
 
                     // Condition:
                     // Start an indefinite wait if and only if there are no pending closes.
@@ -400,7 +396,7 @@ public class ZipFileReaper {
 
                     // The reaper delay logic is fragile: Put in these extra checks to guard
                     // against incorrectly putting the reaper in an indefinite wait, since that
-                    // cannoe be recovered.
+                    // cannot be recovered.
 
                     String errorMessage;
 
@@ -455,12 +451,12 @@ public class ZipFileReaper {
                     }
 
                     nextReapAt = SystemUtils.getNanoTime();
-                    
+
                     if ( doDebug ) {
-                        Tr.debug(tc, methodName + " Reap [ " + toRelSec(startAt, nextReapAt) + " (s) ]");
+                        Tr.debug(tc, methodName + " Reap [ " + reaper.fromInitial_s(nextReapAt) + " ]");
                         
                         // Issue #7770 - Remove reaper stall warning - change to debug
-                        // asyncWarning("reaper.stall", toAbsSec(actualDelay), toAbsSec(reapDelay));
+                        // asyncWarning("reaper.stall", toAbsSec_s(actualDelay), toAbsSec_s(reapDelay));
                         
                         String message;
                         long actualReapDelay = nextReapAt - lastReapAt;
@@ -475,8 +471,8 @@ public class ZipFileReaper {
                             message = " Reap cycle time:";
                         }
                         Tr.debug(tc, methodName + message + " Actual delay [ " 
-                                        + toAbsSec(actualReapDelay) + " (s) ]; Requested delay [ " 
-                                        + toAbsSec(nextReapDelay) + " (s) ]");
+                                        + toAbsSec_s(actualReapDelay) + " ]; Requested delay [ " 
+                                        + toAbsSec_s(nextReapDelay) + " ]");
                     }
 
                     ZipFileData ripestPending = reaper.getRipest();
@@ -506,7 +502,7 @@ public class ZipFileReaper {
                         nextReapDelay = pendMax - consumedPend;
                         reaper.addWaitReason("specific (incomplete pend)");
                         if ( doDebug ) {
-                            Tr.debug(tc, methodName + " Ripest [ " + ripestPending.path + " ] waited [ " + toAbsSec(consumedPend) + " (s) ] remaining [ " + toAbsSec(nextReapDelay) + " (s) ]");
+                            Tr.debug(tc, methodName + " Ripest [ " + ripestPending.path + " ] waited [ " + toAbsSec_s(consumedPend) + " ] remaining [ " + toAbsSec_s(nextReapDelay) + " ]");
                         }
 
                     } else {
@@ -514,24 +510,31 @@ public class ZipFileReaper {
                         // other pending closes which are fully ripe, and set the next reap delay
                         // according to the ripest but not fully ripe pending close. 
                         if ( doDebug ) {
-                            Tr.debug(tc, methodName + " Ripest [ " + ripestPending.path + " ] waited [ " + toAbsSec(consumedPend) + " (s) ]");
+                            Tr.debug(tc, methodName + " Ripest [ " + ripestPending.path + " ] waited [ " + toAbsSec_s(consumedPend) + " ]");
                         }
 
                         nextReapDelay = reaper.reap(nextReapAt, ZipFileReaper.IS_NOT_SHUTDOWN_REAP);
                         reaper.addWaitReason("specific (reap)");
                     }
                 }
+            } finally {
+                reaper.reaperLock.releaseWriteLock();
             }
 
             long shutdownAt = SystemUtils.getNanoTime();
             if ( doDebug ) {
-                Tr.debug(tc, methodName + " Shutting down [ " + toRelSec(startAt, shutdownAt) + " (s) ]");
+                Tr.debug(tc, methodName + " Shutting down [ " + reaper.fromInitial_s(shutdownAt) + " ]");
             }
-            reaper.reap(shutdownAt, ZipFileReaper.IS_SHUTDOWN_REAP); // Maybe, move this to the shutdown thread.
+            reaper.reaperLock.acquireWriteLock();
+            try {
+                reaper.reap(shutdownAt, ZipFileReaper.IS_SHUTDOWN_REAP); // Maybe, move this to the shutdown thread.
+            } finally {
+                reaper.reaperLock.releaseWriteLock();
+            }
 
             long stopAt = SystemUtils.getNanoTime();
             if ( doDebug ) {
-                Tr.debug(tc, methodName + " Stop [ " + toRelSec(startAt, stopAt) + " (s) ]");
+                Tr.debug(tc, methodName + " Stop [ " + reaper.fromInitial_s(stopAt) + " ]");
             }
         }
     }
@@ -545,17 +548,18 @@ public class ZipFileReaper {
 
     @Trivial
     public ZipFileReaper(String reaperName, long initialAt) {
-        this(reaperName,
-             ZipCachingProperties.ZIP_REAPER_DEBUG_STATE,
-             ZipCachingProperties.ZIP_CACHE_REAPER_MAX_PENDING,
-             ZipCachingProperties.ZIP_CACHE_REAPER_QUICK_PEND_MIN,
-             ZipCachingProperties.ZIP_CACHE_REAPER_QUICK_PEND_MIN,
-             ZipCachingProperties.ZIP_CACHE_REAPER_SLOW_PEND_MAX,
-             ZipCachingProperties.ZIP_CACHE_REAPER_SLOW_PEND_MAX,
-             NULL_ERROR_HANDLER);
+        this( reaperName,
+              ZipCachingProperties.ZIP_REAPER_DEBUG_STATE,
+              ZipCachingProperties.ZIP_CACHE_REAPER_MAX_PENDING,
+              ZipCachingProperties.ZIP_CACHE_REAPER_QUICK_PEND_MIN,
+              ZipCachingProperties.ZIP_CACHE_REAPER_QUICK_PEND_MIN,
+              ZipCachingProperties.ZIP_CACHE_REAPER_SLOW_PEND_MAX,
+              ZipCachingProperties.ZIP_CACHE_REAPER_SLOW_PEND_MAX,
+              NULL_ERROR_HANDLER,
+              initialAt );
     }
 
-    protected static final ErrorConsumer<String> NULL_ERROR_HANDLER = null;
+    private static final ErrorConsumer<String> NULL_ERROR_HANDLER = null;
 
     @Trivial
     public ZipFileReaper(
@@ -566,35 +570,27 @@ public class ZipFileReaper {
         long slowPendMin, long slowPendMax,
         ErrorConsumer<String> errorHandler) {
 
-        this(reaperName,
-             debugState,
-             maxCache,
-             quickPendMin, quickPendMax,
-             slowPendMin, slowPendMax,
-             errorHandler,
-             SystemUtils.getNanoTime() );
+        this( reaperName, debugState,
+              maxCache,
+              quickPendMin, quickPendMax,
+              slowPendMin, slowPendMax,
+              errorHandler,
+              SystemUtils.getNanoTime() );
     }
 
     @Trivial
     public ZipFileReaper(
-        String reaperName,
-        boolean debugState,
+        String reaperName, boolean debugState,
         int maxCache,
-        long quickPendMin,
-        long quickPendMax,
-        long slowPendMin,
-        long slowPendMax
-    ) {
-        this(
-            reaperName,
-            debugState,
-            maxCache,
-            quickPendMin,
-            quickPendMax,
-            slowPendMin,
-            slowPendMax,
-            ZipFileReaper.NULL_ERROR_HANDLER
-        );
+        long quickPendMin, long quickPendMax,
+        long slowPendMin, long slowPendMax) {
+
+        this( reaperName, debugState,
+              maxCache,
+              quickPendMin, quickPendMax,
+              slowPendMin, slowPendMax,
+              ZipFileReaper.NULL_ERROR_HANDLER,
+              SystemUtils.getNanoTime() );
     }
 
     private static void validate(
@@ -658,7 +654,7 @@ public class ZipFileReaper {
 
         this.reaperName = reaperName;
         this.debugState = debugState;
-        
+
         this.maxCache = maxCache;
 
         this.quickPendMin = quickPendMin;
@@ -669,7 +665,7 @@ public class ZipFileReaper {
 
         // Storage ...
 
-        this.storage = new HashMap<String, ZipFileData>();
+        this.storage = new ConcurrentHashMap<String, ZipFileData>();
         this.pendingQuickStorage = new ZipFileDataStore("pendingQuick");
         this.pendingSlowStorage = new ZipFileDataStore("pendingSlow");
         
@@ -859,6 +855,11 @@ public class ZipFileReaper {
     private final long initialAt;
 
     /**
+     * Setting of whether the reaper has been shut down.
+     */
+    private boolean isFinal;
+
+    /**
      * Setting of when the reaper was shutdown.
      * Used when displaying zip file statistics.
      */
@@ -870,49 +871,121 @@ public class ZipFileReaper {
     }
 
     @Trivial
+    public boolean getIsFinal() {
+        return isFinal;
+    }
+
+    @Trivial
     public long getFinalAt() {
         return finalAt;
     }
 
-    @Trivial
     private void setFinalAt(long finalAt) {
+        this.isFinal = true;
         this.finalAt = finalAt;
+    }
+
+    @Trivial
+    private String fromInitial_s(long actualNS) {
+        return toRelSec_s( getInitialAt(), actualNS);
     }
 
     //
 
-    private final Map<String, ZipFileData> storage;
+    private final ConcurrentMap<String, ZipFileData> storage;
 
     private final ZipFileDataStore pendingQuickStorage;
     private final ZipFileDataStore pendingSlowStorage;
+    private final Object pendingStorageLock = new Integer(0);
 
     private final ZipFileDataStore completedStorage;
 
     //
 
-    public ZipFileData.ZipFileState getState(String path) {
-        synchronized ( reaperLock ) {
-            ZipFileData data = storage.get(path);
-            if ( data == null ) {
-                if ( !debugState ) {
-                    data = completedStorage.get(path);
-                }
-            }
-            return ( (data == null) ? null : data.zipFileState );
+    private static final class ZipFilePathLock { }
+
+    static ReferenceQueue<ZipFilePathLock> refQueue = new ReferenceQueue<>();
+    private static ConcurrentHashMap<String, ZipFilePathLockRef> zipFilePathLockMap = new ConcurrentHashMap<>();
+
+    private static final class ZipFilePathLockRef extends WeakReference<ZipFilePathLock> {
+        final String  key;
+        @Trivial
+        public ZipFilePathLockRef(ZipFilePathLock referent, String keyValue) {
+                super(referent, refQueue);
+                key = keyValue;
         }
     }
 
-    protected ZipFileData getRipest() {
+    @Trivial
+    private final ZipFilePathLock getLockForPath(String path) {
+        poll();
+        ZipFilePathLockRef lockRef = zipFilePathLockMap.get(path);
+        ZipFilePathLock lock = lockRef != null ? lockRef.get() : null;
+        if (lock != null) {
+            return lock;
+        }
+
+        lock = new ZipFilePathLock();
+
+        while (true) {
+            ZipFilePathLockRef retVal = zipFilePathLockMap.putIfAbsent(path, new ZipFilePathLockRef(lock, path));
+            if (retVal == null) {
+                return lock;
+            }
+
+            ZipFilePathLock retLock = retVal.get();
+            if (retLock != null) {
+                return retLock;
+            }
+            zipFilePathLockMap.remove(path, retVal);
+        }
+    }
+
+    @Trivial
+    private final void poll() {
+        ZipFilePathLockRef lockRef;
+        while ((lockRef = (ZipFilePathLockRef) refQueue.poll()) != null) {
+            zipFilePathLockMap.remove(lockRef.key, lockRef);
+        }
+    }
+    
+    public ZipFileData.ZipFileState getState(String path) {
+        reaperLock.acquireReadLock();
+        try {
+            ZipFilePathLock lock = getLockForPath(path);
+            synchronized (lock) {
+                ZipFileData data = storage.get(path);
+                if ( data == null ) {
+                    if ( !debugState ) {
+                        synchronized (completedStorage) {
+                            data = completedStorage.get(path);
+                        }
+                    }
+                }
+                return ( (data == null) ? null : data.zipFileState );
+            }
+        } finally {
+            reaperLock.releaseReadLock();
+        }
+    }
+
+    ZipFileData getRipest() {
+        ZipFileData ripestQuick;
+        ZipFileData ripestSlow;
+
+        synchronized (pendingStorageLock) {
+            ripestQuick = pendingQuickStorage.getFirst();
+            ripestSlow = pendingSlowStorage.getFirst();
+        }
+
         ZipFileData ripest;
-        if ( pendingQuickStorage.isEmpty() ) {
-            ripest = pendingSlowStorage.getFirst();
-        } else if ( pendingSlowStorage.isEmpty() ) {
-            ripest = pendingQuickStorage.getFirst();
+        if (ripestQuick == null) {
+            ripest = ripestSlow;
+        } else if (ripestSlow == null) {
+            ripest = ripestQuick;
         } else {
-            ZipFileData ripestQuick = pendingQuickStorage.getFirst();
             long expireAtQuick = ripestQuick.lastPendAt + quickPendMin;
 
-            ZipFileData ripestSlow = pendingSlowStorage.getFirst();
             long expireAtSlow = ripestSlow.lastPendAt + slowPendMin;
 
             if ( expireAtQuick <= expireAtSlow ) {
@@ -924,10 +997,10 @@ public class ZipFileReaper {
         return ripest;
     }
 
-    protected void fullyClose(ZipFileData data, long fullCloseAt, boolean isShutdown) {
+    private void fullyClose(ZipFileData data, long fullCloseAt, boolean isShutdown) {
         String methodName = "fullyClose";
         if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
-            Tr.debug(tc, methodName + " Path [ " + data.path + " ] at [ " + toRelSec(initialAt, fullCloseAt) + " (s) ]");
+            Tr.debug(tc, methodName + " Path [ " + data.path + " ] at [ " + fromInitial_s(fullCloseAt) + " ]");
         }
 
         data.closeZipFile();
@@ -937,8 +1010,11 @@ public class ZipFileReaper {
             @SuppressWarnings("unused") // Same as 'data'
             ZipFileData fullyClosedData = storage.remove(data.path);
 
-            ZipFileData oldestCompletedClose =
-                completedStorage.addLast( data, getMaxCache() );
+            ZipFileData oldestCompletedClose;
+            synchronized (completedStorage) {
+                oldestCompletedClose =
+                    completedStorage.addLast( data, getMaxCache() );
+            }
             if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
                 if ( oldestCompletedClose != null ) {
                     Tr.debug(tc, methodName + " Discard completed close [ " + oldestCompletedClose.path + " ]");
@@ -975,7 +1051,7 @@ public class ZipFileReaper {
         return reaperThread;
     }
 
-    protected void introspectReaperThread(PrintWriter output) {
+    private void introspectReaperThread(PrintWriter output) {
         output.println();
         output.println("  Reaper [ " + reaperThread + " ]");
         output.println("    Id          [ " + reaperThread.getId() + " ]"); 
@@ -1026,7 +1102,7 @@ public class ZipFileReaper {
 
     //
 
-    public static final int NUM_REASONS = 10;
+    static final int NUM_REASONS = 10;
 
     private static class Reasons {
         private final String description;
@@ -1040,46 +1116,52 @@ public class ZipFileReaper {
         }
 
         public void add(String reason) {
-            reasons[nextReason] = reason;
-            if ( nextReason == NUM_REASONS - 1 ) {
-                nextReason = 0;
-            } else {
-                nextReason = nextReason + 1;
+            synchronized (reasons) {
+                reasons[nextReason] = reason;
+                if ( nextReason == NUM_REASONS - 1 ) {
+                    nextReason = 0;
+                } else {
+                    nextReason = nextReason + 1;
+                }
             }
         }
 
         public void introspect(PrintWriter printWriter) {
             printWriter.println(description + ": ");
 
-            int lastReason = ( (nextReason == 0) ? (NUM_REASONS - 1) : (nextReason - 1) );
-            if ( reasons[lastReason] == null ) {
-                printWriter.println("  *** NONE ***");
-            } else {
-                for ( int reasonNo = 0; reasonNo > -NUM_REASONS; reasonNo-- ) {
-                    int actualReasonNo = nextReason + reasonNo - 1;
-                    if ( actualReasonNo < 0 ) {
-                        actualReasonNo += NUM_REASONS;
-                    }
+            synchronized(reasons)  {
+                int lastReason = ( (nextReason == 0) ? (NUM_REASONS - 1) : (nextReason - 1) );
+                if ( reasons[lastReason] == null ) {
+                    printWriter.println("  *** NONE ***");
+                } else {
+                    for ( int reasonNo = 0; reasonNo > -NUM_REASONS; reasonNo-- ) {
+                        int actualReasonNo = nextReason + reasonNo - 1;
+                        if ( actualReasonNo < 0 ) {
+                            actualReasonNo += NUM_REASONS;
+                        }
 
-                    String reason = reasons[actualReasonNo];
-                    if ( reason == null ) {
-                        break;
-                    }
+                        String reason = reasons[actualReasonNo];
+                        if ( reason == null ) {
+                            break;
+                        }
 
-                    printWriter.println("  [ " + reasonNo + " ] [ " + reasons[actualReasonNo] + " ]");
+                        printWriter.println("  [ " + reasonNo + " ] [ " + reasons[actualReasonNo] + " ]");
+                    }
                 }
             }
         }
     }
 
-    private Reasons waitReasons;
+    private final Reasons waitReasons;
 
-    protected void addWaitReason(String reason) {
+    void addWaitReason(String reason) {
         waitReasons.add(reason);
     }
 
     private static class ReaperLock {
-        Reasons lockReasons;
+        final ReadWriteLock rwLock = new ReentrantReadWriteLock();
+        final Condition condition = rwLock.writeLock().newCondition();
+        final Reasons lockReasons;
 
         public ReaperLock() {
             this.lockReasons = new Reasons("Reaper Lock Activity");
@@ -1101,28 +1183,53 @@ public class ZipFileReaper {
             }
         }
 
-        public void notify(String methodName, String text) {
+        @Trivial
+        void acquireWriteLock() {
+            rwLock.writeLock().lock();
+        }
+
+        @Trivial
+        void releaseWriteLock() {
+            rwLock.writeLock().unlock();
+        }
+
+        @Trivial
+        void acquireReadLock() {
+            rwLock.readLock().lock();
+        }
+
+        @Trivial
+        void releaseReadLock() {
+            rwLock.readLock().unlock();
+        }
+
+        void notify(String methodName, String text) {
             addReason(text);
 
             if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
                 Tr.debug(tc, methodName + " " + text);
             }
-            notify();
+            rwLock.writeLock().lock();
+            try {
+                condition.signal();
+            } finally {
+                rwLock.writeLock().unlock();
+            }
         }
 
-        public void wait(String methodName, String text) throws InterruptedException {
+        void wait(String methodName, String text) throws InterruptedException {
             addReason(text);
 
             if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
                 Tr.debug(tc, methodName + " Waiting for [ " + text + " ]");
             }
-            wait(); // throws InterruptedException
+            condition.await();  // throws InterruptedException
             if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
                 Tr.debug(tc, methodName + " Waited for [ " + text + " ]");
             }
         }
 
-        public void waitNS(long waitNs, String methodName, String text) throws InterruptedException {
+        void waitNS(long waitNs, String methodName, String text) throws InterruptedException {
             addReason(text);
 
             long waitMs = waitNs / ZipCachingProperties.NANO_IN_MILLI;
@@ -1140,7 +1247,7 @@ public class ZipFileReaper {
                 throw new IllegalArgumentException(methodName + ": Invalid zero wait request for [ " + text + " ]");
             }
 
-            wait(waitMs, fracWaitNs); // throws InterruptedException
+            condition.await(waitNs, TimeUnit.NANOSECONDS); // throws InterruptedException
 
             if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
                 Tr.debug(tc, methodName +
@@ -1211,112 +1318,115 @@ public class ZipFileReaper {
      *
      * @return The next reap time.  -1 if there are no pending closes.
      */
-    private long reap(long reapAt, boolean isShutdownReap) {
+    long reap(long reapAt, boolean isShutdownReap) {
         String methodName = "reap";
-        if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
-            Tr.debug(tc, methodName + " At [ " + toRelSec(initialAt, reapAt) + " (s) ] Force [ " + isShutdownReap + " ]");
-            Tr.debug(tc, methodName +
-                " All [ " + storage.size() + " ]" +
-                " Pending Quick [ " + pendingQuickStorage.size() + " ]" +
-                " Pending Slow [ " + pendingSlowStorage.size() + " ]");
-        }
-
-        // Reap the quick pending closes ...
-
         long nextQuickReapDelay = REAP_DELAY_INDEFINITE;
-        Iterator<ZipFileData> pendingQuick = pendingQuickStorage.values();
-        while ( (nextQuickReapDelay == REAP_DELAY_INDEFINITE) && pendingQuick.hasNext() ) {
-            ZipFileData nextPending = pendingQuick.next();
+        long nextSlowReapDelay = REAP_DELAY_INDEFINITE;
 
-            long nextLastPendAt = nextPending.lastPendAt;
-            long nextPendDuration = reapAt - nextLastPendAt;
+        synchronized (pendingStorageLock) {
+            if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+                Tr.debug(tc, methodName + " At [ " + fromInitial_s(reapAt) + " ] Force [ " + isShutdownReap + " ]");
+                Tr.debug(tc, methodName +
+                    " All [ " + storage.size() + " ]" +
+                    " Pending Quick [ " + pendingQuickStorage.size() + " ]" +
+                    " Pending Slow [ " + pendingSlowStorage.size() + " ]");
+            }
 
-            if ( isShutdownReap ) {
-                // Shutdown closes all pending, regardless of how long they have waited.
+            // Reap the quick pending closes ...
 
-                if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
-                    Tr.debug(tc, methodName +
-                            " Path [ " + nextPending.path + " ]" +
-                            " Waiting [ " + toAbsSec(nextPendDuration) + " (s) ] (Quick): Forced");
-                }
+            Iterator<ZipFileData> pendingQuick = pendingQuickStorage.values();
+            while ( (nextQuickReapDelay == REAP_DELAY_INDEFINITE) && pendingQuick.hasNext() ) {
+                ZipFileData nextPending = pendingQuick.next();
 
-                pendingQuick.remove();
+                long nextLastPendAt = nextPending.lastPendAt;
+                long nextPendDuration = reapAt - nextLastPendAt;
 
-                fullyClose(nextPending, reapAt, IS_SHUTDOWN_REAP);
+                if ( isShutdownReap ) {
+                    // Shutdown closes all pending, regardless of how long they have waited.
 
-            } else { // Normal reap.
-                if ( nextPendDuration > quickPendMin) { // Reached the shortest expiration?
                     if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
                         Tr.debug(tc, methodName +
-                            " Path [ " + nextPending.path + " ]" +
-                            " Waiting [ " + toAbsSec(nextPendDuration) + " (s) ] (Quick): Expired");
+                                " Path [ " + nextPending.path + " ]" +
+                                " Waiting [ " + toAbsSec_s(nextPendDuration) + " ] (Quick): Forced");
                     }
 
                     pendingQuick.remove();
 
-                    fullyClose(nextPending, reapAt, IS_NOT_SHUTDOWN_REAP);
+                    fullyClose(nextPending, reapAt, IS_SHUTDOWN_REAP);
 
-                } else { // Not yet reached the shorted expiration.
-                    if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
-                        Tr.debug(tc, methodName +
-                            " Path [ " + nextPending.path + " ]" +
-                            " Waiting [ " + toAbsSec(nextPendDuration) + " (s) ]: Still Waiting");
-                    }
+                } else { // Normal reap.
+                    if ( nextPendDuration > quickPendMin) { // Reached the shortest expiration?
+                        if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+                            Tr.debug(tc, methodName +
+                                " Path [ " + nextPending.path + " ]" +
+                                " Waiting [ " + toAbsSec_s(nextPendDuration) + " ] (Quick): Expired");
+                        }
 
-                    if ( nextPendDuration < 0 ) {
-                        nextPendDuration = 0; // Should never happen;
+                        pendingQuick.remove();
+
+                        fullyClose(nextPending, reapAt, IS_NOT_SHUTDOWN_REAP);
+
+                    } else { // Not yet reached the shorted expiration.
+                        if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+                            Tr.debug(tc, methodName +
+                                " Path [ " + nextPending.path + " ]" +
+                                " Waiting [ " + toAbsSec_s(nextPendDuration) + " ]: Still Waiting");
+                        }
+
+                        if ( nextPendDuration < 0 ) {
+                            nextPendDuration = 0; // Should never happen;
+                        }
+                        nextQuickReapDelay = quickPendMax - nextPendDuration;
                     }
-                    nextQuickReapDelay = quickPendMax - nextPendDuration;
                 }
             }
-        }
 
-        // Reap the slow pending closes ...
+            // Reap the slow pending closes ...
 
-        long nextSlowReapDelay = REAP_DELAY_INDEFINITE;
-        Iterator<ZipFileData> pendingSlow = pendingSlowStorage.values();
-        while ( (nextSlowReapDelay == REAP_DELAY_INDEFINITE) && pendingSlow.hasNext() ) {
-            ZipFileData nextPending = pendingSlow.next();
+            Iterator<ZipFileData> pendingSlow = pendingSlowStorage.values();
+            while ( (nextSlowReapDelay == REAP_DELAY_INDEFINITE) && pendingSlow.hasNext() ) {
+                ZipFileData nextPending = pendingSlow.next();
 
-            long nextLastPendAt = nextPending.lastPendAt;
-            long nextPendDuration = reapAt - nextLastPendAt;
+                long nextLastPendAt = nextPending.lastPendAt;
+                long nextPendDuration = reapAt - nextLastPendAt;
 
-            if ( isShutdownReap ) {
-                // Shutdown closes all pending, regardless of how long they have waited.
+                if ( isShutdownReap ) {
+                    // Shutdown closes all pending, regardless of how long they have waited.
 
-                if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
-                    Tr.debug(tc, methodName +
-                            " Path [ " + nextPending.path + " ]" +
-                            " Waiting [ " + toAbsSec(nextPendDuration) + " (s) ] (Slow): Forced");
-                }
-
-                pendingSlow.remove();
-
-                fullyClose(nextPending, reapAt, IS_SHUTDOWN_REAP);
-
-            } else { // Normal reap.
-                if ( nextPendDuration > slowPendMin ) { // Reached the shortest expiration?
                     if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
                         Tr.debug(tc, methodName +
-                            " Path [ " + nextPending.path + " ]" +
-                            " Waiting [ " + toAbsSec(nextPendDuration) + " (s) ] (Slow): Expired");
+                                " Path [ " + nextPending.path + " ]" +
+                                " Waiting [ " + toAbsSec_s(nextPendDuration) + " ] (Slow): Forced");
                     }
 
                     pendingSlow.remove();
 
-                    fullyClose(nextPending, reapAt, IS_NOT_SHUTDOWN_REAP);
+                    fullyClose(nextPending, reapAt, IS_SHUTDOWN_REAP);
 
-                } else { // Not yet reached the shorted expiration.
-                    if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
-                        Tr.debug(tc, methodName +
-                            " Path [ " + nextPending.path + " ]" +
-                            " Waiting [ " + toAbsSec(nextPendDuration) + " (s) ]: Still Waiting");
-                    }
+                } else { // Normal reap.
+                    if ( nextPendDuration > slowPendMin ) { // Reached the shortest expiration?
+                        if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+                            Tr.debug(tc, methodName +
+                                " Path [ " + nextPending.path + " ]" +
+                                " Waiting [ " + toAbsSec_s(nextPendDuration) + " ] (Slow): Expired");
+                        }
 
-                    if ( nextPendDuration < 0 ) {
-                        nextPendDuration = 0; // Should never happen;
+                        pendingSlow.remove();
+
+                        fullyClose(nextPending, reapAt, IS_NOT_SHUTDOWN_REAP);
+
+                    } else { // Not yet reached the shorted expiration.
+                        if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+                            Tr.debug(tc, methodName +
+                                " Path [ " + nextPending.path + " ]" +
+                                " Waiting [ " + toAbsSec_s(nextPendDuration) + " ]: Still Waiting");
+                        }
+
+                        if ( nextPendDuration < 0 ) {
+                            nextPendDuration = 0; // Should never happen;
+                        }
+                        nextSlowReapDelay = slowPendMax - nextPendDuration;
                     }
-                    nextSlowReapDelay = slowPendMax - nextPendDuration;
                 }
             }
         }
@@ -1403,10 +1513,10 @@ public class ZipFileReaper {
 
         if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
             String delayText =
-                ( (nextReapDelay == REAP_DELAY_INDEFINITE) ? "Indefinite" : toAbsSec(nextReapDelay) );
+                ( (nextReapDelay == REAP_DELAY_INDEFINITE) ? "Indefinite" : toAbsSec_s(nextReapDelay) );
             String speedText =
                 ( useQuick ? "Quick" : "Slow" );
-            Tr.debug(tc, methodName + " Next reap [ " + delayText + " (s) ] (" + speedText + ")");
+            Tr.debug(tc, methodName + " Next reap [ " + delayText + " ] (" + speedText + ")");
         }
         return nextReapDelay;
     }
@@ -1420,100 +1530,110 @@ public class ZipFileReaper {
     public ZipFile open(String path, long openAt) throws IOException, ZipException {
         String methodName = "open";
         if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
-            Tr.debug(tc, methodName + " Path [ " + path + " ] at [ " + toRelSec(initialAt, openAt) + " (s) ]");
+            Tr.debug(tc, methodName + " Path [ " + path + " ] at [ " + toRelSec_s(initialAt, openAt) + " ]");
         }
 
         // Open could try to turn off the reaper thread if the last pending close
         // is removed.  Instead, the reaper allowed to run, and is coded to handle
         // that case.
 
-        synchronized ( reaperLock ) {
+        reaperLock.acquireReadLock();
+        try {
             if ( !getIsActive() ) {
                 asyncWarning("reaper.inactive", path, reaperName);
                 // "Cannot open [ " + path + " ]: ZipFile cache [ " + reaperName + " ] is inactive"
                 throw new IOException("Cannot open [ " + path + " ]: ZipFile cache is inactive");
             }
 
-            ZipFileData data = storage.get(path);
-            ZipFile zipFile;
-
-            if ( data == null ) {
-                if ( !debugState ) {
-                    data = completedStorage.remove(path);
-                }
+            ZipFilePathLock lock = getLockForPath(path);
+            synchronized (lock) {
+                ZipFileData data = storage.get(path);
+                ZipFile zipFile;
 
                 if ( data == null ) {
-                    if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
-                        Tr.debug(tc, methodName + " New [ " + path + " ]");
+                    if ( !debugState ) {
+                        synchronized (completedStorage) {
+                            data = completedStorage.remove(path);
+                        }
                     }
-                    data = new ZipFileData( path, getInitialAt() ); // throws IOException, ZipException
-                } else {
-                    if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
-                        Tr.debug(tc, methodName + " Recovered [ " + path + " ]");
+
+                    if ( data == null ) {
+                        if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+                            Tr.debug(tc, methodName + " New [ " + path + " ]");
+                        }
+                        data = new ZipFileData( path, getInitialAt() ); // throws IOException, ZipException
+                    } else {
+                        if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+                            Tr.debug(tc, methodName + " Recovered [ " + path + " ]");
+                        }
                     }
+
+                    storage.put(path, data);
                 }
 
-                storage.put(path, data);
-            }
+                if ( data.isFullyClosed() ) {
+                    if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+                        Tr.debug(tc, methodName + " Open [ " + path + " ]");
+                    }
 
-            if ( data.isFullyClosed() ) {
-                if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
-                    Tr.debug(tc, methodName + " Open [ " + path + " ]");
-                }
+                    zipFile = data.openZipFile(); // throws IOException, ZipException
 
-                zipFile = data.openZipFile(); // throws IOException, ZipException
+                } else if ( data.isPending() ) {
+                    if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+                        Tr.debug(tc, methodName + " Unpend [ " + path + " ]");
+                    }
 
-            } else if ( data.isPending() ) {
-                if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
-                    Tr.debug(tc, methodName + " Unpend [ " + path + " ]");
-                }
+                    synchronized (pendingStorageLock) {
+                        if ( data.expireQuickly ) {
+                            @SuppressWarnings("unused") // same as 'data'
+                            ZipFileData pendingQuickData = pendingQuickStorage.remove(path);
+                        } else {
+                            @SuppressWarnings("unused") // same as 'data'
+                            ZipFileData pendingSlowData = pendingSlowStorage.remove(path);
+                        }
+                        // Removal from pending may result in the next reap
+                        // discovering no expired closes.
+                    }
 
-                if ( data.expireQuickly ) {
-                    @SuppressWarnings("unused") // same as 'data'
-                    ZipFileData pendingQuickData = pendingQuickStorage.remove(path);
+                    try {
+                        zipFile = data.reacquireZipFile(); // throws IOException, ZipException
+
+                    } catch (Exception e) {
+                        // The closeZipFile() or openZipFile() call failed in reacquireZipFile().
+                        // Either way, the proper state should be fully closed.
+                        data.enactFullClose(openAt);
+                        throw e;
+                    }
+
+                } else if ( data.isOpen() ) {
+                    if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+                        Tr.debug(tc, methodName + " Already open [ " + path + " ]");
+                    }
+
+                    try {
+                        zipFile = data.reacquireZipFile(); // throws IOException, ZipException
+
+                    } catch (Exception e) {
+                        // The closeZipFile() or openZipFile() call failed in reacquireZipFile().
+                        // Either way, the proper state should be fully closed.
+                        data.enactClose(openAt, ZipFileData.CLOSE_ALL);
+                        data.enactFullClose( openAt );
+                        throw e;
+                    }
+
                 } else {
-                    @SuppressWarnings("unused") // same as 'data'
-                    ZipFileData pendingSlowData = pendingSlowStorage.remove(path);
-                }
-                // Removal from pending may result in the next reap
-                // discovering no expired closes.
-
-                try {
-                    zipFile = data.reacquireZipFile(); // throws IOException, ZipException
-
-                } catch (Exception e) {
-                    // The closeZipFile() or openZipFile() call failed in reacquireZipFile().
-                    // Either way, the proper state should be fully closed.
-                    data.enactFullClose(openAt);
-                    throw e;
+                    throw data.unknownState();
                 }
 
-            } else if ( data.isOpen() ) {
+                data.enactOpen(openAt);
+
                 if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
-                    Tr.debug(tc, methodName + " Already open [ " + path + " ]");
+                    Tr.debug(tc, methodName + " Path [ " + path + " ] [ " + zipFile + " ]");
                 }
-
-                try {
-                    zipFile = data.reacquireZipFile(); // throws IOException, ZipException
-
-                } catch (Exception e) {
-                    // The closeZipFile() or openZipFile() call failed in reacquireZipFile().
-                    // Either way, the proper state should be fully closed.
-                    data.enactClose(openAt, ZipFileData.CLOSE_ALL);
-                    data.enactFullClose( openAt );
-                    throw e;
-                }
-
-            } else {
-                throw data.unknownState();
+                return zipFile;
             }
-
-            data.enactOpen(openAt);
-
-            if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
-                Tr.debug(tc, methodName + " Path [ " + path + " ] [ " + zipFile + " ]");
-            }
-            return zipFile;
+        } finally {
+            reaperLock.releaseReadLock();
         }
     }
 
@@ -1524,7 +1644,13 @@ public class ZipFileReaper {
     public ZipFileData.ZipFileState close(String path, long closeAt) {
         String methodName = "close";
 
-        synchronized ( reaperLock ) {
+        String wakeReason = null;
+        String skipWakeReason = null;
+        ZipFileData.ZipFileState state = null;
+        ZipFileData ripestPending = null;
+
+        reaperLock.acquireReadLock();
+        try {
             if ( !getIsActive() ) {
                 if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
                     Tr.debug(tc, methodName + " Path [ " + path + " ]: Ignore: Inactive");
@@ -1532,153 +1658,178 @@ public class ZipFileReaper {
                 return null;
             }
 
-            ZipFileData data = storage.get(path);
+            ZipFilePathLock lock = getLockForPath(path);
 
-            if ( data == null ) {
-                asyncWarning("reaper.unregistered.path", path);
-                // "Unregistered [ " + path + " ]: Ignore"
+            synchronized (lock) {
+                ZipFileData data = storage.get(path);
 
-            } else if ( data.isFullyClosed() ) {
-                asyncWarning("reaper.closed.path", path);
-                // "Fully closed [ " + path + " ]: Ignore"
+                if ( data == null ) {
+                    asyncWarning("reaper.unregistered.path", path);
+                    // "Unregistered [ " + path + " ]: Ignore"
 
-            } else if ( data.isPending() ) {
-                asyncWarning("reaper.pending.path", path);
-                // "Pending [ " + path + " ]: No active opens: Ignore"
+                } else if ( data.isFullyClosed() ) {
+                    asyncWarning("reaper.closed.path", path);
+                    // "Fully closed [ " + path + " ]: Ignore"
 
-            } else if ( data.isOpen() ) {
-                if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
-                    Tr.debug(tc, methodName + " Active opens [ " + path + " ] [ " + data.getActiveOpens() + " ]");
-                }
+                } else if ( data.isPending() ) {
+                    asyncWarning("reaper.pending.path", path);
+                    // "Pending [ " + path + " ]: No active opens: Ignore"
 
-                if ( data.enactClose(closeAt, ZipFileData.CLOSE_ONCE) ) {
-                    boolean expireQuickly = data.setExpireQuickly(slowPendMin);
+                } else if ( data.isOpen() ) {
+                    if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+                        Tr.debug(tc, methodName + " Active opens [ " + path + " ] [ " + data.getActiveOpens() + " ]");
+                    }
 
-                    if ( expireQuickly && (quickPendMin == 0) ) {
-                        fullyClose(data, closeAt, IS_NOT_SHUTDOWN_REAP);
+                    if ( data.enactClose(closeAt, ZipFileData.CLOSE_ONCE) ) {
+                        boolean expireQuickly = data.setExpireQuickly(slowPendMin);
 
-                    } else {
-                        boolean wasQuickEmpty = pendingQuickStorage.isEmpty();
-                        boolean wasSlowEmpty = pendingSlowStorage.isEmpty();
+                        if ( expireQuickly && (quickPendMin == 0) ) {
+                            fullyClose(data, closeAt, IS_NOT_SHUTDOWN_REAP);
 
-                        ZipFileData ripestPending;
-                        if ( expireQuickly ) {
-                            // pendingQuickStorage.display();
-                            ripestPending = pendingQuickStorage.addLast(data, getMaxCache());
-                            // pendingQuickStorage.display();
                         } else {
-                            // pendingSlowStorage.display();
-                            ripestPending = pendingSlowStorage.addLast(data, getMaxCache());
-                            // pendingSlowStorage.display();
-                        }
+                            boolean wasQuickEmpty;
+                            boolean wasSlowEmpty;
+                            synchronized (pendingStorageLock) {
+                                wasQuickEmpty = pendingQuickStorage.isEmpty();
+                                wasSlowEmpty = pendingSlowStorage.isEmpty();
 
-                        if ( ripestPending != null ) {
-                            fullyClose(ripestPending, closeAt, IS_NOT_SHUTDOWN_REAP);
-                        }
-
-                        String wakeReason;
-                        String skipWakeReason;
-
-                        if ( wasQuickEmpty && wasSlowEmpty ) {
-                            // The reaper was in an indefinite wait, since there were
-                            // no pending closes.  Since there are now pending closes,
-                            // the reaper must be woken.
-                            //
-                            // The first reap cycle will perform no closes; the first reap
-                            // will find the ripest pending close and set a definite wait
-                            // based on that pending close.
-                            wakeReason = "Added first pending";
-                            skipWakeReason = null;
-
-                        } else if ( expireQuickly ) {
-                            if ( !wasQuickEmpty ) { // expireQuickly && !wasQuickEmpty
-                                // Either:
-                                //
-                                // The reaper is set to a definite wait based on the ripest
-                                // quick pending.
-                                //
-                                // If the new pending is expiring quickly, it is expiring
-                                // after the ripest quick pending.
-                                //
-                                // Either way, the definite wait already set for the reaper
-                                // remains correct.
-                                wakeReason = null; // Added quick while quick are present.
-                                skipWakeReason = "Quick added with other quick";
-                                // wasQuickEmpty ==> !wasSlowEmpty
-
-                            } else { // expireQuickly && wasQuickEmpty && !wasSlowEmpty
-                                // The reaper is set to a definite wait based on the ripest
-                                // slow pending close.
-                                //
-                                // If the new pending was a slow pending, no update to the
-                                // reaper wait would be needed, since the new pending expiration
-                                // would necessarily be after the first slow pending expiration.
-                                //
-                                // But, the new pending is a quick pending, which might expire
-                                // before or after the first slow pending.  The slow pending will
-                                // expire first if it has waited long enough to put its expiration
-                                // before the new quick pending's expiration. 
-                                //
-                                // What should be done is for the new pending to be compared with
-                                // the prior ripest pending, and if the new pending expires sooner,
-                                // to reset the reaper wait time to the new, earlier expiration.
-                                //
-                                // As a simplification, wake the reaper early and allow the reap
-                                // cycle to run.  The reaper will notice that no pending closes
-                                // have expired, and will recompute and set the reaper wait to a
-                                // newly computed definite wait.
-                                //
-                                // The reaper is set to an indefinite wait, because this close
-                                // captured the notification and prevented the reaper from waking
-                                // up for a prior close request.
-
-                                wakeReason = "Added first quick while slow are present";
-                                skipWakeReason = null;
+                                if ( expireQuickly ) {
+                                    // pendingQuickStorage.display();
+                                    ripestPending = pendingQuickStorage.addLast(data, getMaxCache());
+                                    // pendingQuickStorage.display();
+                                } else {
+                                    // pendingSlowStorage.display();
+                                    ripestPending = pendingSlowStorage.addLast(data, getMaxCache());
+                                    // pendingSlowStorage.display();
+                                }
                             }
 
-                        } else { // !expireQuickly
-                            // Since the new pending expires slowly, it must have an expiration which
-                            // is later than the expiration of the ripest pending close.  The definite
-                            // wait already set for the reaper remains correct.
-                            wakeReason = null; // Added slow while quick or slow are present.
-                            skipWakeReason = "slow added with quick or slow";
+                            if ( wasQuickEmpty && wasSlowEmpty ) {
+                                // The reaper was in an indefinite wait, since there were
+                                // no pending closes.  Since there are now pending closes,
+                                // the reaper must be woken.
+                                //
+                                // The first reap cycle will perform no closes; the first reap
+                                // will find the ripest pending close and set a definite wait
+                                // based on that pending close.
+                                wakeReason = "Added first pending";
+                                skipWakeReason = null;
+                             } else if ( expireQuickly ) {
+                                if ( !wasQuickEmpty ) { // expireQuickly && !wasQuickEmpty
+                                    // Either:
+                                    //
+                                    // The reaper is set to a definite wait based on the ripest
+                                    // quick pending.
+                                    //
+                                    // If the new pending is expiring quickly, it is expiring
+                                    // after the ripest quick pending.
+                                    //
+                                    // Either way, the definite wait already set for the reaper
+                                    // remains correct.
+                                    wakeReason = null; // Added quick while quick are present.
+                                    skipWakeReason = "Quick added with other quick";
+                                    // wasQuickEmpty ==> !wasSlowEmpty
+                                 } else { // expireQuickly && wasQuickEmpty && !wasSlowEmpty
+                                    // The reaper is set to a definite wait based on the ripest
+                                    // slow pending close.
+                                    //
+                                    // If the new pending was a slow pending, no update to the
+                                    // reaper wait would be needed, since the new pending expiration
+                                    // would necessarily be after the first slow pending expiration.
+                                    //
+                                    // But, the new pending is a quick pending, which might expire
+                                    // before or after the first slow pending.  The slow pending will
+                                    // expire first if it has waited long enough to put its expiration
+                                    // before the new quick pending's expiration. 
+                                    //
+                                    // What should be done is for the new pending to be compared with
+                                    // the prior ripest pending, and if the new pending expires sooner,
+                                    // to reset the reaper wait time to the new, earlier expiration.
+                                    //
+                                    // As a simplification, wake the reaper early and allow the reap
+                                    // cycle to run.  The reaper will notice that no pending closes
+                                    // have expired, and will recompute and set the reaper wait to a
+                                    // newly computed definite wait.
+                                    //
+                                    // The reaper is set to an indefinite wait, because this close
+                                    // captured the notification and prevented the reaper from waking
+                                    // up for a prior close request.
+                                    wakeReason = "Added first quick while slow are present";
+                                    skipWakeReason = null;
+                                }
+                             } else { // !expireQuickly
+                                // Since the new pending expires slowly, it must have an expiration which
+                                // is later than the expiration of the ripest pending close.  The definite
+                                // wait already set for the reaper remains correct.
+                                wakeReason = null; // Added slow while quick or slow are present.
+                                skipWakeReason = "slow added with quick or slow";
+                            }
                         }
-
-                        // CAUTION CAUTION CAUTION CAUTION
-                        //
-                        // This notification does not ensure that reap() is continued
-                        // before any other reaper operation is performed.  This notification
-                        // simply unblocks the reap() thread and puts it in the pool of threads
-                        // available to be run.  This has a strong implication on how 'reap()'
-                        // must work.
-                        //
-                        // CAUTION CAUTION CAUTION CAUTION
-
-                        if ( wakeReason != null ) {
-                            reaperLock.notify(methodName, wakeReason);
-                        } else {
-                            reaperLock.skipNotify(methodName, skipWakeReason);
+                    }
+                } else {
+                    throw data.unknownState();
+                }
+                state = data == null ? null : data.zipFileState;
+            }
+            // After we release the reader lock on the current zip file to prevent a dead lock, 
+            // remove the ripestPending if it is still pending closure and not re-added to 
+            // the data structures.
+            if ( ripestPending != null ) {
+                String ripestPath = ripestPending.path;
+                ZipFilePathLock lock2 = getLockForPath(ripestPath);
+                synchronized (lock2) {
+                    // need to check if the data was removed or if the zip file was re-opened
+                    // while we were waiting for the lock.
+                    ZipFileData checkData = storage.get(ripestPath);
+                    if (checkData == ripestPending && checkData.isPending()) {
+                        // verify that the ZipFileData was not added back into pending storage
+                        ZipFileData pendingCheckData;
+                        synchronized (pendingStorageLock) {
+                            if ( checkData.expireQuickly ) {
+                                pendingCheckData = pendingQuickStorage.get(ripestPath);
+                            } else {
+                                pendingCheckData = pendingSlowStorage.get(ripestPath);
+                            }
+                        }
+                        if (pendingCheckData == null) {
+                            fullyClose(ripestPending, closeAt, IS_NOT_SHUTDOWN_REAP);
                         }
                     }
                 }
-
-            } else {
-                throw data.unknownState();
             }
-            
-            return ( (data == null) ? null : data.zipFileState );
+        } finally {
+            reaperLock.releaseReadLock();
         }
+
+        // CAUTION CAUTION CAUTION CAUTION
+        //
+        // This notification does not ensure that reap() is continued
+        // before any other reaper operation is performed.  This notification
+        // simply unblocks the reap() thread and puts it in the pool of threads
+        // available to be run.  This has a strong implication on how 'reap()'
+        // must work.
+        //
+        // CAUTION CAUTION CAUTION CAUTION
+
+        if ( wakeReason != null ) {
+            reaperLock.notify(methodName, wakeReason);
+        } else if (skipWakeReason != null){
+            reaperLock.skipNotify(methodName, skipWakeReason);
+        }
+        
+        return state;
     }
 
     //
 
     public void introspect(PrintWriter output, long introspectAt) {
-        synchronized ( reaperLock ) {
+        reaperLock.acquireReadLock();
+        try {
             output.println();
             output.println("  IsActive [ " + Boolean.valueOf(isActive) + " ]");
-            output.println("  Initial  [ " + toAbsSec(initialAt) + " (s) ]" );
-            output.println("  Final    [ " + toAbsSec(finalAt) + " (s) ]");
-            output.println("  Current  [ " + toAbsSec(introspectAt) + " (s) ]");
+            output.println("  Initial  [ " + toAbsSec_s(initialAt) + " ]" );
+            output.println("  Final    [ " + toAbsSec_s(finalAt) + " ]");
+            output.println("  Current  [ " + toAbsSec_s(introspectAt) + " ]");
 
             introspectReaperThread(output);
 
@@ -1689,20 +1840,27 @@ public class ZipFileReaper {
             } else {
                 for ( Map.Entry<String, ZipFileData> reaperEntry : storage.entrySet() ) {
                     output.println();
-                    reaperEntry.getValue().introspect(output, introspectAt);
+                    synchronized (getLockForPath(reaperEntry.getKey())) {
+                        reaperEntry.getValue().introspect(output, introspectAt);
+                    }
                 }
             }
 
-            pendingQuickStorage.introspect(output, ZipFileDataStore.DISPLAY_SPARSELY, introspectAt);
-            pendingSlowStorage.introspect(output, ZipFileDataStore.DISPLAY_SPARSELY, introspectAt);
+            synchronized (pendingStorageLock) {
+                pendingQuickStorage.introspect(output, ZipFileDataStore.DISPLAY_SPARSELY, introspectAt);
+                pendingSlowStorage.introspect(output, ZipFileDataStore.DISPLAY_SPARSELY, introspectAt);
+            }
 
             if ( completedStorage == null ) {
                 output.println();
                 output.println("Completed zip file data is not being tracked");
             } else {
-                completedStorage.introspect(output, ZipFileDataStore.DISPLAY_FULLY, introspectAt);
+                synchronized (completedStorage) {
+                    completedStorage.introspect(output, ZipFileDataStore.DISPLAY_FULLY, introspectAt);
+                }
             }
+        } finally {
+            reaperLock.releaseReadLock();
         }
     }
 }
-

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/FileUtils.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/FileUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -58,7 +58,7 @@ public class FileUtils {
         }
     }
 
-    public static synchronized boolean fileExists(final File target) {
+    public static boolean fileExists(final File target) {
         Object token = ThreadIdentityManager.runAsServer();
         try {
             return AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
@@ -212,7 +212,7 @@ public class FileUtils {
         }
     }
 
-    public static synchronized boolean fileMkDirs(final File target) {
+    public static boolean fileMkDirs(final File target) {
         Object token = ThreadIdentityManager.runAsServer();
         try {
             return AccessController.doPrivileged(new PrivilegedAction<Boolean>() {

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/wsspi/kernel/service/utils/FileUtils.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/wsspi/kernel/service/utils/FileUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -78,7 +78,7 @@ public class FileUtils {
      * @param target
      * @return
      */
-    public static synchronized boolean fileExists(final File target) {
+    public static boolean fileExists(final File target) {
         Object token = ThreadIdentityManager.runAsServer();
         try {
             return AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
@@ -274,7 +274,7 @@ public class FileUtils {
      * @param target The tarket to make a directory for
      * @return <code>true</code> if this succeeded.
      */
-    public static synchronized boolean fileMkDirs(final File target) {
+    public static boolean fileMkDirs(final File target) {
         Object token = ThreadIdentityManager.runAsServer();
         try {
             return AccessController.doPrivileged(new PrivilegedAction<Boolean>() {


### PR DESCRIPTION
- Change to use read lock for open and close with a per zip lock protecting each zip file individually.
- Use a write lock still for the reaper thread so that things are blocked from opening and closing while the reaper is running.
- Remove synchronized from FileUtils methods that are not needed.  Not having contention in ZipFileReaper caused the next contention point to show up from this unnecessary synchronization.

Fixes #10649