### PR TITLE
Adding JDBC heritage API feature to enable ConnectionWaitTimeoutException

### DIFF
--- a/dev/com.ibm.ws.jdbc/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc/bnd.bnd
@@ -27,7 +27,8 @@ Export-Package: \
     com.ibm.ws.jdbc.timedoperations, \
     com.ibm.ws.rsadapter, \
     com.ibm.ws.rsadapter.jdbc, \
-    com.ibm.ws.rsadapter.impl
+    com.ibm.ws.rsadapter.impl, \
+    com.ibm.websphere.ce.cm
 
 Import-Package: \
     com.ibm.ws.jca.adapter, \
@@ -37,7 +38,6 @@ Import-Package: \
 
 Private-Package: \
     com.ibm.ejs.cm.logger, \
-    com.ibm.websphere.ce.cm, \
     com.ibm.ws.jdbc.internal, \
     com.ibm.ws.jdbc.*, \
     com.ibm.ws.rsadapter.exceptions, \

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/websphere/ce/cm/ConnectionWaitTimeoutException.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/websphere/ce/cm/ConnectionWaitTimeoutException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 IBM Corporation and others.
+ * Copyright (c) 2011, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,11 +21,112 @@ public class ConnectionWaitTimeoutException extends SQLTransientConnectionExcept
     private static final long serialVersionUID = 5958695928250441720L;
 
     /**
-     * Make a new ConnectionWaitTimeoutException.
-     * 
-     * @param message the exception message.
+     * Constructs a <code>ConnectionWaitTimeoutException</code> object.
+     * The <code>reason</code>, <code>SQLState</code> are initialized
+     * to <code>null</code> and the vendor code is initialized to 0.
+     * <p>
      */
-    public ConnectionWaitTimeoutException(String message) {
-        super(message);
+    public ConnectionWaitTimeoutException() {
+        super();
+    }
+
+    /**
+     * Constructs a <code>ConnectionWaitTimeoutException</code> object
+     * with a given <code>reason</code>. The <code>SQLState</code>
+     * is initialized to <code>null</code> and the vendor code is initialized
+     * to 0.
+     * <p>
+     * @param reason a description of the exception
+     */
+    public ConnectionWaitTimeoutException(String reason) {
+        super(reason);
+    }
+
+    /**
+     * Constructs a <code>ConnectionWaitTimeoutException</code> object
+     * with a given <code>reason</code> and <code>SQLState</code>.
+     * 
+     * The vendor code is initialized to 0.
+     * <p>
+     * @param reason a description of the exception
+     * @param SQLState an XOPEN or SQL:2003 code identifying the exception
+     */
+    public ConnectionWaitTimeoutException(String reason, String SQLState) {
+        super(reason,SQLState);
+    }
+
+    /**
+     * Constructs a <code>ConnectionWaitTimeoutException</code> object
+     * with a given <code>reason</code>, <code>SQLState</code>  and
+     * <code>vendorCode</code>.
+     * <p>
+     * @param reason a description of the exception
+     * @param SQLState an XOPEN or SQL:2003 code identifying the exception
+     * @param vendorCode a database vendor specific exception code
+     */
+    public ConnectionWaitTimeoutException(String reason, String SQLState, int vendorCode) {
+        super(reason,SQLState,vendorCode);
+    }
+
+    /**
+     * Constructs a <code>ConnectionWaitTimeoutException</code> object
+     * with a given  <code>cause</code>.
+     * The <code>SQLState</code> is initialized
+     * to <code>null</code> and the vendor code is initialized to 0.
+     * The <code>reason</code>  is initialized to <code>null</code> if
+     * <code>cause==null</code> or to <code>cause.toString()</code> if
+     * <code>cause!=null</code>.
+     * <p>
+     * @param cause the underlying reason for this <code>SQLException</code> (which is saved for later retrieval by the <code>getCause()</code> method); may be null indicating
+     *     the cause is non-existent or unknown.
+     */
+    public ConnectionWaitTimeoutException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a <code>ConnectionWaitTimeoutException</code> object
+     * with a given
+     * <code>reason</code> and  <code>cause</code>.
+     * The <code>SQLState</code> is  initialized to <code>null</code>
+     * and the vendor code is initialized to 0.
+     * <p>
+     * @param reason a description of the exception.
+     * @param cause the underlying reason for this <code>SQLException</code>(which is saved for later retrieval by the <code>getCause()</code> method); may be null indicating
+     *     the cause is non-existent or unknown.
+     */
+    public ConnectionWaitTimeoutException(String reason, Throwable cause) {
+        super(reason,cause);
+    }
+
+    /**
+     * Constructs a <code>ConnectionWaitTimeoutException</code> object
+     * with a given
+     * <code>reason</code>, <code>SQLState</code> and  <code>cause</code>.
+     * The vendor code is initialized to 0.
+     * <p>
+     * @param reason a description of the exception.
+     * @param SQLState an XOPEN or SQL:2003 code identifying the exception
+     * @param cause the underlying reason for this <code>SQLException</code> (which is saved for later retrieval by the <code>getCause()</code> method); may be null indicating
+     *     the cause is non-existent or unknown.
+     */
+    public ConnectionWaitTimeoutException(String reason, String SQLState, Throwable cause) {
+        super(reason,SQLState,cause);
+    }
+
+    /**
+     *  Constructs a <code>ConnectionWaitTimeoutException</code> object
+     * with a given
+     * <code>reason</code>, <code>SQLState</code>, <code>vendorCode</code>
+     * and  <code>cause</code>.
+     * <p>
+     * @param reason a description of the exception
+     * @param SQLState an XOPEN or SQL:2003 code identifying the exception
+     * @param vendorCode a database vendor-specific exception code
+     * @param cause the underlying reason for this <code>SQLException</code> (which is saved for later retrieval by the <code>getCause()</code> method); may be null indicating
+     *     the cause is non-existent or unknown.
+     */
+    public ConnectionWaitTimeoutException(String reason, String SQLState, int vendorCode, Throwable cause) {
+        super(reason,SQLState,vendorCode,cause);
     }
 }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/websphere/ce/cm/package-info.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/websphere/ce/cm/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+package com.ibm.websphere.ce.cm;

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/AdapterUtil.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/AdapterUtil.java
@@ -798,7 +798,7 @@ public class AdapterUtil {
 
     /**
      * Converts a ResourceException to a SQLException. Returns the first chained exception
-     * found to be a SQLException or ConnectionWaitTimeoutException. If none of the chained
+     * found to be a SQLException or ConnectionWaitTimeoutException. If none of the
      * chained exceptions are SQLExceptions or ConnectionWaitTimeoutExceptions, a new
      * SQLException is created containing information from the ResourceException.
      * 
@@ -821,11 +821,15 @@ public class AdapterUtil {
             // The J2C connection manager raises a special exception subclass.
             else if (linkedX instanceof ResourceAllocationException
                      && linkedX.getClass().getName().equals("com.ibm.websphere.ce.j2c.ConnectionWaitTimeoutException")) {
-                // Use a special SQLException subclass for connection wait timeout. 
-                sqlX = new ConnectionWaitTimeoutException(linkedX.getMessage()); 
-                sqlX.initCause(resX); 
-
-                sqlX = new SQLTransientConnectionException(linkedX.getMessage(), "08001", 0, sqlX); 
+                // The following exception was changed from throwing an SQLTransientConnectionException 
+                // to a ConnectionWaitTimeoutException instead to allow for traditional WebSphere applications to work since they expect a 
+                // ConnectionWaitTimeoutException instead.  This will continue to work with existing liberty applications as well since 
+                // SQLTransientConnectionException is the parent class of ConnectionWaitTimeoutException.  
+                // The ConnectionWaitTimeoutException is linked to another ConnectionWaitTimeoutException for backwards compatibility for liberty applications
+                // that were traversing the previous SQLTransientConnectionException to get to the underlying ConnectionWaitTimeoutException
+                SQLException sqlX2 = new ConnectionWaitTimeoutException(linkedX.getMessage());
+                // Keeping the original SQLState and SQLCode from the previous SQLTransientConnectionException
+                sqlX = new ConnectionWaitTimeoutException(linkedX.getMessage(), "08001", 0, sqlX2);
                 break;
             }
         }


### PR DESCRIPTION
In a WebSphere Application Server, if a JDBC connection is requested with a specified timeout, but it is unable to allocate a connection before the connection timeout is reached, a com.ibm.websphere.ce.cm.ConnectionWaitTimeoutException exception gets thrown.

In contrast, Liberty throws an SQLTransientConnectionException exception with a chained ConnectionWaitTimeoutException exception in this case.  

For people that would like a consistent behavior for this exception process between WebSphere Application Server and Liberty, this is an optional new feature to allow this behavior.  The ConnectionWaitTimeoutException already exists in Liberty, but needs to be exposed as an API.  The feature itself will only be offered in the commercial version of Liberty, but the code changes to support this feature will be made in Open Liberty.

Migration of existing apps is the only reason for exposing the ConnectionWaitTimeoutException, we don't encourage it's use for maintenance or new apps. Although there are other exceptions in the com.ibm.websphere.ce.cm package, for the time being we're only going to expose this one exception.

Related issues
Issue #10542
Issue #10379