### PR TITLE
refactor to eliminate Java EE from some jdbc bundles

### DIFF
--- a/dev/com.ibm.ws.jdbc.4.0.feature/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc.4.0.feature/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -23,9 +23,9 @@ Private-Package: \
 -dsannotations: com.ibm.ws.jdbc.osgi.v40.JDBC40Runtime
 
 -buildpath: \
-	com.ibm.websphere.javaee.connector.1.6;version=latest,\
 	com.ibm.websphere.org.osgi.core,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+	com.ibm.ws.jca.cm;version=latest,\
 	com.ibm.ws.jdbc;version=latest,\
-	com.ibm.websphere.appserver.spi.logging, \
+	com.ibm.websphere.appserver.spi.logging,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest

--- a/dev/com.ibm.ws.jdbc.4.0.feature/src/com/ibm/ws/jdbc/osgi/v40/JDBC40Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.0.feature/src/com/ibm/ws/jdbc/osgi/v40/JDBC40Runtime.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corporation and others.
+ * Copyright (c) 2015, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,7 +21,6 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.util.concurrent.Executor;
 
-import javax.resource.spi.ConnectionManager;
 import javax.sql.ConnectionPoolDataSource;
 import javax.sql.DataSource;
 import javax.sql.PooledConnection;
@@ -32,6 +31,7 @@ import org.osgi.framework.Version;
 import org.osgi.service.component.annotations.Component;
 
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.jca.adapter.WSConnectionManager;
 import com.ibm.ws.jdbc.osgi.JDBCRuntimeVersion;
 import com.ibm.ws.rsadapter.impl.StatementCacheKey;
 import com.ibm.ws.rsadapter.impl.WSConnectionRequestInfoImpl;
@@ -66,7 +66,7 @@ public class JDBC40Runtime implements JDBCRuntimeVersion {
     }
 
     @Override
-    public WSJdbcDataSource newDataSource(WSManagedConnectionFactoryImpl mcf, ConnectionManager connMgr) {
+    public WSJdbcDataSource newDataSource(WSManagedConnectionFactoryImpl mcf, WSConnectionManager connMgr) {
         return new WSJdbcDataSource(mcf, connMgr);
     }
 
@@ -162,8 +162,10 @@ public class JDBC40Runtime implements JDBCRuntimeVersion {
     }
 
     @Override
-    public void beginRequest(Connection con) {}
+    public void beginRequest(Connection con) {
+    }
 
     @Override
-    public void endRequest(Connection con) {}
+    public void endRequest(Connection con) {
+    }
 }

--- a/dev/com.ibm.ws.jdbc.4.1.feature/src/com/ibm/ws/jdbc/osgi/v41/JDBC41Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.1.feature/src/com/ibm/ws/jdbc/osgi/v41/JDBC41Runtime.java
@@ -24,7 +24,6 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.util.concurrent.Executor;
 
-import javax.resource.spi.ConnectionManager;
 import javax.sql.ConnectionPoolDataSource;
 import javax.sql.DataSource;
 import javax.sql.PooledConnection;
@@ -35,6 +34,7 @@ import org.osgi.framework.Version;
 import org.osgi.service.component.annotations.Component;
 
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.jca.adapter.WSConnectionManager;
 import com.ibm.ws.jdbc.osgi.JDBCRuntimeVersion;
 import com.ibm.ws.rsadapter.impl.StatementCacheKey;
 import com.ibm.ws.rsadapter.impl.WSConnectionRequestInfoImpl;
@@ -75,7 +75,7 @@ public class JDBC41Runtime implements JDBCRuntimeVersion {
     }
 
     @Override
-    public WSJdbcDataSource newDataSource(WSManagedConnectionFactoryImpl mcf, ConnectionManager connMgr) {
+    public WSJdbcDataSource newDataSource(WSManagedConnectionFactoryImpl mcf, WSConnectionManager connMgr) {
         return new WSJdbcDataSource(mcf, connMgr);
     }
 

--- a/dev/com.ibm.ws.jdbc.4.1/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc.4.1/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -25,7 +25,6 @@ instrument.disabled: true
 
 -buildpath: \
 	com.ibm.websphere.javaee.connector.1.6;version=latest,\
-	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.ws.jca.cm;version=latest,\
 	com.ibm.ws.jdbc;version=latest,\

--- a/dev/com.ibm.ws.jdbc.4.2.feature/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc.4.2.feature/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -25,8 +25,6 @@ Private-Package: \
 -dsannotations: com.ibm.ws.jdbc.osgi.v42.JDBC42Runtime
   
 -buildpath: \
-	com.ibm.websphere.javaee.connector.1.6;version=latest,\
-	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.jca.cm;version=latest,\

--- a/dev/com.ibm.ws.jdbc.4.2.feature/src/com/ibm/ws/jdbc/osgi/v42/JDBC42Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.2.feature/src/com/ibm/ws/jdbc/osgi/v42/JDBC42Runtime.java
@@ -24,7 +24,6 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.util.concurrent.Executor;
 
-import javax.resource.spi.ConnectionManager;
 import javax.sql.ConnectionPoolDataSource;
 import javax.sql.DataSource;
 import javax.sql.PooledConnection;
@@ -35,6 +34,7 @@ import org.osgi.framework.Version;
 import org.osgi.service.component.annotations.Component;
 
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.jca.adapter.WSConnectionManager;
 import com.ibm.ws.jdbc.osgi.JDBCRuntimeVersion;
 import com.ibm.ws.rsadapter.impl.StatementCacheKey;
 import com.ibm.ws.rsadapter.impl.WSConnectionRequestInfoImpl;
@@ -70,7 +70,7 @@ public class JDBC42Runtime implements JDBCRuntimeVersion {
     }
 
     @Override
-    public WSJdbcDataSource newDataSource(WSManagedConnectionFactoryImpl mcf, ConnectionManager connMgr) {
+    public WSJdbcDataSource newDataSource(WSManagedConnectionFactoryImpl mcf, WSConnectionManager connMgr) {
         return new WSJdbcDataSource(mcf, connMgr);
     }
 

--- a/dev/com.ibm.ws.jdbc.4.3.feature/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc.4.3.feature/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -35,7 +35,6 @@ Private-Package: \
   
 -buildpath: \
 	com.ibm.websphere.javaee.connector.1.6;version=latest,\
-	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.kernel.feature;verion=latest,\

--- a/dev/com.ibm.ws.jdbc.4.3.feature/src/com/ibm/ws/jdbc/osgi/v43/JDBC43Runtime.java
+++ b/dev/com.ibm.ws.jdbc.4.3.feature/src/com/ibm/ws/jdbc/osgi/v43/JDBC43Runtime.java
@@ -26,7 +26,6 @@ import java.sql.ShardingKey;
 import java.sql.Statement;
 import java.util.concurrent.Executor;
 
-import javax.resource.spi.ConnectionManager;
 import javax.sql.ConnectionPoolDataSource;
 import javax.sql.DataSource;
 import javax.sql.PooledConnection;
@@ -39,6 +38,7 @@ import org.osgi.framework.Version;
 import org.osgi.service.component.annotations.Component;
 
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.jca.adapter.WSConnectionManager;
 import com.ibm.ws.jdbc.osgi.JDBCRuntimeVersion;
 import com.ibm.ws.rsadapter.impl.StatementCacheKey;
 import com.ibm.ws.rsadapter.impl.WSConnectionRequestInfoImpl;
@@ -81,7 +81,7 @@ public class JDBC43Runtime implements JDBCRuntimeVersion {
     }
 
     @Override
-    public WSJdbcDataSource newDataSource(WSManagedConnectionFactoryImpl mcf, ConnectionManager connMgr) {
+    public WSJdbcDataSource newDataSource(WSManagedConnectionFactoryImpl mcf, WSConnectionManager connMgr) {
         return new WSJdbc43DataSource(mcf, connMgr);
     }
 

--- a/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43DataSource.java
+++ b/dev/com.ibm.ws.jdbc.4.3/src/com/ibm/ws/rsadapter/jdbc/v43/WSJdbc43DataSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,17 +16,17 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.ShardingKeyBuilder;
 
-import javax.resource.spi.ConnectionManager;
 import javax.sql.CommonDataSource;
 import javax.sql.DataSource;
 
+import com.ibm.ws.jca.adapter.WSConnectionManager;
 import com.ibm.ws.rsadapter.impl.WSConnectionRequestInfoImpl;
 import com.ibm.ws.rsadapter.impl.WSManagedConnectionFactoryImpl;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource;
 
 public class WSJdbc43DataSource extends WSJdbcDataSource implements DataSource {
 
-    public WSJdbc43DataSource(WSManagedConnectionFactoryImpl mcf, ConnectionManager connMgr) {
+    public WSJdbc43DataSource(WSManagedConnectionFactoryImpl mcf, WSConnectionManager connMgr) {
         super(mcf, connMgr);
     }
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/osgi/JDBCRuntimeVersion.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/osgi/JDBCRuntimeVersion.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.concurrent.Executor;
 
-import javax.resource.spi.ConnectionManager;
 import javax.sql.ConnectionPoolDataSource;
 import javax.sql.DataSource;
 import javax.sql.PooledConnection;
@@ -37,6 +36,7 @@ import com.ibm.ws.rsadapter.jdbc.WSJdbcObject;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcPreparedStatement;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcResultSet;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcStatement;
+import com.ibm.ws.jca.adapter.WSConnectionManager;
 import com.ibm.ws.rsadapter.impl.StatementCacheKey;
 import com.ibm.ws.rsadapter.impl.WSConnectionRequestInfoImpl;
 import com.ibm.ws.rsadapter.impl.WSManagedConnectionFactoryImpl;
@@ -67,7 +67,7 @@ public interface JDBCRuntimeVersion {
     public WSJdbcDatabaseMetaData newDatabaseMetaData(DatabaseMetaData metaDataImpl,
                                                       WSJdbcConnection connWrapper) throws SQLException;
 
-    public WSJdbcDataSource newDataSource(WSManagedConnectionFactoryImpl mcf, ConnectionManager connMgr);
+    public WSJdbcDataSource newDataSource(WSManagedConnectionFactoryImpl mcf, WSConnectionManager connMgr);
 
     public WSJdbcStatement newStatement(Statement stmtImplObject, WSJdbcConnection connWrapper, int theHoldability);
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2018 IBM Corporation and others.
+ * Copyright (c) 1997, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.PrintWriter;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method; 
 import java.lang.reflect.Proxy;
 import java.security.AccessController;
@@ -23,7 +22,6 @@ import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.sql.Connection;
 import java.sql.Driver;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.SQLNonTransientConnectionException;
 import java.sql.Statement;
@@ -79,7 +77,6 @@ import com.ibm.ws.resource.ResourceRefInfo;
 import com.ibm.ws.rsadapter.AdapterUtil;
 import com.ibm.ws.rsadapter.DSConfig; 
 import com.ibm.ws.rsadapter.exceptions.DataStoreAdapterException;
-import com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource; 
 import com.ibm.ws.rsadapter.jdbc.WSJdbcTracer;
 
 /**
@@ -356,7 +353,7 @@ public class WSManagedConnectionFactoryImpl extends WSManagedConnectionFactory i
         if (isTraceOn && tc.isEntryEnabled()) 
             Tr.entry(this, tc, "createConnectionFactory", connMgr); 
 
-        DataSource connFactory = jdbcRuntime.newDataSource(this, connMgr);
+        DataSource connFactory = jdbcRuntime.newDataSource(this, (WSConnectionManager) connMgr);
 
         if (isTraceOn && tc.isEntryEnabled())
             Tr.exit(this, tc, "createConnectionFactory", connFactory); 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcDataSource.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcDataSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2017 IBM Corporation and others.
+ * Copyright (c) 1997, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 
 import javax.resource.ResourceException;
-import javax.resource.spi.ConnectionManager;
 import javax.resource.spi.ConnectionRequestInfo;
 import javax.sql.DataSource;
 
@@ -68,7 +67,7 @@ public class WSJdbcDataSource extends WSJdbcWrapper implements DataSource, FFDCS
      * @param mcf ManagedConnectionFactory implementation that created this data source.
      * @param connMgr connection manager that manages connections from this data source.
      */
-    public WSJdbcDataSource(WSManagedConnectionFactoryImpl mcf, ConnectionManager connMgr) 
+    public WSJdbcDataSource(WSManagedConnectionFactoryImpl mcf, WSConnectionManager connMgr)
     {
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled(); 
 
@@ -76,7 +75,7 @@ public class WSJdbcDataSource extends WSJdbcWrapper implements DataSource, FFDCS
             Tr.entry(this, tc, "<init>", mcf, connMgr);
 
         this.mcf = mcf;
-        cm = (WSConnectionManager) connMgr;
+        cm = connMgr;
         resRefInfo = cm.getResourceRefInfo(); 
         dsConfig = mcf.dsConfig; 
 


### PR DESCRIPTION
Prepare for Jakarta support by eliminating usage of Java EE packages from some JDBC bundles where we don't really need it.