### PR TITLE
send 401 instead of 403 on redirect to idp

### DIFF
--- a/dev/com.ibm.ws.security.saml.sso/src/com/ibm/ws/security/saml/sso20/sp/Solicited.java
+++ b/dev/com.ibm.ws.security.saml.sso/src/com/ibm/ws/security/saml/sso20/sp/Solicited.java
@@ -399,7 +399,9 @@ public class Solicited {
             throw wtafe;
         }
         // expect to return a form to redirect to the idp by the browser
-        return TAIResult.create(HttpServletResponse.SC_FORBIDDEN); //
+        //return TAIResult.create(HttpServletResponse.SC_FORBIDDEN); //
+        // change to 401 because admincenter intercepts 403
+        return TAIResult.create(HttpServletResponse.SC_UNAUTHORIZED); 
     }
 
     /**

--- a/dev/com.ibm.ws.security.saml.sso/src/com/ibm/ws/security/saml/sso20/sp/Unsolicited.java
+++ b/dev/com.ibm.ws.security.saml.sso/src/com/ibm/ws/security/saml/sso20/sp/Unsolicited.java
@@ -114,6 +114,8 @@ public class Unsolicited {
         }
 
         // expect to return a form to redirect to the idp by the browser
-        return TAIResult.create(HttpServletResponse.SC_FORBIDDEN);
+        // due to admin center intercepting 403, send 401.
+        //return TAIResult.create(HttpServletResponse.SC_FORBIDDEN);
+        return TAIResult.create(HttpServletResponse.SC_UNAUTHORIZED); 
     }
 }


### PR DESCRIPTION
This resolves an exception being thrown back to the browser when the admin center is protected by SAML.  The browser proceeds to redirect to the IDP anyway, and login is ultimately successful, but the display of the exception for several seconds until the IDP responds  is ugly.  The problem occurs because the admin center intercepts 403's using an error-page declaration in its web.xml