### PR TITLE
MP Config 1.4 raw value cache configuration

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/impl/Config14Impl.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/impl/Config14Impl.java
@@ -50,7 +50,7 @@ public class Config14Impl extends AbstractConfig implements WebSphereConfig {
      */
     public Config14Impl(ConversionManager conversionManager, SortedSources sources, ScheduledExecutorService executor, long refreshInterval) {
         super(conversionManager, sources);
-        rawValueCache = new TimedCache<>(executor, 500, TimeUnit.MILLISECONDS);
+        rawValueCache = new TimedCache<>(executor, refreshInterval, TimeUnit.MILLISECONDS);
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/impl/TimedCache.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/impl/TimedCache.java
@@ -90,7 +90,7 @@ public class TimedCache<K, V> {
     public V get(K key, Function<K, V> lookupFunction) {
 
         // If no expiry time is set, do no caching
-        if (delay == 0) {
+        if (delay <= 0) {
             return lookupFunction.apply(key);
         }
 

--- a/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/impl/TimedCache.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/impl/TimedCache.java
@@ -60,9 +60,11 @@ public class TimedCache<K, V> {
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
     /**
-     * @param executor
-     * @param delay
-     * @param unit
+     * Create a new TimedCache instance
+     *
+     * @param executor the executor to use to schedule cache removal tasks
+     * @param delay    the delay before items are removed from the cache
+     * @param unit     the unit of {@code delay}
      */
     public TimedCache(ScheduledExecutorService executor, long delay, TimeUnit unit) {
         if (executor == null) {
@@ -87,6 +89,7 @@ public class TimedCache<K, V> {
      */
     public V get(K key, Function<K, V> lookupFunction) {
 
+        // If no expiry time is set, do no caching
         if (delay == 0) {
             return lookupFunction.apply(key);
         }

--- a/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/impl/TimedCache.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/impl/TimedCache.java
@@ -87,6 +87,10 @@ public class TimedCache<K, V> {
      */
     public V get(K key, Function<K, V> lookupFunction) {
 
+        if (delay == 0) {
+            return lookupFunction.apply(key);
+        }
+
         Object cacheValue = cache.get(key);
 
         if (cacheValue == null) {

--- a/dev/com.ibm.ws.microprofile.config.1.4/test/src/com/ibm/ws/microprofile/config14/test/TimedCacheTest.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4/test/src/com/ibm/ws/microprofile/config14/test/TimedCacheTest.java
@@ -62,4 +62,18 @@ public class TimedCacheTest {
         assertEquals("foobaz", cache.get("foo", lookupFunction));
     }
 
+    @Test
+    public void testCachingNegative() {
+        // Negative delay should be equivalent to zero, i.e. no caching
+        TimedCache<String, String> cache = new TimedCache<>(null, -3000, TimeUnit.MILLISECONDS);
+        AtomicReference<String> suffix = new AtomicReference<>("bar");
+        Function<String, String> lookupFunction = k -> k + suffix.get();
+
+        assertEquals("foobar", cache.get("foo", lookupFunction));
+
+        suffix.set("baz");
+
+        assertEquals("foobaz", cache.get("foo", lookupFunction));
+    }
+
 }

--- a/dev/com.ibm.ws.microprofile.config.1.4/test/src/com/ibm/ws/microprofile/config14/test/TimedCacheTest.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4/test/src/com/ibm/ws/microprofile/config14/test/TimedCacheTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.config14.test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import org.junit.Test;
+
+import com.ibm.ws.microprofile.config14.impl.TimedCache;
+
+public class TimedCacheTest {
+
+    @Test
+    public void testCaching() throws InterruptedException {
+        TimedCache<String, String> cache = new TimedCache<>(null, 500, TimeUnit.MILLISECONDS);
+        AtomicReference<String> suffix = new AtomicReference<>("bar");
+        Function<String, String> lookupFunction = k -> k + suffix.get();
+
+        assertEquals("foobar", cache.get("foo", lookupFunction));
+
+        suffix.set("baz");
+
+        assertEquals("foobar", cache.get("foo", lookupFunction));
+    }
+
+    @Test
+    public void testCacheExpiry() throws InterruptedException {
+        TimedCache<String, String> cache = new TimedCache<>(null, 500, TimeUnit.MILLISECONDS);
+        AtomicReference<String> suffix = new AtomicReference<>("bar");
+        Function<String, String> lookupFunction = k -> k + suffix.get();
+
+        assertEquals("foobar", cache.get("foo", lookupFunction));
+
+        suffix.set("baz");
+
+        Thread.sleep(1000); // Allow cache to expire
+        assertEquals("foobaz", cache.get("foo", lookupFunction));
+    }
+
+    @Test
+    public void testCachingDisabled() {
+        TimedCache<String, String> cache = new TimedCache<>(null, 0, TimeUnit.MILLISECONDS);
+        AtomicReference<String> suffix = new AtomicReference<>("bar");
+        Function<String, String> lookupFunction = k -> k + suffix.get();
+
+        assertEquals("foobar", cache.get("foo", lookupFunction));
+
+        suffix.set("baz");
+
+        assertEquals("foobaz", cache.get("foo", lookupFunction));
+    }
+
+}


### PR DESCRIPTION
Allow the time that values are kept in the cache to be configured.

Fixes #11257