### PR TITLE
Update .classpath to get unit test build in eclipse.

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_timers/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_timers/bnd.bnd
@@ -28,6 +28,7 @@ fat.test.databases: true
 
 -buildpath: \
 	fattest.databases;version=latest,\
+	org.slf4j:slf4j-api;version=1.7.7,\
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\

--- a/dev/com.ibm.ws.jdbc_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat/bnd.bnd
@@ -32,6 +32,7 @@ fat.test.databases: true
 
 -buildpath: \
 	fattest.databases;version=latest,\
+	org.slf4j:slf4j-api;version=1.7.7,\
 	com.ibm.ws.componenttest,\
 	com.ibm.websphere.javaee.annotation.1.1,\
 	com.ibm.websphere.javaee.transaction.1.1,\

--- a/dev/com.ibm.ws.transaction.context/.classpath
+++ b/dev/com.ibm.ws.transaction.context/.classpath
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" output="bin_test" path="test/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
-  <classpathentry kind="src" output="bin_test" path="test"/>
 </classpath>


### PR DESCRIPTION
- Update .classpath src to test/src instead of test to get things building
in eclipse.
- Add slf4j to build path for fats that use fattest.databases.  
In some eclipse environments, there is a failure to build two projects
due to indirect reference errors to slf4j.  These two projects are the
only two that reference fattest.databases in their build path, but do
not include slf4j in their build path.