### PR TITLE
Enable app manager trace

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics_fat/publish/servers/MetricsAuthenticationServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.metrics_fat/publish/servers/MetricsAuthenticationServer/bootstrap.properties
@@ -1,2 +1,2 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.rest.*=all:com.ibm.wsspi.rest.*=all:com.ibm.ws.microprofile.metrics*=all
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.rest.*=all:com.ibm.wsspi.rest.*=all:com.ibm.ws.microprofile.metrics*=all:com.ibm.ws.app.manager.*=all


### PR DESCRIPTION
In relation to https://github.com/OpenLiberty/open-liberty/issues/11255
Need to enable App Manager trace to help with further analysis.