### PR TITLE
Repeat the jsonp1.1_fat for jakarta ee9

### DIFF
--- a/dev/com.ibm.ws.jsonp.1.1_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jsonp.1.1_fat/bnd.bnd
@@ -17,6 +17,11 @@ src: \
 
 fat.project: true
 
+tested.features: \
+  servlet-5.0,\
+  jsonp-1.1,\
+  jsonp-2.0
+
 -buildpath: \
 	com.ibm.websphere.javaee.jsonp.1.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest

--- a/dev/com.ibm.ws.jsonp.1.1_fat/build.gradle
+++ b/dev/com.ibm.ws.jsonp.1.1_fat/build.gradle
@@ -1,0 +1,1 @@
+addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/com.ibm.ws.jsonp.1.1_fat/fat/src/com/ibm/ws/jsonp11/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsonp.1.1_fat/fat/src/com/ibm/ws/jsonp11/fat/FATSuite.java
@@ -10,15 +10,23 @@
  *******************************************************************************/
 package com.ibm.ws.jsonp11.fat;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
+import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
                 AlwaysPassesTest.class, // so we report at least 1 test on java 7 builds
                 JSONP11Test.class
 })
-public class FATSuite {}
+public class FATSuite {
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.withoutModification() // run all tests as-is (e.g. EE8 features)
+                    .andWith(new JakartaEE9Action()); // run all tests again with EE9 features+packages
+}

--- a/dev/com.ibm.ws.jsonp.1.1_fat/test-applications/JSONP11fat/src/web/JSONP11Servlet.java
+++ b/dev/com.ibm.ws.jsonp.1.1_fat/test-applications/JSONP11fat/src/web/JSONP11Servlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/fattest.simplicity/bnd.bnd
+++ b/dev/fattest.simplicity/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/fattest.simplicity/bnd.bnd
+++ b/dev/fattest.simplicity/bnd.bnd
@@ -59,6 +59,7 @@ test.project: true
 	commons-httpclient:commons-httpclient;version=3.1,\
 	com.ibm.websphere.javaee.jsonp.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
+	com.ibm.websphere.jakartaee.servlet.5.0;version=latest,\
     com.ibm.ws:jakartaee-transformer;version=0.0.6,\
 	com.ibm.ws.common.encoder;version=latest,\
 	com.ibm.ws.componenttest;version=latest,\

--- a/dev/fattest.simplicity/src/componenttest/annotation/TestServlet.java
+++ b/dev/fattest.simplicity/src/componenttest/annotation/TestServlet.java
@@ -15,8 +15,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.servlet.http.HttpServlet;
-
 @Target({ ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TestServlet {
@@ -40,6 +38,6 @@ public @interface TestServlet {
     /**
      * The servlet class to scan for '@Test' annotations, which will be invoked automatically via HTTP GET request
      */
-    Class<? extends HttpServlet> servlet();
+    Class<?> servlet();
 
 }

--- a/dev/fattest.simplicity/src/componenttest/annotation/processor/TestServletProcessor.java
+++ b/dev/fattest.simplicity/src/componenttest/annotation/processor/TestServletProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -100,7 +100,11 @@ public class TestServletProcessor {
     private static Method[] getTestServletMethods(TestServlet anno) {
         if (!!!(javax.servlet.http.HttpServlet.class.isAssignableFrom(anno.servlet()) ||
                 jakarta.servlet.http.HttpServlet.class.isAssignableFrom(anno.servlet()))) {
-            throw new IllegalArgumentException("For the @TestServlet annotation, servlet() must be a subclass of javax.servlet.http.HttpServlet or jakarta.servlet.http.HttpServlet!");
+            throw new IllegalArgumentException("The servlet referenced by the " + annoToString(anno) + " annotation " +
+                                               "is not a subclass of javax.servlet.http.HttpServlet nor jakarta.servlet.http.HttpServlet. " +
+                                               "When using the @TestServlet annotation make sure to declare a servlet class that " +
+                                               "extends either javax.servlet.http.HttpServlet or jakarta.servlet.http.HttpServlet");
+
         }
         try {
             return anno.servlet().getMethods();

--- a/dev/fattest.simplicity/src/componenttest/annotation/processor/TestServletProcessor.java
+++ b/dev/fattest.simplicity/src/componenttest/annotation/processor/TestServletProcessor.java
@@ -98,6 +98,10 @@ public class TestServletProcessor {
     }
 
     private static Method[] getTestServletMethods(TestServlet anno) {
+        if (!!!(javax.servlet.http.HttpServlet.class.isAssignableFrom(anno.servlet()) ||
+                jakarta.servlet.http.HttpServlet.class.isAssignableFrom(anno.servlet()))) {
+            throw new IllegalArgumentException("For the @TestServlet annotation, servlet() must be a subclass of javax.servlet.http.HttpServlet or jakarta.servlet.http.HttpServlet!");
+        }
         try {
             return anno.servlet().getMethods();
         } catch (TypeNotPresentException | LinkageError e) {

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE9Action.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE9Action.java
@@ -150,7 +150,7 @@ public class JakartaEE9Action extends FeatureReplacementAction {
      * After completion, the transformed application will be available at the $appPath,
      * and the original application will be available at <server>/backup/
      *
-     * @param  appPath     The application path to be transformed to Jakarta
+     * @param appPath The application path to be transformed to Jakarta
      */
     public static void transformApp(Path appPath) {
         final String m = "transformApp";
@@ -178,33 +178,45 @@ public class JakartaEE9Action extends FeatureReplacementAction {
         //create backup directory
         Path serverPath = appPath.getParent().getParent();
         Path backupPath = serverPath.resolve("backup");
-            try {
-                if(!Files.exists(backupPath)){
-                    Files.createDirectory(backupPath); // throws IOException
-                }
-             } catch(IOException e){
-                 Log.info(c, m, "Unable to create backup directory.");
-                 Log.error(c, m, e);
-                 throw new RuntimeException(e);
-             }
+        try {
+            if (!Files.exists(backupPath)) {
+                Files.createDirectory(backupPath); // throws IOException
+            }
+        } catch (IOException e) {
+            Log.info(c, m, "Unable to create backup directory.");
+            Log.error(c, m, e);
+            throw new RuntimeException(e);
+        }
+
+        String userDir = System.getProperty("user.dir");
+        String transformerRulesRoot = userDir.substring(0, userDir.lastIndexOf("/dev/")) + "/dev/wlp-jakartaee-transform/rules/";
 
         try {
             // Invoke the jakarta transformer
-            String[] args = new String[3];
+            String[] args = new String[11];
             args[0] = appPath.toAbsolutePath().toString(); // input
             args[1] = outputPath.toAbsolutePath().toString(); // output
             args[2] = "-v"; // verbose
+            args[3] = "-tr"; // override default properties in transformer jar
+            args[4] = transformerRulesRoot + "jakarta-renames.properties";
+            args[5] = "-ts";
+            args[6] = transformerRulesRoot + "jakarta-selections.properties";
+            args[7] = "-tv";
+            args[8] = transformerRulesRoot + "jakarta-versions.properties";
+            args[9] = "-tb";
+            args[10] = transformerRulesRoot + "jakarta-bundles.properties";
+
             JakartaTransformer.main(args);
 
             if (outputPath.toFile().exists()) {
 
                 Path backupAppPath = backupPath.resolve(appPath.getFileName());
-                if(!Files.exists(backupAppPath)){
+                if (!Files.exists(backupAppPath)) {
                     Files.createFile(backupAppPath);
                 }
                 //move original to backup
                 Files.move(appPath, backupAppPath, StandardCopyOption.REPLACE_EXISTING);
-                //rename jakarta app to the original filename 
+                //rename jakarta app to the original filename
                 Files.move(outputPath, appPath);
             } else {
                 throw new RuntimeException("Jakarta transformer failed for: " + appPath);

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE9Action.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE9Action.java
@@ -175,7 +175,7 @@ public class JakartaEE9Action extends FeatureReplacementAction {
 
         Path outputPath = appPath.resolveSibling(appPath.getFileName() + ".jakarta");
 
-        //create backup directory
+        // Create backup directory
         Path serverPath = appPath.getParent().getParent();
         Path backupPath = serverPath.resolve("backup");
         try {
@@ -188,9 +188,7 @@ public class JakartaEE9Action extends FeatureReplacementAction {
             throw new RuntimeException(e);
         }
 
-        String userDir = System.getProperty("user.dir");
-        String transformerRulesRoot = userDir.substring(0, userDir.lastIndexOf("/dev/")) + "/dev/wlp-jakartaee-transform/rules/";
-
+        String transformerRulesRoot = System.getProperty("user.dir") + "/autoFVT-templates/";
         try {
             // Invoke the jakarta transformer
             String[] args = new String[11];
@@ -214,9 +212,9 @@ public class JakartaEE9Action extends FeatureReplacementAction {
                 if (!Files.exists(backupAppPath)) {
                     Files.createFile(backupAppPath);
                 }
-                //move original to backup
+                // move original to backup
                 Files.move(appPath, backupAppPath, StandardCopyOption.REPLACE_EXISTING);
-                //rename jakarta app to the original filename
+                // rename jakarta app to the original filename
                 Files.move(outputPath, appPath);
             } else {
                 throw new RuntimeException("Jakarta transformer failed for: " + appPath);

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -82,8 +82,22 @@ task addRequiredLibraries(type: Copy) {
   into new File(autoFvtDir, 'lib')
 }
 
+task addJakartaTransformerRules {
+  mustRunAfter jar
+
+  doLast{
+    copy {
+      from project(':wlp-jakartaee-transform').file('rules')
+      include 'jakarta*.properties'
+      into new File(autoFvtDir, 'autoFVT-templates')
+    }
+  }
+}
+
 task addJakartaTransformer(type: Copy) {
   mustRunAfter jar
+  dependsOn addJakartaTransformerRules
+
   from configurations.jakartaTransformer
   into new File(autoFvtDir, 'lib')
 }

--- a/dev/wlp-jakartaee-transform/rules/jakarta-renames.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-renames.properties
@@ -1,6 +1,3 @@
-javax.json=jakarta.json
-javax.json.spi=jakarta.json.spi
-javax.json.stream=jakarta.json.stream
 javax.inject=jakarta.inject
 javax.servlet=jakarta.servlet
 javax.servlet.annotation=jakarta.servlet.annotation


### PR DESCRIPTION
fixes #11278

- Update the JSONP 1.1 FAT to be repeatable for jakarta ee9.

- Invoke the jakartaee transformer with liberty-specific rules during repeatable ee9 test execution.

- Remove the dependency on HttpServlet from the TestServlet annotation.