### PR TITLE
11479: Finalize RP tracking logic

### DIFF
--- a/dev/com.ibm.ws.security.oauth/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.oauth/resources/OSGI-INF/l10n/metatype.properties
@@ -353,3 +353,6 @@ ropcPreferUserSecurityName.desc=If the user security name differs from the usern
 # -------------------------------------------------------------------------------------------------
 #	End of metatype properties to support OIDC Client Registration
 # -------------------------------------------------------------------------------------------------
+
+trackOAuthClients=Track OAuth clients
+trackOAuthClients.desc=Track all OAuth clients that interact with this OAuth provider.

--- a/dev/com.ibm.ws.security.oauth/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.oauth/resources/OSGI-INF/metatype/metatype.xml
@@ -259,7 +259,7 @@
         </AD>
         <!--  this is fixing a corner bug and has to be behind a property to protect existing users.  -->
         <AD id="ropcPreferUserSecurityName" name="%ropcPreferUserSecurityName" description="%ropcPreferUserSecurityName.desc" required="false" type="Boolean"  default="false"/>
-        <AD id="trackRelyingParties" name="internal" description="internal use only" required="false" type="Boolean" default="false" />
+        <AD id="trackOAuthClients" name="%trackOAuthClients" description="%trackOAuthClients.desc" ibm:beta="true" required="false" type="Boolean" default="false" />
     </OCD>
    <!--   
     <Designate factoryPid="com.ibm.ws.security.oauth20.provider.config">

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/api/OAuth20Provider.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/api/OAuth20Provider.java
@@ -161,6 +161,6 @@ public interface OAuth20Provider extends OAuth20ConfigProvider, OAuthComponentIn
 
     public boolean isROPCPreferUserSecurityName();
 
-    public boolean isTrackRelyingParties();
+    public boolean isTrackOAuthClients();
 
 }

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/internal/LibertyOAuth20Provider.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/internal/LibertyOAuth20Provider.java
@@ -189,7 +189,7 @@ public class LibertyOAuth20Provider implements OAuth20Provider, ConfigurationLis
     protected static final String KEY_logoutRedirectURL = "logoutRedirectURL";
     protected static final String KEY_CACHE_ACCESSTOKEN = "accessTokenCacheEnabled";
     protected static final String KEY_REVOKE_ACCESSTOK_W_REFRESHTOK = "revokeAccessTokensWithRefreshTokens";
-    public static final String KEY_TRACK_RELYING_PARTIES = "trackRelyingParties";
+    public static final String KEY_TRACK_OAUTH_CLIENTS = "trackOAuthClients";
 
     // TODO: Rational Jazz props. Determine if these can be move to OIDC config.
     protected static final String KEY_COVERAGE_MAP_SESSION_MAX_AGE = "coverageMapSessionMaxAge";
@@ -347,7 +347,7 @@ public class LibertyOAuth20Provider implements OAuth20Provider, ConfigurationLis
     private String tokenFormat;
     private boolean revokeAccessTokensWithRefreshTokens = true;
     private boolean ropcPreferUserSecurityName = false;
-    private boolean trackRelyingParties = false;
+    private boolean trackOAuthClients = false;
 
     // DS related methods
 
@@ -470,7 +470,7 @@ public class LibertyOAuth20Provider implements OAuth20Provider, ConfigurationLis
         appTokenOrPasswordLimit = (Long) properties.get(KEY_APP_TOKEN_OR_PASSWORD_LIMIT);
         clientSecretEncoding = getClientSecretEncodingFromConfig();
         ropcPreferUserSecurityName = (Boolean) properties.get(KEY_ROPC_PREFER_USERSECURITYNAME);
-        trackRelyingParties = (Boolean) properties.get(KEY_TRACK_RELYING_PARTIES);
+        trackOAuthClients = (Boolean) properties.get(KEY_TRACK_OAUTH_CLIENTS);
 
         setUpInternalClient();
         // tolerate old jwtAccessToken attrib but if tokenFormat attrib is specified,
@@ -2426,8 +2426,8 @@ public class LibertyOAuth20Provider implements OAuth20Provider, ConfigurationLis
     }
 
     @Override
-    public boolean isTrackRelyingParties() {
-        return trackRelyingParties;
+    public boolean isTrackOAuthClients() {
+        return trackOAuthClients;
     }
 
 }

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/OAuth20EndpointServices.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/OAuth20EndpointServices.java
@@ -767,9 +767,9 @@ public class OAuth20EndpointServices {
             options.setAttribute(OAuth20Constants.SCOPE, OAuth20Constants.ATTRTYPE_RESPONSE_ATTRIBUTE, reducedScopes);
         }
 
-        if (provider.isTrackRelyingParties()) {
-            RelyingPartyTracker rpTracker = new RelyingPartyTracker(request, response, provider);
-            rpTracker.trackRelyingParty(clientId);
+        if (provider.isTrackOAuthClients()) {
+            OAuthClientTracker clientTracker = new OAuthClientTracker(request, response, provider);
+            clientTracker.trackOAuthClient(clientId);
         }
 
         consent.handleConsent(provider, request, prompt, clientId);

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/OAuthClientTracker.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/OAuthClientTracker.java
@@ -157,7 +157,7 @@ public class OAuthClientTracker {
         if (clientIdList == null || clientIdList.isEmpty()) {
             return url;
         }
-        String newUrl = (url.contains("&")) ? (url + "&") : (url + "?");
+        String newUrl = (url.contains("?")) ? (url + "&") : (url + "?");
         newUrl += POST_LOGOUT_QUERY_PARAMETER_NAME + "=";
         for (String clientId : clientIdList) {
             try {

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/OAuthClientTracker.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/OAuthClientTracker.java
@@ -14,8 +14,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -27,9 +25,9 @@ import com.ibm.ws.webcontainer.security.CookieHelper;
 import com.ibm.ws.webcontainer.security.ReferrerURLCookieHandler;
 import com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl;
 
-public class RelyingPartyTracker {
+public class OAuthClientTracker {
 
-    public static final String TRACK_RELYING_PARTY_COOKIE_NAME = "WasOAuthTrackRps";
+    public static final String TRACK_OAUTH_CLIENT_COOKIE_NAME = "WasOAuthTrackClients";
     public static final String POST_LOGOUT_QUERY_PARAMETER_NAME = "clients_interacted_with";
 
     private final String clientIdDelimiter = ",";
@@ -38,17 +36,17 @@ public class RelyingPartyTracker {
     private final HttpServletResponse response;
     private final OAuth20Provider provider;
 
-    public RelyingPartyTracker(HttpServletRequest request, HttpServletResponse response, OAuth20Provider provider) {
+    public OAuthClientTracker(HttpServletRequest request, HttpServletResponse response, OAuth20Provider provider) {
         this.request = request;
         this.response = response;
         this.provider = provider;
     }
 
-    public Cookie trackRelyingParty(String clientId) {
+    public Cookie trackOAuthClient(String clientId) {
         ReferrerURLCookieHandler handler = getReferrerURLCookieHandler();
         Cookie trackingCookie = CookieHelper.getCookie(request.getCookies(), getCookieName());
         if (trackingCookie == null) {
-            trackingCookie = createNewRelyingPartyTrackingCookie(handler, clientId);
+            trackingCookie = createNewClientTrackingCookie(handler, clientId);
         } else {
             trackingCookie = updateExistingTrackingCookie(trackingCookie, clientId, handler);
         }
@@ -73,7 +71,7 @@ public class RelyingPartyTracker {
         return WebAppSecurityCollaboratorImpl.getGlobalWebAppSecurityConfig().createReferrerURLCookieHandler();
     }
 
-    Cookie createNewRelyingPartyTrackingCookie(ReferrerURLCookieHandler handler, String clientId) {
+    Cookie createNewClientTrackingCookie(ReferrerURLCookieHandler handler, String clientId) {
         // Each entry in the cookie value is encoded, then the whole cookie value is encoded - hence the double encoding here
         return createCookie(handler, encodeValue(encodeValue(clientId)));
     }
@@ -87,7 +85,7 @@ public class RelyingPartyTracker {
     Cookie updateExistingTrackingCookie(Cookie trackingCookie, String clientId, ReferrerURLCookieHandler handler) {
         String existingCookieValue = trackingCookie.getValue();
         if (existingCookieValue == null || existingCookieValue.isEmpty()) {
-            trackingCookie = createNewRelyingPartyTrackingCookie(handler, clientId);
+            trackingCookie = createNewClientTrackingCookie(handler, clientId);
         } else {
             trackingCookie = updateExistingCookieValue(existingCookieValue, clientId, handler);
         }
@@ -139,17 +137,11 @@ public class RelyingPartyTracker {
 
     String getCookiePath() {
         String requestUri = request.getRequestURI();
-        int lastSlashIndex = requestUri.lastIndexOf("/");
-        if (lastSlashIndex < 0) {
+        int firstSlashIndex = requestUri.indexOf("/", 1);
+        if (firstSlashIndex < 0) {
             return requestUri;
         }
-        String path = requestUri.substring(0, lastSlashIndex);
-        Pattern pathPattern = Pattern.compile("(/oidc/[^/]+/[^/]+)/authorize");
-        Matcher matcher = pathPattern.matcher(requestUri);
-        if (matcher.matches()) {
-            path = matcher.group(1);
-        }
-        return path;
+        return requestUri.substring(0, firstSlashIndex);
     }
 
     String getUpdatedLogoutUrl(String logoutUrl, Cookie trackingCookie) {
@@ -165,12 +157,7 @@ public class RelyingPartyTracker {
         if (clientIdList == null || clientIdList.isEmpty()) {
             return url;
         }
-        String newUrl = url;
-        if (url.contains("?")) {
-            newUrl += "&";
-        } else {
-            newUrl += "?";
-        }
+        String newUrl = (url.contains("&")) ? (url + "&") : (url + "?");
         newUrl += POST_LOGOUT_QUERY_PARAMETER_NAME + "=";
         for (String clientId : clientIdList) {
             try {
@@ -188,7 +175,9 @@ public class RelyingPartyTracker {
 
     void invalidateCookie() {
         ReferrerURLCookieHandler handler = getReferrerURLCookieHandler();
-        handler.invalidateReferrerURLCookie(request, response, getCookieName());
+        Cookie cookie = createCookie(handler, "");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
     }
 
     String encodeValue(String input) {
@@ -200,7 +189,7 @@ public class RelyingPartyTracker {
     }
 
     private String getCookieName() {
-        return TRACK_RELYING_PARTY_COOKIE_NAME + "_" + provider.getID().hashCode();
+        return TRACK_OAUTH_CLIENT_COOKIE_NAME + "_" + provider.getID().hashCode();
     }
 
 }

--- a/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/internal/LibertyOAuth20ProviderTest.java
+++ b/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/internal/LibertyOAuth20ProviderTest.java
@@ -652,7 +652,7 @@ public class LibertyOAuth20ProviderTest {
         properties.put(LibertyOAuth20Provider.KEY_APP_TOKEN_OR_PASSWORD_LIMIT, 100L);
         properties.put(LibertyOAuth20Provider.KEY_STORE_ACCESSTOKEN_ENCODING, "plain");
         properties.put(LibertyOAuth20Provider.KEY_ROPC_PREFER_USERSECURITYNAME, Boolean.FALSE);
-        properties.put(LibertyOAuth20Provider.KEY_TRACK_RELYING_PARTIES, Boolean.FALSE);
+        properties.put(LibertyOAuth20Provider.KEY_TRACK_OAUTH_CLIENTS, Boolean.FALSE);
 
         return properties;
     }

--- a/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/web/OAuthClientTrackerTest.java
+++ b/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/web/OAuthClientTrackerTest.java
@@ -592,7 +592,7 @@ public class OAuthClientTrackerTest extends CommonTestClass {
         List<String> clientIdList = new ArrayList<String>();
         String clientId = "my client id";
         clientIdList.add(clientId);
-        String logoutUrlWithQuery = logoutUrl + "?with=other&param=values";
+        String logoutUrlWithQuery = logoutUrl + "?with=param";
 
         String result = tracker.addTrackedClientIdsToUrl(logoutUrlWithQuery, clientIdList);
 

--- a/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/web/OAuthClientTrackerTest.java
+++ b/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/web/OAuthClientTrackerTest.java
@@ -36,7 +36,7 @@ import com.ibm.ws.webcontainer.security.WebAppSecurityConfig;
 
 import test.common.SharedOutputManager;
 
-public class RelyingPartyTrackerTest extends CommonTestClass {
+public class OAuthClientTrackerTest extends CommonTestClass {
 
     private static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("com.ibm.ws.security.oauth.*=all");
 
@@ -47,16 +47,16 @@ public class RelyingPartyTrackerTest extends CommonTestClass {
     private final Cookie cookie = mockery.mock(Cookie.class);
 
     private final String providerId = "myOAuthProvider";
-    private final String expectedCookiePath = "/oidc/endpoint/" + providerId;
-    private final String requestUri = expectedCookiePath + "/authorize";
+    private final String expectedCookiePath = "/oidc";
+    private final String requestUri = expectedCookiePath + "/endpoint/" + providerId + "/authorize";
     private final String logoutUrl = "my/logout/url";
 
     private ReferrerURLCookieHandler handler;
 
-    RelyingPartyTracker tracker;
+    OAuthClientTracker tracker;
 
-    class TestRelyingPartyTracker extends RelyingPartyTracker {
-        public TestRelyingPartyTracker(HttpServletRequest request, HttpServletResponse response, OAuth20Provider provider) {
+    class TestOAuthClientTracker extends OAuthClientTracker {
+        public TestOAuthClientTracker(HttpServletRequest request, HttpServletResponse response, OAuth20Provider provider) {
             super(request, response, provider);
         }
 
@@ -75,7 +75,7 @@ public class RelyingPartyTrackerTest extends CommonTestClass {
     public void setUp() throws Exception {
         System.out.println("Entering test: " + testName.getMethodName());
         handler = new ReferrerURLCookieHandler(config);
-        tracker = new TestRelyingPartyTracker(request, response, provider);
+        tracker = new TestOAuthClientTracker(request, response, provider);
 
         // Set some expectations for things that don't overly matter for testing this class
         mockery.checking(new Expectations() {
@@ -106,7 +106,7 @@ public class RelyingPartyTrackerTest extends CommonTestClass {
     }
 
     @Test
-    public void test_trackRelyingParty_noCookies() {
+    public void test_trackOAuthClient_noCookies() {
         String clientId = "myClientId";
         mockery.checking(new Expectations() {
             {
@@ -117,7 +117,7 @@ public class RelyingPartyTrackerTest extends CommonTestClass {
                 one(response).addCookie(with(any(Cookie.class)));
             }
         });
-        Cookie result = tracker.trackRelyingParty(clientId);
+        Cookie result = tracker.trackOAuthClient(clientId);
 
         assertEquals("Created cookie does not have the correct name.", getExpectedCookieName(), result.getName());
         // Each entry should be encoded, then the whole cookie value will be encoded
@@ -157,11 +157,11 @@ public class RelyingPartyTrackerTest extends CommonTestClass {
     public void test_updateLogoutUrlAndDeleteCookie_trackingCookieHasNoValue() {
         mockery.checking(new Expectations() {
             {
-                one(request).getRequestURI();
+                allowing(request).getRequestURI();
                 will(returnValue(requestUri));
             }
         });
-        Cookie trackingCookie = tracker.createNewRelyingPartyTrackingCookie(handler, "");
+        Cookie trackingCookie = tracker.createNewClientTrackingCookie(handler, "");
         mockery.checking(new Expectations() {
             {
                 one(request).getCookies();
@@ -178,11 +178,11 @@ public class RelyingPartyTrackerTest extends CommonTestClass {
         String existingClientId = "client1";
         mockery.checking(new Expectations() {
             {
-                one(request).getRequestURI();
+                allowing(request).getRequestURI();
                 will(returnValue(requestUri));
             }
         });
-        Cookie trackingCookie = tracker.createNewRelyingPartyTrackingCookie(handler, existingClientId);
+        Cookie trackingCookie = tracker.createNewClientTrackingCookie(handler, existingClientId);
         mockery.checking(new Expectations() {
             {
                 one(request).getCookies();
@@ -191,12 +191,12 @@ public class RelyingPartyTrackerTest extends CommonTestClass {
             }
         });
         String result = tracker.updateLogoutUrlAndDeleteCookie(logoutUrl);
-        String expectedResult = logoutUrl + "?" + RelyingPartyTracker.POST_LOGOUT_QUERY_PARAMETER_NAME + "=" + tracker.encodeValue(existingClientId).replace("=", "%3D");
+        String expectedResult = logoutUrl + "?" + OAuthClientTracker.POST_LOGOUT_QUERY_PARAMETER_NAME + "=" + tracker.encodeValue(existingClientId).replace("=", "%3D");
         assertEquals("Updated URL did not match the expected value.", expectedResult, result);
     }
 
     @Test
-    public void test_createNewRelyingPartyTrackingCookie_emptyClientId() {
+    public void test_createNewClientTrackingCookie_emptyClientId() {
         String clientId = "";
         mockery.checking(new Expectations() {
             {
@@ -204,14 +204,14 @@ public class RelyingPartyTrackerTest extends CommonTestClass {
                 will(returnValue(requestUri));
             }
         });
-        Cookie result = tracker.createNewRelyingPartyTrackingCookie(handler, clientId);
+        Cookie result = tracker.createNewClientTrackingCookie(handler, clientId);
 
         assertEquals("Created cookie does not have the correct name.", getExpectedCookieName(), result.getName());
         assertEquals("Created cookie does not have an empty value as expected.", clientId, result.getValue());
     }
 
     @Test
-    public void test_createNewRelyingPartyTrackingCookie_simpleClientId() {
+    public void test_createNewClientTrackingCookie_simpleClientId() {
         String clientId = "myClientId";
         mockery.checking(new Expectations() {
             {
@@ -219,7 +219,7 @@ public class RelyingPartyTrackerTest extends CommonTestClass {
                 will(returnValue(requestUri));
             }
         });
-        Cookie result = tracker.createNewRelyingPartyTrackingCookie(handler, clientId);
+        Cookie result = tracker.createNewClientTrackingCookie(handler, clientId);
 
         assertEquals("Created cookie does not have the correct name.", getExpectedCookieName(), result.getName());
         // Each entry should be encoded, then the whole cookie value will be encoded
@@ -228,7 +228,7 @@ public class RelyingPartyTrackerTest extends CommonTestClass {
     }
 
     @Test
-    public void test_createNewRelyingPartyTrackingCookie_complexClientId() {
+    public void test_createNewClientTrackingCookie_complexClientId() {
         String clientId = "my !@#$%^&*(),./ id";
         mockery.checking(new Expectations() {
             {
@@ -236,7 +236,7 @@ public class RelyingPartyTrackerTest extends CommonTestClass {
                 will(returnValue(requestUri));
             }
         });
-        Cookie result = tracker.createNewRelyingPartyTrackingCookie(handler, clientId);
+        Cookie result = tracker.createNewClientTrackingCookie(handler, clientId);
 
         assertEquals("Created cookie does not have the correct name.", getExpectedCookieName(), result.getName());
         // Each entry should be encoded, then the whole cookie value will be encoded
@@ -504,7 +504,7 @@ public class RelyingPartyTrackerTest extends CommonTestClass {
 
     @Test
     public void test_getCookiePath_requestUriOneSlash() {
-        String firstPart = "myRequest";
+        String firstPart = "/myRequest";
         String requestUri = firstPart + "/uri";
         mockery.checking(new Expectations() {
             {
@@ -513,13 +513,13 @@ public class RelyingPartyTrackerTest extends CommonTestClass {
             }
         });
         String result = tracker.getCookiePath();
-        assertEquals("Result should have matched the request URI up to the last slash.", firstPart, result);
+        assertEquals("Result should have matched the request URI up to the first slash.", firstPart, result);
     }
 
     @Test
     public void test_getCookiePath_requestUriMultipleSlashes() {
-        String firstPart = "my/request/with/multiple";
-        String requestUri = firstPart + "/slashes";
+        String firstPart = "my";
+        String requestUri = firstPart + "/request/with/multiple/slashes";
         mockery.checking(new Expectations() {
             {
                 one(request).getRequestURI();
@@ -527,7 +527,7 @@ public class RelyingPartyTrackerTest extends CommonTestClass {
             }
         });
         String result = tracker.getCookiePath();
-        assertEquals("Result should have matched the request URI up to the last slash.", firstPart, result);
+        assertEquals("Result should have matched the request URI up to the first slash.", firstPart, result);
     }
 
     @Test
@@ -564,7 +564,7 @@ public class RelyingPartyTrackerTest extends CommonTestClass {
             }
         });
         String result = tracker.getUpdatedLogoutUrl(logoutUrl, cookie);
-        String expectedResult = logoutUrl + "?" + RelyingPartyTracker.POST_LOGOUT_QUERY_PARAMETER_NAME + "=" + tracker.encodeValue(clientId);
+        String expectedResult = logoutUrl + "?" + OAuthClientTracker.POST_LOGOUT_QUERY_PARAMETER_NAME + "=" + tracker.encodeValue(clientId);
         assertEquals("URL did not match the expected value.", expectedResult, result);
     }
 
@@ -583,7 +583,7 @@ public class RelyingPartyTrackerTest extends CommonTestClass {
 
         String result = tracker.addTrackedClientIdsToUrl(logoutUrl, clientIdList);
 
-        String expectedResult = logoutUrl + "?" + RelyingPartyTracker.POST_LOGOUT_QUERY_PARAMETER_NAME + "=" + tracker.encodeValue(clientId);
+        String expectedResult = logoutUrl + "?" + OAuthClientTracker.POST_LOGOUT_QUERY_PARAMETER_NAME + "=" + tracker.encodeValue(clientId);
         assertEquals("URL did not match the expected value.", expectedResult, result);
     }
 
@@ -596,7 +596,7 @@ public class RelyingPartyTrackerTest extends CommonTestClass {
 
         String result = tracker.addTrackedClientIdsToUrl(logoutUrlWithQuery, clientIdList);
 
-        String expectedResult = logoutUrlWithQuery + "&" + RelyingPartyTracker.POST_LOGOUT_QUERY_PARAMETER_NAME + "=" + tracker.encodeValue(clientId);
+        String expectedResult = logoutUrlWithQuery + "&" + OAuthClientTracker.POST_LOGOUT_QUERY_PARAMETER_NAME + "=" + tracker.encodeValue(clientId);
         assertEquals("URL did not match the expected value.", expectedResult, result);
     }
 
@@ -610,7 +610,7 @@ public class RelyingPartyTrackerTest extends CommonTestClass {
 
         String result = tracker.addTrackedClientIdsToUrl(logoutUrl, clientIdList);
 
-        String expectedResult = logoutUrl + "?" + RelyingPartyTracker.POST_LOGOUT_QUERY_PARAMETER_NAME + "=" + tracker.encodeValue(client1) + "," + tracker.encodeValue(client2);
+        String expectedResult = logoutUrl + "?" + OAuthClientTracker.POST_LOGOUT_QUERY_PARAMETER_NAME + "=" + tracker.encodeValue(client1) + "," + tracker.encodeValue(client2);
         assertEquals("URL did not match the expected value.", expectedResult, result);
     }
 
@@ -625,7 +625,7 @@ public class RelyingPartyTrackerTest extends CommonTestClass {
 
         String result = tracker.addTrackedClientIdsToUrl(logoutUrlWithQuery, clientIdList);
 
-        String expectedResult = logoutUrlWithQuery + "&" + RelyingPartyTracker.POST_LOGOUT_QUERY_PARAMETER_NAME + "=" + tracker.encodeValue(client1) + "," + tracker.encodeValue(client2);
+        String expectedResult = logoutUrlWithQuery + "&" + OAuthClientTracker.POST_LOGOUT_QUERY_PARAMETER_NAME + "=" + tracker.encodeValue(client1) + "," + tracker.encodeValue(client2);
         assertEquals("URL did not match the expected value.", expectedResult, result);
     }
 
@@ -667,7 +667,7 @@ public class RelyingPartyTrackerTest extends CommonTestClass {
     }
 
     private String getExpectedCookieName() {
-        return RelyingPartyTracker.TRACK_RELYING_PARTY_COOKIE_NAME + "_" + providerId.hashCode();
+        return OAuthClientTracker.TRACK_OAUTH_CLIENT_COOKIE_NAME + "_" + providerId.hashCode();
     }
 
 }

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/OidcEndpointServices.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/OidcEndpointServices.java
@@ -69,7 +69,7 @@ import com.ibm.ws.security.oauth20.util.OidcOAuth20Util;
 import com.ibm.ws.security.oauth20.web.EndpointUtils;
 import com.ibm.ws.security.oauth20.web.OAuth20EndpointServices;
 import com.ibm.ws.security.oauth20.web.OAuth20Request.EndpointType;
-import com.ibm.ws.security.oauth20.web.RelyingPartyTracker;
+import com.ibm.ws.security.oauth20.web.OAuthClientTracker;
 import com.ibm.ws.security.oauth20.web.WebUtils;
 import com.ibm.ws.security.openidconnect.server.internal.HashUtils;
 import com.ibm.ws.security.openidconnect.server.internal.HttpUtils;
@@ -519,8 +519,8 @@ public class OidcEndpointServices extends OAuth20EndpointServices {
                 }
             }
         }
-        if (oauth20provider.isTrackRelyingParties()) {
-            redirectUri = updateRedirectUriWithTrackedRelyingParties(request, response, oauth20provider, redirectUri);
+        if (oauth20provider.isTrackOAuthClients()) {
+            redirectUri = updateRedirectUriWithTrackedOAuthClients(request, response, oauth20provider, redirectUri);
         }
         if (tc.isDebugEnabled()) {
             Tr.debug(tc, "OIDC _SSO OP redirecting to [" + redirectUri +"]");
@@ -528,9 +528,9 @@ public class OidcEndpointServices extends OAuth20EndpointServices {
         response.sendRedirect(redirectUri);
     }
 
-    String updateRedirectUriWithTrackedRelyingParties(HttpServletRequest request, HttpServletResponse response, OAuth20Provider provider, String redirectUri) {
-        RelyingPartyTracker rpTracker = new RelyingPartyTracker(request, response, provider);
-        return rpTracker.updateLogoutUrlAndDeleteCookie(redirectUri);
+    String updateRedirectUriWithTrackedOAuthClients(HttpServletRequest request, HttpServletResponse response, OAuth20Provider provider, String redirectUri) {
+        OAuthClientTracker clientTracker = new OAuthClientTracker(request, response, provider);
+        return clientTracker.updateLogoutUrlAndDeleteCookie(redirectUri);
     }
 
     /**

--- a/dev/com.ibm.ws.security.openidconnect.server/test/com/ibm/ws/security/openidconnect/web/OidcEndpointServicesTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/test/com/ibm/ws/security/openidconnect/web/OidcEndpointServicesTest.java
@@ -207,7 +207,7 @@ public class OidcEndpointServicesTest {
                     will(returnValue(oidcoauth20clientprovider));
                     one(oidcoauth20clientprovider).get(with(clientId));
                     will(returnValue(oidcbaseclient));
-                    one(oauth20Provider).isTrackRelyingParties();
+                    one(oauth20Provider).isTrackOAuthClients();
                     will(returnValue(false));
 
                     one(response).sendRedirect(with(redirectUri));
@@ -273,7 +273,7 @@ public class OidcEndpointServicesTest {
                     will(returnValue(clientId));
                     one(principal).getName();
                     will(returnValue(username2));
-                    one(oauth20Provider).isTrackRelyingParties();
+                    one(oauth20Provider).isTrackOAuthClients();
                     will(returnValue(false));
 
                     one(response).sendRedirect(with("/end_session_error.html"));
@@ -352,7 +352,7 @@ public class OidcEndpointServicesTest {
                     will(returnValue(oidcoauth20clientprovider));
                     one(oidcoauth20clientprovider).get(with(clientId));
                     will(returnValue(oidcbaseclient));
-                    one(oauth20Provider).isTrackRelyingParties();
+                    one(oauth20Provider).isTrackOAuthClients();
                     will(returnValue(false));
                     allowing(response).sendRedirect(with("/end_session_logout.html"));
                 }
@@ -405,7 +405,7 @@ public class OidcEndpointServicesTest {
                     will(returnValue(null));
                     allowing(principal).getName();
                     will(returnValue(IDTokenUtil.KEY_STRING));
-                    one(oauth20Provider).isTrackRelyingParties();
+                    one(oauth20Provider).isTrackOAuthClients();
                     will(returnValue(false));
 
                     allowing(response).sendRedirect(with("/end_session_error.html"));
@@ -454,7 +454,7 @@ public class OidcEndpointServicesTest {
         try {
             context.checking(new Expectations() {
                 {
-                    one(oauth20Provider).isTrackRelyingParties();
+                    one(oauth20Provider).isTrackOAuthClients();
                     will(returnValue(false));
                     one(response).sendRedirect(with("/end_session_logout.html"));
                 }


### PR DESCRIPTION
- Renames config attribute to `trackOAuthClients` (from `trackRelyingParties`)
- Delivers metatype descriptions for `trackOAuthClients`
- Marks `trackOAuthClients` as `ibm:beta="true"`
- Renames tracking cookie to `WasOAuthTrackClients` (from `WasOAuthTrackRps`)
- Updates tracking cookie's path to be `/oidc` instead of `/oidc/<endpoint|providers>/<provider-name`
- Updates the cookie invalidation logic to ensure the cookie is actually deleted once it's used by the end_session logic
- General renaming of files and methods to match config attribute name change