### PR TITLE
Issue #11572: Fix Calendar EJB timer with no expiration

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/TimerNpImpl.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/TimerNpImpl.java
@@ -280,6 +280,10 @@ public final class TimerNpImpl implements Timer, PassivatorSerializable {
         return ivDestroyed;
     }
 
+    long getIvExpiration() {
+        return ivExpiration;
+    }
+
     /**
      * Registers the timer with the TimerService (so that it will be found by
      * getTimers) and either schedules the timer for execution or places it


### PR DESCRIPTION
A calendar EJB timer with no expiration may be returned by getTimers()
if getTimers() is called in the same transaction that creates the timer.
A timer with no expiration is not active and should not be returned by
getTimers().

Updated TimerNpImpl to expose the expiration (i.e 0 means none) and
then updated ContainerTx to not queue a timer for starting if it in
fact has no expirations and will thus never expire. Since the timer
is not queued to start on tx commit, the getTimers() will not find it.

Please ignore formatting changes in ContainerTx; only real changes start at line 1033.

fixes #11572 