### PR TITLE
Issue 11187: Add messages keys and order errors messages for acmeCA

### DIFF
--- a/dev/com.ibm.ws.security.acme/bnd.bnd
+++ b/dev/com.ibm.ws.security.acme/bnd.bnd
@@ -29,6 +29,8 @@ Web-ContextPath: /.well-known/acme-challenge
 
 IBM-Web-Extension-Processing-Disabled: false
 
+Import-Package: !*.internal.*, *
+
 Export-Package: \
     com.ibm.ws.security.acme;version="1.0.0"
  

--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/util/AcmeConstants.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/util/AcmeConstants.java
@@ -52,4 +52,7 @@ public class AcmeConstants {
 	public static final String DEFAULT_KEY_STORE = "defaultKeyStore";
 	public static final String DEFAULT_ALIAS = "default";
 	public static final String KEY_KEYSTORE_SERVICE = "keyStoreService";
+	
+	public static final String ACCOUNT_TYPE = "account";
+	public static final String DOMAIN_TYPE = "domain";
 }

--- a/dev/com.ibm.ws.security.acme/test/com/ibm/ws/security/acme/internal/AcmeClientTest.java
+++ b/dev/com.ibm.ws.security.acme/test/com/ibm/ws/security/acme/internal/AcmeClientTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import com.ibm.ws.security.acme.AcmeCaException;
+import com.ibm.ws.security.acme.internal.util.AcmeConstants;
 
 /**
  * Unit tests for the {@link AcmeClient} class. These tests are limited to those
@@ -36,7 +37,7 @@ public class AcmeClientTest {
 	@Test
 	public void constructor_NullURI() throws Exception {
 		expectedException.expect(AcmeCaException.class);
-		expectedException.expectMessage("The ACME CA's directory URI must be a valid URI.");
+		expectedException.expectMessage("CWPKI2008E");
 
 		new AcmeClient(null, VALID_USER_KEY_PATH, VALID_DOMAIN_KEY_PATH, null);
 	}
@@ -44,7 +45,7 @@ public class AcmeClientTest {
 	@Test
 	public void constructor_EmptyURI() throws Exception {
 		expectedException.expect(AcmeCaException.class);
-		expectedException.expectMessage("The ACME CA's directory URI must be a valid URI.");
+		expectedException.expectMessage("CWPKI2008E");
 
 		new AcmeClient("", VALID_USER_KEY_PATH, VALID_DOMAIN_KEY_PATH, null);
 	}
@@ -52,7 +53,8 @@ public class AcmeClientTest {
 	@Test
 	public void constructor_NullAccountKeyPath() throws Exception {
 		expectedException.expect(AcmeCaException.class);
-		expectedException.expectMessage("The account key file path must be valid.");
+		expectedException.expectMessage("CWPKI2027E");
+		expectedException.expectMessage(AcmeConstants.ACCOUNT_TYPE);
 
 		new AcmeClient(VALID_URI, null, VALID_DOMAIN_KEY_PATH, null);
 	}
@@ -60,7 +62,8 @@ public class AcmeClientTest {
 	@Test
 	public void constructor_EmptyAccountKeyPath() throws Exception {
 		expectedException.expect(AcmeCaException.class);
-		expectedException.expectMessage("The account key file path must be valid.");
+		expectedException.expectMessage("CWPKI2027E");
+		expectedException.expectMessage(AcmeConstants.ACCOUNT_TYPE);
 
 		new AcmeClient(VALID_URI, "", VALID_DOMAIN_KEY_PATH, null);
 	}
@@ -68,7 +71,8 @@ public class AcmeClientTest {
 	@Test
 	public void constructor_NullDomainKeyPath() throws Exception {
 		expectedException.expect(AcmeCaException.class);
-		expectedException.expectMessage("The domain key file path must be valid.");
+		expectedException.expectMessage("CWPKI2027E");
+		expectedException.expectMessage(AcmeConstants.DOMAIN_TYPE);
 
 		new AcmeClient(VALID_URI, VALID_DOMAIN_KEY_PATH, null, null);
 	}
@@ -76,7 +80,8 @@ public class AcmeClientTest {
 	@Test
 	public void constructor_EmptyDomainKeyPath() throws Exception {
 		expectedException.expect(AcmeCaException.class);
-		expectedException.expectMessage("The domain key file path must be valid.");
+		expectedException.expectMessage("CWPKI2027E");
+		expectedException.expectMessage(AcmeConstants.DOMAIN_TYPE);
 
 		new AcmeClient(VALID_URI, VALID_DOMAIN_KEY_PATH, "", null);
 	}

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeClientTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeClientTest.java
@@ -240,49 +240,6 @@ public class AcmeClientTest {
 	}
 
 	/**
-	 * Validate that an exception is thrown if the terms of service are no
-	 * accepted.
-	 * 
-	 * @throws Exception
-	 */
-	@Test
-	public void fetchCertificate_RejectTermsOfService() throws Exception {
-
-		/**
-		 * We want a new account so delete the existing account key file.
-		 */
-		File accountKeyFile = new File(FILE_ACCOUNT_KEY);
-		if (accountKeyFile.exists()) {
-			accountKeyFile.delete();
-		}
-
-		/*
-		 * Without accepting the terms of service, fetchCertificate is going to
-		 * fail. Expect the following exception and message.
-		 */
-		expectedException.expect(AcmeCaException.class);
-		expectedException.expectMessage(
-				"The account must accept the terms of service by setting the ACME CA configuration to have a value of \"true\" for 'acceptTermsOfService' "
-						+ "in the server.xml. The terms of service can be found at the following URI: data:text/plain,Do%20what%20thou%20wilt");
-
-		/*
-		 * Create an AcmeService to test.
-		 */
-		AcmeClient acmeClient = new AcmeClient(acmeDirectoryURI, FILE_ACCOUNT_KEY, FILE_DOMAIN_KEY, null);
-		acmeClient.setAcceptTos(false);
-
-		/*
-		 * Link the new client to the challenge response server.
-		 */
-		challengeServer.setAcmeClient(acmeClient);
-
-		/*
-		 * Get the certificate from the ACME CA server.
-		 */
-		acmeClient.fetchCertificate(new CSROptions(Arrays.asList(new String[] { TEST_DOMAIN_1 })));
-	}
-
-	/**
 	 * Verify that we can revoke a fetched certificate.
 	 * 
 	 * @throws Exception


### PR DESCRIPTION
Fixes #11187 

Added message keys for AcmeClient. Removed some of the termsOfService bits that we won't need. Fixed the acme bnd for eclipse.

Depends on #11206

For #9017