### PR TITLE
Add ibm:obscure to metatype validator tests

### DIFF
--- a/dev/wlp-metatypeValidator/src/com/ibm/ws/metatype/validator/xml/MetatypeAd.java
+++ b/dev/wlp-metatypeValidator/src/com/ibm/ws/metatype/validator/xml/MetatypeAd.java
@@ -111,6 +111,8 @@ public class MetatypeAd extends MetatypeBase {
     private final List<MetatypeAdOption> options = new LinkedList<MetatypeAdOption>();
     @XmlAttribute(name = "beta", namespace = IBM_NAMESPACE)
     private boolean beta;
+    @XmlAttribute(name = "obscure", namespace = IBM_NAMESPACE)
+    private boolean obscure;
 
     private MetatypeOcd parent;
     boolean isTypeValid = false;


### PR DESCRIPTION
Add toleration of ibm:obscure in metatype validation tests