### PR TITLE
Improve log messages from the kafka connector

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.adapter/src/com/ibm/ws/microprofile/reactive/messaging/kafka/adapter/KafkaAdapterException.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.adapter/src/com/ibm/ws/microprofile/reactive/messaging/kafka/adapter/KafkaAdapterException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.microprofile.reactive.messaging.kafka.adapter;
+
+import java.lang.reflect.InvocationTargetException;
 
 /**
  *
@@ -22,7 +24,7 @@ public class KafkaAdapterException extends RuntimeException {
      * @param cause
      */
     public KafkaAdapterException(Exception cause) {
-        super(cause);
+        super(buildMessage(cause), cause);
     }
 
     /**
@@ -30,6 +32,36 @@ public class KafkaAdapterException extends RuntimeException {
      */
     public KafkaAdapterException(String message) {
         super(message);
+    }
+
+    /**
+     * Build a useful message based on the cause chain from Kafka
+     * <p>
+     * In general, the kafka client gives a helpful chain of exceptions explaining what happened and when. However, for liberty log messages, we want to capture the exception cause
+     * chain in a single message.
+     *
+     * @param cause the cause of this exception
+     * @return the message for this exception
+     */
+    private static String buildMessage(Throwable cause) {
+        // Usually the first exception is an InvocationTargetException which isn't helpful in the error message
+        if (cause instanceof InvocationTargetException) {
+            cause = cause.getCause();
+        }
+
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        while (cause != null) {
+            if (!first) {
+                sb.append(": ");
+            }
+            first = false;
+
+            sb.append(cause.toString());
+            cause = cause.getCause();
+        }
+
+        return sb.toString();
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/resources/com/ibm/ws/microprofile/reactive/messaging/kafka/resources/ReactiveMessaging.nlsprops
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/resources/com/ibm/ws/microprofile/reactive/messaging/kafka/resources/ReactiveMessaging.nlsprops
@@ -60,6 +60,16 @@ kafka.library.not.present.CWMRX1006E=CWMRX1006E: Classes from the kafka-clients 
 kafka.library.not.present.CWMRX1006E.explanation=Applications that use the Reactive Messaging Kafka Client must provide the kafka-clients JAR file and its dependencies. They can provide this file and its dependencies either by packaging it as a library within the application or by providing it as a shared library.
 kafka.library.not.present.CWMRX1006E.useraction=Package the kafka-clients JAR file and its dependencies as libraries in your application or as a shared library. The kafka-clients JAR file can be downloaded from the Apache Kafka website or from Maven Central.
 
+# Could not create a Kafka incoming connector for the {0} channel. The error is {1}
+kafka.create.incoming.error.CWMRX1007E=CWMRX1007E: Could not create a Kafka incoming connector for the {0} channel. The error is {1}
+kafka.create.incoming.error.CWMRX1007E.explanation=An error has occurred while setting up the Kafka connector for an incoming reactive messaging channel that prevents normal operation of Reactive Messaging.
+kafka.create.incoming.error.CWMRX1007E.useraction=Review the error message, server message.log and FFDC logs to identify the problem.
+
+# Could not create a Kafka outgoing connector for the {0} channel. The error is {1}
+kafka.create.outgoing.error.CWMRX1008E=CWMRX1008E: Could not create a Kafka outgoing connector for the {0} channel. The error is {1}
+kafka.create.outgoing.error.CWMRX1008E.explanation=An error has occurred while setting up the Kafka connector for an outgoing reactive messaging channel that prevents normal operation of Reactive Messaging.
+kafka.create.outgoing.error.CWMRX1008E.useraction=Review the error message, server message.log and FFDC logs to identify the problem.
+
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Reactive Messaging error message
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/resources/com/ibm/ws/microprofile/reactive/messaging/kafka/resources/ReactiveMessaging.nlsprops
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/resources/com/ibm/ws/microprofile/reactive/messaging/kafka/resources/ReactiveMessaging.nlsprops
@@ -60,15 +60,15 @@ kafka.library.not.present.CWMRX1006E=CWMRX1006E: Classes from the kafka-clients 
 kafka.library.not.present.CWMRX1006E.explanation=Applications that use the Reactive Messaging Kafka Client must provide the kafka-clients JAR file and its dependencies. They can provide this file and its dependencies either by packaging it as a library within the application or by providing it as a shared library.
 kafka.library.not.present.CWMRX1006E.useraction=Package the kafka-clients JAR file and its dependencies as libraries in your application or as a shared library. The kafka-clients JAR file can be downloaded from the Apache Kafka website or from Maven Central.
 
-# Could not create a Kafka incoming connector for the {0} channel. The error is {1}
-kafka.create.incoming.error.CWMRX1007E=CWMRX1007E: Could not create a Kafka incoming connector for the {0} channel. The error is {1}
-kafka.create.incoming.error.CWMRX1007E.explanation=An error has occurred while setting up the Kafka connector for an incoming reactive messaging channel that prevents normal operation of MicroProfile Reactive Messaging.
-kafka.create.incoming.error.CWMRX1007E.useraction=Review the error message, server message.log and FFDC logs to identify the problem.
+# A Kafka incoming connector for the {0} channel cannot be created. The error is {1}
+kafka.create.incoming.error.CWMRX1007E=CWMRX1007E: A Kafka incoming connector for the {0} channel cannot be created. The error is {1}
+kafka.create.incoming.error.CWMRX1007E.explanation=An error that occurred when the Kafka connector was set up for an incoming reactive messaging channel prevents normal operation of MicroProfile Reactive Messaging.
+kafka.create.incoming.error.CWMRX1007E.useraction=Review the error message, server message.log, and FFDC logs to identify the problem.
 
-# Could not create a Kafka outgoing connector for the {0} channel. The error is {1}
-kafka.create.outgoing.error.CWMRX1008E=CWMRX1008E: Could not create a Kafka outgoing connector for the {0} channel. The error is {1}
-kafka.create.outgoing.error.CWMRX1008E.explanation=An error has occurred while setting up the Kafka connector for an outgoing reactive messaging channel that prevents normal operation of MicroProfile Reactive Messaging.
-kafka.create.outgoing.error.CWMRX1008E.useraction=Review the error message, server message.log and FFDC logs to identify the problem.
+# A Kafka outgoing connector for the {0} channel cannot be created. The error is {1}
+kafka.create.outgoing.error.CWMRX1008E=CWMRX1008E: A Kafka outgoing connector for the {0} channel cannot be created. The error is {1}
+kafka.create.outgoing.error.CWMRX1008E.explanation=An error that occurred when the Kafka connector was set up for an outgoing reactive messaging channel prevents normal operation of MicroProfile Reactive Messaging.
+kafka.create.outgoing.error.CWMRX1008E.useraction=Review the error message, server message.log, and FFDC logs to identify the problem.
 
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Reactive Messaging error message

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/resources/com/ibm/ws/microprofile/reactive/messaging/kafka/resources/ReactiveMessaging.nlsprops
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/resources/com/ibm/ws/microprofile/reactive/messaging/kafka/resources/ReactiveMessaging.nlsprops
@@ -62,12 +62,12 @@ kafka.library.not.present.CWMRX1006E.useraction=Package the kafka-clients JAR fi
 
 # Could not create a Kafka incoming connector for the {0} channel. The error is {1}
 kafka.create.incoming.error.CWMRX1007E=CWMRX1007E: Could not create a Kafka incoming connector for the {0} channel. The error is {1}
-kafka.create.incoming.error.CWMRX1007E.explanation=An error has occurred while setting up the Kafka connector for an incoming reactive messaging channel that prevents normal operation of Reactive Messaging.
+kafka.create.incoming.error.CWMRX1007E.explanation=An error has occurred while setting up the Kafka connector for an incoming reactive messaging channel that prevents normal operation of MicroProfile Reactive Messaging.
 kafka.create.incoming.error.CWMRX1007E.useraction=Review the error message, server message.log and FFDC logs to identify the problem.
 
 # Could not create a Kafka outgoing connector for the {0} channel. The error is {1}
 kafka.create.outgoing.error.CWMRX1008E=CWMRX1008E: Could not create a Kafka outgoing connector for the {0} channel. The error is {1}
-kafka.create.outgoing.error.CWMRX1008E.explanation=An error has occurred while setting up the Kafka connector for an outgoing reactive messaging channel that prevents normal operation of Reactive Messaging.
+kafka.create.outgoing.error.CWMRX1008E.explanation=An error has occurred while setting up the Kafka connector for an outgoing reactive messaging channel that prevents normal operation of MicroProfile Reactive Messaging.
 kafka.create.outgoing.error.CWMRX1008E.useraction=Review the error message, server message.log and FFDC logs to identify the problem.
 
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaConnectorException.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaConnectorException.java
@@ -13,7 +13,7 @@ package com.ibm.ws.microprofile.reactive.messaging.kafka;
 /**
  * General exception for problems which originate in the Kafka connector
  */
-public class KafkaConnectorException extends Exception {
+public class KafkaConnectorException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaOutgoingConnector.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaOutgoingConnector.java
@@ -32,12 +32,16 @@ import org.eclipse.microprofile.reactive.messaging.spi.OutgoingConnectorFactory;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterFactory;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaProducer;
 
 @Connector(KafkaConnectorConstants.CONNECTOR_NAME)
 @ApplicationScoped
 public class KafkaOutgoingConnector implements OutgoingConnectorFactory {
+
+    private static final TraceComponent tc = Tr.register(KafkaOutgoingConnector.class);
 
     @Inject
     private KafkaAdapterFactory kafkaAdapterFactory;
@@ -46,27 +50,33 @@ public class KafkaOutgoingConnector implements OutgoingConnectorFactory {
 
     @Override
     public SubscriberBuilder<Message<Object>, Void> getSubscriberBuilder(Config config) {
-        // Configure our defaults
-        Map<String, Object> producerConfig = new HashMap<>();
-
-        //default the key and value serializers to String
-        producerConfig.put(KafkaConnectorConstants.KEY_SERIALIZER, KafkaConnectorConstants.STRING_SERIALIZER);
-        producerConfig.put(KafkaConnectorConstants.VALUE_SERIALIZER, KafkaConnectorConstants.STRING_SERIALIZER);
-
-        // Pass the config directly through to the kafkaProducer
-        producerConfig.putAll(StreamSupport.stream(config.getPropertyNames().spliterator(), false)
-                                           .filter(k -> !KafkaConnectorConstants.NON_KAFKA_PROPS.contains(k))
-                                           .collect(Collectors.toMap(Function.identity(), (k) -> config.getValue(k, String.class))));
-
-        KafkaProducer<String, Object> kafkaProducer = this.kafkaAdapterFactory.newKafkaProducer(producerConfig);
 
         String channelName = config.getValue(ConnectorFactory.CHANNEL_NAME_ATTRIBUTE, String.class);
-        String configuredTopic = config.getOptionalValue(KafkaConnectorConstants.TOPIC, String.class).orElse(null);
 
-        KafkaOutput<String, Object> kafkaOutput = new KafkaOutput<>(this.kafkaAdapterFactory, configuredTopic, channelName, kafkaProducer);
-        this.kafkaOutputs.add(kafkaOutput);
+        try {
+            // Configure our defaults
+            Map<String, Object> producerConfig = new HashMap<>();
 
-        return ReactiveStreams.<Message<Object>> builder().to(kafkaOutput.getSubscriber());
+            //default the key and value serializers to String
+            producerConfig.put(KafkaConnectorConstants.KEY_SERIALIZER, KafkaConnectorConstants.STRING_SERIALIZER);
+            producerConfig.put(KafkaConnectorConstants.VALUE_SERIALIZER, KafkaConnectorConstants.STRING_SERIALIZER);
+
+            // Pass the config directly through to the kafkaProducer
+            producerConfig.putAll(StreamSupport.stream(config.getPropertyNames().spliterator(), false)
+                                               .filter(k -> !KafkaConnectorConstants.NON_KAFKA_PROPS.contains(k))
+                                               .collect(Collectors.toMap(Function.identity(), (k) -> config.getValue(k, String.class))));
+
+            KafkaProducer<String, Object> kafkaProducer = this.kafkaAdapterFactory.newKafkaProducer(producerConfig);
+
+            String configuredTopic = config.getOptionalValue(KafkaConnectorConstants.TOPIC, String.class).orElse(null);
+
+            KafkaOutput<String, Object> kafkaOutput = new KafkaOutput<>(this.kafkaAdapterFactory, configuredTopic, channelName, kafkaProducer);
+            this.kafkaOutputs.add(kafkaOutput);
+
+            return ReactiveStreams.<Message<Object>> builder().to(kafkaOutput.getSubscriber());
+        } catch (Exception e) {
+            throw new KafkaConnectorException(Tr.formatMessage(tc, "kafka.create.outgoing.error.CWMRX1008E", channelName, e.getMessage()), e);
+        }
     }
 
     @PreDestroy


### PR DESCRIPTION
Ensure that we correctly scoop out the exceptions from the cause chain
for any kafka exceptions so that they get displayed in the console.

Example output after this change:
```
[ERROR   ] Unable to create the publisher or subscriber during initialization
CWMRX1007E: Could not create a Kafka incoming connector for the input channel. The error is org.apache.kafka.common.KafkaException: Failed to construct kafka consumer: org.apache.kafka.common.config.ConfigException: No resolvable bootstrap urls given in bootstrap.servers
```

Fixes #11274 