### PR TITLE
Try new mp config bundle 11598

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1732,6 +1732,11 @@
       <version>1.4</version>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.microprofile.config</groupId>
+      <artifactId>microprofile-config-api</artifactId>
+      <version>2.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.microprofile.context-propagation</groupId>
       <artifactId>microprofile-context-propagation-api</artifactId>
       <version>1.0</version>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -342,6 +342,7 @@ org.eclipse.microprofile.config:microprofile-config-api:1.1
 org.eclipse.microprofile.config:microprofile-config-api:1.2.1
 org.eclipse.microprofile.config:microprofile-config-api:1.3
 org.eclipse.microprofile.config:microprofile-config-api:1.4
+org.eclipse.microprofile.config:microprofile-config-api:2.0-SNAPSHOT
 org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.0
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:1.0
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:1.1

--- a/dev/com.ibm.websphere.org.eclipse.microprofile.config.1.4/bnd.bnd
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.config.1.4/bnd.bnd
@@ -11,6 +11,8 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
+-include= jar:${fileuri;${repo;org.eclipse.microprofile.config:microprofile-config-api;2.0.0.SNAPSHOT}}!/META-INF/MANIFEST.MF
+
 
 Bundle-SymbolicName: com.ibm.websphere.org.eclipse.microprofile.config.1.4; singleton:=true
 
@@ -24,7 +26,7 @@ Export-Package: \
   org.eclipse.microprofile.config.spi;version=1.4
 
 Include-Resource: \
-  @${repo;org.eclipse.microprofile.config:microprofile-config-api;1.4;EXACT}
+  @${repo;org.eclipse.microprofile.config:microprofile-config-api;2.0.0.SNAPSHOT;EXACT}
 
 
 WS-TraceGroup: APPCONFIG

--- a/dev/com.ibm.websphere.org.eclipse.microprofile.config.1.4/bnd.bnd
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.config.1.4/bnd.bnd
@@ -11,30 +11,22 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
--include= jar:${fileuri;${repo;org.eclipse.microprofile.config:microprofile-config-api;2.0.0.SNAPSHOT}}!/META-INF/MANIFEST.MF
-
+-include= jar:${fileuri;${repo;org.eclipse.microprofile.config:microprofile-config-api;2.0.0.SNAPSHOT}}!/META-INF/MANIFEST.MF,bnd.overrides
 
 Bundle-SymbolicName: com.ibm.websphere.org.eclipse.microprofile.config.1.4; singleton:=true
 
-Import-Package: \
-  javax.enterprise.util; version="[1.1,3)",\
-  *
-
-Export-Package: \
-  org.eclipse.microprofile.config;version=1.0.1, \
-  org.eclipse.microprofile.config.inject;version=1.1.0, \
-  org.eclipse.microprofile.config.spi;version=1.4
-
-Include-Resource: \
+-includeresource: \
   @${repo;org.eclipse.microprofile.config:microprofile-config-api;2.0.0.SNAPSHOT;EXACT}
-
+  
+-consumer-policy 0
 
 WS-TraceGroup: APPCONFIG
 
 -buildpath: \
 	com.ibm.websphere.javaee.cdi.1.2;version=latest, \
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest
-
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
+	org.eclipse.microprofile.config:microprofile-config-api;version=2.0.0.SNAPSHOT
+	
 instrument.disabled: true
 
 publish.wlp.jar.suffix: dev/api/stable

--- a/dev/com.ibm.websphere.org.eclipse.microprofile.config.1.4/bnd.overrides
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.config.1.4/bnd.overrides
@@ -1,0 +1,8 @@
+bVersion=1.0
+
+Bundle-SymbolicName: com.ibm.websphere.org.eclipse.microprofile.config.1.4; singleton:=true
+
+-include= -../generated.build.id, -liberty-release.props
+bFullVersion=${version;==;${bVersion}}.${libertyBundleMicroVersion}
+Build-Identifier: SNAPSHOT-${now}
+Bundle-Version: ${bFullVersion}.${if;${driver;gradle};${version.qualifier};eclipse}

--- a/dev/com.ibm.ws.microprofile.config.1.1.cdi.services/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.1.cdi.services/bnd.bnd
@@ -18,9 +18,9 @@ Bundle-Description: Microprofile Config 1.1 CDI Services
 
 Import-Package: \
         javax.enterprise.*; version="[1.1,3)", \
-        org.eclipse.microprofile.config;version="[1.0,2)", \
-        org.eclipse.microprofile.config.inject;version="[1.0,2)", \
-        org.eclipse.microprofile.config.spi;version="[1.0,2)", \
+        org.eclipse.microprofile.config;version="[1.0,3)", \
+        org.eclipse.microprofile.config.inject;version="[1.0,3)", \
+        org.eclipse.microprofile.config.spi;version="[1.0,3)", \
         *
 
 Private-Package: \

--- a/dev/com.ibm.ws.microprofile.config.1.1.cdi/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.1.cdi/bnd.bnd
@@ -18,9 +18,9 @@ Bundle-Description: Microprofile Config 1.1 CDI
 
 Import-Package: \
 	javax.enterprise.*; version="[1.1,3)",\
-        org.eclipse.microprofile.config;version="[1.0,2)", \
-        org.eclipse.microprofile.config.inject;version="[1.0,2)", \
-        org.eclipse.microprofile.config.spi;version="[1.0,2)", \
+        org.eclipse.microprofile.config;version="[1.0,3)", \
+        org.eclipse.microprofile.config.inject;version="[1.0,3)", \
+        org.eclipse.microprofile.config.spi;version="[1.0,3)", \
 	*
 
 Export-Package: \

--- a/dev/com.ibm.ws.microprofile.config.1.1.cdi/src/com/ibm/ws/microprofile/config/cdi/ConfigCDIExtension.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1.cdi/src/com/ibm/ws/microprofile/config/cdi/ConfigCDIExtension.java
@@ -96,8 +96,8 @@ public class ConfigCDIExtension implements Extension, WebSphereCDIExtension {
     }
 
     void afterBeanDiscovery(@Observes AfterBeanDiscovery abd, BeanManager beanManager) {
-        ConfigBean configBean = new ConfigBean(beanManager);
-        abd.addBean(configBean);
+
+        addConfigBean(abd, beanManager);
 
         validInjectionTypes.removeAll(badInjectionTypes);
 
@@ -116,6 +116,11 @@ public class ConfigCDIExtension implements Extension, WebSphereCDIExtension {
                 abd.addDefinitionError(e);
             }
         }
+    }
+
+    protected void addConfigBean(AfterBeanDiscovery abd, BeanManager beanManager) {
+        ConfigBean configBean = new ConfigBean(beanManager);
+        abd.addBean(configBean);
     }
 
     protected Throwable processParameterizedType(String propertyName, String defaultValue, ParameterizedType pType, ClassLoader classLoader) {

--- a/dev/com.ibm.ws.microprofile.config.1.1.cdi/src/com/ibm/ws/microprofile/config/cdi/DelegatingConfig.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1.cdi/src/com/ibm/ws/microprofile/config/cdi/DelegatingConfig.java
@@ -45,7 +45,7 @@ public class DelegatingConfig implements Config {
         return getDelegate().getValue(arg0, arg1);
     }
 
-    private Config getDelegate() {
+    protected Config getDelegate() {
         return ConfigProvider.getConfig();
     }
 

--- a/dev/com.ibm.ws.microprofile.config.1.1.services/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.1.services/bnd.bnd
@@ -21,9 +21,9 @@ Bundle-Description:MicroProfile Configuration 1.1 Services, version ${bVersion}
 -dsannotations: com.ibm.ws.microprofile.config11.services.Config11ProviderResolverComponent
 
 Import-Package: \
-        org.eclipse.microprofile.config;version="[1.0,2)", \
-        org.eclipse.microprofile.config.inject;version="[1.0,2)", \
-        org.eclipse.microprofile.config.spi;version="[1.0,2)", \
+        org.eclipse.microprofile.config;version="[1.0,3)", \
+        org.eclipse.microprofile.config.inject;version="[1.0,3)", \
+        org.eclipse.microprofile.config.spi;version="[1.0,3)", \
         *
 
 Private-Package: \

--- a/dev/com.ibm.ws.microprofile.config.1.1/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.1/bnd.bnd
@@ -31,9 +31,9 @@ Private-Package: \
         com.ibm.ws.microprofile.config.archaius.composite
 
 Import-Package: \
-        org.eclipse.microprofile.config;version="[1.0,2)", \
-        org.eclipse.microprofile.config.inject;version="[1.0,2)", \
-        org.eclipse.microprofile.config.spi;version="[1.0,2)", \
+        org.eclipse.microprofile.config;version="[1.0,3)", \
+        org.eclipse.microprofile.config.inject;version="[1.0,3)", \
+        org.eclipse.microprofile.config.spi;version="[1.0,3)", \
         *
 
 WS-TraceGroup: APPCONFIG

--- a/dev/com.ibm.ws.microprofile.config.1.1/src/com/ibm/ws/microprofile/config/sources/PropertiesConfigSource.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1/src/com/ibm/ws/microprofile/config/sources/PropertiesConfigSource.java
@@ -48,7 +48,7 @@ public class PropertiesConfigSource extends InternalConfigSource implements Stat
 
     @Override
     public ConcurrentMap<String, String> getProperties() {
-        return properties;
+        return this.properties;
     }
 
     @Trivial
@@ -88,5 +88,10 @@ public class PropertiesConfigSource extends InternalConfigSource implements Stat
         }
 
         return props;
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return getProperties().keySet();
     }
 }

--- a/dev/com.ibm.ws.microprofile.config.1.2.cdi.services/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.2.cdi.services/bnd.bnd
@@ -18,9 +18,9 @@ Bundle-Description: Microprofile Config 1.2 CDI Services, version ${bVersion}
 
 Import-Package: \
         javax.enterprise.*; version="[1.1,3)", \
-        org.eclipse.microprofile.config;version="[1.0,2)", \
-        org.eclipse.microprofile.config.inject;version="[1.0,2)", \
-        org.eclipse.microprofile.config.spi;version="[1.2,2)", \
+        org.eclipse.microprofile.config;version="[1.0,3)", \
+        org.eclipse.microprofile.config.inject;version="[1.0,3)", \
+        org.eclipse.microprofile.config.spi;version="[1.2,3)", \
         *
 
 Private-Package: \

--- a/dev/com.ibm.ws.microprofile.config.1.2.cdi/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.2.cdi/bnd.bnd
@@ -18,9 +18,9 @@ Bundle-Description: Microprofile Config 1.2 CDI, version ${bVersion}
 
 Import-Package: \
 	javax.enterprise.*; version="[1.1,3)",\
-	org.eclipse.microprofile.config;version="[1.0,2)", \
-        org.eclipse.microprofile.config.inject;version="[1.0,2)", \
-        org.eclipse.microprofile.config.spi;version="[1.2,2)", \
+	org.eclipse.microprofile.config;version="[1.0,3)", \
+        org.eclipse.microprofile.config.inject;version="[1.0,3)", \
+        org.eclipse.microprofile.config.spi;version="[1.2,3)", \
         *
 
 Export-Package: \

--- a/dev/com.ibm.ws.microprofile.config.1.2.services/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.2.services/bnd.bnd
@@ -21,9 +21,9 @@ Bundle-Description:MicroProfile Configuration 1.2 Services, version ${bVersion}
 -dsannotations: com.ibm.ws.microprofile.config12.services.Config12ProviderResolverComponent
 
 Import-Package: \
-        org.eclipse.microprofile.config;version="[1.0,2)", \
-        org.eclipse.microprofile.config.inject;version="[1.0,2)", \
-        org.eclipse.microprofile.config.spi;version="[1.2,2)", \
+        org.eclipse.microprofile.config;version="[1.0,3)", \
+        org.eclipse.microprofile.config.inject;version="[1.0,3)", \
+        org.eclipse.microprofile.config.spi;version="[1.2,3)", \
         *
 
 Private-Package: \

--- a/dev/com.ibm.ws.microprofile.config.1.2/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.2/bnd.bnd
@@ -26,9 +26,9 @@ Export-Package: \
 Private-Package: com.ibm.ws.microprofile.config12.resources
 
 Import-Package: \
-        org.eclipse.microprofile.config;version="[1.0,2)", \
-        org.eclipse.microprofile.config.inject;version="[1.0,2)", \
-        org.eclipse.microprofile.config.spi;version="[1.2,2)", \
+        org.eclipse.microprofile.config;version="[1.0,3)", \
+        org.eclipse.microprofile.config.inject;version="[1.0,3)", \
+        org.eclipse.microprofile.config.spi;version="[1.2,3)", \
         *
 
 WS-TraceGroup: APPCONFIG

--- a/dev/com.ibm.ws.microprofile.config.1.3.services/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.3.services/bnd.bnd
@@ -24,9 +24,9 @@ Private-Package: \
     com.ibm.ws.microprofile.config13.services
 
 Import-Package: \
-        org.eclipse.microprofile.config;version="[1.0.1,2)", \
-        org.eclipse.microprofile.config.spi;version="[1.3,2)", \
-        org.eclipse.microprofile.config.inject;version="[1.0,2)", \
+        org.eclipse.microprofile.config;version="[1.0.1,3)", \
+        org.eclipse.microprofile.config.spi;version="[1.3,3)", \
+        org.eclipse.microprofile.config.inject;version="[1.0,3)", \
         *
 
 WS-TraceGroup: APPCONFIG

--- a/dev/com.ibm.ws.microprofile.config.1.3/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.3/bnd.bnd
@@ -29,8 +29,8 @@ Private-Package: \
         com.ibm.ws.microprofile.config13.interfaces
 
 Import-Package: \
-        org.eclipse.microprofile.config;version="[1.0.1,2)", \
-        org.eclipse.microprofile.config.spi;version="[1.3,2)", \
+        org.eclipse.microprofile.config;version="[1.0.1,3)", \
+        org.eclipse.microprofile.config.spi;version="[1.3,3)", \
         *
 
 WS-TraceGroup: APPCONFIG

--- a/dev/com.ibm.ws.microprofile.config.1.3/src/com/ibm/ws/microprofile/config13/sources/ServerXMLVariableConfigSource.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3/src/com/ibm/ws/microprofile/config13/sources/ServerXMLVariableConfigSource.java
@@ -14,6 +14,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.osgi.framework.BundleContext;
 
@@ -104,6 +105,11 @@ public class ServerXMLVariableConfigSource extends InternalConfigSource implemen
             props = OSGiConfigUtils.getVariablesFromServerXML(configVariables);
         }
         return props;
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return getProperties().keySet();
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.config.1.4.cdi.services/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.4.cdi.services/bnd.bnd
@@ -18,9 +18,9 @@ Bundle-Description: Microprofile Config 1.4 CDI Services
 
 Import-Package: \
         javax.enterprise.*; version="[1.1,3)", \
-        org.eclipse.microprofile.config;version="[1.0.1,2)", \
-        org.eclipse.microprofile.config.inject;version="[1.1.0,2)", \
-        org.eclipse.microprofile.config.spi;version="[1.4,2)", \
+        org.eclipse.microprofile.config;version="[1.0.1,3)", \
+        org.eclipse.microprofile.config.inject;version="[1.0,3)", \
+        org.eclipse.microprofile.config.spi;version="[1.4,3)", \
         *
 
 Private-Package: \

--- a/dev/com.ibm.ws.microprofile.config.1.4.cdi/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.4.cdi/bnd.bnd
@@ -18,7 +18,7 @@ Bundle-Description: Microprofile Config 1.4 CDI
 
 Import-Package: \
 	javax.enterprise.*; version="[1.1,3)",\
-        org.eclipse.microprofile.config.inject;version="[1.1.0,2)", \
+        org.eclipse.microprofile.config.inject;version="[1.0,3)", \
         com.ibm.ws.microprofile.config.cdi.resources, \
         *
 

--- a/dev/com.ibm.ws.microprofile.config.1.4.cdi/src/com/ibm/ws/microprofile/config14/cdi/Config14CDIExtension.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4.cdi/src/com/ibm/ws/microprofile/config14/cdi/Config14CDIExtension.java
@@ -47,6 +47,12 @@ public class Config14CDIExtension extends Config12CDIExtension implements Extens
     }
 
     @Override
+    protected void addConfigBean(AfterBeanDiscovery abd, BeanManager beanManager) {
+        Config14ConfigBean configBean = new Config14ConfigBean(beanManager);
+        abd.addBean(configBean);
+    }
+
+    @Override
     protected <T> void addConfigPropertyBean(AfterBeanDiscovery abd, BeanManager beanManager, Type beanType, Class<T> clazz) {
         ConfigPropertyBean<T> converterBean = new ConfigPropertyBean<T>(beanManager, beanType, clazz, Config14PropertyLiteral.INSTANCE);
         abd.addBean(converterBean);
@@ -78,4 +84,5 @@ public class Config14CDIExtension extends Config12CDIExtension implements Extens
             Tr.error(tc, "unable.to.process.observer.injection.point.CWMCG5006E", pot.getObserverMethod().getBeanClass());
         }
     }
+
 }

--- a/dev/com.ibm.ws.microprofile.config.1.4.cdi/src/com/ibm/ws/microprofile/config14/cdi/Config14ConfigBean.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4.cdi/src/com/ibm/ws/microprofile/config14/cdi/Config14ConfigBean.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.config14.cdi;
+
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.BeanManager;
+
+import org.eclipse.microprofile.config.Config;
+
+import com.ibm.ws.microprofile.config.cdi.ConfigBean;
+
+/**
+ * This CDI Bean controls the creation and destruction of Config instances injected by CDI.
+ * They are all Dependent scope.
+ */
+public class Config14ConfigBean extends ConfigBean {
+
+    /** {@inheritDoc} */
+    public Config14ConfigBean(BeanManager beanManager) {
+        super(beanManager);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Config create(CreationalContext<Config> creationalContext) {
+        // Although this is a singleton bean, the DelegatingConfig checks the current classloader on each method call
+        // The config for each classloader is cached so this is ok
+        // However, the config object is updated with new values dynamically, so the user shouldn't notice any difference.
+        // This means that calling an injected Config always gives the same result as making the same call on the result of getConfig()
+        return Config14DelegatingConfig.INSTANCE;
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.config.1.4.cdi/src/com/ibm/ws/microprofile/config14/cdi/Config14DelegatingConfig.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4.cdi/src/com/ibm/ws/microprofile/config14/cdi/Config14DelegatingConfig.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.config14.cdi;
+
+import java.util.Optional;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.Converter;
+
+import com.ibm.ws.microprofile.config.cdi.DelegatingConfig;
+
+/**
+ * Config implementation which delegates to the config for the current TCCL
+ * <p>
+ * This can be used as the Config Bean implementation to work around the difference between the scope of a Config and the standard CDI scopes.
+ */
+public class Config14DelegatingConfig extends DelegatingConfig implements Config {
+
+    public static Config14DelegatingConfig INSTANCE = new Config14DelegatingConfig();
+
+    @Override
+    public <T> Optional<Converter<T>> getConverter(Class<T> forType) {
+        return getDelegate().getConverter(forType);
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.config.1.4.services/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.4.services/bnd.bnd
@@ -24,9 +24,9 @@ Private-Package: \
     com.ibm.ws.microprofile.config14.services
 
 Import-Package: \
-        org.eclipse.microprofile.config;version="[1.0.1,2)", \
-        org.eclipse.microprofile.config.inject;version="[1.1.0,2)", \
-        org.eclipse.microprofile.config.spi;version="[1.4,2)", \
+        org.eclipse.microprofile.config;version="[1.0.1,3)", \
+        org.eclipse.microprofile.config.inject;version="[1.0,3)", \
+        org.eclipse.microprofile.config.spi;version="[1.4,3)", \
         *
 
 WS-TraceGroup: APPCONFIG

--- a/dev/com.ibm.ws.microprofile.config.1.4/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.4/bnd.bnd
@@ -28,9 +28,10 @@ Private-Package: \
         com.ibm.ws.microprofile.config14.sources
 
 Import-Package: \
-        org.eclipse.microprofile.config;version="[1.0.1,2)", \
-        org.eclipse.microprofile.config.inject;version="[1.1.0,2)", \
-        org.eclipse.microprofile.config.spi;version="[1.4,2)", \
+
+        org.eclipse.microprofile.config;version="[1.0.1,3)", \
+        org.eclipse.microprofile.config.inject;version="[1.0,3)", \
+        org.eclipse.microprofile.config.spi;version="[1.4,3)", \
         *
 
 WS-TraceGroup: APPCONFIG

--- a/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/impl/Config14Impl.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/impl/Config14Impl.java
@@ -185,7 +185,7 @@ public class Config14Impl extends AbstractConfig implements WebSphereConfig {
 
     @Override
     public <T> Optional<Converter<T>> getConverter(Class<T> forType) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/impl/Config14Impl.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/impl/Config14Impl.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
@@ -22,6 +23,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.Converter;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
@@ -179,6 +181,11 @@ public class Config14Impl extends AbstractConfig implements WebSphereConfig {
 
         return sb.toString();
 
+    }
+
+    @Override
+    public <T> Optional<Converter<T>> getConverter(Class<T> forType) {
+        return null;
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/sources/AppPropertyConfig14Source.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/sources/AppPropertyConfig14Source.java
@@ -11,6 +11,7 @@
 package com.ibm.ws.microprofile.config14.sources;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -39,6 +40,11 @@ public class AppPropertyConfig14Source extends AppPropertyConfigSource {
 
     public void close() {
         cache.close();
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return getProperties().keySet();
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.config.1.4_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.4_fat_tck/publish/tckRunner/tck/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-tck</artifactId>
-            <version>${microprofile.config.version}</version>
+            <version>2.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Some of the FAT and TCK tests for the build below will knowingly fail due to newer methods not being properly implemented. 

This is a test build to see whether the new MANIFEST.MF works from this PR: https://github.com/eclipse/microprofile-config/pull/381/files 

#build
#spawn.fullfat.buckets=com.ibm.ws.microprofile.config.1.4_fat, com.ibm.ws.microprofile.config.1.3_fat, com.ibm.ws.microprofile.config.1.2_fat, com.ibm.ws.microprofile.config.1.1_fat, com.ibm.ws.microprofile.config.1.4_fat_tck, com.ibm.ws.microprofile.config.1.3_fat_tck, com.ibm.ws.microprofile.config.1.2_fat_tck, com.ibm.ws.microprofile.config.1.1_fat_tck

