### PR TITLE
remove dependencies on JCA bundles from jca.management.j2ee

### DIFF
--- a/dev/com.ibm.ws.jca.management.j2ee/bnd.bnd
+++ b/dev/com.ibm.ws.jca.management.j2ee/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -31,9 +31,8 @@ Private-Package: com.ibm.ws.jca.management.j2ee.*
 	com.ibm.websphere.appserver.api.j2eemanagement;version=latest, \
 	com.ibm.websphere.appserver.spi.kernel.service;version=latest,\
 	com.ibm.websphere.appserver.spi.logging;version=latest,\
-	com.ibm.websphere.javaee.connector.1.6;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.websphere.org.osgi.service.component;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
-	com.ibm.ws.jca.cm;version=latest,\
+	com.ibm.ws.app.manager.lifecycle;version=latest,\
 	com.ibm.ws.resource;version=latest

--- a/dev/com.ibm.ws.jca.management.j2ee/src/com/ibm/ws/jca/management/j2ee/internal/JCAConnectionFactoryMBeanImpl.java
+++ b/dev/com.ibm.ws.jca.management.j2ee/src/com/ibm/ws/jca/management/j2ee/internal/JCAConnectionFactoryMBeanImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,6 @@ import javax.management.StandardMBean;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 
-import com.ibm.ejs.j2c.J2CConstants;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.management.j2ee.JCAConnectionFactoryMBean;
@@ -37,7 +36,7 @@ import com.ibm.ws.ffdc.FFDCFilter;
 public class JCAConnectionFactoryMBeanImpl extends StandardMBean implements JCAConnectionFactoryMBean {
 
     /////////////////////////////////// Variables used in tracing. ///////////////////////////////////
-    private static final TraceComponent tc = Tr.register(JCAConnectionFactoryMBeanImpl.class, J2CConstants.traceSpec);
+    private static final TraceComponent tc = Tr.register(JCAConnectionFactoryMBeanImpl.class, "WAS.j2c");
     private static final boolean IS_DEBUGGING = false; //Change to true if testing needed only.
     private static final String className = "JCAConnectionFactoryMBeanImpl";
 

--- a/dev/com.ibm.ws.jca.management.j2ee/src/com/ibm/ws/jca/management/j2ee/internal/JCAMBeanRuntime.java
+++ b/dev/com.ibm.ws.jca.management.j2ee/src/com/ibm/ws/jca/management/j2ee/internal/JCAMBeanRuntime.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015,2017 IBM Corporation and others.
+ * Copyright (c) 2015,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,8 +19,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.resource.spi.BootstrapContext;
-
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
@@ -34,10 +32,10 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
 
-import com.ibm.ejs.j2c.J2CConstants;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.wsspi.application.lifecycle.ApplicationRecycleContext;
 import com.ibm.wsspi.kernel.service.location.WsLocationConstants;
 import com.ibm.wsspi.resource.ResourceFactory;
 
@@ -51,7 +49,7 @@ import com.ibm.wsspi.resource.ResourceFactory;
 public class JCAMBeanRuntime {
 
     //////////////////////////////Logs & Trace variables //////////////////////////////
-    private static final TraceComponent tc = Tr.register(JCAMBeanRuntime.class, J2CConstants.traceSpec);
+    private static final TraceComponent tc = Tr.register(JCAMBeanRuntime.class, "WAS.j2c");
     private static final String className = "JCAMBeanRuntime :";
     private static int counterSetConnectionFactory = 0;
     private static int counterSetResourceAdapter = 0;
@@ -156,13 +154,13 @@ public class JCAMBeanRuntime {
     }
 
     @SuppressWarnings("unchecked")
-    @Reference(service = BootstrapContext.class,
+    @Reference(service = ApplicationRecycleContext.class,
                cardinality = ReferenceCardinality.MULTIPLE,
                policy = ReferencePolicy.DYNAMIC,
                policyOption = ReferencePolicyOption.GREEDY,
                target = "(component.name=com.ibm.ws.jca.resourceAdapter.properties)")
     // Temporary work around ibm:extends behavior. In the future will only need target = (component.name=com.ibm.ws.jca.resourceAdapter.properties)
-    protected void setResourceAdapter(ServiceReference<BootstrapContext> ref) {
+    protected void setResourceAdapter(ServiceReference<ApplicationRecycleContext> ref) {
         final String methodName = "setResourceAdapter";
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
@@ -305,7 +303,7 @@ public class JCAMBeanRuntime {
             Tr.exit(tc, methodName);
     }
 
-    protected void unsetResourceAdapter(ServiceReference<BootstrapContext> ref) {
+    protected void unsetResourceAdapter(ServiceReference<ApplicationRecycleContext> ref) {
         final String methodName = "unsetResourceAdapter";
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())

--- a/dev/com.ibm.ws.jca.management.j2ee/src/com/ibm/ws/jca/management/j2ee/internal/JCAManagedConnectionFactoryMBeanImpl.java
+++ b/dev/com.ibm.ws.jca.management.j2ee/src/com/ibm/ws/jca/management/j2ee/internal/JCAManagedConnectionFactoryMBeanImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,6 @@ import javax.management.StandardMBean;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 
-import com.ibm.ejs.j2c.J2CConstants;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.management.j2ee.JCAManagedConnectionFactoryMBean;
@@ -36,7 +35,7 @@ import com.ibm.ws.ffdc.FFDCFilter;
 public class JCAManagedConnectionFactoryMBeanImpl extends StandardMBean implements JCAManagedConnectionFactoryMBean {
 
     /////////////////////////////////// Variables used in tracing. ///////////////////////////////////
-    private static final TraceComponent tc = Tr.register(JCAManagedConnectionFactoryMBeanImpl.class, J2CConstants.traceSpec);
+    private static final TraceComponent tc = Tr.register(JCAManagedConnectionFactoryMBeanImpl.class, "WAS.j2c");
     private static final boolean IS_DEBUGGING = false; //Change to true if testing needed only.
     private static final String className = "JCAManagedConnectionFactoryMBeanImpl";
 

--- a/dev/com.ibm.ws.jca.management.j2ee/src/com/ibm/ws/jca/management/j2ee/internal/JCAResourceMBeanImpl.java
+++ b/dev/com.ibm.ws.jca.management.j2ee/src/com/ibm/ws/jca/management/j2ee/internal/JCAResourceMBeanImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,7 +21,6 @@ import javax.management.StandardMBean;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 
-import com.ibm.ejs.j2c.J2CConstants;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.management.j2ee.JCAResourceMBean;
@@ -37,7 +36,7 @@ import com.ibm.ws.ffdc.FFDCFilter;
 public class JCAResourceMBeanImpl extends StandardMBean implements JCAResourceMBean {
 
     /////////////////////////////////// Variables used in tracing. ///////////////////////////////////
-    private static final TraceComponent tc = Tr.register(JCAResourceMBeanImpl.class, J2CConstants.traceSpec);
+    private static final TraceComponent tc = Tr.register(JCAResourceMBeanImpl.class, "WAS.j2c");
     private static final boolean IS_DEBUGGING = false; //Change to true if testing needed only.
     private static final String className = "JCAResourceMBeanImpl";
 

--- a/dev/com.ibm.ws.jca.management.j2ee/src/com/ibm/ws/jca/management/j2ee/internal/ResourceAdapterMBeanImpl.java
+++ b/dev/com.ibm.ws.jca.management.j2ee/src/com/ibm/ws/jca/management/j2ee/internal/ResourceAdapterMBeanImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,7 +21,6 @@ import javax.management.StandardMBean;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 
-import com.ibm.ejs.j2c.J2CConstants;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.management.j2ee.ResourceAdapterMBean;
@@ -37,7 +36,7 @@ import com.ibm.ws.ffdc.FFDCFilter;
 public class ResourceAdapterMBeanImpl extends StandardMBean implements ResourceAdapterMBean {
 
     /////////////////////////////////// Variables used in tracing. ///////////////////////////////////
-    private static final TraceComponent tc = Tr.register(ResourceAdapterMBeanImpl.class, J2CConstants.traceSpec);
+    private static final TraceComponent tc = Tr.register(ResourceAdapterMBeanImpl.class, "WAS.j2c");
     private static final boolean IS_DEBUGGING = false; //Change to true if testing needed only.
     private static final String className = "ResourceAdapterMBeanImpl";
 

--- a/dev/com.ibm.ws.jca.management.j2ee/src/com/ibm/ws/jca/management/j2ee/internal/ResourceAdapterModuleMBeanImpl.java
+++ b/dev/com.ibm.ws.jca.management.j2ee/src/com/ibm/ws/jca/management/j2ee/internal/ResourceAdapterModuleMBeanImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -51,7 +51,6 @@ import javax.xml.transform.stream.StreamResult;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 
-import com.ibm.ejs.j2c.J2CConstants;
 import com.ibm.websphere.management.j2ee.ResourceAdapterModuleMBean;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -67,7 +66,7 @@ import com.ibm.ws.ffdc.FFDCFilter;
 public class ResourceAdapterModuleMBeanImpl extends StandardMBean implements ResourceAdapterModuleMBean {
 
     /////////////////////////////////// Variables used in tracing. ///////////////////////////////////
-    private static final TraceComponent tc = Tr.register(ResourceAdapterModuleMBeanImpl.class, J2CConstants.traceSpec);
+    private static final TraceComponent tc = Tr.register(ResourceAdapterModuleMBeanImpl.class, "WAS.j2c");
     private static final boolean IS_DEBUGGING = false; //Change to true if testing needed only.
     private static final String className = "ResourceAdapterModuleMBeanImpl";
 


### PR DESCRIPTION
Supporting both javax and jakarta package names will be simpler if less bundles rely on these packages.  We can remove usage from the com.ibm.ws.jca.management.j2ee bundle with some minor refactoring, and then we won't need to worry about updating it for the package rename at all.