### PR TITLE
Fix processing of windows paths that start with a variable

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/XMLConfigParser.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/XMLConfigParser.java
@@ -619,7 +619,7 @@ public class XMLConfigParser {
             String normalIncludePath = resolvePath(includePath);
             return wsLocationAdmin.resolveResource(normalIncludePath);
         } else {
-            String normalIncludePath = resolvePath(includePath);
+            String normalIncludePath = PathUtils.normalize(resolvePath(includePath));
             if (PathUtils.pathIsAbsolute(normalIncludePath)) {
                 // includePath is absolute - resolve includePath as is
                 return wsLocationAdmin.resolveResource(normalIncludePath);


### PR DESCRIPTION
Fix processing of windows paths that start with a variable. We used to interpret any path that starts with an environment variable as absolute, but when we added support for variable resolution in include strings it changed the timing so that the environment variable was resolved before the 'absolute' check. 