### PR TITLE
Disable genChecksums and publish to Maven tasks for iFix builds

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -241,7 +241,7 @@ def excludedEE7Features = ['cdi-1.2',
                            'jaxrsClient-2.0',
                            'servlet-3.1']
 
-if (isAutomatedBuild) {
+if (isAutomatedBuild && !isIFIXBuild) {
     task packageOpenLibertyAll(type: PackageLibertyWithFeatures) {
         def excludedFeatures = []
         doFirst {
@@ -250,7 +250,6 @@ if (isAutomatedBuild) {
                 this.&removeFeature("${it}")
             }
         }
-        enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
         withFeatures this.&allFeatures
@@ -263,7 +262,6 @@ if (isAutomatedBuild) {
     }
 
     task packageOpenLiberty(type: PackageLibertyWithFeatures) {
-        enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
         withFeatures this.&gaPublicFeatures
@@ -271,7 +269,6 @@ if (isAutomatedBuild) {
     }
 
     task packageOpenLibertyKernel(type: PackageLibertyWithFeatures) {
-        enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
         withFeatures { '' }
@@ -284,7 +281,6 @@ if (isAutomatedBuild) {
                 this.&removeFeature("${it}")
             }
         }
-        enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
         withFeatures this.&webProfile8Features
@@ -311,7 +307,6 @@ if (isAutomatedBuild) {
             }
         }
 
-        enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
         withFeatures this.&javaee8Features
@@ -338,7 +333,6 @@ if (isAutomatedBuild) {
             }
         }
 
-        enabled rootProject.userProps["ghe.build.type"] == null || !rootProject.userProps["ghe.build.type"].contains("ifix")
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
         withFeatures this.&microProfile3Features
@@ -357,6 +351,7 @@ if (isAutomatedBuild) {
 
 // Generate checksums
 task genChecksums() {
+  enabled !isIFIXBuild
   dependsOn parent.subprojects.assemble
   doLast {
  	generateChecksums(ant)
@@ -379,7 +374,7 @@ task zipOpenLibertyDev(type: Zip) {
 }
 publish.dependsOn zipOpenLibertyDev
 
-if (isAutomatedBuild) {
+if (isAutomatedBuild && !isIFIXBuild) {
     // Includes all features except excluded features.
     task zipOpenLibertyAll(type: Zip) {
         dependsOn packageOpenLibertyAll
@@ -482,7 +477,7 @@ publishing {
             version project.version
             artifact zipOpenLibertyDev
         }
-        if (isAutomatedBuild) {
+        if (isAutomatedBuild && !isIFIXBuild) {
             openLibertyAll(MavenPublication) {
                 artifactId 'openliberty-all'
                 version project.version

--- a/dev/wlp-gradle/propertiesSettings.gradle
+++ b/dev/wlp-gradle/propertiesSettings.gradle
@@ -48,6 +48,7 @@ def setProperties = { props ->
     boolean isRelease           = props.getProperty('is.release') == null               ? false : 'true'.equalsIgnoreCase(props.getProperty('is.release'))
     boolean isPublicPublishing  = props.getProperty('is.public.publishing') == null     ? false : 'true'.equalsIgnoreCase(props.getProperty('is.public.publishing'))
     boolean isUnittestsDisabled = props.getProperty('disable.run.runUnitTests') == null ? false : 'true'.equalsIgnoreCase(props.getProperty('disable.run.runUnitTests'))
+    boolean isIFIXBuild         = props.getProperty('ghe.build.type') == null           ? false : props.getProperty('ghe.build.type').containsIgnoreCase('ifix')
 
     props.setProperty('is.automated.build',       isAutomatedBuild.toString())
     props.setProperty('is.personal',              isPersonal.toString())
@@ -65,6 +66,7 @@ def setProperties = { props ->
         rootProject.ext.isAutomatedBuild    = isAutomatedBuild
         rootProject.ext.isPersonal          = isPersonal
         rootProject.ext.isContinuousBuild   = isContinuousBuild
+        rootProject.ext.isIFIXBuild         = isIFIXBuild
         rootProject.ext.isRelease           = isRelease
         rootProject.ext.isPublicPublishing  = isPublicPublishing
         rootProject.ext.isUnittestsDisabled = isUnittestsDisabled


### PR DESCRIPTION
Skip automated build tasks that create the various published images when the build is creating an iFix in order to save time.