### PR TITLE
Fix up eclipse settings

### DIFF
--- a/dev/com.ibm.ws.grpc.client/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.grpc.client/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.grpc.common/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.grpc.common/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.grpc.server/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.grpc.server/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.grpc.servlet/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.grpc.servlet/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.security.acme/bnd.bnd
+++ b/dev/com.ibm.ws.security.acme/bnd.bnd
@@ -48,7 +48,7 @@ Include-Resource: \
     @${repo;org.bouncycastle:bcprov-jdk15on;1.61;EXACT},\
     @${repo;org.bouncycastle:bcpkix-jdk15on;1.61;EXACT},\
     @${repo;org.bitbucket.b_c:jose4j;0.6.5;EXACT},\
-    org=build/classes/java/main/org
+    org=${bin}/org
 
 -dsannotations: \
     com.ibm.ws.security.acme.internal.web.AcmeAuthorizationServlet, \


### PR DESCRIPTION
- Add bndtools.core.prefs files to the grpc components
- Change from build/classes/java/main to ${bin} to support both gradle
and eclipse for creating bundle file for com.ibm.ws.security.acme
