### PR TITLE
Issue 11727: Fix read and write file unit tests for Win

### DIFF
--- a/dev/com.ibm.ws.security.acme/test/com/ibm/ws/security/acme/internal/AcmeConfigTest.java
+++ b/dev/com.ibm.ws.security.acme/test/com/ibm/ws/security/acme/internal/AcmeConfigTest.java
@@ -18,6 +18,7 @@ import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -64,6 +65,8 @@ public class AcmeConfigTest {
 
 	@Test
 	public void constructor_accountKeyFile_unreadable() throws Exception {
+		
+		Assume.assumeTrue(!System.getProperty("os.name", "unknown").toLowerCase().contains("windows")); // windows not enforcing the setReadable
 
 		expectedException.expect(AcmeCaException.class);
 		expectedException.expectMessage("CWPKI2021E");
@@ -81,6 +84,8 @@ public class AcmeConfigTest {
 
 	@Test
 	public void constructor_accountKeyFile_unwritable() throws Exception {
+		
+		Assume.assumeTrue(!System.getProperty("os.name", "unknown").toLowerCase().contains("windows")); // windows not enforcing the setWritable
 
 		expectedException.expect(AcmeCaException.class);
 		expectedException.expectMessage("CWPKI2023E");
@@ -151,6 +156,8 @@ public class AcmeConfigTest {
 
 	@Test
 	public void constructor_domainKeyFile_unreadable() throws Exception {
+		
+		Assume.assumeTrue(!System.getProperty("os.name", "unknown").toLowerCase().contains("windows")); // windows not enforcing the setReadable
 
 		expectedException.expect(AcmeCaException.class);
 		expectedException.expectMessage("CWPKI2020E");
@@ -169,6 +176,8 @@ public class AcmeConfigTest {
 
 	@Test
 	public void constructor_domainKeyFile_unwritable() throws Exception {
+		
+		Assume.assumeTrue(!System.getProperty("os.name", "unknown").toLowerCase().contains("windows")); // windows not enforcing the setWritable
 
 		expectedException.expect(AcmeCaException.class);
 		expectedException.expectMessage("CWPKI2022E");

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSimpleTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSimpleTest.java
@@ -563,43 +563,50 @@ public class AcmeSimpleTest {
 			 * unreadable.
 			 * 
 			 **********************************************************************/
-			Log.info(AcmeSimpleTest.class, methodName, "Test 6 - unreadable account key file");
-			acmeCA.setSubjectDN("cn=domain1.com");
-			AcmeFatUtils.configureAcmeCA(server, configuration);
-			assertNotNull("Expected CWPKI2021E in logs.", server.waitForStringInLog("CWPKI2021E"));
+			
+			if (System.getProperty("os.name", "unknown").toLowerCase().contains("windows")) { // windows not enforcing the setReadable/setWriteable
+				Log.info(AcmeSimpleTest.class, methodName, "Skipping unreadable/unwriteable file tests on Windows: " + System.getProperty("os.name", "unknown"));
+				acmeCA.setSubjectDN("cn=domain1.com");
+				acmeCA.setAccountKeyFile(null);
+			} else {
+				Log.info(AcmeSimpleTest.class, methodName, "Test 6 - unreadable account key file");
+				acmeCA.setSubjectDN("cn=domain1.com");
+				AcmeFatUtils.configureAcmeCA(server, configuration);
+				assertNotNull("Expected CWPKI2021E in logs.", server.waitForStringInLog("CWPKI2021E"));
 
-			/***********************************************************************
-			 * 
-			 * Set the account key file to be unwritable. The account key file
-			 * is unwritable.
-			 * 
-			 **********************************************************************/
-			Log.info(AcmeSimpleTest.class, methodName, "Test 7 - unwritable account key file");
-			acmeCA.setAccountKeyFile(unwritableDir + "/unwritable.key");
-			AcmeFatUtils.configureAcmeCA(server, configuration);
-			assertNotNull("Expected CWPKI2023E in logs.", server.waitForStringInLog("CWPKI2023E"));
+				/***********************************************************************
+				 * 
+				 * Set the account key file to be unwritable. The account key file
+				 * is unwritable.
+				 * 
+				 **********************************************************************/
+				Log.info(AcmeSimpleTest.class, methodName, "Test 7 - unwritable account key file");
+				acmeCA.setAccountKeyFile(unwritableDir + "/unwritable.key");
+				AcmeFatUtils.configureAcmeCA(server, configuration);
+				assertNotNull("Expected CWPKI2023E in logs.", server.waitForStringInLog("CWPKI2023E"));
 
-			/***********************************************************************
-			 * 
-			 * Set the account key file to default. The domain key file is
-			 * unreadable.
-			 * 
-			 **********************************************************************/
-			Log.info(AcmeSimpleTest.class, methodName, "Test 8 - unreadable domain key file");
-			acmeCA.setAccountKeyFile(null);
-			AcmeFatUtils.configureAcmeCA(server, configuration);
-			assertNotNull("Expected CWPKI2020E in logs.", server.waitForStringInLog("CWPKI2020E"));
+				/***********************************************************************
+				 * 
+				 * Set the account key file to default. The domain key file is
+				 * unreadable.
+				 * 
+				 **********************************************************************/
+				Log.info(AcmeSimpleTest.class, methodName, "Test 8 - unreadable domain key file");
+				acmeCA.setAccountKeyFile(null);
+				AcmeFatUtils.configureAcmeCA(server, configuration);
+				assertNotNull("Expected CWPKI2020E in logs.", server.waitForStringInLog("CWPKI2020E"));
 
-			/***********************************************************************
-			 * 
-			 * Set the domain key file to be unwritable. The domain key file is
-			 * unwritable.
-			 * 
-			 **********************************************************************/
-			Log.info(AcmeSimpleTest.class, methodName, "Test 9 - unwritable domain key file");
-			acmeCA.setDomainKeyFile(unwritableDir + "/unwritable.key");
-			AcmeFatUtils.configureAcmeCA(server, configuration);
-			assertNotNull("Expected CWPKI2022E in logs.", server.waitForStringInLog("CWPKI2022E"));
+				/***********************************************************************
+				 * 
+				 * Set the domain key file to be unwritable. The domain key file is
+				 * unwritable.
+				 * 
+				 **********************************************************************/
+				Log.info(AcmeSimpleTest.class, methodName, "Test 9 - unwritable domain key file");
+				acmeCA.setDomainKeyFile(unwritableDir + "/unwritable.key");
+				AcmeFatUtils.configureAcmeCA(server, configuration);
+				assertNotNull("Expected CWPKI2022E in logs.", server.waitForStringInLog("CWPKI2022E"));
+			}
 
 			/***********************************************************************
 			 * 


### PR DESCRIPTION
Fixes #11727 

Skip read/write file on Windows.