### PR TITLE
enable Jakarta in concurrent db, ejb, config tests

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_config/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent_fat_config/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ src: \
 fat.project: true
 
 -buildpath: \
+  com.ibm.websphere.jakarta.concurrency.2.0;version=latest,\
   com.ibm.websphere.javaee.annotation.1.1;version=latest,\
   com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
   com.ibm.websphere.javaee.ejb.3.2;version=latest,\

--- a/dev/com.ibm.ws.concurrent_fat_config/publish/servers/concurrent.config.fat/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_config/publish/servers/concurrent.config.fat/server.xml
@@ -1,8 +1,8 @@
 <server>
     <featureManager>
-        <feature>concurrent-1.0</feature>
-        <feature>ejbLite-3.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>concurrent-2.0</feature>
+        <feature>ejbLite-3.2</feature> <!-- TODO update to Jakarta once available -->
+        <feature>servlet-3.1</feature> <!-- TODO update to Jakarta once available -->
         <feature>usr:concurrentInternals-1.0</feature>
         <feature>componenttest-1.0</feature>
     </featureManager>

--- a/dev/com.ibm.ws.concurrent_fat_config/test-applications/concurrent/src/fat/concurrent/web/EEConcurrencyUtilsFATServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_config/test-applications/concurrent/src/fat/concurrent/web/EEConcurrencyUtilsFATServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,7 +34,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Resource;
-import javax.enterprise.concurrent.ManagedTask;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.servlet.ServletException;
@@ -48,6 +47,7 @@ import javax.transaction.UserTransaction;
 
 import componenttest.app.FATServlet;
 import fat.concurrent.ejb.EEConcurrencyUtilsStatelessBean;
+import jakarta.enterprise.concurrent.ManagedTask;
 
 @SuppressWarnings("serial")
 @WebServlet("/*")

--- a/dev/com.ibm.ws.concurrent_fat_config/test-applications/concurrent/src/fat/concurrent/web/IncrementTask.java
+++ b/dev/com.ibm.ws.concurrent_fat_config/test-applications/concurrent/src/fat/concurrent/web/IncrementTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,8 +16,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.enterprise.concurrent.ManagedTask;
-import javax.enterprise.concurrent.ManagedTaskListener;
+import jakarta.enterprise.concurrent.ManagedTask;
+import jakarta.enterprise.concurrent.ManagedTaskListener;
 
 /**
  * Task that adds 1 to a counter when it runs and returns the current count.

--- a/dev/com.ibm.ws.concurrent_fat_db/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent_fat_db/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@ src: \
 fat.project: true
 
 -buildpath: \
+	com.ibm.websphere.jakarta.concurrency.2.0;version=latest,\
 	com.ibm.websphere.javaee.annotation.1.2;version=latest,\
-	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.1;version=latest

--- a/dev/com.ibm.ws.concurrent_fat_db/publish/servers/concurrent_fat_db/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_db/publish/servers/concurrent_fat_db/server.xml
@@ -11,7 +11,7 @@
 <server>
 
 	<featureManager>
-	    <feature>concurrent-1.0</feature>
+	    <feature>concurrent-2.0</feature>
 	    <feature>jdbc-4.1</feature>
 	    <feature>servlet-3.1</feature>
 	    <feature>componenttest-1.0</feature>

--- a/dev/com.ibm.ws.concurrent_fat_db/test-applications/concurrentdbtest/src/concurrent/fat/db/web/ConcurrentDBTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_db/test-applications/concurrentdbtest/src/concurrent/fat/db/web/ConcurrentDBTestServlet.java
@@ -22,12 +22,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Resource;
-import javax.enterprise.concurrent.ContextService;
-import javax.enterprise.concurrent.ManagedExecutorService;
-import javax.enterprise.concurrent.ManagedExecutors;
-import javax.enterprise.concurrent.ManagedScheduledExecutorService;
-import javax.enterprise.concurrent.ManagedTask;
-import javax.enterprise.concurrent.ManagedTaskListener;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.sql.DataSource;
@@ -38,6 +32,13 @@ import javax.transaction.UserTransaction;
 import org.junit.Test;
 
 import componenttest.app.FATDatabaseServlet;
+
+import jakarta.enterprise.concurrent.ContextService;
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.enterprise.concurrent.ManagedExecutors;
+import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
+import jakarta.enterprise.concurrent.ManagedTask;
+import jakarta.enterprise.concurrent.ManagedTaskListener;
 
 @SuppressWarnings("serial")
 @WebServlet("/*")

--- a/dev/com.ibm.ws.concurrent_fat_ejb/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent_fat_ejb/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -18,8 +18,8 @@ src: \
 fat.project: true
 
 -buildpath: \
+	com.ibm.websphere.jakarta.concurrency.2.0;version=latest,\
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
-	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
 	com.ibm.websphere.javaee.ejb.3.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.1;version=latest

--- a/dev/com.ibm.ws.concurrent_fat_ejb/publish/servers/com.ibm.ws.concurrent.fat.ejb/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_ejb/publish/servers/com.ibm.ws.concurrent.fat.ejb/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017,2020 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -10,9 +10,9 @@
  -->
 <server>
     <featureManager>
-        <feature>concurrent-1.0</feature>
-        <feature>ejbLite-3.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>concurrent-2.0</feature>
+        <feature>ejbLite-3.2</feature> <!-- TODO use Jakarta spec once available -->
+        <feature>servlet-3.1</feature> <!-- TODO use Jakarta spec once available -->
         <feature>componentTest-1.0</feature>
     </featureManager>
 

--- a/dev/com.ibm.ws.concurrent_fat_ejb/test-applications/concurrent/src/web/ConcurrentFATServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_ejb/test-applications/concurrent/src/web/ConcurrentFATServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,6 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Resource;
 import javax.ejb.EJBException;
 import javax.ejb.EJBTransactionRequiredException;
-import javax.enterprise.concurrent.ManagedExecutorService;
 import javax.naming.InitialContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -33,6 +32,7 @@ import componenttest.annotation.ExpectedFFDC;
 import componenttest.app.FATServlet;
 import ejb.ConcurrentBMT;
 import ejb.ConcurrentCMT;
+import jakarta.enterprise.concurrent.ManagedExecutorService;
 
 @SuppressWarnings("serial")
 public class ConcurrentFATServlet extends FATServlet {


### PR DESCRIPTION
Run 3 additional test buckets using the Jakarta packages for Concurrency.
Some other features used by these tests will temporarily remain at Java EE until Jakarta versions of other features are available.  It is only possible to mix & match Jakarta/Java EE like this while the features are in beta.  Use of one vs the other will later be enforced.