### PR TITLE
test connectionManager pool size increase and app restart

### DIFF
--- a/dev/com.ibm.ws.jca_fat/test-applications/fvtweb/src/web/JCAFVTServlet.java
+++ b/dev/com.ibm.ws.jca_fat/test-applications/fvtweb/src/web/JCAFVTServlet.java
@@ -52,6 +52,12 @@ public class JCAFVTServlet extends HttpServlet {
      */
     public static final String SUCCESS_MESSAGE = "COMPLETED SUCCESSFULLY";
 
+    /**
+     * This state is used by certain tests to determine whether a Servlet instance,
+     * and thus the application as a whole, survives a config update.
+     */
+    private String state = "NEW";
+
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         String test = request.getParameter("test");
@@ -71,6 +77,24 @@ public class JCAFVTServlet extends HttpServlet {
             x.printStackTrace(out);
             out.println("</pre>");
         }
+    }
+
+    public void requireNewServletInstance(HttpServletRequest request, HttpServletResponse response) throws Throwable {
+        if (!"NEW".equals(state))
+            throw new Exception("It appears that the existing servlet instance was used, meaning the app was not restarted. State: " + state);
+    }
+
+    public void requireServletInstanceStillActive(HttpServletRequest request, HttpServletResponse response) throws Throwable {
+        if (!"SERVLET_INSTANCE_STILL_ACTIVE".equals(state))
+            throw new Exception("It appears that a different servlet instance was used, meaning the app was restarted. State: " + state);
+    }
+
+    public void resetState(HttpServletRequest request, HttpServletResponse response) throws Throwable {
+        state = "NEW";
+    }
+
+    public void setServletInstanceStillActive(HttpServletRequest request, HttpServletResponse response) throws Throwable {
+        state = "SERVLET_INSTANCE_STILL_ACTIVE";
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/ConfigTest.java
+++ b/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/ConfigTest.java
@@ -379,7 +379,7 @@ public class ConfigTest extends FATServletClient {
 
         try {
             updateServerConfig(config, EMPTY_EXPR_LIST);
-            // Behavior should now reflect the new setting of 1 for maxPoolSize
+            // Behavior should now reflect the new setting of 2 for maxPoolSize
             runTest(basicfat, "testMaxPoolSize2");
         } catch (Throwable x) {
             System.out.println("Failure during " + method + " with the following config:");

--- a/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/ConfigTest.java
+++ b/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/ConfigTest.java
@@ -372,6 +372,25 @@ public class ConfigTest extends FATServletClient {
             throw x;
         }
 
+        runTest(basicfat, "setServletInstanceStillActive");
+
+        // Increase maxPoolSize to 2
+        conMgr2.setMaxPoolSize("2");
+
+        try {
+            updateServerConfig(config, EMPTY_EXPR_LIST);
+            // Behavior should now reflect the new setting of 1 for maxPoolSize
+            runTest(basicfat, "testMaxPoolSize2");
+        } catch (Throwable x) {
+            System.out.println("Failure during " + method + " with the following config:");
+            System.out.println(config);
+            throw x;
+        }
+
+        runTest(basicfat, "requireServletInstanceStillActive");
+
+        runTest(basicfat, "resetState");
+
         cleanUpExprs = EMPTY_EXPR_LIST;
     }
 
@@ -764,6 +783,8 @@ public class ConfigTest extends FATServletClient {
             throw x;
         }
 
+        runTest(basicfat, "setServletInstanceStillActive");
+
         // Modify the nested config after it has been used
         conMgr2.setMaxPoolSize("2");
         conMgr2.setPurgePolicy("ValidateAllConnections"); // just to change the file size
@@ -777,6 +798,9 @@ public class ConfigTest extends FATServletClient {
             System.out.println(config);
             throw x;
         }
+
+        runTest(basicfat, "requireServletInstanceStillActive");
+        runTest(basicfat, "resetState");
 
         // Move the connectionManager back to top level config.
         dsfat2.setConnectionManagerRef("conMgr2");

--- a/dev/com.ibm.ws.jdbc_fat/test-applications/basicfat/src/basicfat/DataSourceTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat/test-applications/basicfat/src/basicfat/DataSourceTestServlet.java
@@ -55,6 +55,8 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 import javax.transaction.HeuristicMixedException;
 import javax.transaction.UserTransaction;
@@ -198,6 +200,12 @@ public class DataSourceTestServlet extends FATServlet {
     @Resource(lookup = "java:comp/env/jdbc/dsValTderbyAnn")
     DataSource dsValTderbyAnn;
 
+    /**
+     * This state is used by certain tests to determine whether a Servlet instance,
+     * and thus the application as a whole, survives a config update.
+     */
+    private String state = "NEW";
+
     @Resource
     private UserTransaction tran;
 
@@ -268,6 +276,24 @@ public class DataSourceTestServlet extends FATServlet {
         // End the current LTC and get a new one, so that test methods start from the correct place
         tran.begin();
         tran.commit();
+    }
+
+    public void requireNewServletInstance(HttpServletRequest request, HttpServletResponse response) throws Throwable {
+        if (!"NEW".equals(state))
+            throw new Exception("It appears that the existing servlet instance was used, meaning the app was not restarted. State: " + state);
+    }
+
+    public void requireServletInstanceStillActive(HttpServletRequest request, HttpServletResponse response) throws Throwable {
+        if (!"SERVLET_INSTANCE_STILL_ACTIVE".equals(state))
+            throw new Exception("It appears that a different servlet instance was used, meaning the app was restarted. State: " + state);
+    }
+
+    public void resetState(HttpServletRequest request, HttpServletResponse response) throws Throwable {
+        state = "NEW";
+    }
+
+    public void setServletInstanceStillActive(HttpServletRequest request, HttpServletResponse response) throws Throwable {
+        state = "SERVLET_INSTANCE_STILL_ACTIVE";
     }
 
     /**


### PR DESCRIPTION
Write tests that identify whether updates to nested and top level connectionManager elements causes an application restart, in the case of dataSource and connection factories.
The test is enabled for dataSource, where it enforces that the application does not restart.
Part of the test is commented out for connection factories, where observed behavior is that the application does restart. In that case, the connectionManager element handles its own modified, however, OSGi wants to sent a modified (leading to deactivate/activate) to the connection factory, triggering the app recycle logic.