### PR TITLE
gRPC Servlet routing 

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -528,6 +528,11 @@
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
+      <artifactId>grpc-census</artifactId>
+      <version>1.27.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
       <artifactId>grpc-context</artifactId>
       <version>1.27.0</version>
     </dependency>

--- a/dev/com.ibm.ws.grpc.servlet/.classpath
+++ b/dev/com.ibm.ws.grpc.servlet/.classpath
@@ -3,5 +3,6 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="src" path="/com.ibm.ws.transport.http"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.grpc.servlet/.classpath
+++ b/dev/com.ibm.ws.grpc.servlet/.classpath
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="test"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="src" path="/com.ibm.ws.transport.http"/>
+	<classpathentry kind="src" path="/com.ibm.ws.junit.extensions"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.grpc.servlet/bnd.bnd
+++ b/dev/com.ibm.ws.grpc.servlet/bnd.bnd
@@ -46,6 +46,7 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=11))"
   com.ibm.ws.anno;version=latest,\
   com.ibm.ws.logging.core,\
   com.ibm.ws.grpc.common.1.0;version=latest,\
+  com.ibm.ws.transport.http;version=latest,\
   com.ibm.ws.webcontainer,\
   com.google.code.findbugs:jsr305;version=3.0.2,\
   com.google.guava:guava;version=27.0.1

--- a/dev/com.ibm.ws.grpc.servlet/bnd.bnd
+++ b/dev/com.ibm.ws.grpc.servlet/bnd.bnd
@@ -50,3 +50,15 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=11))"
   com.ibm.ws.webcontainer,\
   com.google.code.findbugs:jsr305;version=3.0.2,\
   com.google.guava:guava;version=27.0.1
+
+-testpath: \
+    org.hamcrest:hamcrest-all;version=1.3, \
+    org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
+    org.jmock:jmock;strategy=exact;version=2.5.1, \
+    ../build.sharedResources/lib/junit/old/junit.jar;version=file, \
+    com.ibm.ws.junit.extensions;version=latest, \
+    cglib:cglib-nodep;version=3.3.0, \
+    org.jmock:jmock-legacy;version=2.5.0, \
+    com.ibm.ws.org.objenesis:objenesis;version=1.0, \
+    com.ibm.ws.logging;version=latest, \
+    com.ibm.ws.kernel.boot;version=latest

--- a/dev/com.ibm.ws.grpc.servlet/src/com/ibm/ws/grpc/servlet/GrpcServletApplication.java
+++ b/dev/com.ibm.ws.grpc.servlet/src/com/ibm/ws/grpc/servlet/GrpcServletApplication.java
@@ -1,0 +1,61 @@
+package com.ibm.ws.grpc.servlet;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.ibm.ws.http2.GrpcServletServices;
+
+/**
+ * Keep track of gRPC service names and their class names
+ */
+class GrpcServletApplication {
+
+	Set<String> serviceNames;
+	Set<String> serviceClassNames;
+
+	/**
+	 * Add a service name to context path mapping
+	 * @param String serviceName
+	 * @param String ontextPath
+	 */
+	void addServiceName(String serviceName, String contextPath) {
+		if (serviceNames == null) {
+			serviceNames = new HashSet<String>();
+		}
+		serviceNames.add(serviceName);
+		if (serviceName != null && contextPath != null) {
+			GrpcServletServices.addServletGrpcService(serviceName, contextPath);
+		}
+	}
+
+	/**
+	 * Add the set of class names that contain gRPC services.
+	 * These classes will be initialized by Libery during startup.
+	 * @param Set<String> service class names
+	 */
+	void addServiceClassNames(Set<String> names) {
+		if (serviceClassNames == null) {
+			serviceClassNames = new HashSet<String>();
+		}
+		serviceClassNames.addAll(names);
+	}
+
+	/**
+	 * @return Set<String> all service class names that have been registered
+	 */
+	Set<String> getServiceClassNames() {
+		return serviceClassNames;
+	}
+
+	/**
+	 * Unregister and clean up any associated services and mappings 
+	 */
+	void destroy() {
+		for (String service : serviceNames) {
+			GrpcServletServices.removeServletGrpcService(service);
+		}
+		serviceNames = null;
+		serviceClassNames = null;
+	}
+}
+

--- a/dev/com.ibm.ws.grpc.servlet/src/com/ibm/ws/grpc/servlet/GrpcServletContainerInitializer.java
+++ b/dev/com.ibm.ws.grpc.servlet/src/com/ibm/ws/grpc/servlet/GrpcServletContainerInitializer.java
@@ -5,6 +5,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -25,6 +26,7 @@ import com.ibm.ws.container.service.app.deploy.ApplicationInfo;
 import com.ibm.ws.container.service.state.ApplicationStateListener;
 import com.ibm.ws.container.service.state.StateChangeException;
 import com.ibm.ws.grpc.Utils;
+import com.ibm.ws.http2.GrpcServletServices;
 import com.ibm.ws.webcontainer.webapp.WebApp;
 import com.ibm.wsspi.adaptable.module.UnableToAdaptException;
 import com.ibm.wsspi.anno.targets.AnnotationTargets_Targets;
@@ -39,7 +41,7 @@ public class GrpcServletContainerInitializer implements ServletContainerInitiali
 	private static final String CLASS_NAME = GrpcServletContainerInitializer.class.getName();
 	private static final Logger logger = Logger.getLogger(GrpcServletContainerInitializer.class.getName());
 
-	private static ConcurrentHashMap<String, Set<String>> grpcServiceClassNames;
+	private static ConcurrentHashMap<String, GrpcServletApplication>  grpcApplications;
 	GrpcServlet grpcServlet;
 
 	/**
@@ -49,13 +51,14 @@ public class GrpcServletContainerInitializer implements ServletContainerInitiali
 	@Override
 	public void onStartup(Set<Class<?>> ctx, ServletContext sc) throws ServletException {
 
-		if (grpcServiceClassNames != null) {
+		if (grpcApplications != null) {
 			Utils.traceMessage(logger, CLASS_NAME, Level.FINE, "onStartup",
 					"Attempting to load gRPC services for app " + sc.getServletContextName());
 
 			// TODO: optionally load classes with CDI to allow injection in service classes
 			// init all other BindableService classes via reflection
-			Set<String> services = grpcServiceClassNames.get(((WebApp) sc).getApplicationName());
+			GrpcServletApplication currentApp = grpcApplications.get(((WebApp) sc).getApplicationName());
+			Set<String> services = currentApp.getServiceClassNames();
 			if (services != null) {
 				Map<String, BindableService> grpcServiceClasses = new HashMap<String, BindableService>();
 				for (String serviceClassName : services) {
@@ -65,6 +68,7 @@ public class GrpcServletContainerInitializer implements ServletContainerInitiali
 					}
 				}
 				if (!grpcServiceClasses.isEmpty()) {
+					Set<String> serviceNames = new HashSet<String>();
 					// pass all of our grpc service implementors into a new GrpcServlet
 					// and register that new Servlet on this context
 					grpcServlet = new GrpcServlet(new ArrayList<BindableService>(grpcServiceClasses.values()));
@@ -76,9 +80,13 @@ public class GrpcServletContainerInitializer implements ServletContainerInitiali
 						String serviceName = service.bindService().getServiceDescriptor().getName();
 						String urlPattern = "/" + serviceName + "/*";
 						servletRegistration.addMapping(urlPattern);
+						// keep track of this service name -> application path mapping
+						GrpcServletServices.addServletGrpcService(serviceName, sc.getContextPath());
+						serviceNames.add(serviceName);
 						Utils.traceMessage(logger, CLASS_NAME, Level.INFO, "onStartup",
 								"Registered gRPC service at URL: " + urlPattern);
 					}
+					currentApp.addServiceNames(serviceNames);
 					return;
 				}
 			}
@@ -130,10 +138,12 @@ public class GrpcServletContainerInitializer implements ServletContainerInitiali
 
 			if (services != null && !services.isEmpty()) {
 				if (!services.isEmpty()) {
-					if (grpcServiceClassNames == null) {
-						grpcServiceClassNames = new ConcurrentHashMap<String, Set<String>>();
+					if (grpcApplications == null) {
+						grpcApplications = new ConcurrentHashMap<String, GrpcServletApplication>();
 					}
-					grpcServiceClassNames.put(appInfo.getName(), services);
+					GrpcServletApplication currentApplication = new GrpcServletApplication();
+					currentApplication.addServiceClassNames(services);
+					grpcApplications.put(appInfo.getName(), currentApplication);
 				}
 			}
 		} catch (UnableToAdaptException e) {
@@ -152,11 +162,54 @@ public class GrpcServletContainerInitializer implements ServletContainerInitiali
 
 	@Override
 	public void applicationStopping(ApplicationInfo appInfo) {
-		grpcServiceClassNames = null;
 		grpcServlet = null;
+		// clean up any grpc URL mappings
+		if (grpcApplications != null) {
+			GrpcServletApplication currentApp = grpcApplications.remove(appInfo.getName());
+			if (currentApp != null) {
+				currentApp.destroy();
+				if (grpcApplications.isEmpty()) {
+					grpcApplications = null;
+				}
+			}
+		}
 	}
 
 	@Override
 	public void applicationStopped(ApplicationInfo appInfo) {
+	}
+
+	/**
+	 * Keep track of gRPC service names and their class names
+	 */
+	private class GrpcServletApplication {
+
+		Set<String> serviceNames;
+		Set<String> serviceClassNames;
+
+		GrpcServletApplication() {
+			serviceNames = new HashSet<String>();
+			serviceClassNames = new HashSet<String>();
+		}
+
+		void addServiceNames(Set<String> serviceNames) {
+			serviceNames.addAll(serviceNames);
+		}
+
+		void addServiceClassNames(Set<String> serviceNames) {
+			serviceClassNames.addAll(serviceNames);
+		}
+
+		Set<String> getServiceClassNames() {
+			return serviceClassNames;
+		}
+
+		private void destroy() {
+			for (String service : serviceNames) {
+				GrpcServletServices.removeServletGrpcService(service);
+			}
+			serviceNames = null;
+			serviceClassNames = null;
+		}
 	}
 }

--- a/dev/com.ibm.ws.grpc.servlet/src/com/ibm/ws/grpc/servlet/GrpcServletUtils.java
+++ b/dev/com.ibm.ws.grpc.servlet/src/com/ibm/ws/grpc/servlet/GrpcServletUtils.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.grpc.servlet;
+
+public class GrpcServletUtils {
+	
+	  /**
+	   * Removes the application context root from the front gRPC request path. For example:
+	   * "app_context_root/helloworld.Greeter/SayHello" -> "helloworld.Greeter/SayHello"
+	   * 
+	   * @param String original request path
+	   * @return String request path without app context root
+	   */
+	  public static String translateLibertyPath(String requestPath) {
+		    int count = requestPath.length() - requestPath.replace("/", "").length();
+		    // if count < 2 there is no app context root to remove
+		    if (count == 2) {
+		        int index = requestPath.indexOf('/');
+		        requestPath = requestPath.substring(index + 1);
+		    }
+		    return requestPath;
+	  }
+}

--- a/dev/com.ibm.ws.grpc.servlet/src/io/grpc/servlet/ServletAdapter.java
+++ b/dev/com.ibm.ws.grpc.servlet/src/io/grpc/servlet/ServletAdapter.java
@@ -24,6 +24,7 @@ import static java.util.logging.Level.FINEST;
 
 import com.google.common.io.BaseEncoding;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.grpc.servlet.GrpcServletUtils;
 
 import io.grpc.Attributes;
 import io.grpc.ExperimentalApi;
@@ -37,6 +38,7 @@ import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.ReadableBuffers;
 import io.grpc.internal.ServerTransportListener;
 import io.grpc.internal.StatsTraceContext;
+
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -123,6 +125,14 @@ public final class ServletAdapter {
     AsyncContext asyncCtx = req.startAsync(req, resp);
 
     String method = req.getRequestURI().substring(1); // remove the leading "/"
+
+    // Liberty change: remove application context root from path 
+    method = GrpcServletUtils.translateLibertyPath(method);
+
+    if (logger.isLoggable(FINEST)) {
+        logger.log(FINE, "Liberty inbound gRPC request path translated to {0}" + method);
+    }
+
     Metadata headers = getHeaders(req);
 
     if (logger.isLoggable(FINEST)) {

--- a/dev/com.ibm.ws.grpc.servlet/test/com/ibm/ws/grpc/servlet/GrpcServletTest.java
+++ b/dev/com.ibm.ws.grpc.servlet/test/com/ibm/ws/grpc/servlet/GrpcServletTest.java
@@ -1,0 +1,183 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.grpc.servlet;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.rules.TestRule;
+
+import com.ibm.ws.http2.GrpcServletServices;
+
+import test.common.SharedOutputManager;
+
+/**
+ * Basic unit tests for the grpcServlet feature
+ */
+public class GrpcServletTest {
+
+	private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+
+	@Rule
+	public TestRule rule = outputMgr;
+
+	@Rule
+	public TestName name = new TestName();
+
+	@After
+	public void tearDown() {
+	}
+
+	/**
+	 * Verify that the GrpcServletServices map works as expected
+	 */
+	@Test
+	public void testGrpcServletServices() {
+		String grpcService1 = "helloworld.Greeter1";
+		String grpcService2 = "helloworld.Greeter2";
+		String grpcService3 = "helloworld.Greeter3";
+		String grpcService4 = "helloworld.Greeter4";
+		String grpcService5 = "helloworld.Greeter5";
+		String grpcService6 = "helloworld.Greeter6";
+		String grpcService7 = "helloworld.Greeter7";
+		String grpcService8 = "helloworld.Greeter8";
+		String app1 = "app1";
+		String app2 = "app2";
+		String app3 = "app3";
+		
+		CountDownLatch latch = new CountDownLatch(3);
+
+		// simulate async app startup
+		Thread appThread1 = new Thread() {
+			public void run() {
+				GrpcServletServices.addServletGrpcService(grpcService1, app1);
+				GrpcServletServices.addServletGrpcService(grpcService6, app1);
+				GrpcServletServices.addServletGrpcService(grpcService8, app1);
+				GrpcServletServices.addServletGrpcService(grpcService3, app1);
+				latch.countDown();
+			}
+		};
+		Thread appThread2 = new Thread() {
+			public void run() {
+				GrpcServletServices.addServletGrpcService(grpcService4, app2);
+				GrpcServletServices.addServletGrpcService(grpcService5, app2);
+				latch.countDown();
+			}
+		};
+		Thread appThread3 = new Thread() {
+			public void run() {
+				GrpcServletServices.addServletGrpcService(grpcService2, app3);
+				GrpcServletServices.addServletGrpcService(grpcService7, app3);
+				latch.countDown();
+			}
+		};
+
+		appThread1.start();
+		appThread2.start();
+		appThread3.start();
+		try {
+			latch.await(5, TimeUnit.SECONDS);
+		} catch (InterruptedException e) {
+			Assert.fail("GrpcServletServices.addServletGrpcService() "
+					+ "timed out");
+		}
+
+		// make sure all 8 applications were added
+		Map<String, String> services = GrpcServletServices.getServletGrpcServices();
+		Assert.assertEquals(8, services.size());
+		try {
+			GrpcServletServices.addServletGrpcService(grpcService1, app2);
+			Assert.fail("GrpcServletServices.addServletGrpcService() "
+					+ "should have failed when passed a duplicate service name");
+		} catch (RuntimeException re) {}
+		
+		// verify the services are mapped correctly
+		Assert.assertEquals(8, services.size());
+		Assert.assertEquals(app1, services.get(grpcService1));
+		Assert.assertEquals(app2, services.get(grpcService4));
+		Assert.assertEquals(app3, services.get(grpcService7));
+		
+		// remove a few services and make sure the mappings are correct
+		GrpcServletServices.removeServletGrpcService(grpcService1);
+		GrpcServletServices.removeServletGrpcService(grpcService4);
+		GrpcServletServices.removeServletGrpcService(grpcService7);
+		Assert.assertEquals(5, services.size());
+		Assert.assertNull(services.get(grpcService1));
+		GrpcServletServices.destroy();
+	}
+	
+	/**
+	 * Test the GrpcServletApplication object
+	 */
+	@Test
+	public void testGrpcServletApplication() {
+		String serviceClassName = "com.ibm.ws.grpc.servlet.ExampleServletService";
+		Set<String> serviceClassNames = new HashSet<String>();
+		serviceClassNames.add(serviceClassName);
+		String serviceName = "helloworld.Greeter";
+		String contextRoot = "sample_application";
+
+		// create a GrpcServletApplication
+		GrpcServletApplication app = new GrpcServletApplication();
+		app.addServiceClassNames(serviceClassNames);
+		app.addServiceName(serviceName, contextRoot);
+		
+		// make sure that GrpcServletApplication is correct 
+		Assert.assertEquals(1, app.getServiceClassNames().size());
+		Assert.assertEquals(1, GrpcServletServices.getServletGrpcServices().size());
+		Assert.assertTrue(app.getServiceClassNames().contains(serviceClassName));
+		// GrpcServletServices should have been updated with the new service
+		Assert.assertEquals(contextRoot, GrpcServletServices.getServletGrpcServices().get(serviceName));
+
+		// destroy the app and make sure everything has been cleaned up
+		app.destroy();
+		Assert.assertNull(app.getServiceClassNames());
+		Assert.assertNull(GrpcServletServices.getServletGrpcServices());
+		
+		// check that the same path can be re-added
+		app.addServiceClassNames(serviceClassNames);
+		app.addServiceName(serviceName, contextRoot);
+		Assert.assertEquals(contextRoot, GrpcServletServices.getServletGrpcServices().get(serviceName));
+		app.destroy();
+		GrpcServletServices.destroy();
+	}
+
+	/**
+	 * Verify that the gRPC URL translation works as expected
+	 */
+	@Test
+	public void testPathTranslation() {
+		String normalPath1 = "app_context_root/helloworld.Greeter/SayHello";
+		String normalPath2 = "helloworld.Greeter/SayHello";
+		String badPath1 = "//";
+		String badPath2 = "helloworld.Greeter/";
+		String badPath3 = "/";
+		String badPath4 = "/SayHello/";
+		String badPath5 = "helloworld.Greeter/SayHello/";
+		Assert.assertEquals("helloworld.Greeter/SayHello", GrpcServletUtils.translateLibertyPath(normalPath1));
+		Assert.assertEquals("helloworld.Greeter/SayHello", GrpcServletUtils.translateLibertyPath(normalPath2));
+		Assert.assertEquals("/", GrpcServletUtils.translateLibertyPath(badPath1));
+		Assert.assertEquals(badPath2, GrpcServletUtils.translateLibertyPath(badPath2));
+		Assert.assertEquals(badPath3, GrpcServletUtils.translateLibertyPath(badPath3));
+		Assert.assertEquals("SayHello/", GrpcServletUtils.translateLibertyPath(badPath4));
+		Assert.assertEquals("SayHello/", GrpcServletUtils.translateLibertyPath(badPath5));
+	}
+	
+
+}

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/H2HttpInboundLinkWrap.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/H2HttpInboundLinkWrap.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -123,7 +124,7 @@ public class H2HttpInboundLinkWrap extends HttpInboundLink {
                 }
             } else if (GrpcServletServices.getServletGrpcServices() != null) {
 
-                HashMap<String, String> servicePaths = GrpcServletServices.getServletGrpcServices();
+                Map<String, String> servicePaths = GrpcServletServices.getServletGrpcServices();
                 if (servicePaths != null) {
                     routeGrpcServletRequest(servicePaths);
                 }
@@ -138,7 +139,7 @@ public class H2HttpInboundLinkWrap extends HttpInboundLink {
      * the correct application context root to the request. For this example, the URL will change from
      * "/helloworld.Greeter/SayHello" -> "/app_context_root/helloworld.Greeter/SayHello"
      */
-    private void routeGrpcServletRequest(HashMap<String, String> servicePaths) {
+    private void routeGrpcServletRequest(Map<String, String> servicePaths) {
         String requestContentType = getContentType().toLowerCase();
         if ("application/grpc".equalsIgnoreCase(requestContentType)) {
 

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http2/GrpcServletServices.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http2/GrpcServletServices.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.http2;
+
+import java.util.HashMap;
+
+/**
+ * Keep track of gRPC service to application mappings
+ */
+public class GrpcServletServices {
+
+    private static HashMap<String, String> servletGrpcServices;
+
+    /**
+     * Register an a gRPC service with its application
+     *
+     * @param String gRPC service name
+     * @param String contextRoot for the app
+     */
+    public static void addServletGrpcService(String service, String contextRoot) {
+        if (servletGrpcServices == null) {
+            servletGrpcServices = new HashMap<String, String>();
+        }
+        if (servletGrpcServices.containsKey(service)) {
+            throw new RuntimeException("duplicate gRPC service added: " + service);
+        } else {
+            servletGrpcServices.put(service, contextRoot);
+        }
+    }
+
+    /**
+     * Remove a service mapping
+     *
+     * @param String service
+     */
+    public static void removeServletGrpcService(String service) {
+        if (servletGrpcServices != null) {
+            servletGrpcServices.remove(service);
+        }
+    }
+
+    /**
+     * Return the set of servlet gRPC Services that have been registered.
+     *
+     * @return HashMap<String service, String contextRoot> or null if the set is empty
+     */
+    public static HashMap<String, String> getServletGrpcServices() {
+        if (servletGrpcServices == null || servletGrpcServices.isEmpty()) {
+            return null;
+        }
+        return servletGrpcServices;
+    }
+}

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http2/GrpcServletServices.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http2/GrpcServletServices.java
@@ -46,6 +46,9 @@ public class GrpcServletServices {
         if (servletGrpcServices != null) {
             servletGrpcServices.remove(service);
         }
+        if (servletGrpcServices.isEmpty()) {
+            servletGrpcServices = null;
+        }
     }
 
     /**
@@ -54,9 +57,13 @@ public class GrpcServletServices {
      * @return HashMap<String service, String contextRoot> or null if the set is empty
      */
     public static Map<String, String> getServletGrpcServices() {
-        if (servletGrpcServices == null || servletGrpcServices.isEmpty()) {
+        if (servletGrpcServices == null) {
             return null;
         }
         return servletGrpcServices;
+    }
+
+    public static void destroy() {
+        servletGrpcServices = null;
     }
 }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http2/GrpcServletServices.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http2/GrpcServletServices.java
@@ -10,14 +10,15 @@
  *******************************************************************************/
 package com.ibm.ws.http2;
 
-import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Keep track of gRPC service to application mappings
  */
 public class GrpcServletServices {
 
-    private static HashMap<String, String> servletGrpcServices;
+    private static Map<String, String> servletGrpcServices;
 
     /**
      * Register an a gRPC service with its application
@@ -27,7 +28,7 @@ public class GrpcServletServices {
      */
     public static void addServletGrpcService(String service, String contextRoot) {
         if (servletGrpcServices == null) {
-            servletGrpcServices = new HashMap<String, String>();
+            servletGrpcServices = new ConcurrentHashMap<String, String>();
         }
         if (servletGrpcServices.containsKey(service)) {
             throw new RuntimeException("duplicate gRPC service added: " + service);
@@ -52,7 +53,7 @@ public class GrpcServletServices {
      *
      * @return HashMap<String service, String contextRoot> or null if the set is empty
      */
-    public static HashMap<String, String> getServletGrpcServices() {
+    public static Map<String, String> getServletGrpcServices() {
         if (servletGrpcServices == null || servletGrpcServices.isEmpty()) {
             return null;
         }


### PR DESCRIPTION
Adds support for deploying gRPC services via `grpcServlet-1.0` on any context root on the server.  Previously, apps needed to be deployed at `/` for gRPC requests to get routed correctly.

For #10088