### PR TITLE
Timer Action Test Handle Slow Systems

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/test-applications/MissedTimerActionEJB.jar/src/com/ibm/ws/ejbcontainer/timer/persistent/missed/ejb/MissedTimerActionBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/test-applications/MissedTimerActionEJB.jar/src/com/ibm/ws/ejbcontainer/timer/persistent/missed/ejb/MissedTimerActionBean.java
@@ -105,6 +105,11 @@ public class MissedTimerActionBean implements MissedTimerAction {
                 if (index == 0) {
                     assertTrue("getNextTimeout() not >= DELAY : " + interval + " >= " + DELAY, interval >= DELAY);
                 } else {
+                    // Interval needs to be > 0 and a multiple of INTERVAL.
+                    // Normally would be INTERVAL, but on slow systems ONCE may skip to next future time.
+                    if (interval > INTERVAL && interval % INTERVAL == 0) {
+                        interval = INTERVAL;
+                    }
                     assertEquals("getNextTimeout() interval not expected on result #" + index, INTERVAL, interval);
                 }
                 nextExpected = nextTimeout.getTime();

--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/test-applications/RestartMissedTimerActionEJB.jar/src/com/ibm/ws/ejbcontainer/timer/persistent/restart/missed/ejb/RestartMissedTimerActionBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/test-applications/RestartMissedTimerActionEJB.jar/src/com/ibm/ws/ejbcontainer/timer/persistent/restart/missed/ejb/RestartMissedTimerActionBean.java
@@ -130,6 +130,11 @@ public class RestartMissedTimerActionBean implements RestartMissedTimerAction {
                 Date nextTimeout = nextTimeouts.get(index);
                 assertNotNull("Unexpected null for getNextTimeout() on result #" + index, nextTimeout);
                 long interval = nextTimeout.getTime() - nextExpected;
+                // Interval needs to be > 0 and a multiple of INTERVAL.
+                // Normally would be INTERVAL, but on slow systems ONCE may skip to next future time.
+                if (interval > INTERVAL && interval % INTERVAL == 0) {
+                    interval = INTERVAL;
+                }
                 assertEquals("getNextTimeout() interval not expected on result #" + index, INTERVAL, interval);
                 nextExpected = nextTimeout.getTime();
             }


### PR DESCRIPTION
Test is expecting timer to run every 1 second, which may not occur on "slow" systems.
When using "ONCE", slow systems may skip to the next future 1 second boundary,
so the test needs to account for that.
