### PR TITLE
test is missing Async and accidentally runs inline

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2018 IBM Corporation and others.
+    Copyright (c) 2018,2020 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -44,7 +44,7 @@
     <properties databaseName="memory:testdb;create=true"/>
   </dataSource>
 
-  <dataSource jndiName="jdbc/poolOf1" type="javax.sql.ConnectionPoolDataSource"
+  <dataSource id="poolOf1" jndiName="jdbc/poolOf1" type="javax.sql.ConnectionPoolDataSource"
               enableBeginEndRequest="true"> <!-- Not a supported property. Only for internal testing/experimentation. -->
     <connectionManager maxPoolSize="1"/>
     <jdbcDriver libraryRef="D43Lib"/>


### PR DESCRIPTION
A test that I recently wrote accidentally uses thenApply where it meant to use thenApplyAsync, causing incorrect test logic which made it look like a local transaction remains open across servlet boundaries.  After fixing the test logic, the test needs some updates elsewhere per the expected behavior of having the local transaction rolled back per the default unresolved action.  This test was written to investigate what behavior we are getting absent a HandleList implementation, and is expected to be updated once HandleList is in place.