### PR TITLE
Fix NPE in OpentracingUtils.lookupAppName()

### DIFF
--- a/dev/com.ibm.ws.opentracing.1.1/bnd.bnd
+++ b/dev/com.ibm.ws.opentracing.1.1/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -52,4 +52,5 @@ Private-Package: com.ibm.ws.opentracing.resources
         com.ibm.websphere.org.osgi.service.cm;version=latest, \
         com.ibm.ws.io.opentracing.opentracing-api.0.31.0;version=latest, \
         com.ibm.ws.io.opentracing.opentracing-util.0.31.0;version=latest, \
-        com.ibm.websphere.javaee.servlet.3.1; version=latest
+        com.ibm.websphere.javaee.servlet.3.1; version=latest, \
+        com.ibm.ws.container.service;version=latest

--- a/dev/com.ibm.ws.opentracing.1.1/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
+++ b/dev/com.ibm.ws.opentracing.1.1/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
@@ -275,6 +276,10 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
     @Override
     public Response toResponse(Throwable exception) {
         Tr.warning(tc, "OPENTRACING_UNHANDLED_JAXRS_EXCEPTION", exception);
+        if (exception instanceof WebApplicationException) {
+            return Response.fromResponse(((WebApplicationException) exception).getResponse()).header(EXCEPTION_KEY, exception).build();
+        }
         return Response.serverError().header(EXCEPTION_KEY, exception).build();
     }
+
 }

--- a/dev/com.ibm.ws.opentracing.1.1/src/com/ibm/ws/opentracing/OpentracingUtils.java
+++ b/dev/com.ibm.ws.opentracing.1.1/src/com/ibm/ws/opentracing/OpentracingUtils.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package com.ibm.ws.opentracing;
 
 import javax.naming.InitialContext;
@@ -6,6 +17,8 @@ import javax.naming.NamingException;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 
 import io.opentracing.Tracer;
 
@@ -49,13 +62,31 @@ public class OpentracingUtils {
      *         the name cannot be retrieved by doing a context lookup.
      */
     @Trivial
-    public static String lookupAppName() {
+    public static String lookupAppNameFallback() {
         String appName;
         try {
             appName = (String) new InitialContext().lookup("java:app/AppName");
         } catch (NamingException e) {
             Tr.error(tc, "OPENTRACING_NO_APPNAME_FOUND_IN_JNDI"); // Should never happen
             appName = DEFAULT_SERVICE_NAME;
+        }
+        return appName;
+    }
+
+    /**
+     * This is a more efficient way to obtain the current application name.
+     *
+     * @return The current application name.
+     */
+    @Trivial
+    public static String lookupAppName() {
+        String appName = null;
+        ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+        if (cmd != null) {
+            appName = cmd.getModuleMetaData().getApplicationMetaData().getName();
+        }
+        if (appName == null) {
+            appName = lookupAppNameFallback();
         }
         return appName;
     }

--- a/dev/com.ibm.ws.opentracing.1.2/bnd.bnd
+++ b/dev/com.ibm.ws.opentracing.1.2/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -54,4 +54,5 @@ Private-Package: com.ibm.ws.opentracing.resources
         com.ibm.ws.io.opentracing.opentracing-api.0.31.0;version=latest, \
         com.ibm.ws.io.opentracing.opentracing-util.0.31.0;version=latest, \
         com.ibm.websphere.org.eclipse.microprofile.config.1.3;version=latest,\
-        com.ibm.websphere.javaee.servlet.3.1; version=latest
+        com.ibm.websphere.javaee.servlet.3.1; version=latest, \
+        com.ibm.ws.container.service;version=latest

--- a/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
+++ b/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
@@ -276,6 +277,10 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
     @Override
     public Response toResponse(Throwable exception) {
         Tr.warning(tc, "OPENTRACING_UNHANDLED_JAXRS_EXCEPTION", exception);
+        if (exception instanceof WebApplicationException) {
+            return Response.fromResponse(((WebApplicationException) exception).getResponse()).header(EXCEPTION_KEY, exception).build();
+        }
         return Response.serverError().header(EXCEPTION_KEY, exception).build();
     }
+
 }

--- a/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/OpentracingUtils.java
+++ b/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/OpentracingUtils.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package com.ibm.ws.opentracing;
 
 import javax.naming.InitialContext;
@@ -6,6 +17,8 @@ import javax.naming.NamingException;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 
 import io.opentracing.Tracer;
 
@@ -49,13 +62,31 @@ public class OpentracingUtils {
      *         the name cannot be retrieved by doing a context lookup.
      */
     @Trivial
-    public static String lookupAppName() {
+    public static String lookupAppNameFallback() {
         String appName;
         try {
             appName = (String) new InitialContext().lookup("java:app/AppName");
         } catch (NamingException e) {
             Tr.error(tc, "OPENTRACING_NO_APPNAME_FOUND_IN_JNDI"); // Should never happen
             appName = DEFAULT_SERVICE_NAME;
+        }
+        return appName;
+    }
+
+    /**
+     * This is a more efficient way to obtain the current application name.
+     *
+     * @return The current application name.
+     */
+    @Trivial
+    public static String lookupAppName() {
+        String appName = null;
+        ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+        if (cmd != null) {
+            appName = cmd.getModuleMetaData().getApplicationMetaData().getName();
+        }
+        if (appName == null) {
+            appName = lookupAppNameFallback();
         }
         return appName;
     }

--- a/dev/com.ibm.ws.opentracing.1.3/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
+++ b/dev/com.ibm.ws.opentracing.1.3/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
@@ -276,6 +277,9 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
     @Override
     public Response toResponse(Throwable exception) {
         Tr.warning(tc, "OPENTRACING_UNHANDLED_JAXRS_EXCEPTION", exception);
+        if (exception instanceof WebApplicationException) {
+            return Response.fromResponse(((WebApplicationException) exception).getResponse()).header(EXCEPTION_KEY, exception).build();
+        }
         return Response.serverError().header(EXCEPTION_KEY, exception).build();
     }
 }

--- a/dev/com.ibm.ws.opentracing.1.3/src/com/ibm/ws/opentracing/OpentracingUtils.java
+++ b/dev/com.ibm.ws.opentracing.1.3/src/com/ibm/ws/opentracing/OpentracingUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import javax.naming.NamingException;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 
 import io.opentracing.Tracer;
@@ -79,7 +80,11 @@ public class OpentracingUtils {
      */
     @Trivial
     public static String lookupAppName() {
-        String appName = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData().getModuleMetaData().getApplicationMetaData().getName();
+        String appName = null;
+        ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+        if (cmd != null) {
+            appName = cmd.getModuleMetaData().getApplicationMetaData().getName();
+        }
         if (appName == null) {
             appName = lookupAppNameFallback();
         }

--- a/dev/com.ibm.ws.opentracing.1.x_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATMPOpenTracing.java
+++ b/dev/com.ibm.ws.opentracing.1.x_fat/fat/src/com/ibm/ws/testing/opentracing/test/FATMPOpenTracing.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corpo<ration and others.
+ * Copyright (c) 2017, 2020 IBM Corpo<ration and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import java.util.List;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -73,7 +74,12 @@ public class FATMPOpenTracing {
      */
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer("CWMOT0009W");
+    }
+    
+    @Before
+    public void clearTracer() throws Exception {
+    	executeWebService(FATUtilsServer.HttpRequestMethod.DELETE, "reset");
     }
 
     /**
@@ -99,22 +105,57 @@ public class FATMPOpenTracing {
             tracerState += actualResponseLine;
         }
 
-        int expectedSpans = 2;
+        int expectedSpans = 3;
         int spanCount = getSpanCount(tracerState);
         if (spanCount != expectedSpans) {
             Assert.assertEquals("Expected " + expectedSpans + " spans but found " + spanCount + ":", tracerState);
         }
     }
+    
+    @Test
+    public void testNotFoundException() throws Exception {
+    	String methodName = "testNotFoundException";
+
+        try {
+            
+            executeWebService("notFound");
+        } catch (TestAppException tae) {
+            FATLogging.info(CLASS, methodName, "Expection exception", tae);
+            Assert.assertEquals("Unexpected HTTP response code", 404, tae.getHttpStatusCode());
+        } catch (Exception ex) {
+            FATLogging.info(CLASS, methodName, "Unexpected exception", ex);
+            ex.printStackTrace();
+            Assert.fail("Unexpected exception caught:" + ex);
+        }
+
+        List<String> actualResponseLines = executeWebService("getTracerState");
+        
+        String tracerState = "";
+        for (String actualResponseLine : actualResponseLines) {
+            tracerState += actualResponseLine;
+        }
+
+        int expectedSpans = 2;
+        int spanCount = getSpanCount(tracerState);
+        if (spanCount != expectedSpans) {
+            Assert.assertEquals("Expected " + expectedSpans + " spans but found " + spanCount + ":", tracerState);
+        }
+
+    }
 
     protected List<String> executeWebService(String method) throws Exception {
+        return executeWebService(FATUtilsServer.HttpRequestMethod.GET, method);
+    }
+    
+    protected List<String> executeWebService(FATUtilsServer.HttpRequestMethod requestMethod, String method) throws Exception {
         String requestUrl = "http://" +
                             server.getHostname() + ":" +
                             server.getHttpDefaultPort() +
                             "/mpOpenTracing/rest/ws/" + method;
 
-        return FATUtilsServer.gatherHttpRequest(FATUtilsServer.HttpRequestMethod.GET, requestUrl);
+        return FATUtilsServer.gatherHttpRequest(requestMethod, requestUrl);
     }
-    
+
     protected int getSpanCount(String tracerState) {
         int result = 0;
         int i = 0;

--- a/dev/com.ibm.ws.opentracing.1.x_fat/fat/src/com/ibm/ws/testing/opentracing/test/TestAppException.java
+++ b/dev/com.ibm.ws.opentracing.1.x_fat/fat/src/com/ibm/ws/testing/opentracing/test/TestAppException.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corpo<ration and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.testing.opentracing.test;
+
+/**
+ *
+ */
+public class TestAppException extends Exception {
+
+    /**  */
+    private static final long serialVersionUID = 1L;
+
+    private int httpStatusCode;
+
+    /**
+     * @return the httpStatusCode
+     */
+    public int getHttpStatusCode() {
+        return httpStatusCode;
+    }
+
+    /**
+     * @param httpStatusCode
+     */
+    public TestAppException(int httpStatusCode) {
+        super();
+        this.httpStatusCode = httpStatusCode;
+    }
+
+}

--- a/dev/com.ibm.ws.opentracing.1.x_fat/test-applications/mpOpenTracing/src/com/ibm/ws/testing/mpOpenTracing/MPOpenTracing.java
+++ b/dev/com.ibm.ws.opentracing.1.x_fat/test-applications/mpOpenTracing/src/com/ibm/ws/testing/mpOpenTracing/MPOpenTracing.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,19 +10,20 @@
  *******************************************************************************/
 package com.ibm.ws.testing.mpOpenTracing;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
 import javax.inject.Inject;
 import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
-
-import org.eclipse.microprofile.opentracing.Traced;
 
 import io.opentracing.Tracer;
 
@@ -56,6 +57,13 @@ public class MPOpenTracing extends Application {
         return "Hello World";
     }
 
+    @GET
+    @Path("notFound")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String notFound() {
+        throw new NotFoundException("This is an expected exception.  Do not open a defect.");
+    }
+
     /**
      * List classes of providers.
      */
@@ -82,5 +90,11 @@ public class MPOpenTracing extends Application {
         } else {
             return tracer.toString();
         }
+    }
+    
+    @DELETE
+    @Path("reset")
+    public void clearTracer() throws IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException {
+        tracer.getClass().getMethod("reset").invoke(tracer);
     }
 }

--- a/dev/com.ibm.ws.opentracing.1.x_fat/test-bundles/opentracing.mock/src/com/ibm/ws/opentracing/mock/OpentracingMockTracer.java
+++ b/dev/com.ibm.ws.opentracing.1.x_fat/test-bundles/opentracing.mock/src/com/ibm/ws/opentracing/mock/OpentracingMockTracer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -160,5 +160,11 @@ public class OpentracingMockTracer implements Tracer {
     @Override
     public ScopeManager scopeManager() {
         return getTracer().scopeManager();
+    }
+    /**
+     * Clear the tracer
+     */
+    public void reset() {
+        this.tracer.reset();
     }
 }

--- a/dev/com.ibm.ws.opentracing/bnd.bnd
+++ b/dev/com.ibm.ws.opentracing/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -30,20 +30,21 @@ Import-Package: \
     *
 
 Export-Package: \
-	com.ibm.ws.opentracing;version=1.0,\
-	com.ibm.ws.opentracing.filters;version=1.0,\
-	com.ibm.ws.opentracing.tracer;version=1.0;provide=true
+    com.ibm.ws.opentracing;version=1.0,\
+    com.ibm.ws.opentracing.filters;version=1.0,\
+    com.ibm.ws.opentracing.tracer;version=1.0;provide=true
                 
 Private-Package: com.ibm.ws.opentracing.resources
 
 
 -buildpath: \
-	com.ibm.websphere.javaee.jaxrs.2.0;version=latest,\
-	com.ibm.ws.logging;version=latest,\
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-	com.ibm.ws.jaxrs.2.0.common;version=latest,\
-	com.ibm.wsspi.org.osgi.service.component;version=latest,\
-	com.ibm.wsspi.org.osgi.core;version=latest,\
-	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
-	com.ibm.websphere.org.osgi.service.cm;version=latest,\
-	com.ibm.ws.io.opentracing.opentracing-api;version=latest
+    com.ibm.websphere.javaee.jaxrs.2.0;version=latest,\
+    com.ibm.ws.logging;version=latest,\
+    com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+    com.ibm.ws.jaxrs.2.0.common;version=latest,\
+    com.ibm.wsspi.org.osgi.service.component;version=latest,\
+    com.ibm.wsspi.org.osgi.core;version=latest,\
+    com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+    com.ibm.websphere.org.osgi.service.cm;version=latest,\
+    com.ibm.ws.io.opentracing.opentracing-api;version=latest,\
+    com.ibm.ws.container.service;version=latest

--- a/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
+++ b/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingContainerFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
@@ -267,6 +268,10 @@ public class OpentracingContainerFilter implements ContainerRequestFilter, Conta
     @Override
     public Response toResponse(Throwable exception) {
         Tr.warning(tc, "OPENTRACING_UNHANDLED_JAXRS_EXCEPTION", exception);
+        if (exception instanceof WebApplicationException) {
+            return Response.fromResponse(((WebApplicationException) exception).getResponse()).header(EXCEPTION_KEY, exception).build();
+        }
         return Response.serverError().header(EXCEPTION_KEY, exception).build();
     }
+
 }

--- a/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingUtils.java
+++ b/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingUtils.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package com.ibm.ws.opentracing;
 
 import javax.naming.InitialContext;
@@ -6,6 +17,8 @@ import javax.naming.NamingException;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 
 import io.opentracing.Tracer;
 
@@ -49,13 +62,31 @@ public class OpentracingUtils {
      *         the name cannot be retrieved by doing a context lookup.
      */
     @Trivial
-    public static String lookupAppName() {
+    public static String lookupAppNameFallback() {
         String appName;
         try {
             appName = (String) new InitialContext().lookup("java:app/AppName");
         } catch (NamingException e) {
             Tr.error(tc, "OPENTRACING_NO_APPNAME_FOUND_IN_JNDI"); // Should never happen
             appName = DEFAULT_SERVICE_NAME;
+        }
+        return appName;
+    }
+
+    /**
+     * This is a more efficient way to obtain the current application name.
+     *
+     * @return The current application name.
+     */
+    @Trivial
+    public static String lookupAppName() {
+        String appName = null;
+        ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+        if (cmd != null) {
+            appName = cmd.getModuleMetaData().getApplicationMetaData().getName();
+        }
+        if (appName == null) {
+            appName = lookupAppNameFallback();
         }
         return appName;
     }


### PR DESCRIPTION
`ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData()` can return `null` in some rare situations.  Added a check for `null`.

Fixes #11582 

