### PR TITLE
Add capabilities that are not effective

### DIFF
--- a/dev/com.ibm.ws.diagnostics/src/com/ibm/ws/diagnostics/osgi/BundleWiringIntrospection.java
+++ b/dev/com.ibm.ws.diagnostics/src/com/ibm/ws/diagnostics/osgi/BundleWiringIntrospection.java
@@ -25,6 +25,7 @@ import org.osgi.framework.wiring.BundleCapability;
 import org.osgi.framework.wiring.BundleRequirement;
 import org.osgi.framework.wiring.BundleWire;
 import org.osgi.framework.wiring.BundleWiring;
+import org.osgi.resource.Namespace;
 
 import com.ibm.wsspi.logging.Introspector;
 
@@ -93,7 +94,7 @@ public class BundleWiringIntrospection implements Introspector {
 
                                 if (!removed) {
                                     // print the requirement
-                                    result.println("  Requirement:");
+                                    result.println("  Requirement: " + req.getNamespace());
                                     introspectBundleRequirementInfo(req, result);
                                     reqsItr.remove();
                                     removed = true;
@@ -117,7 +118,7 @@ public class BundleWiringIntrospection implements Introspector {
             if (reqs != null && !reqs.isEmpty()) {
                 result.println("Not Satisfied Requirements:");
                 for (BundleRequirement req : reqs) {
-                    result.println("  Requirement:");
+                    result.println("  Requirement: " + req.getNamespace());
                     introspectBundleRequirementInfo(req, result);
                 }
             }
@@ -146,7 +147,7 @@ public class BundleWiringIntrospection implements Introspector {
                             if (provWire.getCapability().equals(cap)) {
                                 if (!removed) {
                                     // print the capability
-                                    result.println("  Capability:");
+                                    result.println("  Capability: " + cap.getNamespace());
                                     introspectBundleCapabilityInfo(cap, result);
                                     capsItr.remove();
                                     removed = true;
@@ -170,11 +171,24 @@ public class BundleWiringIntrospection implements Introspector {
             if (caps != null && !caps.isEmpty()) {
                 result.println("Not Utilized Capabilities:");
                 for (BundleCapability cap : caps) {
-                    result.println("  Capability:");
+                    result.println("  Capability: " + cap.getNamespace());
                     introspectBundleCapabilityInfo(cap, result);
                 }
             }
 
+            List<BundleCapability> declaredCaps = wiring.getRevision().getDeclaredCapabilities(null);
+            boolean printHeader = true;
+            for (BundleCapability cap : declaredCaps) {
+                String effective = cap.getDirectives().get(Namespace.CAPABILITY_EFFECTIVE_DIRECTIVE);
+                if (effective != null && !effective.equals(Namespace.EFFECTIVE_RESOLVE)) {
+                    if (printHeader) {
+                        result.println("Declared Capabilities:");
+                        printHeader = false;
+                    }
+                    result.println("  Capability: " + cap.getNamespace());
+                    introspectBundleCapabilityInfo(cap, result);
+                }
+            }
         } else {// means it is in the INSTALLED or UNINSTALLED state
             result.println("No wiring");
         }


### PR DESCRIPTION
Some capabilities are informational only, but
they can provide some useful information.
For example, the equinox.module.data capability
is generated by the framework and contains
information such as the bundle's activator
class
