### PR TITLE
Ejb custom binding namespace error bug fix

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/BndErrorTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/BndErrorTest.java
@@ -45,12 +45,17 @@ public class BndErrorTest extends FATServletClient {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        server.startServer(false, false);
+
+        server.deleteAllDropinApplications();
+        server.removeAllInstalledAppsForValidation();
+
+        server.startServer(true, false);
     }
 
     @AfterClass
     public static void cleanUp() throws Exception {
         if (server != null && server.isStarted()) {
+
             server.stopServer("CNTR4002E", "CWWKZ0106E", "CWWKZ0002E", "CNTR0136E", "CNTR0137E", "CNTR0138E", "CNTR0139E", "CNTR0130E", "CNTR0140", "CNTR0141E", "CNTR0339W",
                               "CNTR0340W", "CWWKZ0004E");
         }
@@ -233,7 +238,7 @@ public class BndErrorTest extends FATServletClient {
     @Test
     @AllowedFFDC({ "com.ibm.ejs.container.EJBConfigurationException", "com.ibm.ws.container.service.state.StateChangeException" })
     public void testNamepsaceInLocalHomeBindingName() throws Exception {
-        testHelper(18, "CNTR0340W:", false);
+        testHelper(18, "CNTR0340W:.*ejblocal:local:ejb/myBean", false);
     }
 
     /**
@@ -242,7 +247,7 @@ public class BndErrorTest extends FATServletClient {
     @Test
     @AllowedFFDC({ "javax.ejb.EJBException", "com.ibm.ws.container.service.state.StateChangeException" })
     public void testNamepsaceInBindingName() throws Exception {
-        testHelper(19, "CNTR0339W:", false);
+        testHelper(19, "CNTR0339W:.*ejblocal:local:ejb/myBean", false);
     }
 
     /**
@@ -251,7 +256,7 @@ public class BndErrorTest extends FATServletClient {
     @Test
     @AllowedFFDC({ "com.ibm.ejs.container.EJBConfigurationException", "com.ibm.ws.container.service.state.StateChangeException" })
     public void testNamepsaceInRemoteHomeBindingName() throws Exception {
-        testHelper(20, "CNTR0339W:", false);
+        testHelper(20, "CNTR0339W:.*local:RemoteTargetHome", false);
     }
 
     /**
@@ -260,7 +265,7 @@ public class BndErrorTest extends FATServletClient {
     @Test
     @AllowedFFDC({ "com.ibm.ejs.container.EJBConfigurationException", "com.ibm.ws.container.service.state.StateChangeException" })
     public void testRandomColonInRemoteHomeBindingName() throws Exception {
-        testHelper(21, "CNTR0339W:", false);
+        testHelper(21, "CNTR0339W:.*myBean:RemoteTargetHome", false);
     }
 
     /**
@@ -269,7 +274,7 @@ public class BndErrorTest extends FATServletClient {
     @Test
     @AllowedFFDC({ "javax.ejb.EJBException", "com.ibm.ws.container.service.state.StateChangeException" })
     public void testJavaAppInSimpleBindingName() throws Exception {
-        testHelper(22, "CNTR0339W:", false);
+        testHelper(22, "CNTR0339W:.*java:app/MyLocalTargetBean", false);
     }
 
     /**
@@ -278,7 +283,7 @@ public class BndErrorTest extends FATServletClient {
     @Test
     @AllowedFFDC({ "com.ibm.ejs.container.EJBConfigurationException", "com.ibm.ws.container.service.state.StateChangeException" })
     public void testNamespaceInBindingName() throws Exception {
-        testHelper(23, "CNTR0339W:", false);
+        testHelper(23, "CNTR0339W:.*local:ejb/RemoteTargetBiz", false);
     }
 
     /**
@@ -287,7 +292,7 @@ public class BndErrorTest extends FATServletClient {
     @Test
     @AllowedFFDC({ "com.ibm.ejs.container.EJBConfigurationException", "com.ibm.ws.container.service.state.StateChangeException" })
     public void testNamespaceInComponentId() throws Exception {
-        testHelper(24, "CNTR0339W:", false);
+        testHelper(24, "CNTR0339W:.*local:ejb/MyLocalTargetBean", false);
     }
 
     /**
@@ -305,7 +310,7 @@ public class BndErrorTest extends FATServletClient {
     @Test
     @AllowedFFDC({ "javax.ejb.EJBException", "com.ibm.ws.container.service.state.StateChangeException" })
     public void testNamespaceInJNDIName() throws Exception {
-        testHelper(26, "CNTR0339W:", false);
+        testHelper(26, "CNTR0339W:.*local:ejb/com/ibm/ejb2x/jndiName/ejb/JNDINameHome1", false);
     }
 
     /**
@@ -323,7 +328,7 @@ public class BndErrorTest extends FATServletClient {
     @Test
     @AllowedFFDC({ "com.ibm.ejs.container.EJBConfigurationException", "com.ibm.ws.container.service.state.StateChangeException" })
     public void testDoubleColonInLocalHomeBindingName() throws Exception {
-        testHelper(28, "CNTR0340W:", false);
+        testHelper(28, "CNTR0340W:.*ejblocal::ejb/myBean", false);
     }
 
     /**

--- a/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/EJBMDOrchestratorImpl.java
+++ b/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/EJBMDOrchestratorImpl.java
@@ -529,6 +529,7 @@ public class EJBMDOrchestratorImpl extends EJBMDOrchestrator {
 
         if (bmd.ivComponent_Id != null) {
             if (bmd.ivComponent_Id.contains(":")) {
+                String providedBinding = bmd.ivComponent_Id;
                 bmd.ivComponent_Id = null;
                 OnError onError = ContainerProperties.customBindingsOnErr;
                 switch (onError) {
@@ -536,13 +537,13 @@ public class EJBMDOrchestratorImpl extends EJBMDOrchestrator {
                         Tr.warning(tcContainer, "NAMESPACE_IN_JNDI_BINDING_NAME_CNTR0339W",
                                    new Object[] { bmd.enterpriseBeanName,
                                                   bmd._moduleMetaData.ivName,
-                                                  bmd.ivComponent_Id });
+                                                  providedBinding });
                         break;
                     case FAIL:
                         Tr.error(tcContainer, "NAMESPACE_IN_JNDI_BINDING_NAME_CNTR0339W",
                                  new Object[] { bmd.enterpriseBeanName,
                                                 bmd._moduleMetaData.ivName,
-                                                bmd.ivComponent_Id });
+                                                providedBinding });
                         throw new EJBConfigurationException("The " + bmd.enterpriseBeanName +
                                                             " bean or home in the " + bmd._moduleMetaData.ivName +
                                                             " module contains a namespace in the string value for the" +
@@ -846,6 +847,7 @@ public class EJBMDOrchestratorImpl extends EJBMDOrchestrator {
                         break;
                 }
             } else if (trimmedBindingValue.contains(":")) {
+                String providedBinding = bmd.localHomeJndiBindingName;
                 bmd.localHomeJndiBindingName = null;
                 OnError onError = ContainerProperties.customBindingsOnErr;
                 switch (onError) {
@@ -853,13 +855,13 @@ public class EJBMDOrchestratorImpl extends EJBMDOrchestrator {
                         Tr.warning(tcContainer, "NAMESPACE_IN_LOCAL_JNDI_BINDING_NAME_CNTR0340W",
                                    new Object[] { bmd.enterpriseBeanName,
                                                   bmd._moduleMetaData.ivName,
-                                                  bmd.localHomeJndiBindingName });
+                                                  providedBinding });
                         break;
                     case FAIL:
                         Tr.error(tcContainer, "NAMESPACE_IN_LOCAL_JNDI_BINDING_NAME_CNTR0340W",
                                  new Object[] { bmd.enterpriseBeanName,
                                                 bmd._moduleMetaData.ivName,
-                                                bmd.localHomeJndiBindingName });
+                                                providedBinding });
                         throw new EJBConfigurationException("The " + bmd.enterpriseBeanName +
                                                             " bean or home in the " + bmd._moduleMetaData.ivName +
                                                             " module contains a namespace in the string value for the" +
@@ -919,6 +921,7 @@ public class EJBMDOrchestratorImpl extends EJBMDOrchestrator {
                         break;
                 }
             } else if (bmd.remoteHomeJndiBindingName.contains(":")) {
+                String providedBinding = bmd.remoteHomeJndiBindingName;
                 bmd.remoteHomeJndiBindingName = null;
                 OnError onError = ContainerProperties.customBindingsOnErr;
                 switch (onError) {
@@ -926,13 +929,13 @@ public class EJBMDOrchestratorImpl extends EJBMDOrchestrator {
                         Tr.warning(tcContainer, "NAMESPACE_IN_JNDI_BINDING_NAME_CNTR0339W",
                                    new Object[] { bmd.enterpriseBeanName,
                                                   bmd._moduleMetaData.ivName,
-                                                  bmd.localHomeJndiBindingName });
+                                                  providedBinding });
                         break;
                     case FAIL:
                         Tr.error(tcContainer, "NAMESPACE_IN_JNDI_BINDING_NAME_CNTR0339W",
                                  new Object[] { bmd.enterpriseBeanName,
                                                 bmd._moduleMetaData.ivName,
-                                                bmd.localHomeJndiBindingName });
+                                                providedBinding });
                         throw new EJBConfigurationException("The " + bmd.enterpriseBeanName +
                                                             " bean or home in the " + bmd._moduleMetaData.ivName +
                                                             " module contains a namespace in the string value for the" +

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -5516,6 +5516,11 @@ public class LibertyServer implements LogMonitorClient {
     public void startServer(boolean cleanStart, boolean validateApps) throws Exception {
         startServerAndValidate(true, cleanStart, validateApps);
     }
+    
+    public void deleteAllDropinApplications() throws Exception {
+        LibertyFileManager.deleteLibertyDirectoryAndContents(machine, getServerRoot() + "/dropins");
+        LibertyFileManager.createRemoteFile(machine, getServerRoot() + "/dropins");
+    }
 
     /**
      * Restart a drop-ins application.


### PR DESCRIPTION
Originally for a build break caused by the server installing every application at startup because a previous run had added them to dropins, and even though they were "removed" from dropins, they were still in the list of installed applications and being cached in the server after it stopped.

I then noticed a bug in my namespace warning code. some of my message printouts had null for the binding-value, so I fixed that too, and updated relevant tests to catch it.
