### PR TITLE
Updates for recent changes

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -218,16 +218,6 @@
     </dependency>
     <dependency>
       <groupId>com.graphql-java</groupId>
-      <artifactId>graphql-java-servlet</artifactId>
-      <version>6.1.3</version>
-    </dependency>
-    <dependency>
-      <groupId>com.graphql-java</groupId>
-      <artifactId>graphql-java</artifactId>
-      <version>11.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.graphql-java</groupId>
       <artifactId>graphql-java</artifactId>
       <version>14.0</version>
     </dependency>
@@ -527,11 +517,6 @@
       <version>1.7</version>
     </dependency>
     <dependency>
-      <groupId>io.github.classgraph</groupId>
-      <artifactId>classgraph</artifactId>
-      <version>4.6.7</version>
-    </dependency>
-    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
       <version>1.27.0</version>
@@ -592,11 +577,6 @@
       <version>0.34.0</version>
     </dependency>
     <dependency>
-      <groupId>io.leangen.geantyref</groupId>
-      <artifactId>geantyref</artifactId>
-      <version>1.3.6</version>
-    </dependency>
-    <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-api</artifactId>
       <version>0.21.0</version>
@@ -655,6 +635,26 @@
       <groupId>io.reactivex.rxjava2</groupId>
       <artifactId>rxjava</artifactId>
       <version>2.2.13</version>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-graphql</artifactId>
+      <version>1.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-graphql-schema-builder</artifactId>
+      <version>1.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-graphql-schema-model</artifactId>
+      <version>1.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-graphql-servlet</artifactId>
+      <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>io.smallrye.reactive</groupId>
@@ -2124,12 +2124,12 @@
     <dependency>
       <groupId>org.jboss.weld</groupId>
       <artifactId>weld-osgi-bundle</artifactId>
-      <version>3.1.1.Final</version>
+      <version>3.1.4.Final</version>
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se-core</artifactId>
-      <version>3.1.1.Final</version>
+      <version>3.1.4.Final</version>
     </dependency>
     <dependency>
       <groupId>org.jboss</groupId>

--- a/dev/com.ibm.ws.transport.iiop.open_fat/.classpath
+++ b/dev/com.ibm.ws.transport.iiop.open_fat/.classpath
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="src" path="test-applications/TestCorbaEjb.jar/src"/>
+	<classpathentry kind="src" path="test-applications/TestCorbaWeb.war/src"/>
+	<classpathentry kind="src" path="test-applications/Interfaces.jar/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.transport.iiop.open_fat/.project
+++ b/dev/com.ibm.ws.transport.iiop.open_fat/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.ibm.ws.transport.iiop.open_fat</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/com.ibm.ws.transport.iiop.open_fat/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.transport.iiop.open_fat/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.transport.iiop.open_fat/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.transport.iiop.open_fat/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,12 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=1.8


### PR DESCRIPTION
- Add eclipse files for com.ibm.ws.transport.iiop.open_fat
- Remove src directory from com.ibm.ws.org.apache.aries.jndi.core .classpath
- Include the latest dependabot pom.xml that was updated with recent oss_dependencies.maven changes.