### PR TITLE
Append interface to simple-binding-name for beans with multiple interfaces

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/NoInterfaceBindingsTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/NoInterfaceBindingsTest.java
@@ -50,13 +50,13 @@ public class NoInterfaceBindingsTest extends FATServletClient {
         JavaArchive NoInterfaceBndBean = ShrinkHelper.buildJavaArchive("NoInterfaceBndBean.jar", "com.ibm.ws.ejbcontainer.bindings.noInterface.bnd.ejb.");
         ShrinkHelper.addDirectory(NoInterfaceBndBean, "test-applications/NoInterfaceBndBean.jar/resources");
 
-        JavaArchive NoInterfaceBndCompBean = ShrinkHelper.buildJavaArchive("NoInterfaceBndCompBean.jar", "no.packages.to.add.");
+        JavaArchive NoInterfaceBndCompBean = ShrinkHelper.buildJavaArchive("NoInterfaceBndCompBean.jar", "com.ibm.ws.ejbcontainer.bindings.noInterface.bnd.ejb.");
         ShrinkHelper.addDirectory(NoInterfaceBndCompBean, "test-applications/NoInterfaceBndCompBean.jar/resources");
 
-        JavaArchive NoInterfaceBndCustomBean = ShrinkHelper.buildJavaArchive("NoInterfaceBndCustomBean.jar", "no.packages.to.add.");
+        JavaArchive NoInterfaceBndCustomBean = ShrinkHelper.buildJavaArchive("NoInterfaceBndCustomBean.jar", "com.ibm.ws.ejbcontainer.bindings.noInterface.bnd.ejb.");
         ShrinkHelper.addDirectory(NoInterfaceBndCustomBean, "test-applications/NoInterfaceBndCustomBean.jar/resources");
 
-        JavaArchive NoInterfaceBndSimpleBean = ShrinkHelper.buildJavaArchive("NoInterfaceBndSimpleBean.jar", "no.packages.to.add.");
+        JavaArchive NoInterfaceBndSimpleBean = ShrinkHelper.buildJavaArchive("NoInterfaceBndSimpleBean.jar", "com.ibm.ws.ejbcontainer.bindings.noInterface.bnd.ejb.");
         ShrinkHelper.addDirectory(NoInterfaceBndSimpleBean, "test-applications/NoInterfaceBndSimpleBean.jar/resources");
 
         WebArchive NoInterfaceBndWeb = ShrinkHelper.buildDefaultApp("NoInterfaceBndWeb.war", "com.ibm.ws.ejbcontainer.bindings.noInterface.bnd.web.");

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/NoInterfaceBndWeb.war/src/com/ibm/ws/ejbcontainer/bindings/noInterface/bnd/web/NoInterfaceBindingAbstractServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/NoInterfaceBndWeb.war/src/com/ibm/ws/ejbcontainer/bindings/noInterface/bnd/web/NoInterfaceBindingAbstractServlet.java
@@ -20,6 +20,8 @@ import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
+import org.junit.Test;
+
 // import com.ibm.websphere.ejbcontainer.AmbiguousEJBReferenceException;
 import com.ibm.ws.ejbcontainer.bindings.noInterface.bnd.ejb.ComplexNoInterfaceBean;
 import com.ibm.ws.ejbcontainer.bindings.noInterface.bnd.ejb.LocalBusiness;
@@ -312,7 +314,7 @@ public abstract class NoInterfaceBindingAbstractServlet extends FATServlet {
      * local interfaces, just the simple name is used. The No-Interface
      * view is considered a 'local' interface.
      **/
-    //@Test
+    @Test
     public void testNoInterfaceSimpleBindings() throws Exception {
         String beanNameLocal = beanName + "Local";
         String beanNameRemote = beanName + "Remote";

--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/ejbcontainer/runtime/NameSpaceBinder.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/ejbcontainer/runtime/NameSpaceBinder.java
@@ -197,8 +197,12 @@ public interface NameSpaceBinder<T> {
      * @param bindingObject - the EJBBinding
      * @param hr - the bean home record
      * @param local - if it is a local bean
+     * @param generateDisambiguatedSimpleBindingNames - A boolean, which when true
+     *            will cause any generated simple binding names to be
+     *            constructed to include "#<interfaceName>" at the end
+     *            of the binding name.
      */
-    void bindSimpleBindingName(T bindingObject, HomeRecord hr, boolean local);
+    void bindSimpleBindingName(T bindingObject, HomeRecord hr, boolean local, boolean generateDisambiguatedSimpleBindingNames);
 
     /**
      * Binds the localHomeBindingName custom binding

--- a/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/SystemNameSpaceBinderImpl.java
+++ b/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/SystemNameSpaceBinderImpl.java
@@ -117,7 +117,7 @@ public class SystemNameSpaceBinderImpl implements NameSpaceBinder<String> {
     public void unbindEJBLocal(List<String> names) throws NamingException {}
 
     @Override
-    public void bindSimpleBindingName(String bindingObject, HomeRecord hr, boolean local) {}
+    public void bindSimpleBindingName(String bindingObject, HomeRecord hr, boolean local, boolean generateDisambiguatedSimpleBindingNames) {}
 
     @Override
     public void bindLocalHomeBindingName(String bindingObject, HomeRecord hr) {}


### PR DESCRIPTION
#11584

It turns out when a bean has a simple-binding-name binding specified but has multiple interfaces, it will append the interface to the end of the simple-binding-name.

We already print this warning out:
`SIMPLE_BINDING_NAME_MISSUSED_CNTR0168W=CNTR0168W: The {0} enterprise bean in the {1} module within the {2} application is configured with a simple binding name, but has multiple local or remote interfaces.  The naming locations that are used to bind these interfaces will differ from the simple binding name that is specified.`
`SIMPLE_BINDING_NAME_MISSUSED_CNTR0168W.explanation=Because the enterprise bean has multiple interfaces, each binding name must be extended to make it unique.`
`SIMPLE_BINDING_NAME_MISSUSED_CNTR0168W.useraction=Complete one of the following actions: /n Look up the interfaces for this enterprise bean using the extended names. /n Change the configuration data for this bean to specify unique binding locations for each interface.`
