### PR TITLE
Fix JarFileClassLoader to ignore redefined package when parallel-enabled

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/JarFileClassLoader.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/internal/classloader/JarFileClassLoader.java
@@ -207,7 +207,11 @@ public class JarFileClassLoader extends SecureClassLoader implements Closeable {
                 }
             }
 
-            definePackage(packageName, specTitle, specVersion, specVendor, implTitle, implVersion, implVendor, sealBase);
+            try {
+                definePackage(packageName, specTitle, specVersion, specVendor, implTitle, implVersion, implVendor, sealBase);
+            } catch (IllegalArgumentException iae) {
+                // Ignore rather than protect against redefining packages when parallel-enabled
+            }
         }
     }
 


### PR DESCRIPTION
Modify JarFileClassLoader.definePackage() to ignore the IllegalArgumentException that may be thrown by the call to java.lang.ClassLoader.definePackage whenever JarFileClassLoader is parallel enabled. The exception occurs when two threads attempt to concurrently define the same package via the JarFileClassLoader, where the first thread defines the package before the second, and the second fails with the exception. 