### PR TITLE
Issue 11154: Add first pass of messages for the acmeCA feature

### DIFF
--- a/dev/com.ibm.ws.security.acme/resources/com/ibm/ws/security/acme/resources/AcmeMessages.nlsprops
+++ b/dev/com.ibm.ws.security.acme/resources/com/ibm/ws/security/acme/resources/AcmeMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2012, 2013 IBM Corporation and others.
+# Copyright (c) 2019,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -10,19 +10,123 @@
 ###############################################################################
 # -------------------------------------------------------------------------------------------------
 #CMVCPATHNAME com.ibm.ws.security.acme/resources/com/ibm/ws/security/acme/resources/AcmeMessages.nlsprops
-#COMPONENTPREFIX CWWKX
+#COMPONENTPREFIX CWPKI
 #COMPONENTNAMEFOR WebSphere ACME
 #ISMESSAGEFILE TRUE
 #NLS_MESSAGEFORMAT_VAR
 #NLS_ENCODING=UNICODE
 # -------------------------------------------------------------------------------------------------
-
-# TODO: Get the correct Message Prefix block for ACME feature
-# liberty wiki should have a list of the Message Prefix
-# Message prefix block: CWWKJ0200 - CWWKJ0299
-
+# Message prefix block: CWPKI2000 - CWPKI2299
 #-----  ACME messages
 
-CWWKX0000I=CWWKX0000I: Test message
-CWWKX0000I.explanation= Test message description
-CWWKX0000I.useraction= No action is necessary at this time
+# The ACME referred to in these messages stands for Automatic Certificate Management Environment.
+# The term "certificate authority" is in reference to SSL/TLS certificate providers.
+# The URI parameter in these messages is for the ACME certificate authority, such as https://sampleCAProvider.org/directory
+
+CWPKI2001E=CWPKI2001E: The ACME certificate authority at the {0} URI responded that the authorization challenge failed for the {1} domain. The challenge status is {2}.  The error is {3}.
+CWPKI2001E.explanation=The challenge status indicated that the authorization challenge request failed and a certificate cannot be created.
+CWPKI2001E.useraction=Review the status message and error for details on the failure.
+
+CWPKI2002E=CWPKI2002E: The ACME service polling timed out while checking for a successful authorization challenge for the {0} domain from the ACME certificate authority at the {1} URI. The status is {2}. The configured timeout is {3}.
+CWPKI2002E.explanation=The certificate authority challenge request was not validated in the configured time and a certificate cannot be created.
+CWPKI2002E.useraction=Review the configured certificate authority URI. Verify that the URI can be successfully accessed by the calling server. Verify that the calling server can receive a response from the certificate authority. Review the status code. Some certificate authorities might require a longer timeout.
+
+CWPKI2003E=CWPKI2003E: The ACME certificate authority at the {0} URI responded that the certificate order failed for the {1} domains. The order status is {2}. The error is {3}.
+CWPKI2003E.explanation=The order status indicated that the authorization order request failed and a certificate cannot be created.
+CWPKI2003E.useraction=Review the status message and error for details on the failure.
+
+CWPKI2004E=CWPKI2004E: The ACME service polling timed out while checking for a successful order for the {0} domain from the ACME certificate authority at the {1} URI. The status is {2}.  The configured timeout is {3}.
+CWPKI2004E.explanation=The certificate authority domain certificate order request did not complete in the configured time and a certificate cannot be created.
+CWPKI2004E.useraction=Review the configured certificate authority URI. Verify that the URI can be successfully accessed by the calling server. Verify that the calling server can receive a response from the certificate authority. Review the status code. Some certificate authorities might require a longer timeout.
+
+CWPKI2005E=CWPKI2005E: The authorization returned from the ACME certificate authority at the {0} URI did not include a valid challenge type. Supported challenge types include {1}.
+CWPKI2005E.explanation=The certificate authority returned a challenge type that is currently unsupported. Verify that the certificate authority uses a type in the supported list.
+CWPKI2005E.useraction=Select a certificate authority that provides a supported challenge type.
+
+CWPKI2006I=CWPKI2006I: The ACME certificate authority at the {0} URI provided the following terms of service: {1}
+CWPKI2006I.explanation=The certificate authority provides terms of service.
+CWPKI2006I.useraction= Review the provided terms of service.
+
+CWPKI2007I=CWPKI2007I: The ACME service installed a certificate that is signed by the ACME certificate authority at the {0} URI. The expiration date is {1}.
+CWPKI2007I.explanation=The ACME service successfully retrieved and installed a certificate from the configured certificate authority.
+CWPKI2007I.useraction=No action is required.
+
+CWPKI2008E=CWPKI2008E: The ACME certificate authority directory URI must be a valid URI. The URI received was null or empty. The URI received was '{0}'.
+CWPKI2008E.explanation=The certificate authority directory URI was not configured correctly.
+CWPKI2008E.useraction=Enter a valid ACME certificate authority directory URI in the configuration.
+
+CWPKI2009E=CWPKI2009E: The challenge request to the ACME certificate authority at the {0} URI failed. The error is {1}.
+CWPKI2009E.explanation=The challenge request failed and a certificate cannot be created.
+CWPKI2009E.useraction=Review the error message for details on the failure.
+
+CWPKI2010E=CWPKI2010E: The challenge update to the ACME certificate authority at the {0} URI failed.The error is {1}.
+CWPKI2010E.explanation=The challenge update failed and a certificate cannot be updated.
+CWPKI2010E.useraction=Review the error message for details on the failure.
+
+CWPKI2011E=CWPKI2011E: The ACME service failed to create the certificate order for the ACME certificate authority at the {0} URI. The error is {1}.
+CWPKI2011E.explanation=The certificate order creation failed and a signed certificate cannot be requested.
+CWPKI2011E.useraction=Review the error message for details on the failure.
+
+CWPKI2012E=CWPKI2012E: The ACME service failed to sign the certificate signing request for the ACME certificate authority at the {0} URI. The error is {1}.
+CWPKI2012E.explanation=The certificate order was created, but signing the request failed and a signed certificate cannot be requested.
+CWPKI2012E.useraction=Review the error message for details on the failure.
+
+CWPKI2013E=CWPKI2013E: The certificate signing request was created and signed, but the order request to the ACME certificate authority at the {0} URI failed. The error is {1}.
+CWPKI2013E.explanation=The certificate order was created and signed, but ordering the certificate from the certificate authority failed.
+CWPKI2013E.useraction=Review the error message for details on the failure.
+
+CWPKI2014E=CWPKI2014E: The certificate signing request for the ACME certificate authority at the {0} URI was created and signed, but encoding the request failed. The error is {1}.
+CWPKI2014E.explanation=Encoding the certificate signing request failed and a signed certificate cannot be created.
+CWPKI2014E.useraction=Review the error message for details on the failure.
+
+CWPKI2015E=CWPKI2015E: The ACME service certificate order status request from the ACME certificate authority at the {0} URI failed. The error is {1}.
+CWPKI2015E.explanation=An order is completed asynchronously by the certificate authority. The ACME service received an error while checking on the status of the order. A signed certificate cannot be requested.
+CWPKI2015E.useraction=Review the error message for details on the failure.
+
+CWPKI2016E=CWPKI2016E: The ACME service request for an existing account from the ACME certificate authority at the {0} URI failed. The error is {1}.
+CWPKI2016E.explanation=An existing account was not found or another error occurred. Changes cannot be made to the account or certificate.
+CWPKI2016E.useraction=Review the error message for details on the failure. Verify that the URI can be successfully accessed by the calling server. Verify that the calling server can receive a response from the certificate authority.
+
+CWPKI2017E=CWPKI2017E: The ACME request for the terms of service from the ACME certificate authority at the {0} URI failed. The error is {1}.
+CWPKI2017E.explanation=The terms of service for the ACME certificate authority cannot be logged. 
+CWPKI2017E.useraction=Review the error message for details on the failure. Visit the ACME certificate authority website to review the terms of service.
+
+CWPKI2018E=CWPKI2018E: The user account could not be created on the ACME certificate authority at the {0} URI. The error is {1}.
+CWPKI2018E.explanation=The user account creation request failed.
+CWPKI2018E.useraction=Review the error message for details on the failure.
+
+CWPKI2019I=CWPKI2019I: The account URL provided by the ACME certificate authority at the {0} URI is {1}.
+CWPKI2019I.explanation=The account was successfully created.
+CWPKI2019I.useraction=No action is required.
+
+CWPKI2020E=CWPKI2020E: The ACME service could not read the domain key file for the ACME certificate authority account at the {0} URI. The file location is {1}. The error is {2}.
+CWPKI2020E.explanation=The domain key file for the certificate authority account could not be opened. This can occur if file permissions are incorrect or if the file does not exist.
+CWPKI2020E.useraction=Review the error message for details on the failure. Verify that the file location is correct and the server has read file permissions.
+
+CWPKI2021E=CWPKI2021E: The ACME service could not read the account key file for the ACME certificate authority account at the {0} URI. The file location is {1}. The error is {2}.
+CWPKI2021E.explanation=The account key file for the certificate authority account could not be opened. This can occur if file permissions are incorrect or if the file does not exist.
+CWPKI2021E.useraction=Review the error message for details on the failure. Verify the file location is correct and the server has read file permissions.
+
+CWPKI2022E=CWPKI2022E: The ACME service could not write to the domain key file for the ACME certificate authority account at the {0} URI. The file location is {1}. The error is {2}.
+CWPKI2022E.explanation=The domain keys could not be stored in the domain key file. This can occur if the file permissions are incorrect or the file does not exist.
+CWPKI2022E.useraction=Review the error message for details on the failure. Verify the file location is correct and  the server has write file permissions.
+
+CWPKI2023E=CWPKI2023E: Failed to write the account key file for the ACME certificate authority account at the {0} URI. The file location is {1}. The error is {2}.
+CWPKI2023E.explanation=The account keys could not be stored in the account key file. This can occur if the file permissions are incorrect or the file does not exist.
+CWPKI2023E.useraction=Review the error message for details on the failure. Verify the file location is correct and the server has write file permissions.
+
+CWPKI2024E=CWPKI2024E: The ACME service failed to revoke the requested certificate for the ACME certificate authority at the {0} URI. The certificate is serial number {1}. The error is {2}.
+CWPKI2024E.explanation=A certificate revoke request failed. The certificate might not be revoked and could still be in use.
+CWPKI2024E.useraction=Review the error message for details on the failure.
+
+CWPKI2025W=CWPKI2025W: The ACME service received a certificate revoke request, but the account key pair for the ACME certificate authority at the {0} URI could not be loaded.
+CWPKI2025W.explanation=The certificate revoke request failed because the account key pair could not be loaded.
+CWPKI2025W.useraction=Review the log for any earlier errors for details on the failure. Review the keystore file to verify that the certificate exists.
+
+CWPKI2026W=CWPKI2026W: The ACME service received a certificate revoke request, but the account was not found at the ACME certificate authority at the {0} URI.
+CWPKI2026W.explanation=The certificate revoke request failed because the account was not found.
+CWPKI2026W.useraction=Review the certificate authority URI. Review the keystore file to verify that the certificate exists.
+
+CWPKI2027E=CWPKI2027E: The {0} file path for the ACME service is null or empty. The path provided is '{1}'.
+CWPKI2027E.explanation=The file path was null or empty and cannot be used for the domain and account keys.
+CWPKI2027E.useraction=Provide a valid file path in the configuration.


### PR DESCRIPTION
Fixes #11154 

We're working on code in parallel, so  I pulled messages out of AcmeClient in #11008 with comments on what they were originally. I will pair up message keys in the code separately.

Ready for review. This is the first block of messages for ACME -- so all the messages are new.

For Feature #9017 