### PR TITLE
Issue #11735: When ACME fails to create a certificiate or keystore on…

### DIFF
--- a/dev/com.ibm.ws.crypto.certificate.creator.acme/src/com/ibm/ws/crypto/certificate/creator/acme/AcmeSSLCertificateCreator.java
+++ b/dev/com.ibm.ws.crypto.certificate.creator.acme/src/com/ibm/ws/crypto/certificate/creator/acme/AcmeSSLCertificateCreator.java
@@ -24,9 +24,9 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.crypto.certificateutil.DefaultSSLCertificateCreator;
-import com.ibm.ws.security.acme.AcmeCaException;
 import com.ibm.ws.security.acme.AcmeProvider;
 
 /**
@@ -36,41 +36,26 @@ import com.ibm.ws.security.acme.AcmeProvider;
 @Component(configurationPolicy = ConfigurationPolicy.IGNORE, property = { "service.vendor=IBM" })
 public class AcmeSSLCertificateCreator implements DefaultSSLCertificateCreator {
 
-    private final TraceComponent tc = Tr.register(AcmeSSLCertificateCreator.class);
+    private static final TraceComponent tc = Tr.register(AcmeSSLCertificateCreator.class);
 
     /** Reference to the AcmeProvider service. */
     private static final AtomicReference<AcmeProvider> acmeProviderRef = new AtomicReference<AcmeProvider>();
 
     @Override
-    public File createDefaultSSLCertificate(String filePath, String password, int validity, String subjectDN, int keySize, String sigAlg,
+    public File createDefaultSSLCertificate(String filePath, @Sensitive String password, String keyStoreType, String keyStoreProvider, int validity, String subjectDN, int keySize,
+                                            String sigAlg,
                                             List<String> extInfo) throws CertificateException {
-
-        String methodName = "createDefaultSSLCertificate(String,String,int,String,int,String,List<String>)";
-        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
-            Tr.entry(tc, methodName, filePath, "******", validity, subjectDN, keySize, sigAlg, extInfo);
-        }
-
-        File file = getAcmeProvider().createDefaultSSLCertificate(filePath, password);
-
-        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
-            Tr.exit(tc, methodName, file);
-        }
-        return file;
+        return getAcmeProvider().createDefaultSSLCertificate(filePath, password, keyStoreType, keyStoreProvider);
     }
 
     @Override
-    public void updateDefaultSSLCertificate(KeyStore keyStore, File keyStoreFile, String password) throws CertificateException {
-
-        String methodName = "updateDefaultSSLCertificate(KeyStore,File,String)";
-        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
-            Tr.entry(tc, methodName, keyStore, keyStoreFile, "******");
-        }
-
+    public void updateDefaultSSLCertificate(KeyStore keyStore, File keyStoreFile, @Sensitive String password) throws CertificateException {
         getAcmeProvider().updateDefaultSSLCertificate(keyStore, keyStoreFile, password);
+    }
 
-        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
-            Tr.exit(tc, methodName);
-        }
+    @Override
+    public String getType() {
+        return TYPE_ACME;
     }
 
     /**

--- a/dev/com.ibm.ws.crypto.certificateutil/src/com/ibm/ws/crypto/certificateutil/DefaultSSLCertificateCreator.java
+++ b/dev/com.ibm.ws.crypto.certificateutil/src/com/ibm/ws/crypto/certificateutil/DefaultSSLCertificateCreator.java
@@ -82,10 +82,22 @@ public interface DefaultSSLCertificateCreator {
     });
 
     /**
+     * Self-signed certificate creator type.
+     */
+    public static final String TYPE_SELF_SIGNED = "SELF-SIGNED";
+
+    /**
+     * ACME certificate creator type.
+     */
+    public static final String TYPE_ACME = "ACME";
+
+    /**
      * Creates a default SSL certificate.
      *
      * @param filePath The valid, complete path on the file system of the keystore to create. e.g. /tmp/key.p12
      * @param password Minimum 6 characters
+     * @param keyStoreType Keystore type
+     * @param keyStoreProvider Keystore provider
      * @param validity Minimum 365 days (?)
      * @param subjectDN The subjectDN. Use {@link DefaultSubjectDN} to construct the default value.
      * @param keySize The size of the certificate key. Default is 2048.
@@ -95,7 +107,7 @@ public interface DefaultSSLCertificateCreator {
      * @throws CertificateException if the certificate could not be created
      * @throws IllegalArgumentException if an argument violates the minimum required value or if the value is otherwise considered invalid
      */
-    File createDefaultSSLCertificate(String filePath, String password, int validity, String subjectDN, int keySize, String sigAlg,
+    File createDefaultSSLCertificate(String filePath, String password, String keyStoreType, String keyStoreProvider, int validity, String subjectDN, int keySize, String sigAlg,
                                      List<String> extInfo) throws CertificateException;
 
     /**
@@ -109,4 +121,10 @@ public interface DefaultSSLCertificateCreator {
      */
     void updateDefaultSSLCertificate(KeyStore keyStore, File keyStoreFile, String password) throws CertificateException;
 
+    /**
+     * Get the {@link DefaultSSLCertificateCreator} type.
+     *
+     * @return The type.
+     */
+    String getType();
 }

--- a/dev/com.ibm.ws.crypto.certificateutil/src/com/ibm/ws/crypto/certificateutil/keytool/KeytoolSSLCertificateCreator.java
+++ b/dev/com.ibm.ws.crypto.certificateutil/src/com/ibm/ws/crypto/certificateutil/keytool/KeytoolSSLCertificateCreator.java
@@ -27,25 +27,19 @@ public class KeytoolSSLCertificateCreator implements DefaultSSLCertificateCreato
 
     /** {@inheritDoc} */
     @Override
-    public File createDefaultSSLCertificate(String filePath, String password, int validity, String subjectDN, int keySize, String sigAlg,
+    public File createDefaultSSLCertificate(String filePath, String password, String keyStoreType, String keyStoreProvider, int validity, String subjectDN, int keySize,
+                                            String sigAlg,
                                             List<String> extInfo) throws CertificateException {
 
-        String setKeyStoreType = null;
         KeytoolCommand keytoolCmd = null;
 
         validateParameters(filePath, password, validity, subjectDN, keySize, sigAlg);
 
         String keyType = getKeyFromSigAlg(sigAlg);
 
-        if (filePath.lastIndexOf(".") != -1) {
-            setKeyStoreType = filePath.substring(filePath.lastIndexOf(".") + 1, filePath.length());
-        }
+        keyStoreType = (keyStoreType == null) ? DEFAULT_KEYSTORE_TYPE : keyStoreType;
 
-        if (!setKeyStoreType.equals("p12") && (!setKeyStoreType.equals(DEFAULT_KEYSTORE_TYPE))) {
-            keytoolCmd = new KeytoolCommand(filePath, password, validity, subjectDN, keySize, keyType, sigAlg, setKeyStoreType, extInfo);
-        } else {
-            keytoolCmd = new KeytoolCommand(filePath, password, validity, subjectDN, keySize, keyType, sigAlg, DEFAULT_KEYSTORE_TYPE, extInfo);
-        }
+        keytoolCmd = new KeytoolCommand(filePath, password, validity, subjectDN, keySize, keyType, sigAlg, keyStoreType, extInfo);
 
         keytoolCmd.executeCommand();
         File f = new File(filePath);
@@ -151,5 +145,10 @@ public class KeytoolSSLCertificateCreator implements DefaultSSLCertificateCreato
         /*
          * Will not be updating self-signed certificates at this time.
          */
+    }
+
+    @Override
+    public String getType() {
+        return TYPE_SELF_SIGNED;
     }
 }

--- a/dev/com.ibm.ws.crypto.certificateutil/test/com/ibm/ws/crypto/certificateutil/keytool/KeytoolSSLCertificateCreatorTest.java
+++ b/dev/com.ibm.ws.crypto.certificateutil/test/com/ibm/ws/crypto/certificateutil/keytool/KeytoolSSLCertificateCreatorTest.java
@@ -51,6 +51,8 @@ public class KeytoolSSLCertificateCreatorTest {
     @Test(expected = IllegalArgumentException.class)
     public void createKeytoolCommand_nullLocation() throws Exception {
         creator.createDefaultSSLCertificate(null, "Liberty",
+                                            DefaultSSLCertificateCreator.DEFAULT_KEYSTORE_TYPE,
+                                            null,
                                             DefaultSSLCertificateCreator.DEFAULT_VALIDITY,
                                             new DefaultSubjectDN().getSubjectDN(),
                                             DefaultSSLCertificateCreator.DEFAULT_SIZE,
@@ -64,6 +66,8 @@ public class KeytoolSSLCertificateCreatorTest {
     @Test(expected = IllegalArgumentException.class)
     public void createKeytoolCommand_emptyLocation() throws Exception {
         creator.createDefaultSSLCertificate("", "Liberty",
+                                            DefaultSSLCertificateCreator.DEFAULT_KEYSTORE_TYPE,
+                                            null,
                                             DefaultSSLCertificateCreator.DEFAULT_VALIDITY,
                                             new DefaultSubjectDN().getSubjectDN(),
                                             DefaultSSLCertificateCreator.DEFAULT_SIZE,
@@ -77,6 +81,8 @@ public class KeytoolSSLCertificateCreatorTest {
     @Test(expected = IllegalArgumentException.class)
     public void createKeytoolCommand_nullPassword() throws Exception {
         creator.createDefaultSSLCertificate("/", null,
+                                            DefaultSSLCertificateCreator.DEFAULT_KEYSTORE_TYPE,
+                                            null,
                                             DefaultSSLCertificateCreator.DEFAULT_VALIDITY,
                                             new DefaultSubjectDN().getSubjectDN(),
                                             DefaultSSLCertificateCreator.DEFAULT_SIZE,
@@ -90,6 +96,8 @@ public class KeytoolSSLCertificateCreatorTest {
     @Test(expected = IllegalArgumentException.class)
     public void createKeytoolCommand_emptyPassword() throws Exception {
         creator.createDefaultSSLCertificate("/", "",
+                                            DefaultSSLCertificateCreator.DEFAULT_KEYSTORE_TYPE,
+                                            null,
                                             DefaultSSLCertificateCreator.DEFAULT_VALIDITY,
                                             new DefaultSubjectDN().getSubjectDN(),
                                             DefaultSSLCertificateCreator.DEFAULT_SIZE,
@@ -103,6 +111,8 @@ public class KeytoolSSLCertificateCreatorTest {
     @Test(expected = IllegalArgumentException.class)
     public void createKeytoolCommand_passwordTooShort() throws Exception {
         creator.createDefaultSSLCertificate("/", "WebAS",
+                                            DefaultSSLCertificateCreator.DEFAULT_KEYSTORE_TYPE,
+                                            null,
                                             DefaultSSLCertificateCreator.DEFAULT_VALIDITY,
                                             new DefaultSubjectDN().getSubjectDN(),
                                             DefaultSSLCertificateCreator.DEFAULT_SIZE,
@@ -115,7 +125,10 @@ public class KeytoolSSLCertificateCreatorTest {
      */
     @Test(expected = IllegalArgumentException.class)
     public void createKeytoolCommand_negativeValidity() throws Exception {
-        creator.createDefaultSSLCertificate("/", null, -1,
+        creator.createDefaultSSLCertificate("/", null,
+                                            DefaultSSLCertificateCreator.DEFAULT_KEYSTORE_TYPE,
+                                            null,
+                                            -1,
                                             new DefaultSubjectDN().getSubjectDN(),
                                             DefaultSSLCertificateCreator.DEFAULT_SIZE,
                                             DefaultSSLCertificateCreator.KEYALG,
@@ -127,7 +140,10 @@ public class KeytoolSSLCertificateCreatorTest {
      */
     @Test(expected = IllegalArgumentException.class)
     public void createKeytoolCommand_zeroValidity() throws Exception {
-        creator.createDefaultSSLCertificate("/", "Liberty", 0,
+        creator.createDefaultSSLCertificate("/", "Liberty",
+                                            DefaultSSLCertificateCreator.DEFAULT_KEYSTORE_TYPE,
+                                            null,
+                                            0,
                                             new DefaultSubjectDN().getSubjectDN(),
                                             DefaultSSLCertificateCreator.DEFAULT_SIZE,
                                             DefaultSSLCertificateCreator.KEYALG,
@@ -140,6 +156,8 @@ public class KeytoolSSLCertificateCreatorTest {
     @Test(expected = IllegalArgumentException.class)
     public void createKeytoolCommand_belowMinimumValidity() throws Exception {
         creator.createDefaultSSLCertificate("/", "Liberty",
+                                            DefaultSSLCertificateCreator.DEFAULT_KEYSTORE_TYPE,
+                                            null,
                                             DefaultSSLCertificateCreator.MINIMUM_VALIDITY - 1,
                                             new DefaultSubjectDN().getSubjectDN(),
                                             DefaultSSLCertificateCreator.DEFAULT_SIZE,
@@ -153,6 +171,8 @@ public class KeytoolSSLCertificateCreatorTest {
     @Test(expected = IllegalArgumentException.class)
     public void createKeytoolCommand_nullSubjectDN() throws Exception {
         File ks = creator.createDefaultSSLCertificate(location, "Liberty",
+                                                      DefaultSSLCertificateCreator.DEFAULT_KEYSTORE_TYPE,
+                                                      null,
                                                       DefaultSSLCertificateCreator.DEFAULT_VALIDITY,
                                                       null,
                                                       DefaultSSLCertificateCreator.DEFAULT_SIZE,
@@ -168,6 +188,8 @@ public class KeytoolSSLCertificateCreatorTest {
     @Test(expected = IllegalArgumentException.class)
     public void createKeytoolCommand_emptySubjectDN() throws Exception {
         File ks = creator.createDefaultSSLCertificate(location, "Liberty",
+                                                      DefaultSSLCertificateCreator.DEFAULT_KEYSTORE_TYPE,
+                                                      null,
                                                       DefaultSSLCertificateCreator.DEFAULT_VALIDITY,
                                                       "",
                                                       DefaultSSLCertificateCreator.DEFAULT_SIZE,
@@ -183,6 +205,8 @@ public class KeytoolSSLCertificateCreatorTest {
     @Test(expected = IllegalArgumentException.class)
     public void createKeytoolCommand_invalidDN() throws Exception {
         creator.createDefaultSSLCertificate("/", "Liberty",
+                                            DefaultSSLCertificateCreator.DEFAULT_KEYSTORE_TYPE,
+                                            null,
                                             DefaultSSLCertificateCreator.DEFAULT_VALIDITY,
                                             "invalidDN",
                                             DefaultSSLCertificateCreator.DEFAULT_SIZE,
@@ -196,6 +220,8 @@ public class KeytoolSSLCertificateCreatorTest {
     @Test(expected = IllegalArgumentException.class)
     public void createKeytoolCommand_invalidSigAlg() throws Exception {
         creator.createDefaultSSLCertificate("/", "Liberty",
+                                            DefaultSSLCertificateCreator.DEFAULT_KEYSTORE_TYPE,
+                                            null,
                                             DefaultSSLCertificateCreator.DEFAULT_VALIDITY,
                                             null,
                                             DefaultSSLCertificateCreator.DEFAULT_SIZE,
@@ -209,6 +235,8 @@ public class KeytoolSSLCertificateCreatorTest {
     @Test(expected = IllegalArgumentException.class)
     public void createKeytoolCommand_SigAlgWrongSize() throws Exception {
         creator.createDefaultSSLCertificate("/", "Liberty",
+                                            DefaultSSLCertificateCreator.DEFAULT_KEYSTORE_TYPE,
+                                            null,
                                             DefaultSSLCertificateCreator.DEFAULT_VALIDITY,
                                             null,
                                             DefaultSSLCertificateCreator.DEFAULT_SIZE,
@@ -222,6 +250,8 @@ public class KeytoolSSLCertificateCreatorTest {
     @Test
     public void createKeytoolCommand_defaultValidity() throws Exception {
         File ks = creator.createDefaultSSLCertificate(location, "Liberty",
+                                                      DefaultSSLCertificateCreator.DEFAULT_KEYSTORE_TYPE,
+                                                      null,
                                                       DefaultSSLCertificateCreator.DEFAULT_VALIDITY,
                                                       "CN=localhost",
                                                       DefaultSSLCertificateCreator.DEFAULT_SIZE,
@@ -237,6 +267,8 @@ public class KeytoolSSLCertificateCreatorTest {
     @Test(expected = CertificateException.class)
     public void createKeytoolCommand_doubleCallTriggersException() throws Exception {
         File ks = creator.createDefaultSSLCertificate(location, "Liberty",
+                                                      DefaultSSLCertificateCreator.DEFAULT_KEYSTORE_TYPE,
+                                                      null,
                                                       DefaultSSLCertificateCreator.DEFAULT_VALIDITY,
                                                       "CN=localhost",
                                                       DefaultSSLCertificateCreator.DEFAULT_SIZE,
@@ -245,6 +277,8 @@ public class KeytoolSSLCertificateCreatorTest {
         assertNotNull("keystore was not created", ks);
         assertTrue("keystore was not created", ks.exists());
         creator.createDefaultSSLCertificate(location, "Liberty",
+                                            DefaultSSLCertificateCreator.DEFAULT_KEYSTORE_TYPE,
+                                            null,
                                             DefaultSSLCertificateCreator.DEFAULT_VALIDITY,
                                             "CN=localhost",
                                             DefaultSSLCertificateCreator.DEFAULT_SIZE,

--- a/dev/com.ibm.ws.security.acme/resources/com/ibm/ws/security/acme/resources/AcmeMessages.nlsprops
+++ b/dev/com.ibm.ws.security.acme/resources/com/ibm/ws/security/acme/resources/AcmeMessages.nlsprops
@@ -154,9 +154,9 @@ CWPKI2032E=CWPKI2032E: The certificate subject alternative names in the default 
 CWPKI2032E.explanation=The certificate is an invalid DER-encoded certificate or contains unsupported DER features.
 CWPKI2032E.useraction=Review the error message for details on the failure. Revoke or remove the invalid certificate.
 
-CWPKI2033E=CWPKI2033E: The ACME service could not find the certificate for the {0} alias in the {1} keystore. The error is ''{2}''.
-CWPKI2033E.explanation=A certificate authority signed certificate is stored in the default keystore and replaces any existing default certificate, but keystore or default certificate could not be accessed.
-CWPKI2033E.useraction=Review the error message for details on the failure.
+#CWPKI2033E=CWPKI2033E: The ACME service could not find the certificate for the {0} alias in the {1} keystore. The error is ''{2}''.
+#CWPKI2033E.explanation=A certificate authority signed certificate is stored in the default keystore and replaces any existing default certificate, but keystore or default certificate could not be accessed.
+#CWPKI2033E.useraction=Review the error message for details on the failure.
 
 CWPKI2034E=CWPKI2034E: The ACME service could not create a keystore instance. The error is ''{0}''.
 CWPKI2034E.explanation=The ACME service fetched a new certificate, but creating or initializing a keystore for storing the certificate failed.

--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/AcmeProvider.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/AcmeProvider.java
@@ -32,10 +32,15 @@ public interface AcmeProvider {
 	 *            The path to generate the new keystore.
 	 * @param password
 	 *            The password for the generated keystore and certificate.
+	 * @param keyStoreType
+	 *            The keystore type.
+	 * @param keyStoreProvider
+	 *            the keystore provider.
 	 * @see DefaultSSLCertificateCreator#createDefaultSSLCertificate(String,
 	 *      String, int, String, int, String, List)
 	 */
-	public File createDefaultSSLCertificate(String filePath, String password) throws CertificateException;
+	public File createDefaultSSLCertificate(String filePath, String password, String keyStoreType,
+			String keyStoreProvider) throws CertificateException;
 
 	/**
 	 * Get the HTTP-01 challenge authorization for the specified challenge

--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeClient.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeClient.java
@@ -688,6 +688,10 @@ public class AcmeClient {
 	@FFDCIgnore(AcmeException.class)
 	public void revoke(X509Certificate certificate) throws AcmeCaException {
 
+		if (certificate == null) {
+			return;
+		}
+
 		/*
 		 * Load the account key file.
 		 */
@@ -712,7 +716,7 @@ public class AcmeClient {
 			 */
 			Login login = new Login(acct.getLocation(), accountKeyPair, session);
 			try {
-				Certificate.revoke(login, certificate, RevocationReason.UNSPECIFIED);
+				Certificate.revoke(login, certificate, RevocationReason.SUPERSEDED);
 			} catch (AcmeException e) {
 				throw new AcmeCaException(Tr.formatMessage(tc, "CWPKI2024E", acmeConfig.getDirectoryURI(),
 						certificate.getSerialNumber().toString(16), e.getMessage()), e);

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
@@ -399,19 +399,20 @@ public class AcmeFatUtils {
 	 * @param server
 	 *            The server to check.
 	 */
-	public static final void waitForAcmeToCreateCertificate(LibertyServer server) {
+	public static final void waitForSSLToCreateKeystore(LibertyServer server) {
 		assertNotNull("ACME did not create a new certificate.",
 				server.waitForStringInLog("CWPKI0803A: SSL certificate created"));
 	}
 
 	/**
-	 * Wait for the ACME service to report that the certificate has been
-	 * replaced.
+	 * Wait for the ACME service to report that a new certificate has been
+	 * created.
 	 * 
 	 * @param server
+	 *            The server to check.
 	 */
-	public static final void waitForAcmeToReplaceCertificate(LibertyServer server) {
-		assertNotNull("ACME did not replace the certificate.", server.waitForStringInLog("CWPKI2007I"));
+	public static final void waitForAcmeToCreateCertificate(LibertyServer server) {
+		assertNotNull("ACME did not create the certificate.", server.waitForStringInLog("CWPKI2007I"));
 	}
 
 	/**
@@ -490,7 +491,7 @@ public class AcmeFatUtils {
 		 * Generate the new keystore with the self-signed certificate.
 		 */
 		KeytoolSSLCertificateCreator creator = new KeytoolSSLCertificateCreator();
-		certFile = creator.createDefaultSSLCertificate(filePath, SELF_SIGNED_KEYSTORE_PASSWORD,
+		certFile = creator.createDefaultSSLCertificate(filePath, SELF_SIGNED_KEYSTORE_PASSWORD, "PKCS12", null,
 				DefaultSSLCertificateCreator.DEFAULT_VALIDITY, "cn=localhost",
 				DefaultSSLCertificateCreator.DEFAULT_SIZE, DefaultSSLCertificateCreator.SIGALG, null);
 

--- a/dev/com.ibm.ws.security.utility/src/com/ibm/ws/security/utility/tasks/CreateSSLCertificateTask.java
+++ b/dev/com.ibm.ws.security.utility/src/com/ibm/ws/security/utility/tasks/CreateSSLCertificateTask.java
@@ -188,7 +188,7 @@ public class CreateSSLCertificateTask extends BaseCommandTask {
             String key = getArgumentValue(ARG_KEY, args, null);
             stdout.println(getMessage("sslCert.createKeyStore", location));
             String encodedPassword = PasswordUtil.encode(password, encoding, key);
-            creator.createDefaultSSLCertificate(location, password, validity, subjectDN, keySize, sigAlg, extInfo);
+            creator.createDefaultSSLCertificate(location, password, keyType, null, validity, subjectDN, keySize, sigAlg, extInfo);
             String xmlSnippet = null;
             if (serverName != null) {
                 stdout.println(getMessage("sslCert.serverXML", serverName, subjectDN));

--- a/dev/com.ibm.ws.security.utility/test/com/ibm/ws/security/utility/tasks/CreateSSLCertificateTaskTest.java
+++ b/dev/com.ibm.ws.security.utility/test/com/ibm/ws/security/utility/tasks/CreateSSLCertificateTaskTest.java
@@ -419,6 +419,8 @@ public class CreateSSLCertificateTaskTest {
                 will(returnValue(true));
                 one(creator).createDefaultSSLCertificate(EXPECTED_KEYSTORE_PATH,
                                                          PLAINTEXT,
+                                                         "PKCS12",
+                                                         null,
                                                          DefaultSSLCertificateCreator.DEFAULT_VALIDITY,
                                                          new DefaultSubjectDN(null, SERVER_NAME).getSubjectDN(),
                                                          DefaultSSLCertificateCreator.DEFAULT_SIZE,
@@ -454,6 +456,8 @@ public class CreateSSLCertificateTaskTest {
                 will(returnValue(true));
                 one(creator).createDefaultSSLCertificate(EXPECTED_CLIENT_KEYSTORE_PATH,
                                                          PLAINTEXT,
+                                                         "PKCS12",
+                                                         null,
                                                          DefaultSSLCertificateCreator.DEFAULT_VALIDITY,
                                                          new DefaultSubjectDN(null, CLIENT_NAME).getSubjectDN(),
                                                          DefaultSSLCertificateCreator.DEFAULT_SIZE,
@@ -525,6 +529,8 @@ public class CreateSSLCertificateTaskTest {
 
                 one(creator).createDefaultSSLCertificate(EXPECTED_KEYSTORE_PATH,
                                                          PLAINTEXT,
+                                                         "PKCS12",
+                                                         null,
                                                          DefaultSSLCertificateCreator.DEFAULT_VALIDITY,
                                                          new DefaultSubjectDN(null, SERVER_NAME).getSubjectDN(),
                                                          DefaultSSLCertificateCreator.DEFAULT_SIZE,
@@ -561,6 +567,8 @@ public class CreateSSLCertificateTaskTest {
                 will(returnValue(true));
                 one(creator).createDefaultSSLCertificate(EXPECTED_KEYSTORE_PATH,
                                                          PLAINTEXT,
+                                                         "PKCS12",
+                                                         null,
                                                          Integer.valueOf(VALIDITY),
                                                          new DefaultSubjectDN(null, SERVER_NAME).getSubjectDN(),
                                                          DefaultSSLCertificateCreator.DEFAULT_SIZE,
@@ -597,6 +605,8 @@ public class CreateSSLCertificateTaskTest {
                 will(returnValue(true));
                 one(creator).createDefaultSSLCertificate(EXPECTED_KEYSTORE_PATH,
                                                          PLAINTEXT,
+                                                         "PKCS12",
+                                                         null,
                                                          DefaultSSLCertificateCreator.DEFAULT_VALIDITY,
                                                          SUBJECT_DN,
                                                          DefaultSSLCertificateCreator.DEFAULT_SIZE,
@@ -633,6 +643,8 @@ public class CreateSSLCertificateTaskTest {
                 will(returnValue(true));
                 one(creator).createDefaultSSLCertificate(EXPECTED_KEYSTORE_PATH,
                                                          PLAINTEXT,
+                                                         "PKCS12",
+                                                         null,
                                                          DefaultSSLCertificateCreator.DEFAULT_VALIDITY,
                                                          LONG_SUBJECT_DN,
                                                          DefaultSSLCertificateCreator.DEFAULT_SIZE,
@@ -670,6 +682,8 @@ public class CreateSSLCertificateTaskTest {
                 will(returnValue(true));
                 one(creator).createDefaultSSLCertificate(EXPECTED_KEYSTORE_PATH,
                                                          PLAINTEXT,
+                                                         "PKCS12",
+                                                         null,
                                                          Integer.valueOf(VALIDITY),
                                                          SUBJECT_DN,
                                                          DefaultSSLCertificateCreator.DEFAULT_SIZE,
@@ -707,6 +721,8 @@ public class CreateSSLCertificateTaskTest {
                 will(returnValue(true));
                 one(creator).createDefaultSSLCertificate(EXPECTED_KEYSTORE_PATH,
                                                          PLAINTEXT,
+                                                         "PKCS12",
+                                                         null,
                                                          Integer.valueOf(VALIDITY),
                                                          SUBJECT_DN,
                                                          DefaultSSLCertificateCreator.DEFAULT_SIZE,
@@ -749,6 +765,8 @@ public class CreateSSLCertificateTaskTest {
                 will(returnValue(true));
                 one(creator).createDefaultSSLCertificate(EXPECTED_KEYSTORE_PATH,
                                                          PLAINTEXT,
+                                                         "PKCS12",
+                                                         null,
                                                          Integer.valueOf(VALIDITY),
                                                          SUBJECT_DN,
                                                          DefaultSSLCertificateCreator.DEFAULT_SIZE,
@@ -880,6 +898,8 @@ public class CreateSSLCertificateTaskTest {
                 will(returnValue(true));
                 one(creator).createDefaultSSLCertificate(EXPECTED_KEYSTORE_PATH,
                                                          PLAINTEXT,
+                                                         "PKCS12",
+                                                         null,
                                                          Integer.valueOf(VALIDITY),
                                                          SUBJECT_DN,
                                                          DefaultSSLCertificateCreator.DEFAULT_SIZE,

--- a/dev/com.ibm.ws.ssl/resources/com/ibm/ws/ssl/resources/ssl.nlsprops
+++ b/dev/com.ibm.ws.ssl/resources/com/ibm/ws/ssl/resources/ssl.nlsprops
@@ -549,9 +549,13 @@ ssl.create.certificate.end=CWPKI0803A: SSL certificate created in {0} seconds. S
 ssl.create.certificate.end.explanation=The SSL certificate was generated in the amount of time specified.
 ssl.create.certificate.end.useraction=No action is required.
 #--------------------------------------------------------------------------------------------------
-ssl.create.certificate.error=CWPKI0804E: SSL certificate creation error. Unable to create SSL key file: {0}
+ssl.create.certificate.error=CWPKI0804E: SSL certificate creation error. {0}
 ssl.create.certificate.error.explanation=The SSL certificate could not be created at the specified location.
 ssl.create.certificate.error.useraction=Ensure the location is accessible by the server process. Any FFDCs may indicate a fatal error in generating or loading the keys.
+
+# Messages for the CWPKI0804E message descriptor {0}.
+ssl.create.certificate.error.reason1=Unable to create SSL key file: {0}
+ssl.create.certificate.error.reason2=The error is: {0}
 #--------------------------------------------------------------------------------------------------
 ssl.default.keystore.config.error=CWPKI0805E: A password is required for the default keystore is missing.
 ssl.default.keystore.config.error.explanation=The keystore configuration does not specify a password for the default keystore.


### PR DESCRIPTION
… initial startup due to configuration, ACME should generate the certificate upon updating the configuration to a valid state.

fixes #11735, fixes #11733