### PR TITLE
Issue #11938: Export jakarta annotation API

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.anno-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.anno-2.0.feature
@@ -1,0 +1,22 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=com.ibm.websphere.appserver.anno-2.0
+IBM-API-Package: jakarta.annotation; type="spec", \
+ jakarta.annotation.security; type="spec", \
+ jakarta.annotation.sql; type="spec"
+IBM-SPI-Package: \
+ com.ibm.wsspi.anno.classsource, \
+ com.ibm.wsspi.anno.info, \
+ com.ibm.wsspi.anno.service, \
+ com.ibm.wsspi.anno.targets, \
+ com.ibm.wsspi.anno.util
+Manifest-Version: 1.0
+IBM-Process-Types: server, \
+ client
+-features=com.ibm.websphere.appserver.artifact-1.0, \
+ com.ibm.websphere.appserver.jakarta.annotation-2.0
+-bundles=com.ibm.ws.anno
+-jars=com.ibm.websphere.appserver.spi.anno; location:=dev/spi/ibm/
+-files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.anno_1.1-javadoc.zip
+kind=noship
+edition=full
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.injection-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.injection-2.0.feature
@@ -3,7 +3,7 @@ symbolicName=com.ibm.websphere.appserver.injection-2.0
 IBM-Process-Types: client, \
  server
 -features=com.ibm.websphere.appserver.containerServices-1.0, \
- com.ibm.websphere.appserver.anno-1.0
+ com.ibm.websphere.appserver.anno-2.0
 -bundles=com.ibm.ws.injection.jakarta
 kind=noship
 edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.containerServices-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.containerServices-1.0.feature
@@ -14,7 +14,7 @@ IBM-Process-Types: server, \
  client
 -features=com.ibm.websphere.appserver.artifact-1.0, \
  com.ibm.websphere.appserver.javaeedd-1.0, \
- com.ibm.websphere.appserver.anno-1.0
+ com.ibm.websphere.appserver.anno-1.0; ibm.tolerates:=2.0
 -bundles=com.ibm.ws.resource, \
  com.ibm.ws.container.service, \
  com.ibm.ws.javaee.version, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/servlet-5.0/com.ibm.websphere.appserver.servlet-5.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/servlet-5.0/com.ibm.websphere.appserver.servlet-5.0.feature
@@ -40,9 +40,8 @@ Subsystem-Category: JavaEE8Application
  com.ibm.websphere.appserver.classloading-1.0, \
  com.ibm.websphere.appserver.appmanager-1.0, \
  com.ibm.websphere.appserver.javaeePlatform-8.0, \
- com.ibm.websphere.appserver.anno-1.0, \
+ com.ibm.websphere.appserver.anno-2.0, \
  com.ibm.websphere.appserver.jakarta.annotation-2.0, \
- com.ibm.websphere.appserver.javax.annotation-1.3, \
  com.ibm.websphere.appserver.httptransport-1.0, \
  com.ibm.websphere.appserver.jakarta.servlet-5.0, \
  com.ibm.websphere.appserver.requestProbes-1.0, \


### PR DESCRIPTION
feature com.ibm.websphere.appserver.anno-1.0 exports the
javax.annotation API as a spec API to make it accessible
to applications; the same needs to be done for jakarta.annotation.

create new feature com.ibm.websphere.appserver.anno-2.0 to
perform the export; updates other jakarta features to include
the new feature instead of the old, and updated container
services to tolerate either (not javax/jakarta dependent)

fixes #11938 
