### PR TITLE
Make tests in MetricsMonitorTest wait for LTPA key to be created/ready

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/MetricsMonitorTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/MetricsMonitorTest.java
@@ -97,6 +97,7 @@ public class MetricsMonitorTest {
     	Log.info(c, testName, "------- Enable mpMetrics-1.1 and monitor-1.0: vendor metrics should be available ------");
     	server.setServerConfigurationFile("server_monitor.xml");
     	server.startServer();
+        Assert.assertNotNull("LTPA keys are not created/ready within timeout period of " + 60000 + "ms.", server.waitForStringInLog("CWWKS4104A.*|CWWKS4105I.*",60000));
     	Assert.assertNotNull("CWWKO0219I NOT FOUND",server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- server started -----");
     	Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLogUsingMark("CWWKT0016I"));
@@ -119,6 +120,7 @@ public class MetricsMonitorTest {
     	Log.info(c, testName, "------- Enable mpMetrics-2.0 and monitor-1.0: vendor metrics should be available ------");
     	server.setServerConfigurationFile("server_monitor2.xml");
     	server.startServer();
+        Assert.assertNotNull("LTPA keys are not created/ready within timeout period of " + 60000 + "ms.", server.waitForStringInLog("CWWKS4104A.*|CWWKS4105I.*",60000));
     	Assert.assertNotNull("CWWKO0219I NOT FOUND", server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- server started -----");
     	Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLogUsingMark("CWWKT0016I"));
@@ -142,6 +144,7 @@ public class MetricsMonitorTest {
     	Log.info(c, testName, "------- Enable mpMetrics-2.3 and monitor-1.0: vendor metrics should be available ------");
     	server.setServerConfigurationFile("server_monitor2.xml");
     	server.startServer();
+        Assert.assertNotNull("LTPA keys are not created/ready within timeout period of " + 60000 + "ms.", server.waitForStringInLog("CWWKS4104A.*|CWWKS4105I.*",60000));
     	Assert.assertNotNull("CWWKO0219I NOT FOUND", server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- server started -----");
     	Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLogUsingMark("CWWKT0016I"));
@@ -165,6 +168,7 @@ public class MetricsMonitorTest {
     	Log.info(c, testName, "------- Enable mpMetrics-1.0 and monitor-1.0: vendor metrics should not be available ------");
     	server.setServerConfigurationFile("server_mpMetric10Monitor10.xml");
     	server.startServer();
+        Assert.assertNotNull("LTPA keys are not created/ready within timeout period of " + 60000 + "ms.", server.waitForStringInLog("CWWKS4104A.*|CWWKS4105I.*",60000));
     	Assert.assertNotNull("CWWKO0219I NOT FOUND", server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
         String logMsg = server.waitForStringInLog("SRVE9103I",60000);   
         Log.info(c, testName, logMsg);
@@ -184,6 +188,7 @@ public class MetricsMonitorTest {
     	Log.info(c, testName, "------- Enable microProfile-1.3 and monitor-1.0: vendor metrics should be available ------");
     	server.setServerConfigurationFile("server_microProfile13Monitor10.xml");
     	server.startServer();
+        Assert.assertNotNull("LTPA keys are not created/ready within timeout period of " + 60000 + "ms.", server.waitForStringInLog("CWWKS4104A.*|CWWKS4105I.*",60000));
     	Log.info(c, testName, server.waitForStringInLog("CWWKS5500I",60000));
     	Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLog(".*CWWKT0016I.*metrics.*",60000));
     	Assert.assertNotNull("CWWKO0219I NOT FOUND",server.waitForStringInLog(".*CWWKO0219I.*defaultHttpEndpoint-ssl.*",60000));

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/MetricsMonitorTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/MetricsMonitorTest.java
@@ -95,6 +95,7 @@ public class MetricsMonitorTest {
     	Log.info(c, testName, "------- Enable mpMetrics-1.1 and monitor-1.0: vendor metrics should be available ------");
     	server.setServerConfigurationFile("server_monitor.xml");
     	server.startServer();
+        Assert.assertNotNull("LTPA keys are not created/ready within timeout period of " + 60000 + "ms.", server.waitForStringInLog("CWWKS4104A.*|CWWKS4105I.*",60000));
     	Assert.assertNotNull("CWWKO0219I NOT FOUND",server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, "------- server started -----");
@@ -118,6 +119,7 @@ public class MetricsMonitorTest {
     	Log.info(c, testName, "------- Enable mpMetrics-1.0 and monitor-1.0: vendor metrics should not be available ------");
     	server.setServerConfigurationFile("server_mpMetric10Monitor10.xml");
     	server.startServer();
+        Assert.assertNotNull("LTPA keys are not created/ready within timeout period of " + 60000 + "ms.", server.waitForStringInLog("CWWKS4104A.*|CWWKS4105I.*",60000));
     	Assert.assertNotNull("CWWKO0219I NOT FOUND",server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
         String logMsg = server.waitForStringInLog("SRVE9103I",60000);   
         Log.info(c, testName, logMsg);
@@ -137,6 +139,7 @@ public class MetricsMonitorTest {
     	Log.info(c, testName, "------- Enable microProfile-1.3 and monitor-1.0: vendor metrics should be available ------");
     	server.setServerConfigurationFile("server_microProfile13Monitor10.xml");
     	server.startServer();
+        Assert.assertNotNull("LTPA keys are not created/ready within timeout period of " + 60000 + "ms.", server.waitForStringInLog("CWWKS4104A.*|CWWKS4105I.*",60000));
     	Assert.assertNotNull("CWWKO0219I NOT FOUND",server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
     	Log.info(c, testName, server.waitForStringInLog("CWWKS5500I",60000));
     	Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLog(".*CWWKT0016I.*metrics.*",60000));
@@ -226,4 +229,5 @@ public class MetricsMonitorTest {
     		}
     	}
     }
+
 }


### PR DESCRIPTION
Fixes #11455
Test failure caused by hitting URL before LTPA key is created.