### PR TITLE
handle  openliberty.io can't be reached to retrieve https://openliber…

### DIFF
--- a/dev/com.ibm.ws.transport.http/resources/OSGI-INF/welcome/index.html
+++ b/dev/com.ibm.ws.transport.http/resources/OSGI-INF/welcome/index.html
@@ -873,8 +873,14 @@
 				}
 			}
 		}
-		
-        doVersionCheck(latestReleasedVersion);
+
+        try {
+			if (latestReleasedVersion) {
+			    doVersionCheck(latestReleasedVersion);
+            }
+        } catch (ex) {
+            console.error("Failed to to load https://openliberty.io/latestVersion.js");
+        }
 
 		var url = getUrl();
 		externalizedStrings(url).then(function(response) {


### PR DESCRIPTION
If openliberty.io can't be reached to retrieve "https://openliberty.io/latestVersion.js" to do the version comparison, then the nls text is not displayed because of the js undefined error. 
The check whether "latestReleasedVersion" has been defined before calling doVersionCheck(latestReleasedVersion) won't fix the problem, instead we would need to do a try catch to handle the Reference error when unable to load latestVersion.js