### PR TITLE
Re-enable usage of injection in context customproviders test bucket

### DIFF
--- a/dev/com.ibm.ws.context_fat_customproviders/test-applications/contextbvt/src/test/context/app/ContextServiceTestServlet.java
+++ b/dev/com.ibm.ws.context_fat_customproviders/test-applications/contextbvt/src/test/context/app/ContextServiceTestServlet.java
@@ -91,13 +91,6 @@ public class ContextServiceTestServlet extends FATServlet {
     @Override
     public void init(ServletConfig config) throws ServletException {
         super.init(config);
-        // TODO remove this workaround for injection intermittently not working
-        if (mapContextSvc == null)
-            try {
-                mapContextSvc = InitialContext.doLookup("concurrent/MapContextSvc");
-            } catch (NamingException x) {
-                throw new ServletException(x);
-            }
     }
 
     /**


### PR DESCRIPTION
Enable usage of resource injection in the  test bucket for custom thread context providers, now that resource injection is working in Jakarta.