### PR TITLE
Add debug trace for JSF23ViewParametersTests

### DIFF
--- a/dev/com.ibm.ws.jsf.2.3_fat/publish/servers/jsf23CDIBVServer/server.xml
+++ b/dev/com.ibm.ws.jsf.2.3_fat/publish/servers/jsf23CDIBVServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017, 2018 IBM Corporation and others.
+    Copyright (c) 2017, 2020 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -16,7 +16,7 @@
         <feature>cdi-2.0</feature>
         <feature>beanValidation-2.0</feature>
     </featureManager>
-    
-    <logging traceSpecification="*=info:org.apache.myfaces.*=all:com.ibm.ws.jsf*=all" maxFileSize="20" maxFiles="10" traceFormat="BASIC"/> 
+    <!-- CDI and WC trace added for #11250 --> 
+    <logging traceSpecification="*=info:org.apache.myfaces.*=all:com.ibm.ws.jsf*=all:com.ibm.ws.webcontainer*=all:JCDI=all:org.jboss.weld*=all:com.ibm.ws.cdi*=all" maxFileSize="20" maxFiles="10" traceFormat="BASIC"/> 
 
 </server>


### PR DESCRIPTION
Add CDI trace to the JSF23ViewParametersTests server so that we can get more information about a rare problem that occurs in testing: `javax.el.PropertyNotFoundException: Target Unreachable, identifier 'viewParamBean' resolved to null`