### PR TITLE
set up Jakarta autofeatures for jdbc

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.connectionManagementJakarta-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.connectionManagementJakarta-1.0.feature
@@ -1,0 +1,11 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=com.ibm.websphere.appserver.connectionManagementJakarta-1.0
+IBM-Provision-Capability:\
+ osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.transaction-2.0)))", \
+ osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.connectionManagement-1.0))"
+IBM-Install-Policy: when-satisfied
+-features=com.ibm.websphere.appserver.javax.connector.internal-1.7
+-bundles=com.ibm.ws.jca.cm.jakarta
+kind=noship
+edition=core
+#TODO switch feature to Jakarta Connectors once available

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.connectionManagementJavaEE-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.connectionManagementJavaEE-1.0.feature
@@ -1,0 +1,10 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=com.ibm.websphere.appserver.connectionManagementJavaEE-1.0
+IBM-Provision-Capability:\
+ osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.transaction-1.2)(osgi.identity=com.ibm.websphere.appserver.transaction-1.1)))", \
+ osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.connectionManagement-1.0))"
+IBM-Install-Policy: when-satisfied
+-features=com.ibm.websphere.appserver.javax.connector.internal-1.6; ibm.tolerates:=1.7
+-bundles=com.ibm.ws.jca.cm
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jcaSecurityJakarta-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jcaSecurityJakarta-1.0.feature
@@ -1,0 +1,9 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=com.ibm.websphere.appserver.jcaSecurityJakarta-1.0
+IBM-Provision-Capability:\
+ osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.transaction-2.0)))", \
+ osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.jcaSecurity-1.0))"
+IBM-Install-Policy: when-satisfied
+-bundles=com.ibm.ws.security.jca.jakarta
+kind=noship
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jcaSecurityJavaEE-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jcaSecurityJavaEE-1.0.feature
@@ -1,0 +1,9 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=com.ibm.websphere.appserver.jcaSecurityJavaEE-1.0
+IBM-Provision-Capability:\
+ osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.transaction-1.2)(osgi.identity=com.ibm.websphere.appserver.transaction-1.1)))", \
+ osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.jcaSecurity-1.0))"
+IBM-Install-Policy: when-satisfied
+-bundles=com.ibm.ws.security.jca
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jdbcJakarta-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jdbcJakarta-1.0.feature
@@ -1,0 +1,9 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=com.ibm.websphere.appserver.jdbcJakarta-1.0
+IBM-Provision-Capability:\
+ osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.transaction-2.0)))", \
+ osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.jdbc-4.3)(osgi.identity=com.ibm.websphere.appserver.jdbc-4.2)(osgi.identity=com.ibm.websphere.appserver.jdbc-4.1)(osgi.identity=com.ibm.websphere.appserver.jdbc-4.0)))"
+IBM-Install-Policy: when-satisfied
+-bundles=com.ibm.ws.jdbc.jakarta
+kind=noship
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jdbcJavaEE-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jdbcJavaEE-1.0.feature
@@ -1,0 +1,9 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=com.ibm.websphere.appserver.jdbcJavaEE-1.0
+IBM-Provision-Capability:\
+ osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.transaction-1.2)(osgi.identity=com.ibm.websphere.appserver.transaction-1.1)))", \
+ osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.jdbc-4.3)(osgi.identity=com.ibm.websphere.appserver.jdbc-4.2)(osgi.identity=com.ibm.websphere.appserver.jdbc-4.1)(osgi.identity=com.ibm.websphere.appserver.jdbc-4.0)))"
+IBM-Install-Policy: when-satisfied
+-bundles=com.ibm.ws.jdbc
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.connectionManagement-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.connectionManagement-1.0.feature
@@ -2,10 +2,9 @@
 symbolicName=com.ibm.websphere.appserver.connectionManagement-1.0
 IBM-API-Package: com.ibm.ws.jca.cm.mbean; type="ibm-api"
 visibility=private
--features=com.ibm.websphere.appserver.transaction-1.1; ibm.tolerates:=1.2, \
+-features=com.ibm.websphere.appserver.transaction-1.1; ibm.tolerates:="1.2, 2.0", \
  com.ibm.websphere.appserver.containerServices-1.0, \
  com.ibm.websphere.appserver.jcaSecurity-1.0
--bundles=com.ibm.ws.jca.cm
 -jars=com.ibm.websphere.appserver.api.connectionmanager; location:=dev/api/ibm/
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.connectionmanager_1.2-javadoc.zip
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jdbc-4.0/com.ibm.websphere.appserver.jdbc-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jdbc-4.0/com.ibm.websphere.appserver.jdbc-4.0.feature
@@ -5,14 +5,14 @@ singleton=true
 IBM-API-Package: com.ibm.wsspi.zos.tx; type="internal"
 IBM-ShortName: jdbc-4.0
 Subsystem-Name: Java Database Connectivity 4.0
--features=com.ibm.websphere.appserver.javax.connector.internal-1.6; ibm.tolerates:=1.7, \
+-features=\
  com.ibm.websphere.appserver.jndi-1.0, \
- com.ibm.websphere.appserver.transaction-1.1; ibm.tolerates:=1.2, \
+ com.ibm.websphere.appserver.transaction-1.1; ibm.tolerates:="1.2, 2.0", \
  com.ibm.websphere.appserver.classloading-1.0, \
  com.ibm.websphere.appserver.appLifecycle-1.0, \
  com.ibm.websphere.appserver.connectionManagement-1.0, \
  com.ibm.websphere.appserver.requestProbes-1.0
--bundles=com.ibm.ws.jdbc, \
+-bundles=\
  com.ibm.ws.jdbc.4.0.feature
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jdbc-4.1/com.ibm.websphere.appserver.jdbc-4.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jdbc-4.1/com.ibm.websphere.appserver.jdbc-4.1.feature
@@ -5,13 +5,13 @@ singleton=true
 IBM-API-Package: com.ibm.wsspi.zos.tx; type="internal"
 IBM-ShortName: jdbc-4.1
 Subsystem-Name: Java Database Connectivity 4.1
--features=com.ibm.websphere.appserver.javax.connector.internal-1.7; ibm.tolerates:=1.6, \
+-features=\
  com.ibm.websphere.appserver.classloading-1.0, \
  com.ibm.websphere.appserver.appLifecycle-1.0, \
- com.ibm.websphere.appserver.transaction-1.2; ibm.tolerates:=1.1, \
+ com.ibm.websphere.appserver.transaction-1.2; ibm.tolerates:="1.1, 2.0", \
  com.ibm.websphere.appserver.connectionManagement-1.0, \
  com.ibm.websphere.appserver.requestProbes-1.0
--bundles=com.ibm.ws.jdbc, \
+-bundles=\
  com.ibm.ws.jdbc.4.1, \
  com.ibm.ws.jdbc.4.1.feature
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jdbc-4.2/com.ibm.websphere.appserver.jdbc-4.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jdbc-4.2/com.ibm.websphere.appserver.jdbc-4.2.feature
@@ -5,13 +5,13 @@ singleton=true
 IBM-API-Package: com.ibm.wsspi.zos.tx; type="internal"
 IBM-ShortName: jdbc-4.2
 Subsystem-Name: Java Database Connectivity 4.2
--features=com.ibm.websphere.appserver.javax.connector.internal-1.7; ibm.tolerates:=1.6, \
+-features=\
  com.ibm.websphere.appserver.classloading-1.0, \
  com.ibm.websphere.appserver.appLifecycle-1.0, \
- com.ibm.websphere.appserver.transaction-1.2; ibm.tolerates:=1.1, \
+ com.ibm.websphere.appserver.transaction-1.2; ibm.tolerates:="1.1, 2.0", \
  com.ibm.websphere.appserver.connectionManagement-1.0, \
  com.ibm.websphere.appserver.requestProbes-1.0
--bundles=com.ibm.ws.jdbc, \
+-bundles=\
  com.ibm.ws.jdbc.4.1, \
  com.ibm.ws.jdbc.4.2, \
  com.ibm.ws.jdbc.4.2.feature

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jdbc-4.3/com.ibm.websphere.appserver.jdbc-4.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jdbc-4.3/com.ibm.websphere.appserver.jdbc-4.3.feature
@@ -6,14 +6,12 @@ IBM-API-Package: com.ibm.wsspi.zos.tx; type="internal"
 IBM-ShortName: jdbc-4.3
 Subsystem-Name: Java Database Connectivity 4.3
 -features=\
-  com.ibm.websphere.appserver.javax.connector.internal-1.7; ibm.tolerates:=1.6, \
   com.ibm.websphere.appserver.classloading-1.0, \
   com.ibm.websphere.appserver.appLifecycle-1.0, \
-  com.ibm.websphere.appserver.transaction-1.2; ibm.tolerates:=1.1, \
+  com.ibm.websphere.appserver.transaction-1.2; ibm.tolerates:="1.1, 2.0", \
   com.ibm.websphere.appserver.connectionManagement-1.0, \
   com.ibm.websphere.appserver.requestProbes-1.0
 -bundles=\
-  com.ibm.ws.jdbc, \
   com.ibm.ws.jdbc.4.1, \
   com.ibm.ws.jdbc.4.2, \
   com.ibm.ws.jdbc.4.3, \

--- a/dev/com.ibm.ws.jca.cm/bnd.bnd
+++ b/dev/com.ibm.ws.jca.cm/bnd.bnd
@@ -15,6 +15,8 @@ Bundle-Name: Connection Management and Pooling
 Bundle-SymbolicName: com.ibm.ws.jca.cm
 Bundle-Description: Connection Management and Pooling; version=${bVersion}
 
+jakartaeeMe: true
+
 WS-TraceGroup: WAS.j2c
 
 Export-Package: \

--- a/dev/com.ibm.ws.jdbc/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc/bnd.bnd
@@ -15,6 +15,8 @@ Bundle-Name: Database Connectivity
 Bundle-SymbolicName: com.ibm.ws.jdbc
 Bundle-Description: Database connectivity infrastructure, version ${bVersion}
 
+jakartaeeMe: true
+
 WS-TraceGroup: RRA
 
 IBM-Default-Config: OSGI-INF/wlp/defaultInstances.xml

--- a/dev/com.ibm.ws.security.jca/bnd.bnd
+++ b/dev/com.ibm.ws.security.jca/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -14,6 +14,8 @@ bVersion=1.0
 Bundle-Name: JCA Security
 Bundle-SymbolicName: com.ibm.ws.security.jca
 Bundle-Description: JCA Security, version=${bVersion}
+
+jakartaeeMe: true
 
 WS-TraceGroup: \
   JCASecurity

--- a/dev/wlp-jakartaee-transform/rules/jakarta-renames.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-renames.properties
@@ -54,6 +54,13 @@ javax.interceptor=jakarta.interceptor
 
 javax.inject=jakarta.inject
 
+javax.resoure=jakarta.resource
+javax.resoure.cci=jakarta.resource.cci
+javax.resoure.spi=jakarta.resource.spi
+javax.resoure.spi.endpoint=jakarta.resource.spi.endpoint
+javax.resoure.spi.security=jakarta.resource.spi.security
+javax.resoure.spi.work=jakarta.resource.spi.work
+
 javax.ws.rs=jakarta.ws.rs
 javax.ws.rs.client=jakarta.ws.rs.client
 javax.ws.rs.core=jakarta.ws.rs.core


### PR DESCRIPTION
Create new autofeatures for to bring in Java EE vs Jakarta packages when one of the jdbc features is enabled.  Given that Jakarta Connectors spec API isn't in Liberty yet, this will only be done partially under this pull as a first step, and will confirm that we aren't breaking existing features with this approach.