### PR TITLE
Handled case of non-existent os-release file

### DIFF
--- a/dev/com.ibm.ws.install.packaging_fat/build.gradle
+++ b/dev/com.ibm.ws.install.packaging_fat/build.gradle
@@ -19,13 +19,19 @@ task copyTestPackages(type: Copy ) {
 		into ("${buildDir}/autoFVT/publish/packages.test")
 }
 
+
 task copyCurrentPackages(type: Copy ) {
-	from "${project(':build.image').projectDir}/packaging/rpmbuild/RPMS/noarch/"
-		into ("${buildDir}/autoFVT/publish/packages.current")
-        include '*.rpm'
+	into ("${buildDir}/autoFVT/publish")
+	
+	into ("packages.current") {
 	from "${project(':build.image').projectDir}/packaging/debuild/"
-		into ("${buildDir}/autoFVT/publish/packages.current")
-  	        include '*.deb'
+	    include ('*.deb', '*.build', '*.buildinfo', '*.changes')
+	}
+
+	into ("packages.current") {
+	from "${project(':build.image').projectDir}/packaging/rpmbuild/RPMS/noarch/"
+        include ('*.rpm')
+    }
 }
 
 zipAutoFVT.dependsOn copyServerFolder, copyTestPackages, copyCurrentPackages

--- a/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/InstallPackagesToolTest.java
+++ b/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/InstallPackagesToolTest.java
@@ -232,23 +232,11 @@ public abstract class InstallPackagesToolTest {
     protected static boolean isLinuxRHEL() throws Exception {
         boolean rc = false;
         String osReleaseFileName = "/etc/os-release";
-        String redhatReleaseFileName = "/etc/redhat-release";
-        String centosReleaseFileName = "/etc/centos-release";
 
         if (isLinux) {
             if (new File(osReleaseFileName).exists()) {
                 String content = new Scanner(new File(osReleaseFileName)).useDelimiter("\\Z").next();
                 if (content.contains("rhel") || content.contains("centos")) {
-                    rc = true;
-                }
-            } else if (new File(redhatReleaseFileName).exists()) {
-                String content = new Scanner(new File(redhatReleaseFileName)).useDelimiter("\\Z").next();
-                if (content.contains("Red Hat") || content.contains("CentOS")) {
-                    rc = true;
-                }
-            } else if (new File(centosReleaseFileName).exists()) {
-                String content = new Scanner(new File(centosReleaseFileName)).useDelimiter("\\Z").next();
-                if (content.contains("CentOS")) {
                     rc = true;
                 }
             } else {

--- a/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/InstallPackagesToolTest.java
+++ b/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/InstallPackagesToolTest.java
@@ -208,23 +208,54 @@ public abstract class InstallPackagesToolTest {
     }
 
     protected static boolean isLinuxUbuntu() throws Exception {
+        boolean rc = false;
+        String osReleaseFileName = "/etc/os-release";
         if (isLinux) {
-            String content = new Scanner(new File("/etc/os-release")).useDelimiter("\\Z").next();
-            if (content.contains("ubuntu")) {
-                return true;
+            if (new File(osReleaseFileName).exists()) {
+                String content = new Scanner(new File("/etc/os-release")).useDelimiter("\\Z").next();
+                if (content.contains("ubuntu")) {
+                    rc = true;
+                }
+            } else {
+                rc = false;
             }
         }
-        return false;
+        return rc;
     }
 
+    /**
+     * Checks if OS is RHEL or CENTOS
+     *
+     * @return
+     * @throws Exception
+     */
     protected static boolean isLinuxRHEL() throws Exception {
+        boolean rc = false;
+        String osReleaseFileName = "/etc/os-release";
+        String redhatReleaseFileName = "/etc/redhat-release";
+        String centosReleaseFileName = "/etc/centos-release";
+
         if (isLinux) {
-            String content = new Scanner(new File("/etc/os-release")).useDelimiter("\\Z").next();
-            if (content.contains("rhel")) {
-                return true;
+            if (new File(osReleaseFileName).exists()) {
+                String content = new Scanner(new File(osReleaseFileName)).useDelimiter("\\Z").next();
+                if (content.contains("rhel") || content.contains("centos")) {
+                    rc = true;
+                }
+            } else if (new File(redhatReleaseFileName).exists()) {
+                String content = new Scanner(new File(redhatReleaseFileName)).useDelimiter("\\Z").next();
+                if (content.contains("Red Hat") || content.contains("CentOS")) {
+                    rc = true;
+                }
+            } else if (new File(centosReleaseFileName).exists()) {
+                String content = new Scanner(new File(centosReleaseFileName)).useDelimiter("\\Z").next();
+                if (content.contains("CentOS")) {
+                    rc = true;
+                }
+            } else {
+                rc = false;
             }
         }
-        return false;
+        return rc;
     }
 
     protected static ProgramOutput runCommand(String testcase, String command, String[] params) throws Exception {


### PR DESCRIPTION
Apparently the /etc/os-release file does not exist on some CENTOS distributions.
Added a check for existence of this file and added additional checks to allow running of com.ibm.ws.install.packaging_fat on CENTOS.