### PR TITLE
7182 AutoExpand Only When Modified

### DIFF
--- a/dev/com.ibm.ws.app.manager.war/src/com/ibm/ws/app/manager/ear/internal/EARDeployedAppInfoFactoryImpl.java
+++ b/dev/com.ibm.ws.app.manager.war/src/com/ibm/ws/app/manager/ear/internal/EARDeployedAppInfoFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -155,113 +155,28 @@ public class EARDeployedAppInfoFactoryImpl extends AbstractDeployedAppInfoFactor
         return deployedAppServices.getLocationAdmin().resolveResource(AppManagerConstants.EXPANDED_APPS_DIR + appName + ".ear/");
     }
 
-    // Time stamps of EAR files which have been expanded during this JVM launch..
-
-    // TODO: This will cause a slow memory leak during a long run which adds then removes
-    //       a long sequence of applications.
-    //
-    //       But, there will also be a gradual accumulation of files on disk, as removing
-    //       unexpanded EAR files doesn't cause the expansions of those files to be removed.
-
-    private static final Map<String, Long> expansionStamps = new HashMap<String, Long>(1);
-
-    /**
-     * Tell if a file should be expanded by answering the updated time stamp
-     * of the file.
-     *
-     * If the file was previously expanded during this JVM run, and the file
-     * time stamp is the same as when the file was expanded, answer null.
-     *
-     * If either the file was not yet expanded during this JVM run, or if the
-     * the current file time stamp is different than the time stamp of the file
-     * when it was expanded, update the recorded time stamp, and answer the new
-     * time stamp.
-     *
-     * @param absPath The absolute path of the file which is to be tested.
-     * @param file    The file which is to be tested.
-     *
-     * @return The new time stamp of the file, if the file is to be expanded.
-     *     Null if the file is not to be expanded.
-     */
-    private static Long getUpdatedStamp(String absPath, File file) {
-        String methodName = "getUpdatedStamp";
-        boolean doDebug = _tc.isDebugEnabled();
-
-        Long currentStamp = Long.valueOf(file.lastModified());
-
-        Long newStamp;
-        String newStampReason = null;
-
-        synchronized (expansionStamps) {
-            Long priorStamp = expansionStamps.put(absPath, currentStamp);
-
-            if (priorStamp == null) {
-                newStamp = currentStamp;
-                if (doDebug) {
-                    newStampReason = "First extraction; stamp [ " + currentStamp + " ]";
-                }
-            } else if (currentStamp.longValue() != priorStamp.longValue()) {
-                newStamp = currentStamp;
-                if (doDebug) {
-                    newStampReason = "Additional extraction; old stamp [ " + priorStamp + " ] new stamp [ " + currentStamp + " ]";
-                }
-            } else {
-                newStamp = null;
-                if (doDebug) {
-                    newStampReason = "No extraction; stamp [ " + currentStamp + " ]";
-                }
-            }
-        }
-
-        if (doDebug) {
-            Tr.debug(_tc, methodName + ": " + newStampReason);
-        }
-        return newStamp;
-    }
-
-    private static void clearStamp(String absPath, File file) {
-        synchronized (expansionStamps) {
-            expansionStamps.remove(absPath);
-        }
-    }
-
     protected void expand(
         String name, File collapsedFile,
         WsResource expandedResource, File expandedFile) throws IOException {
 
         String collapsedPath = collapsedFile.getAbsolutePath();
 
-        Long updatedStamp = getUpdatedStamp(collapsedPath, collapsedFile);
-        if (updatedStamp == null) {
-            // Nothing to do: Already extracted by this JVM, and has the same
-            // time stamp as when previously extracted.
-            return;
-        }
-
-        try {
-            if (expandedFile.exists()) {
-                File failedDelete = ZipUtils.deleteWithRetry(expandedFile);
-                if (failedDelete != null) {
-                    if (failedDelete == expandedFile) {
-                        throw new IOException("Failed to delete [ " + expandedFile.getAbsolutePath() + " ]");
-                    } else {
-                        throw new IOException("Failed to delete [ " + expandedFile.getAbsolutePath() + " ]" +
-                                              " because [ " + failedDelete.getAbsolutePath() + " ]" +
-                                              " could not be deleted.");
-                    }
+        if (expandedFile.exists()) {
+            File failedDelete = ZipUtils.deleteWithRetry(expandedFile);
+            if (failedDelete != null) {
+                if (failedDelete == expandedFile) {
+                    throw new IOException("Failed to delete [ " + expandedFile.getAbsolutePath() + " ]");
+                } else {
+                    throw new IOException("Failed to delete [ " + expandedFile.getAbsolutePath() + " ]" +
+                                          " because [ " + failedDelete.getAbsolutePath() + " ]" +
+                                          " could not be deleted.");
                 }
             }
-
-            expandedResource.create();
-
-            ZipUtils.unzip(collapsedFile, expandedFile, ZipUtils.IS_EAR, updatedStamp); // throws IOException
-
-        } catch (IOException e) {
-            // Forget about the expansion if it failed.
-            clearStamp(collapsedPath, collapsedFile);
-
-            throw e;
         }
+
+        expandedResource.create();
+
+        ZipUtils.unzip(collapsedFile, expandedFile, ZipUtils.IS_EAR, collapsedFile.lastModified()); // throws IOException
     }
 
     /**
@@ -313,9 +228,11 @@ public class EARDeployedAppInfoFactoryImpl extends AbstractDeployedAppInfoFactor
                 WsResource expandedResource = resolveExpansion(appName);
                 File expandedFile = expandedResource.asFile();
 
-                Tr.info(_tc, "info.expanding.app", appName, appPath, expandedFile.getAbsolutePath());
+                if (applicationManager.shouldExpand(expandedFile.getName(), appFile, expandedFile)) {
+                    Tr.info(_tc, "info.expanding.app", appName, appPath, expandedFile.getAbsolutePath());
 
-                expand(appName, appFile, expandedResource, expandedFile);
+                    expand(appName, appFile, expandedResource, expandedFile);
+                }
 
                 originalAppContainer = appContainer;
                 appContainer = deployedAppServices.setupContainer(appPid, expandedFile);

--- a/dev/com.ibm.ws.app.manager.war/src/com/ibm/ws/app/manager/war/internal/WARDeployedAppInfoFactoryImpl.java
+++ b/dev/com.ibm.ws.app.manager.war/src/com/ibm/ws/app/manager/war/internal/WARDeployedAppInfoFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -56,112 +56,28 @@ public class WARDeployedAppInfoFactoryImpl extends AbstractDeployedAppInfoFactor
         return deployedAppServices.getLocationAdmin().resolveResource(AppManagerConstants.EXPANDED_APPS_DIR + appName + ".war/");
     }
 
-    // Time stamps of WAR files which have been expanded during this JVM launch..
-
-    // TODO: This will cause a slow memory leak during a long run which adds then removes
-    //       a long sequence of applications.
-    //
-    //       But, there will also be a gradual accumulation of files on disk, as removing
-    //       unexpanded WAR files doesn't cause the expansions of those files to be removed.
-
-    private static final Map<String, Long> expansionStamps = new HashMap<String, Long>(1);
-
-    /**
-     * Tell if a file should be expanded by answering the updated time stamp
-     * of the file.
-     *
-     * If the file was previously expanded during this JVM run, and the file
-     * time stamp is the same as when the file was expanded, answer null.
-     *
-     * If either the file was not yet expanded during this JVM run, or if the
-     * the current file time stamp is different than the time stamp of the file
-     * when it was expanded, update the recorded time stamp, and answer the new
-     * time stamp.
-     *
-     * @param absPath The absolute path of the file which is to be tested.
-     * @param file The file which is to be tested.
-     *
-     * @return The new time stamp of the file, if the file is to be expanded.
-     *         Null if the file is not to be expanded.
-     */
-    private static Long getUpdatedStamp(String absPath, File file) {
-        String methodName = "getUpdatedStamp";
-        boolean doDebug = tc.isDebugEnabled();
-
-        Long currentStamp = Long.valueOf(file.lastModified());
-
-        Long newStamp;
-        String newStampReason = null;
-
-        synchronized (expansionStamps) {
-            Long priorStamp = expansionStamps.put(absPath, currentStamp);
-
-            if (priorStamp == null) {
-                newStamp = currentStamp;
-                if (doDebug) {
-                    newStampReason = "First extraction; stamp [ " + currentStamp + " ]";
-                }
-            } else if (currentStamp.longValue() != priorStamp.longValue()) {
-                newStamp = currentStamp;
-                if (doDebug) {
-                    newStampReason = "Additional extraction; old stamp [ " + priorStamp + " ] new stamp [ " + currentStamp + " ]";
-                }
-            } else {
-                newStamp = null;
-                if (doDebug) {
-                    newStampReason = "No extraction; stamp [ " + currentStamp + " ]";
-                }
-            }
-        }
-
-        if (doDebug) {
-            Tr.debug(tc, methodName + ": " + newStampReason);
-        }
-        return newStamp;
-    }
-
-    private static void clearStamp(String absPath, File file) {
-        synchronized (expansionStamps) {
-            expansionStamps.remove(absPath);
-        }
-    }
-
     protected void expand(
                           String name, File collapsedFile,
                           WsResource expandedResource, File expandedFile) throws IOException {
 
         String collapsedPath = collapsedFile.getAbsolutePath();
 
-        Long updatedStamp = getUpdatedStamp(collapsedPath, collapsedFile);
-        if (updatedStamp == null) {
-            // Nothing to do: Already extracted by this JVM, and has the same
-            // time stamp as when previously extracted.
-            return;
-        }
-
-        try {
-            if (expandedFile.exists()) {
-                File failedDelete = ZipUtils.deleteWithRetry(expandedFile);
-                if (failedDelete != null) {
-                    if (failedDelete == expandedFile) {
-                        throw new IOException("Failed to delete [ " + expandedFile.getAbsolutePath() + " ]");
-                    } else {
-                        throw new IOException("Failed to delete [ " + expandedFile.getAbsolutePath() + " ] because [ " + failedDelete.getAbsolutePath()
-                                              + " ] could not be deleted.");
-                    }
+        if (expandedFile.exists()) {
+            File failedDelete = ZipUtils.deleteWithRetry(expandedFile);
+            if (failedDelete != null) {
+                if (failedDelete == expandedFile) {
+                    throw new IOException("Failed to delete [ " + expandedFile.getAbsolutePath() + " ]");
+                } else {
+                    throw new IOException("Failed to delete [ " + expandedFile.getAbsolutePath() + " ] because [ " + failedDelete.getAbsolutePath()
+                                          + " ] could not be deleted.");
                 }
             }
-
-            expandedResource.create();
-
-            ZipUtils.unzip(collapsedFile, expandedFile, ZipUtils.IS_NOT_EAR, updatedStamp); // throws IOException
-
-        } catch (IOException e) {
-            // Forget about the expansion if it failed.
-            clearStamp(collapsedPath, collapsedFile);
-
-            throw e;
         }
+
+        expandedResource.create();
+
+        ZipUtils.unzip(collapsedFile, expandedFile, ZipUtils.IS_NOT_EAR, collapsedFile.lastModified()); // throws IOException
+
     }
 
     @Override
@@ -186,8 +102,10 @@ public class WARDeployedAppInfoFactoryImpl extends AbstractDeployedAppInfoFactor
 
                 WsResource expandedResource = resolveExpansion(warName);
                 File expandedFile = expandedResource.asFile();
-                Tr.info(tc, "info.expanding.app", warName, warPath, expandedFile.getAbsolutePath());
-                expand(warName, warFile, expandedResource, expandedFile);
+                if (applicationManager.shouldExpand(expandedFile.getName(), warFile, expandedFile)) {
+                    Tr.info(tc, "info.expanding.app", warName, warPath, expandedFile.getAbsolutePath());
+                    expand(warName, warFile, expandedResource, expandedFile);
+                }
 
                 Container expandedContainer = deployedAppServices.setupContainer(warPid, expandedFile);
                 appInfo.setContainer(expandedContainer);

--- a/dev/com.ibm.ws.app.manager_fat/publish/files/test.file
+++ b/dev/com.ibm.ws.app.manager_fat/publish/files/test.file
@@ -1,0 +1,1 @@
+This is a test update


### PR DESCRIPTION
Store the app archive size and last modified date in a cache file in the
workarea. Then on restart check this file against the original archive
and only extract if they are different.  If anything goes wrong assume
we reextract.
Fixes #7182