### PR TITLE
Issue 11185: Add renewal request time configuration

### DIFF
--- a/dev/com.ibm.ws.security.acme/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.acme/resources/OSGI-INF/l10n/metatype.properties
@@ -63,3 +63,6 @@ trustStorePassword.desc=The password that is used to load the truststore file. T
 
 trustStoreType=Truststore type
 trustStoreType.desc=The keystore type for the truststore. Supported types are JKS, PKCS12 and JCEKS.
+
+renewBeforeExpiration=Renew time before expiration
+renewBeforeExpiration.desc=The amount of time before the expiration date of the certificate to request a new certificate. If the first request fails, the certificate renewal request continues until a new certificate is received. For example, if the renewBeforeExpiration property is set to seven days, the ACME service starts requesting a new certificate seven days before the expiration date of the current certificate. Setting the renewBeforeExpiration property to zero or a negative value disables automatic certificate renewal.

--- a/dev/com.ibm.ws.security.acme/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.acme/resources/OSGI-INF/metatype/metatype.xml
@@ -41,6 +41,9 @@
 
   <!-- Transport configuration. -->
   <AD id="acmeTransportConfig"  name="internal" description="internal use only" type="String"  required="false" ibm:flat="true" ibm:type="pid" ibm:reference="com.ibm.ws.security.acme.transport" />
+  
+  <!-- Renewal configuration options -->
+  <AD id="renewBeforeExpiration"     name="internal" description="internal use only" type="String" required="false" ibm:type="duration" default="7d" />
 
  </OCD>
   

--- a/dev/com.ibm.ws.security.acme/resources/com/ibm/ws/security/acme/resources/AcmeMessages.nlsprops
+++ b/dev/com.ibm.ws.security.acme/resources/com/ibm/ws/security/acme/resources/AcmeMessages.nlsprops
@@ -202,7 +202,6 @@ CWPKI2044E=CWPKI2044E: The certificate is not an X.509 certificate. The certific
 CWPKI2044E.explanation=The ACME service expects all certificates in the certificate chain to be X.509 certificates.
 CWPKI2044E.useraction=Ensure that all the certificates in the certificate chain are X.509 certificates and try again.
 
-# {2} is a time stamp
 CWPKI2045W=CWPKI2045W: The certificate with {0} serial number that is signed by the ACME certificate authority at the {1} URI is not valid until {2}.
 CWPKI2045W.explanation=The valid period on the certificate is in the future. SSL/TLS requests fail until the current date and time are within the range that is specified by the valid period on the certificate.
 CWPKI2045W.useraction=Update the local time on the server if the time is incorrect.
@@ -226,3 +225,28 @@ CWPKI2049E.useraction=Manually replace the account key pair files as directed in
 CWPKI2050E=CWPKI2050E: Failed to back up the existing account key pair file while refreshing the account key pair. The error is ''{0}''.
 CWPKI2050E.explanation=The existing account key pair file was not be backed up. 
 CWPKI2050E.useraction=Ensure that the directory that contains the existing account key pair file is writable. Review the error message for details on the failure.
+
+CWPKI2051W=CWPKI2051W: The renewBeforeExpiration property was set to {0} which is shorter than the minimum renew time. The renewBeforeExpiration property is reset to {1}.
+CWPKI2051W.explanation=The value for the renewBeforeExpiration property was below the minimum duration to request a new certificate and is reset to the minimum renew time. This could have a negative impact on server performance.
+CWPKI2051W.useraction=To avoid this warning message, set the renewBeforeExpiration property in the server configuration to a duration that is longer than the minimum renew time. To use the default setting, remove the renewBeforeExpiration property from the server configuration.
+
+CWPKI2052I=CWPKI2052I: The certificate with {0} serial number expires on {1}. The ACME service will request a new certificate from the ACME certificate authority at the {2} URI.
+CWPKI2052I.explanation=The ACME service requests a new certificate based on the renewBeforeExpiration property in the server configuration and the expiration date of the certificate. If the renewBeforeExpiration property is not configured, the default value is used.
+CWPKI2052I.useraction=No action is required.
+
+CWPKI2053W=CWPKI2053W: The certificate with {0} serial number expired on {1}. The ACME service is not configured to automatically request a new certificate.
+CWPKI2053W.explanation=The TLS/SSL requests cannot complete because the certificate expired.
+CWPKI2053W.useraction=Update the renewBeforeExpiration property in the server configuration to a value greater than 0 to automatically request a new certificate or use the ACME REST interface to request a new certificate.
+
+CWPKI2054W=CWPKI2054W: The renewBeforeExpiration property was set to {0}, which is equal to or longer than the validity period of the certificate with {1} serial number. The validity period of the certificate is {2}. The renewBeforeExpiration property is reset to {3}.
+CWPKI2054W.explanation=The value of the renewBeforeExpiration property was longer than the validity period of the certificate. The renewBeforeExpiration property is reset to the default value.
+CWPKI2054W.useraction=To avoid this warning message, set the renewBeforeExpiration property in the server configuration to an amount that is less than the length of the validity period of the certificate. To use the default setting, remove the renewBeforeExpiration property.
+
+CWPKI2055W=CWPKI2055W: The renewBeforeExpiration property is set to a short amount of time. The ACME service makes frequent requests for a new certificate. The renewBeforeExpiration property is {0}.
+CWPKI2055W.explanation=Frequent certificate requests can have a negative impact on server performance. The number of requests can also exceed the number allowed by the certificate authority.
+CWPKI2055W.useraction=To avoid this warning message, set the renewBeforeExpiration property in the server configuration to a longer duration. To use the default setting, remove the renewBeforeExpiration property from the server configuration.
+
+CWPKI2056W=CWPKI2056W: The validity period of the certificate with {0} serial number is shorter than the {1} minimum renew time. The validity period of the certification is {2}. The renewBeforeExpiration property is reset to {3}.
+CWPKI2056W.explanation=The validity period is shorter than the minimum renew time. The certificate expires before a new certificate is requested.
+CWPKI2056W.useraction=To avoid certificate expiration, request a certificate with a longer validity period. If the certificate authority supports a custom validity period, set the validFor property in the server configuration.
+

--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/util/AcmeConstants.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/util/AcmeConstants.java
@@ -11,6 +11,8 @@
 
 package com.ibm.ws.security.acme.internal.util;
 
+import java.util.concurrent.TimeUnit;
+
 public class AcmeConstants {
 
 	public static final String ACME_CONFIG_PID = "com.ibm.ws.security.acme.config";
@@ -41,6 +43,9 @@ public class AcmeConstants {
 	public static final String TRANSPORT_TRUST_STORE = "trustStore";
 	public static final String TRANSPORT_TRUST_STORE_PASSWORD = "trustStorePassword";
 	public static final String TRANSPORT_TRUST_STORE_TYPE = "trustStoreType";
+	
+	// Renewal configuration options
+	public static final String RENEW_BEFORE_EXPIRATION = "renewBeforeExpiration";
 
 	/*
 	 * End constants that match the metatype fields
@@ -57,4 +62,11 @@ public class AcmeConstants {
 
 	public static final String ACCOUNT_TYPE = "account";
 	public static final String DOMAIN_TYPE = "domain";
+	
+	public static final long RENEW_CERT_MIN = 15000L; // Minimum allowed time to check for expiration
+	public static final Long RENEW_CERT_MIN_WARN_LEVEL = 60000L; // The renew time that we'll put out a warning that you've picked a very low renew time
+	public static final int RENEW_DEFAULT_DAYS = 7;
+	public static final Long RENEW_DEFAULT_MS = TimeUnit.DAYS.toMillis(RENEW_DEFAULT_DAYS);  // 604800000L; 
+	public static final double RENEW_DIVISOR = .5;
+
 }

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeValidityAndRenewTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeValidityAndRenewTest.java
@@ -1,0 +1,360 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.acme.fat;
+
+import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.security.acme.docker.CAContainer;
+import com.ibm.ws.security.acme.internal.util.AcmeConstants;
+import com.ibm.ws.security.acme.utils.AcmeFatUtils;
+
+import componenttest.annotation.CheckForLeakedPasswords;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * Verify that we log the correct warnings for different
+ * validity/renewBeforeExpiration settings
+ */
+@RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
+public class AcmeValidityAndRenewTest {
+
+	@Server("com.ibm.ws.security.acme.fat.simple")
+	public static LibertyServer server;
+
+	private static ServerConfiguration ORIGINAL_CONFIG;
+	private static final String[] DOMAINS1 = { "domain1.com" };
+
+	public static CAContainer caContainer;
+
+	public static final long timeBufferToExpire = 30000L; // milliseconds
+
+	@BeforeClass
+	public static void beforeClass() throws Exception {
+		ORIGINAL_CONFIG = server.getServerConfiguration();
+		caContainer = new com.ibm.ws.security.acme.docker.pebble.PebbleContainer();
+		AcmeFatUtils.checkPortOpen(caContainer.getHttpPort(), 60000);
+	}
+
+	@AfterClass
+	public static void afterClass() throws Exception {
+		if (caContainer != null) {
+			caContainer.stop();
+		}
+	}
+
+	@After
+	public void afterTest() {
+		/*
+		 * Cleanup any generated ACME files.
+		 */
+		AcmeFatUtils.deleteAcmeFiles(server);
+
+	}
+
+	/**
+	 * The server will start with a renewBeforeExpiration set lower than the lowest minimum
+	 * renew time allowed. The renewBeforeExpiration is reset to the minimum renew time.
+	 * 
+	 * @throws Exception If the test failed for some reason.
+	 */
+	@Test
+	@CheckForLeakedPasswords(AcmeFatUtils.PEBBLE_TRUSTSTORE_PASSWORD)
+	public void serverBelowMinRenew() throws Exception {
+		final String methodName = "serverBelowMinRenew";
+
+		/*
+		 * Configure the acmeCA-2.0 feature.
+		 * 
+		 */
+
+		ServerConfiguration configuration = ORIGINAL_CONFIG.clone();
+		configuration.getAcmeCA().setRenewBeforeExpiration(AcmeConstants.RENEW_CERT_MIN - 1000 + "ms");
+		AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, DOMAINS1);
+
+		/***********************************************************************
+		 * 
+		 * TEST 1: The server will start with a renewBeforeExpiration set lower than the lowest minimum
+		 * renew time allowed.
+		 * 
+		 **********************************************************************/
+		try {
+			Log.info(this.getClass(), methodName, "TEST renew is set to below the minimum renew time.");
+
+			/*
+			 * Start the server and wait for the certificate to be installed.
+			 */
+			server.startServer();
+			AcmeFatUtils.waitForAcmeToCreateCertificate(server);
+			AcmeFatUtils.waitForSslEndpoint(server);
+
+			/*
+			 * Verify that the server is now using a certificate signed by the CA.
+			 */
+			AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			assertNotNull("Should log warning on minimum renewBeforeExpiration",
+					server.waitForStringInLog("CWPKI2051W"));
+
+		} finally {
+			Log.info(this.getClass(), methodName, "TEST 1: Shutdown.");
+
+			/*
+			 * Stop the server.
+			 */
+			server.stopServer("CWPKI2051W");
+		}
+	}
+
+	
+	/**
+	 * The server will start with a renewBeforeExpiration set lower than the warning level
+	 * for having a short renew time. A warning message should be logged.
+	 * 
+	 * @throws Exception If the test failed for some reason.
+	 */
+	@Test
+	@CheckForLeakedPasswords(AcmeFatUtils.PEBBLE_TRUSTSTORE_PASSWORD)
+	public void serverBelowWarnRenew() throws Exception {
+		final String methodName = "serverBelowWarnRenew";
+
+		/*
+		 * Configure the acmeCA-2.0 feature.
+		 * 
+		 */
+
+		ServerConfiguration configuration = ORIGINAL_CONFIG.clone();
+		configuration.getAcmeCA().setRenewBeforeExpiration(AcmeConstants.RENEW_CERT_MIN_WARN_LEVEL - 1000 + "ms");
+		AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, DOMAINS1);
+
+		/***********************************************************************
+		 * 
+		 * TEST The server will start with a renewBeforeExpiration set lower than the warning level
+		 * for having a short renew time.
+		 * 
+		 **********************************************************************/
+		try {
+			Log.info(this.getClass(), methodName, "TEST renew is set to below the minimum renew warning time.");
+
+			/*
+			 * Start the server and wait for acme to determine the certificate was good.
+			 */
+			server.startServer();
+			AcmeFatUtils.waitForAcmeAppToStart(server);
+			AcmeFatUtils.waitForSslEndpoint(server);
+
+			/*
+			 * Verify that the server is using a certificate signed by the CA.
+			 */
+			AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			assertNotNull("Should log warning on renewBeforeExpiration being too short",
+					server.waitForStringInLog("CWPKI2055W"));
+
+		} finally {
+			Log.info(this.getClass(), methodName, "TEST: Shutdown.");
+
+			/*
+			 * Stop the server.
+			 */
+			server.stopServer("CWPKI2055W");
+		}
+
+	}
+
+	/**
+	 * Starting the server with a renewBeforeExpiration longer than the certificate
+	 * validity period. The renewBeforeExpiration will be reset to the default time.
+	 * @throws Exception
+	 */
+	@Test
+	@CheckForLeakedPasswords(AcmeFatUtils.PEBBLE_TRUSTSTORE_PASSWORD)
+	public void serverRenewLongerThanValidity() throws Exception {
+		final String methodName = "serverRenewLongerThanValidity";
+
+		/*
+		 * Configure the acmeCA-2.0 feature.
+		 * 
+		 */
+
+		ServerConfiguration configuration = ORIGINAL_CONFIG.clone();
+		configuration.getAcmeCA().setRenewBeforeExpiration(365 * 5 + 1 + "d");
+		AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, DOMAINS1);
+
+		/***********************************************************************
+		 * 
+		 * TEST The server will start with a renewBeforeExpiration set longer than the 
+		 * certificate validity period..
+		 * 
+		 **********************************************************************/
+		try {
+			Log.info(this.getClass(), methodName, "TEST renew is set longer than the certificate validity period.");
+
+			/*
+			 * Start the server and wait for acme to determine the certificate was good.
+			 */
+			server.startServer();
+			AcmeFatUtils.waitForAcmeAppToStart(server);
+			AcmeFatUtils.waitForSslEndpoint(server);
+
+			/*
+			 * Verify that the server is using a certificate signed by the CA.
+			 */
+			AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			assertNotNull(
+					"Should log warning that renewBeforeExpiration is too long compared to the cert validity period",
+					server.waitForStringInLog("CWPKI2054W"));
+
+		} finally {
+			Log.info(this.getClass(), methodName, "TEST Shutdown.");
+
+			/*
+			 * Stop the server.
+			 */
+			server.stopServer("CWPKI2054W");
+		}
+
+	}
+
+	/**
+	 * Test renewing the certification on server startup due to the expiration date.
+	 * 
+	 * This test calculates the renewBeforeExpiration based on the validity period of
+	 * the certificate received. It is slightly shorter than the validity period so we
+	 * can test it in an automated test.
+	 * 
+	 */
+	@Test
+	@CheckForLeakedPasswords(AcmeFatUtils.PEBBLE_TRUSTSTORE_PASSWORD)
+	public void serverRenewOnRestart() throws Exception {
+		final String methodName = "serverRenewOnRestart";
+		Certificate[] startingCertificateChain = null, endingCertificateChain = null;
+
+		/*
+		 * Configure the acmeCA-2.0 feature.
+		 * 
+		 */
+
+		ServerConfiguration configuration = ORIGINAL_CONFIG.clone();
+		AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, DOMAINS1);
+
+		long serverTime = System.currentTimeMillis();
+		/***********************************************************************
+		 * 
+		 * TEST 1: The server generate a certificate normally.
+		 * 
+		 **********************************************************************/
+
+		try {
+			Log.info(this.getClass(), methodName, "TEST 1: renew is fine, get a certificate at startup.");
+
+			/*
+			 * Start the server and wait for acme to determine the certificate was good.
+			 */
+			server.startServer();
+			AcmeFatUtils.waitForAcmeAppToStart(server);
+			AcmeFatUtils.waitForSslEndpoint(server);
+
+			serverTime = System.currentTimeMillis();
+
+			/*
+			 * Verify that the server is using a certificate signed by the CA.
+			 */
+			startingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+		} finally {
+			Log.info(this.getClass(), methodName, "TEST 1: Shutdown.");
+
+			/*
+			 * Stop the server.
+			 */
+			server.stopServer();
+		}
+
+		/***********************************************************************
+		 * 
+		 * TEST 2: Start with a very short renew period, causing a renewal on startup.
+		 * 
+		 **********************************************************************/
+		try {
+			Log.info(this.getClass(), methodName, "TEST 2: Restart with renew time close to validity period.");
+
+			long notAfter = ((X509Certificate) startingCertificateChain[0]).getNotAfter().getTime();
+			long notBefore = ((X509Certificate) startingCertificateChain[0]).getNotBefore().getTime();
+
+			long extraBuffer = serverTime - notBefore;
+			// check if the certificate is slightly in the future to make sure we wait long
+			// enough.
+			long totalBuffer = (extraBuffer > 0 ? extraBuffer : 0) + timeBufferToExpire;
+
+			Log.info(this.getClass(), methodName, "Not before: " + notBefore + ", extra buffer " + extraBuffer);
+
+			/*
+			 * Set a renew time just shy of default Pebble validity period) so we will
+			 * request a new certificate on restart)
+			 */
+			long justShyOfValidityPeriod = (notAfter - notBefore) - timeBufferToExpire;
+			Log.info(this.getClass(), methodName, "Time configured: " + justShyOfValidityPeriod);
+
+			/*
+			 * Wait a bit before we start the server to make sure we'll be in the renew
+			 * period.
+			 */
+			while ((System.currentTimeMillis() - serverTime) < totalBuffer) {
+				Log.info(this.getClass(), methodName,
+						"Waiting for " + totalBuffer + "ms to pass before restarting the server.");
+				Thread.sleep(2000);
+			}
+
+			configuration = ORIGINAL_CONFIG.clone();
+			configuration.getAcmeCA().setRenewBeforeExpiration(justShyOfValidityPeriod + "ms");
+			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, DOMAINS1);
+
+			server.startServer();
+			AcmeFatUtils.waitForAcmeAppToStart(server);
+			AcmeFatUtils.waitForSslEndpoint(server);
+
+			/*
+			 * Verify that the server got a new certificate
+			 */
+			endingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			assertNotSame("The certificate should have been marked as expired at startup and renewed.",
+					((X509Certificate) startingCertificateChain[0]).getSerialNumber(),
+					((X509Certificate) endingCertificateChain[0]).getSerialNumber());
+		} finally {
+			Log.info(this.getClass(), methodName, "TEST 2: Shutdown.");
+
+			/*
+			 * Stop the server.
+			 */
+			server.stopServer("CWPKI2055W"); // we are running with and intentionally short renewBeforeExpiration.
+		}
+
+	}
+}

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/FATSuite.java
@@ -17,8 +17,12 @@ import org.junit.runners.Suite.SuiteClasses;
 import componenttest.topology.utils.ExternalTestServiceDockerClientStrategy;
 
 @RunWith(Suite.class)
-@SuiteClasses({ AcmeClientTest.class, AcmeSimpleTest.class, AcmeURISimpleTest.class, AcmeBoulderSimpleTest.class,
-		AcmeCaRestHandlerTest.class
+@SuiteClasses({ AcmeClientTest.class, 
+	AcmeSimpleTest.class,
+	AcmeURISimpleTest.class,
+	AcmeBoulderSimpleTest.class,  
+	AcmeCaRestHandlerTest.class, 
+	AcmeValidityAndRenewTest.class
 	 })
 public class FATSuite {
 

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/AcmeCA.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/AcmeCA.java
@@ -45,6 +45,8 @@ public class AcmeCA extends ConfigElement {
 
     private String validFor; // Duration
 
+    private String renewBeforeExpiration;
+
     /**
      * @return the accountContact
      */
@@ -225,6 +227,21 @@ public class AcmeCA extends ConfigElement {
         this.validFor = validFor;
     }
 
+    /**
+     * @return the renewBeforeExpiration
+     */
+    public String getRenewBeforeExpiration() {
+        return renewBeforeExpiration;
+    }
+
+    /**
+     * @param renewBeforeExpiration the renewBeforeExpiration to set
+     */
+    @XmlAttribute(name = "renewBeforeExpiration")
+    public void setRenewBeforeExpiration(String renewBeforeExpiration) {
+        this.renewBeforeExpiration = renewBeforeExpiration;
+    }
+
     @Override
     public String toString() {
         StringBuffer sb = new StringBuffer();
@@ -266,6 +283,9 @@ public class AcmeCA extends ConfigElement {
         }
         if (validFor != null) {
             sb.append("validFor=\"").append(validFor).append("\" ");;
+        }
+        if (renewBeforeExpiration != null) {
+            sb.append("renewBeforeExpiration=\"").append(renewBeforeExpiration).append("\" ");;
         }
 
         sb.append("}");


### PR DESCRIPTION
Fixes #11185 

Updated the timing for when we mark a certificate as expired:

Config: `renewBeforeExpiration`

Added min/default and some automatic adjustments.
- Default `renewBeforeExpiration`: 7 days
- Minimum `renewBeforeExpiration`: 15 seconds
- Warning level on short `renewBeforeExpiration`: 60 seconds


At init, we'll verify the `renewBeforeExpiration` and adjust and/or warn if necessary:
- If `renewBeforeExpiration` is less than the minumum (15 seconds) adjust to minimum and log warning.
- If `renewBeforeExpiration` is less than the warning level (60 seconds), do not change but log a warning.

After we fetch the certificate, we'll compare the `renewBeforeExpiration` to the validity period of the certificate (notAfter - notBefore = validity period).

We'll adjust the `renewBeforeExpiration` if it is longer than the validity period using the following rules (and log a warning message):
- If the validity period is longer than the default (7 days), we'll adjust `renewBeforeExpiration` to 7 days
- If the validity period is shorter than the default (7 days), we'll adjust `renewBeforeExpiration` by dividing by 2 and rounding with a floor of the minimum duration (15 seconds).

| Configured renewBeforeExpiration | Validity Period | Adjusted renewBeforeExpiration | action taken |
| ------------- | ------------- | ------------- | ------------- |
| 95d  | 90d  | 7d | set to default |
| 95d  | 5d  |  3d | duration by half |
| 95d |  1m | 30s | duration by half |
| 95d |  20s | 15s | min duration | 

For #9017 