### PR TITLE
Update FAT Framework for Jakarta WebServlet

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/annotation/processor/TestServletProcessor.java
+++ b/dev/fattest.simplicity/src/componenttest/annotation/processor/TestServletProcessor.java
@@ -85,17 +85,15 @@ public class TestServletProcessor {
         // Infer queryPath from contextRoot() and @WebServlet annotation
         String[] webServletValue = new String[] {};
         String[] webServletUrlPatterns = new String[] {};
-        if (javax.servlet.http.HttpServlet.class.isAssignableFrom(anno.servlet())) {
-            javax.servlet.annotation.WebServlet webServlet = anno.servlet().getAnnotation(javax.servlet.annotation.WebServlet.class);
-            if (webServlet != null) {
-                webServletValue = webServlet.value();
-                webServletUrlPatterns = webServlet.urlPatterns();
-            }
+        javax.servlet.annotation.WebServlet webServlet = anno.servlet().getAnnotation(javax.servlet.annotation.WebServlet.class);
+        if (webServlet != null) {
+            webServletValue = webServlet.value();
+            webServletUrlPatterns = webServlet.urlPatterns();
         } else {
-            jakarta.servlet.annotation.WebServlet webServlet = anno.servlet().getAnnotation(jakarta.servlet.annotation.WebServlet.class);
-            if (webServlet != null) {
-                webServletValue = webServlet.value();
-                webServletUrlPatterns = webServlet.urlPatterns();
+            jakarta.servlet.annotation.WebServlet jakartaServlet = anno.servlet().getAnnotation(jakarta.servlet.annotation.WebServlet.class);
+            if (jakartaServlet != null) {
+                webServletValue = jakartaServlet.value();
+                webServletUrlPatterns = jakartaServlet.urlPatterns();
             }
         }
         if (webServletValue.length == 0 && webServletUrlPatterns.length == 0)


### PR DESCRIPTION
For a Jakarta EE 9 only FAT, the FAT client will still be running
with componenttest-1.0, so if the servlet extends FATServlet, it
will extend javax.servlet.http.HttpServlet when loaded by the
client, rather than jakarta.servlet.http.HttpServlet.

TestServletProcessor needs to be updated to look for
javax.servlet.annotation.WebServlet and
jakarta.servlet.annotation.WebServlet
regardless what the servlet implements.

In the running server, jakarta will be used, since
componenttest-2.0 will be used.
