### PR TITLE
Perf changes to improve startup

### DIFF
--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ContainerClassLoader.java
@@ -232,11 +232,11 @@ abstract class ContainerClassLoader extends IdentifiedLoader {
             sharedClassCacheURL = null;
         } else {
             String protocol = resourceURL.getProtocol();
-            if ("jar".equals(protocol)) {
-                sharedClassCacheURL = resourceURL;
-            } else if ("wsjar".equals(protocol)) {
+            // Doing the conversion that the shared class cache logic does for jar
+            // URLs in order to do less work while holding a shared class cache monitor.
+            if ("jar".equals(protocol) || "wsjar".equals(protocol)) {
                 try {
-                    sharedClassCacheURL = new URL(resourceURL.toExternalForm().substring(2));
+                    sharedClassCacheURL = new URL(resourceURL.getPath());
                 } catch (MalformedURLException e) {
                     sharedClassCacheURL = null;
                 }

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ShadowClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/ShadowClassLoader.java
@@ -127,7 +127,8 @@ class ShadowClassLoader extends IdentifiedLoader {
 
     @Override
     protected Class<?> findClass(final String name) throws ClassNotFoundException {
-        final ByteResourceInformation classBytesResourceInformation = shadowedLoader.findClassBytes(name);
+        String resourceName = Util.convertClassNameToResourceName(name);
+        final ByteResourceInformation classBytesResourceInformation = shadowedLoader.findClassBytes(name, resourceName);
 
         if (classBytesResourceInformation == null) {
             throw new ClassNotFoundException(name);

--- a/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/LibertyClassLoaderTest.java
+++ b/dev/com.ibm.ws.classloading_test/test/com/ibm/ws/classloading/internal/LibertyClassLoaderTest.java
@@ -55,7 +55,7 @@ public class LibertyClassLoaderTest {
 
     @Test
     public void testClassNotFound() {
-        assertNull(loader.findClassBytes("non.existent.Class"));
+        assertNull(loader.findClassBytes("non.existent.Class", "non/existent/Class.class"));
     }
 
     @Test
@@ -71,7 +71,7 @@ public class LibertyClassLoaderTest {
         };
 
         try {
-            loader.findClassBytes("test");
+            loader.findClassBytes("test", "test.class");
             fail("call should have thrown an exception");
         } catch (ClassFormatError e) {
             assertTrue("Should have traced an error", outputManager.checkForStandardErr("CWWKL0002E"));

--- a/dev/com.ibm.ws.kernel.security.thread/src/com/ibm/ws/kernel/security/thread/ThreadIdentityManager.java
+++ b/dev/com.ibm.ws.kernel.security.thread/src/com/ibm/ws/kernel/security/thread/ThreadIdentityManager.java
@@ -41,12 +41,14 @@ public class ThreadIdentityManager {
      * The ThreadIdentityService references. The references are set by the
      * ThreadIdentityManagerConfigurator.
      */
-    private static List<ThreadIdentityService> threadIdentityServices = new CopyOnWriteArrayList<>();
+    private static final List<ThreadIdentityService> threadIdentityServices = new CopyOnWriteArrayList<>();
 
     /**
      * The J2CIdentityService references. The references are set by the ThreadIdentityManagerConfigurator.
      */
-    private static List<J2CIdentityService> j2cIdentityServices = new CopyOnWriteArrayList<>();
+    private static final List<J2CIdentityService> j2cIdentityServices = new CopyOnWriteArrayList<>();
+
+    private static final Object emptyToken = Collections.EMPTY_MAP;
 
     /**
      * Add a ThreadIdentityService reference. This method is called by
@@ -319,7 +321,7 @@ public class ThreadIdentityManager {
                 resetRecursionCheck();
             }
         }
-        return token == null ? Collections.EMPTY_MAP : token;
+        return token == null ? emptyToken : token;
     }
 
     /**
@@ -410,9 +412,11 @@ public class ThreadIdentityManager {
      * @see #resetChecked(Object)
      */
     public static void reset(Object token) {
-        try {
-            resetCheckedInternal(token, null);
-        } catch (ThreadIdentityException tie) {
+        if (token != emptyToken && token != null) {
+            try {
+                resetCheckedInternal(token, null);
+            } catch (ThreadIdentityException tie) {
+            }
         }
     }
 }


### PR DESCRIPTION
- The ThreadIdentityManager.reset method shows up as very hot in profiles for startup.  Short circuits the method not to call the internal method if it is not going to do anything.
- Update ContainerClassLoader.getSharedClassCacheURL() to do the URL conversion that the SCC function does while in a sync block.  This reduces the amount of time other threads have to wait for the lock in the SCC function.
- Other small updates to not have to compute the class to resource name conversion multiple times and to use the result from putIfAbsent instead of always re-getting from the Map to get the value.
