### PR TITLE
Update oracle docker image

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/FATSuite.java
@@ -12,7 +12,6 @@ package com.ibm.ws.jdbc.fat.oracle;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -31,7 +30,7 @@ import componenttest.topology.utils.ExternalTestServiceDockerClientStrategy;
 public class FATSuite {
 	
     //TODO replace this container with the official oracle-xe container if/when it is available without a license
-    static OracleContainer oracle = new OracleContainer("oracleinanutshell/oracle-xe-11g").withLogConsumer(FATSuite::log);
+    static OracleContainer oracle = new OracleContainer("kyleaure/oracle-18.4.0-xe-prebuilt:1.0").withLogConsumer(FATSuite::log);
     
     private static void log(OutputFrame frame) {
         String msg = frame.getUtf8String();

--- a/dev/fattest.databases/src/componenttest/topology/database/container/DatabaseContainerFactory.java
+++ b/dev/fattest.databases/src/componenttest/topology/database/container/DatabaseContainerFactory.java
@@ -120,7 +120,7 @@ public class DatabaseContainerFactory {
 					cont = (JdbcDatabaseContainer<?>) clazz.getConstructor().newInstance();
 					break;
 	            case Oracle:          	
-	            	cont = (JdbcDatabaseContainer<?>) clazz.getConstructor(String.class).newInstance("oracleinanutshell/oracle-xe-11g");
+	            	cont = (JdbcDatabaseContainer<?>) clazz.getConstructor(String.class).newInstance("kyleaure/oracle-18.4.0-xe-prebuilt:1.0");
 	                break;
 	            case Postgres:
 	            	cont = (JdbcDatabaseContainer<?>) clazz.getConstructor().newInstance();


### PR DESCRIPTION
Updating the oracle docker images from using Oracle 11g to Oracle 18c.

This is a necessary change to ensure that we continue to support the latest database versions. In addition, the previous docker image we were using was slimmed down and as a result removed support for distributed transactions (XA).

