### PR TITLE
Disable Quarantined test testHTTP2HTTPSRedirect()

### DIFF
--- a/dev/wlp.lib.extract_fat/fat/src/wlp/lib/extract/ExternalDependencyDownloadTest.java
+++ b/dev/wlp.lib.extract_fat/fat/src/wlp/lib/extract/ExternalDependencyDownloadTest.java
@@ -30,8 +30,6 @@ import org.junit.Test;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
-import componenttest.custom.junit.runner.Mode;
-import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
@@ -57,8 +55,9 @@ public class ExternalDependencyDownloadTest {
         }
     }
 
-    @Mode(TestMode.QUARANTINE)
-    @Test
+//    @Mode(TestMode.QUARANTINE)
+//    @Test
+//    Test should not be hitting an external site.  Need to find a better implemenation before re-enabling.
     public void testHTTP2HTTPSRedirect() throws Exception {
         String serverName = "http2httpsRedirectGood";
         String dependencyTargetFile = "shared/lib/" + serverName + ".testfile.jar";


### PR DESCRIPTION
Test case depends on maven.org to redirect from http to https.  Since Maven has changed to only support https, we can no longer use maven to test http redirects.  Disabling this test.

Will use https://github.com/OpenLiberty/open-liberty/issues/11183 to implement this test case properly.