### PR TITLE
AutonomicalPolling1ServerTest sees J2CA0079E and J2CA008W after server shutdown

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_auto_pollinterval/fat/src/com/ibm/ws/concurrent/persistent/fat/autonomicalpolling1serv/AutonomicalPolling1ServerTest.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_auto_pollinterval/fat/src/com/ibm/ws/concurrent/persistent/fat/autonomicalpolling1serv/AutonomicalPolling1ServerTest.java
@@ -66,7 +66,7 @@ public class AutonomicalPolling1ServerTest extends FATServletClient {
 	@AfterClass
 	public static void tearDown() throws Exception {
 		try {
-			server.stopServer("J2CA0027E", "DSRA0304E", "DSRA0302E");
+			server.stopServer("J2CA0027E", "J2CA0079E", "J2CA0088W", "DSRA0304E", "DSRA0302E");
 		} finally {
 			server.updateServerConfiguration(originalConfig);
 		}


### PR DESCRIPTION
fixes #11567