### PR TITLE
test unshared autocommit connection across servlet requests

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_v43/fat/src/com/ibm/ws/jdbc/fat/v43/JDBC43Test.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/fat/src/com/ibm/ws/jdbc/fat/v43/JDBC43Test.java
@@ -84,4 +84,20 @@ public class JDBC43Test extends FATServletClient {
         runTest(server, "app43/JDBC43TestServlet", "testCompletionStageCachesUnsharedAutocommitConnectionAcrossServletBoundaryPart1");
         runTest(server, "app43/JDBC43TestServlet", "testCompletionStageCachesUnsharedAutocommitConnectionAcrossServletBoundaryPart2");
     }
+
+    /**
+     * testCompletionStageCachesUnsharedManualCommitConnectionAcrossServletBoundary - obtains an unshared connection in
+     * one servlet method and uses it, but does not commit it or close it, instead allowing it to continue to execution
+     * operations under the same transaction asynchronously via a completion stage, which ultimately commits the transaction
+     * if successful and closes the connection. After the servlet method ends and goes out of scope, invokes a second servlet method,
+     * which under a new scope, accesses the completion stage, joins it, and checks that the operations executed successfully.
+     * This behavior is currently possible without the HandleList implementation in place to prevent it.
+     * Although we do not recommend this pattern, some users might be relying upon it, and there needs to be a way
+     * to avoid breaking these users when HandleList is put in place to clean up connections when requests go out of scope.
+     */
+    @Test
+    public void testCompletionStageCachesUnsharedManualCommitConnectionAcrossServletBoundary() throws Exception {
+        runTest(server, "app43/JDBC43TestServlet", "testCompletionStageCachesUnsharedManualCommitConnectionAcrossServletBoundaryPart1");
+        runTest(server, "app43/JDBC43TestServlet", "testCompletionStageCachesUnsharedManualCommitConnectionAcrossServletBoundaryPart2");
+    }
 }

--- a/dev/com.ibm.ws.jdbc_fat_v43/fat/src/com/ibm/ws/jdbc/fat/v43/JDBC43Test.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/fat/src/com/ibm/ws/jdbc/fat/v43/JDBC43Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.test.d43.jdbc.D43Driver;
 
@@ -66,5 +67,21 @@ public class JDBC43Test extends FATServletClient {
                           "DSRA8790W", // expected for begin/endRequest invoked by application being ignored
                           "J2CA0081E", // TODO why does Derby think a transaction is still active?
                           "WLTC0018E"); // TODO remove once transactions bug is fixed
+    }
+
+    /**
+     * testCompletionStageCachesUnsharedAutocommitConnectionAcrossServletBoundary - obtains an unshared connection in
+     * one servlet method and uses it, but does not close it, instead allowing it to continue to execution operations
+     * asynchronously via a completion stage. After the servlet method ends and goes out of scope, invokes a second
+     * servlet method, which under a new scope, accesses the completion stage, joins it, and checks that the operations
+     * executed successfully.
+     * This behavior is currently possible without the HandleList implementation in place to prevent it.
+     * Although we do not recommend this pattern, some users might be relying upon it, and there needs to be a way
+     * to avoid breaking these users when HandleList is put in place to clean up connections when requests go out of scope.
+     */
+    @Test
+    public void testCompletionStageCachesUnsharedAutocommitConnectionAcrossServletBoundary() throws Exception {
+        runTest(server, "app43/JDBC43TestServlet", "testCompletionStageCachesUnsharedAutocommitConnectionAcrossServletBoundaryPart1");
+        runTest(server, "app43/JDBC43TestServlet", "testCompletionStageCachesUnsharedAutocommitConnectionAcrossServletBoundaryPart2");
     }
 }


### PR DESCRIPTION
Add a test case that obtains an unshared connection in one servlet method and uses it, but does not close it, instead allowing it to continue to execution operations asynchronously via a completion stage. After the servlet method ends and goes out of scope, invokes a second servlet method, which under a new scope, accesses the completion stage, joins it, and checks that the operations executed successfully.  This is likely only possible due to the lack of the HandleList implementation.