### PR TITLE
Put getProperty usage in doPrivileged block

### DIFF
--- a/dev/com.ibm.ws.logging.core/src/com/ibm/ws/kernel/provisioning/packages/PackageIndex.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/ws/kernel/provisioning/packages/PackageIndex.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2014 IBM Corporation and others.
+ * Copyright (c) 2013, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.kernel.provisioning.packages;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -24,7 +26,15 @@ import com.ibm.ws.ffdc.FFDCSelfIntrospectable;
  */
 public class PackageIndex<T> implements FFDCSelfIntrospectable, Iterable<T> {
     private static final String WILDCARD = "*";
-    private static String nl = System.getProperty("line.separator");
+    
+    private static String nl = AccessController.doPrivileged(
+    		new PrivilegedAction<String>() {
+    			@Override
+    			public String run() {
+    				return System.getProperty("line.separator");
+    			}
+            }
+    );
 
     /**
      * Each node is a package segment, which may not contain a wildcard (i.e. a* is not

--- a/dev/com.ibm.ws.logging.core/src/com/ibm/ws/logging/internal/PackageProcessor.java
+++ b/dev/com.ibm.ws.logging.core/src/com/ibm/ws/logging/internal/PackageProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2017 IBM Corporation and others.
+ * Copyright (c) 2013, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -155,7 +155,7 @@ public class PackageProcessor implements BundleTrackerCustomizer<Object> {
 
     private BundlePackages populatePackageLists() {
         // Concurrency: we could go through this process twice, but that's non-fatal, only slightly annoying.
-        // I judge the performance risk of going through it twice to be lower than the performance risk of synchronisation.
+        // I judge the performance risk of going through it twice to be lower than the performance risk of synchronization
 
         BundlePackages p = packages.get();
         if (p == null) {
@@ -203,7 +203,16 @@ public class PackageProcessor implements BundleTrackerCustomizer<Object> {
         Set<Pattern> patterns = new HashSet<Pattern>();
         // OSGi and Java require that java.* packages are always boot delegated
         patterns.add(Pattern.compile("java..*"));
-        String boots = bundleContext.getProperty("org.osgi.framework.bootdelegation");
+        
+        String boots = AccessController.doPrivileged(
+        		new PrivilegedAction<String>() {
+        			@Override
+        			public String run() {
+        				return bundleContext.getProperty("org.osgi.framework.bootdelegation");
+        			}
+                }
+        );
+        
         String[] packages = boots.split(",");
         for (String packageRegex : packages) {
             // Do a little manipulation to turn a little-p pattern into a regex so we can turn it into a big-p pattern


### PR DESCRIPTION
In relation to https://github.com/OpenLiberty/open-liberty/issues/11043

The build failure and error comes from not being able to read a property from a budleContext (osgi bundle). The property is org.osgi.framework.bootdelegation.
From the stacktrace we can see that the first line that includes our code is ...
com.ibm.ws.logging.internal.PackageProcessor.populateBootDelegationPackageList(PackageProcessor.java:206). On line 206 the code is attempting to read the org.osgi.framework.bootdelegation property from a bundleContext. That leads to an Access denied. We believe that simply putting line 206 into a doPrivileged should fix the permissions issue. 

