### PR TITLE
Issue 11184: Remove app-early and trace fixes for AcmeCA

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/acmeCA-2.0/com.ibm.websphere.appserver.acmeCA-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/acmeCA-2.0/com.ibm.websphere.appserver.acmeCA-2.0.feature
@@ -13,6 +13,6 @@ Subsystem-Name: Automatic Certificate Management Environment (ACME) Support 2.0
   com.ibm.websphere.appserver.certificateCreator-2.0, \
   com.ibm.websphere.appserver.restHandler-1.0
 -bundles=\
-  com.ibm.ws.security.acme; start-phase:=APPLICATION_EARLY
+  com.ibm.ws.security.acme
 kind=noship
 edition=full

--- a/dev/com.ibm.ws.security.acme/bnd.bnd
+++ b/dev/com.ibm.ws.security.acme/bnd.bnd
@@ -51,6 +51,8 @@ Include-Resource: \
     @${repo;org.bitbucket.b_c:jose4j;0.6.5;EXACT},\
     org=${bin}/org
 
+instrument.classesExcludes: com/ibm/ws/security/acme/resources/*.class
+
 -dsannotations: \
     com.ibm.ws.security.acme.internal.web.AcmeAuthorizationServlet, \
     com.ibm.ws.security.acme.internal.web.AcmeCaRestHandler, \

--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeClient.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeClient.java
@@ -399,6 +399,9 @@ public class AcmeClient {
 		 * If there is no existing account, create one.
 		 */
 		if (account == null) {
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc, "An existing account was not found, requesting terms of service.");
+			}
 			/*
 			 * Get the terms of service from the ACME server.
 			 */
@@ -415,7 +418,9 @@ public class AcmeClient {
 			 * them.
 			 */
 			if (tosURI == null) {
-				Tr.debug(tc, "No terms of service provided");
+				if (tc.isDebugEnabled()) {
+					Tr.debug(tc, "No terms of service provided");
+				}
 			} else {
 				Tr.audit(tc, "CWPKI2006I", acmeConfig.getDirectoryURI(), tosURI);
 			}


### PR DESCRIPTION
Fixes #11184

Removed the application early attribute from the feature
Skipped added trace to the generated message file (creates a much of unneeded noise in the trace)
Add a trace statement, wrap existing trace.

For #9017 