### PR TITLE
Revert "Avoid NPE"

### DIFF
--- a/dev/com.ibm.ws.tx.embeddable/src/com/ibm/tx/jta/embeddable/impl/EmbeddableTransactionImpl.java
+++ b/dev/com.ibm.ws.tx.embeddable/src/com/ibm/tx/jta/embeddable/impl/EmbeddableTransactionImpl.java
@@ -1165,8 +1165,6 @@ public class EmbeddableTransactionImpl extends com.ibm.tx.jta.impl.TransactionIm
     @Override
     public String toString() {
         return super.toString() + ",active=" + _activeAssociations + ",suspended=" + _suspendedAssociations + ","
-               + (_thread != null ? "thread=" + String.format("%08X", _thread.getId())
-                                  : "Not on a thread, globalId=" + (null!=_globalId?_globalId:"<null>,getGlobalId()="+getGlobalId())
-                 );
+               + (_thread != null ? "thread=" + String.format("%08X", _thread.getId()) : "Not on a thread, globalId=" + _globalId);
     }
 }


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#11306

Causes 

`'com.ibm.ws.logging.internal.impl.BaseTraceService.publishTraceLogRecord:1,013'
java.lang.StackOverflowError
	at com.ibm.ws.logging.internal.impl.BaseTraceService.publishTraceLogRecord(BaseTraceService.java:1013)
	at com.ibm.ws.logging.internal.impl.BaseTraceService.debug(BaseTraceService.java:686)
	at com.ibm.websphere.ras.Tr.debug(Tr.java:424)
	at com.ibm.ejs.ras.Tr.debug(Tr.java:204)
	at com.ibm.ws.tx.util.logging.WASTr.debug(WASTr.java:26)
	at com.ibm.tx.util.logging.Tr.debug(Tr.java:343)
	at com.ibm.tx.jta.impl.TransactionImpl.getXidImpl(TransactionImpl.java:2379)
	at com.ibm.tx.jta.impl.TransactionImpl.getXid(TransactionImpl.java:2411)
	at com.ibm.tx.jta.embeddable.impl.EmbeddableTransactionImpl.getGlobalId(EmbeddableTransactionImpl.java:517)
	at com.ibm.tx.jta.embeddable.impl.EmbeddableTransactionImpl.toString(EmbeddableTransactionImpl.java:1169)
	at com.ibm.ws.logging.internal.impl.BaseTraceFormatter.formatObject(BaseTraceFormatter.java:1050)
	at com.ibm.ws.logging.internal.impl.BaseTraceFormatter.formatObj(BaseTraceFormatter.java:990)
	at com.ibm.ws.logging.internal.impl.BaseTraceFormatter.formatObj(BaseTraceFormatter.java:975)
	at com.ibm.ws.logging.internal.impl.BaseTraceFormatter.formatMessage(BaseTraceFormatter.java:303)
	at com.ibm.ws.logging.internal.impl.BaseTraceFormatter.formatVerboseMessage(BaseTraceFormatter.java:373)
	at com.ibm.ws.logging.internal.impl.BaseTraceService.publishTraceLogRecord(BaseTraceService.java:1013)
	at com.ibm.ws.logging.internal.impl.BaseTraceService.debug(BaseTraceService.java:686)
	at com.ibm.websphere.ras.Tr.debug(Tr.java:424)
	at com.ibm.ejs.ras.Tr.debug(Tr.java:204)
`

which leads to client-side failures, and also OOMs. 

See https://ibm-cloud.slack.com/archives/C30NGUQ9E/p1584391723343400 for more.