### PR TITLE
Invalid charset

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/endpoint/AbstractJaxRsWebEndpoint.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/endpoint/AbstractJaxRsWebEndpoint.java
@@ -18,9 +18,11 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.BadRequestException;
 
 import org.apache.cxf.jaxrs.utils.HttpUtils;
 import org.apache.cxf.transport.http.AbstractHTTPDestination;
+import org.apache.cxf.transport.http.InvalidCharsetException;
 import org.apache.cxf.transport.servlet.BaseUrlHelper;
 
 import com.ibm.websphere.ras.Tr;
@@ -133,6 +135,9 @@ public abstract class AbstractJaxRsWebEndpoint implements JaxRsWebEndpoint {
             updateDestination(request);
             destination.invoke(servletConfig, servletConfig.getServletContext(), request, response);
         } catch (IOException e) {
+            if (e instanceof InvalidCharsetException) {
+                throw new BadRequestException(e);
+            }
             throw new ServletException(e);
         } catch (JaxRsRuntimeException ex) {
             throw new ServletException(ex.getCause());

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
@@ -463,10 +463,11 @@ public abstract class AbstractHTTPDestination
             //allow gets/deletes/options to not specify an encoding
             String normalizedEncoding = HttpHeaderHelper.mapCharset(enc);
             if (normalizedEncoding == null) {
-                String m = new org.apache.cxf.common.i18n.Message("INVALID_ENCODING_MSG", tc.getLogger(), enc).toString();
-                //LOG.log(Level.WARNING, m);
+                // Liberty Change Start
+                String m = "Invalid encoding: " + enc;
                 Tr.warning(tc, m);
-                throw new IOException(m);
+                throw new InvalidCharsetException(m);
+                // Liberty Change End
             }
             inMessage.put(Message.ENCODING, normalizedEncoding);
         }

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/transport/http/InvalidCharsetException.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/transport/http/InvalidCharsetException.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.apache.cxf.transport.http;
+
+import java.io.IOException;
+
+public class InvalidCharsetException extends IOException {
+
+    public InvalidCharsetException(String m) {
+        super(m);
+    }
+
+    private static final long serialVersionUID = 1676878985438910205L;
+
+}

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/helloworld/HelloWorldTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/helloworld/HelloWorldTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.jaxrs20.fat.helloworld;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.io.BufferedReader;
@@ -83,6 +84,12 @@ public class HelloWorldTest {
         runGetMethod(200, "/helloworld/apppathrest%21/helloworld", "Hello World");
     }
 
+    // disable this test until webcontainer fixes on their end as well
+//    @Test
+    public void testInvalidCharset() throws Exception {
+        assertEquals(400, runGetMethodInvalidCharset("/helloworld/rest/helloworld"));
+    }
+
     private StringBuilder runGetMethod(int exprc, String requestUri, String testOut)
                     throws IOException {
         URL url = new URL("http://" + getHost() + ":" + getPort() + requestUri);
@@ -119,36 +126,18 @@ public class HelloWorldTest {
         }
     }
 
-    private StringBuilder runDeleteMethod(int exprc, String testOut)
+    private int runGetMethodInvalidCharset(String requestUri)
                     throws IOException {
-        URL url = new URL("http://localhost:" + getPort()
-                          + "/helloworld/rest/helloworld");
-        int retcode;
+        URL url = new URL("http://" + getHost() + ":" + getPort() + requestUri);
         HttpURLConnection con = (HttpURLConnection) url.openConnection();
         try {
             con.setDoInput(true);
             con.setDoOutput(true);
             con.setUseCaches(false);
-            con.setRequestMethod("DELETE");
+            con.setRequestProperty("Content-Type", "text/plain; charset=invalid");
+            con.setRequestMethod("GET");
 
-            retcode = con.getResponseCode();
-            if (retcode != exprc)
-                fail("Bad return Code from Delete");
-
-            InputStream is = con.getInputStream();
-            InputStreamReader isr = new InputStreamReader(is);
-            BufferedReader br = new BufferedReader(isr);
-
-            String sep = System.getProperty("line.separator");
-            StringBuilder lines = new StringBuilder();
-            for (String line = br.readLine(); line != null; line = br
-                            .readLine())
-                lines.append(line).append(sep);
-
-            if (lines.indexOf("COMPLETED SUCCESSFULLY") < 0)
-                fail("Missing success message in output. " + lines);
-
-            return lines;
+            return con.getResponseCode();
         } finally {
             con.disconnect();
         }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs20/endpoint/AbstractJaxRsWebEndpoint.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs20/endpoint/AbstractJaxRsWebEndpoint.java
@@ -18,9 +18,11 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.BadRequestException;
 
 import org.apache.cxf.jaxrs.utils.HttpUtils;
 import org.apache.cxf.transport.http.AbstractHTTPDestination;
+import org.apache.cxf.transport.http.InvalidCharsetException;
 import org.apache.cxf.transport.servlet.BaseUrlHelper;
 
 import com.ibm.websphere.ras.Tr;
@@ -133,6 +135,9 @@ public abstract class AbstractJaxRsWebEndpoint implements JaxRsWebEndpoint {
             updateDestination(request);
             destination.invoke(servletConfig, servletConfig.getServletContext(), request, response);
         } catch (IOException e) {
+            if (e instanceof InvalidCharsetException) {
+                throw new BadRequestException(e);
+            }
             throw new ServletException(e);
         } catch (JaxRsRuntimeException ex) {
             throw new ServletException(ex.getCause());

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
@@ -465,10 +465,11 @@ public abstract class AbstractHTTPDestination
             //allow gets/deletes/options to not specify an encoding
             String normalizedEncoding = HttpHeaderHelper.mapCharset(enc);
             if (normalizedEncoding == null) {
-                String m = new org.apache.cxf.common.i18n.Message("INVALID_ENCODING_MSG", tc.getLogger(), enc).toString();
-                //LOG.log(Level.WARNING, m);
+                // Liberty Change Start
+                String m = "Invalid encoding: " + enc;
                 Tr.warning(tc, m);
-                throw new IOException(m);
+                throw new InvalidCharsetException(m);
+                // Liberty Change End
             }
             inMessage.put(Message.ENCODING, normalizedEncoding);
         }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/InvalidCharsetException.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/InvalidCharsetException.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.apache.cxf.transport.http;
+
+import java.io.IOException;
+
+public class InvalidCharsetException extends IOException {
+
+    public InvalidCharsetException(String m) {
+        super(m);
+    }
+
+    private static final long serialVersionUID = 1676878985438910205L;
+
+}


### PR DESCRIPTION
This change makes Jaxrs requests with an invalid charset in the ```content-type``` header return HTTP 400 instead of 500 by throwing a ```BadRequestException``` instead of a generic ```IOException```.

However, this is only the fix for Jaxrs. After this change, the webcontainer throws it's own exception which causes the return code to still be 500 instead of 400 because they also process the ```content-type``` independently from Jaxrs.

Here is the new webcontainer stack:
```[3/20/20, 17:19:06:739 CDT] 00000045 com.ibm.ws.webcontainer.srt                                  I Unable to set request character encoding based upon request header 
java.io.UnsupportedEncodingException: SRVE0254E: Failed to set request character encoding: [invalid].
	at com.ibm.ws.webcontainer.srt.SRTServletRequest.setCharacterEncoding(SRTServletRequest.java:474)
	at com.ibm.ws.webcontainer.srt.SRTServletRequest.getCharacterEncoding(SRTServletRequest.java:1531)
	at com.ibm.ws.webcontainer.webapp.WebApp.sendError(WebApp.java:4164)
	at com.ibm.ws.webcontainer.webapp.WebApp.handleException(WebApp.java:5110)
	at com.ibm.ws.webcontainer.webapp.WebApp.handleRequest(WebApp.java:5090)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.handleRequest(DynamicVirtualHost.java:314)
	at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:1007)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:279)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1134)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:415)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:374)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:551)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:484)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:346)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.ready(HttpInboundLink.java:317)
	at com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.sendToDiscriminators(NewConnectionInitialReadCallback.java:167)
	at com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.complete(NewConnectionInitialReadCallback.java:75)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:504)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:574)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:958)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1047)
	at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:239)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:831)```

