### PR TITLE
Enable trace for logservice and yoko

### DIFF
--- a/dev/com.ibm.ws.javaee.7.0_fat/publish/servers/javaee7Full.simpleEar/bootstrap.properties
+++ b/dev/com.ibm.ws.javaee.7.0_fat/publish/servers/javaee7Full.simpleEar/bootstrap.properties
@@ -9,4 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info
+com.ibm.ws.logging.trace.specification=*=info:logservice=all:org.apache.yoko.*=all

--- a/dev/com.ibm.ws.javaee.7.0_fat/publish/servers/javaee7Full.simpleWar/bootstrap.properties
+++ b/dev/com.ibm.ws.javaee.7.0_fat/publish/servers/javaee7Full.simpleWar/bootstrap.properties
@@ -9,4 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info
+com.ibm.ws.logging.trace.specification=*=info:logservice=all:org.apache.yoko.*=all

--- a/dev/com.ibm.ws.javaee.7.0_fat/publish/servers/javaee7Web.simpleEar/bootstrap.properties
+++ b/dev/com.ibm.ws.javaee.7.0_fat/publish/servers/javaee7Web.simpleEar/bootstrap.properties
@@ -9,4 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info
+com.ibm.ws.logging.trace.specification=*=info:logservice=all:org.apache.yoko.*=all

--- a/dev/com.ibm.ws.javaee.7.0_fat/publish/servers/javaee7Web.simpleWar/bootstrap.properties
+++ b/dev/com.ibm.ws.javaee.7.0_fat/publish/servers/javaee7Web.simpleWar/bootstrap.properties
@@ -9,4 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info
+com.ibm.ws.logging.trace.specification=*=info:logservice=all:org.apache.yoko.*=all


### PR DESCRIPTION
For diagnostic purposes only.