### PR TITLE
enable Services Test

### DIFF
--- a/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/DummyTest.java
+++ b/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/DummyTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import junit.framework.Assert;
 
-public class DummyTest extends InstallUtilityToolTest {
+public class DummyTest extends InstallPackagesToolTest {
     private static final Class<?> c = DummyTest.class;
 
     /**

--- a/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/FATSuite.java
+++ b/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/FATSuite.java
@@ -18,9 +18,8 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({
                 DummyTest.class,
-                InstallPackagesTest.class
-
-//              ,ServicesTest.class
+                InstallPackagesTest.class,
+                ServicesTest.class
 })
 public class FATSuite {
 

--- a/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/InstallPackagesTest.java
+++ b/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/InstallPackagesTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.log.Log;
 
-public class InstallPackagesTest extends InstallUtilityToolTest {
+public class InstallPackagesTest extends InstallPackagesToolTest {
     private static final Class<?> c = InstallPackagesTest.class;
 
     @BeforeClass

--- a/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/InstallPackagesToolTest.java
+++ b/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/InstallPackagesToolTest.java
@@ -18,9 +18,9 @@ import com.ibm.websphere.simplicity.log.Log;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
-public abstract class InstallUtilityToolTest {
+public abstract class InstallPackagesToolTest {
 
-    private static final Class<?> c = InstallUtilityToolTest.class;
+    private static final Class<?> c = InstallPackagesToolTest.class;
     public static LibertyServer server;
     public static String installRoot;
     public static boolean isLinux = System.getProperty("os.name").toLowerCase().contains("linux");

--- a/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/InstallUtilityToolTest.java
+++ b/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/InstallUtilityToolTest.java
@@ -32,6 +32,7 @@ public abstract class InstallUtilityToolTest {
     public static boolean connectedToRepo = true;
     public static Logger logger = Logger.getLogger("com.ibm.ws.install.packaging.fat");
     public static String javaHome;
+    public static Boolean isjavaHomeExecutable = false;
     public static String currentDirectory = ".";
     public static String autoFVTRoot = currentDirectory;
     public static String publishPath = autoFVTRoot + "/publish";
@@ -102,6 +103,9 @@ public abstract class InstallUtilityToolTest {
         Log.info(c, METHOD_NAME, "installRoot: " + installRoot);
         javaHome = server.getMachineJavaJDK();
         Log.info(c, METHOD_NAME, "javaHome: " + javaHome);
+        // check if javaHome is executable
+        isjavaHomeExecutable = isFileExecutable(javaHome);
+
         cleanDirectories = new ArrayList<String>();
         cleanFiles = new ArrayList<String>();
 
@@ -142,6 +146,22 @@ public abstract class InstallUtilityToolTest {
             Log.info(c, METHOD_NAME, "package not found");
             packagesBuilt = false;
         }
+    }
+
+    protected static Boolean isFileExecutable(String filePath) throws Exception {
+        String METHOD_NAME = "isFileExecutable";
+        Boolean RC = false;
+        String[] po1args = { "-m -v " + filePath + "|sed \"1 d\" | cut -c 10 |grep -v x" };
+        ProgramOutput po1 = runCommand(METHOD_NAME, "namei", po1args);
+        if (po1.getReturnCode() == 0) {
+            RC = false;
+            String[] po2args = { "-m -v " + filePath };
+            ProgramOutput po2 = runCommand(METHOD_NAME, "namei", po2args);
+            Log.info(c, METHOD_NAME, "Non executable directory or file found.:\n" + po2.getStdout());
+        } else {
+            RC = true;
+        }
+        return RC;
     }
 
     protected static void entering(Class<?> c, String METHOD_NAME) {

--- a/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/ServicesTest.java
+++ b/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/ServicesTest.java
@@ -7,6 +7,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.log.Log;
@@ -18,6 +19,7 @@ public class ServicesTest extends InstallUtilityToolTest {
     public static void beforeClassSetup() throws Exception {
         Assume.assumeTrue(isSupportedOS());
         setupEnv();
+        Assume.assumeTrue(isjavaHomeExecutable);
     }
 
     @AfterClass
@@ -42,20 +44,14 @@ public class ServicesTest extends InstallUtilityToolTest {
      * 5. stop service
      * 6. Uninstall TestRPM
      */
-// test currently disabled.
-//    @Test
+//  currently disabled.
+    @Test
     public void testService() throws Exception {
 
         String METHOD_NAME = "testService";
         entering(c, METHOD_NAME);
 
         Boolean testsPassed = false;
-
-        // Should not be necessary to chmod a+X java.  Test machines should be setup so that java can be executed by openliberty user.
-//        // ensure java_home and parent dirs have +x attribute
-//        String[] param1a = { "chmod", "-R", "a+X", "/home" };
-//        ProgramOutput po1a = runCommand(METHOD_NAME, "sudo ", param1a);
-//        Log.info(c, METHOD_NAME, "add permissions RC:" + po1a.getReturnCode());
 
         //Install package
         ProgramOutput po1 = installCurrentPackage(METHOD_NAME, packageExt);

--- a/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/ServicesTest.java
+++ b/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/ServicesTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.log.Log;
 
-public class ServicesTest extends InstallUtilityToolTest {
+public class ServicesTest extends InstallPackagesToolTest {
     private static final Class<?> c = ServicesTest.class;
 
     @BeforeClass


### PR DESCRIPTION
Modified ServicesTest to check for an executable java.
Will skip test if java is not executable by openliberty.
