### PR TITLE
[#11534] Ensure type arguments are preserved for CompletionStage types

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/collectionsApp/src/mpRestClient10/collections/CollectionsClient.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/collectionsApp/src/mpRestClient10/collections/CollectionsClient.java
@@ -13,6 +13,7 @@ package mpRestClient10.collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletionStage;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -42,5 +43,13 @@ public interface CollectionsClient {
     @DELETE
     @Path("/byName")
     Map<String, Widget> removeWidgets(Set<String> names) throws UnknownWidgetException;
+    
+    @GET
+    CompletionStage<Set<Widget>> getWidgetsAsync();
+
+    @GET
+    @Path("/byName/{search}")
+    CompletionStage<Map<String, Widget>> getWidgetsByNameAsync(@PathParam("search") String search) 
+                    throws UnknownWidgetException;
 
 }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs21/providers/json/JsonBProvider.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs21/providers/json/JsonBProvider.java
@@ -144,17 +144,16 @@ public class JsonBProvider implements MessageBodyWriter<Object>, MessageBodyRead
     @Override
     public Object readFrom(Class<Object> clazz, Type genericType, Annotation[] annotations,
                            MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
-        Object obj = null;
+        
         // For most generic return types, we want to use the genericType so as to ensure
         // that the generic value is not lost on conversion - specifically in collections.
         // But for CompletionStage<SomeType> we want to use clazz to pull the right value
         // - and then client code will handle the result, storing it in the CompletionStage.
         if ((genericType instanceof ParameterizedType) &&
             CompletionStage.class.equals( ((ParameterizedType)genericType).getRawType())) {
-            obj = getJsonb().fromJson(entityStream, clazz);
-        } else {
-            obj = getJsonb().fromJson(entityStream, genericType);
+            genericType = ((ParameterizedType)genericType).getActualTypeArguments()[0];
         }
+        Object obj = getJsonb().fromJson(entityStream, genericType);
 
         if (tc.isDebugEnabled()) {
             Tr.debug(tc, "object=" + obj);


### PR DESCRIPTION
Fixes #11534 - ensures that the type argument for CompletionStages is preserved and handled similar to how a sync call works.