### PR TITLE
update jsp 3.0 bnd.bnd buildpath

### DIFF
--- a/dev/com.ibm.websphere.jakartaee.jsp.3.0/bnd.bnd
+++ b/dev/com.ibm.websphere.jakartaee.jsp.3.0/bnd.bnd
@@ -33,5 +33,4 @@ instrument.disabled: true
 publish.wlp.jar.suffix: dev/api/spec
 
 -buildpath: \
-  com.ibm.ws.javax.j2ee:servlet.jsp.resources;version=2.3, \
   jakarta.servlet.jsp-api;version=3.0.0


### PR DESCRIPTION
Previous commit did not include this change.  Since resources are overlay-ed, there is no need for this package.  (I don't believe it's even picked up in the jakarta bundle). 
