### PR TITLE
Social login: Minor fixes for SameSite cookies to work

### DIFF
--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/web/EndpointServices.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/web/EndpointServices.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -56,13 +56,8 @@ public class EndpointServices {
 
     static ConcurrentServiceReferenceMap<String, SocialLoginConfig> socialLoginConfigRef = null;
     static AtomicServiceReference<SecurityService> securityServiceRef = null;
-    static transient ReferrerURLCookieHandler referrerURLCookieHandler = null;
 
     SocialWebUtils webUtils = new SocialWebUtils();
-
-    public static void setReferrerURLCookieHandler(ReferrerURLCookieHandler referrerURLCookieHandler) {
-        EndpointServices.referrerURLCookieHandler = referrerURLCookieHandler;
-    }
 
     public static void setActivatedSocialLoginConfigRef(ConcurrentServiceReferenceMap<String, SocialLoginConfig> socialLoginConfigRef) {
         EndpointServices.socialLoginConfigRef = socialLoginConfigRef;
@@ -354,11 +349,13 @@ public class EndpointServices {
             }
             return;
         }
-        if (referrerURLCookieHandler == null) {
-            referrerURLCookieHandler = WebAppSecurityCollaboratorImpl.getGlobalWebAppSecurityConfig().createReferrerURLCookieHandler();
-        }
+        ReferrerURLCookieHandler referrerURLCookieHandler = getReferrerUrlCookieHandler();
         Cookie c = referrerURLCookieHandler.createCookie(cookieName, value, req);
         resp.addCookie(c);
+    }
+
+    ReferrerURLCookieHandler getReferrerUrlCookieHandler() {
+        return WebAppSecurityCollaboratorImpl.getGlobalWebAppSecurityConfig().createReferrerURLCookieHandler();
     }
 
     protected void cacheSensitiveValueInCookie(HttpServletRequest req, HttpServletResponse resp, String cookieName, @Sensitive String value) {
@@ -368,9 +365,7 @@ public class EndpointServices {
             }
             return;
         }
-        if (referrerURLCookieHandler == null) {
-            referrerURLCookieHandler = WebAppSecurityCollaboratorImpl.getGlobalWebAppSecurityConfig().createReferrerURLCookieHandler();
-        }
+        ReferrerURLCookieHandler referrerURLCookieHandler = getReferrerUrlCookieHandler();
         Cookie c = referrerURLCookieHandler.createCookie(cookieName, value, req);
         resp.addCookie(c);
     }

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/web/EndpointServlet.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/web/EndpointServlet.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.social.web;
 
@@ -39,7 +39,6 @@ public class EndpointServlet extends HttpServlet {
     private transient ServletContext servletContext = null;
     private transient BundleContext bundleContext = null;
     private transient ServiceReference<EndpointServices> endpointServicesRef = null;
-    private transient ReferrerURLCookieHandler referrerURLCookieHandler = null;
 
     private static final long serialVersionUID = 1L;
 
@@ -52,8 +51,6 @@ public class EndpointServlet extends HttpServlet {
         servletContext = getServletContext();
         bundleContext = (BundleContext) servletContext.getAttribute("osgi-bundlecontext");
         endpointServicesRef = bundleContext.getServiceReference(EndpointServices.class);
-        referrerURLCookieHandler = WebAppSecurityCollaboratorImpl.getGlobalWebAppSecurityConfig().createReferrerURLCookieHandler();
-        EndpointServices.setReferrerURLCookieHandler(referrerURLCookieHandler);
 
         if (tc.isDebugEnabled()) {
             Tr.debug(tc, "init:" + servletContext + "   " + bundleContext + "  " + endpointServicesRef);

--- a/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/web/EndpointServicesTest.java
+++ b/dev/com.ibm.ws.security.social/test/com/ibm/ws/security/social/web/EndpointServicesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corporation and others.
+ * Copyright (c) 2016, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -146,7 +146,6 @@ public class EndpointServicesTest extends CommonTestClass {
                 will(returnValue(referrerURLCookieHandler));
             }
         });
-        EndpointServices.setReferrerURLCookieHandler(referrerURLCookieHandler);
         EndpointServices.setActivatedSocialLoginConfigRef(socialLoginConfigRef);
         EndpointServices.setActivatedSecurityServiceRef(securityServiceRef);
     }


### PR DESCRIPTION
Ensures that the `ReferrerURLCookieHandler` object being used by the social login code is using the most up to date web application security configuration. Previously a `ReferrerURLCookieHandler` object had been getting instantiated but then never updated even if the web app security configuration changed. That led to no longer valid values being used to create cookies by the social login code.

Fixes #11682