### PR TITLE
Fix unset token

### DIFF
--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/DeleteAuthCacheImpl.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/DeleteAuthCacheImpl.java
@@ -34,7 +34,6 @@ import com.ibm.ws.security.authentication.cache.DeleteAuthCache;
  */
 @Component(service = { DeleteAuthCache.class, DynamicMBean.class },
            configurationPolicy = ConfigurationPolicy.IGNORE,
-           immediate = true,
            property = { "service.vendor=IBM", "jmx.objectname=" + DeleteAuthCache.INSTANCE_NAME })
 public class DeleteAuthCacheImpl extends StandardMBean implements DeleteAuthCache {
 

--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/keyproviders/CustomCacheKeyProvider.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/keyproviders/CustomCacheKeyProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 IBM Corporation and others.
+ * Copyright (c) 2011, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -53,7 +53,7 @@ public class CustomCacheKeyProvider implements CacheKeyProvider {
     }
 
     protected void unsetTokenManager(ServiceReference<TokenManager> ref) {
-        tokenManager.setReference(ref);
+        tokenManager.unsetReference(ref);
     }
 
     protected void activate(ComponentContext cc, Map<String, Object> properties) {


### PR DESCRIPTION
Fixed unset tokenManager and there is no need for the DeleteAuthCache service to start immediately set to true.
