### PR TITLE
Fix NPE in lookupAppName()

### DIFF
--- a/dev/com.ibm.ws.opentracing.1.1/bnd.bnd
+++ b/dev/com.ibm.ws.opentracing.1.1/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -52,4 +52,5 @@ Private-Package: com.ibm.ws.opentracing.resources
         com.ibm.websphere.org.osgi.service.cm;version=latest, \
         com.ibm.ws.io.opentracing.opentracing-api.0.31.0;version=latest, \
         com.ibm.ws.io.opentracing.opentracing-util.0.31.0;version=latest, \
-        com.ibm.websphere.javaee.servlet.3.1; version=latest
+        com.ibm.websphere.javaee.servlet.3.1; version=latest, \
+        com.ibm.ws.container.service;version=latest

--- a/dev/com.ibm.ws.opentracing.1.1/src/com/ibm/ws/opentracing/OpentracingUtils.java
+++ b/dev/com.ibm.ws.opentracing.1.1/src/com/ibm/ws/opentracing/OpentracingUtils.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package com.ibm.ws.opentracing;
 
 import javax.naming.InitialContext;
@@ -6,6 +17,8 @@ import javax.naming.NamingException;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 
 import io.opentracing.Tracer;
 
@@ -49,13 +62,31 @@ public class OpentracingUtils {
      *         the name cannot be retrieved by doing a context lookup.
      */
     @Trivial
-    public static String lookupAppName() {
+    public static String lookupAppNameFallback() {
         String appName;
         try {
             appName = (String) new InitialContext().lookup("java:app/AppName");
         } catch (NamingException e) {
             Tr.error(tc, "OPENTRACING_NO_APPNAME_FOUND_IN_JNDI"); // Should never happen
             appName = DEFAULT_SERVICE_NAME;
+        }
+        return appName;
+    }
+
+    /**
+     * This is a more efficient way to obtain the current application name.
+     *
+     * @return The current application name.
+     */
+    @Trivial
+    public static String lookupAppName() {
+        String appName = null;
+        ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+        if (cmd != null) {
+            appName = cmd.getModuleMetaData().getApplicationMetaData().getName();
+        }
+        if (appName == null) {
+            appName = lookupAppNameFallback();
         }
         return appName;
     }

--- a/dev/com.ibm.ws.opentracing.1.2/bnd.bnd
+++ b/dev/com.ibm.ws.opentracing.1.2/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -54,4 +54,5 @@ Private-Package: com.ibm.ws.opentracing.resources
         com.ibm.ws.io.opentracing.opentracing-api.0.31.0;version=latest, \
         com.ibm.ws.io.opentracing.opentracing-util.0.31.0;version=latest, \
         com.ibm.websphere.org.eclipse.microprofile.config.1.3;version=latest,\
-        com.ibm.websphere.javaee.servlet.3.1; version=latest
+        com.ibm.websphere.javaee.servlet.3.1; version=latest, \
+        com.ibm.ws.container.service;version=latest

--- a/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/OpentracingUtils.java
+++ b/dev/com.ibm.ws.opentracing.1.2/src/com/ibm/ws/opentracing/OpentracingUtils.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package com.ibm.ws.opentracing;
 
 import javax.naming.InitialContext;
@@ -6,6 +17,8 @@ import javax.naming.NamingException;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 
 import io.opentracing.Tracer;
 
@@ -49,13 +62,31 @@ public class OpentracingUtils {
      *         the name cannot be retrieved by doing a context lookup.
      */
     @Trivial
-    public static String lookupAppName() {
+    public static String lookupAppNameFallback() {
         String appName;
         try {
             appName = (String) new InitialContext().lookup("java:app/AppName");
         } catch (NamingException e) {
             Tr.error(tc, "OPENTRACING_NO_APPNAME_FOUND_IN_JNDI"); // Should never happen
             appName = DEFAULT_SERVICE_NAME;
+        }
+        return appName;
+    }
+
+    /**
+     * This is a more efficient way to obtain the current application name.
+     *
+     * @return The current application name.
+     */
+    @Trivial
+    public static String lookupAppName() {
+        String appName = null;
+        ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+        if (cmd != null) {
+            appName = cmd.getModuleMetaData().getApplicationMetaData().getName();
+        }
+        if (appName == null) {
+            appName = lookupAppNameFallback();
         }
         return appName;
     }

--- a/dev/com.ibm.ws.opentracing.1.3/src/com/ibm/ws/opentracing/OpentracingUtils.java
+++ b/dev/com.ibm.ws.opentracing.1.3/src/com/ibm/ws/opentracing/OpentracingUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import javax.naming.NamingException;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 
 import io.opentracing.Tracer;
@@ -79,7 +80,11 @@ public class OpentracingUtils {
      */
     @Trivial
     public static String lookupAppName() {
-        String appName = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData().getModuleMetaData().getApplicationMetaData().getName();
+        String appName = null;
+        ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+        if (cmd != null) {
+            appName = cmd.getModuleMetaData().getApplicationMetaData().getName();
+        }
         if (appName == null) {
             appName = lookupAppNameFallback();
         }

--- a/dev/com.ibm.ws.opentracing/bnd.bnd
+++ b/dev/com.ibm.ws.opentracing/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -30,20 +30,21 @@ Import-Package: \
     *
 
 Export-Package: \
-	com.ibm.ws.opentracing;version=1.0,\
-	com.ibm.ws.opentracing.filters;version=1.0,\
-	com.ibm.ws.opentracing.tracer;version=1.0;provide=true
+    com.ibm.ws.opentracing;version=1.0,\
+    com.ibm.ws.opentracing.filters;version=1.0,\
+    com.ibm.ws.opentracing.tracer;version=1.0;provide=true
                 
 Private-Package: com.ibm.ws.opentracing.resources
 
 
 -buildpath: \
-	com.ibm.websphere.javaee.jaxrs.2.0;version=latest,\
-	com.ibm.ws.logging;version=latest,\
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-	com.ibm.ws.jaxrs.2.0.common;version=latest,\
-	com.ibm.wsspi.org.osgi.service.component;version=latest,\
-	com.ibm.wsspi.org.osgi.core;version=latest,\
-	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
-	com.ibm.websphere.org.osgi.service.cm;version=latest,\
-	com.ibm.ws.io.opentracing.opentracing-api;version=latest
+    com.ibm.websphere.javaee.jaxrs.2.0;version=latest,\
+    com.ibm.ws.logging;version=latest,\
+    com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+    com.ibm.ws.jaxrs.2.0.common;version=latest,\
+    com.ibm.wsspi.org.osgi.service.component;version=latest,\
+    com.ibm.wsspi.org.osgi.core;version=latest,\
+    com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+    com.ibm.websphere.org.osgi.service.cm;version=latest,\
+    com.ibm.ws.io.opentracing.opentracing-api;version=latest,\
+    com.ibm.ws.container.service;version=latest

--- a/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingUtils.java
+++ b/dev/com.ibm.ws.opentracing/src/com/ibm/ws/opentracing/OpentracingUtils.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
 package com.ibm.ws.opentracing;
 
 import javax.naming.InitialContext;
@@ -6,6 +17,8 @@ import javax.naming.NamingException;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 
 import io.opentracing.Tracer;
 
@@ -49,13 +62,31 @@ public class OpentracingUtils {
      *         the name cannot be retrieved by doing a context lookup.
      */
     @Trivial
-    public static String lookupAppName() {
+    public static String lookupAppNameFallback() {
         String appName;
         try {
             appName = (String) new InitialContext().lookup("java:app/AppName");
         } catch (NamingException e) {
             Tr.error(tc, "OPENTRACING_NO_APPNAME_FOUND_IN_JNDI"); // Should never happen
             appName = DEFAULT_SERVICE_NAME;
+        }
+        return appName;
+    }
+
+    /**
+     * This is a more efficient way to obtain the current application name.
+     *
+     * @return The current application name.
+     */
+    @Trivial
+    public static String lookupAppName() {
+        String appName = null;
+        ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+        if (cmd != null) {
+            appName = cmd.getModuleMetaData().getApplicationMetaData().getName();
+        }
+        if (appName == null) {
+            appName = lookupAppNameFallback();
         }
         return appName;
     }


### PR DESCRIPTION
ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData() can return null in some rare situations. Added a check for null.

Fixes #11582