### PR TITLE
Fix build break

### DIFF
--- a/dev/com.ibm.ws.grpc_fat/bnd.bnd
+++ b/dev/com.ibm.ws.grpc_fat/bnd.bnd
@@ -36,7 +36,7 @@ tested.features:\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.4.0;version=latest,\
 	com.ibm.ws.grpc.client.1.0;version=latest,\
-	com.ibm.ws.grpc.common.1.0;version=latest,\
+	com.ibm.ws.grpc.common;version=latest,\
 	com.ibm.ws.grpc.servlet.1.0;version=latest,\
 	com.ibm.ws.transport.http;version=latest,\
 	com.google.protobuf;version=latest,\


### PR DESCRIPTION
- grpc_fat referenced com.ibm.ws.grpc.common.1.0 but it should be
com.ibm.ws.grpc.common instead.
