### PR TITLE
Test managed executor from CDI producer used by ServletContainerInitializer

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/.classpath
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/.classpath
@@ -2,6 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/concurrentCDIApp/src"/>
+	<classpathentry kind="src" path="test-applications/concurrentCDI2App/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.concurrent_fat_cdi/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -13,7 +13,8 @@ bVersion=1.0
 
 src: \
 	fat/src,\
-	test-applications/concurrentCDIApp/src
+	test-applications/concurrentCDIApp/src,\
+	test-applications/concurrentCDI2App/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDI2Test.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDI2Test.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.cdi.fat;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import concurrent.cdi2.web.ConcurrentCDI2Servlet;
+
+@RunWith(FATRunner.class)
+public class ConcurrentCDI2Test extends FATServletClient {
+
+    public static final String APP_NAME = "concurrentCDI2App";
+
+    @Server("concurrent_fat_cdi2")
+    @TestServlet(servlet = ConcurrentCDI2Servlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultDropinApp(server, APP_NAME, "concurrent.cdi2.web");
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer("CWOWB1009W" // Implicit bean archives are disabled (by the test case on purpose)
+        );
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,5 +17,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({
                 ConcurrentCDITest.class,
+                ConcurrentCDI2Test.class
 })
-public class FATSuite {}
+public class FATSuite {
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/publish/servers/concurrent_fat_cdi2/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/publish/servers/concurrent_fat_cdi2/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info=enabled:concurrent=all:context=all:concurrencyPolicy=all

--- a/dev/com.ibm.ws.concurrent_fat_cdi/publish/servers/concurrent_fat_cdi2/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/publish/servers/concurrent_fat_cdi2/server.xml
@@ -1,0 +1,22 @@
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+  <featureManager>
+    <feature>cdi-2.0</feature>
+    <feature>componenttest-1.0</feature>
+    <feature>jaxrs-2.1</feature>
+    <feature>jsonp-1.1</feature>
+  </featureManager>
+
+  <cdi12 enableImplicitBeanArchives='false'/>
+
+  <include location="../fatTestPorts.xml"/>
+</server>

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDI2App/resources/META-INF/services/javax.servlet.ServletContainerInitializer
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDI2App/resources/META-INF/services/javax.servlet.ServletContainerInitializer
@@ -1,0 +1,1 @@
+concurrent.cdi2.web.ConcurrentCDI2ServletContainerInit

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDI2App/resources/WEB-INF/beans.xml
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDI2App/resources/WEB-INF/beans.xml
@@ -12,9 +12,4 @@
 <beans xmlns="http://java.sun.com/xml/ns/javaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
-   <interceptors>
-   </interceptors>
-
-   <decorators>
-   </decorators>
 </beans>

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDI2App/resources/WEB-INF/beans.xml
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDI2App/resources/WEB-INF/beans.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+   <interceptors>
+   </interceptors>
+
+   <decorators>
+   </decorators>
+</beans>

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDI2App/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDI2App/resources/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2017 IBM Corporation and others.
+Copyright (c) 2020 IBM Corporation and others.
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDI2App/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDI2App/resources/WEB-INF/web.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2017 IBM Corporation and others.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+Contributors:
+    IBM Corporation - initial API and implementation
+-->
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+		 http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+
+  <listener>
+    <listener-class>concurrent.cdi2.web.ConcurrentCDI2ServletContextListener</listener-class>
+  </listener>
+
+  <!-- ENV ENTRIES -->
+  <env-entry>
+    <env-entry-name>java:comp/env/entry1</env-entry-name>
+    <env-entry-type>java.lang.String</env-entry-type>
+    <env-entry-value>value1</env-entry-value>
+  </env-entry>
+
+</web-app>

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDI2App/src/concurrent/cdi2/web/ConcurrentCDI2AppScopedBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDI2App/src/concurrent/cdi2/web/ConcurrentCDI2AppScopedBean.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi2.web;
+
+import java.util.concurrent.Future;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class ConcurrentCDI2AppScopedBean {
+    private Future<Integer> servletContainerInitFuture;
+    private Future<Integer> servletContextListenerFuture;
+
+    public Future<Integer> getServletContainerInitFuture() {
+        return servletContainerInitFuture;
+    }
+
+    public Future<Integer> getServletContextListenerFuture() {
+        return servletContextListenerFuture;
+    }
+
+    public void setServletContainerInitFuture(Future<Integer> future) {
+        servletContainerInitFuture = future;
+    }
+
+    public void setServletContextListenerFuture(Future<Integer> future) {
+        servletContextListenerFuture = future;
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDI2App/src/concurrent/cdi2/web/ConcurrentCDI2Servlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDI2App/src/concurrent/cdi2/web/ConcurrentCDI2Servlet.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi2.web;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet("/*")
+public class ConcurrentCDI2Servlet extends FATServlet {
+
+    /**
+     * Maximum number of nanoseconds to wait for a task to finish.
+     */
+    private static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(2);
+
+    @Inject
+    private ConcurrentCDI2AppScopedBean appScopedBean;
+
+    @Test
+    public void testTaskScheduledByServletContainerInitializerCompletes() throws Exception {
+        Future<Integer> future = appScopedBean.getServletContainerInitFuture();
+        assertEquals(Integer.valueOf(1), future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+    }
+
+    @Test
+    public void testTaskScheduledByServletContextListenerCompletes() throws Exception {
+        Future<Integer> future = appScopedBean.getServletContextListenerFuture();
+        assertEquals(Integer.valueOf(2), future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDI2App/src/concurrent/cdi2/web/ConcurrentCDI2ServletContainerInit.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDI2App/src/concurrent/cdi2/web/ConcurrentCDI2ServletContainerInit.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi2.web;
+
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.CDI;
+import javax.servlet.ServletContainerInitializer;
+import javax.servlet.ServletContext;
+
+public class ConcurrentCDI2ServletContainerInit implements ServletContainerInitializer {
+    @Override
+    public void onStartup(Set<Class<?>> classes, ServletContext ctx) {
+        Instance<ExecutorService> instance = CDI.current().select(ExecutorService.class);
+        ExecutorService executor = instance.get();
+
+        Future<Integer> future = executor.submit(new Callable<Integer>() {
+            @Override
+            public Integer call() {
+                return 1;
+            }
+        });
+
+        if (false) // TODO this causes deadlock with com/ibm/ws/webcontainer/webapp/WebApp$1
+            try {
+                future.get();
+            } catch (Exception x) {
+                throw new RuntimeException(x);
+            }
+
+        Instance<ConcurrentCDI2AppScopedBean> bean = CDI.current().select(ConcurrentCDI2AppScopedBean.class);
+        bean.get().setServletContainerInitFuture(future);
+
+        System.out.println("ServletContainerInitializer.onStartup invoked, using " + executor);
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDI2App/src/concurrent/cdi2/web/ConcurrentCDI2ServletContextListener.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDI2App/src/concurrent/cdi2/web/ConcurrentCDI2ServletContextListener.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.cdi2.web;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.CDI;
+import javax.inject.Inject;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+public class ConcurrentCDI2ServletContextListener implements ServletContextListener {
+    @Inject
+    ExecutorService executor;
+
+    @Override
+    public void contextInitialized(ServletContextEvent event) {
+        Future<Integer> future = executor.submit(new Callable<Integer>() {
+            @Override
+            public Integer call() {
+                return 2;
+            }
+        });
+
+        if (false) // TODO this causes deadlock with com/ibm/ws/webcontainer/webapp/WebApp$1
+            try {
+                future.get();
+            } catch (Exception x) {
+                throw new RuntimeException(x);
+            }
+
+        Instance<ConcurrentCDI2AppScopedBean> bean = CDI.current().select(ConcurrentCDI2AppScopedBean.class);
+        bean.get().setServletContextListenerFuture(future);
+
+        System.out.println("ServletContextListener.contextInitialized invoked, using injected " + executor);
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent event) {
+        System.out.println("ServletContextListener.contextDestroyed invoked");
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDI2App/src/concurrent/cdi2/web/ExecutorProducer.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDI2App/src/concurrent/cdi2/web/ExecutorProducer.java
@@ -1,0 +1,22 @@
+/**
+ *
+ */
+package concurrent.cdi2.web;
+
+import java.util.concurrent.ExecutorService;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+/**
+ * Producer that allows injection of ManagedExecutorService.
+ */
+public class ExecutorProducer {
+    @Produces
+    @ApplicationScoped
+    ExecutorService getDefaultExecutor() throws NamingException {
+        return InitialContext.doLookup("java:comp/DefaultManagedExecutorService");
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDI2App/src/concurrent/cdi2/web/ExecutorProducer.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDI2App/src/concurrent/cdi2/web/ExecutorProducer.java
@@ -1,6 +1,13 @@
-/**
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  *
- */
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package concurrent.cdi2.web;
 
 import java.util.concurrent.ExecutorService;


### PR DESCRIPTION
Add a test case where a ServletContainerInitializer (and a ServletContextListener) use a ManagedExecutorService.  They can submit tasks fine, however, there is a deadlock with the webcontainer if attempting to wait for the task to run because running the task involves establishing context on the thread and running it as though it were part of the web app, which is currently requiring the web application to have already initialized.   This part is commented out, because a discussion is needed with the webcontainer team about it.