### PR TITLE
Issue 10519: Add automatic certificate checker for ACME

### DIFF
--- a/dev/com.ibm.ws.security.acme/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.acme/resources/OSGI-INF/l10n/metatype.properties
@@ -63,7 +63,7 @@ trustStoreType=Truststore type
 trustStoreType.desc=The keystore type for the truststore. Supported types are JKS, PKCS12 and JCEKS.
 
 renewBeforeExpiration=Renew time before expiration
-renewBeforeExpiration.desc=Time period before the expiration date of the certificate to request a new certificate. If the first request doesn't work, the certificate renewal request continues until a new certificate is received. For example, if the renewBeforeExpiration property is set to seven days, the ACME service requests a new certificate seven days before the expiration date of the current certificate. Setting the renewBeforeExpiration property to zero or a negative value disables automatic certificate renewal.
+renewBeforeExpiration.desc=Time period before the expiration date of the certificate to request a new certificate. For example, if the renewBeforeExpiration property is set to seven days, the ACME service requests a new certificate seven days before the expiration date of the current certificate. Setting the renewBeforeExpiration property to zero or a negative value disables automatic certificate renew requests.
 
 acmeRevocationChecker=ACME Certificate Revocation Checker
 acmeRevocationChecker.desc=Configuration for checking the revocation status of certificates with the Online Certificate Status Protocol (OCSP) or Certificate Revocation Lists (CRLs).
@@ -80,3 +80,12 @@ preferCRLs.desc=By default, OCSP is the preferred mechanism for checking revocat
 
 disableFallback=No fallback
 disableFallback.desc=Disable the certificate revocation status checker fallback mechanism. During certificate revocation status check, the default behavior is fallback and check by using the non-preferred mechanism (OCSP or CRLs). Default is false.
+
+certCheckerSchedule=Certificate checker schedule
+certCheckerSchedule.desc=Interval for the ACME CA service to check if the certificate is expiring or revoked. If the certificate is expiring or revoked, the ACME CA service issues a certificate renew request. If the first renew request fails, the certificate renew request continues according to the timing set by the certCheckerErrorSchedule attribute until a new certificate is received. Setting the certCheckerSchedule property to zero or a negative value disables automatic certificate renew requests.
+
+certCheckerErrorSchedule=Certificate checker error schedule
+certCheckerErrorSchedule.desc=Performs the same function as the certCheckerSchedule attribute, but on an alternate schedule. For example, the certCheckerErrorSchedule attribute can be set to a shorter interval than the certCheckerSchedule attribute, to increase the frequency of checks after a failed request. The interval from the certCheckerSchedule attribute is resumed after the certificate is renewed. 
+
+disableMinRenewWindow=Disable minimum renew window
+disableMinRenewWindow.desc=Enables immediate certificate renew requests by disabling the specified minimum amount of time between renew requests. The minimum renew time is to 15 seconds.

--- a/dev/com.ibm.ws.security.acme/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.acme/resources/OSGI-INF/metatype/metatype.xml
@@ -45,7 +45,14 @@
 
    <!-- Revocation checker configuration. -->
    <AD id="acmeRevocationChecker" name="%acmeRevocationChecker" description="%acmeRevocationChecker.desc" type="String"  required="false" ibm:flat="true" ibm:type="pid" ibm:reference="com.ibm.ws.security.acme.revocation" />
-  
+
+   <!-- Automatic renew or revoke checking configuration -->
+   <AD id="certCheckerSchedule"       name="internal" description="internal use only" type="String"  required="false" ibm:type="duration" default="1d" />
+   <AD id="certCheckerErrorSchedule"  name="internal" description="internal use only" type="String"  required="false" ibm:type="duration" default="1h" />
+   
+   <!--  Allow immediate REST renew requests -->
+   <AD id="disableMinRenewWindow"     name="internal" description="internal use only" type="Boolean"  required="false" default="false" />
+
  </OCD>
   
  <Designate factoryPid="com.ibm.ws.security.acme.transport">

--- a/dev/com.ibm.ws.security.acme/resources/com/ibm/ws/security/acme/resources/AcmeMessages.nlsprops
+++ b/dev/com.ibm.ws.security.acme/resources/com/ibm/ws/security/acme/resources/AcmeMessages.nlsprops
@@ -20,7 +20,7 @@
 #-----  ACME messages
 
 # The ACME referred to in these messages stands for Automatic Certificate Management Environment.
-# The term "certificate authority" is in reference to SSL/TLS certificate providers.
+# The term "certificate authority" is in reference to SSL and TLS requests certificate providers.
 # The URI parameter in these messages is for the ACME certificate authority, such as https://sampleCAProvider.org/directory
 
 ###############################################################################
@@ -32,6 +32,7 @@ REST_FORBIDDEN=Forbidden
 REST_INVALID_CONTENT_TYPE=The request's content-type header was not 'application/json'.
 REST_MISSING_OPERATION=The operation was not specified for the request.
 REST_NO_ACME_SERVICE=An AcmeProvider service was not registered.
+REST_TOO_MANY_REQUESTS=The user sent too many requests in a given amount of time. The amount of time remaining until the next request is allowed is {0}.
 ###############################################################################
 
 FILE_NOT_READABLE=the file is not readable
@@ -215,7 +216,7 @@ CWPKI2044E.explanation=The ACME service expects all certificates in the certific
 CWPKI2044E.useraction=Ensure that all the certificates in the certificate chain are X.509 certificates and try again.
 
 CWPKI2045W=CWPKI2045W: The certificate with {0} serial number that is signed by the ACME certificate authority at the {1} URI is not valid until {2}.
-CWPKI2045W.explanation=The valid period on the certificate is in the future. SSL/TLS requests fail until the current date and time are within the range that is specified by the valid period on the certificate.
+CWPKI2045W.explanation=The valid period on the certificate is in the future. SSL and TLS requests fail until the current date and time are within the range that is specified by the valid period on the certificate.
 CWPKI2045W.useraction=Update the local time on the server if the time is incorrect.
 
 CWPKI2046E=CWPKI2046E: The certificate {0} revocation reason is invalid. Supported revocation reasons are: unspecified, key_compromise, ca_compromise, affiliation_changed, superseded, cessation_of_operations, certificate_hold, remove_from_crl, privilege_withdrawn and aa_compromise.
@@ -230,11 +231,11 @@ CWPKI2048I=CWPKI2048I: The account key pair renewal is successful. The old accou
 CWPKI2048I.explanation=The previous account key pair is no longer associated with the account and is backed up to a file. The new account key pair replaced the old account key pair file.
 CWPKI2048I.useraction=No action is required.
 
-CWPKI2049E=CWPKI2049E: The account key pair didn''t renew or restore to the existing key pair file. Manually replace the {0} account key pair file with the {1} account key pair file.
+CWPKI2049E=CWPKI2049E: The account key pair did not renew or restore to the existing key pair file. Manually replace the {0} account key pair file with the {1} account key pair file.
 CWPKI2049E.explanation=The key pair didn't renew or restore to the old key pair file.
 CWPKI2049E.useraction=Manually replace the account key pair files as directed in the message.
 
-CWPKI2050E=CWPKI2050E: The existing account key pair file didn''t back up during while the account key pair renewal. The error is ''{0}''.
+CWPKI2050E=CWPKI2050E: The existing account key pair file did not back up during the account key pair renewal. The error is ''{0}''.
 CWPKI2050E.explanation=The existing account key pair file could not be backed up. 
 CWPKI2050E.useraction=Ensure that the directory that contains the existing account key pair file is writable. Review the error message for details on the failure.
 
@@ -247,7 +248,7 @@ CWPKI2052I.explanation=The ACME service requests a new certificate based on the 
 CWPKI2052I.useraction=No action is required.
 
 CWPKI2053W=CWPKI2053W: The certificate with {0} serial number expired on {1}. The ACME service is not configured to automatically request a new certificate.
-CWPKI2053W.explanation=The TLS/SSL requests cannot complete because the certificate expired.
+CWPKI2053W.explanation=The SSL and TLS requests cannot complete because the certificate expired.
 CWPKI2053W.useraction=Update the renewBeforeExpiration property in the server configuration to a value greater than 0 to automatically request a new certificate or use the ACME REST interface to request a new certificate.
 
 CWPKI2054W=CWPKI2054W: The renewBeforeExpiration property was set to {0}, which is equal to or longer than the validity period of the certificate with {1} serial number. The validity period of the certificate is {2}. The renewBeforeExpiration property is reset to {3}.
@@ -262,8 +263,8 @@ CWPKI2056W=CWPKI2056W: The validity period of the certificate with {0} serial nu
 CWPKI2056W.explanation=The validity period is shorter than the minimum renew time. The certificate expires before a new certificate is requested.
 CWPKI2056W.useraction=To avoid certificate expiration, request a certificate with a longer validity period. If the certificate authority supports a custom validity period, set the validFor property in the server configuration.
 
-CWPKI2057E=CWPKI2057E: Certificate revocation status checking didn''t create a CertPathValidator to validate the certificate. The error is ''{0}''.
-CWPKI2057E.explanation=The certificate revocation checker needs to build a CertPathValidator to check OCSP and CRLs revocation status.
+CWPKI2057E=CWPKI2057E: Certificate revocation status checking did not create a Java certificate path validation tool to validate the certificate. The error is ''{0}''.
+CWPKI2057E.explanation=The certificate revocation checker needs to build a Java certificate path validation tool to check OCSP and CRLs revocation status.
 CWPKI2057E.useraction=Review the status message and error for details.
 
 CWPKI2058W=CWPKI2058W: Certificate revocation status checking ignored soft failures. Revocation checking might be incomplete. The failures are: ''{0}''.
@@ -274,18 +275,17 @@ CWPKI2059I=CWPKI2059I: Certificate revocation status checking found that the cer
 CWPKI2059I.explanation=The ACME service found that the certificate was marked revoked by either a CRL or OSCP responder. 
 CWPKI2059I.useraction=No action is required.
 
-CWPKI2060E=CWPKI2060E: The OCSP URL from the certificate with the {0} serial number wasn''t retrieved. The error is: ''{1}''.
+CWPKI2060E=CWPKI2060E: The OCSP URL from the certificate with the {0} serial number was not retrieved. The error is: ''{1}''.
 CWPKI2060E.explanation=The OCSP URL was not retrieved.
 CWPKI2060E.useraction=Ensure that the certificate is a valid X.509 certificate. If it is not valid, request a new certificate.
 
-CWPKI2061E=CWPKI2061E: The CRL distribution points from the certificate with the {0} serial number weren''t retrieved. The error is ''{1}''.
+CWPKI2061E=CWPKI2061E: The CRL distribution points from the certificate with the {0} serial number were not retrieved. The error is ''{1}''.
 CWPKI2061E.explanation=The CRL distribution points were not retrieved.
 CWPKI2061E.useraction=Ensure that the certificate is a valid X.509 certificate. If it is not valid, request a new certificate.
 
 CWPKI2062E=CWPKI2062E: The {0} OCSP responder URL defined in the server configuration is not a valid URI. If defined, it must be a valid URI to override the OSCP responder URL contained in the certificate.
 CWPKI2062E.explanation=Certificate revocation checking requires a valid OCSP responder URL.
 CWPKI2062E.useraction=Provide a valid OCSP responder URL in the server configuration.
-
 
 CWPKI2063E=CWPKI2063E: The ACME certificate authority at the {0} URI updated its terms of service and now requires the user to agree to the new terms of service at the following URI before it processes any further requests: {1}
 CWPKI2063E.explanation=The certificate authority updated its terms of service and requires user interaction.
@@ -294,3 +294,31 @@ CWPKI2063E.useraction=Review the provided terms of service.
 CWPKI2064I=CWPKI2064I: The ACME service retrieved the certificate with the {0} serial number from the {1} URI in {2} seconds.
 CWPKI2064I.explanation=The ACME service successfully requested a certificate.
 CWPKI2064I.useraction=No action is required.
+
+CWPKI2065W=CWPKI2065W: The ACME service failed to automatically renew the certificate with the {0} serial number. The request is scheduled to try again in {1}. The certificate expires on {2}. The renew request error is ''{3}''.
+CWPKI2065W.explanation=The ACME service tried to renew a certificate but encountered an error. The ACME service continues to request a new certificate until a new certificate is issued.
+CWPKI2065W.useraction=Review the error message for details on the failure.
+
+CWPKI2066E=CWPKI2066E: The ACME service failed to automatically renew the certificate with the {0} serial number. The certificate is revoked. The request is scheduled to try again in {1}. The renew request error is ''{2}''.
+CWPKI2066E.explanation=The ACME service tried to renew a certificate but encountered an error. The ACME service continues to request a new certificate until a new certificate is issued. SSL and TLS requests fail until a new certificate request is successful.
+CWPKI2066E.useraction=Review the error message for details on the failure. 
+
+CWPKI2067I=CWPKI2067I: The certificate with the {0} serial number is revoked. The ACME service requests a new certificate from the ACME certificate authority at the {1} URI.
+CWPKI2067I.explanation=When the ACME service detects that the certificate is revoked, it automatically requests a new certificate.
+CWPKI2067I.useraction=No action is required.
+
+CWPKI2068W=CWPKI2068W: The ACME service automatic certificate checking failed to check if the certificate with the {0} serial number is expiring or revoked. The check is scheduled to try again in {1}. The error is ''{2}''.
+CWPKI2068W.explanation=The ACME service started checking if the certificate is expiring or revoked, but failed.
+CWPKI2068W.useraction=Review the error message for details on the failure. Review the certificate status using the ACME REST interface. If the certificate needs to be renewed, use the ACME REST interface to request a new certificate.
+
+CWPKI2069I=CWPKI2069I: The ACME service automatic certificate checking is disabled. Expiring or revoked certificates are not automatically renewed.
+CWPKI2069I.explanation=The ACME service does not check for expiring or revoked certificates on an automated schedule. If the certificate expires or is revoked, SSL and TLS requests cannot complete unless the server is restarted or the REST interface is used to renew the certificate.
+CWPKI2069I.useraction=No action is required. To enable automatic certificate checking, update the certCheckerSchedule property in the server configuration to a value greater than 0.
+
+CWPKI2070W=CWPKI2070W: The certCheckerSchedule property was set to {0}, which is shorter than the minimum schedule time. The certCheckerSchedule property is reset to {1}.
+CWPKI2070W.explanation=The value for the certCheckerSchedule property was below the minimum duration to check for expiring or revoked certificates and is reset to the minimum schedule time.
+CWPKI2070W.useraction=To avoid this warning message, set the certCheckerSchedule property in the server configuration to a duration that is longer than the minimum schedule time. To use the default setting, remove the certCheckerSchedule property from the server configuration.
+
+CWPKI2071W=CWPKI2071W: The certCheckerErrorSchedule property was set to {0}, which is shorter than the minimum schedule time. The certCheckerErrorSchedule property is reset to {1}.
+CWPKI2071W.explanation=The value for the certCheckerErrorSchedule property was below the minimum duration to check for expiring or revoked certificates and is reset to the minimum schedule time.
+CWPKI2071W.useraction=To avoid this warning message, set the certCheckerErrorSchedule property in the server configuration to a duration that is longer than the minimum schedule time. To use the default setting, remove the certCheckerErrorSchedule property from the server configuration.

--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/AcmeProvider.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/AcmeProvider.java
@@ -18,6 +18,7 @@ import java.util.List;
 import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.ws.crypto.certificateutil.DefaultSSLCertificateCreator;
 import com.ibm.ws.security.acme.internal.AcmeClient.AcmeAccount;
+import com.ibm.ws.security.acme.internal.exceptions.CertificateRenewRequestBlockedException;
 
 /**
  * An interface to define the methods that an ACME 2.0 OSGi service will
@@ -124,5 +125,14 @@ public interface AcmeProvider {
 	 */
 	public void updateDefaultSSLCertificate(KeyStore keyStore, File keyStoreFile, @Sensitive String password)
 			throws CertificateException;
+	
+	/**
+	 * Checks whether a certificate renew is allowed. If a renew just happened, the
+	 * request is blocked.
+	 * 
+	 * @throws AcmeCaException
+	 * 			If a certificate renew just happened
+	 */
+	public void checkCertificateRenewAllowed() throws AcmeCaException;
 
 }

--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeCertCheckerTask.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeCertCheckerTask.java
@@ -1,0 +1,233 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.security.acme.internal;
+
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+/**
+ * The AcmeCertCheckerTask runs in the background and periodically checks if the
+ * ACME CA certificate is either expiring or revoked and renews the certificate
+ * if necessary.
+ */
+public class AcmeCertCheckerTask implements Runnable {
+
+	private static final TraceComponent tc = Tr.register(AcmeCertCheckerTask.class);
+
+	private final AcmeProviderImpl acmeProviderImpl;
+
+	private ScheduledFuture<?> certChecker;
+
+	private ScheduledExecutorService service = null;
+	
+	private volatile boolean runningOnErrorSchedule = false;
+
+	public AcmeCertCheckerTask(AcmeProviderImpl acmePI) {
+		acmeProviderImpl = acmePI;
+	}
+
+	/**
+	 * Stop the scheduler and void the ScheduledFuture
+	 */
+	public synchronized void stop() {
+		cancel(true);
+		certChecker = null;
+	}
+
+	/**
+	 * Start the certificate checker scheduled task. It will first cancel any
+	 * existing task and then schedule a new repeating task.
+	 * 
+	 * @param service
+	 *           The scheduler service ref
+	 */
+	protected synchronized void startCertificateChecker(ScheduledExecutorService service) {
+		cancel(true);
+
+		if (acmeProviderImpl.getAcmeConfig() == null) {
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc, "Provided acmeProviderImpl.getAcmeConfig() is null, cannot start certificate checker");
+			}
+			return;
+		}
+
+		if (acmeProviderImpl.getAcmeConfig().getCertCheckerScheduler() == 0
+				|| (!acmeProviderImpl.getAcmeConfig().isAutoRenewOnExpiration()
+						&& !acmeProviderImpl.getAcmeConfig().isRevocationCheckerEnabled())) {
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc,
+						"ScheduledExecutorService not started for AcmeCertChecker, it is disabled-- getCertCheckerScheduler: "
+								+ acmeProviderImpl.getAcmeConfig().getCertCheckerScheduler()
+								+ ", isAutoRenewOnExpiration: "
+								+ acmeProviderImpl.getAcmeConfig().isAutoRenewOnExpiration()
+								+ ", isRevocationCheckerEnabled: "
+								+ acmeProviderImpl.getAcmeConfig().isRevocationCheckerEnabled());
+			}
+			return;
+		}
+
+		if (service == null) {
+			if (tc.isDebugEnabled()) {
+				Tr.debug(tc, "Provided ScheduledExecutorService is null, cannot start certificate checker");
+			}
+			return;
+		}
+
+		this.service = service;
+
+		if (tc.isDebugEnabled()) {
+			Tr.debug(tc, "ScheduledExecutorService starting, time: "
+					+ acmeProviderImpl.getAcmeConfig().getCertCheckerScheduler());
+		}
+		startRegularSchedule();
+	}
+
+	/**
+	 * Scheduled task to check if the current certificate is expiring or revoked. If
+	 * it is expiring or revoked, a certificate request is made. If an exception occurs,
+	 * it continues to run, but is rescheduled on the error schedule.
+	 */
+	@Override
+	public void run() {
+
+		boolean isExpired = false, isRevoked = false;
+		List<X509Certificate> currentCert = null;
+
+		acmeProviderImpl.acquireWriteLock();
+		try {
+			currentCert = acmeProviderImpl.getConfiguredDefaultCertificateChain();
+
+			if (currentCert == null) {
+				if (tc.isDebugEnabled()) {
+					Tr.debug(tc, "Attempted to check the current certificate, but it was null.");
+				}
+				return;
+			} else {
+				if (acmeProviderImpl.getAcmeConfig().isAutoRenewOnExpiration()
+						&& acmeProviderImpl.isExpired(currentCert)) {
+					isExpired = true;
+				} else if (acmeProviderImpl.isRevoked(currentCert)) {
+					isRevoked = true;
+				}
+			}
+
+			if (isExpired || isRevoked) {
+				if (isExpired) {
+					Tr.info(tc, "CWPKI2052I", currentCert.get(0).getSerialNumber().toString(16),
+							currentCert.get(0).getNotAfter().toInstant().toString(),
+							acmeProviderImpl.getAcmeConfig().getDirectoryURI());
+				} else if (isRevoked) {
+					Tr.info(tc, "CWPKI2067I", currentCert.get(0).getSerialNumber().toString(16),
+							acmeProviderImpl.getAcmeConfig().getDirectoryURI());
+				}
+				acmeProviderImpl.renewCertificate();
+			} else {
+				if (tc.isDebugEnabled()) {
+					Tr.debug(tc,
+							"ACME automatic certificate checker verified that the ACME CA cert is valid. Next check is "
+									+ acmeProviderImpl.getAcmeConfig().getCertCheckerScheduler() + "ms. SN is "
+									+ currentCert.get(0).getSerialNumber().toString(16));
+				}
+
+				if (runningOnErrorSchedule) {
+					if (tc.isDebugEnabled()) {
+						Tr.debug(tc,
+								"ACME automatic certificate checker was running on error time, but we have a valid certificate, swap back to the regular schedule");
+					}
+					startRegularSchedule();
+				}
+				
+			}
+
+		} catch (Throwable t) {
+			try {
+				if (tc.isDebugEnabled()) {
+					Tr.debug(tc, "Requested a new certificate, but request failed.", t);
+				}
+				if (currentCert == null) {
+					if (tc.isDebugEnabled()) {
+						Tr.debug(tc,
+								"Attempted to check the current certificate, but it was null. Stay on regular schedule.");
+					}
+					return;
+				} else {
+					String sn = currentCert.get(0).getSerialNumber().toString(16);
+					if (isExpired) {
+						Tr.warning(tc, "CWPKI2065W", sn,
+								acmeProviderImpl.getAcmeConfig().getCertCheckerErrorScheduler() + "ms",
+								currentCert.get(0).getNotAfter().toInstant().toString(), t);
+					} else if (isRevoked) {
+						Tr.error(tc, "CWPKI2066E", sn,
+								acmeProviderImpl.getAcmeConfig().getCertCheckerErrorScheduler() + "ms", t);
+					} else {
+						Tr.warning(tc, "CWPKI2068W", sn,
+								acmeProviderImpl.getAcmeConfig().getCertCheckerErrorScheduler() + "ms", t);
+					}
+				}
+
+				cancel(false);
+
+				if (tc.isDebugEnabled()) {
+					Tr.debug(tc, "Certificate request failed, swapping to the error schedule: "
+							+ acmeProviderImpl.getAcmeConfig().getCertCheckerErrorScheduler());
+				}
+			} finally {
+				startErrorSchedule();
+			}
+
+		} finally {
+			acmeProviderImpl.releaseWriteLock();
+		}
+	}
+
+	/**
+	 * Cancel the current certChecker future.
+	 * 
+	 * @param interrupt
+	 *           Whether to interrupt the current certChecker future
+	 */
+	private synchronized void cancel(boolean interrupt) {
+		if (certChecker != null) {
+			certChecker.cancel(interrupt);
+		}
+	}
+
+	/**
+	 * Start the certChecker using the regular timing schedule. The current future ref
+	 * is cancelled.
+	 */
+	private void startRegularSchedule() {
+		cancel(false);
+		certChecker = service.scheduleAtFixedRate(this,
+				acmeProviderImpl.getAcmeConfig().getCertCheckerScheduler(),
+				acmeProviderImpl.getAcmeConfig().getCertCheckerScheduler(), TimeUnit.MILLISECONDS);
+		runningOnErrorSchedule = false;
+	}
+
+	/**
+	 * Start the certChecker using the error timing schedule. The current future ref
+	 * is cancelled.
+	 */
+	private void startErrorSchedule() {
+		cancel(false);
+		certChecker = service.scheduleAtFixedRate(this,
+				acmeProviderImpl.getAcmeConfig().getCertCheckerErrorScheduler(),
+				acmeProviderImpl.getAcmeConfig().getCertCheckerErrorScheduler(), TimeUnit.MILLISECONDS);
+		runningOnErrorSchedule = true;
+	}
+}

--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeProviderImpl.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeProviderImpl.java
@@ -33,13 +33,18 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
 
 import org.bouncycastle.asn1.x509.GeneralName;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
@@ -56,8 +61,11 @@ import com.ibm.ws.security.acme.AcmeCaException;
 import com.ibm.ws.security.acme.AcmeCertificate;
 import com.ibm.ws.security.acme.AcmeProvider;
 import com.ibm.ws.security.acme.internal.AcmeClient.AcmeAccount;
+import com.ibm.ws.security.acme.internal.exceptions.CertificateRenewRequestBlockedException;
+import com.ibm.ws.security.acme.internal.util.AcmeConstants;
 import com.ibm.ws.ssl.JSSEProviderFactory;
 import com.ibm.ws.ssl.KeyStoreService;
+import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 
 /**
  * ACME 2.0 support component service.
@@ -76,11 +84,31 @@ public class AcmeProviderImpl implements AcmeProvider {
 	 */
 	private final static AtomicReference<AcmeApplicationStateListener> applicationStateListenerRef = new AtomicReference<AcmeApplicationStateListener>();
 
+	/**
+	 * A scheduler service used to scheduler the {@link AcmeCertCheckerTask} for checking
+	 * whether the certificate is expiring or revoked
+	 */
+	private final AtomicServiceReference<ScheduledExecutorService> scheduledExecutorServiceRef = new AtomicServiceReference<ScheduledExecutorService>("scheduledExecutorService");
+
 	/** Client used to communicate with the ACME CA server. */
 	private static AcmeClient acmeClient;
 
 	/** Configuration for the ACME client. */
 	private static AcmeConfig acmeConfig;
+
+	/** Scheduled thread to check if the certificate is reaching expiration or is revoked **/
+	private AcmeCertCheckerTask acmeCertChecker = null;
+	
+	/** Read/Write lock to prevent multiple processes from renewing the certificate at the same or similar time. **/
+	private final ReadWriteLock rwRenewCertLock = new ReentrantReadWriteLock();
+	
+	/** The last time the certificate was renewed **/
+	private long lastCertificateRenewalTimestamp = -1;
+	
+	/** Activate for the scheduler ref **/
+	public void activate(ComponentContext cc) {
+		scheduledExecutorServiceRef.activate(cc);
+	}
 
 	@Override
 	public void renewAccountKeyPair() throws AcmeCaException {
@@ -128,6 +156,9 @@ public class AcmeProviderImpl implements AcmeProvider {
 	@FFDCIgnore({ AcmeCaException.class })
 	private void checkAndInstallCertificate(boolean forceRefresh, KeyStore keyStore, File keyStoreFile,
 			@Sensitive String password) throws AcmeCaException {
+		
+		acquireWriteLock();
+		try {
 		/*
 		 * Wait until the ACME authorization web application is available. At
 		 * this point, it always should be, but check just in case.
@@ -183,6 +214,13 @@ public class AcmeProviderImpl implements AcmeProvider {
 				throw new AcmeCaException(
 						Tr.formatMessage(tc, "CWPKI2030E", DEFAULT_ALIAS, DEFAULT_KEY_STORE, ex.getMessage()), ex);
 			}
+			
+			/*
+			 * Mark the timestamp for this renew request
+			 */
+			if (!acmeConfig.isDisableMinRenewWindow()) {
+				lastCertificateRenewalTimestamp = System.currentTimeMillis();
+			}
 
 			/*
 			 * Revoke the old certificate, which has now been replaced in the
@@ -192,8 +230,8 @@ public class AcmeProviderImpl implements AcmeProvider {
 				try {
 					revoke(existingCertChain, "SUPERSEDED");
 				} catch (AcmeCaException e) {
-					if (TraceComponent.isAnyTracingEnabled() && tc.isWarningEnabled()) {
-						Tr.debug(tc, "Failed to revoke the certificate.", existingCertChain);
+					if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+						Tr.debug(tc, "Failed to revoke the certificate.", existingCertChain, e);
 					}
 				}
 			}
@@ -209,6 +247,15 @@ public class AcmeProviderImpl implements AcmeProvider {
 			if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
 				Tr.debug(tc, "Previous certificate requested from ACME CA server is still valid.");
 			}
+		}
+
+		/*
+		 * Start the certificate checker task, will cancel any existing tasks and restart
+		 */
+		acmeCertChecker.startCertificateChecker(getScheduledExecutorService());
+
+		} finally {
+			releaseWriteLock();
 		}
 	}
 
@@ -234,8 +281,13 @@ public class AcmeProviderImpl implements AcmeProvider {
 	 *             If there was an error revoking the certificate.
 	 */
 	public void revoke(List<X509Certificate> certificateChain, String reason) throws AcmeCaException {
-		X509Certificate certificate = getLeafCertificate(certificateChain);
-		getAcmeClient().revoke(certificate, reason);
+		acquireWriteLock();
+		try {
+			X509Certificate certificate = getLeafCertificate(certificateChain);
+			getAcmeClient().revoke(certificate, reason);
+		} finally {
+			releaseWriteLock();
+		}
 	}
 
 	/**
@@ -252,6 +304,17 @@ public class AcmeProviderImpl implements AcmeProvider {
 			throw new AcmeCaException("Internal error. ACME client was not initialized.");
 		}
 		return acmeClient;
+	}
+	
+	/**
+	 * Convenience method that will retrieve the {@link AcmeConfig}
+	 * 
+	 * @return The {@link AcmeConfig} instance to use.
+	 * 
+	 */
+	@Trivial
+	protected AcmeConfig getAcmeConfig() {
+		return acmeConfig;
 	}
 
 	/**
@@ -332,8 +395,13 @@ public class AcmeProviderImpl implements AcmeProvider {
 		/*
 		 * Check if we need to get a new certificate.
 		 */
-		if (forceRefresh || isCertificateRequired(existingCertChain)) {
-			return fetchCertificate();
+		acquireWriteLock();
+		try {
+			if (forceRefresh || isCertificateRequired(existingCertChain)) {
+				return fetchCertificate();
+			}
+		} finally {
+			releaseWriteLock();
 		}
 
 		return null;
@@ -545,7 +613,7 @@ public class AcmeProviderImpl implements AcmeProvider {
 	 *            The certificate chain to check.
 	 * @return true if the leaf certificate is expired or nearly expiring.
 	 */
-	private boolean isExpired(List<X509Certificate> certificateChain) {
+	protected boolean isExpired(List<X509Certificate> certificateChain) {
 		X509Certificate certificate = getLeafCertificate(certificateChain);
 		if (certificate == null) {
 			return false;
@@ -589,8 +657,7 @@ public class AcmeProviderImpl implements AcmeProvider {
 	 * @return True if the certificate has been revoked, false otherwise.
 	 * @throws AcmeCaException
 	 */
-	private boolean isRevoked(List<X509Certificate> certificateChain) throws AcmeCaException {
-
+	protected boolean isRevoked(List<X509Certificate> certificateChain) throws AcmeCaException {
 		CertificateRevocationChecker checker = new CertificateRevocationChecker(acmeConfig);
 		return checker.isRevoked(certificateChain);
 	}
@@ -663,7 +730,7 @@ public class AcmeProviderImpl implements AcmeProvider {
 	 *             chain
 	 */
 	@FFDCIgnore({ CertificateException.class })
-	private List<X509Certificate> getConfiguredDefaultCertificateChain() throws AcmeCaException {
+	protected List<X509Certificate> getConfiguredDefaultCertificateChain() throws AcmeCaException {
 		/*
 		 * Get our existing certificate.
 		 */
@@ -705,12 +772,25 @@ public class AcmeProviderImpl implements AcmeProvider {
 			File file = createKeyStore(filePath, acmeCertificate, password, keyStoreType, keyStoreProvider);
 
 			/*
+			 * Mark the timestamp for this creation request
+			 */
+			if (!acmeConfig.isDisableMinRenewWindow()) {
+				lastCertificateRenewalTimestamp = System.currentTimeMillis();
+			}
+
+			/*
 			 * Finally, log a message indicate the new certificate has been
 			 * installed and return the file.
 			 */
 			Tr.audit(tc, "CWPKI2007I", acmeCertificate.getCertificate().getSerialNumber().toString(16),
 					acmeConfig.getDirectoryURI(),
 					acmeCertificate.getCertificate().getNotAfter().toInstant().toString());
+
+			/*
+			 * Start the certificate checker task, will cancel any existing tasks and restart
+			 */
+			acmeCertChecker.startCertificateChecker(getScheduledExecutorService());
+
 			return file;
 		} catch (AcmeCaException ace) {
 			createKeyStore(filePath, null, password, keyStoreType, keyStoreProvider);
@@ -820,6 +900,12 @@ public class AcmeProviderImpl implements AcmeProvider {
 			 * Update the account.
 			 */
 			acmeClient.updateAccount();
+
+			/*
+			 * Create a new certificate checker
+			 */
+			acmeCertChecker = new AcmeCertCheckerTask(this);
+
 		} catch (AcmeCaException e) {
 			Tr.error(tc, e.getMessage()); // AcmeCaExceptions are localized.
 		}
@@ -832,6 +918,9 @@ public class AcmeProviderImpl implements AcmeProvider {
 	 *            the {@link AcmeConfigService} instance to unet.
 	 */
 	protected void unsetAcmeConfigService(AcmeConfigService acmeConfigService) {
+		if (acmeCertChecker != null) {
+			acmeCertChecker.stop();
+		}
 		acmeConfig = null;
 		acmeClient = null;
 	}
@@ -848,18 +937,14 @@ public class AcmeProviderImpl implements AcmeProvider {
 	 */
 	protected void updateAcmeConfigService(AcmeConfigService acmeConfigService, Map<String, Object> properties) {
 		try {
+
+			if (acmeCertChecker == null) {
+				acmeCertChecker = new AcmeCertCheckerTask(this);
+			}
+
 			acmeConfig = new AcmeConfig(properties);
 			acmeClient = new AcmeClient(acmeConfig);
 
-			/*
-			 * TODO We need to determine which configuration changes will result
-			 * in requiring a certificate to be refreshed. Some that might
-			 * trigger a refresh: validFor, directoryURI, country, locality,
-			 * state, organization, organizationUnit
-			 *
-			 * We can't necessarily just check the certificate, b/c they don't
-			 * always honor them.
-			 */
 			checkAndInstallCertificate(false, null, null, null);
 
 			/*
@@ -881,5 +966,72 @@ public class AcmeProviderImpl implements AcmeProvider {
 	public void setAcmeApplicationStateListener(AcmeApplicationStateListener acmeApplicationStateListener) {
 		applicationStateListenerRef.set(acmeApplicationStateListener);
 	}
+	
+	/**
+	 * Set the Scheduler service ref
+	 */
+	@Reference(name = "scheduledExecutorService", service = ScheduledExecutorService.class, target = "(deferrable=false)")
+	protected void setScheduledExecutorService(ServiceReference<ScheduledExecutorService> ref) {
+		scheduledExecutorServiceRef.setReference(ref);
+	}
 
+	/**
+	 * Unset the scheduler ref and stop the certificate checker
+	 */
+	protected void unsetScheduledExecutorService(ServiceReference<ScheduledExecutorService> ref) {
+		if (acmeCertChecker != null) {
+			acmeCertChecker.stop();
+		}
+		scheduledExecutorServiceRef.unsetReference(ref);
+	}
+
+	/**
+	 * Get the scheduler ref
+	 */
+	public ScheduledExecutorService getScheduledExecutorService() {
+		return scheduledExecutorServiceRef.getService();
+	}
+
+    /**
+     * Acquire the writer lock. To be used to prevent concurrent certificate
+     * renew or revoke requests. Must be used with releaseWriteLock
+     */
+    @Trivial
+    void acquireWriteLock() {
+		rwRenewCertLock.writeLock().lock();
+    }
+    
+    /**
+     * Release the writer lock. To be used to prevent concurrent certificate
+     * renew or revoke requests. Must be used with acquireWriteLock
+     */
+    @Trivial
+    void releaseWriteLock() {
+    	rwRenewCertLock.writeLock().unlock();
+    }
+    
+	/**
+	 * Checks whether certificate renewal is allowed. It is allowed if:
+	 * <li>Certificate renewal checking is disabled</li>
+	 * <li>This is the first certificate request</li>
+	 * <li>Enough time has passed since the last renewal</li>
+	 * 
+	 * If certificate renewal is not allowed, an exception is thrown.
+	 */
+	@Override
+	public void checkCertificateRenewAllowed() throws CertificateRenewRequestBlockedException {
+		long timeDiff = System.currentTimeMillis() - lastCertificateRenewalTimestamp;
+		if (acmeConfig.isDisableMinRenewWindow() || lastCertificateRenewalTimestamp == -1
+				|| (timeDiff >= AcmeConstants.RENEW_CERT_MIN)) {
+			return;
+		}
+
+		if (tc.isDebugEnabled()) {
+			Tr.debug(tc, "Too soon to renew, last certificate renewal was " + lastCertificateRenewalTimestamp);
+		}
+		CertificateRenewRequestBlockedException cr = new CertificateRenewRequestBlockedException(
+				"Too soon to renew, last certificate renewal was " + lastCertificateRenewalTimestamp,
+				AcmeConstants.RENEW_CERT_MIN - timeDiff);
+		throw cr;
+	}
 }

--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/exceptions/CertificateRenewRequestBlockedException.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/exceptions/CertificateRenewRequestBlockedException.java
@@ -14,13 +14,18 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.security.acme.AcmeCaException;
 
 /**
- * Exception that is thrown when an invalid revocation reason was provided when
- * revoking a certificate.
+ * Exception that is thrown when a certificate renew request occurs too
+ * soon after the prior request.
  */
 @Trivial
-public class IllegalRevocationReasonException extends AcmeCaException {
+public class CertificateRenewRequestBlockedException extends AcmeCaException {
 
-	private static final long serialVersionUID = 1692383936175962063L;
+	private static final long serialVersionUID = -2381844611991560528L;
+	
+	/*
+	 * Time left until the renew request is allowed, expressed in milliseconds
+	 */
+	private long timeLeftMs = -1;
 
 	/**
 	 * Constructs a new exception with the specified detail message. The cause
@@ -31,8 +36,25 @@ public class IllegalRevocationReasonException extends AcmeCaException {
 	 *            the detail message. The detail message is saved for later
 	 *            retrieval by the {@link #getMessage()} method.
 	 */
-	public IllegalRevocationReasonException(String message) {
+	public CertificateRenewRequestBlockedException(String message) {
 		super(message);
+	}
+	
+	/**
+	 * Constructs a new exception with the specified detail message. The cause
+	 * is not initialized, and may subsequently be initialized by a call to
+	 * initCause.
+	 * 
+	 * @param message
+	 *            the detail message. The detail message is saved for later
+	 *            retrieval by the {@link #getMessage()} method.
+	 * @param timeLeft
+	 *            amount of time in milliseconds before the next renew request
+	 *            is allowed
+	 */
+	public CertificateRenewRequestBlockedException(String message, long timeLeft) {
+		super(message);
+		timeLeftMs = timeLeft;
 	}
 
 	/**
@@ -49,7 +71,26 @@ public class IllegalRevocationReasonException extends AcmeCaException {
 	 *            {@link #getCause()} method). (A null value is permitted, and
 	 *            indicates that the cause is nonexistent or unknown.)
 	 */
-	public IllegalRevocationReasonException(String message, Throwable cause) {
+	public CertificateRenewRequestBlockedException(String message, Throwable cause) {
 		super(message, cause);
+	}
+	
+	/**
+	 * Set the amount of time left in milliseconds before the next renewal request is allowed.
+	 * 
+	 * @param timeLeft
+	 *            amount of time in milliseconds before the next renew request is allowed
+	 */
+	public void setTimeLeftForBlackout(long timeLeft) {
+		timeLeftMs = timeLeft;
+	}
+
+	/**
+	 * Get the amount of time left in milliseconds before the next renewal request is allowed.
+	 * 
+	 * @return The amount of time in milliseconds before the next renew request is allowed
+	 */
+	public long getTimeLeftForBlackout() {
+		return timeLeftMs;
 	}
 }

--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/util/AcmeConstants.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/util/AcmeConstants.java
@@ -52,6 +52,13 @@ public class AcmeConstants {
 	public static final String REVOCATION_PREFER_CRLS = "preferCRLs";
 	public static final String REVOCATION_DISABLE_FALLBACK = "disableFallback";
 	
+	// Certificate checker configuration options, currently intended to be internal only
+	public static final String CERT_CHECKER_SCHEDULE = "certCheckerSchedule";
+	public static final String CERT_CHECKER_ERROR_SCHEDULE = "certCheckerErrorSchedule";
+	
+	// Allow immediate requests for certificate renewal
+	public static final String DISABLE_MIN_RENEW_WINDOW = "disableMinRenewWindow";
+
 	/*
 	 * End constants that match the metatype fields
 	 */
@@ -70,10 +77,13 @@ public class AcmeConstants {
 	
 	public static final long RENEW_CERT_MIN = 15000L; // Minimum allowed time to check for expiration
 	public static final Long RENEW_CERT_MIN_WARN_LEVEL = 60000L; // The renew time that we'll put out a warning that you've picked a very low renew time
-	public static final int RENEW_DEFAULT_DAYS = 7;
-	public static final Long RENEW_DEFAULT_MS = TimeUnit.DAYS.toMillis(RENEW_DEFAULT_DAYS);  // 604800000L; 
+	public static final Long RENEW_DEFAULT_MS = TimeUnit.DAYS.toMillis(7L);  // 604800000L; 
 	public static final double RENEW_DIVISOR = .5;
 	public static final long CHALLENGE_POLL_DEFAULT = 120000l;
 	public static final long ORDER_POLL_DEFAULT = 120000l;
+
+
+	public static final Long SCHEDULER_MS = TimeUnit.HOURS.toMillis(24L);
+	public static final Long SCHEDULER_ERROR_MS = TimeUnit.HOURS.toMillis(1L);
 
 }

--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/web/AcmeCaRestHandler.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/web/AcmeCaRestHandler.java
@@ -44,6 +44,7 @@ import com.ibm.ws.management.security.ManagementSecurityConstants;
 import com.ibm.ws.security.acme.AcmeCaException;
 import com.ibm.ws.security.acme.AcmeProvider;
 import com.ibm.ws.security.acme.internal.AcmeClient.AcmeAccount;
+import com.ibm.ws.security.acme.internal.exceptions.CertificateRenewRequestBlockedException;
 import com.ibm.ws.security.acme.internal.exceptions.IllegalRevocationReasonException;
 import com.ibm.ws.ssl.KeyStoreService;
 import com.ibm.wsspi.rest.handler.RESTHandler;
@@ -258,7 +259,7 @@ public class AcmeCaRestHandler implements RESTHandler {
 	 * @throws IOException
 	 *             If there was an issue processing the request.
 	 */
-	@FFDCIgnore({ AcmeCaException.class, IllegalRevocationReasonException.class })
+	@FFDCIgnore({ AcmeCaException.class, IllegalRevocationReasonException.class, CertificateRenewRequestBlockedException.class })
 	private void handleCertificate(RESTRequest request, RESTResponse response) throws IOException {
 		String method = request.getMethod();
 		if (HTTP_GET.equalsIgnoreCase(method)) {
@@ -327,9 +328,15 @@ public class AcmeCaRestHandler implements RESTHandler {
 				}
 
 				try {
+					acmeProvider.checkCertificateRenewAllowed();
 					acmeProvider.renewCertificate();
 					commitJsonResponse(response, 200, null);
 					return;
+				} catch (CertificateRenewRequestBlockedException cr) {
+					/*
+					 * Use 429: Too Many Requests
+					 */
+					commitJsonResponse(response, 429, Tr.formatMessage(tc, "REST_TOO_MANY_REQUESTS", cr.getTimeLeftForBlackout() + "ms"));
 				} catch (AcmeCaException e) {
 					commitJsonResponse(response, 500, e.getMessage());
 					return;

--- a/dev/com.ibm.ws.security.acme/test/com/ibm/ws/security/acme/internal/AcmeClientTest.java
+++ b/dev/com.ibm.ws.security.acme/test/com/ibm/ws/security/acme/internal/AcmeClientTest.java
@@ -117,7 +117,7 @@ public class AcmeClientTest {
 		 */
 		Calendar cal = Calendar.getInstance();
 		Date notBefore = cal.getTime();
-		cal.add(Calendar.DAY_OF_MONTH, AcmeConstants.RENEW_DEFAULT_DAYS *2);
+		cal.setTimeInMillis(notBefore.getTime() + AcmeConstants.RENEW_DEFAULT_MS * 2);
 		Date notAfter = cal.getTime();
 		
 		AcmeClient acmeClient = new AcmeClient(acmeConfig);

--- a/dev/com.ibm.ws.security.acme/test/com/ibm/ws/security/acme/internal/AcmeConfigTest.java
+++ b/dev/com.ibm.ws.security.acme/test/com/ibm/ws/security/acme/internal/AcmeConfigTest.java
@@ -392,6 +392,8 @@ public class AcmeConfigTest {
 		 */
 		Map<String, Object> properties = getBasicConfig();
 		properties.put(AcmeConstants.RENEW_BEFORE_EXPIRATION, -1L);
+		properties.put(AcmeConstants.CERT_CHECKER_SCHEDULE, -1L);
+		properties.put(AcmeConstants.CERT_CHECKER_ERROR_SCHEDULE, -1L);
 
 		/*
 		 * Instantiate the ACME configuration.
@@ -404,6 +406,8 @@ public class AcmeConfigTest {
 
 		assertEquals(0L, acmeConfig.getRenewBeforeExpirationMs().longValue());
 		assertFalse("Auto-renewal should be disabled", acmeConfig.isAutoRenewOnExpiration());
+		assertEquals(0L, acmeConfig.getCertCheckerScheduler().longValue());
+		assertEquals(AcmeConstants.RENEW_CERT_MIN, acmeConfig.getCertCheckerErrorScheduler().longValue());
 	}
 
 	@Test
@@ -421,6 +425,8 @@ public class AcmeConfigTest {
 		properties.put(AcmeConstants.ORDER_POLL_TIMEOUT, -4L);
 		properties.put(AcmeConstants.VALID_FOR, -5L);
 		properties.put(AcmeConstants.RENEW_BEFORE_EXPIRATION, AcmeConstants.RENEW_CERT_MIN - 10);
+		properties.put(AcmeConstants.CERT_CHECKER_SCHEDULE, AcmeConstants.RENEW_CERT_MIN - 10);
+		properties.put(AcmeConstants.CERT_CHECKER_ERROR_SCHEDULE, AcmeConstants.RENEW_CERT_MIN - 10);
 
 		/*
 		 * Instantiate the ACME configuration.
@@ -435,6 +441,8 @@ public class AcmeConfigTest {
 		assertEquals(null, acmeConfig.getValidForMs());
 		assertEquals(AcmeConstants.RENEW_CERT_MIN, acmeConfig.getRenewBeforeExpirationMs().longValue());
 		assertTrue("Auto-renewal should be enabled", acmeConfig.isAutoRenewOnExpiration());
+		assertEquals(AcmeConstants.RENEW_CERT_MIN, acmeConfig.getCertCheckerScheduler().longValue());
+		assertEquals(AcmeConstants.RENEW_CERT_MIN, acmeConfig.getCertCheckerErrorScheduler().longValue());
 	}
 
 	private Map<String, Object> getBasicConfig() {

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/docker/CAContainer.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/docker/CAContainer.java
@@ -668,4 +668,20 @@ public abstract class CAContainer extends GenericContainer<CAContainer> {
 	 *             if the container does not support an OCSP responder.
 	 */
 	public abstract String getOcspResponderUrl();
+	
+	/**
+	 * Start the DNS server for this {@link CAContainer}.
+	 * 
+	 * @throws UnsupportedOperationException
+	 *             if the container does not support starting the a DNS server
+	 */
+	public abstract void startDNSServer();
+
+	/**
+	 * Stop the DNS server for this {@link CAContainer}.
+	 * 
+	 * @throws UnsupportedOperationException
+	 *             if the container does not support stopping the a DNS server
+	 */
+	public abstract void stopDNSServer();
 }

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/docker/boulder/BoulderContainer.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/docker/boulder/BoulderContainer.java
@@ -211,4 +211,16 @@ public class BoulderContainer extends CAContainer {
 	public String getOcspResponderUrl() {
 		return "http://" + this.getContainerIpAddress() + ":" + this.getMappedPort(OCSP_PORT);
 	}
+
+	@Override
+	public void startDNSServer() {
+		throw new UnsupportedOperationException(
+				getClass().getSimpleName() + " does not provider support for starting the DNS server.");
+	}
+
+	@Override
+	public void stopDNSServer() {
+		throw new UnsupportedOperationException(
+				getClass().getSimpleName() + " does not provider support for stopping the DNS server.");
+	}
 }

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeValidityAndRenewTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeValidityAndRenewTest.java
@@ -10,8 +10,15 @@
  *******************************************************************************/
 package com.ibm.ws.security.acme.fat;
 
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
@@ -19,15 +26,19 @@ import java.security.cert.X509Certificate;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.acme.docker.CAContainer;
+import com.ibm.ws.security.acme.docker.pebble.PebbleContainer;
 import com.ibm.ws.security.acme.internal.util.AcmeConstants;
 import com.ibm.ws.security.acme.utils.AcmeFatUtils;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.CheckForLeakedPasswords;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -53,6 +64,11 @@ public class AcmeValidityAndRenewTest {
 
 	public static final long timeBufferToExpire = 30000L; // milliseconds
 
+	public static final int CHECKER_SECONDS = 1000;
+
+	@Rule
+	public TestName testName = new TestName();
+
 	@BeforeClass
 	public static void beforeClass() throws Exception {
 		ORIGINAL_CONFIG = server.getServerConfiguration();
@@ -77,16 +93,15 @@ public class AcmeValidityAndRenewTest {
 	}
 
 	/**
-	 * The server will start with a renewBeforeExpiration set lower than the lowest minimum
-	 * renew time allowed. The renewBeforeExpiration is reset to the minimum renew time.
+	 * The server will start with a renewBeforeExpiration set lower than the lowest
+	 * minimum renew time allowed. The renewBeforeExpiration is reset to the minimum
+	 * renew time.
 	 * 
 	 * @throws Exception If the test failed for some reason.
 	 */
 	@Test
 	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
 	public void serverBelowMinRenew() throws Exception {
-		final String methodName = "serverBelowMinRenew";
-
 		/*
 		 * Configure the acmeCA-2.0 feature.
 		 * 
@@ -98,12 +113,12 @@ public class AcmeValidityAndRenewTest {
 
 		/***********************************************************************
 		 * 
-		 * TEST 1: The server will start with a renewBeforeExpiration set lower than the lowest minimum
-		 * renew time allowed.
+		 * TEST 1: The server will start with a renewBeforeExpiration set lower than the
+		 * lowest minimum renew time allowed.
 		 * 
 		 **********************************************************************/
 		try {
-			Log.info(this.getClass(), methodName, "TEST renew is set to below the minimum renew time.");
+			Log.info(this.getClass(), testName.getMethodName(), "TEST renew is set to below the minimum renew time.");
 
 			/*
 			 * Start the server and wait for the certificate to be installed.
@@ -119,9 +134,10 @@ public class AcmeValidityAndRenewTest {
 
 			assertNotNull("Should log warning on minimum renewBeforeExpiration",
 					server.waitForStringInLog("CWPKI2051W"));
+			AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
 
 		} finally {
-			Log.info(this.getClass(), methodName, "TEST 1: Shutdown.");
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 1: Shutdown.");
 
 			/*
 			 * Stop the server.
@@ -132,16 +148,14 @@ public class AcmeValidityAndRenewTest {
 
 	
 	/**
-	 * The server will start with a renewBeforeExpiration set lower than the warning level
-	 * for having a short renew time. A warning message should be logged.
+	 * The server will start with a renewBeforeExpiration set lower than the warning
+	 * level for having a short renew time. A warning message should be logged.
 	 * 
 	 * @throws Exception If the test failed for some reason.
 	 */
 	@Test
 	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
 	public void serverBelowWarnRenew() throws Exception {
-		final String methodName = "serverBelowWarnRenew";
-
 		/*
 		 * Configure the acmeCA-2.0 feature.
 		 * 
@@ -153,12 +167,12 @@ public class AcmeValidityAndRenewTest {
 
 		/***********************************************************************
 		 * 
-		 * TEST The server will start with a renewBeforeExpiration set lower than the warning level
-		 * for having a short renew time.
+		 * TEST The server will start with a renewBeforeExpiration set lower than the
+		 * warning level for having a short renew time.
 		 * 
 		 **********************************************************************/
 		try {
-			Log.info(this.getClass(), methodName, "TEST renew is set to below the minimum renew warning time.");
+			Log.info(this.getClass(), testName.getMethodName(), "TEST renew is set to below the minimum renew warning time.");
 
 			/*
 			 * Start the server and wait for acme to determine the certificate was good.
@@ -176,8 +190,7 @@ public class AcmeValidityAndRenewTest {
 					server.waitForStringInLog("CWPKI2055W"));
 
 		} finally {
-			Log.info(this.getClass(), methodName, "TEST: Shutdown.");
-
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 2: Shutdown.");
 			/*
 			 * Stop the server.
 			 */
@@ -189,13 +202,12 @@ public class AcmeValidityAndRenewTest {
 	/**
 	 * Starting the server with a renewBeforeExpiration longer than the certificate
 	 * validity period. The renewBeforeExpiration will be reset to the default time.
+	 * 
 	 * @throws Exception
 	 */
 	@Test
 	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
 	public void serverRenewLongerThanValidity() throws Exception {
-		final String methodName = "serverRenewLongerThanValidity";
-
 		/*
 		 * Configure the acmeCA-2.0 feature.
 		 * 
@@ -207,12 +219,12 @@ public class AcmeValidityAndRenewTest {
 
 		/***********************************************************************
 		 * 
-		 * TEST The server will start with a renewBeforeExpiration set longer than the 
+		 * TEST The server will start with a renewBeforeExpiration set longer than the
 		 * certificate validity period..
 		 * 
 		 **********************************************************************/
 		try {
-			Log.info(this.getClass(), methodName, "TEST renew is set longer than the certificate validity period.");
+			Log.info(this.getClass(), testName.getMethodName(), "TEST renew is set longer than the certificate validity period.");
 
 			/*
 			 * Start the server and wait for acme to determine the certificate was good.
@@ -231,7 +243,7 @@ public class AcmeValidityAndRenewTest {
 					server.waitForStringInLog("CWPKI2054W"));
 
 		} finally {
-			Log.info(this.getClass(), methodName, "TEST Shutdown.");
+			Log.info(this.getClass(), testName.getMethodName(), "TEST Shutdown.");
 
 			/*
 			 * Stop the server.
@@ -244,15 +256,14 @@ public class AcmeValidityAndRenewTest {
 	/**
 	 * Test renewing the certification on server startup due to the expiration date.
 	 * 
-	 * This test calculates the renewBeforeExpiration based on the validity period of
-	 * the certificate received. It is slightly shorter than the validity period so we
-	 * can test it in an automated test.
+	 * This test calculates the renewBeforeExpiration based on the validity period
+	 * of the certificate received. It is slightly shorter than the validity period
+	 * so we can test it in an automated test.
 	 * 
 	 */
 	@Test
 	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
-	public void serverRenewOnRestart() throws Exception {
-		final String methodName = "serverRenewOnRestart";
+	public void autoRenewOnRestartAndCertChecker() throws Exception {
 		Certificate[] startingCertificateChain = null, endingCertificateChain = null;
 
 		/*
@@ -265,13 +276,12 @@ public class AcmeValidityAndRenewTest {
 
 		long serverTime = System.currentTimeMillis();
 		/***********************************************************************
-		 * 
 		 * TEST 1: The server generate a certificate normally.
 		 * 
 		 **********************************************************************/
 
 		try {
-			Log.info(this.getClass(), methodName, "TEST 1: renew is fine, get a certificate at startup.");
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 1: renew is fine, get a certificate at startup.");
 
 			/*
 			 * Start the server and wait for acme to determine the certificate was good.
@@ -288,7 +298,7 @@ public class AcmeValidityAndRenewTest {
 			startingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
 
 		} finally {
-			Log.info(this.getClass(), methodName, "TEST 1: Shutdown.");
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 1: Shutdown.");
 
 			/*
 			 * Stop the server.
@@ -302,7 +312,8 @@ public class AcmeValidityAndRenewTest {
 		 * 
 		 **********************************************************************/
 		try {
-			Log.info(this.getClass(), methodName, "TEST 2: Restart with renew time close to validity period.");
+			Log.info(this.getClass(), testName.getMethodName(),
+					"TEST 2: Restart with renew time close to validity period.");
 
 			long notAfter = ((X509Certificate) startingCertificateChain[0]).getNotAfter().getTime();
 			long notBefore = ((X509Certificate) startingCertificateChain[0]).getNotBefore().getTime();
@@ -312,21 +323,22 @@ public class AcmeValidityAndRenewTest {
 			// enough.
 			long totalBuffer = (extraBuffer > 0 ? extraBuffer : 0) + timeBufferToExpire;
 
-			Log.info(this.getClass(), methodName, "Not before: " + notBefore + ", extra buffer " + extraBuffer);
+			Log.info(this.getClass(), testName.getMethodName(),
+					"Not before: " + notBefore + ", extra buffer " + extraBuffer);
 
 			/*
 			 * Set a renew time just shy of default Pebble validity period) so we will
 			 * request a new certificate on restart)
 			 */
 			long justShyOfValidityPeriod = (notAfter - notBefore) - timeBufferToExpire;
-			Log.info(this.getClass(), methodName, "Time configured: " + justShyOfValidityPeriod);
+			Log.info(this.getClass(), testName.getMethodName(), "Time configured: " + justShyOfValidityPeriod);
 
 			/*
 			 * Wait a bit before we start the server to make sure we'll be in the renew
 			 * period.
 			 */
 			while ((System.currentTimeMillis() - serverTime) < totalBuffer) {
-				Log.info(this.getClass(), methodName,
+				Log.info(this.getClass(), testName.getMethodName(),
 						"Waiting for " + totalBuffer + "ms to pass before restarting the server.");
 				Thread.sleep(2000);
 			}
@@ -347,8 +359,11 @@ public class AcmeValidityAndRenewTest {
 			assertNotSame("The certificate should have been marked as expired at startup and renewed.",
 					((X509Certificate) startingCertificateChain[0]).getSerialNumber(),
 					((X509Certificate) endingCertificateChain[0]).getSerialNumber());
+
+			assertNotNull("Should log  message that the certificate was renewed",
+					server.waitForStringInLogUsingMark("CWPKI2052I"));
 		} finally {
-			Log.info(this.getClass(), methodName, "TEST 2: Shutdown.");
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 2: Shutdown.");
 
 			/*
 			 * Stop the server.
@@ -356,5 +371,293 @@ public class AcmeValidityAndRenewTest {
 			server.stopServer("CWPKI2055W"); // we are running with and intentionally short renewBeforeExpiration.
 		}
 
+		/***********************************************************************
+		 * 
+		 * TEST 3: Start with a very short renew period and short cert checker time out,
+		 * causing a renew request at runtime.
+		 * 
+		 **********************************************************************/
+		try {
+			Log.info(this.getClass(), testName.getMethodName(),
+					"TEST 3: Restart with renew time close to validity period and short cert checker.");
+
+			configuration.getAcmeCA().setCertCheckerSchedule((timeBufferToExpire + 1000) + "ms");
+			configuration.getAcmeCA().setCertCheckerSchedule(AcmeConstants.RENEW_CERT_MIN + "ms");
+
+			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, DOMAINS1);
+
+			server.startServer();
+			AcmeFatUtils.waitForAcmeAppToStart(server);
+			AcmeFatUtils.waitForSslEndpoint(server);
+
+			/*
+			 * Verify that the server got a new certificate at startup
+			 */
+			endingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			String serial1 = ((X509Certificate) startingCertificateChain[0]).getSerialNumber().toString(16);
+			String serial2 = ((X509Certificate) endingCertificateChain[0]).getSerialNumber().toString(16);
+
+			assertThat("The certificate should have been marked as expired at startup and renewed.", serial1, not(equalTo(serial2)));	
+
+			startingCertificateChain = endingCertificateChain;
+
+			/*
+			 * The certificate checker should automatically renew the certificate.
+			 */
+			AcmeFatUtils.waitForNewCert(server, caContainer, startingCertificateChain, timeBufferToExpire * 2);
+
+			assertNotNull("Should log message that the certificate was renewed",
+					server.waitForStringInLogUsingMark("CWPKI2052I"));
+
+		} finally {
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 3: Shutdown.");
+
+			/*
+			 * Stop the server.
+			 */
+			server.stopServer("CWPKI2049W");
+		}
 	}
+
+	/**
+	 * This test will verify that the server starts up and requests a new
+	 * certificate from the ACME server when required.
+	 * 
+	 * @throws Exception If the test failed for some reason.
+	 */
+	@Test
+	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
+	public void certCheckerRunningNoRenew() throws Exception {
+
+		Certificate[] startingCertificateChain = null, endingCertificateChain = null;
+
+		/*
+		 * Configure the acmeCA-2.0 feature.
+		 */
+
+		ServerConfiguration configuration = ORIGINAL_CONFIG.clone();
+		configuration.getAcmeCA().setCertCheckerSchedule(AcmeConstants.RENEW_CERT_MIN + "ms");
+		AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, DOMAINS1);
+
+		/***********************************************************************
+		 * 
+		 * TEST 1: The server will start up without the specified keystore available. It
+		 * should generate a new keystore with a certificate retrieved from the ACME CA
+		 * server.
+		 * 
+		 **********************************************************************/
+		try {
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 1: Start");
+
+			/*
+			 * Start the server and wait for the certificate to be installed.
+			 */
+			server.startServer();
+			AcmeFatUtils.waitForAcmeToCreateCertificate(server);
+			AcmeFatUtils.waitForSslToCreateKeystore(server);
+			AcmeFatUtils.waitForSslEndpoint(server);
+
+			/*
+			 * Verify that the server is now using a certificate signed by the CA.
+			 */
+			startingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			assertNotNull("Should have found the cert checker waking up: " + AcmeFatUtils.ACME_CHECKER_TRACE,
+					server.waitForStringInTrace(AcmeFatUtils.ACME_CHECKER_TRACE));
+
+			/*
+			 * Should have the same certificate
+			 */
+			endingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			assertEquals("The certificate should be the same after the cert checker runs.",
+					((X509Certificate) startingCertificateChain[0]).getSerialNumber(),
+					((X509Certificate) endingCertificateChain[0]).getSerialNumber());
+		} finally {
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 1: Shutdown.");
+
+			/*
+			 * Stop the server.
+			 */
+			server.stopServer();
+		}
+	}
+
+	/**
+	 * This test will verify that the server starts up and requests a new
+	 * certificate from the ACME server when required.
+	 * 
+	 * @throws Exception If the test failed for some reason.
+	 */
+	@Test
+	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
+	public void certCheckerDisabled() throws Exception {
+
+		Certificate[] startingCertificateChain = null, endingCertificateChain = null;
+
+		/*
+		 * Configure the acmeCA-2.0 feature.
+		 */
+
+		ServerConfiguration configuration = ORIGINAL_CONFIG.clone();
+		configuration.getAcmeCA().setCertCheckerSchedule(AcmeConstants.RENEW_CERT_MIN + "ms");
+		configuration.getAcmeCA().setRenewBeforeExpiration("0ms");
+		AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, DOMAINS1);
+
+		/***********************************************************************
+		 * 
+		 * TEST 1: The server will start up without the specified keystore available. It
+		 * should generate a new keystore with a certificate retrieved from the ACME CA
+		 * server.
+		 * 
+		 **********************************************************************/
+		try {
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 1: Start");
+
+			/*
+			 * Start the server and wait for the certificate to be installed.
+			 */
+			server.startServer();
+			AcmeFatUtils.waitForAcmeToCreateCertificate(server);
+			AcmeFatUtils.waitForSslToCreateKeystore(server);
+			AcmeFatUtils.waitForSslEndpoint(server);
+
+			/*
+			 * Verify that the server is now using a certificate signed by the CA.
+			 */
+			startingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+			assertNull("Should not have found the cert checker waking up: " + AcmeFatUtils.ACME_CHECKER_TRACE,
+					server.waitForStringInTrace(AcmeFatUtils.ACME_CHECKER_TRACE, CHECKER_SECONDS + 5000));
+
+			/*
+			 * Should have the same certificate
+			 */
+			endingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			assertEquals("The certificate should be the same after the cert checker runs.",
+					((X509Certificate) startingCertificateChain[0]).getSerialNumber(),
+					((X509Certificate) endingCertificateChain[0]).getSerialNumber());
+			
+			assertNotNull("Should log disabled message", server.findStringsInLogs("CWPKI2069I"));
+		} finally {
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 1: Shutdown.");
+
+			/*
+			 * Stop the server.
+			 */
+			server.stopServer();
+		}
+	}
+
+	/**
+	 * Verifies that the certificate checker can hit an exception, recover and fetch
+	 * a new certificate.
+	 * 
+	 * The setRenewBeforeExpiration is configured to be slightly less than the
+	 * Pebble certificate validity period so the certificate checker will renew it
+	 * for us.
+	 * 
+	 */
+	@Test
+	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
+	@AllowedFFDC(value = { "java.io.IOException", "org.shredzone.acme4j.exception.AcmeNetworkException",
+			"com.ibm.ws.security.acme.AcmeCaException" })
+	public void autoRenewWithErrorAndRecovery() throws Exception {
+		Certificate[] startingCertificateChain = null;
+
+		/*
+		 * Configure the acmeCA-2.0 feature.
+		 * 
+		 */
+
+		ServerConfiguration configuration = ORIGINAL_CONFIG.clone();
+		AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, DOMAINS1);
+
+		try {
+			Log.info(this.getClass(), testName.getMethodName(),
+					"TEST: Restart the Challenge server, check that the cert checker hits an error and recovers.");
+
+			/*
+			 * Start the server and wait for acme to determine the certificate was good.
+			 */
+			server.startServer();
+			AcmeFatUtils.waitForAcmeAppToStart(server);
+			AcmeFatUtils.waitForSslEndpoint(server);
+
+			/*
+			 * Verify that the server is using a certificate signed by the CA.
+			 */
+			startingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			/*
+			 * Set a setRenewBeforeExpiration time just shy of default Pebble validity
+			 * period so we will request a new certificate on restart)
+			 */
+			long notAfter = ((X509Certificate) startingCertificateChain[0]).getNotAfter().getTime();
+			long notBefore = ((X509Certificate) startingCertificateChain[0]).getNotBefore().getTime();
+			long justShyOfValidityPeriod = (notAfter - notBefore) - timeBufferToExpire;
+			Log.info(this.getClass(), testName.getMethodName(), "Time configured: " + justShyOfValidityPeriod);
+
+			configuration.getAcmeCA().setRenewBeforeExpiration(justShyOfValidityPeriod + "ms");
+			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, DOMAINS1);
+			configuration.getAcmeCA().setCertCheckerSchedule((timeBufferToExpire + 1000) + "ms");
+			configuration.getAcmeCA().setCertCheckerErrorSchedule(AcmeConstants.RENEW_CERT_MIN + "ms");
+
+			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, DOMAINS1);
+
+			/*
+			 * The certificate checker should automatically renew the certificate.
+			 */
+			AcmeFatUtils.waitForNewCert(server, caContainer, startingCertificateChain, timeBufferToExpire * 2);
+
+			assertNotNull("Should log message that the certificate was renewed",
+					server.waitForStringInLogUsingMark("CWPKI2052I"));
+
+			assertNotNull("Should log message that the certificate was renewed after restarting Pebble",
+					server.waitForStringInLogUsingMark("CWPKI2007I"));
+			server.setMarkToEndOfLog();
+
+			startingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			/*
+			 * Stop the Challenge server so we should hit an error on the cert checker.
+			 *
+			 */
+			caContainer.stopDNSServer();
+
+			assertNotNull("Should log message that the certificate renew failed",
+					server.waitForStringInLogUsingMark("CWPKI2065W", timeBufferToExpire * 2));
+
+			/*
+			 * Start the Challenge server and the cert checker should recover and fetch a
+			 * new cert
+			 *
+			 */
+			try {
+				caContainer.startDNSServer();
+			} catch (Throwable t) {
+
+				/*
+				 * Running locally on windows, the start fails intermittently
+				 */
+				Log.info(this.getClass(), testName.getMethodName(),
+						"First try to restart DNS server failed, try again");
+				caContainer.startDNSServer();
+			}
+
+			assertNotNull("Should log message that the certificate was renewed after restarting the challenge server",
+					server.waitForStringInLogUsingMark("CWPKI2007I", (AcmeConstants.RENEW_CERT_MIN * 2)));
+			AcmeFatUtils.waitForNewCert(server, caContainer, startingCertificateChain, timeBufferToExpire);
+
+		} finally {
+			Log.info(this.getClass(), testName.getMethodName(), "TEST Shutdown.");
+
+			/*
+			 * Stop the server.
+			 */
+			server.stopServer("CWPKI2049W", "CWPKI2065W");
+		}
+	}
+
 }

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/AcmeCA.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/AcmeCA.java
@@ -49,6 +49,12 @@ public class AcmeCA extends ConfigElement {
 
     private String renewBeforeExpiration;
 
+    private String certCheckerSchedule;
+
+    private String certCheckerErrorSchedule;
+
+    private boolean disableMinRenewWindow;
+
     /**
      * @return the accountContact
      */
@@ -259,6 +265,33 @@ public class AcmeCA extends ConfigElement {
         this.renewBeforeExpiration = renewBeforeExpiration;
     }
 
+    public String getCertCheckerSchedule() {
+        return certCheckerSchedule;
+    }
+
+    @XmlAttribute(name = "certCheckerSchedule")
+    public void setCertCheckerSchedule(String certCheckerSchedule) {
+        this.certCheckerSchedule = certCheckerSchedule;
+    }
+
+    public String getCertCheckerErrorSchedule() {
+        return certCheckerErrorSchedule;
+    }
+
+    @XmlAttribute(name = "certCheckerErrorSchedule")
+    public void setCertCheckerErrorSchedule(String certCheckerErrorSchedule) {
+        this.certCheckerErrorSchedule = certCheckerErrorSchedule;
+    }
+
+    @XmlAttribute(name = "disableMinRenewWindow")
+    public void setDisableMinRenewWindow(boolean disableMinRenewWindow) {
+        this.disableMinRenewWindow = disableMinRenewWindow;
+    }
+
+    public boolean isDisableMinRenewWindow() {
+        return disableMinRenewWindow;
+    }
+
     @Override
     public String toString() {
         StringBuffer sb = new StringBuffer();
@@ -277,6 +310,12 @@ public class AcmeCA extends ConfigElement {
         if (acmeTransportConfig != null) {
             sb.append("acmeTransportConfig=\"").append(acmeTransportConfig).append("\" ");;
         }
+        if (certCheckerSchedule != null) {
+            sb.append("certCheckerSchedule=\"").append(certCheckerSchedule).append("\" ");;
+        }
+        if (certCheckerErrorSchedule != null) {
+            sb.append("certCheckerErrorSchedule=\"").append(certCheckerErrorSchedule).append("\" ");;
+        }
         if (challengeRetries != null) {
             sb.append("challengeRetries=\"").append(challengeRetries).append("\" ");;
         }
@@ -285,6 +324,9 @@ public class AcmeCA extends ConfigElement {
         }
         if (directoryURI != null) {
             sb.append("directoryURI=\"").append(directoryURI).append("\" ");;
+        }
+        if (disableMinRenewWindow) {
+            sb.append("disableMinRenewWindow=\"").append(disableMinRenewWindow).append("\" ");;
         }
         if (domainKeyFile != null) {
             sb.append("domainKeyFile=\"").append(domainKeyFile).append("\" ");;
@@ -298,14 +340,14 @@ public class AcmeCA extends ConfigElement {
         if (orderRetryWait != null) {
             sb.append("orderRetryWait=\"").append(orderRetryWait).append("\" ");;
         }
+        if (renewBeforeExpiration != null) {
+            sb.append("renewBeforeExpiration=\"").append(renewBeforeExpiration).append("\" ");;
+        }
         if (subjectDN != null) {
             sb.append("subjectDN=\"").append(subjectDN).append("\" ");;
         }
         if (validFor != null) {
             sb.append("validFor=\"").append(validFor).append("\" ");;
-        }
-        if (renewBeforeExpiration != null) {
-            sb.append("renewBeforeExpiration=\"").append(renewBeforeExpiration).append("\" ");;
         }
 
         sb.append("}");


### PR DESCRIPTION
Fixes #10519 

- Added a scheduler to check for expiration or revocation
- Added locking around renew/revoke
- Added a timer window around REST renewal

Tests added:
- Scheduler renews expiring certificate
- Scheduler renews revoked certificate
- Scheduler doesn't run if disabled
- Back to back renewal
- Scheduler stops when acmeCA feature is removed, restarts on addition
- Scheduler runs after bad config is updated to valid config
- Stop Pebble during test, ensure we reschedule the certchecker and renew cert that's expiring

Test to add in another PR: Opened #12328 to address
- Enable/disable the cert checker during runtime (set `certCheckerSchedule` to 0), make sure it stops/starts appropriately
- Call renew while certchecker is going -- disable auto? What are we checking for here?
- Call revoke and renew at the same time?
- Stop Pebble during test, ensure we reschedule the certchecker and renew cert that's revoked

For #9017 