### PR TITLE
Preserve HTTP response code in mpOpenTracing

### DIFF
--- a/dev/com.ibm.ws.opentracing.1.1/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
+++ b/dev/com.ibm.ws.opentracing.1.1/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
@@ -275,6 +276,10 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
     @Override
     public Response toResponse(Throwable exception) {
         Tr.warning(tc, "OPENTRACING_UNHANDLED_JAXRS_EXCEPTION", exception);
+        if (exception instanceof WebApplicationException) {
+            return Response.fromResponse(((WebApplicationException) exception).getResponse()).header(EXCEPTION_KEY, exception).build();
+        }
         return Response.serverError().header(EXCEPTION_KEY, exception).build();
     }
+
 }

--- a/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
+++ b/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
@@ -276,6 +277,10 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
     @Override
     public Response toResponse(Throwable exception) {
         Tr.warning(tc, "OPENTRACING_UNHANDLED_JAXRS_EXCEPTION", exception);
+        if (exception instanceof WebApplicationException) {
+            return Response.fromResponse(((WebApplicationException) exception).getResponse()).header(EXCEPTION_KEY, exception).build();
+        }
         return Response.serverError().header(EXCEPTION_KEY, exception).build();
     }
+
 }

--- a/dev/com.ibm.ws.opentracing.1.3/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
+++ b/dev/com.ibm.ws.opentracing.1.3/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
@@ -276,6 +277,9 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
     @Override
     public Response toResponse(Throwable exception) {
         Tr.warning(tc, "OPENTRACING_UNHANDLED_JAXRS_EXCEPTION", exception);
+        if (exception instanceof WebApplicationException) {
+            return Response.fromResponse(((WebApplicationException) exception).getResponse()).header(EXCEPTION_KEY, exception).build();
+        }
         return Response.serverError().header(EXCEPTION_KEY, exception).build();
     }
 }

--- a/dev/com.ibm.ws.opentracing.1.x_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATMPOpenTracing.java
+++ b/dev/com.ibm.ws.opentracing.1.x_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATMPOpenTracing.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corpo<ration and others.
+ * Copyright (c) 2017, 2020 IBM Corpo<ration and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import java.util.List;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -73,7 +74,12 @@ public class FATMPOpenTracing {
      */
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer("CWMOT0009W");
+    }
+    
+    @Before
+    public void clearTracer() throws Exception {
+    	executeWebService(FATUtilsServer.HttpRequestMethod.DELETE, "reset");
     }
 
     /**
@@ -99,22 +105,57 @@ public class FATMPOpenTracing {
             tracerState += actualResponseLine;
         }
 
-        int expectedSpans = 2;
+        int expectedSpans = 3;
         int spanCount = getSpanCount(tracerState);
         if (spanCount != expectedSpans) {
             Assert.assertEquals("Expected " + expectedSpans + " spans but found " + spanCount + ":", tracerState);
         }
     }
+    
+    @Test
+    public void testNotFoundException() throws Exception {
+    	String methodName = "testNotFoundException";
+
+        try {
+            
+            executeWebService("notFound");
+        } catch (TestAppException tae) {
+            FATLogging.info(CLASS, methodName, "Expected exception", tae);
+            Assert.assertEquals("Unexpected HTTP response code", 404, tae.getHttpStatusCode());
+        } catch (Exception ex) {
+            FATLogging.info(CLASS, methodName, "Unexpected exception", ex);
+            ex.printStackTrace();
+            Assert.fail("Unexpected exception caught:" + ex);
+        }
+
+        List<String> actualResponseLines = executeWebService("getTracerState");
+        
+        String tracerState = "";
+        for (String actualResponseLine : actualResponseLines) {
+            tracerState += actualResponseLine;
+        }
+
+        int expectedSpans = 2;
+        int spanCount = getSpanCount(tracerState);
+        if (spanCount != expectedSpans) {
+            Assert.assertEquals("Expected " + expectedSpans + " spans but found " + spanCount + ":", tracerState);
+        }
+
+    }
 
     protected List<String> executeWebService(String method) throws Exception {
+        return executeWebService(FATUtilsServer.HttpRequestMethod.GET, method);
+    }
+    
+    protected List<String> executeWebService(FATUtilsServer.HttpRequestMethod requestMethod, String method) throws Exception {
         String requestUrl = "http://" +
                             server.getHostname() + ":" +
                             server.getHttpDefaultPort() +
                             "/mpOpenTracing/rest/ws/" + method;
 
-        return FATUtilsServer.gatherHttpRequest(FATUtilsServer.HttpRequestMethod.GET, requestUrl);
+        return FATUtilsServer.gatherHttpRequest(requestMethod, requestUrl);
     }
-    
+
     protected int getSpanCount(String tracerState) {
         int result = 0;
         int i = 0;

--- a/dev/com.ibm.ws.opentracing.1.x_fat/fat/src/com/ibm/ws/testing/opentracing/test/TestAppException.java
+++ b/dev/com.ibm.ws.opentracing.1.x_fat/fat/src/com/ibm/ws/testing/opentracing/test/TestAppException.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corpo<ration and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.testing.opentracing.test;
+
+/**
+ *
+ */
+public class TestAppException extends Exception {
+
+    /**  */
+    private static final long serialVersionUID = 1L;
+
+    private int httpStatusCode;
+
+    /**
+     * @return the httpStatusCode
+     */
+    public int getHttpStatusCode() {
+        return httpStatusCode;
+    }
+
+    /**
+     * @param httpStatusCode
+     */
+    public TestAppException(int httpStatusCode) {
+        super();
+        this.httpStatusCode = httpStatusCode;
+    }
+
+}

--- a/dev/com.ibm.ws.opentracing.1.x_fat/test-applications/mpOpenTracing/src/com/ibm/ws/testing/mpOpenTracing/MPOpenTracing.java
+++ b/dev/com.ibm.ws.opentracing.1.x_fat/test-applications/mpOpenTracing/src/com/ibm/ws/testing/mpOpenTracing/MPOpenTracing.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,19 +10,20 @@
  *******************************************************************************/
 package com.ibm.ws.testing.mpOpenTracing;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
 import javax.inject.Inject;
 import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
-
-import org.eclipse.microprofile.opentracing.Traced;
 
 import io.opentracing.Tracer;
 
@@ -56,6 +57,13 @@ public class MPOpenTracing extends Application {
         return "Hello World";
     }
 
+    @GET
+    @Path("notFound")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String notFound() {
+        throw new NotFoundException("This is an expected exception.  Do not open a defect.");
+    }
+
     /**
      * List classes of providers.
      */
@@ -82,5 +90,11 @@ public class MPOpenTracing extends Application {
         } else {
             return tracer.toString();
         }
+    }
+    
+    @DELETE
+    @Path("reset")
+    public void clearTracer() throws IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException {
+        tracer.getClass().getMethod("reset").invoke(tracer);
     }
 }

--- a/dev/com.ibm.ws.opentracing.1.x_fat/test-bundles/opentracing.mock/src/com/ibm/ws/opentracing/mock/OpentracingMockTracer.java
+++ b/dev/com.ibm.ws.opentracing.1.x_fat/test-bundles/opentracing.mock/src/com/ibm/ws/opentracing/mock/OpentracingMockTracer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -160,5 +160,11 @@ public class OpentracingMockTracer implements Tracer {
     @Override
     public ScopeManager scopeManager() {
         return getTracer().scopeManager();
+    }
+    /**
+     * Clear the tracer
+     */
+    public void reset() {
+        this.tracer.reset();
     }
 }

--- a/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
+++ b/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
@@ -267,6 +268,10 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
     @Override
     public Response toResponse(Throwable exception) {
         Tr.warning(tc, "OPENTRACING_UNHANDLED_JAXRS_EXCEPTION", exception);
+        if (exception instanceof WebApplicationException) {
+            return Response.fromResponse(((WebApplicationException) exception).getResponse()).header(EXCEPTION_KEY, exception).build();
+        }
         return Response.serverError().header(EXCEPTION_KEY, exception).build();
     }
+
 }


### PR DESCRIPTION
When using `mpOpenTracing-1.x`, exceptions thrown by applications were always mapped to response code 500.

In the exception mapper, preserve the `Response` if the exception is an instance of `WebApplicationException` and the original response code is kept.

Fixes #11408 