### PR TITLE
Issue #11816: Avoid EJB app start on server shutdown

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/EJBContainerImpl.java
+++ b/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/EJBContainerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2015 IBM Corporation and others.
+ * Copyright (c) 2012, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -218,6 +218,11 @@ public class EJBContainerImpl implements EJBContainer {
                                              EJBSystemBeanConfig[] ejbs,
                                              EJBRemoteRuntime ejbRemoteRuntime) {
         EJBRuntimeImpl runtime = runtimeSR.getServiceWithException();
+
+        // Don't bother starting a system module if the server is shutting down
+        if (runtime.isStopping()) {
+            return null;
+        }
 
         ModuleInitDataImpl mid = createSystemModuleInitData(moduleName, classLoader, ejbs);
         OSGiEJBModuleMetaDataImpl mmd = (OSGiEJBModuleMetaDataImpl) runtime.createSystemModuleMetaData(mid);


### PR DESCRIPTION
When the server is being stopped, there is no point in attempting
to restart a system application. EJB Container should just no-op
system application starts that occur once the serve has begun
shutting down.

fixes #11816 
