### PR TITLE
Part 1 of split package issue with com.ibm.ejs.j2c: stop importing from cm bundle

### DIFF
--- a/dev/com.ibm.ws.container.service.compat/src/com/ibm/ejs/j2c/HandleList.java
+++ b/dev/com.ibm.ws.container.service.compat/src/com/ibm/ejs/j2c/HandleList.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 IBM Corporation and others.
+ * Copyright (c) 2010,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,16 +11,10 @@
 package com.ibm.ejs.j2c;
 
 /**
- * Stub - Liberty does not support DissociatableManagedConnection
+ * Copied to the com.ibm.ws.jca.cm.handle package in order to avoid causing split packages
+ * on com.ibm.ej2.j2c with the com.ibm.ws.jca.cm bundle.
+ * TODO see if we can switch over usage throughout all other bundles and
+ * completely remove com.ibm.ej2.j2c from com.ibm.ejs.j2c from container.service.compat
  */
-public class HandleList implements HandleListInterface {
-    @Override
-    public void parkHandle() {}
-
-    @Override
-    public void reAssociate() {}
-
-    public void close() {}
-
-    public void componentDestroyed() {}
+public class HandleList extends com.ibm.ws.jca.cm.handle.HandleList implements HandleListInterface {
 }

--- a/dev/com.ibm.ws.container.service.compat/src/com/ibm/ws/jca/cm/handle/HandleList.java
+++ b/dev/com.ibm.ws.container.service.compat/src/com/ibm/ws/jca/cm/handle/HandleList.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012,2020 IBM Corporation and others.
+ * Copyright (c) 2010,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,13 +8,23 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ejs.j2c;
+package com.ibm.ws.jca.cm.handle;
 
 /**
- * Copied to the com.ibm.ws.jca.cm.handle package in order to avoid causing split packages
- * on com.ibm.ej2.j2c with the com.ibm.ws.jca.cm bundle.
- * TODO see if we can switch over usage throughout all other bundles and
- * completely remove com.ibm.ej2.j2c from com.ibm.ejs.j2c from container.service.compat
+ * TODO implementation needed
  */
-public interface HandleListInterface extends com.ibm.ws.jca.cm.handle.HandleListInterface {
+public class HandleList implements HandleListInterface {
+    public void close() {
+    }
+
+    public void componentDestroyed() {
+    }
+
+    @Override
+    public void parkHandle() {
+    }
+
+    @Override
+    public void reAssociate() {
+    }
 }

--- a/dev/com.ibm.ws.container.service.compat/src/com/ibm/ws/jca/cm/handle/HandleListInterface.java
+++ b/dev/com.ibm.ws.container.service.compat/src/com/ibm/ws/jca/cm/handle/HandleListInterface.java
@@ -8,13 +8,13 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ejs.j2c;
+package com.ibm.ws.jca.cm.handle;
 
 /**
- * Copied to the com.ibm.ws.jca.cm.handle package in order to avoid causing split packages
- * on com.ibm.ej2.j2c with the com.ibm.ws.jca.cm bundle.
- * TODO see if we can switch over usage throughout all other bundles and
- * completely remove com.ibm.ej2.j2c from com.ibm.ejs.j2c from container.service.compat
+ * TODO implementation needed
  */
-public interface HandleListInterface extends com.ibm.ws.jca.cm.handle.HandleListInterface {
+public interface HandleListInterface {
+    void parkHandle();
+
+    void reAssociate();
 }

--- a/dev/com.ibm.ws.container.service.compat/src/com/ibm/ws/jca/cm/handle/package-info.java
+++ b/dev/com.ibm.ws.container.service.compat/src/com/ibm/ws/jca/cm/handle/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012,2020 IBM Corporation and others.
+ * Copyright (c) 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,13 +8,8 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ejs.j2c;
-
 /**
- * Copied to the com.ibm.ws.jca.cm.handle package in order to avoid causing split packages
- * on com.ibm.ej2.j2c with the com.ibm.ws.jca.cm bundle.
- * TODO see if we can switch over usage throughout all other bundles and
- * completely remove com.ibm.ej2.j2c from com.ibm.ejs.j2c from container.service.compat
+ * @version 1.1.0
  */
-public interface HandleListInterface extends com.ibm.ws.jca.cm.handle.HandleListInterface {
-}
+@org.osgi.annotation.versioning.Version("1.1.0")
+package com.ibm.ws.jca.cm.handle;

--- a/dev/com.ibm.ws.container.service.compat/src/com/ibm/ws/threadContext/ConnectionHandleAccessorImpl.java
+++ b/dev/com.ibm.ws.container.service.compat/src/com/ibm/ws/threadContext/ConnectionHandleAccessorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.threadContext;
 
-import com.ibm.ejs.j2c.HandleListInterface;
+import com.ibm.ws.jca.cm.handle.HandleListInterface;
 
 /**
  * Stub until LazyAssociatableConnectionManager is designed with J2C.

--- a/dev/com.ibm.ws.container.service/bnd.bnd
+++ b/dev/com.ibm.ws.container.service/bnd.bnd
@@ -44,6 +44,7 @@ Export-Package: \
    com.ibm.ws.container.service.security; provide:=true, \
    com.ibm.ws.container.service.state; provide:=true, \
    com.ibm.ws.exception;provide:=true, \
+   com.ibm.ws.jca.cm.handle, \
    com.ibm.ws.runtime.metadata, \
    com.ibm.ws.threadContext, \
    com.ibm.ws.util;provide:=true, \

--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/EJBThreadData.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/EJBThreadData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2016 IBM Corporation and others.
+ * Copyright (c) 2010, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -57,7 +57,7 @@ public class EJBThreadData
      */
     private final FastStack<Object> ivClassLoaderStack = new FastStack<Object>();
 
-    final ThreadContext<HandleListInterface> ivHandleListContext =
+    final ThreadContext<com.ibm.ws.jca.cm.handle.HandleListInterface> ivHandleListContext =
                     getCurrentThreadContext(ConnectionHandleAccessorImpl.getConnectionHandleAccessor().getThreadContext()); // d662032
 
     /**

--- a/dev/com.ibm.ws.jca.cm/bnd.bnd
+++ b/dev/com.ibm.ws.jca.cm/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2019 IBM Corporation and others.
+# Copyright (c) 2017,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -25,7 +25,9 @@ Export-Package: \
     com.ibm.wsspi.zos.tx \
 
 Import-Package: \
+    com.ibm.ws.jca.cm.handle, \
     com.ibm.ws.util;version="[1.0,2)", \
+    !com.ibm.ejs.j2c, \
     !*.internal.*, *
 
 Private-Package: \

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManager.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2019 IBM Corporation and others.
+ * Copyright (c) 1997, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -49,6 +49,7 @@ import com.ibm.ws.jca.adapter.PurgePolicy;
 import com.ibm.ws.jca.adapter.WSManagedConnectionFactory;
 import com.ibm.ws.jca.cm.AbstractConnectionFactoryService;
 import com.ibm.ws.jca.cm.AppDefinedResource;
+import com.ibm.ws.jca.cm.handle.HandleList;
 import com.ibm.ws.kernel.security.thread.ThreadIdentityManager;
 import com.ibm.ws.resource.ResourceRefInfo;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
@@ -152,7 +153,6 @@ public final class ConnectionManager implements com.ibm.ws.j2c.ConnectionManager
         if (isTraceOn && tc.isEntryEnabled()) {
             Tr.entry(this, tc, "<init>");
         }
-
         this.connectionFactorySvc = cfSvc;
         this._pm = pm;
         this.gConfigProps = gconfigProps;

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/MCWrapper.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/MCWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2019 IBM Corporation and others.
+ * Copyright (c) 1997, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -45,6 +45,7 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.j2c.TranWrapper;
 import com.ibm.ws.jca.adapter.WSManagedConnection;
 import com.ibm.ws.jca.adapter.WSManagedConnectionFactory;
+import com.ibm.ws.jca.cm.handle.HandleList;
 import com.ibm.ws.tx.rrs.RRSXAResourceFactory;
 
 /**


### PR DESCRIPTION
Minor refactoring so that the com.ibm.ws.jca.cm bundle can stop importing classes defined elsewhere from the same com.ibm.ejs.j2c package that it declares as a private package for the connection manager implementation.

It should be noted that the cm bundle cannot stop using the com.ibm.ejs.j2c package for its implementation because at least one of its classes in that package is serialized to the transaction recovery logs and cannot be renamed.

This pull is part 1 to at least clear up the issue for the cm bundle.
A second part 2 can be done after this to refactor more of the Liberty code and remove its com.ibm.ejs.j2c package classes from the compat bundle entirely, after which only the cm bundle will define classes in that package.