### PR TITLE
Allow the creation of the KafkaConsumer to be retried

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/resources/com/ibm/ws/microprofile/reactive/messaging/kafka/resources/ReactiveMessaging.nlsprops
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/resources/com/ibm/ws/microprofile/reactive/messaging/kafka/resources/ReactiveMessaging.nlsprops
@@ -63,17 +63,17 @@ kafka.library.not.present.CWMRX1006E.useraction=Package the kafka-clients JAR fi
 # A Kafka incoming connector for the {0} channel cannot be created. The error is {1}
 kafka.create.incoming.error.CWMRX1007E=CWMRX1007E: A Kafka incoming connector for the {0} channel cannot be created. The error is {1}
 kafka.create.incoming.error.CWMRX1007E.explanation=An error that occurred when the Kafka connector was set up for an incoming reactive messaging channel prevents normal operation of MicroProfile Reactive Messaging.
-kafka.create.incoming.error.CWMRX1007E.useraction=Review the error message, server message.log, and FFDC logs to identify the problem.
+kafka.create.incoming.error.CWMRX1007E.useraction=Review the error message, the messages.log file on the server, and FFDC logs to identify the problem.
 
 # A Kafka outgoing connector for the {0} channel cannot be created. The error is {1}
 kafka.create.outgoing.error.CWMRX1008E=CWMRX1008E: A Kafka outgoing connector for the {0} channel cannot be created. The error is {1}
 kafka.create.outgoing.error.CWMRX1008E.explanation=An error that occurred when the Kafka connector was set up for an outgoing reactive messaging channel prevents normal operation of MicroProfile Reactive Messaging.
-kafka.create.outgoing.error.CWMRX1008E.useraction=Review the error message, server message.log, and FFDC logs to identify the problem.
+kafka.create.outgoing.error.CWMRX1008E.useraction=Review the error message, the messages.log file on the server, and FFDC logs to identify the problem.
 
 # {0} = channel name, {1} = error message
 kafka.create.incoming.retry.CWMRX1009W=CWMRX1009W: A Kafka incoming connector for the {0} channel could not be created but this operation will be retried. The error is {1}
 kafka.create.incoming.retry.CWMRX1009W.explanation=An error occurred when the Kafka connector was set up for an incoming reactive messaging channel but the set up will be retried.
-kafka.create.incoming.retry.CWMRX1009W.useraction=Review the error message, server message.log, and FFDC logs to identify whether the problem was transient and was resolved by retrying the connector set up.
+kafka.create.incoming.retry.CWMRX1009W.useraction=Review the error message, the messages.log file on the server, and FFDC logs to identify whether the problem was transient and was resolved by retrying the connector set up.
 
 
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/resources/com/ibm/ws/microprofile/reactive/messaging/kafka/resources/ReactiveMessaging.nlsprops
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/resources/com/ibm/ws/microprofile/reactive/messaging/kafka/resources/ReactiveMessaging.nlsprops
@@ -70,6 +70,12 @@ kafka.create.outgoing.error.CWMRX1008E=CWMRX1008E: A Kafka outgoing connector fo
 kafka.create.outgoing.error.CWMRX1008E.explanation=An error that occurred when the Kafka connector was set up for an outgoing reactive messaging channel prevents normal operation of MicroProfile Reactive Messaging.
 kafka.create.outgoing.error.CWMRX1008E.useraction=Review the error message, server message.log, and FFDC logs to identify the problem.
 
+# {0} = channel name, {1} = error message
+kafka.create.incoming.retry.CWMRX1009W=CWMRX1009W: A Kafka incoming connector for the {0} channel could not be created but this operation will be retried. The error is {1}
+kafka.create.incoming.retry.CWMRX1009W.explanation=An error occurred when the Kafka connector was set up for an incoming reactive messaging channel but the set up will be retried.
+kafka.create.incoming.retry.CWMRX1009W.useraction=Review the error message, server message.log, and FFDC logs to identify whether the problem was transient and was resolved by retrying the connector set up.
+
+
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Reactive Messaging error message
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/resources/com/ibm/ws/microprofile/reactive/messaging/kafka/resources/ReactiveMessaging.nlsprops
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/resources/com/ibm/ws/microprofile/reactive/messaging/kafka/resources/ReactiveMessaging.nlsprops
@@ -62,17 +62,17 @@ kafka.library.not.present.CWMRX1006E.useraction=Package the kafka-clients JAR fi
 
 # A Kafka incoming connector for the {0} channel cannot be created. The error is {1}
 kafka.create.incoming.error.CWMRX1007E=CWMRX1007E: A Kafka incoming connector for the {0} channel cannot be created. The error is {1}
-kafka.create.incoming.error.CWMRX1007E.explanation=An error that occurred when the Kafka connector was set up for an incoming reactive messaging channel prevents normal operation of MicroProfile Reactive Messaging. This may be caused by a problem with the connector configuration, or by a problem resolving the Kafka broker hostname.
+kafka.create.incoming.error.CWMRX1007E.explanation=An error that occurred when the Kafka connector was set up for an incoming reactive messaging channel prevents normal operation of MicroProfile Reactive Messaging. This might be caused by a problem with the connector configuration, or by a problem resolving the Kafka broker hostname.
 kafka.create.incoming.error.CWMRX1007E.useraction=Review the error message, the messages.log file on the server, and FFDC logs to identify the problem.
 
 # A Kafka outgoing connector for the {0} channel cannot be created. The error is {1}
 kafka.create.outgoing.error.CWMRX1008E=CWMRX1008E: A Kafka outgoing connector for the {0} channel cannot be created. The error is {1}
-kafka.create.outgoing.error.CWMRX1008E.explanation=An error that occurred when the Kafka connector was set up for an outgoing reactive messaging channel prevents normal operation of MicroProfile Reactive Messaging. This may be caused by a problem with the connector configuration, or by a problem resolving the Kafka broker hostname.
+kafka.create.outgoing.error.CWMRX1008E.explanation=An error that occurred when the Kafka connector was set up for an outgoing reactive messaging channel prevents normal operation of MicroProfile Reactive Messaging. This might be caused by a problem with the connector configuration, or by a problem resolving the Kafka broker hostname.
 kafka.create.outgoing.error.CWMRX1008E.useraction=Review the error message, the messages.log file on the server, and FFDC logs to identify the problem.
 
 # {0} = channel name, {1} = error message
 kafka.create.incoming.retry.CWMRX1009W=CWMRX1009W: A Kafka incoming connector for the {0} channel cannot be created but this operation is being retried. The error is {1}
-kafka.create.incoming.retry.CWMRX1009W.explanation=An error occurred when the Kafka connector was set up for an incoming reactive messaging channel. This may be caused by a problem with the connector configuration, or by a problem resolving the Kafka broker hostname.
+kafka.create.incoming.retry.CWMRX1009W.explanation=An error occurred when the Kafka connector was set up for an incoming reactive messaging channel. This might be caused by a problem with the connector configuration, or by a problem resolving the Kafka broker hostname.
 kafka.create.incoming.retry.CWMRX1009W.useraction=Review the error message, the messages.log file on the server, and FFDC logs to identify whether the problem was transient and was resolved by retrying the connector setup.
 
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/resources/com/ibm/ws/microprofile/reactive/messaging/kafka/resources/ReactiveMessaging.nlsprops
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/resources/com/ibm/ws/microprofile/reactive/messaging/kafka/resources/ReactiveMessaging.nlsprops
@@ -62,18 +62,18 @@ kafka.library.not.present.CWMRX1006E.useraction=Package the kafka-clients JAR fi
 
 # A Kafka incoming connector for the {0} channel cannot be created. The error is {1}
 kafka.create.incoming.error.CWMRX1007E=CWMRX1007E: A Kafka incoming connector for the {0} channel cannot be created. The error is {1}
-kafka.create.incoming.error.CWMRX1007E.explanation=An error that occurred when the Kafka connector was set up for an incoming reactive messaging channel prevents normal operation of MicroProfile Reactive Messaging.
+kafka.create.incoming.error.CWMRX1007E.explanation=An error that occurred when the Kafka connector was set up for an incoming reactive messaging channel prevents normal operation of MicroProfile Reactive Messaging. This may be caused by a problem with the connector configuration, or by a problem resolving the Kafka broker hostname.
 kafka.create.incoming.error.CWMRX1007E.useraction=Review the error message, the messages.log file on the server, and FFDC logs to identify the problem.
 
 # A Kafka outgoing connector for the {0} channel cannot be created. The error is {1}
 kafka.create.outgoing.error.CWMRX1008E=CWMRX1008E: A Kafka outgoing connector for the {0} channel cannot be created. The error is {1}
-kafka.create.outgoing.error.CWMRX1008E.explanation=An error that occurred when the Kafka connector was set up for an outgoing reactive messaging channel prevents normal operation of MicroProfile Reactive Messaging.
+kafka.create.outgoing.error.CWMRX1008E.explanation=An error that occurred when the Kafka connector was set up for an outgoing reactive messaging channel prevents normal operation of MicroProfile Reactive Messaging. This may be caused by a problem with the connector configuration, or by a problem resolving the Kafka broker hostname.
 kafka.create.outgoing.error.CWMRX1008E.useraction=Review the error message, the messages.log file on the server, and FFDC logs to identify the problem.
 
 # {0} = channel name, {1} = error message
-kafka.create.incoming.retry.CWMRX1009W=CWMRX1009W: A Kafka incoming connector for the {0} channel could not be created but this operation will be retried. The error is {1}
-kafka.create.incoming.retry.CWMRX1009W.explanation=An error occurred when the Kafka connector was set up for an incoming reactive messaging channel but the set up will be retried.
-kafka.create.incoming.retry.CWMRX1009W.useraction=Review the error message, the messages.log file on the server, and FFDC logs to identify whether the problem was transient and was resolved by retrying the connector set up.
+kafka.create.incoming.retry.CWMRX1009W=CWMRX1009W: A Kafka incoming connector for the {0} channel cannot be created but this operation is being retried. The error is {1}
+kafka.create.incoming.retry.CWMRX1009W.explanation=An error occurred when the Kafka connector was set up for an incoming reactive messaging channel. This may be caused by a problem with the connector configuration, or by a problem resolving the Kafka broker hostname.
+kafka.create.incoming.retry.CWMRX1009W.useraction=Review the error message, the messages.log file on the server, and FFDC logs to identify whether the problem was transient and was resolved by retrying the connector setup.
 
 
 #-----------------------------------------------------------------------------------------------------------------------------

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaConnectorConstants.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaConnectorConstants.java
@@ -22,19 +22,27 @@ import org.eclipse.microprofile.reactive.messaging.spi.ConnectorFactory;
  */
 public class KafkaConnectorConstants {
 
+    //The unique name of this MicroProfile Reactive Messaging Connector for Kafka
+    public static final String CONNECTOR_NAME = "liberty-kafka";
+
     //Our own custom properties that we extract from config for the connector
+
     //The producer or consumer topic
     public static final String TOPIC = "topic";
 
     //The limit on on the number of un-acknowledged messages
     public static final String UNACKED_LIMIT = "unacked.limit";
 
-    //The unique name of this MicroProfile Reactive Messaging Connector for Kafka
-    public static final String CONNECTOR_NAME = "liberty-kafka";
+    //The length of time to retry creation of the KafkaConsumer
+    public static final String CREATION_RETRY_SECONDS = "creation.retry.seconds";
 
     //The set of properties which should NOT be passed through to the Kafka client
-    public static final Set<String> NON_KAFKA_PROPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(new String[] { TOPIC, ConnectorFactory.CONNECTOR_ATTRIBUTE,
-                                                                                                                             ConnectorFactory.CHANNEL_NAME_ATTRIBUTE })));
+    public static final Set<String> NON_KAFKA_PROPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(new String[] { TOPIC,
+                                                                                                                             ConnectorFactory.CONNECTOR_ATTRIBUTE,
+                                                                                                                             ConnectorFactory.CHANNEL_NAME_ATTRIBUTE,
+                                                                                                                             UNACKED_LIMIT,
+                                                                                                                             CREATION_RETRY_SECONDS
+    })));
 
 //=======================Kafka Properties===============================//
     //Kafka property - org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaIncomingConnector.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaIncomingConnector.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.reactive.messaging.kafka;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,6 +39,7 @@ import org.osgi.framework.ServiceReference;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterException;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterFactory;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaConsumer;
 
@@ -96,6 +98,7 @@ public class KafkaIncomingConnector implements IncomingConnectorFactory {
             String topic = config.getOptionalValue(KafkaConnectorConstants.TOPIC, String.class).orElse(channelName);
             int maxPollRecords = config.getOptionalValue(KafkaConnectorConstants.MAX_POLL_RECORDS, Integer.class).orElse(500);
             int unackedLimit = config.getOptionalValue(KafkaConnectorConstants.UNACKED_LIMIT, Integer.class).orElse(maxPollRecords);
+            int retrySeconds = config.getOptionalValue(KafkaConnectorConstants.CREATION_RETRY_SECONDS, Integer.class).orElse(0);
 
             // Configure our defaults
             Map<String, Object> consumerConfig = new HashMap<>();
@@ -113,7 +116,7 @@ public class KafkaIncomingConnector implements IncomingConnectorFactory {
             boolean enableAutoCommit = "true".equalsIgnoreCase((String) consumerConfig.get(KafkaConnectorConstants.ENABLE_AUTO_COMMIT));
 
             // Create the kafkaConsumer
-            KafkaConsumer<String, Object> kafkaConsumer = this.kafkaAdapterFactory.newKafkaConsumer(consumerConfig);
+            KafkaConsumer<String, Object> kafkaConsumer = getKafkaConsumerWithRetry(consumerConfig, retrySeconds, channelName);
 
             PartitionTrackerFactory partitionTrackerFactory = new PartitionTrackerFactory();
             partitionTrackerFactory.setExecutor(executor);
@@ -132,6 +135,27 @@ public class KafkaIncomingConnector implements IncomingConnectorFactory {
             return kafkaInput.getPublisher();
         } catch (Exception e) {
             throw new KafkaConnectorException(Tr.formatMessage(tc, "kafka.create.incoming.error.CWMRX1007E", channelName, e.getMessage()), e);
+        }
+    }
+
+    private <K, V> KafkaConsumer<K, V> getKafkaConsumerWithRetry(Map<String, Object> consumerConfig, int retrySeconds, String channelName) throws InterruptedException {
+        if (retrySeconds == 0) {
+            return this.kafkaAdapterFactory.newKafkaConsumer(consumerConfig);
+        }
+
+        long retryNs = Duration.ofSeconds(retrySeconds).toNanos();
+        long startTime = System.nanoTime();
+
+        while (true) {
+            try {
+                return this.kafkaAdapterFactory.newKafkaConsumer(consumerConfig);
+            } catch (KafkaAdapterException e) {
+                if ((System.nanoTime() - startTime) > retryNs) {
+                    throw e;
+                }
+                Tr.warning(tc, "kafka.create.incoming.retry.CWMRX1009W", channelName, e.getMessage());
+            }
+            Thread.sleep(1000);
         }
     }
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/badconfig/KafkaBadConfigBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/badconfig/KafkaBadConfigBean.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.invalid.badconfig;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+@ApplicationScoped
+public class KafkaBadConfigBean {
+
+    public static final String CHANNEL_NAME = "bad-config-input";
+
+    @Incoming(CHANNEL_NAME)
+    public void receive(String input) {
+        // Do nothing
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/badconfig/KafkaBadConfigTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/badconfig/KafkaBadConfigTest.java
@@ -1,0 +1,149 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.invalid.badconfig;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.ConnectorProperties.simpleIncomingChannel;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils.kafkaPermissions;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.PropertiesAsset;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.ConnectorProperties;
+import com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils;
+import com.ibm.ws.microprofile.reactive.messaging.kafka.KafkaConnectorConstants;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * Test that when invalid config is given to Kafka, an error is printed in the log.
+ * <p>
+ * Also test that if creation.retry.seconds set, the creation of the KafkaConsumer is retried. This is specifically to cope with the case where, in a Kubernetes environment, the
+ * hostname of the kafka broker does not resolve at startup.
+ */
+@RunWith(FATRunner.class)
+public class KafkaBadConfigTest {
+
+    private static final String APP_NAME = "KafkaBadConfig";
+    private static final String APP_GROUP_ID = "bad-config-test-group";
+
+    @Server("SimpleRxMessagingServer")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void teardownTest() throws Exception {
+        server.stopServer("CWMRX1007E", // Expected error message
+                          "CWWKZ000[1-4]", // Generic "Exception starting app" messages
+                          "CWMRX1009W" // Connector initialization failed but will be retried message
+        );
+    }
+
+    @Test
+    @AllowedFFDC
+    public void testBadConfig() throws Exception {
+
+        // Invalid config because bootstrap.servers not set
+        ConnectorProperties incomingProperties = simpleIncomingChannel("", KafkaBadConfigBean.CHANNEL_NAME, APP_GROUP_ID);
+
+        PropertiesAsset appConfig = new PropertiesAsset()
+                        .include(incomingProperties);
+
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addAsLibraries(KafkaUtils.kafkaClientLibs())
+                        .addAsManifestResource(kafkaPermissions(), "permissions.xml")
+                        .addClass(KafkaBadConfigBean.class)
+                        .addAsResource(appConfig, "META-INF/microprofile-config.properties");
+
+        server.setMarkToEndOfLog();
+        // Deploy the application
+        ShrinkHelper.exportToServer(server, "dropins", war, SERVER_ONLY);
+
+        // Wait for the app either to start, or to fail to start
+        String logLine = server.waitForStringInLogUsingMark("CWWKZ000[1-4].*" + APP_NAME);
+        assertNotNull("Application startup didn't complete - app startup line not found", logLine);
+
+        // Check that the bad config error was emitted
+        List<String> configErrorLines = server.findStringsInLogsUsingMark("CWMRX1007E:", server.getDefaultLogFile());
+        assertThat(configErrorLines, hasSize(1));
+        String configErrorLine = configErrorLines.get(0);
+        // ...and that it contained the channel name
+        assertThat(configErrorLine, containsString(KafkaBadConfigBean.CHANNEL_NAME));
+
+        // Check that the failure was not retried
+        List<String> retryLines = server.findStringsInLogsUsingMark("CWMRX1009W", server.getDefaultLogFile());
+        assertThat(retryLines, is(empty()));
+    }
+
+    @Test
+    @AllowedFFDC
+    public void testBadConfigRetry() throws Exception {
+        // Invalid config because bootstrap.servers not set, but creation retry enabled
+        ConnectorProperties incomingProperties = simpleIncomingChannel("", KafkaBadConfigBean.CHANNEL_NAME, APP_GROUP_ID)
+                        .addProperty(KafkaConnectorConstants.CREATION_RETRY_SECONDS, "5");
+
+        PropertiesAsset appConfig = new PropertiesAsset()
+                        .include(incomingProperties);
+
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addAsLibraries(KafkaUtils.kafkaClientLibs())
+                        .addAsManifestResource(kafkaPermissions(), "permissions.xml")
+                        .addClass(KafkaBadConfigBean.class)
+                        .addAsResource(appConfig, "META-INF/microprofile-config.properties");
+
+        server.setMarkToEndOfLog();
+        // Deploy the application
+        ShrinkHelper.exportToServer(server, "dropins", war, SERVER_ONLY);
+
+        // Wait for the app either to start, or to fail to start
+        String logLine = server.waitForStringInLogUsingMark("CWWKZ000[1-4].*" + APP_NAME);
+        assertNotNull("Application startup didn't complete - app startup line not found", logLine);
+
+        // Check that the bad config error was emitted
+        List<String> configErrorLines = server.findStringsInLogsUsingMark("CWMRX1007E:", server.getDefaultLogFile());
+        assertThat(configErrorLines, hasSize(1));
+        String configErrorLine = configErrorLines.get(0);
+        // ...and that it contained the channel name
+        assertThat(configErrorLine, containsString(KafkaBadConfigBean.CHANNEL_NAME));
+
+        // Check that the failure was retried
+        List<String> retryLines = server.findStringsInLogsUsingMark("CWMRX1009W:", server.getDefaultLogFile());
+        assertThat(retryLines, not(empty()));
+        for (String retryLine : retryLines) {
+            // placeholder in message should be replaced by channel name
+            assertThat(retryLine, containsString(KafkaBadConfigBean.CHANNEL_NAME));
+        }
+
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/badconfig/package-info.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/badconfig/package-info.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ *
+ */
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.invalid.badconfig;

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/suite/FATSuite.java
@@ -16,6 +16,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.microprofile.reactive.messaging.fat.jsonb.JsonbTest;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.tests.KafkaTestClientProviderTest;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.invalid.badconfig.KafkaBadConfigTest;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.invalid.nolib.KafkaNoLibTest;
 import com.ibm.ws.microprofile.reactive.messaging.fat.loginModuleClassloading.LoginModuleClassloadingTest;
 
@@ -27,8 +28,10 @@ import com.ibm.ws.microprofile.reactive.messaging.fat.loginModuleClassloading.Lo
                 KafkaTestClientProviderTest.class,
                 LoginModuleClassloadingTest.class,
                 KafkaNoLibTest.class,
+                KafkaBadConfigTest.class,
                 JsonbTest.class
 })
+
 public class FATSuite {
 
 }


### PR DESCRIPTION
Fixes #10937 

This has been built on top of #11309 since it changes the same code but will be rebased once that PR has been merged.

Adds a new config property to the kafka connector `creation.retry.seconds` which configures how long liberty should retry the creation of the `KafkaConsumer`.