### PR TITLE
run context custom providers test with Jakarta interfaces

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceImpl.java
@@ -79,7 +79,9 @@ import com.ibm.wsspi.threadcontext.WSContextService;
  */
 @Component(name = "com.ibm.ws.context.service",
            configurationPolicy = ConfigurationPolicy.REQUIRE,
-           service = { ResourceFactory.class, javax.enterprise.concurrent.ContextService.class, //
+           service = { ResourceFactory.class, //
+                       jakarta.enterprise.concurrent.ContextService.class, //
+                       javax.enterprise.concurrent.ContextService.class, //
                        ThreadContext.class, WSContextService.class, ApplicationRecycleComponent.class },
            property = { "creates.objectClass=jakarta.enterprise.concurrent.ContextService",
                         "creates.objectClass=javax.enterprise.concurrent.ContextService",

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
@@ -37,7 +37,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
@@ -74,6 +73,7 @@ import com.ibm.wsspi.threadcontext.WSContextService;
 
 @Component(configurationPid = "com.ibm.ws.concurrent.managedExecutorService", configurationPolicy = ConfigurationPolicy.REQUIRE,
            service = { ExecutorService.class, ManagedExecutor.class, //
+                       jakarta.enterprise.concurrent.ManagedExecutorService.class, //
                        javax.enterprise.concurrent.ManagedExecutorService.class, //
                        ResourceFactory.class, ApplicationRecycleComponent.class },
            reference = @Reference(name = "ApplicationRecycleCoordinator", service = ApplicationRecycleCoordinator.class),

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedScheduledExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedScheduledExecutorServiceImpl.java
@@ -44,8 +44,12 @@ import com.ibm.wsspi.threadcontext.ThreadContextProvider;
 import com.ibm.wsspi.threadcontext.WSContextService;
 
 @Component(configurationPid = "com.ibm.ws.concurrent.managedScheduledExecutorService", configurationPolicy = ConfigurationPolicy.REQUIRE,
-           service = { ExecutorService.class, javax.enterprise.concurrent.ManagedExecutorService.class,
-                       ResourceFactory.class, ApplicationRecycleComponent.class, ScheduledExecutorService.class,
+           service = { ExecutorService.class, //
+                       jakarta.enterprise.concurrent.ManagedExecutorService.class, //
+                       javax.enterprise.concurrent.ManagedExecutorService.class, //
+                       ResourceFactory.class, ApplicationRecycleComponent.class, //
+                       ScheduledExecutorService.class, //
+                       jakarta.enterprise.concurrent.ManagedScheduledExecutorService.class, //
                        javax.enterprise.concurrent.ManagedScheduledExecutorService.class },
            reference = @Reference(name = "ApplicationRecycleCoordinator", service = ApplicationRecycleCoordinator.class),
            property = { "creates.objectClass=java.util.concurrent.ExecutorService",
@@ -240,6 +244,7 @@ public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceI
         super.setContextService(ref);
     }
 
+    @Override
     @Reference(service = JavaEEVersion.class,
                cardinality = ReferenceCardinality.OPTIONAL,
                policy = ReferencePolicy.STATIC,
@@ -280,6 +285,7 @@ public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceI
         super.unsetContextService(ref);
     }
 
+    @Override
     protected void unsetEEVersion(ServiceReference<JavaEEVersion> ref) {
         super.unsetEEVersion(ref);
     }

--- a/dev/com.ibm.ws.context_fat_customproviders/bnd.bnd
+++ b/dev/com.ibm.ws.context_fat_customproviders/bnd.bnd
@@ -21,6 +21,8 @@ src: \
 
 fat.project: true
 
+tested.features=concurrent-2.0, servlet-5.0
+
 -sub: *.bnd
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)

--- a/dev/com.ibm.ws.context_fat_customproviders/build.gradle
+++ b/dev/com.ibm.ws.context_fat_customproviders/build.gradle
@@ -9,6 +9,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
+addRequiredLibraries.dependsOn addJakartaTransformer
+
 task copyFeatureBundle_buffer(type: Copy) {
   from buildDir
   into new File(autoFvtDir, 'lib/LibertyFATTestFiles/bundles')

--- a/dev/com.ibm.ws.context_fat_customproviders/fat/src/test/context/ContextServiceTest.java
+++ b/dev/com.ibm.ws.context_fat_customproviders/fat/src/test/context/ContextServiceTest.java
@@ -16,6 +16,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -23,12 +24,19 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import test.context.app.ContextServiceTestServlet;
 
 @RunWith(FATRunner.class)
 public class ContextServiceTest extends FATServletClient {
+    @ClassRule
+    public static RepeatTests r = RepeatTests
+                    .withoutModification()
+                    .andWith(new JakartaEE9Action());
+
     @Server("com.ibm.ws.context.fat.customproviders")
     @TestServlet(servlet = ContextServiceTestServlet.class, path = "contextbvt/ContextServiceTestServlet")
     public static LibertyServer server;
@@ -47,6 +55,9 @@ public class ContextServiceTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer(
+                          "CWNEN0046W.*javax", // TODO temporarily ignore until transformer supports deployment descriptors
+                          "CWNEN0047W.*javax" // TODO temporarily ignore until transformer supports deployment descriptors
+        );
     }
 }

--- a/dev/com.ibm.ws.context_fat_customproviders/test-applications/contextbvt/src/test/context/app/ContextServiceTestServlet.java
+++ b/dev/com.ibm.ws.context_fat_customproviders/test-applications/contextbvt/src/test/context/app/ContextServiceTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011,2017 IBM Corporation and others.
+ * Copyright (c) 2011,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1652,7 +1652,7 @@ public class ContextServiceTestServlet extends FATServlet {
             ContextServiceImpl_name.setAccessible(true);
             String name = (String) ContextServiceImpl_name.get(svc2);
             if (!"contextService[DefaultContextService]".equals(name))
-                throw new Exception("Unexpected ContextService given highest ranking: " + svc2);
+                throw new Exception("Unexpected ContextService given highest ranking: " + svc2 + ". Name is " + name);
         } finally {
             bundleContext.ungetService(ref2);
         }

--- a/dev/com.ibm.ws.context_fat_customproviders/test-bundles/buffer/src/test/buffer/internal/BufferContextProvider.java
+++ b/dev/com.ibm.ws.context_fat_customproviders/test-bundles/buffer/src/test/buffer/internal/BufferContextProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012,2017 IBM Corporation and others.
+ * Copyright (c) 2012,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,8 +16,6 @@ import java.io.ObjectInputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import javax.enterprise.concurrent.ManagedTask;
 
 import org.osgi.service.component.ComponentContext;
 
@@ -59,9 +57,11 @@ public class BufferContextProvider implements ThreadContextProvider {
      */
     @Override
     public ThreadContext captureThreadContext(Map<String, String> execProps, Map<String, ?> threadContextConfig) {
-        BufferContext context = new BufferContext(
-                        execProps.get(ManagedTask.IDENTITY_NAME),
-                        execProps.get(WSContextService.TASK_OWNER));
+        // These User Feature bundles don't get transformed from javax to jakarta and so need to be generic and work with either
+        String identityName = execProps.get("javax.enterprise.concurrent.IDENTITY_NAME");
+        if (identityName == null)
+            identityName = execProps.get("jakarta.enterprise.concurrent.IDENTITY_NAME");
+        BufferContext context = new BufferContext(identityName, execProps.get(WSContextService.TASK_OWNER));
         String type = execProps.get("test.buffer.context.capture");
         type = type == null ? (String) threadContextConfig.get("buffer") : type;
         if ("Default".equals(type))
@@ -77,9 +77,11 @@ public class BufferContextProvider implements ThreadContextProvider {
      */
     @Override
     public ThreadContext createDefaultThreadContext(Map<String, String> execProps) {
-        return new BufferContext(
-                        execProps.get(ManagedTask.IDENTITY_NAME),
-                        execProps.get(WSContextService.TASK_OWNER));
+        // These User Feature bundles don't get transformed from javax to jakarta and so need to be generic and work with either
+        String identityName = execProps.get("javax.enterprise.concurrent.IDENTITY_NAME");
+        if (identityName == null)
+            identityName = execProps.get("jakarta.enterprise.concurrent.IDENTITY_NAME");
+        return new BufferContext(identityName, execProps.get(WSContextService.TASK_OWNER));
     }
 
     /**
@@ -90,7 +92,9 @@ public class BufferContextProvider implements ThreadContextProvider {
         ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes));
         try {
             BufferContext context = (BufferContext) in.readObject();
-            context.identityName = info.getExecutionProperty(ManagedTask.IDENTITY_NAME);
+            context.identityName = info.getExecutionProperty("javax.enterprise.concurrent.IDENTITY_NAME");
+            if (context.identityName == null)
+                context.identityName = info.getExecutionProperty("jakarta.enterprise.concurrent.IDENTITY_NAME");
             context.taskOwner = info.getExecutionProperty(WSContextService.TASK_OWNER);
             return context;
         } finally {

--- a/dev/wlp-jakartaee-transform/rules/jakarta-renames.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-renames.properties
@@ -31,7 +31,8 @@ javax.json.bind.annotation=jakarta.json.bind.annotation
 javax.json.bind.serializer=jakarta.json.bind.serializer
 javax.json.bind.spi=jakarta.json.bind.spi
 javax.json.bind.config=jakarta.json.bind.config
- 
+
+javax.enterprise.concurrent=jakarta.enterprise.concurrent
 javax.enterprise.context.spi=jakarta.enterprise.context.spi
 javax.enterprise.inject.spi=jakarta.enterprise.inject.spi
 javax.decorator=jakarta.decorator


### PR DESCRIPTION
Enable the context_fat_customproviders test bucket to run with Jakarta interfaces as well as Java EE.