### PR TITLE
Add java 2 security trace for testAppOrder

### DIFF
--- a/dev/com.ibm.ws.app.manager_fat/publish/files/appOrder/serverBarFoo.xml
+++ b/dev/com.ibm.ws.app.manager_fat/publish/files/appOrder/serverBarFoo.xml
@@ -8,5 +8,7 @@
     <application id="app1" name="bar" type="war" location="bar.war"/>
     <application id="app2" name="foo" type="war" location="foo.war"/>
 
+    <logging traceSpecification="*=info:com.ibm.ws.security.java2sec.*=all:com.ibm.ws.classloading.java2sec.*=all"/>
+
     <include location="../fatTestPorts.xml"/>
 </server>

--- a/dev/com.ibm.ws.app.manager_fat/publish/files/appOrder/serverFooBar.xml
+++ b/dev/com.ibm.ws.app.manager_fat/publish/files/appOrder/serverFooBar.xml
@@ -8,5 +8,7 @@
     <application id="app1" name="foo" type="war" location="foo.war"/>
     <application id="app2" name="bar" type="war" location="bar.war"/>
 
+    <logging traceSpecification="*=info:com.ibm.ws.security.java2sec.*=all:com.ibm.ws.classloading.java2sec.*=all"/>
+
     <include location="../fatTestPorts.xml"/>
 </server>


### PR DESCRIPTION
`testAppOrder` in the `com.ibm.ws.app.manager_fat` bucket very intermittently encounters a `AccessControlException`.  I'll add some trace for the test so we can attempt to understand why this ACE is intermittent.