### PR TITLE
Transform com.ibm.websphere.javaee.jsp.tld.2.2

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-2.2/com.ibm.websphere.appserver.jsp-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-2.2/com.ibm.websphere.appserver.jsp-2.2.feature
@@ -45,7 +45,7 @@ Subsystem-Name: JavaServer Pages 2.2
  com.ibm.ws.jsp.jstl.facade, \
  com.ibm.ws.org.apache.jasper.el.2.2
 -jars=com.ibm.websphere.appserver.spi.jsp; location:=dev/spi/ibm/, \
- com.ibm.websphere.javaee.jsp.tld.2.2; location:=dev/api/spec/
+ com.ibm.websphere.javaee.jsp.tld.2.2.jakarta; location:=dev/api/spec/
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.jsp_1.0-javadoc.zip
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.javaee.jsp.tld.2.2/bnd.bnd
+++ b/dev/com.ibm.websphere.javaee.jsp.tld.2.2/bnd.bnd
@@ -14,6 +14,8 @@ bVersion=1.2
 
 Bundle-SymbolicName: com.ibm.websphere.javaee.jsp.tld.2.2
 
+jakartaeeMe: true
+
 Export-Package: \
     org.apache.taglibs.standard.tag.common.core;version="1.0.0", \
     org.apache.taglibs.standard.tag.common.xml;version="1.0.0", \


### PR DESCRIPTION
The jsp tld need to be transformed ( as it imports javax.el ).  I believe no jakarta equivalent jar exists for us to update to. 