### PR TITLE
Adding functionality for appending preformatted JSON

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2448,6 +2448,11 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <version>2.2.5.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
       <version>1.5.9.RELEASE</version>
     </dependency>
@@ -2467,6 +2472,11 @@
       <version>2.1.2.RELEASE</version>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+      <version>2.2.5.RELEASE</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
       <version>5.0.7.RELEASE</version>
@@ -2475,6 +2485,11 @@
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
       <version>5.1.3.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-config</artifactId>
+      <version>5.2.2.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
@@ -2488,6 +2503,11 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-core</artifactId>
+      <version>5.2.2.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
       <version>5.0.7.RELEASE</version>
     </dependency>
@@ -2495,6 +2515,11 @@
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
       <version>5.1.3.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-web</artifactId>
+      <version>5.2.2.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -2543,6 +2568,11 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+      <version>5.2.4.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
       <version>3.0.7.RELEASE</version>
     </dependency>
@@ -2568,6 +2598,11 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <version>5.2.4.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
       <version>3.0.7.RELEASE</version>
     </dependency>
@@ -2590,6 +2625,11 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
       <version>5.1.4.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>5.2.4.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -2630,6 +2670,11 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
       <version>5.1.4.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <version>5.2.4.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -2638,16 +2683,6 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
-      <artifactId>spring-webflux</artifactId>
-      <version>5.1.4.RELEASE</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-webmvc</artifactId>
-      <version>4.3.13.RELEASE</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
       <artifactId>spring-webmvc</artifactId>
       <version>5.0.8.RELEASE</version>
     </dependency>
@@ -2655,6 +2690,11 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-webmvc</artifactId>
       <version>5.1.4.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-webmvc</artifactId>
+      <version>5.2.4.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonHelpers.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonHelpers.java
@@ -318,7 +318,7 @@ public class CollectorJsonHelpers {
         String tempStartFields = startAuditJsonFields;
 
         if (tempStartFields != null) {
-            jsonBuilder.addFields(tempStartFields);
+            jsonBuilder.addPreformatted(tempStartFields);
         } else {
             //@formatter:off
             jsonBuilder.addField(AuditData.getTypeKeyJSON(), CollectorConstants.AUDIT_LOG_EVENT_TYPE, false, false)
@@ -336,7 +336,7 @@ public class CollectorJsonHelpers {
         String tempStartFields = startMessageJsonFields;
 
         if (tempStartFields != null)
-            jsonBuilder.addFields(tempStartFields);
+            jsonBuilder.addPreformatted(tempStartFields);
         else {
             //@formatter:off
             jsonBuilder.addField(LogTraceData.getTypeKeyJSON(true), CollectorConstants.MESSAGES_LOG_EVENT_TYPE, false, false)
@@ -354,7 +354,7 @@ public class CollectorJsonHelpers {
         String tempStartFields = startTraceJsonFields;
 
         if (tempStartFields != null)
-            jsonBuilder.addFields(tempStartFields);
+            jsonBuilder.addPreformatted(tempStartFields);
         else {
             //@formatter:off
             jsonBuilder.addField(LogTraceData.getTypeKeyJSON(false), CollectorConstants.TRACE_LOG_EVENT_TYPE, false, false)
@@ -372,7 +372,7 @@ public class CollectorJsonHelpers {
         String tempStartFields = startFFDCJsonFields;
 
         if (tempStartFields != null)
-            jsonBuilder.addFields(tempStartFields);
+            jsonBuilder.addPreformatted(tempStartFields);
         else {
             //@formatter:off
             jsonBuilder.addField(FFDCData.getTypeKeyJSON(), CollectorConstants.FFDC_EVENT_TYPE, false, false)
@@ -390,7 +390,7 @@ public class CollectorJsonHelpers {
         String tempStartFields = startAccessLogJsonFields;
 
         if (tempStartFields != null)
-            jsonBuilder.addFields(tempStartFields);
+            jsonBuilder.addPreformatted(tempStartFields);
         else {
             //@formatter:off
             jsonBuilder.addField(AccessLogData.getTypeKeyJSON(), CollectorConstants.ACCESS_LOG_EVENT_TYPE, false, false)

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils_JSON.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/CollectorJsonUtils_JSON.java
@@ -97,7 +97,7 @@ public class CollectorJsonUtils_JSON {
         //@formatter:on
 
         if (tags != null) {
-            jsonBuilder.addField("\"ibm_tags\":", CollectorJsonHelpers.jsonifyTags(tags), false, false);
+            jsonBuilder.addPreformattedField("ibm_tags", CollectorJsonHelpers.jsonifyTags(tags));
         }
 
         return jsonBuilder.build().toString();
@@ -140,7 +140,7 @@ public class CollectorJsonUtils_JSON {
         //@formatter:on
 
         if (tags != null) {
-            jsonBuilder.addField("\"ibm_tags\":", CollectorJsonHelpers.jsonifyTags(tags), false, false);
+            jsonBuilder.addPreformattedField("ibm_tags", CollectorJsonHelpers.jsonifyTags(tags));
         }
 
         return jsonBuilder.build().toString();
@@ -212,9 +212,9 @@ public class CollectorJsonUtils_JSON {
             }
         }
 
-        //append tags like a string
+        //append tags with preformatted string field value
         if (tags != null) {
-            jsonBuilder.addField("\"ibm_tags\":", CollectorJsonHelpers.jsonifyTags(tags), false, false);
+            jsonBuilder.addPreformattedField("ibm_tags", CollectorJsonHelpers.jsonifyTags(tags));
         }
 
         return jsonBuilder.build().toString();
@@ -260,18 +260,12 @@ public class CollectorJsonUtils_JSON {
                     }
 
                 } //There shouldn't be any list items from Audit's Generic Data object
+
             }
 
         }
 
         return jsonBuilder.build().toString();
-    }
-
-    private static StringBuilder addTagNameForVersion(StringBuilder sb) {
-
-        sb.append(",\"ibm_tags\":");
-
-        return sb;
     }
 
 }

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/data/JSONObject.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/data/JSONObject.java
@@ -59,15 +59,31 @@ public class JSONObject {
         }
 
         /**
-         * Add multiple fields
+         * Add formatted JSON, primarily used for adding multiple fields
          */
-        public JSONObjectBuilder addFields(String s) {
+        public JSONObjectBuilder addPreformatted(String s) {
             if (s.isEmpty()) {
                 return this;
             }
             prepForNewField();
 
             jsonBuilder.append(s);
+            return this;
+        }
+
+        /**
+         * Add preformatted field that is omittable, primarily used for adding "ibm_tags" and "tags" fields
+         */
+        public JSONObjectBuilder addPreformattedField(String name, String preformattedValue) {
+            if (name.isEmpty() || preformattedValue.isEmpty())
+                return this;
+
+            if (name.equals(OMIT_FIELDS_STRING))
+                return this;
+
+            prepForNewField();
+
+            jsonBuilder.append("\"" + name + "\":" + preformattedValue);
             return this;
         }
 


### PR DESCRIPTION
#build

Adding a method `addPreformattedField` to append `ibm_tags` (Liberty JSON logging) or `tags` (logstashCollector) when creating JSON logs because the tag field values are quoteless strings.

Also renaming method `addFields(String s)`, for appending multiple preformatted fields as one string, to `addPreformatted(String s)`.

