### PR TITLE
Switch from JCache to Infinispan API via reflection for cache creation.

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/SessionCacheTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/SessionCacheTimeoutTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -203,7 +203,7 @@ public class SessionCacheTimeoutTest extends FATServletClient {
      */
     @Test
     public void testInfinispanClassCastException() throws Exception {
-        app.invokeServlet("testInfinispanClassCastException&shouldFail=true", null);
+        app.invokeServlet("testInfinispanClassCastException&shouldFail=false", null);
     }
 
     /**

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/SessionCacheTwoServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/SessionCacheTwoServerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -301,6 +301,6 @@ public class SessionCacheTwoServerTest extends FATServletClient {
      */
     @Test
     public void testInfinispanClassCastException() throws Exception {
-        appA.invokeServlet("testInfinispanClassCastException&shouldFail=true", null);
+        appA.invokeServlet("testInfinispanClassCastException&shouldFail=false", null);
     }
 }

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/SessionCacheTwoServerTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/fat/src/com/ibm/ws/session/cache/fat/infinispan/container/SessionCacheTwoServerTimeoutTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -177,6 +177,6 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
      */
     @Test
     public void testInfinispanClassCastException() throws Exception {
-        appA.invokeServlet("testInfinispanClassCastException&shouldFail=true", null);
+        appA.invokeServlet("testInfinispanClassCastException&shouldFail=false", null);
     }
 }

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/files/infinispan/config.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/files/infinispan/config.xml
@@ -3,6 +3,11 @@
         xsi:schemaLocation="urn:infinispan:config:10.0 http://www.infinispan.org/schemas/infinispan-config-10.0.xsd
                             urn:infinispan:server:10.0 http://www.infinispan.org/schemas/infinispan-server-10.0.xsd">
 
+   <!-- transport is required when not using local caches -->
+  <cache-container>
+    <transport/>
+  </cache-container>
+  
    <!-- Infinispan Server config -->
    <server xmlns='urn:infinispan:server:10.0'>
      <!-- Access definitions -->

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/servers/com.ibm.ws.session.cache.fat.infinispan.container.server/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/servers/com.ibm.ws.session.cache.fat.infinispan.container.server/server.xml
@@ -19,6 +19,7 @@
 		<properties infinispan.client.hotrod.auth_password="pass"/> <!-- set in users.properties -->
 		<properties infinispan.client.hotrod.auth_realm="default"/>
 		<properties infinispan.client.hotrod.sasl_mechanism="PLAIN"/>
+		<properties infinispan.client.hotrod.client_intelligence="BASIC"/> <!-- prevent client from using internal/unreachable docker IP addresses -->
 	</httpSessionCache>
 	
     <library id="InfinispanLib">

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/servers/com.ibm.ws.session.cache.fat.infinispan.container.serverA/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/servers/com.ibm.ws.session.cache.fat.infinispan.container.serverA/server.xml
@@ -17,6 +17,7 @@
 		<properties infinispan.client.hotrod.auth_password="pass"/> <!-- set in users.properties -->
 		<properties infinispan.client.hotrod.auth_realm="default"/>
 		<properties infinispan.client.hotrod.sasl_mechanism="PLAIN"/>
+		<properties infinispan.client.hotrod.client_intelligence="BASIC"/> <!-- prevent client from using internal/unreachable docker IP addresses -->
     </httpSessionCache>
 
     <library id="InfinispanLib">

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/servers/com.ibm.ws.session.cache.fat.infinispan.container.serverB/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/servers/com.ibm.ws.session.cache.fat.infinispan.container.serverB/server.xml
@@ -22,6 +22,7 @@
 		<properties infinispan.client.hotrod.auth_password="pass"/> <!-- set in users.properties -->
 		<properties infinispan.client.hotrod.auth_realm="default"/>
 		<properties infinispan.client.hotrod.sasl_mechanism="PLAIN"/>
+		<properties infinispan.client.hotrod.client_intelligence="BASIC"/> <!-- prevent client from using internal/unreachable docker IP addresses -->
     </httpSessionCache>
 
     <library id="InfinispanLib">

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/servers/com.ibm.ws.session.cache.fat.infinispan.container.timeoutServerA/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/servers/com.ibm.ws.session.cache.fat.infinispan.container.timeoutServerA/server.xml
@@ -17,6 +17,7 @@
 		<properties infinispan.client.hotrod.auth_password="pass"/> <!-- set in users.properties -->
 		<properties infinispan.client.hotrod.auth_realm="default"/>
 		<properties infinispan.client.hotrod.sasl_mechanism="PLAIN"/>
+		<properties infinispan.client.hotrod.client_intelligence="BASIC"/> <!-- prevent client from using internal/unreachable docker IP addresses -->
     </httpSessionCache>
 
     <application location="sessionCacheApp.war">

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/servers/com.ibm.ws.session.cache.fat.infinispan.container.timeoutServerB/server.xml
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/publish/servers/com.ibm.ws.session.cache.fat.infinispan.container.timeoutServerB/server.xml
@@ -22,6 +22,7 @@
 		<properties infinispan.client.hotrod.auth_password="pass"/> <!-- set in users.properties -->
 		<properties infinispan.client.hotrod.auth_realm="default"/>
 		<properties infinispan.client.hotrod.sasl_mechanism="PLAIN"/>
+		<properties infinispan.client.hotrod.client_intelligence="BASIC"/> <!-- prevent client from using internal/unreachable docker IP addresses -->
     </httpSessionCache>
 
     <application location="sessionCacheApp.war">


### PR DESCRIPTION
When Liberty connects to Infinispan servers through the JCache API and hotrod client, the infinispan.xml configuration is getting lost. To work around this we are using the Infinispan API directly to ensure caches are replicated throughout an Infinispan cluster. This work is done via reflection to prevent dependencies on Infinispan code.