### PR TITLE
11479: Initial config for tracking relying parties

### DIFF
--- a/dev/com.ibm.ws.security.oauth/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.oauth/resources/OSGI-INF/metatype/metatype.xml
@@ -259,6 +259,7 @@
         </AD>
         <!--  this is fixing a corner bug and has to be behind a property to protect existing users.  -->
         <AD id="ropcPreferUserSecurityName" name="%ropcPreferUserSecurityName" description="%ropcPreferUserSecurityName.desc" required="false" type="Boolean"  default="false"/>
+        <AD id="trackRelyingParties" name="internal" description="internal use only" required="false" type="Boolean" default="false" />
     </OCD>
    <!--   
     <Designate factoryPid="com.ibm.ws.security.oauth20.provider.config">

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/api/OAuth20Provider.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/api/OAuth20Provider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2019 IBM Corporation and others.
+ * Copyright (c) 1997, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -160,5 +160,7 @@ public interface OAuth20Provider extends OAuth20ConfigProvider, OAuthComponentIn
     public String getInternalClientSecret();
 
     public boolean isROPCPreferUserSecurityName();
+
+    public boolean isTrackRelyingParties();
 
 }

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/internal/LibertyOAuth20Provider.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/internal/LibertyOAuth20Provider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -189,6 +189,7 @@ public class LibertyOAuth20Provider implements OAuth20Provider, ConfigurationLis
     protected static final String KEY_logoutRedirectURL = "logoutRedirectURL";
     protected static final String KEY_CACHE_ACCESSTOKEN = "accessTokenCacheEnabled";
     protected static final String KEY_REVOKE_ACCESSTOK_W_REFRESHTOK = "revokeAccessTokensWithRefreshTokens";
+    public static final String KEY_TRACK_RELYING_PARTIES = "trackRelyingParties";
 
     // TODO: Rational Jazz props. Determine if these can be move to OIDC config.
     protected static final String KEY_COVERAGE_MAP_SESSION_MAX_AGE = "coverageMapSessionMaxAge";
@@ -346,6 +347,7 @@ public class LibertyOAuth20Provider implements OAuth20Provider, ConfigurationLis
     private String tokenFormat;
     private boolean revokeAccessTokensWithRefreshTokens = true;
     private boolean ropcPreferUserSecurityName = false;
+    private boolean trackRelyingParties = false;
 
     // DS related methods
 
@@ -468,6 +470,7 @@ public class LibertyOAuth20Provider implements OAuth20Provider, ConfigurationLis
         appTokenOrPasswordLimit = (Long) properties.get(KEY_APP_TOKEN_OR_PASSWORD_LIMIT);
         clientSecretEncoding = getClientSecretEncodingFromConfig();
         ropcPreferUserSecurityName = (Boolean) properties.get(KEY_ROPC_PREFER_USERSECURITYNAME);
+        trackRelyingParties = (Boolean) properties.get(KEY_TRACK_RELYING_PARTIES);
 
         setUpInternalClient();
         // tolerate old jwtAccessToken attrib but if tokenFormat attrib is specified,
@@ -2421,4 +2424,10 @@ public class LibertyOAuth20Provider implements OAuth20Provider, ConfigurationLis
     public boolean isROPCPreferUserSecurityName() {
         return this.ropcPreferUserSecurityName;
     }
+
+    @Override
+    public boolean isTrackRelyingParties() {
+        return trackRelyingParties;
+    }
+
 }

--- a/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/internal/LibertyOAuth20ProviderTest.java
+++ b/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/internal/LibertyOAuth20ProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -652,6 +652,7 @@ public class LibertyOAuth20ProviderTest {
         properties.put(LibertyOAuth20Provider.KEY_APP_TOKEN_OR_PASSWORD_LIMIT, 100L);
         properties.put(LibertyOAuth20Provider.KEY_STORE_ACCESSTOKEN_ENCODING, "plain");
         properties.put(LibertyOAuth20Provider.KEY_ROPC_PREFER_USERSECURITYNAME, Boolean.FALSE);
+        properties.put(LibertyOAuth20Provider.KEY_TRACK_RELYING_PARTIES, Boolean.FALSE);
 
         return properties;
     }


### PR DESCRIPTION
Deliver the initial metatype changes for tracking relying parties by the OP.