### PR TITLE
Fix failing FAT for com.ibm.ws.logging.hpel_fat

### DIFF
--- a/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/BinaryLogExec.java
+++ b/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/BinaryLogExec.java
@@ -78,14 +78,6 @@ public class BinaryLogExec {
         assumeTrue(!skipTest());
         ShrinkHelper.defaultDropinApp(server, "LogFat", "com.ibm.ws.logging.hpel");
         ShrinkHelper.defaultDropinApp(server, "HpelFat", "com.ibm.ws.logging.hpel.servlet");
-        if (!CommonTasks.isHpelEnabled(server)) {
-            // HPEL is not enabled.
-            CommonTasks.writeLogMsg(Level.INFO, "HPEL is not enabled on " + server.getServerName() + ", attempting to enable.");
-            CommonTasks.setHpelEnabled(server, true);
-            // RestartServer now to complete switching to HPEL
-            server.restartServer();
-
-        }
 
         // Liberty profile root is the install root.
         rProfRootDir = new RemoteFile(server.getMachine(), server.getInstallRoot());

--- a/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/BinaryLogRecordContextTest.java
+++ b/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/BinaryLogRecordContextTest.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.ProtocolException;
 import java.net.URL;
-import java.util.logging.Level;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -52,14 +51,6 @@ public class BinaryLogRecordContextTest {
         // Confirm HPEL is enabled
         ShrinkHelper.defaultDropinApp(server, "LogFat", "com.ibm.ws.logging.hpel");
         ShrinkHelper.defaultDropinApp(server, "HpelFat", "com.ibm.ws.logging.hpel.servlet");
-        if (!CommonTasks.isHpelEnabled(server)) {
-            // HPEL is not enabled.
-            CommonTasks.writeLogMsg(Level.INFO, "HPEL is not enabled on " + server.getServerName() + ", attempting to enable.");
-            CommonTasks.setHpelEnabled(server, true);
-            // Restart now to complete switching to HPEL
-            server.restartServer();
-        }
-
         // Liberty profile root is the install root.
         rProfRootDir = new RemoteFile(server.getMachine(), server.getInstallRoot());
 //        rProfRootDir = new RemoteFile(HpelSetup.getNodeUnderTest().getMachine(), HpelSetup.getNodeUnderTest().getProfileDir());

--- a/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/ConcurrentLoggingAccuracyTest.java
+++ b/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/ConcurrentLoggingAccuracyTest.java
@@ -65,16 +65,6 @@ public class ConcurrentLoggingAccuracyTest {
         ShrinkHelper.defaultDropinApp(server, "LogFat", "com.ibm.ws.logging.hpel");
         ShrinkHelper.defaultDropinApp(server, "HpelFat", "com.ibm.ws.logging.hpel.servlet");
 
-        // Confirm HPEL is enabled
-        if (!CommonTasks.isHpelEnabled(server)) {
-            // HPEL is not enabled.
-            CommonTasks.writeLogMsg(Level.INFO, "HPEL is not enabled on " + server.getServerName() + ", attempting to enable.");
-            CommonTasks.setHpelEnabled(server, true);
-            // if HPEL was not enabled, make sure trace spec is not valid to ensure restart below.
-            CommonTasks.setHpelTraceSpec(server, null);
-
-        }
-
         /*
          * Since we have multiple test methods in this test case, we will only restart if the spec is not already set to
          * what we need. This will avoid extra server restarts which adds to the bucket execution time.
@@ -87,7 +77,7 @@ public class ConcurrentLoggingAccuracyTest {
 
             // need to restart the application server now
             // stopServer Server first.
-            CommonTasks.writeLogMsg(Level.INFO, "Bouncing server for new spec to take effect. stopServerping application server");
+            CommonTasks.writeLogMsg(Level.INFO, "Bouncing server for new spec to take effect. stopping application server");
             server.stopServer();
 
             Thread.sleep(10000); // stopServer operation blocks, but want short pause before restarting.

--- a/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/HPELHideMessagesTest.java
+++ b/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/HPELHideMessagesTest.java
@@ -66,7 +66,8 @@ public class HPELHideMessagesTest {
             CommonTasks.writeLogMsg(Level.INFO, "HPEL is not enabled on " + server.getServerName() + ", attempting to enable.");
             CommonTasks.setHpelEnabled(server, true);
             // Restart now to complete switching to HPEL
-            server.restartServer();
+            server.stopServer();
+            server.startServer();
 
         }
 
@@ -78,8 +79,7 @@ public class HPELHideMessagesTest {
         // Setting the server.xml with the hideMessages logging attribute
         server.updateServerConfiguration(new File(server.pathToAutoFVTTestFiles, "server-HPELHideMessagesTest.xml"));
         // Restart server
-        server.stopServer();
-        server.startServer();
+        server.restartServer();
     }
 
     /**

--- a/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/HPELHideMessagesTest.java
+++ b/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/HPELHideMessagesTest.java
@@ -66,8 +66,7 @@ public class HPELHideMessagesTest {
             CommonTasks.writeLogMsg(Level.INFO, "HPEL is not enabled on " + server.getServerName() + ", attempting to enable.");
             CommonTasks.setHpelEnabled(server, true);
             // Restart now to complete switching to HPEL
-            server.stopServer();
-            server.startServer();
+            server.restartServer();
 
         }
 
@@ -79,8 +78,8 @@ public class HPELHideMessagesTest {
         // Setting the server.xml with the hideMessages logging attribute
         server.updateServerConfiguration(new File(server.pathToAutoFVTTestFiles, "server-HPELHideMessagesTest.xml"));
         // Restart server
-        server.restartServer();
-
+        server.stopServer();
+        server.startServer();
     }
 
     /**
@@ -111,6 +110,7 @@ public class HPELHideMessagesTest {
         if (server != null && server.isStarted()) {
             server.stopServer();
         }
+
     }
 
 }

--- a/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/HPELHideMessagesTest.java
+++ b/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/HPELHideMessagesTest.java
@@ -108,6 +108,9 @@ public class HPELHideMessagesTest {
         if (backup != null && backup.exists()) {
             server.getServerConfigurationFile().copyFromSource(backup);
         }
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
     }
 
 }

--- a/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/HpelDeleteEmptyDirectories.java
+++ b/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/HpelDeleteEmptyDirectories.java
@@ -74,13 +74,6 @@ public class HpelDeleteEmptyDirectories {
         // Confirm HPEL is enabled
         ShrinkHelper.defaultDropinApp(server, "LogFat", "com.ibm.ws.logging.hpel");
         ShrinkHelper.defaultDropinApp(server, "HpelFat", "com.ibm.ws.logging.hpel.servlet");
-        if (!CommonTasks.isHpelEnabled(server)) {
-            // HPEL is not enabled.
-            CommonTasks.writeLogMsg(Level.INFO, "HPEL is not enabled on " + server.getServerName() + ", attempting to enable.");
-            CommonTasks.setHpelEnabled(server, true);
-            server.stopServer();
-            server.startServer();
-        }
 
         backup = new RemoteFile(server.getMachine(), new File(server.getServerRoot(), "server-backup.xml").getPath());
         if (!backup.exists()) {

--- a/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/HpelPurgeMaxSizeIgnoreTest_1.java
+++ b/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/HpelPurgeMaxSizeIgnoreTest_1.java
@@ -78,24 +78,13 @@ public class HpelPurgeMaxSizeIgnoreTest_1 {
         // Confirm HPEL is enabled
         ShrinkHelper.defaultDropinApp(server, "LogFat", "com.ibm.ws.logging.hpel");
         ShrinkHelper.defaultDropinApp(server, "HpelFat", "com.ibm.ws.logging.hpel.servlet");
-        if (!CommonTasks.isHpelEnabled(server)) {
-            // HPEL is not enabled.
-            CommonTasks.writeLogMsg(Level.INFO, "HPEL is not enabled on " + server.getServerName() + ", attempting to enable.");
-            CommonTasks.setHpelEnabled(server, true);
-            // RestartServer now to complete switching to HPEL
-            server.restartServer();
-        }
 
         // Setting the bootstrap with trace specification to get the trace logs.
         CommonTasks.addBootstrapProperty(server, "com.ibm.ws.logging.trace.specification", "*=fine=enabled");
         server.stopServer();
-        //server.startServer();
 
         CommonTasks.writeLogMsg(Level.INFO, "Configuring server for test case.");
-//        backup = new RemoteFile(server.getMachine(), new File(server.getServerRoot(), "server-backup.xml").getPath());
-//        if (!backup.exists()) {
-//            backup.copyFromSource(server.getServerConfigurationFile());
-//        }
+
         server.updateServerConfiguration(new File(server.pathToAutoFVTTestFiles, "server-HpelLogDirectoryChange_1.xml"));
         if (!server.isStarted()) {
             server.startServer();

--- a/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/HpelPurgeMaxSizeIgnoreTest_2.java
+++ b/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/HpelPurgeMaxSizeIgnoreTest_2.java
@@ -256,8 +256,6 @@ public class HpelPurgeMaxSizeIgnoreTest_2 {
         if (backup != null && backup.exists()) {
             server.getServerConfigurationFile().copyFromSource(backup);
         }
-        RemoteFile bootstrapFile = server.getServerBootstrapPropertiesFile();
-        bootstrapFile.delete();
         // call the super
     }
 

--- a/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/HpelPurgeMaxSizeIgnoreTest_2.java
+++ b/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/HpelPurgeMaxSizeIgnoreTest_2.java
@@ -75,15 +75,6 @@ public class HpelPurgeMaxSizeIgnoreTest_2 {
         assumeTrue(!skipTest());
         ShrinkHelper.defaultDropinApp(server, "LogFat", "com.ibm.ws.logging.hpel");
         ShrinkHelper.defaultDropinApp(server, "HpelFat", "com.ibm.ws.logging.hpel.servlet");
-        if (!CommonTasks.isHpelEnabled(server)) {
-            // HPEL is not enabled.
-            CommonTasks.writeLogMsg(Level.INFO, "HPEL is not enabled on " + server.getServerName() + ", attempting to enable.");
-            CommonTasks.setHpelEnabled(server, true);
-            // RestartServer now to complete switching to HPEL
-            server.stopServer();
-            server.startServer();
-
-        }
 
         // Setting the bootstrap with trace specification to get the trace logs.
         CommonTasks.addBootstrapProperty(server, "com.ibm.ws.logging.trace.specification", "*=fine=enabled");
@@ -265,7 +256,8 @@ public class HpelPurgeMaxSizeIgnoreTest_2 {
         if (backup != null && backup.exists()) {
             server.getServerConfigurationFile().copyFromSource(backup);
         }
-
+        RemoteFile bootstrapFile = server.getServerBootstrapPropertiesFile();
+        bootstrapFile.delete();
         // call the super
     }
 

--- a/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/TraceSpecificationSetToAllTest.java
+++ b/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/TraceSpecificationSetToAllTest.java
@@ -39,7 +39,7 @@ import componenttest.topology.utils.HttpUtils;
 @RunWith(FATRunner.class)
 public class TraceSpecificationSetToAllTest {
 
-    @Server("HpelServer")
+    @Server("HpelServer2")
     public static LibertyServer server;
     private static final int CONN_TIMEOUT = 60;
     private final Class<?> c = TraceSpecificationSetToAllTest.class;
@@ -53,17 +53,8 @@ public class TraceSpecificationSetToAllTest {
     public static void setUp() throws Exception {
         ShrinkHelper.defaultDropinApp(server, "LogFat", "com.ibm.ws.logging.hpel");
         ShrinkHelper.defaultDropinApp(server, "HpelFat", "com.ibm.ws.logging.hpel.servlet");
-        if (!CommonTasks.isHpelEnabled(server)) {
-            // HPEL is not enabled.
-            CommonTasks.writeLogMsg(Level.INFO, "HPEL is not enabled on " + server.getServerName() + ", attempting to enable.");
-            CommonTasks.setHpelEnabled(server, true);
-            // if HPEL was not enabled, make sure trace spec is not valid to ensure restart below.
-
-        }
 
         CommonTasks.setHpelTraceSpec(server, traceSpecification);
-
-        CommonTasks.addBootstrapProperty(server, "com.ibm.ws.logging.trace.specification", "com.ibm.ws.logging.*=all:com.ibm.ws.org.*=all=enabled");
 
         CommonTasks.writeLogMsg(Level.INFO, "Bouncing server for new spec to take effect. Stopping application server");
         server.stopServer();

--- a/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/VerifyRepositoryAccuracy.java
+++ b/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/VerifyRepositoryAccuracy.java
@@ -78,14 +78,6 @@ public class VerifyRepositoryAccuracy {
         // Confirm HPEL is enabled
         ShrinkHelper.defaultDropinApp(server, "LogFat", "com.ibm.ws.logging.hpel");
         ShrinkHelper.defaultDropinApp(server, "HpelFat", "com.ibm.ws.logging.hpel.servlet");
-        if (!CommonTasks.isHpelEnabled(server)) {
-            // HPEL is not enabled.
-            CommonTasks.writeLogMsg(Level.INFO, "HPEL is not enabled on " + server.getServerName() + ", attempting to enable.");
-            CommonTasks.setHpelEnabled(server, true);
-            // if HPEL was not enabled, make sure trace spec is not valid to ensure restartServer below.
-            CommonTasks.setHpelTraceSpec(server, null);
-
-        }
         /*
          * Since we have multiple test methods in this test case, we will only restartServer if the spec is not already set to
          * what we need. This will avoid extra server restartServers which adds to the bucket execution time.

--- a/dev/com.ibm.ws.logging.hpel_fat/publish/servers/HpelServer2/bootstrap.properties
+++ b/dev/com.ibm.ws.logging.hpel_fat/publish/servers/HpelServer2/bootstrap.properties
@@ -1,3 +1,4 @@
 bootstrap.include=../testports.properties
 websphere.log.provider=binaryLogging-1.0
 com.ibm.ws.logging.console.log.level=INFO
+com.ibm.ws.logging.trace.specification=com.ibm.ws.logging.*=all:com.ibm.ws.org.*=all=enabled


### PR DESCRIPTION
Remove check for binaryLogging enablement bootstrap.properties file since in Windows platforms it can't delete the file if it's being opened. binaryLogging is always enabled in the servers bootstrap.properties.
Fixes  #11945