### PR TITLE
Update ClassLoaders to be marked parallel capable correctly

### DIFF
--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/LibertyClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/LibertyClassLoader.java
@@ -24,6 +24,9 @@ import com.ibm.wsspi.classloading.ApiType;
  * </strong> work predictably with the Liberty
  */
 public abstract class LibertyClassLoader extends SecureClassLoader {
+    static {
+        ClassLoader.registerAsParallelCapable();
+    }
     protected LibertyClassLoader(ClassLoader parent) {
         super(parent);
     }

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
@@ -75,6 +75,9 @@ import com.ibm.wsspi.kernel.service.utils.CompositeEnumeration;
 import com.ibm.wsspi.kernel.service.utils.PathUtils;
 
 abstract class ContainerClassLoader extends IdentifiedLoader {
+    static {
+        ClassLoader.registerAsParallelCapable();
+    }
     static final TraceComponent tc = Tr.register(ContainerClassLoader.class);
 
     /**

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/IdentifiedLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/IdentifiedLoader.java
@@ -14,6 +14,9 @@ import com.ibm.ws.classloading.internal.util.Keyed;
 import com.ibm.wsspi.classloading.ClassLoaderIdentity;
 
 abstract class IdentifiedLoader extends LibertyLoader implements Keyed<ClassLoaderIdentity> {
+    static {
+        ClassLoader.registerAsParallelCapable();
+    }
     public IdentifiedLoader(ClassLoader parent) {
         super(parent);
     }

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/LibertyLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/LibertyLoader.java
@@ -19,6 +19,9 @@ import org.osgi.framework.Bundle;
 import com.ibm.ws.classloading.LibertyClassLoader;
 
 public abstract class LibertyLoader extends LibertyClassLoader implements DeclaredApiAccess {
+    static {
+        ClassLoader.registerAsParallelCapable();
+    }
     public LibertyLoader(ClassLoader parent) {
         super(parent);
     }

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ShadowClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ShadowClassLoader.java
@@ -44,6 +44,9 @@ import com.ibm.wsspi.classloading.ClassLoaderIdentity;
  * any associated resources to be cleared up.
  */
 class ShadowClassLoader extends IdentifiedLoader {
+    static {
+        ClassLoader.registerAsParallelCapable();
+    }
     static final TraceComponent tc = Tr.register(ShadowClassLoader.class);
 
     private static final Enumeration<URL> EMPTY_ENUMERATION = new Enumeration<URL>() {

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ThreadContextClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ThreadContextClassLoader.java
@@ -37,6 +37,9 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
  * A specific type of UnifiedClassLoader: ThreadContextClassLoader
  */
 public class ThreadContextClassLoader extends UnifiedClassLoader implements Keyed<String> {
+    static {
+        ClassLoader.registerAsParallelCapable();
+    }
     static final TraceComponent tc = Tr.register(ThreadContextClassLoader.class);
     private final AtomicReference<Bundle> bundle = new AtomicReference<Bundle>();
     protected final String key;

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ThreadContextClassLoaderForBundles.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ThreadContextClassLoaderForBundles.java
@@ -23,6 +23,9 @@ import org.osgi.framework.BundleReference;
  */
 public class ThreadContextClassLoaderForBundles extends ThreadContextClassLoader implements BundleReference
 {
+    static {
+        ClassLoader.registerAsParallelCapable();
+    }
 
     public ThreadContextClassLoaderForBundles(GatewayClassLoader augLoader, ClassLoader appLoader, String key, ClassLoadingServiceImpl clSvc) {
         super(augLoader, appLoader, key, clSvc);

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/UnifiedClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/UnifiedClassLoader.java
@@ -37,6 +37,9 @@ import com.ibm.wsspi.kernel.service.utils.CompositeEnumeration;
  * to discover the special methods:
  */
 public class UnifiedClassLoader extends LibertyLoader implements SpringLoader {
+    static {
+        ClassLoader.registerAsParallelCapable();
+    }
     private final static TraceComponent tc = Tr.register(UnifiedClassLoader.class);
 
     /**


### PR DESCRIPTION
- AppClassLoader was marked parallel capable, but the way that the
enablement works is that it only enables it for parallel capability if
the super class is also marked parallel capable.  This PR updates the
super classes to be marked parallel capable.
- Additionally other classes that are sub classes were also not marked
parallel capable.  This PR also updates those sub classes.