### PR TITLE
remove EE Concurrency dependency from transaction context

### DIFF
--- a/dev/com.ibm.ws.microprofile.contextpropagation.1.0/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.contextpropagation.1.0/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018,2019 IBM Corporation and others.
+# Copyright (c) 2018,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -42,7 +42,6 @@ instrument.classesExcludes: com/ibm/ws/microprofile/context/resources/*.class
 
 -buildpath: \
   com.ibm.websphere.appserver.spi.logging,\
-  com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
   com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.0,\
   com.ibm.websphere.org.eclipse.microprofile.config.1.4;version=latest,\
   com.ibm.websphere.org.osgi.core;version=latest,\

--- a/dev/com.ibm.ws.microprofile.contextpropagation.1.0/src/com/ibm/ws/microprofile/context/TransactionContextProvider.java
+++ b/dev/com.ibm.ws.microprofile.contextpropagation.1.0/src/com/ibm/ws/microprofile/context/TransactionContextProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2019 IBM Corporation and others.
+ * Copyright (c) 2018,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,15 +11,11 @@
 package com.ibm.ws.microprofile.context;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Map;
-
-import javax.enterprise.concurrent.ManagedTask;
+import java.util.TreeMap;
 
 import org.eclipse.microprofile.context.ThreadContext;
 
-import com.ibm.websphere.ras.Tr;
-import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.microprofile.contextpropagation.ContextOp;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
@@ -31,12 +27,15 @@ import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 @Trivial
 @SuppressWarnings("deprecation")
 public class TransactionContextProvider extends ContainerContextProvider {
-    private static final TraceComponent tc = Tr.register(TransactionContextProvider.class);
-
     /**
      * Map with execution property that instructs the transaction context to propagate transactions for serial use.
      */
-    private static final Map<String, String> PROPAGATE_TX_FOR_SERIAL_USE = Collections.singletonMap(ManagedTask.TRANSACTION, "PROPAGATE");
+    private static final Map<String, String> PROPAGATE_TX_FOR_SERIAL_USE = new TreeMap<String, String>();
+    static {
+        // Including both keys. It's not worth it to compute the EE spec/version here given that this class is not an OSGi service component.
+        PROPAGATE_TX_FOR_SERIAL_USE.put("jakarta.enterprise.concurrent.TRANSACTION", "PROPAGATE");
+        PROPAGATE_TX_FOR_SERIAL_USE.put("java.enterprise.concurrent.TRANSACTION", "PROPAGATE");
+    }
 
     public final AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider> transactionContextProviderRef = new AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider>("TransactionContextProvider");
 

--- a/dev/com.ibm.ws.transaction.context/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.context/bnd.bnd
@@ -26,8 +26,11 @@ Service-Component: \
     implementation:=com.ibm.ws.transaction.context.internal.TransactionContextProviderImpl; \
     provide:='com.ibm.wsspi.threadcontext.ThreadContextProvider,com.ibm.wsspi.threadcontext.jca.JCAContextProvider'; \
     configuration-policy:=ignore;\
+    EEVersion='com.ibm.ws.javaee.version.JavaEEVersion';\
     transactionInflowManager=com.ibm.tx.jta.TransactionInflowManager;\
     transactionManager=com.ibm.ws.tx.embeddable.EmbeddableWebSphereTransactionManager; \
+    greedy:='EEVersion';\
+    optional:='EEVersion';\
     properties:='\
      alwaysCaptureThreadContext:Boolean=true,\
      type=javax.resource.spi.work.TransactionContext'
@@ -39,8 +42,8 @@ Service-Component: \
 	com.ibm.tx.ltc;version=latest,\
 	com.ibm.ws.tx.embeddable;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
-	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
 	com.ibm.websphere.javaee.connector.1.6;version=latest,\
+	com.ibm.ws.javaee.version;version=latest,\
 	com.ibm.ws.kernel.service,\
 	com.ibm.ws.container.service;version=latest,\
 	com.ibm.websphere.org.osgi.core,\


### PR DESCRIPTION
Minor updates to Transaction context propagation and the MicroProfile wrapper around it, in order to remove the dependency of both on EE Concurrency API.  This will aid in the update to support Jakarta by making it possible to convert fewer bundles. (The transaction context provider bundle would still need updates for other EE specs, but this is a start and will allow work to proceed with the Concurrency spec)