### PR TITLE
Fix availability of fat.test.localrun

### DIFF
--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -382,6 +382,9 @@ task runfat(type: Exec) {
   mustRunAfter buildfat
   mustRunAfter cleanBeforeRun
   environment System.getProperties()
+  //Add fat.test.localrun to JVM environment.
+  //Not accessible during builds since tests are run on child systems with a different JVM
+  environment "fat.test.localrun", "true"
   if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
     executable "cmd"
     args '/c', 'ant', "-f", new File(autoFvtDir, 'TestBuild.xml')
@@ -390,11 +393,7 @@ task runfat(type: Exec) {
     args "-f", new File(autoFvtDir, 'TestBuild.xml')
   }
 
-  doLast {
-    //This should be set during the execution phase and not the configuration stage
-    //Only set this property to true if the runfat task is called (which should only happen when calling buildandrun)
-    System.setProperty("fat.test.localrun", "true");
-    
+  doLast {    
     // We can have this here because this task only ever runs locally, and thus is OK to unconditionally fail
     // the build. If we ever run FATs in remote builds, we should also gate this on a property like 
     // 'is.running.remote.build' so we don't fail the entire build whenever a testcase fails


### PR DESCRIPTION
Previously we were performing the following sequence of steps to set fat.test.localrun to true:

```java
  System.setProperty("fat.test.localrun", "true");
  environment System.getProperties()
```

This is done during a gradle task's configuration step. Which happens regardless of whether the task runs. I had moved it to the execution step, to ensure this property is not set when running remote builds. However, this resulted in the property not being set locally during test runtime.

Instead, let's just add fat.test.localrun to the environment directly. No need to set it as a system property. Since, our build infrastructure runs tests on child build machines this environment variable won't be available at run time in those cases.