### PR TITLE
choose ManagedTask constant based on EE spec level

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.contextService-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.contextService-1.0.feature
@@ -4,6 +4,7 @@ visibility=protected
 IBM-API-Package: com.ibm.ws.context.service.serializable; type="internal"
 -features=com.ibm.websphere.appserver.appLifecycle-1.0
 -bundles=com.ibm.ws.resource, \
+ com.ibm.ws.javaee.version, \
  com.ibm.ws.context
 kind=ga
 edition=core

--- a/dev/com.ibm.ws.concurrent.persistent/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent/bnd.bnd
@@ -58,6 +58,7 @@ instrument.classesExcludes: com/ibm/ws/concurrent/persistent/resources/*.class
 	com.ibm.ws.app.manager;version=latest,\
 	com.ibm.ws.app.manager.lifecycle;version=latest,\
 	com.ibm.ws.container.service;version=latest,\
+	com.ibm.ws.javaee.version;version=latest,\
 	com.ibm.ws.kernel.boot;version=latest,\
 	com.ibm.ws.persistence;version=latest,\
 	com.ibm.ws.resource;version=latest,\

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
@@ -90,6 +90,7 @@ import com.ibm.ws.concurrent.persistent.ejb.TimerStatus;
 import com.ibm.ws.concurrent.persistent.ejb.TimerTrigger;
 import com.ibm.ws.concurrent.persistent.ejb.TimersPersistentExecutor;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.javaee.version.JavaEEVersion;
 import com.ibm.ws.kernel.feature.ServerStarted;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.ws.runtime.update.RuntimeUpdateListener;
@@ -194,6 +195,11 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
      * Default execution properties to use when none are present for the task.
      */
     private final Map<String, String> defaultExecProps = new TreeMap<String, String>();
+
+    /**
+     * Jakarta EE versiom if Jakarta EE 9 or higher. If 0, assume a lesser EE spec version.
+     */
+    private int eeVersion;
 
     /**
      * Common Liberty thread pool.
@@ -329,7 +335,8 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
                 throw new IllegalArgumentException("id: null, jndiName: null");
         }
 
-        defaultExecProps.put(ManagedTask.TRANSACTION, ManagedTask.USE_TRANSACTION_OF_EXECUTION_THREAD);
+        String TRANSACTION_PROP_KEY = eeVersion < 9 ? "javax.enterprise.concurrent.TRANSACTION" : "jakarta.enterprise.concurrent.TRANSACTION"; // ManagedTask.TRANSACTION
+        defaultExecProps.put(TRANSACTION_PROP_KEY, "USE_TRANSACTION_OF_EXECUTION_THREAD"); // ManagedTask.USE_TRANSACTION_OF_EXECUTION_THREAD
         defaultExecProps.put(WSContextService.DEFAULT_CONTEXT, WSContextService.UNCONFIGURED_CONTEXT_TYPES);
         defaultExecProps.put(WSContextService.TASK_OWNER, name);
 
@@ -717,7 +724,15 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
         if (execProps == null)
             execProps = defaultExecProps;
         else {
-            Map<String, String> mergedProps = new TreeMap<String, String>(defaultExecProps);
+            Map<String, String> mergedProps;
+            if (execProps.containsKey("jakarta.enterprise.concurrent.TRANSACTION")
+                || execProps.containsKey("javax.enterprise.concurrent.TRANSACTION")) { // ManagedTask.TRANSACTION is specified by the task
+                mergedProps = new TreeMap<String, String>();
+                mergedProps.put(WSContextService.DEFAULT_CONTEXT, WSContextService.UNCONFIGURED_CONTEXT_TYPES);
+                mergedProps.put(WSContextService.TASK_OWNER, name);
+            } else {
+                mergedProps = new TreeMap<String, String>(defaultExecProps);
+            }
             mergedProps.putAll(execProps);
             execProps = mergedProps;
         }
@@ -1206,12 +1221,32 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
 
         Map<String, String> execProps = getExecutionProperties(task);
 
-        String name = execProps.get(ManagedTask.IDENTITY_NAME);
+        // ManagedTask.IDENTITY_NAME
+        String name;
+        if (eeVersion < 9) {
+            name = execProps.get("javax.enterprise.concurrent.IDENTITY_NAME");
+            if (name == null)
+                name = execProps.get("jakarta.enterprise.concurrent.IDENTITY_NAME");
+        } else {
+            name = execProps.get("jakarta.enterprise.concurrent.IDENTITY_NAME");
+            if (name == null)
+                name = execProps.get("javax.enterprise.concurrent.IDENTITY_NAME");
+        }
         record.setName(Utils.normalizeString(name));
 
-        String longRunningHint = execProps.get(ManagedTask.LONGRUNNING_HINT);
+        // ManagedTask.LONGRUNNING_HINT
+        String longRunningHint, key;
+        if (eeVersion < 9) {
+            longRunningHint = execProps.get(key = "javax.enterprise.concurrent.LONGRUNNING_HINT");
+            if (longRunningHint == null)
+                longRunningHint = execProps.get(key = "jakarta.enterprise.concurrent.LONGRUNNING_HINT");
+        } else {
+            longRunningHint = execProps.get(key = "jakarta.enterprise.concurrent.LONGRUNNING_HINT");
+            if (longRunningHint == null)
+                longRunningHint = execProps.get(key = "javax.enterprise.concurrent.LONGRUNNING_HINT");
+        }
         if (Boolean.parseBoolean(longRunningHint))
-            throw new RejectedExecutionException(ManagedTask.LONGRUNNING_HINT + ": " + longRunningHint);
+            throw new RejectedExecutionException(key + ": " + longRunningHint);
 
         int txTimeout;
         String txTimeoutString = execProps.get(PersistentExecutor.TRANSACTION_TIMEOUT);
@@ -1227,6 +1262,18 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
             }
         record.setTransactionTimeout(txTimeout);
 
+        // ManagedTask.TRANSACTION
+        String transaction;
+        if (eeVersion < 9) {
+            transaction = execProps.get("javax.enterprise.concurrent.TRANSACTION");
+            if (transaction == null)
+                transaction = execProps.get("jakarta.enterprise.concurrent.TRANSACTION");
+        } else {
+            transaction = execProps.get("jakarta.enterprise.concurrent.TRANSACTION");
+            if (transaction == null)
+                transaction = execProps.get("javax.enterprise.concurrent.TRANSACTION");
+        }
+
         short flags = 0;
         String autoPurge = execProps.get(AutoPurge.PROPERTY_NAME);
         if (autoPurge == null || AutoPurge.ON_SUCCESS.toString().equals(autoPurge))
@@ -1239,7 +1286,7 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
             flags |= TaskRecord.Flags.EJB_TIMER.bit;
         if (taskInfo.getInterval() == -1 && taskInfo.getInitialDelay() != -1)
             flags |= TaskRecord.Flags.ONE_SHOT_TASK.bit;
-        if (config.missedTaskThreshold > 0 || ManagedTask.SUSPEND.equals(execProps.get(ManagedTask.TRANSACTION)))
+        if (config.missedTaskThreshold > 0 || "SUSPEND".equals(transaction)) // ManagedTask.SUSPEND
             flags |= TaskRecord.Flags.SUSPEND_TRAN_OF_EXECUTOR_THREAD.bit;
 
         record.setMiscBinaryFlags(flags);
@@ -1722,6 +1769,27 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
     }
 
     /**
+     * Declarative Services method for setting the Jakarta/Java EE version
+     *
+     * @param ref reference to the service
+     */
+    @Reference(service = JavaEEVersion.class,
+               cardinality = ReferenceCardinality.OPTIONAL,
+               policy = ReferencePolicy.STATIC,
+               policyOption = ReferencePolicyOption.GREEDY,
+               target = "(id=unbound)")
+    protected void setEEVersion(ServiceReference<JavaEEVersion> ref) {
+        String version = (String) ref.getProperty("version");
+        if (version == null) {
+            eeVersion = 0;
+        } else {
+            int dot = version.indexOf('.');
+            String major = dot > 0 ? version.substring(0, dot) : version;
+            eeVersion = Integer.parseInt(major);
+        }
+    }
+
+    /**
      * Declarative Services method for setting the Liberty executor.
      *
      * @param svc the service
@@ -1964,6 +2032,15 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
      */
     protected void unsetContextService(ServiceReference<WSContextService> ref) {
         contextSvcRef.unsetReference(ref);
+    }
+
+    /**
+     * Declarative Services method for unsetting the Jakarta/Java EE version
+     *
+     * @param ref reference to the service
+     */
+    protected void unsetEEVersion(ServiceReference<JavaEEVersion> ref) {
+        eeVersion = 0;
     }
 
     /**

--- a/dev/com.ibm.ws.context/bnd.bnd
+++ b/dev/com.ibm.ws.context/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -41,4 +41,5 @@ instrument.classesExcludes: com/ibm/ws/context/service/resources/*.class
 	com.ibm.websphere.appserver.spi.kernel.service,\
 	com.ibm.websphere.org.osgi.service.component,\
 	com.ibm.wsspi.org.osgi.service.component.annotations, \
+	com.ibm.ws.javaee.version;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest

--- a/dev/com.ibm.ws.context/src/com/ibm/ws/context/service/serializable/ThreadContextDescriptorImpl.java
+++ b/dev/com.ibm.ws.context/src/com/ibm/ws/context/service/serializable/ThreadContextDescriptorImpl.java
@@ -346,7 +346,16 @@ public class ThreadContextDescriptorImpl implements ThreadContextDescriptor, Thr
         // java.lang.IllegalStateException exception if the application component is not started or deployed.
         if (!"false".equalsIgnoreCase(execProps.get(WSContextService.REQUIRE_AVAILABLE_APP)) &&
             metaDataIdentifier != null && threadContextMgr.metadataIdentifierService.getMetaData(metaDataIdentifier) == null) {
-            String taskName = execProps.get("javax.enterprise.concurrent.IDENTITY_NAME"); // ManagedTask.IDENTITY_NAME
+            String taskName; // ManagedTask.IDENTITY_NAME
+            if (threadContextMgr.eeVersion < 9) {
+                taskName = execProps.get("javax.enterprise.concurrent.IDENTITY_NAME");
+                if (taskName == null)
+                    taskName = execProps.get("jakarta.enterprise.concurrent.IDENTITY_NAME");
+            } else {
+                taskName = execProps.get("jakarta.enterprise.concurrent.IDENTITY_NAME");
+                if (taskName == null)
+                    taskName = execProps.get("javax.enterprise.concurrent.IDENTITY_NAME");
+            }
             notAvailable(metaDataIdentifier, taskName);
         }
 

--- a/dev/com.ibm.ws.context/src/com/ibm/ws/context/service/serializable/ThreadContextManager.java
+++ b/dev/com.ibm.ws.context/src/com/ibm/ws/context/service/serializable/ThreadContextManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -37,6 +37,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import com.ibm.ws.container.service.metadata.extended.MetaDataIdentifierService;
+import com.ibm.ws.javaee.version.JavaEEVersion;
 import com.ibm.wsspi.kernel.service.utils.ConcurrentServiceReferenceMap;
 import com.ibm.wsspi.threadcontext.ThreadContext;
 import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
@@ -63,6 +64,11 @@ public class ThreadContextManager implements WSContextService {
     private final Set<String> alwaysEnabled = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
 
     /**
+     * Jakarta EE versiom if Jakarta EE 9 or higher. If 0, assume a lesser EE spec version.
+     */
+    int eeVersion;
+
+    /**
      * The metadata identifier service.
      */
     MetaDataIdentifierService metadataIdentifierService;
@@ -75,7 +81,7 @@ public class ThreadContextManager implements WSContextService {
     /**
      * DS method to activate this component.
      * Best practice: this should be a protected method, not public or private
-     * 
+     *
      * @param context for this component instance
      */
     @Activate
@@ -107,9 +113,9 @@ public class ThreadContextManager implements WSContextService {
 
     /**
      * Capture thread context.
-     * 
+     *
      * @param threadContextConfigurations map of thread context provider name to configured thread context.
-     * @param execProps execution properties.
+     * @param execProps                   execution properties.
      * @return thread context descriptor for the captured thread context.
      */
     public ThreadContextDescriptor captureThreadContext(final Map<String, Map<String, ?>> threadContextConfigurations, final Map<String, String> execProps) {
@@ -200,7 +206,7 @@ public class ThreadContextManager implements WSContextService {
     /**
      * DS method to deactivate this component.
      * Best practice: this should be a protected method, not public or private
-     * 
+     *
      * @param context for this component instance
      */
     @Deactivate
@@ -210,15 +216,37 @@ public class ThreadContextManager implements WSContextService {
 
     /**
      * Called by Declarative Services to modify service config properties
-     * 
+     *
      * @param context DeclarativeService defined/populated component context
      */
     @Modified
-    protected void modified(ComponentContext context) {}
+    protected void modified(ComponentContext context) {
+    }
+
+    /**
+     * Declarative Services method for setting the Jakarta/Java EE version
+     *
+     * @param ref reference to the service
+     */
+    @Reference(service = JavaEEVersion.class,
+               cardinality = ReferenceCardinality.OPTIONAL,
+               policy = ReferencePolicy.STATIC,
+               policyOption = ReferencePolicyOption.GREEDY,
+               target = "(id=unbound)")
+    protected void setEEVersion(ServiceReference<JavaEEVersion> ref) {
+        String version = (String) ref.getProperty("version");
+        if (version == null) {
+            eeVersion = 0;
+        } else {
+            int dot = version.indexOf('.');
+            String major = dot > 0 ? version.substring(0, dot) : version;
+            eeVersion = Integer.parseInt(major);
+        }
+    }
 
     /**
      * Declarative Services method for setting the metadata identifier service.
-     * 
+     *
      * @param svc the service
      */
     @Reference(service = MetaDataIdentifierService.class)
@@ -228,7 +256,7 @@ public class ThreadContextManager implements WSContextService {
 
     /**
      * Declarative Services method for adding a thread context provider.
-     * 
+     *
      * @param ref reference to the service
      */
     @Reference(name = THREAD_CONTEXT_PROVIDER,
@@ -244,8 +272,17 @@ public class ThreadContextManager implements WSContextService {
     }
 
     /**
+     * Declarative Services method for unsetting the Jakarta/Java EE version
+     *
+     * @param ref reference to the service
+     */
+    protected void unsetEEVersion(ServiceReference<JavaEEVersion> ref) {
+        eeVersion = 0;
+    }
+
+    /**
      * Declarative Services method for unsetting the metadata identifier service.
-     * 
+     *
      * @param ref reference to the service
      */
     protected void unsetMetadataIdentifierService(MetaDataIdentifierService svc) {
@@ -254,7 +291,7 @@ public class ThreadContextManager implements WSContextService {
 
     /**
      * Declarative Services method for removing a thread context provider.
-     * 
+     *
      * @param ref reference to the service
      */
     protected void unsetThreadContextProvider(ServiceReference<ThreadContextProvider> ref) {

--- a/dev/com.ibm.ws.microprofile.health.2.0/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.health.2.0/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -73,6 +73,7 @@ testsrc: test/src
         com.ibm.ws.container.service;version=latest,\
         com.ibm.ws.context;version=latest,\
         com.ibm.ws.javaee.metadata.context;version=latest,\
+        com.ibm.ws.javaee.version;version=latest,\
         com.ibm.ws.kernel.service;version=latest,\
         com.ibm.ws.logging;version=latest,\
         com.ibm.ws.org.osgi.annotation.versioning;version=latest,\

--- a/dev/com.ibm.ws.microprofile.health.2.0/src/com/ibm/ws/microprofile/health20/services/impl/HealthCheck20ExecutorImpl.java
+++ b/dev/com.ibm.ws.microprofile.health.2.0/src/com/ibm/ws/microprofile/health20/services/impl/HealthCheck20ExecutorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,12 +18,17 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import com.ibm.websphere.csi.J2EEName;
 import com.ibm.websphere.csi.J2EENameFactory;
+import com.ibm.ws.javaee.version.JavaEEVersion;
 import com.ibm.ws.microprofile.health.services.HealthCheckBeanCallException;
 import com.ibm.ws.microprofile.health.services.impl.AppModuleContextService;
 import com.ibm.ws.microprofile.health20.services.HealthCheck20CDIBeanInvoker;
@@ -38,14 +43,16 @@ public class HealthCheck20ExecutorImpl implements HealthCheck20Executor {
      * app/module name.
      */
     private AppModuleContextService appModuleContextService;
+
+    /**
+     * Jakarta EE versiom if Jakarta EE 9 or higher. If 0, assume a lesser EE spec version.
+     */
+    private int eeVersion;
+
     private HealthCheck20CDIBeanInvoker healthCheckCDIBeanInvoker;
     private J2EENameFactory j2eeNameFactory;
     private final static Logger logger = Logger.getLogger(HealthCheck20ExecutorImpl.class.getName(), "com.ibm.ws.microprofile.health20.resources.Health20");
 
-    /**
-     * For creating J2EENames.
-     */
-    private static final String MANAGEDTASK_IDENTITY_NAME = "javax.enterprise.concurrent.IDENTITY_NAME";
     private final static String HC_MANAGEDTASK_IDENTITY_NAME = "mp.healthcheck.proxy";
     private final static String HC_TASK_OWNER = "mp.healthcheck.runtime";
     private final static String ONLY_WAR_EJB_NOT_SUPPORTED = null;
@@ -74,6 +81,7 @@ public class HealthCheck20ExecutorImpl implements HealthCheck20Executor {
         Set<HealthCheckResponse> retval;
 
         // TaskIdentity identifies the task for the purposes of mgmt/auditing.
+        final String MANAGEDTASK_IDENTITY_NAME = eeVersion < 9 ? "javax.enterprise.concurrent.IDENTITY_NAME" : "jakarta.enterprise.concurrent.IDENTITY_NAME";
         execProps.put(MANAGEDTASK_IDENTITY_NAME, HC_MANAGEDTASK_IDENTITY_NAME);
 
         // TaskOwner identifies the submitter of the task.
@@ -107,5 +115,35 @@ public class HealthCheck20ExecutorImpl implements HealthCheck20Executor {
     @Override
     public void removeModuleReferences(String appName, String moduleName) {
         healthCheckCDIBeanInvoker.removeModuleReferences(appName, moduleName);
+    }
+
+    /**
+     * Declarative Services method for setting the Jakarta/Java EE version
+     *
+     * @param ref reference to the service
+     */
+    @Reference(service = JavaEEVersion.class,
+               cardinality = ReferenceCardinality.OPTIONAL,
+               policy = ReferencePolicy.STATIC,
+               policyOption = ReferencePolicyOption.GREEDY,
+               target = "(id=unbound)")
+    protected void setEEVersion(ServiceReference<JavaEEVersion> ref) {
+        String version = (String) ref.getProperty("version");
+        if (version == null) {
+            eeVersion = 0;
+        } else {
+            int dot = version.indexOf('.');
+            String major = dot > 0 ? version.substring(0, dot) : version;
+            eeVersion = Integer.parseInt(major);
+        }
+    }
+
+    /**
+     * Declarative Services method for unsetting the Jakarta/Java EE version
+     *
+     * @param ref reference to the service
+     */
+    protected void unsetEEVersion(ServiceReference<JavaEEVersion> ref) {
+        eeVersion = 0;
     }
 }

--- a/dev/com.ibm.ws.microprofile.health/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.health/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2019 IBM Corporation and others.
+# Copyright (c) 2017, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -76,6 +76,7 @@ testsrc: test/src
         com.ibm.ws.container.service;version=latest,\
         com.ibm.ws.context;version=latest,\
         com.ibm.ws.javaee.metadata.context;version=latest,\
+        com.ibm.ws.javaee.version;version=latest,\
         com.ibm.ws.kernel.service;version=latest,\
         com.ibm.ws.logging;version=latest,\
         com.ibm.ws.org.osgi.annotation.versioning;version=latest,\

--- a/dev/com.ibm.ws.microprofile.health/src/com/ibm/ws/microprofile/health/services/impl/HealthExecutorImpl.java
+++ b/dev/com.ibm.ws.microprofile.health/src/com/ibm/ws/microprofile/health/services/impl/HealthExecutorImpl.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package com.ibm.ws.microprofile.health.services.impl;
 
 import java.util.HashMap;
@@ -7,12 +17,17 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import com.ibm.websphere.csi.J2EEName;
 import com.ibm.websphere.csi.J2EENameFactory;
+import com.ibm.ws.javaee.version.JavaEEVersion;
 import com.ibm.ws.microprofile.health.services.HealthCheckBeanCallException;
 import com.ibm.ws.microprofile.health.services.HealthCheckCDIBeanInvoker;
 import com.ibm.ws.microprofile.health.services.HealthExecutor;
@@ -26,14 +41,16 @@ public class HealthExecutorImpl implements HealthExecutor {
      * app/module name.
      */
     private AppModuleContextService appModuleContextService;
+
+    /**
+     * Jakarta EE versiom if Jakarta EE 9 or higher. If 0, assume a lesser EE spec version.
+     */
+    private int eeVersion;
+
     private HealthCheckCDIBeanInvoker healthCheckCDIBeanInvoker;
     private J2EENameFactory j2eeNameFactory;
     private final static Logger logger = Logger.getLogger(HealthExecutorImpl.class.getName(), "com.ibm.ws.microprofile.health.resources.Health");
 
-    /**
-     * For creating J2EENames.
-     */
-    private static final String MANAGEDTASK_IDENTITY_NAME = "javax.enterprise.concurrent.IDENTITY_NAME";
     private final static String HC_MANAGEDTASK_IDENTITY_NAME = "mp.healthcheck.proxy";
     private final static String HC_TASK_OWNER = "mp.healthcheck.runtime";
     private final static String ONLY_WAR_EJB_NOT_SUPPORTED = null;
@@ -62,6 +79,7 @@ public class HealthExecutorImpl implements HealthExecutor {
         Set<HealthCheckResponse> retval;
 
         // TaskIdentity identifies the task for the purposes of mgmt/auditing.
+        final String MANAGEDTASK_IDENTITY_NAME = eeVersion < 9 ? "javax.enterprise.concurrent.IDENTITY_NAME" : "jakarta.enterprise.concurrent.IDENTITY_NAME";
         execProps.put(MANAGEDTASK_IDENTITY_NAME, HC_MANAGEDTASK_IDENTITY_NAME);
 
         // TaskOwner identifies the submitter of the task.
@@ -95,5 +113,35 @@ public class HealthExecutorImpl implements HealthExecutor {
     @Override
     public void removeModuleReferences(String appName, String moduleName) {
         healthCheckCDIBeanInvoker.removeModuleReferences(appName, moduleName);
+    }
+
+    /**
+     * Declarative Services method for setting the Jakarta/Java EE version
+     *
+     * @param ref reference to the service
+     */
+    @Reference(service = JavaEEVersion.class,
+               cardinality = ReferenceCardinality.OPTIONAL,
+               policy = ReferencePolicy.STATIC,
+               policyOption = ReferencePolicyOption.GREEDY,
+               target = "(id=unbound)")
+    protected void setEEVersion(ServiceReference<JavaEEVersion> ref) {
+        String version = (String) ref.getProperty("version");
+        if (version == null) {
+            eeVersion = 0;
+        } else {
+            int dot = version.indexOf('.');
+            String major = dot > 0 ? version.substring(0, dot) : version;
+            eeVersion = Integer.parseInt(major);
+        }
+    }
+
+    /**
+     * Declarative Services method for unsetting the Jakarta/Java EE version
+     *
+     * @param ref reference to the service
+     */
+    protected void unsetEEVersion(ServiceReference<JavaEEVersion> ref) {
+        eeVersion = 0;
     }
 }


### PR DESCRIPTION
This covers a subset (not all) of the occurrences of code using constants from javax.enterprise.concurrent.ManagedTask.

It includes usage by:
mpHealth
contextService
persistentExecutor