### PR TITLE
GA of EJB persistent timer fail over

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.concurrent.persistent/resources/OSGI-INF/metatype/metatype.xml
@@ -26,7 +26,7 @@
   <AD id="enableTaskExecution"               type="Boolean" default="true" name="%enableTaskExecution" description="%enableTaskExecution.desc"/>
   <AD id="initialPollDelay"                  type="String"  default="0" ibm:type="duration" name="%initialPollDelay" description="%initialPollDelay.desc"/>
   <AD id="jndiName"                          type="String"  required="false" ibm:unique="jndiName" name="internal" description="internal use only"/>
-  <AD id="missedTaskThreshold"               type="String"  ibm:beta="true" default="-1" ibm:type="duration(s)" name="%missedTaskThreshold" description="%missedTaskThreshold.desc"/>
+  <AD id="missedTaskThreshold"               type="String"  default="-1" ibm:type="duration(s)" name="%missedTaskThreshold" description="%missedTaskThreshold.desc"/>
   <AD id="pollInterval"                      type="String"  required="false" ibm:type="duration" name="%pollInterval" description="%pollInterval.desc"/>
   <AD id="pollSize"                          type="Integer" required="false" min="1" name="%pollSize" description="%pollSize.desc"/>
   <AD id="retryInterval"                     type="String"  required="false" ibm:type="duration" name="%retryInterval" description="%retryInterval.desc"/>

--- a/dev/com.ibm.ws.ejbcontainer.timer/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.ejbcontainer.timer/resources/OSGI-INF/metatype/metatype.xml
@@ -42,7 +42,7 @@
             default="(service.pid=${nonPersistentContextServiceRef})" 
             name="internal" description="internal use only"/>
 
-        <AD id="missedPersistentTimerAction" type="String" ibm:beta="true" required="false"
+        <AD id="missedPersistentTimerAction" type="String" required="false"
             name="%missedPersistentTimerAction" description="%missedPersistentTimerAction.desc">
             <Option value="ALL"  label="%missedPersistentTimerAction.ALL"/>
             <Option value="ONCE" label="%missedPersistentTimerAction.ONCE"/>


### PR DESCRIPTION
This pull removes the beta indicators from metatype and GA's the EJB persistent timer fail over feature.

This pull was opened prematurely so that we can get this to run through metatype validation. DO NOT MERGE it yet, even if the build comes back successful.