### PR TITLE
update jakarta servlet version rule; correct eclipse package

### DIFF
--- a/dev/com.ibm.websphere.jakartaee.servlet.5.0/.project
+++ b/dev/com.ibm.websphere.jakartaee.servlet.5.0/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>com.ibm.websphere.javaee.servlet.5.0</name>
+	<name>com.ibm.websphere.jakartaee.servlet.5.0</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/dev/wlp-jakartaee-transform/rules/jakarta-versions.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-versions.properties
@@ -1,8 +1,8 @@
-jakarta.servlet=[2.4,5.0]
-jakarta.servlet.annotation=[2.4,5.0]
-jakarta.servlet.descriptor=[2.4,5.0]
-jakarta.servlet.http=[2.4,5.0]
-jakarta.servlet.resources=[2.4,5.0]
+jakarta.servlet=[5.0,6)
+jakarta.servlet.annotation=[5.0,6)
+jakarta.servlet.descriptor=[5.0,6)
+jakarta.servlet.http=[5.0,6)
+jakarta.servlet.resources=[5.0,6)
 
 jakarta.el=[4.0,5)
 com.ibm.wsspi.el=[4.0,5)


### PR DESCRIPTION
Missed one javaee - > jakartaee change. (Hidden file, and I don't use Eclipse often.) 

To keep the versioning rules consistent, I've updated the servlet version rules.   

Box Note has been updated as well. 

