### PR TITLE
updates to bring us closer to aligning with Jakarta for Concurrency spec

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp_fat/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp_fat/bnd.bnd
@@ -26,6 +26,7 @@ fat.project: true
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.2;version=latest,\
 	com.ibm.tx.core;version=latest,\
+	com.ibm.websphere.jakarta.concurrency.2.0;version=latest,\
 	com.ibm.websphere.javaee.cdi.2.0;version=latest,\
 	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
 	com.ibm.websphere.javaee.jaxrs.2.1;version=latest,\

--- a/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentTxTestServer/server.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentTxTestServer/server.xml
@@ -12,6 +12,7 @@
 
     <featureManager>
         <feature>componenttest-1.0</feature>
+        <feature>concurrent-2.0</feature>
         <feature>jdbc-4.2</feature>
         <feature>jndi-1.0</feature>
         <feature>mpContextPropagation-1.0</feature>

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
@@ -1679,7 +1679,7 @@ public class MPConcurrentTestServlet extends FATServlet {
     }
 
     /**
-     * When the mpConcurrency-1.0 feature is enabled, The OpenLiberty implementation of
+     * When the mpContextPropagation-1.0 feature is enabled, The OpenLiberty implementation of
      * javax.enterprise.concurrent.ManagedExecutorService and
      * javax.enterprise.concurrent.ManagedScheduledExecutorService are also implementations of
      * org.eclipse.microprofile.context.ManagedExecutor
@@ -1697,7 +1697,7 @@ public class MPConcurrentTestServlet extends FATServlet {
     }
 
     /**
-     * When the mpConcurrency-1.0 feature is enabled, The OpenLiberty implementation of
+     * When the mpContextPropagation-1.0 feature is enabled, The OpenLiberty implementation of
      * javax.enterprise.concurrent.ContextService is also an implementation of
      * org.eclipse.microprofile.context.ThreadContext
      */

--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
@@ -1776,8 +1776,7 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
     @Reference(service = JavaEEVersion.class,
                cardinality = ReferenceCardinality.OPTIONAL,
                policy = ReferencePolicy.STATIC,
-               policyOption = ReferencePolicyOption.GREEDY,
-               target = "(id=unbound)")
+               policyOption = ReferencePolicyOption.GREEDY)
     protected void setEEVersion(ServiceReference<JavaEEVersion> ref) {
         String version = (String) ref.getProperty("version");
         if (version == null) {

--- a/dev/com.ibm.ws.concurrent/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent/bnd.bnd
@@ -74,6 +74,7 @@ instrument.classesExcludes: com/ibm/ws/concurrent/resources/*.class
 	com.ibm.ws.concurrency.policy;version=latest,\
 	com.ibm.ws.container.service;version=latest,\
 	com.ibm.ws.context;version=latest,\
+	com.ibm.ws.javaee.version;version=latest,\
 	com.ibm.ws.kernel.service;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.ws.resource;version=latest,\

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceImpl.java
@@ -81,7 +81,8 @@ import com.ibm.wsspi.threadcontext.WSContextService;
            configurationPolicy = ConfigurationPolicy.REQUIRE,
            service = { ResourceFactory.class, javax.enterprise.concurrent.ContextService.class, //
                        ThreadContext.class, WSContextService.class, ApplicationRecycleComponent.class },
-           property = { "creates.objectClass=javax.enterprise.concurrent.ContextService",
+           property = { "creates.objectClass=jakarta.enterprise.concurrent.ContextService",
+                        "creates.objectClass=javax.enterprise.concurrent.ContextService",
                         "creates.objectClass=org.eclipse.microprofile.context.ThreadContext" })
 public class ContextServiceImpl implements //
                 jakarta.enterprise.concurrent.ContextService, //
@@ -760,8 +761,7 @@ public class ContextServiceImpl implements //
     @Reference(service = JavaEEVersion.class,
                cardinality = ReferenceCardinality.OPTIONAL,
                policy = ReferencePolicy.STATIC,
-               policyOption = ReferencePolicyOption.GREEDY,
-               target = "(id=unbound)")
+               policyOption = ReferencePolicyOption.GREEDY)
     protected void setEEVersion(ServiceReference<JavaEEVersion> ref) {
         String version = (String) ref.getProperty("version");
         if (version == null) {

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/LastExecutionImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/LastExecutionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,15 +12,13 @@ package com.ibm.ws.concurrent.internal;
 
 import java.util.Date;
 
-import javax.enterprise.concurrent.LastExecution;
-
 import com.ibm.websphere.ras.annotation.Trivial;
 
 /**
  * Information about a single execution of a task.
  */
 @Trivial
-public class LastExecutionImpl implements LastExecution {
+public class LastExecutionImpl implements jakarta.enterprise.concurrent.LastExecution, javax.enterprise.concurrent.LastExecution {
     private final long endTime;
     private final String identityName;
     private final Object result;

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
@@ -78,6 +78,7 @@ import com.ibm.wsspi.threadcontext.WSContextService;
                        ResourceFactory.class, ApplicationRecycleComponent.class },
            reference = @Reference(name = "ApplicationRecycleCoordinator", service = ApplicationRecycleCoordinator.class),
            property = { "creates.objectClass=java.util.concurrent.ExecutorService",
+                        "creates.objectClass=jakarta.enterprise.concurrent.ManagedExecutorService",
                         "creates.objectClass=javax.enterprise.concurrent.ManagedExecutorService",
                         "creates.objectClass=org.eclipse.microprofile.context.ManagedExecutor" })
 public class ManagedExecutorServiceImpl implements ExecutorService, ManagedExecutor, //
@@ -567,8 +568,7 @@ public class ManagedExecutorServiceImpl implements ExecutorService, ManagedExecu
     @Reference(service = JavaEEVersion.class,
                cardinality = ReferenceCardinality.OPTIONAL,
                policy = ReferencePolicy.STATIC,
-               policyOption = ReferencePolicyOption.GREEDY,
-               target = "(id=unbound)")
+               policyOption = ReferencePolicyOption.GREEDY)
     protected void setEEVersion(ServiceReference<JavaEEVersion> ref) {
         String version = (String) ref.getProperty("version");
         if (version == null) {

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
@@ -37,8 +37,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import javax.enterprise.concurrent.ManagedExecutorService;
-import javax.enterprise.concurrent.ManagedTask;
 
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.osgi.framework.ServiceReference;
@@ -51,6 +49,7 @@ import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -58,6 +57,7 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrency.policy.ConcurrencyPolicy;
 import com.ibm.ws.concurrent.ContextualAction;
 import com.ibm.ws.concurrent.WSManagedExecutorService;
+import com.ibm.ws.javaee.version.JavaEEVersion;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 import com.ibm.ws.threading.PolicyExecutor;
@@ -73,12 +73,17 @@ import com.ibm.wsspi.threadcontext.ThreadContextProvider;
 import com.ibm.wsspi.threadcontext.WSContextService;
 
 @Component(configurationPid = "com.ibm.ws.concurrent.managedExecutorService", configurationPolicy = ConfigurationPolicy.REQUIRE,
-           service = { ExecutorService.class, ManagedExecutor.class, ManagedExecutorService.class, ResourceFactory.class, ApplicationRecycleComponent.class },
+           service = { ExecutorService.class, ManagedExecutor.class, //
+                       javax.enterprise.concurrent.ManagedExecutorService.class, //
+                       ResourceFactory.class, ApplicationRecycleComponent.class },
            reference = @Reference(name = "ApplicationRecycleCoordinator", service = ApplicationRecycleCoordinator.class),
            property = { "creates.objectClass=java.util.concurrent.ExecutorService",
                         "creates.objectClass=javax.enterprise.concurrent.ManagedExecutorService",
                         "creates.objectClass=org.eclipse.microprofile.context.ManagedExecutor" })
-public class ManagedExecutorServiceImpl implements ExecutorService, ManagedExecutor, ManagedExecutorService, ResourceFactory, ApplicationRecycleComponent, WSManagedExecutorService {
+public class ManagedExecutorServiceImpl implements ExecutorService, ManagedExecutor, //
+                jakarta.enterprise.concurrent.ManagedExecutorService, //
+                javax.enterprise.concurrent.ManagedExecutorService, //
+                ResourceFactory, ApplicationRecycleComponent, WSManagedExecutorService {
     private static final TraceComponent tc = Tr.register(ManagedExecutorServiceImpl.class);
 
     /**
@@ -87,9 +92,14 @@ public class ManagedExecutorServiceImpl implements ExecutorService, ManagedExecu
     static final String APP_RECYCLE_SERVICE = "ApplicationRecycleCoordinator";
 
     /**
-     * Execution properties that specify to suspend the current transaction.
+     * Jakarta EE Concurrency execution properties that specify to suspend the current transaction.
      */
-    private static final Map<String, String> XPROPS_SUSPEND_TRAN = Collections.singletonMap(ManagedTask.TRANSACTION, ManagedTask.SUSPEND);
+    private static final Map<String, String> JAKARTA_SUSPEND_TRAN = Collections.singletonMap("jakarta.enterprise.concurrent.TRANSACTION", "SUSPEND");
+
+    /**
+     * Java EE Concurrency execution properties that specify to suspend the current transaction.
+     */
+    private static final Map<String, String> JAVAX_SUSPEND_TRAN = Collections.singletonMap("javax.enterprise.concurrent.TRANSACTION", "SUSPEND");
 
     private final boolean allowLifeCycleMethods;
 
@@ -122,6 +132,11 @@ public class ManagedExecutorServiceImpl implements ExecutorService, ManagedExecu
      * Default execution properties to use for tasks where none are specified.
      */
     private final AtomicReference<Map<String, String>> defaultExecutionProperties = new AtomicReference<Map<String, String>>();
+
+    /**
+     * Jakarta EE versiom if Jakarta EE 9 or higher. If 0, assume a lesser EE spec version.
+     */
+    int eeVersion;
 
     /**
      * Hash code for this instance.
@@ -396,14 +411,24 @@ public class ManagedExecutorServiceImpl implements ExecutorService, ManagedExecu
         if (task == null) // NullPointerException is required per the JavaDoc API
             throw new NullPointerException(Tr.formatMessage(tc, "CWWKC1111.task.invalid", (Object) null));
 
-        Map<String, String> execProps = task instanceof ManagedTask ? ((ManagedTask) task).getExecutionProperties() : null;
+        Map<String, String> execProps;
+        if (task instanceof jakarta.enterprise.concurrent.ManagedTask)
+            execProps = ((jakarta.enterprise.concurrent.ManagedTask) task).getExecutionProperties();
+        else if (task instanceof javax.enterprise.concurrent.ManagedTask)
+            execProps = ((javax.enterprise.concurrent.ManagedTask) task).getExecutionProperties();
+        else
+            execProps = null;
+
         if (execProps == null)
             execProps = defaultExecutionProperties.get();
         else {
             execProps = new TreeMap<String, String>(execProps);
-            String tranProp = execProps.remove(ManagedTask.TRANSACTION);
-            if (tranProp != null && !ManagedTask.SUSPEND.equals(tranProp)) // USE_TRANSACTION_OF_EXECUTION_THREAD not valid for managed tasks
-                throw new RejectedExecutionException(Tr.formatMessage(tc, "CWWKC1130.xprop.value.invalid", name, ManagedTask.TRANSACTION, tranProp));
+            String tranPropKey;
+            String tranProp = execProps.remove(tranPropKey = "jakarta.enterprise.concurrent.TRANSACTION");
+            if (tranProp == null)
+                tranProp = execProps.remove(tranPropKey = "javax.enterprise.concurrent.TRANSACTION");
+            if (tranProp != null && !"SUSPEND".equals(tranProp)) // USE_TRANSACTION_OF_EXECUTION_THREAD not valid for managed tasks
+                throw new RejectedExecutionException(Tr.formatMessage(tc, "CWWKC1130.xprop.value.invalid", name, tranPropKey, tranProp));
             if (!execProps.containsKey(WSContextService.DEFAULT_CONTEXT))
                 execProps.put(WSContextService.DEFAULT_CONTEXT, WSContextService.UNCONFIGURED_CONTEXT_TYPES);
             if (!execProps.containsKey(WSContextService.TASK_OWNER))
@@ -535,6 +560,27 @@ public class ManagedExecutorServiceImpl implements ExecutorService, ManagedExecu
     }
 
     /**
+     * Declarative Services method for setting the Jakarta/Java EE version
+     *
+     * @param ref reference to the service
+     */
+    @Reference(service = JavaEEVersion.class,
+               cardinality = ReferenceCardinality.OPTIONAL,
+               policy = ReferencePolicy.STATIC,
+               policyOption = ReferencePolicyOption.GREEDY,
+               target = "(id=unbound)")
+    protected void setEEVersion(ServiceReference<JavaEEVersion> ref) {
+        String version = (String) ref.getProperty("version");
+        if (version == null) {
+            eeVersion = 0;
+        } else {
+            int dot = version.indexOf('.');
+            String major = dot > 0 ? version.substring(0, dot) : version;
+            eeVersion = Integer.parseInt(major);
+        }
+    }
+
+    /**
      * Declarative Services method for setting the long running concurrency policy.
      *
      * @param svc the service
@@ -631,7 +677,9 @@ public class ManagedExecutorServiceImpl implements ExecutorService, ManagedExecu
      * @return ThreadContext instance that must be used to restore the suspended transaction context if returned.
      *         Null if transaction context is unavailable.
      */
+    @SuppressWarnings("deprecation")
     ThreadContext suspendTransaction() {
+        Map<String, String> XPROPS_SUSPEND_TRAN = eeVersion < 9 ? JAVAX_SUSPEND_TRAN : JAKARTA_SUSPEND_TRAN;
         ThreadContextProvider tranContextProvider = AccessController.doPrivileged(tranContextProviderAccessor);
         ThreadContext suspendedTranSnapshot = tranContextProvider == null ? null : tranContextProvider.captureThreadContext(XPROPS_SUSPEND_TRAN, null);
         if (suspendedTranSnapshot != null)
@@ -661,6 +709,15 @@ public class ManagedExecutorServiceImpl implements ExecutorService, ManagedExecu
      */
     protected void unsetContextService(ServiceReference<WSContextService> ref) {
         contextSvcRef.unsetReference(ref);
+    }
+
+    /**
+     * Declarative Services method for unsetting the Jakarta/Java EE version
+     *
+     * @param ref reference to the service
+     */
+    protected void unsetEEVersion(ServiceReference<JavaEEVersion> ref) {
+        eeVersion = 0;
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedScheduledExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedScheduledExecutorServiceImpl.java
@@ -30,11 +30,13 @@ import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrency.policy.ConcurrencyPolicy;
+import com.ibm.ws.javaee.version.JavaEEVersion;
 import com.ibm.wsspi.application.lifecycle.ApplicationRecycleComponent;
 import com.ibm.wsspi.application.lifecycle.ApplicationRecycleCoordinator;
 import com.ibm.wsspi.resource.ResourceFactory;
@@ -48,6 +50,8 @@ import com.ibm.wsspi.threadcontext.WSContextService;
            reference = @Reference(name = "ApplicationRecycleCoordinator", service = ApplicationRecycleCoordinator.class),
            property = { "creates.objectClass=java.util.concurrent.ExecutorService",
                         "creates.objectClass=java.util.concurrent.ScheduledExecutorService",
+                        "creates.objectClass=jakarta.enterprise.concurrent.ManagedExecutorService",
+                        "creates.objectClass=jakarta.enterprise.concurrent.ManagedScheduledExecutorService",
                         "creates.objectClass=javax.enterprise.concurrent.ManagedExecutorService",
                         "creates.objectClass=javax.enterprise.concurrent.ManagedScheduledExecutorService" })
 public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceImpl implements //
@@ -236,6 +240,14 @@ public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceI
         super.setContextService(ref);
     }
 
+    @Reference(service = JavaEEVersion.class,
+               cardinality = ReferenceCardinality.OPTIONAL,
+               policy = ReferencePolicy.STATIC,
+               policyOption = ReferencePolicyOption.GREEDY)
+    protected void setEEVersion(ServiceReference<JavaEEVersion> ref) {
+        super.setEEVersion(ref);
+    }
+
     @Override
     @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.OPTIONAL, target = "(id=unbound)")
     @Trivial
@@ -266,6 +278,10 @@ public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceI
     @Trivial
     protected void unsetContextService(ServiceReference<WSContextService> ref) {
         super.unsetContextService(ref);
+    }
+
+    protected void unsetEEVersion(ServiceReference<JavaEEVersion> ref) {
+        super.unsetEEVersion(ref);
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedScheduledExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedScheduledExecutorServiceImpl.java
@@ -20,10 +20,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import javax.enterprise.concurrent.ManagedExecutorService;
-import javax.enterprise.concurrent.ManagedScheduledExecutorService;
-import javax.enterprise.concurrent.Trigger;
-
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -46,14 +42,17 @@ import com.ibm.wsspi.threadcontext.ThreadContextProvider;
 import com.ibm.wsspi.threadcontext.WSContextService;
 
 @Component(configurationPid = "com.ibm.ws.concurrent.managedScheduledExecutorService", configurationPolicy = ConfigurationPolicy.REQUIRE,
-           service = { ExecutorService.class, ManagedExecutorService.class, ResourceFactory.class, ApplicationRecycleComponent.class, ScheduledExecutorService.class,
-                       ManagedScheduledExecutorService.class },
+           service = { ExecutorService.class, javax.enterprise.concurrent.ManagedExecutorService.class,
+                       ResourceFactory.class, ApplicationRecycleComponent.class, ScheduledExecutorService.class,
+                       javax.enterprise.concurrent.ManagedScheduledExecutorService.class },
            reference = @Reference(name = "ApplicationRecycleCoordinator", service = ApplicationRecycleCoordinator.class),
            property = { "creates.objectClass=java.util.concurrent.ExecutorService",
                         "creates.objectClass=java.util.concurrent.ScheduledExecutorService",
                         "creates.objectClass=javax.enterprise.concurrent.ManagedExecutorService",
                         "creates.objectClass=javax.enterprise.concurrent.ManagedScheduledExecutorService" })
-public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceImpl implements ManagedScheduledExecutorService {
+public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceImpl implements //
+                jakarta.enterprise.concurrent.ManagedScheduledExecutorService, javax.enterprise.concurrent.ManagedScheduledExecutorService {
+
     private static final TraceComponent tc = Tr.register(ManagedScheduledExecutorServiceImpl.class);
 
     /**
@@ -129,12 +128,26 @@ public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceI
     }
 
     /**
+     * @see jakarta.enterprise.concurrent.ManagedScheduledExecutorService#schedule(java.util.concurrent.Callable, jakarta.enterprise.concurrent.Trigger)
+     */
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> task, jakarta.enterprise.concurrent.Trigger trigger) {
+        if (trigger == null)
+            throw new NullPointerException(jakarta.enterprise.concurrent.Trigger.class.getName());
+
+        ScheduledTask<V> scheduledTask = new ScheduledTask<V>(this, task, true, trigger);
+        if (futures.add(scheduledTask.future) && ++futureCount % FUTURE_PURGE_INTERVAL == 0)
+            purgeFutures();
+        return scheduledTask.future;
+    }
+
+    /**
      * @see javax.enterprise.concurrent.ManagedScheduledExecutorService#schedule(java.util.concurrent.Callable, javax.enterprise.concurrent.Trigger)
      */
     @Override
-    public <V> ScheduledFuture<V> schedule(Callable<V> task, Trigger trigger) {
+    public <V> ScheduledFuture<V> schedule(Callable<V> task, javax.enterprise.concurrent.Trigger trigger) {
         if (trigger == null)
-            throw new NullPointerException(Trigger.class.getName());
+            throw new NullPointerException(javax.enterprise.concurrent.Trigger.class.getName());
 
         ScheduledTask<V> scheduledTask = new ScheduledTask<V>(this, task, true, trigger);
         if (futures.add(scheduledTask.future) && ++futureCount % FUTURE_PURGE_INTERVAL == 0)
@@ -154,12 +167,26 @@ public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceI
     }
 
     /**
+     * @see jakarta.enterprise.concurrent.ManagedScheduledExecutorService#schedule(java.lang.Runnable, jakarta.enterprise.concurrent.Trigger)
+     */
+    @Override
+    public ScheduledFuture<?> schedule(Runnable task, jakarta.enterprise.concurrent.Trigger trigger) {
+        if (trigger == null)
+            throw new NullPointerException(jakarta.enterprise.concurrent.Trigger.class.getName());
+
+        ScheduledTask<?> scheduledTask = new ScheduledTask<Void>(this, task, false, trigger);
+        if (futures.add(scheduledTask.future) && ++futureCount % FUTURE_PURGE_INTERVAL == 0)
+            purgeFutures();
+        return scheduledTask.future;
+    }
+
+    /**
      * @see javax.enterprise.concurrent.ManagedScheduledExecutorService#schedule(java.lang.Runnable, javax.enterprise.concurrent.Trigger)
      */
     @Override
-    public ScheduledFuture<?> schedule(Runnable task, Trigger trigger) {
+    public ScheduledFuture<?> schedule(Runnable task, javax.enterprise.concurrent.Trigger trigger) {
         if (trigger == null)
-            throw new NullPointerException(Trigger.class.getName());
+            throw new NullPointerException(javax.enterprise.concurrent.Trigger.class.getName());
 
         ScheduledTask<?> scheduledTask = new ScheduledTask<Void>(this, task, false, trigger);
         if (futures.add(scheduledTask.future) && ++futureCount % FUTURE_PURGE_INTERVAL == 0)

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedThreadImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedThreadImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,8 +14,6 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
 
-import javax.enterprise.concurrent.ManageableThread;
-
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
@@ -25,7 +23,7 @@ import com.ibm.wsspi.threadcontext.ThreadContext;
 /**
  * Thread created by a managed thread factory.
  */
-class ManagedThreadImpl extends Thread implements ManageableThread {
+class ManagedThreadImpl extends Thread implements jakarta.enterprise.concurrent.ManageableThread, javax.enterprise.concurrent.ManageableThread {
     private static final TraceComponent tc = Tr.register(ManagedThreadImpl.class);
 
     /**

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/TaskLifeCycleCallback.java
@@ -16,10 +16,6 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;
 
-import javax.enterprise.concurrent.AbortedException;
-import javax.enterprise.concurrent.ManagedTask;
-import javax.enterprise.concurrent.ManagedTaskListener;
-
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
@@ -55,7 +51,7 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
     /**
      * Construct a new task life cycle callback. A single instance can be used for multiple tasks.
      *
-     * @param managedExecutor the managed executor to which the task was submitted.
+     * @param managedExecutor         the managed executor to which the task was submitted.
      * @param threadContextDescriptor represents thread context captured from the submitting thread.
      */
     TaskLifeCycleCallback(ManagedExecutorServiceImpl managedExecutor, ThreadContextDescriptor threadContextDescriptor) {
@@ -63,7 +59,11 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
         this.threadContextDescriptor = threadContextDescriptor;
 
         Map<String, String> execProps = threadContextDescriptor.getExecutionProperties();
-        PolicyExecutor executor = Boolean.parseBoolean(execProps.get(ManagedTask.LONGRUNNING_HINT)) ? managedExecutor.longRunningPolicyExecutorRef.get() : null;
+        // TODO check the eeVersion of the managedExecutor to decide which constant takes precedence
+        String longRunning = execProps.get("jakarta.enterprise.concurrent.LONGRUNNING_HINT");
+        if (longRunning == null)
+            longRunning = execProps.get("javax.enterprise.concurrent.LONGRUNNING_HINT");;
+        PolicyExecutor executor = Boolean.parseBoolean(longRunning) ? managedExecutor.longRunningPolicyExecutorRef.get() : null;
         this.policyExecutor = executor == null ? managedExecutor.policyExecutor : executor;
     }
 
@@ -83,8 +83,8 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
      * Allows for replacing the identifier that is used in exception messages and log messages about the policy executor.
      *
      * @param policyExecutorIdentifier unique identifier for the policy executor. Some examples:
-     *            concurrencyPolicy[longRunningPolicy]
-     *            managedExecutorService[executor1]/longRunningPolicy[default-0]
+     *                                     concurrencyPolicy[longRunningPolicy]
+     *                                     managedExecutorService[executor1]/longRunningPolicy[default-0]
      * @return identifier to use in messages.
      */
     @Override
@@ -103,7 +103,14 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
     @Trivial
     public final String getName(Object task) {
         Map<String, String> execProps = threadContextDescriptor.getExecutionProperties();
-        String taskName = execProps == null ? null : execProps.get(ManagedTask.IDENTITY_NAME);
+        String taskName;
+        if (execProps == null)
+            taskName = null;
+        else {
+            taskName = execProps.get("jakarta.enterprise.concurrent.IDENTITY_NAME");
+            if (taskName == null)
+                taskName = execProps.get("javax.enterprise.concurrent.IDENTITY_NAME");
+        }
         return taskName == null ? task.toString() : taskName;
     }
 
@@ -122,90 +129,170 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
         }
     }
 
+    @Trivial
+    private ExecutionException newAbortedException(Throwable failure) {
+        return managedExecutor.eeVersion < 9 //
+                        ? new javax.enterprise.concurrent.AbortedException(failure) //
+                        : new jakarta.enterprise.concurrent.AbortedException(failure);
+    }
+
     @FFDCIgnore({ Error.class, RuntimeException.class }) // No need for FFDC, error is logged instead
     @Override
     public void onCancel(Object task, PolicyTaskFuture<?> future, boolean whileRunning) {
         // Tasks that are canceled while running have the taskAborted notification sent on the thread of execution instead.
 
         // notify listener: taskAborted (if task was canceled before it started)
-        if (!whileRunning && task instanceof ManagedTask) {
-            ManagedTaskListener listener = ((ManagedTask) task).getManagedTaskListener();
-            if (listener != null) {
-                Throwable failure = null;
-                ThreadContext tranContextRestorer = managedExecutor.suspendTransaction();
-                try {
-                    CancellationException x = new CancellationException(Tr.formatMessage(tc, "CWWKC1110.task.canceled", getName(task), managedExecutor.name));
-
-                    if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
-                        Tr.event(this, tc, "taskAborted", managedExecutor, task, x);
-                    listener.taskAborted(future, managedExecutor, task, x);
-                } catch (Error x) {
-                    Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
-                    failure = x;
-                    throw x;
-                } catch (RuntimeException x) {
-                    Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
-                    failure = x;
-                    throw x;
-                } finally {
+        if (!whileRunning)
+            if (task instanceof jakarta.enterprise.concurrent.ManagedTask) {
+                jakarta.enterprise.concurrent.ManagedTaskListener listener = ((jakarta.enterprise.concurrent.ManagedTask) task).getManagedTaskListener();
+                if (listener != null) {
+                    Throwable failure = null;
+                    ThreadContext tranContextRestorer = managedExecutor.suspendTransaction();
                     try {
+                        CancellationException x = new CancellationException(Tr.formatMessage(tc, "CWWKC1110.task.canceled", getName(task), managedExecutor.name));
+
                         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
-                            Tr.event(this, tc, "taskDone", managedExecutor, task, failure);
-                        listener.taskDone(future, managedExecutor, task, failure);
+                            Tr.event(this, tc, "taskAborted", managedExecutor, task, x);
+                        listener.taskAborted(future, managedExecutor, task, x);
                     } catch (Error x) {
                         Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
+                        failure = x;
                         throw x;
                     } catch (RuntimeException x) {
                         Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
+                        failure = x;
                         throw x;
                     } finally {
-                        if (tranContextRestorer != null)
-                            tranContextRestorer.taskStopping();
+                        try {
+                            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
+                                Tr.event(this, tc, "taskDone", managedExecutor, task, failure);
+                            listener.taskDone(future, managedExecutor, task, failure);
+                        } catch (Error x) {
+                            Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
+                            throw x;
+                        } catch (RuntimeException x) {
+                            Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
+                            throw x;
+                        } finally {
+                            if (tranContextRestorer != null)
+                                tranContextRestorer.taskStopping();
+                        }
+                    }
+                }
+            } else if (task instanceof javax.enterprise.concurrent.ManagedTask) {
+                javax.enterprise.concurrent.ManagedTaskListener listener = ((javax.enterprise.concurrent.ManagedTask) task).getManagedTaskListener();
+                if (listener != null) {
+                    Throwable failure = null;
+                    ThreadContext tranContextRestorer = managedExecutor.suspendTransaction();
+                    try {
+                        CancellationException x = new CancellationException(Tr.formatMessage(tc, "CWWKC1110.task.canceled", getName(task), managedExecutor.name));
+
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
+                            Tr.event(this, tc, "taskAborted", managedExecutor, task, x);
+                        listener.taskAborted(future, managedExecutor, task, x);
+                    } catch (Error x) {
+                        Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
+                        failure = x;
+                        throw x;
+                    } catch (RuntimeException x) {
+                        Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
+                        failure = x;
+                        throw x;
+                    } finally {
+                        try {
+                            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
+                                Tr.event(this, tc, "taskDone", managedExecutor, task, failure);
+                            listener.taskDone(future, managedExecutor, task, failure);
+                        } catch (Error x) {
+                            Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
+                            throw x;
+                        } catch (RuntimeException x) {
+                            Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
+                            throw x;
+                        } finally {
+                            if (tranContextRestorer != null)
+                                tranContextRestorer.taskStopping();
+                        }
                     }
                 }
             }
-        }
     }
 
     @FFDCIgnore(Throwable.class) // No need for FFDC given that an error is already logged
     @Override
     public void onEnd(Object task, PolicyTaskFuture<?> future, Object startObj, boolean aborted, int pending, Throwable failure) {
-        if (pending >= 0 && task instanceof ManagedTask) {
-            ManagedTaskListener listener = ((ManagedTask) task).getManagedTaskListener();
-            if (listener != null) {
-                // notify listener: taskAborted
-                try {
-                    Throwable x;
-                    boolean canceled = future.isCancelled();
-                    if (canceled || aborted) {
-                        if (failure instanceof CancellationException)
-                            x = failure;
-                        else if (canceled)
-                            x = new CancellationException(Tr.formatMessage(tc, "CWWKC1110.task.canceled", getName(task), managedExecutor.name));
-                        else if (aborted)
-                            x = new AbortedException(failure);
-                        else
-                            x = failure;
-                        if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
-                            Tr.event(this, tc, "taskAborted", managedExecutor, task, x);
-                        listener.taskAborted(future, managedExecutor, task, x);
+        if (pending >= 0)
+            if (task instanceof jakarta.enterprise.concurrent.ManagedTask) {
+                jakarta.enterprise.concurrent.ManagedTaskListener listener = ((jakarta.enterprise.concurrent.ManagedTask) task).getManagedTaskListener();
+                if (listener != null) {
+                    // notify listener: taskAborted
+                    try {
+                        Throwable x;
+                        boolean canceled = future.isCancelled();
+                        if (canceled || aborted) {
+                            if (failure instanceof CancellationException)
+                                x = failure;
+                            else if (canceled)
+                                x = new CancellationException(Tr.formatMessage(tc, "CWWKC1110.task.canceled", getName(task), managedExecutor.name));
+                            else if (aborted)
+                                x = newAbortedException(failure);
+                            else
+                                x = failure;
+                            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
+                                Tr.event(this, tc, "taskAborted", managedExecutor, task, x);
+                            listener.taskAborted(future, managedExecutor, task, x);
+                        }
+                    } catch (Throwable x) {
+                        Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
+                        if (failure == null)
+                            failure = x;
                     }
-                } catch (Throwable x) {
-                    Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
-                    if (failure == null)
-                        failure = x;
-                }
 
-                // notify listener: taskDone
-                try {
-                    if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
-                        Tr.event(this, tc, "taskDone", managedExecutor, task, failure);
-                    listener.taskDone(future, managedExecutor, task, failure);
-                } catch (Throwable x) {
-                    Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
+                    // notify listener: taskDone
+                    try {
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
+                            Tr.event(this, tc, "taskDone", managedExecutor, task, failure);
+                        listener.taskDone(future, managedExecutor, task, failure);
+                    } catch (Throwable x) {
+                        Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
+                    }
+                }
+            } else if (task instanceof javax.enterprise.concurrent.ManagedTask) {
+                javax.enterprise.concurrent.ManagedTaskListener listener = ((javax.enterprise.concurrent.ManagedTask) task).getManagedTaskListener();
+                if (listener != null) {
+                    // notify listener: taskAborted
+                    try {
+                        Throwable x;
+                        boolean canceled = future.isCancelled();
+                        if (canceled || aborted) {
+                            if (failure instanceof CancellationException)
+                                x = failure;
+                            else if (canceled)
+                                x = new CancellationException(Tr.formatMessage(tc, "CWWKC1110.task.canceled", getName(task), managedExecutor.name));
+                            else if (aborted)
+                                x = newAbortedException(failure);
+                            else
+                                x = failure;
+                            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
+                                Tr.event(this, tc, "taskAborted", managedExecutor, task, x);
+                            listener.taskAborted(future, managedExecutor, task, x);
+                        }
+                    } catch (Throwable x) {
+                        Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
+                        if (failure == null)
+                            failure = x;
+                    }
+
+                    // notify listener: taskDone
+                    try {
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
+                            Tr.event(this, tc, "taskDone", managedExecutor, task, failure);
+                        listener.taskDone(future, managedExecutor, task, failure);
+                    } catch (Throwable x) {
+                        Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
+                    }
                 }
             }
-        }
 
         // Restore thread context
         if (pending <= 0 && startObj != null) {
@@ -223,8 +310,24 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
         ArrayList<ThreadContext> contextAppliedToThread = threadContextDescriptor.taskStarting();
 
         // notify listener: taskStarting
-        if (task instanceof ManagedTask) {
-            ManagedTaskListener listener = ((ManagedTask) task).getManagedTaskListener();
+        if (task instanceof jakarta.enterprise.concurrent.ManagedTask) {
+            jakarta.enterprise.concurrent.ManagedTaskListener listener = ((jakarta.enterprise.concurrent.ManagedTask) task).getManagedTaskListener();
+            if (listener != null)
+                try {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
+                        Tr.event(this, tc, "taskStarting", managedExecutor, task);
+                    listener.taskStarting(future, managedExecutor, task);
+                } catch (Error x) {
+                    Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
+                    threadContextDescriptor.taskStopping(contextAppliedToThread);
+                    throw x;
+                } catch (RuntimeException x) {
+                    Tr.error(tc, "CWWKC1102.listener.failed", getName(task), managedExecutor.name, x);
+                    threadContextDescriptor.taskStopping(contextAppliedToThread);
+                    throw x;
+                }
+        } else if (task instanceof javax.enterprise.concurrent.ManagedTask) {
+            javax.enterprise.concurrent.ManagedTaskListener listener = ((javax.enterprise.concurrent.ManagedTask) task).getManagedTaskListener();
             if (listener != null)
                 try {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
@@ -247,8 +350,27 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
     @Override
     public void onSubmit(Object task, PolicyTaskFuture<?> future, int invokeAnyCount) {
         // notify listener: taskSubmitted
-        if (task instanceof ManagedTask) {
-            ManagedTaskListener listener = ((ManagedTask) task).getManagedTaskListener();
+        if (task instanceof jakarta.enterprise.concurrent.ManagedTask) {
+            jakarta.enterprise.concurrent.ManagedTaskListener listener = ((jakarta.enterprise.concurrent.ManagedTask) task).getManagedTaskListener();
+            if (listener != null) {
+                ThreadContext tranContextRestorer = managedExecutor.suspendTransaction();
+                try {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled())
+                        Tr.event(this, tc, "taskSubmitted", managedExecutor, task);
+                    listener.taskSubmitted(future, managedExecutor, task);
+                } finally {
+                    if (tranContextRestorer != null)
+                        tranContextRestorer.taskStopping();
+                }
+
+                if (invokeAnyCount <= 1 && future.isCancelled())
+                    if (invokeAnyCount == 1)
+                        throw new RejectedExecutionException(Tr.formatMessage(tc, "CWWKC1112.all.tasks.canceled"));
+                    else
+                        throw new RejectedExecutionException(Tr.formatMessage(tc, "CWWKC1110.task.canceled", getName(task), managedExecutor.name));
+            }
+        } else if (task instanceof javax.enterprise.concurrent.ManagedTask) {
+            javax.enterprise.concurrent.ManagedTaskListener listener = ((javax.enterprise.concurrent.ManagedTask) task).getManagedTaskListener();
             if (listener != null) {
                 ThreadContext tranContextRestorer = managedExecutor.suspendTransaction();
                 try {
@@ -271,7 +393,7 @@ public class TaskLifeCycleCallback extends PolicyTaskCallback {
 
     @Override
     public void raiseAbortedException(Throwable x) throws ExecutionException {
-        throw new AbortedException(x);
+        throw newAbortedException(x);
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent_fat_policy/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent_fat_policy/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ fat.project: true
 fat.minimum.java.level: 1.8
 
 -buildpath: \
+	com.ibm.websphere.jakarta.concurrency.2.0;version=latest,\
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
-	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.1;version=latest

--- a/dev/com.ibm.ws.concurrent_fat_policy/publish/servers/com.ibm.ws.concurrent.fat.policy/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_policy/publish/servers/com.ibm.ws.concurrent.fat.policy/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017,2020 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -11,10 +11,10 @@
 <server>
   <featureManager>
     <feature>componentTest-1.0</feature>
-    <feature>concurrent-1.0</feature>
+    <feature>concurrent-2.0</feature>
     <feature>jdbc-4.2</feature> <!-- for javax.transaction.UserTransaction API -->
     <feature>jndi-1.0</feature>
-    <feature>servlet-4.0</feature>
+    <feature>servlet-4.0</feature> <!-- TODO this will need to move to 5.0 to align with Jakarta 9 once enforced -->
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>

--- a/dev/com.ibm.ws.concurrent_fat_policy/test-applications/concurrentpolicyfat/src/web/ConcurrentPolicyFATServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_policy/test-applications/concurrentpolicyfat/src/web/ConcurrentPolicyFATServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2019 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,10 +33,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.Resource;
-import javax.enterprise.concurrent.AbortedException;
-import javax.enterprise.concurrent.ManagedExecutorService;
-import javax.enterprise.concurrent.ManagedScheduledExecutorService;
-import javax.enterprise.concurrent.ManagedTask;
 import javax.naming.NamingException;
 import javax.servlet.annotation.WebServlet;
 import javax.transaction.TransactionSynchronizationRegistry;
@@ -47,6 +43,10 @@ import org.junit.Test;
 
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.app.FATServlet;
+import jakarta.enterprise.concurrent.AbortedException;
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
+import jakarta.enterprise.concurrent.ManagedTask;
 
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = "/ConcurrentPolicyFATServlet")

--- a/dev/com.ibm.ws.concurrent_fat_policy/test-applications/concurrentpolicyfat/src/web/CountingTask.java
+++ b/dev/com.ibm.ws.concurrent_fat_policy/test-applications/concurrentpolicyfat/src/web/CountingTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,8 +17,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.enterprise.concurrent.ManagedTask;
-import javax.enterprise.concurrent.ManagedTaskListener;
+import jakarta.enterprise.concurrent.ManagedTask;
+import jakarta.enterprise.concurrent.ManagedTaskListener;
 
 class CountingTask implements Callable<Integer>, ManagedTask {
     final CountDownLatch beginLatch;

--- a/dev/com.ibm.ws.concurrent_fat_policy/test-applications/concurrentpolicyfat/src/web/TaskListener.java
+++ b/dev/com.ibm.ws.concurrent_fat_policy/test-applications/concurrentpolicyfat/src/web/TaskListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,9 +14,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import javax.enterprise.concurrent.ManagedExecutorService;
-import javax.enterprise.concurrent.ManagedTaskListener;
 import javax.naming.InitialContext;
+
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.enterprise.concurrent.ManagedTaskListener;
 
 /**
  * General purpose ManagedTaskListener, intended for one-time use, that records the parameters supplied to listener methods

--- a/dev/com.ibm.ws.context/src/com/ibm/ws/context/service/serializable/ThreadContextManager.java
+++ b/dev/com.ibm.ws.context/src/com/ibm/ws/context/service/serializable/ThreadContextManager.java
@@ -231,8 +231,7 @@ public class ThreadContextManager implements WSContextService {
     @Reference(service = JavaEEVersion.class,
                cardinality = ReferenceCardinality.OPTIONAL,
                policy = ReferencePolicy.STATIC,
-               policyOption = ReferencePolicyOption.GREEDY,
-               target = "(id=unbound)")
+               policyOption = ReferencePolicyOption.GREEDY)
     protected void setEEVersion(ServiceReference<JavaEEVersion> ref) {
         String version = (String) ref.getProperty("version");
         if (version == null) {

--- a/dev/com.ibm.ws.microprofile.health.2.0/src/com/ibm/ws/microprofile/health20/services/impl/HealthCheck20ExecutorImpl.java
+++ b/dev/com.ibm.ws.microprofile.health.2.0/src/com/ibm/ws/microprofile/health20/services/impl/HealthCheck20ExecutorImpl.java
@@ -125,8 +125,7 @@ public class HealthCheck20ExecutorImpl implements HealthCheck20Executor {
     @Reference(service = JavaEEVersion.class,
                cardinality = ReferenceCardinality.OPTIONAL,
                policy = ReferencePolicy.STATIC,
-               policyOption = ReferencePolicyOption.GREEDY,
-               target = "(id=unbound)")
+               policyOption = ReferencePolicyOption.GREEDY)
     protected void setEEVersion(ServiceReference<JavaEEVersion> ref) {
         String version = (String) ref.getProperty("version");
         if (version == null) {

--- a/dev/com.ibm.ws.microprofile.health/src/com/ibm/ws/microprofile/health/services/impl/HealthExecutorImpl.java
+++ b/dev/com.ibm.ws.microprofile.health/src/com/ibm/ws/microprofile/health/services/impl/HealthExecutorImpl.java
@@ -123,8 +123,7 @@ public class HealthExecutorImpl implements HealthExecutor {
     @Reference(service = JavaEEVersion.class,
                cardinality = ReferenceCardinality.OPTIONAL,
                policy = ReferencePolicy.STATIC,
-               policyOption = ReferencePolicyOption.GREEDY,
-               target = "(id=unbound)")
+               policyOption = ReferencePolicyOption.GREEDY)
     protected void setEEVersion(ServiceReference<JavaEEVersion> ref) {
         String version = (String) ref.getProperty("version");
         if (version == null) {


### PR DESCRIPTION
Make updates to the EE Concurrency impl to be mostly interchangeable with Jakarta/Java EE.  One part which is left out for now is actually enabling lookup as the Jakarta interfaces.