### PR TITLE
Update loadClass methods to do less work while holding a lock

### DIFF
--- a/dev/com.ibm.ws.artifact.file/src/com/ibm/ws/artifact/file/internal/FileContainer.java
+++ b/dev/com.ibm.ws.artifact.file/src/com/ibm/ws/artifact/file/internal/FileContainer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -234,10 +234,13 @@ public class FileContainer implements com.ibm.wsspi.artifact.ArtifactContainer {
 
         //quick test..
         File target = new File(dir, pathAndName);
+        Boolean fileExists = null;
         if ((!isRoot && !pathAndName.startsWith("/")) || isRoot) {
             //if path is relative, and we're not root, then validate path
             //or if we are root, just validate it anyways.
-            if (!FileUtils.fileExists(target) || !PathUtils.checkCase(target, pathAndName)) {
+            boolean exists = FileUtils.fileExists(target);
+            fileExists = exists ? Boolean.TRUE : Boolean.FALSE;
+            if (!exists || !PathUtils.checkCase(target, pathAndName)) {
                 //no file/dir ? bug out early.
                 return null;
             }
@@ -245,7 +248,8 @@ public class FileContainer implements com.ibm.wsspi.artifact.ArtifactContainer {
 
         //if there's no / in the name.. it's immediately relative to here.. build & return it.
         if (pathAndName.indexOf("/") == -1) {
-            if (FileUtils.fileExists(target) && PathUtils.checkCase(target, pathAndName))
+            boolean exists = fileExists != null ? fileExists.booleanValue() : FileUtils.fileExists(target);
+            if (exists && PathUtils.checkCase(target, pathAndName))
                 return new FileEntry(this, target, root, containerFactoryHolder);
             else
                 return null;

--- a/dev/com.ibm.ws.artifact.url/test/com/ibm/ws/artifact/zip/internal/ZipFileContainerTest.java
+++ b/dev/com.ibm.ws.artifact.url/test/com/ibm/ws/artifact/zip/internal/ZipFileContainerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,11 +27,11 @@ import org.junit.Test;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.url.URLStreamHandlerSetter;
 
-import test.common.SharedOutputManager;
-
 import com.ibm.ws.artifact.url.internal.WSJarURLStreamHandler;
 import com.ibm.ws.artifact.zip.cache.ZipCachingService;
 import com.ibm.wsspi.artifact.factory.ArtifactContainerFactory;
+
+import test.common.SharedOutputManager;
 
 /**
  * TODO: this class could be simplified by using the java.nio.file package
@@ -75,12 +75,12 @@ public class ZipFileContainerTest {
 
     /**
      * Capture stdout/stderr output to the manager.
-     * 
+     *
      * @throws Exception
      */
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
-        // There are variations of this constructor: 
+        // There are variations of this constructor:
         // e.g. to specify a log location or an enabled trace spec. Ctrl-Space for suggestions
         outputMgr = SharedOutputManager.getInstance();
         outputMgr.captureStreams();
@@ -129,7 +129,7 @@ public class ZipFileContainerTest {
 
     /**
      * Final teardown work when class is exiting.
-     * 
+     *
      * @throws Exception
      */
     @AfterClass
@@ -140,7 +140,7 @@ public class ZipFileContainerTest {
 
     /**
      * Individual teardown after each test.
-     * 
+     *
      * @throws Exception
      */
     @After
@@ -155,7 +155,7 @@ public class ZipFileContainerTest {
         try {
             f = File.createTempFile("testSpaceInPathToJar", ".zip"); // used for zfc ctor to avoid NPE
             ZipFileContainer zfc = new ZipFileContainer(null, f, MOCK_CFH);
-            URI uri = zfc.createEntryUri("/META-INF/somefile.txt", SOME_JAR_IN_DIR_WITH_SPACES);
+            URI uri = zfc.createEntryUri("/META-INF/somefile.txt", SOME_JAR_IN_DIR_WITH_SPACES.toURI());
 
             URL wsjarUrl = uri.toURL();
             URLConnection conn = HANDLER.openConnection(wsjarUrl);
@@ -173,7 +173,7 @@ public class ZipFileContainerTest {
         try {
             f = File.createTempFile("testSpaceInJarEntry", ".zip"); // used for zfc ctor to avoid NPE
             ZipFileContainer zfc = new ZipFileContainer(null, f, MOCK_CFH);
-            URI uri = zfc.createEntryUri("/META-INF/some file with spaces.txt", SOME_JAR);
+            URI uri = zfc.createEntryUri("/META-INF/some file with spaces.txt", SOME_JAR.toURI());
 
             URL wsjarUrl = uri.toURL();
             URLConnection conn = HANDLER.openConnection(wsjarUrl);

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainer.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011,2019 IBM Corporation and others.
+ * Copyright (c) 2011,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -294,6 +294,7 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
         this.archiveFileLock = null;
         this.archiveFile = archiveFile;
         String useArchivePath = archiveFile.getAbsolutePath();
+        this.archiveFileURI = getURI(archiveFile);
         this.archiveFilePath = useArchivePath;
         this.archiveName = archiveFile.getName();
 
@@ -353,6 +354,7 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
             this.archiveFileLock = null;
             String useArchivePath =  archiveFile.getAbsolutePath();
             this.archiveFilePath = useArchivePath;
+            this.archiveFileURI = getURI(archiveFile);
             this.zipFileNotifier = new ZipFileArtifactNotifier(this, useArchivePath);
             this.archiveName = archiveFile.getName();
         } else {
@@ -589,6 +591,7 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
     // Get this once: the usual java file implementation does not
     // cache file absolute paths.
     private String archiveFilePath;
+    private URI archiveFileURI;
 
     /**
      * Answer the archive file.  Extract it if necessary.  Answer null
@@ -621,6 +624,7 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
 
                         if ( archiveFile != null ) {
                             archiveFilePath = archiveFile.getAbsolutePath();
+                            archiveFileURI = getURI(archiveFile);
                             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
                                 Tr.debug(tc, methodName + " Archive file [ " + archiveFilePath + " ]");
                             }
@@ -1315,7 +1319,7 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
         }
 
         try {
-            return Collections.singleton( getURI(useArchiveFile).toURL() );
+            return Collections.singleton( archiveFileURI.toURL() );
         } catch ( MalformedURLException e ) {
             // FFDC
             return Collections.emptySet();
@@ -1328,7 +1332,7 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
         if ( useArchiveFile == null ) {
             return null;
         }
-        return createEntryUri(r_entryPath, useArchiveFile);
+        return createEntryUri(r_entryPath, archiveFileURI);
     }
 
     /**
@@ -1351,8 +1355,7 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
      *       protection allows it to be used from
      *       "com.ibm.ws.artifact.zip.internal.ZipFileContainerTest".
      */
-    URI createEntryUri(String r_entryPath, File useArchiveFile) {
-        URI archiveUri = getURI(useArchiveFile);
+    URI createEntryUri(String r_entryPath, URI archiveUri) {
         if ( archiveUri == null ) {
             return null;
         }

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/AppClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/AppClassLoader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 IBM Corporation and others.
+ * Copyright (c) 2011, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,10 +33,12 @@ import java.security.ProtectionDomain;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.jar.Manifest;
@@ -82,21 +84,21 @@ public class AppClassLoader extends ContainerClassLoader implements SpringLoader
 
     static final List<SearchLocation> PARENT_FIRST_SEARCH_ORDER = freeze(list(PARENT, SELF, DELEGATES));
 
+    private final Set<String> packagesDefined = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>()); 
+
     static final String CLASS_LOADING_TRACE_PREFIX = "com.ibm.ws.class.load.";
     static final String DEFAULT_PACKAGE = "default.package";
     /** per class loader collection of per-package trace components */
     final ConcurrentMap<String, TraceComponent> perPackageClassLoadingTraceComponents = new ConcurrentHashMap<String, TraceComponent>();
 
-    private TraceComponent registerClassLoadingTraceComponent(String pkg) {
-        TraceComponent tc = Tr.register(CLASS_LOADING_TRACE_PREFIX + pkg, AppClassLoader.class, (String) null);
-        perPackageClassLoadingTraceComponents.put(pkg, tc);
-        return tc;
-    }
-
     private TraceComponent getClassLoadingTraceComponent(String pkg) {
-        TraceComponent tc = perPackageClassLoadingTraceComponents.get(pkg);
         // tc will be null if this is the first time we used the default package or a package defined by another CL
-        return tc == null ? registerClassLoadingTraceComponent(pkg) : tc;
+        TraceComponent tc = perPackageClassLoadingTraceComponents.get(pkg);
+        if (tc == null) {
+            tc = Tr.register(CLASS_LOADING_TRACE_PREFIX + pkg, AppClassLoader.class, (String) null);
+            perPackageClassLoadingTraceComponents.put(pkg, tc);
+        }
+        return tc;
     }
 
     protected final ClassLoaderConfiguration config;
@@ -352,31 +354,23 @@ public class AppClassLoader extends ContainerClassLoader implements SpringLoader
     }
 
     private Class<?> definePackageAndClass(final String name, String resourceName, final ByteResourceInformation byteResourceInformation, byte[] bytes) throws ClassFormatError {
-        final TraceComponent cltc;
+        URL resourceURL = byteResourceInformation.getResourceUrl();
         // Now define a package for this class if it has one
         int lastDotIndex = name.lastIndexOf('.');
+        String packageName = DEFAULT_PACKAGE;
         if (lastDotIndex != -1) {
-            String packageName = name.substring(0, lastDotIndex);
-
-            // See if this package is already defined, we will handle multi-threaded code with a try catch later
-            if (this.getPackage(packageName) == null) {
-                definePackage(byteResourceInformation, packageName);
-                cltc = registerClassLoadingTraceComponent(packageName);
-            } else {
-                cltc = getClassLoadingTraceComponent(packageName);
-            }
-        } else {
-            cltc = getClassLoadingTraceComponent(DEFAULT_PACKAGE);
+            packageName = name.substring(0, lastDotIndex);
+            definePackage(byteResourceInformation, resourceURL, packageName);
         }
 
-        URL resourceURL = byteResourceInformation.getResourceUrl();
         ProtectionDomain pd = getClassSpecificProtectionDomain(resourceName, resourceURL);
 
         Class<?> clazz = null;
         try {
             clazz = defineClass(name, bytes, 0, bytes.length, pd);
         } finally {
-            if (cltc.isDebugEnabled()) {
+            final TraceComponent cltc;
+            if (TraceComponent.isAnyTracingEnabled() && (cltc = getClassLoadingTraceComponent(packageName)).isDebugEnabled()) {
                 String loc = "" + byteResourceInformation.getResourceUrl();
                 String path = byteResourceInformation.getResourcePath();
                 if (loc.endsWith(path))
@@ -459,20 +453,31 @@ public class AppClassLoader extends ContainerClassLoader implements SpringLoader
      * @param packageName The name of the package to create
      */
     @FFDCIgnore(value = { IllegalArgumentException.class })
-    private void definePackage(ByteResourceInformation byteResourceInformation, String packageName) {
-        // If the package is in a JAR then we can load the JAR manifest to see what package definitions it's got
-        Manifest manifest = byteResourceInformation.getManifest();
+    private void definePackage(ByteResourceInformation byteResourceInformation, URL resourceURL, String packageName) {
 
-        try {
-            // The URLClassLoader.definePackage() will NPE with a null manifest so use the other definePackage if we don't have a manifest
-            if (manifest == null) {
-                definePackage(packageName, null, null, null, null, null, null, null);
-            } else {
-                definePackage(packageName, manifest, byteResourceInformation.getResourceUrl());
+        // Using packagesDefined instead of getPackage since getPackage has a lot of path length
+        // and in the race condition we avoid all the Manifest length.
+        if (!packagesDefined.contains(packageName)) {
+            synchronized (getClassLoadingLock(packageName)) {
+                // have to check again
+                if (!packagesDefined.contains(packageName)) {
+                    // If the package is in a JAR then we can load the JAR manifest to see what package definitions it's got
+                    Manifest manifest = byteResourceInformation.getManifest();
+
+                    try {
+                        // The URLClassLoader.definePackage() will NPE with a null manifest so use the other definePackage if we don't have a manifest
+                        if (manifest == null) {
+                            definePackage(packageName, null, null, null, null, null, null, null);
+                        } else {
+                            definePackage(packageName, manifest, resourceURL);
+                        }
+                    } catch (IllegalArgumentException e) {
+                        // Ignore, this happens if the package is already defined but it is hard to guard against this in a thread safe way. See:
+                        // http://bugs.sun.com/view_bug.do?bug_id=4841786
+                    }
+                    packagesDefined.add(packageName);
+                }
             }
-        } catch (IllegalArgumentException e) {
-            // Ignore, this happens if the package is already defined but it is hard to guard against this in a thread safe way. See:
-            // http://bugs.sun.com/view_bug.do?bug_id=4841786
         }
     }
 

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/BootstrapChildFirstJarClassloader.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/BootstrapChildFirstJarClassloader.java
@@ -79,26 +79,20 @@ public final class BootstrapChildFirstJarClassloader extends JarFileClassLoader 
             return super.loadClass(name, resolve);
         }
 
+        Class<?> result = null;
         synchronized (getClassLoadingLock(name)) {
-            Class<?> result = null;
-
             result = findLoadedClass(name);
             if (result == null) {
                 // Try to load the class from this classpath
                 result = findClass(name, true);
-                if (result == null) {
-                    if (parent == null || resolve) {
-                        result = super.loadClass(name, resolve);
-                    } else {
-                        // calling using this way to avoid calling findLoadedClass
-                        // and findClass again
-                        result = parent.loadClass(name);
-                    }
-                }
             }
-
-            return result;
         }
+
+        if (result == null) {
+            result = parent.loadClass(name);
+        }
+
+        return result;
     }
 
     @Override


### PR DESCRIPTION
Profiling showed contention on the class name scoped lock.  To reduce having to wait for the lock, this pull request changes the liberty ClassLoaders to do less work while holding the lock:
- Update BootChildFirstJarClassLoader to call the parent classloader outside of the class name scoped lock
- Update AppClassLoader to reset the ThreadIdentityManager and to calculate the ClassNotFoundException outside of class name scoped lock.
- Only get the class loading TraceComponent if any tracing is enabled. This should help footprint potentially as well.
- Avoid computing the Resource URI again in definePackage
- Avoid calling FileUtils.fileExists multiple times for the same File.
- When calculating the Entry URI, don't compute the ZipFile URI more than once for the same ZipFile.
- Change defining of the package in AppClassLoader to not call getPackage to avoid extra lock contention on the packages HashMap that is synchronized on.