### PR TITLE
Test case for `CompletionStage<Response>` in MP Rest Client

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/AsyncTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/AsyncTestServlet.java
@@ -61,6 +61,7 @@ public class AsyncTestServlet extends FATServlet {
     public void before() {
         assertNotNull(executor);
         App.executorService.compareAndSet(null, executor);
+        BankAccountService.setBalance(1300.75);
     }
 
     @Override
@@ -168,7 +169,7 @@ public class AsyncTestServlet extends FATServlet {
                         .executorService(executor)
                         .baseUri(URI.create(URI_CONTEXT_ROOT))
                         .build(BankAccountClient.class);
-        
+
         List<String> uris = Collections.synchronizedList(new ArrayList<>());
         Handler auditLog = new Handler(){
 
@@ -187,21 +188,21 @@ public class AsyncTestServlet extends FATServlet {
                 // no-op
             }};
         RestClientAuditLogger._log.addHandler(auditLog);
-        
+
         acctsPayable.getAllAccounts().toCompletableFuture().get(TIMEOUT, TimeUnit.SECONDS);
         assertEquals(1, uris.size());
         assertTrue(uris.get(0).contains("/accountsPayable/accounts"));
-        
+
         bank.currentBalance().toCompletableFuture().get(TIMEOUT, TimeUnit.SECONDS);
         assertEquals(2, uris.size());
         assertTrue(uris.get(1).contains("/bank"));
-        
+
         acctsPayable.getAllAccounts().toCompletableFuture().get(TIMEOUT, TimeUnit.SECONDS);
         assertEquals(3, uris.size());
         assertTrue(uris.get(2).contains("/accountsPayable/accounts"));
         assertTrue("UniqueURIFilter not invoked", !uris.get(0).equals(uris.get(2)));
     }
-    
+
     @Test
     public void testCompletionStageCompletesExceptionally(HttpServletRequest req, HttpServletResponse resp) throws Exception {
         BankAccountClient bank = RestClientBuilder.newBuilder()
@@ -240,6 +241,19 @@ public class AsyncTestServlet extends FATServlet {
         assertNotNull(t);
         assertEquals(InsufficientFundsException.class.getName(), t.getClass().getName());
         assertEquals(-1.0, exceptionValue, 0.0);
-        
+    }
+
+    @Test
+    public void testCompletionStageWithResponseType() throws Exception {
+        final double expected = 28380.79;
+        BankAccountService.setBalance(expected);
+        BankAccountClient bank = RestClientBuilder.newBuilder()
+                        .register(DoubleReader.class)
+                        .register(InsufficientFundsExceptionMapper.class)
+                        .executorService(executor)
+                        .baseUri(URI.create(URI_CONTEXT_ROOT))
+                        .build(BankAccountClient.class);
+        Double d = bank.currentBalanceResponse().toCompletableFuture().get().readEntity(Double.class);
+        assertEquals(expected, d, 0.001);
     }
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/BankAccountClient.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/BankAccountClient.java
@@ -19,6 +19,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 @Path("/bank")
 @Produces(MediaType.APPLICATION_JSON)
@@ -27,8 +28,15 @@ public interface BankAccountClient {
 
     @GET
     CompletionStage<Double> currentBalance();
-    
+
     @DELETE
     @Path("/{amt}")
     CompletionStage<Double> withdraw(@PathParam("amt") Double amount) throws InsufficientFundsException;
+
+    @GET
+    CompletionStage<Response> currentBalanceResponse();
+
+    @DELETE
+    @Path("/{amt}")
+    CompletionStage<Response> withdrawResponse(@PathParam("amt") Double amount) throws InsufficientFundsException;
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/BankAccountService.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/asyncApp/src/mpRestClient11/async/BankAccountService.java
@@ -25,9 +25,13 @@ import javax.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public class BankAccountService {
     private final static Logger _log = Logger.getLogger(BankAccountService.class.getName());
-    
-    static Double balance = 1300.75;
-    
+
+    static Double balance;
+
+    static void setBalance(double d) {
+        balance = d;
+    }
+
     @GET
     public Double currentBalance() {
         synchronized (balance) {
@@ -35,7 +39,7 @@ public class BankAccountService {
             return balance;
         }
     }
-    
+
     @DELETE
     @Path("/{amt}")
     public Double withdraw(@PathParam("amt") Double amount) throws InsufficientFundsException {
@@ -47,6 +51,5 @@ public class BankAccountService {
             _log.info("withdraw " + amount + " " + balance);
             return balance;
         }
-        
     }
 }


### PR DESCRIPTION
This PR adds a test case for a MP Rest Client interface method that returns `CompletionStage<Response>`.  

This PR is an attempt to reproduce issue #11638 