### PR TITLE
Updates to remove contention / overhead during server startup

### DIFF
--- a/dev/com.ibm.ws.kernel.security.thread/src/com/ibm/ws/kernel/security/thread/ThreadIdentityManager.java
+++ b/dev/com.ibm.ws.kernel.security.thread/src/com/ibm/ws/kernel/security/thread/ThreadIdentityManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corporation and others.
+ * Copyright (c) 2012, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.security.auth.Subject;
 
@@ -40,12 +41,12 @@ public class ThreadIdentityManager {
      * The ThreadIdentityService references. The references are set by the
      * ThreadIdentityManagerConfigurator.
      */
-    private static List<ThreadIdentityService> threadIdentityServices = Collections.synchronizedList(new ArrayList<ThreadIdentityService>());
+    private static List<ThreadIdentityService> threadIdentityServices = new CopyOnWriteArrayList<>();
 
     /**
      * The J2CIdentityService references. The references are set by the ThreadIdentityManagerConfigurator.
      */
-    private static List<J2CIdentityService> j2cIdentityServices = Collections.synchronizedList(new ArrayList<J2CIdentityService>());
+    private static List<J2CIdentityService> j2cIdentityServices = new CopyOnWriteArrayList<>();
 
     /**
      * Add a ThreadIdentityService reference. This method is called by
@@ -306,8 +307,7 @@ public class ThreadIdentityManager {
 
         if (!checkForRecursionAndSet()) {
             try {
-                for (int i = 0, size = threadIdentityServices.size(); i < size; ++i) {
-                    ThreadIdentityService tis = threadIdentityServices.get(i);
+                for (ThreadIdentityService tis : threadIdentityServices) {
                     if (tis.isAppThreadIdentityEnabled()) {
                         if (token == null) {
                             token = new LinkedHashMap<ThreadIdentityService, Object>();

--- a/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/TrOSGiLogForwarder.java
+++ b/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/TrOSGiLogForwarder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -273,36 +273,35 @@ public class TrOSGiLogForwarder implements SynchronousLogListener, SynchronousBu
             return false;
         }
         boolean isAnyTraceEnabled = TraceComponent.isAnyTracingEnabled();
-        OSGiTraceComponent tc = getTraceComponent(b);
 
         // Do error first because we don't do the check below for errors
         if (level == LogLevel.ERROR.ordinal()) {
-            return tc.isErrorEnabled();
+            return getTraceComponent(b).isErrorEnabled();
         }
 
         // check for events specifically to log them with Tr.event
         if (loggerName != null && loggerName.startsWith(LOGGER_EVENTS_PREFIX))  {
-            return isAnyTraceEnabled && tc.isEventEnabled();
+            return isAnyTraceEnabled && getTraceComponent(b).isEventEnabled();
         }
 
         if (level == LogLevel.AUDIT.ordinal()) {
-            return tc.isAuditEnabled();
+            return getTraceComponent(b).isAuditEnabled();
         }
 
         if (level == LogLevel.INFO.ordinal()) {
-            return tc.isInfoEnabled();
+            return getTraceComponent(b).isInfoEnabled();
         }
 
         if (level == LogLevel.WARN.ordinal()) {
-            return tc.isWarningEnabled();
+            return getTraceComponent(b).isWarningEnabled();
         }
 
         if (level == LogLevel.DEBUG.ordinal()) {
-            return isAnyTraceEnabled && tc.isDebugEnabled();
+            return isAnyTraceEnabled && getTraceComponent(b).isDebugEnabled();
         }
 
         if (level == LogLevel.TRACE.ordinal()) {
-            return isAnyTraceEnabled && tc.isDumpEnabled();
+            return isAnyTraceEnabled && getTraceComponent(b).isDumpEnabled();
         }
 
         return false;


### PR DESCRIPTION
- Update BootstrapChildFirst Classloaders to be like
ParentLastClassLoader to call parent.loadClass instead of
super.loadClass to avoid looking up the class again in the current
ClassLoader.
- Update ThreadIdentitytManager to not used a synchronized List to avoid
contention.
- Update TrOSGiLogForwarder to not get the TraceComponent unless some
tracing is enabled.  This avoids synchronzation and loading a bundle to
get the bundle name.