### PR TITLE
gRPC service config support

### DIFF
--- a/dev/com.ibm.ws.grpc/bnd.bnd
+++ b/dev/com.ibm.ws.grpc/bnd.bnd
@@ -17,7 +17,8 @@ Bundle-SymbolicName: com.ibm.ws.grpc
 Bundle-Description: Libery gRPC, version ${bVersion}
 
 -dsannotations: \
-  com.ibm.ws.grpc.servlet.GrpcServerComponent
+  com.ibm.ws.grpc.servlet.GrpcServerComponent,\
+  com.ibm.ws.grpc.config.GrpcServiceConfigImpl
 
 Import-Package: !sun.*,\
   !com.google.code.gson,\
@@ -25,11 +26,16 @@ Import-Package: !sun.*,\
   *
 
 Export-Package: io.grpc.servlet,\
+  com.ibm.ws.grpc.config,\
   com.ibm.ws.grpc.servlet
 
 javac.args.release: current
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=11))"
+
+Include-Resource: \
+  OSGI-INF=resources/OSGI-INF, \
+  OSGI-INF/metatype/metatype.xml=resources/OSGI-INF/metatype/metatype.xml
 
 -buildpath: \
   com.ibm.ws.container.service;version=latest,\
@@ -51,7 +57,8 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=11))"
   com.ibm.ws.webcontainer,\
   com.google.code.findbugs:jsr305;version=3.0.2,\
   com.google.guava:guava;version=27.0.1,\
-  com.ibm.ws.security.authorization.util
+  com.ibm.ws.security.authorization.util,\
+  org.osgi.service.component.annotations;version=latest
 
 -testpath: \
     org.hamcrest:hamcrest-all;version=1.3, \

--- a/dev/com.ibm.ws.grpc/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.grpc/resources/OSGI-INF/l10n/metatype.properties
@@ -15,17 +15,17 @@
 #NLS_MESSAGEFORMAT_NONE
 
 
-serviceConfig=GRPC Service Properties
-clientConfig.desc=Configuration properties to be applied to gRPC services that match the specified URI.
+serverConfig=GRPC Server Properties
+serverConfig.desc=Configuration properties to be applied to gRPC endpoints that match the specified URI.
 
-serviceName=GRPC service name
-serviceName.desc=The gRPC service name, with wildcard support.
+target=GRPC target endpoint
+target.desc=The gRPC endpoint target name, with wildcard support.
 
 httpEndpoints=HTTP endpoints
-httpEndpoints.desc=The list of HTTP endpoints on which to service gRPC requests.
+httpEndpoints.desc=The list of HTTP endpoints on which to handle gRPC requests.
 
-serviceInterceptors=GRPC service interceptors
-serviceInterceptors.desc=A list of fully qualified class names for gRPC service interceptor classes.
+serverInterceptors=GRPC server interceptors
+serverInterceptors.desc=A list of fully qualified class names for gRPC server interceptor classes.
 
 maxInboundMessageSize=Maximum message size
 maxInboundMessageSize.desc=The maximum inbound message size.

--- a/dev/com.ibm.ws.grpc/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.grpc/resources/OSGI-INF/l10n/metatype.properties
@@ -1,0 +1,34 @@
+###############################################################################
+# Copyright (c) 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+# -------------------------------------------------------------------------------------------------
+#CMVCPATHNAME com.ibm.ws.grpc/resources/OSGI-INF/l10n/metatype.properties
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+
+
+serviceConfig=GRPC Service Properties
+clientConfig.desc=Configuration properties to be applied to gRPC services that match the specified URI.
+
+serviceName=GRPC service name
+serviceName.desc=The gRPC service name, with wildcard support.
+
+httpEndpoints=HTTP endpoints
+httpEndpoints.desc=The list of HTTP endpoints on which to service gRPC requests.
+
+serviceInterceptors=GRPC service interceptors
+serviceInterceptors.desc=A list of fully qualified class names for gRPC service interceptor classes.
+
+maxInboundMessageSize=Maximum message size
+maxInboundMessageSize.desc=The maximum inbound message size.
+
+other=Any other variables
+other.desc=Any other variables that can be specified and passed to the GrpcTarget intact.

--- a/dev/com.ibm.ws.grpc/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.grpc/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+ 
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.1.0"  
+                   xmlns:ibm="http://www.ibm.com/xmlns/appservers/osgi/metatype/v1.0.0"
+                   localization="OSGI-INF/l10n/metatype">
+
+    <!-- id gets mapped to configuration class impl in Designate element below --> 
+    <OCD id="com.ibm.ws.grpc.serviceConfig.metatype" name="%serviceConfig" description="%serviceConfig.desc"
+         ibm:alias="grpcService" >
+         
+         <!-- the following lines will define defaults and variable types for these parameters.
+              Also drives the documentation for them based on metatype.properties 
+              and makes pretty panels in wdt. 
+         -->
+         
+        <AD id="serviceName" name="serviceName" description="serviceName" required="true" type="String" />
+        <AD id="httpEndpoints" name="%httpEndpoints" description="%enableKeepAlive.desc" required="false" type="String" />
+        <AD id="maxInboundMessageSize" name="%maxInboundMessageSize" description="%maxInboundMessageSize.desc" required="false" type="Integer" />
+        <AD id="serviceInterceptors" name="%clientInterceptors" description="%clientInterceptors.desc" required="false" type="String" />
+        <AD id="other" name="%other" description="%other.desc" required="false" type="String" />
+
+    </OCD>
+
+    <!-- factoryPid allows multiple instances in server.xml, activate will be called multiple times --> 
+    <Designate factoryPid="com.ibm.ws.grpc.serviceConfig">       <!-- matches pid in java file -->                        
+        <Object ocdref="com.ibm.ws.grpc.serviceConfig.metatype" /> <!-- matches id of ocd above --> 
+    </Designate>
+
+
+</metatype:MetaData>

--- a/dev/com.ibm.ws.grpc/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.grpc/resources/OSGI-INF/metatype/metatype.xml
@@ -15,25 +15,25 @@
                    localization="OSGI-INF/l10n/metatype">
 
     <!-- id gets mapped to configuration class impl in Designate element below --> 
-    <OCD id="com.ibm.ws.grpc.serviceConfig.metatype" name="%serviceConfig" description="%serviceConfig.desc"
-         ibm:alias="grpcService" >
+    <OCD id="com.ibm.ws.grpc.serverConfig.metatype" name="%serverConfig" description="%serverConfig.desc"
+         ibm:alias="grpc" >
          
          <!-- the following lines will define defaults and variable types for these parameters.
               Also drives the documentation for them based on metatype.properties 
               and makes pretty panels in wdt. 
          -->
          
-        <AD id="serviceName" name="serviceName" description="serviceName" required="true" type="String" />
+        <AD id="target" name="%target" description="%target" required="true" type="String" />
         <AD id="httpEndpoints" name="%httpEndpoints" description="%httpEndpoints.desc" required="false" type="String" />
         <AD id="maxInboundMessageSize" name="%maxInboundMessageSize" description="%maxInboundMessageSize.desc" required="false" type="Integer" />
-        <AD id="serviceInterceptors" name="%serviceInterceptors" description="%serviceInterceptors.desc" required="false" type="String" />
+        <AD id="serverInterceptors" name="%serverInterceptors" description="%serverInterceptors.desc" required="false" type="String" />
         <AD id="other" name="%other" description="%other.desc" required="false" type="String" />
 
     </OCD>
 
     <!-- factoryPid allows multiple instances in server.xml, activate will be called multiple times --> 
-    <Designate factoryPid="com.ibm.ws.grpc.serviceConfig">       <!-- matches pid in java file -->                        
-        <Object ocdref="com.ibm.ws.grpc.serviceConfig.metatype" /> <!-- matches id of ocd above --> 
+    <Designate factoryPid="com.ibm.ws.grpc.serverConfig">       <!-- matches pid in java file -->
+        <Object ocdref="com.ibm.ws.grpc.serverConfig.metatype" /> <!-- matches id of ocd above -->
     </Designate>
 
 

--- a/dev/com.ibm.ws.grpc/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.grpc/resources/OSGI-INF/metatype/metatype.xml
@@ -24,9 +24,9 @@
          -->
          
         <AD id="serviceName" name="serviceName" description="serviceName" required="true" type="String" />
-        <AD id="httpEndpoints" name="%httpEndpoints" description="%enableKeepAlive.desc" required="false" type="String" />
+        <AD id="httpEndpoints" name="%httpEndpoints" description="%httpEndpoints.desc" required="false" type="String" />
         <AD id="maxInboundMessageSize" name="%maxInboundMessageSize" description="%maxInboundMessageSize.desc" required="false" type="Integer" />
-        <AD id="serviceInterceptors" name="%clientInterceptors" description="%clientInterceptors.desc" required="false" type="String" />
+        <AD id="serviceInterceptors" name="%serviceInterceptors" description="%serviceInterceptors.desc" required="false" type="String" />
         <AD id="other" name="%other" description="%other.desc" required="false" type="String" />
 
     </OCD>

--- a/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/config/GrpcConfigConstants.java
+++ b/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/config/GrpcConfigConstants.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.grpc.config;
+
+/**
+ * Config-related constants
+ */
+public class GrpcConfigConstants {
+    public static final String SERVICE_NAME_PROP = "serviceName";
+    public static final String HTTP_ENDPOINTS_PROP = "httpEndpoints";
+    public static final String MAX_INBOUND_MSG_SIZE_PROP = "maxInboundMessageSize";
+    public static final String SERVICE_INTERCEPTORS_PROP = "serviceInterceptors";
+}

--- a/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/config/GrpcConfigConstants.java
+++ b/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/config/GrpcConfigConstants.java
@@ -14,8 +14,8 @@ package com.ibm.ws.grpc.config;
  * Config-related constants
  */
 public class GrpcConfigConstants {
-    public static final String SERVICE_NAME_PROP = "serviceName";
+    public static final String TARGET_PROP = "target";
     public static final String HTTP_ENDPOINTS_PROP = "httpEndpoints";
     public static final String MAX_INBOUND_MSG_SIZE_PROP = "maxInboundMessageSize";
-    public static final String SERVICE_INTERCEPTORS_PROP = "serviceInterceptors";
+    public static final String SERVER_INTERCEPTORS_PROP = "serverInterceptors";
 }

--- a/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/config/GrpcServiceConfig.java
+++ b/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/config/GrpcServiceConfig.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.grpc.config;
+
+/**
+ * Representation of the service configuration used by OSGI.
+ */
+public interface GrpcServiceConfig {
+
+}

--- a/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/config/GrpcServiceConfigHolder.java
+++ b/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/config/GrpcServiceConfigHolder.java
@@ -1,0 +1,192 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.grpc.config;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeMap;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+/**
+ * Adapted from com.ibm.ws.jaxrs20.clientconfig.JAXRSClientConfigHolder
+ */
+public class GrpcServiceConfigHolder {
+	private static final TraceComponent tc = Tr.register(GrpcServiceConfigHolder.class);
+
+	// a map of configuration properties keyed on uri.
+	// note that treemap sorts by key order, which we need to properly deal with the
+	// wildcards
+	private static volatile Map<String, Map<String, String>> configInfo = new TreeMap<>();
+
+	// a map of service object id's to uri, so we can track which service added
+	// which uri.
+	private static volatile Map<String, String> serviceMap = new HashMap<>();
+
+	// a cached map of search results
+	// that have been processed to look up the best match for the uri strings
+	private static volatile Map<String, Map<String, String>> resolvedConfigInfoCache = new HashMap<>();
+
+	private static boolean wildcardsPresentInConfigInfo = false;
+
+	/**
+	 * add a configuration for a URL We'd like a set of hashmaps keyed by URL,
+	 * however when osgi calls deactivate, we have no arguments, so we have to
+	 * associate a url with the object id of the service. That allows us to remove
+	 * the right one.
+	 *
+	 * @param id     - the object id of the service instance that added this.
+	 * @param url    - the uri of the record being added. Might end with *
+	 * @param params - the properties applicable to this url.
+	 */
+	public static synchronized void addConfig(String id, String uri, Map<String, String> params) {
+		serviceMap.put(id, uri);
+		configInfo.put(uri, params);
+		resolvedConfigInfoCache.clear();
+		if (uri.endsWith("*")) {
+			wildcardsPresentInConfigInfo = true;
+		}
+	}
+
+	/**
+	 * remove a configuration (we'll look up the uri from the objectId)
+	 *
+	 * @param id - the object id of the service that called us
+	 */
+	public static synchronized void removeConfig(String objectId) {
+		String uri = serviceMap.get(objectId);
+		if (uri != null) {
+			configInfo.remove(uri);
+		}
+		serviceMap.remove(objectId);
+		resolvedConfigInfoCache.clear();
+	}
+
+	public static String getServiceInterceptors(String uri) {
+		Map<String, String> props = getURIProps(uri);
+		if (props != null) {
+			return props.get(GrpcConfigConstants.SERVICE_INTERCEPTORS_PROP);
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * @param uri
+	 * @return the max inbound message size for the given URI, or -1 if there are no config matches
+	 */
+	public static int getMaxInboundMessageSize(String uri) {
+		Map<String, String> props = getURIProps(uri);
+		if (props != null) {
+			String prop = props.get(GrpcConfigConstants.MAX_INBOUND_MSG_SIZE_PROP);
+			if (prop != null && prop != "") {
+				return Integer.parseInt(prop);
+			}
+		}
+		return -1;
+	}
+
+	/**
+	 * Find the applicable set of properties for a given URI, and return them. Note
+	 * that config uri's ending with * might match more than one uri.
+	 *
+	 * First we look for exact matches, then if applicable wildcard matches are
+	 * found, we merge those into the results in order of most general to most
+	 * specific.
+	 *
+	 *
+	 * @param uri - the uri to retrieve the props for, probably of form
+	 *            http(s)://something...(*)
+	 * @return - map of merged applicable properties, or null if no applicable props
+	 *         found
+	 */
+	public static Map<String, String> getURIProps(String uri) {
+		boolean debug = tc.isDebugEnabled() && TraceComponent.isAnyTracingEnabled();
+		if (configInfo.isEmpty()) {
+			if (debug) {
+				Tr.debug(tc, "getUriprops is empty, return null");
+			}
+			return null;
+		}
+
+		// look in the cache in case we've resolved this before
+		synchronized (resolvedConfigInfoCache) {
+			Map<String, String> props = resolvedConfigInfoCache.get(uri);
+			if (props != null) {
+				if (debug) {
+					Tr.debug(tc, "getUriprops cache hit, uri: " + uri + "props: " + props);
+				}
+				return (props.isEmpty() ? null : props);
+			}
+		}
+
+		// at this point we might have to merge something, set up a new hashmap to hold
+		// the results
+		HashMap<String, String> mergedProps = new HashMap<>();
+		synchronized (GrpcServiceConfigHolder.class) {
+			// try for exact match
+			Map<String, String> props = configInfo.get(uri);
+			if (props != null) {
+				if (debug) {
+					Tr.debug(tc, "getUriprops exact match: " + uri);
+				}
+				mergedProps.putAll(props);
+			}
+		}
+
+		if (!wildcardsPresentInConfigInfo) {
+			if (debug) {
+				Tr.debug(tc, "getUriprops no wildcards, cache and return what we've got: " + mergedProps);
+			}
+			synchronized (GrpcServiceConfigHolder.class) {
+				resolvedConfigInfoCache.put(uri, mergedProps);
+			}
+			return (mergedProps.isEmpty() ? null : mergedProps);
+		}
+
+		// if a wildcard match exists, merge it to what we have already.
+		if (debug) {
+			Tr.debug(tc, "begin wildcard search");
+		}
+		// try to find a match from wildcards
+		synchronized (GrpcServiceConfigHolder.class) {
+			Iterator<String> it = configInfo.keySet().iterator();
+			String trimmedKey = null;
+			while (it.hasNext()) {
+				String key = it.next();
+				if (key.endsWith("*")) {
+					trimmedKey = key.substring(0, key.length() - 1);
+				} else {
+					continue;
+				}
+				// if we got here, we have a wildcard
+				// since configinfo is a sorted treemap,
+				// general results should come first, followed by more specific results
+				// if we have two keys of same length and both match, last one wins
+				if (uri.startsWith(trimmedKey)) {
+					if (debug) {
+						Tr.debug(tc, "getUriprops match = " + key + ", will merge these props: " + configInfo.get(key));
+					}
+					mergedProps.putAll(configInfo.get(key)); // merge props for this wildcard.
+				}
+			}
+			// at this point everything has been merged, cache and return what we have.
+			// if there was no match anywhere, this is an empty map.
+			resolvedConfigInfoCache.put(uri, mergedProps);
+			if (debug) {
+				Tr.debug(tc, "getUriprops final result for uri: " + uri + "values: " + mergedProps);
+			}
+			return (mergedProps.isEmpty() ? null : mergedProps);
+		} // end sync block
+	}
+}

--- a/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/config/GrpcServiceConfigHolder.java
+++ b/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/config/GrpcServiceConfigHolder.java
@@ -75,7 +75,7 @@ public class GrpcServiceConfigHolder {
 	public static String getServiceInterceptors(String uri) {
 		Map<String, String> props = getURIProps(uri);
 		if (props != null) {
-			return props.get(GrpcConfigConstants.SERVICE_INTERCEPTORS_PROP);
+			return props.get(GrpcConfigConstants.SERVER_INTERCEPTORS_PROP);
 		} else {
 			return null;
 		}

--- a/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/config/GrpcServiceConfigImpl.java
+++ b/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/config/GrpcServiceConfigImpl.java
@@ -1,0 +1,194 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.grpc.config;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.wsspi.application.lifecycle.ApplicationRecycleComponent;
+import com.ibm.wsspi.application.lifecycle.ApplicationRecycleContext;
+import com.ibm.wsspi.application.lifecycle.ApplicationRecycleCoordinator;
+
+/**
+ * Adapted from com.ibm.ws.jaxrs20.clientconfig.JAXRSClientConfig
+ */
+@Component(immediate = true, service = { GrpcServiceConfig.class,
+		ApplicationRecycleComponent.class }, configurationPid = "com.ibm.ws.grpc.serviceConfig", configurationPolicy = ConfigurationPolicy.REQUIRE, property = {
+				"service.vendor=IBM" })
+public class GrpcServiceConfigImpl implements GrpcServiceConfig, ApplicationRecycleComponent {
+	private static final TraceComponent tc = Tr.register(GrpcServiceConfigImpl.class);
+
+	/**
+	 * Reference to the ApplicationRecycleCoordinator which will be used to restart
+	 * apps on a config update
+	 */
+	@Reference(name = "appRecycleService")
+	private ApplicationRecycleCoordinator appRecycleSvcRef;
+
+	/**
+	 * J2EE of applications providing grpc services
+	 */
+	private final static Set<String> applications = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+
+	private static final HashSet<String> propertiesToRemove = new HashSet<>();
+
+	static {
+		// this is stuff the framework always adds, we don't need it so we'll filter it
+		// out.
+		propertiesToRemove.add("defaultSSHPublicKeyPath");
+		propertiesToRemove.add("defaultSSHPrivateKeyPath");
+		propertiesToRemove.add("config.overrides");
+		propertiesToRemove.add("config.id");
+		propertiesToRemove.add("component.id");
+		propertiesToRemove.add("config.displayId");
+		propertiesToRemove.add("component.name");
+		propertiesToRemove.add("config.source");
+		propertiesToRemove.add("service.pid");
+		propertiesToRemove.add("service.vendor");
+		propertiesToRemove.add("service.factoryPid");
+		propertiesToRemove.add(GrpcConfigConstants.SERVICE_NAME_PROP);
+	}
+
+	/**
+	 * given the map of properties, remove ones we don't care about, and translate
+	 * some others. If it's not one we're familiar with, transfer it unaltered
+	 *
+	 * @param props - input list of properties
+	 * @return - a new Map of the filtered properties.
+	 */
+	private Map<String, String> filterProps(Map<String, Object> props) {
+		HashMap<String, String> filteredProps = new HashMap<>();
+		Iterator<String> it = props.keySet().iterator();
+		boolean debug = tc.isDebugEnabled() && TraceComponent.isAnyTracingEnabled();
+
+		while (it.hasNext()) {
+			String key = it.next();
+
+			if (debug) {
+				Tr.debug(tc, "key: " + key + " value: " + props.get(key));
+			}
+			// skip stuff we don't care about
+			if (propertiesToRemove.contains(key)) {
+				continue;
+			}
+			if (key.compareTo(GrpcConfigConstants.MAX_INBOUND_MSG_SIZE_PROP) == 0) {
+				if (!GrpcServiceConfigValidation.validateMaxInboundMessageSize(props.get(key).toString()))
+					continue;
+			}
+			filteredProps.put(key, props.get(key).toString());
+
+		}
+		return filteredProps;
+	}
+
+	/**
+	 * find the serviceName parameter which we will key off of
+	 *
+	 * @param props
+	 * @return value of serviceName param within props, or null if no serviceName
+	 *         param
+	 */
+	private String getServiceName(Map<String, Object> props) {
+		if (props == null)
+			return null;
+		if (props.keySet().contains(GrpcConfigConstants.SERVICE_NAME_PROP)) {
+			return (props.get(GrpcConfigConstants.SERVICE_NAME_PROP).toString());
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * Invoked when <grpcService/> element is first processed; the new configuration
+	 * is processed and added to the GrpcServiceConfigHolder
+	 */
+	@Activate
+	protected void activate(Map<String, Object> properties) {
+		if (properties == null)
+			return;
+		String serviceName = getServiceName(properties);
+		if (serviceName == null)
+			return;
+		GrpcServiceConfigHolder.addConfig(this.toString(), serviceName, filterProps(properties));
+	}
+
+	/**
+	 * Invoked when <grpcService/> element is updated. This will: 1. remove the
+	 * previous configuration assigned in GrpcServiceConfigHolder 2. process the new
+	 * configuration 3. add the new config to GrpcServiceConfigHolder 4. restart all
+	 * active grpc service applications
+	 */
+	@Modified
+	protected void modified(Map<String, Object> properties) {
+		if (properties == null) {
+			return;
+		}
+		GrpcServiceConfigHolder.removeConfig(this.toString());
+		String serviceName = getServiceName(properties);
+		if (serviceName == null) {
+			// if there isn't a service name then this config has no meaning
+			return;
+		}
+		GrpcServiceConfigHolder.addConfig(this.toString(), serviceName, filterProps(properties));
+
+		// TODO: for now, any change will force all grpc apps to be restarted
+		if (!applications.isEmpty()) {
+			Set<String> members = getDependentApplications();
+			if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+				Tr.debug(this, tc, "recycling applications: " + members);
+			appRecycleSvcRef.recycleApplications(members);
+		}
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		GrpcServiceConfigHolder.removeConfig(this.toString());
+	}
+
+	@Override
+	public ApplicationRecycleContext getContext() {
+		return null;
+	}
+
+	/**
+	 * Get the J2EE names for apps that provide grpc services, and clear the map
+	 */
+	@Override
+	public Set<String> getDependentApplications() {
+		Set<String> members = new HashSet<String>(applications);
+		applications.removeAll(members);
+		if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+			Tr.debug(this, tc, "getDependentApplications: " + members);
+		return members;
+	}
+
+	public static void addApplication(String name) {
+		applications.add(name);
+	}
+
+	public static void removeApplication(String name) {
+		applications.remove(name);
+	}
+}

--- a/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/config/GrpcServiceConfigImpl.java
+++ b/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/config/GrpcServiceConfigImpl.java
@@ -35,7 +35,7 @@ import com.ibm.wsspi.application.lifecycle.ApplicationRecycleCoordinator;
  * Adapted from com.ibm.ws.jaxrs20.clientconfig.JAXRSClientConfig
  */
 @Component(immediate = true, service = { GrpcServiceConfig.class,
-		ApplicationRecycleComponent.class }, configurationPid = "com.ibm.ws.grpc.serviceConfig", configurationPolicy = ConfigurationPolicy.REQUIRE, property = {
+		ApplicationRecycleComponent.class }, configurationPid = "com.ibm.ws.grpc.serverConfig", configurationPolicy = ConfigurationPolicy.REQUIRE, property = {
 				"service.vendor=IBM" })
 public class GrpcServiceConfigImpl implements GrpcServiceConfig, ApplicationRecycleComponent {
 	private static final TraceComponent tc = Tr.register(GrpcServiceConfigImpl.class);
@@ -68,7 +68,7 @@ public class GrpcServiceConfigImpl implements GrpcServiceConfig, ApplicationRecy
 		propertiesToRemove.add("service.pid");
 		propertiesToRemove.add("service.vendor");
 		propertiesToRemove.add("service.factoryPid");
-		propertiesToRemove.add(GrpcConfigConstants.SERVICE_NAME_PROP);
+		propertiesToRemove.add(GrpcConfigConstants.TARGET_PROP);
 	}
 
 	/**
@@ -113,15 +113,15 @@ public class GrpcServiceConfigImpl implements GrpcServiceConfig, ApplicationRecy
 	private String getServiceName(Map<String, Object> props) {
 		if (props == null)
 			return null;
-		if (props.keySet().contains(GrpcConfigConstants.SERVICE_NAME_PROP)) {
-			return (props.get(GrpcConfigConstants.SERVICE_NAME_PROP).toString());
+		if (props.keySet().contains(GrpcConfigConstants.TARGET_PROP)) {
+			return (props.get(GrpcConfigConstants.TARGET_PROP).toString());
 		} else {
 			return null;
 		}
 	}
 
 	/**
-	 * Invoked when <grpcService/> element is first processed; the new configuration
+	 * Invoked when <grpc/> element is first processed; the new configuration
 	 * is processed and added to the GrpcServiceConfigHolder
 	 */
 	@Activate

--- a/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/config/GrpcServiceConfigValidation.java
+++ b/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/config/GrpcServiceConfigValidation.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.grpc.config;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+public class GrpcServiceConfigValidation {
+
+	private static final TraceComponent tc = Tr.register(GrpcServiceConfigValidation.class);
+
+	/**
+	 * @param value - key name
+	 * @return true if max inbound message size value is valid
+	 */
+	static boolean validateMaxInboundMessageSize(String value) {
+		int size = Integer.parseInt(value);
+		if (size < 1) {
+			Tr.warning(tc, "grpcTarget maxInboundMessageSize is invalid", size);
+			return false;
+		}
+		return true;
+	}
+}

--- a/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/config/package-info.java
+++ b/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/config/package-info.java
@@ -1,0 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+@org.osgi.annotation.versioning.Version("1.0")
+package com.ibm.ws.grpc.config;

--- a/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/servlet/GrpcServerComponent.java
+++ b/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/servlet/GrpcServerComponent.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package com.ibm.ws.grpc.servlet;
 
 import java.lang.reflect.Constructor;
@@ -31,7 +41,10 @@ import com.ibm.ws.container.service.app.deploy.ApplicationInfo;
 import com.ibm.ws.container.service.state.ApplicationStateListener;
 import com.ibm.ws.container.service.state.StateChangeException;
 import com.ibm.ws.grpc.Utils;
+import com.ibm.ws.grpc.config.GrpcServiceConfigImpl;
 import com.ibm.ws.kernel.feature.FeatureProvisioner;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 import com.ibm.ws.webcontainer.webapp.WebApp;
 import com.ibm.wsspi.adaptable.module.UnableToAdaptException;
 import com.ibm.wsspi.anno.targets.AnnotationTargets_Targets;
@@ -101,6 +114,12 @@ public class GrpcServerComponent implements ServletContainerInitializer, Applica
 							}
 						}
 						if (!grpcServiceClasses.isEmpty()) {
+							// keep track of the current application so that we can restart it if <grpcService/> is updated
+					        ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+					        if (cmd != null) {
+				        		currentApp.setAppName(cmd.getJ2EEName().getApplication());
+					        }
+
 							// pass all of our grpc service implementors into a new GrpcServlet
 							// and register that new Servlet on this context
 							GrpcServlet grpcServlet = new GrpcServlet(

--- a/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/servlet/GrpcServletApplication.java
+++ b/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/servlet/GrpcServletApplication.java
@@ -3,6 +3,7 @@ package com.ibm.ws.grpc.servlet;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.ibm.ws.grpc.config.GrpcServiceConfigImpl;
 import com.ibm.ws.http2.GrpcServletServices;
 
 /**
@@ -10,16 +11,17 @@ import com.ibm.ws.http2.GrpcServletServices;
  */
 class GrpcServletApplication {
 
-	Set<String> serviceNames = new HashSet<String>();
-	Set<String> serviceClassNames = new HashSet<String>();
+	private Set<String> serviceNames = new HashSet<String>();
+	private Set<String> serviceClassNames = new HashSet<String>();
+	private String j2eeAppName;
 
 	/**
 	 * Add a service name to context path mapping
+	 * 
 	 * @param String serviceName
 	 * @param String ontextPath
 	 */
 	void addServiceName(String serviceName, String contextPath, Class<?> clazz) {
-
 		serviceNames.add(serviceName);
 		if (serviceName != null && contextPath != null && clazz != null) {
 			GrpcServletServices.addServletGrpcService(serviceName, contextPath, clazz);
@@ -27,8 +29,9 @@ class GrpcServletApplication {
 	}
 
 	/**
-	 * Add the set of class names that contain gRPC services.
-	 * These classes will be initialized by Libery during startup.
+	 * Add the set of class names that contain gRPC services. These classes will be
+	 * initialized by Liberty during startup.
+	 * 
 	 * @param Set<String> service class names
 	 */
 	void addServiceClassName(String name) {
@@ -43,15 +46,27 @@ class GrpcServletApplication {
 	}
 
 	/**
-	 * Unregister and clean up any associated services and mappings 
+	 * Set the current J2EE application name and register it with
+	 * GrpcServiceConfigImpl
+	 * 
+	 * @param name
+	 */
+	void setAppName(String name) {
+		j2eeAppName = name;
+		GrpcServiceConfigImpl.addApplication(j2eeAppName);
+	}
+
+	/**
+	 * Unregister and clean up any associated services and mappings
 	 */
 	void destroy() {
 		for (String service : serviceNames) {
 			GrpcServletServices.removeServletGrpcService(service);
 		}
+		if (j2eeAppName != null) {
+			GrpcServiceConfigImpl.removeApplication(j2eeAppName);
+		}
 		serviceNames = null;
 		serviceClassNames = null;
 	}
 }
-
-

--- a/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/servlet/GrpcServletUtils.java
+++ b/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/servlet/GrpcServletUtils.java
@@ -63,7 +63,9 @@ public class GrpcServletUtils {
 		byteArrays.add(GrpcServletUtils.LIBERTY_AUTH_KEY.name().getBytes(StandardCharsets.US_ASCII));
 		byteArrays.add((String.valueOf(req.hashCode())).getBytes(StandardCharsets.US_ASCII));
 		authMap.put(String.valueOf(req.hashCode()), authorized);
-		System.out.println("addLibertyAuthHeader " + req.hashCode() + " authorized " + authorized);
+		if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+			Tr.debug(tc, "adding " + req.hashCode() + "to authMap with value " + authorized);
+		}
 	}
 
 	/**
@@ -186,7 +188,7 @@ public class GrpcServletUtils {
 		if (key == null) {
 			return false;
 		}
-		return authMap.remove(key);
+		else return Boolean.TRUE.equals(authMap.remove(key));
 	}
 
 	/**
@@ -245,6 +247,9 @@ public class GrpcServletUtils {
 			int maxInboundMsgSize = GrpcServiceConfigHolder.getMaxInboundMessageSize(name);
 			if (maxInboundMsgSize != -1) {
 				serverBuilder.maxInboundMessageSize(maxInboundMsgSize);
+			}
+			if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+				Tr.debug(tc, "gRPC service " + name + " has been registered");
 			}
 		}
 	}

--- a/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/servlet/GrpcServletUtils.java
+++ b/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/servlet/GrpcServletUtils.java
@@ -11,9 +11,12 @@
 package com.ibm.ws.grpc.servlet;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.AccessDeniedException;
+import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -22,23 +25,35 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.grpc.config.GrpcServiceConfigHolder;
 import com.ibm.ws.http2.GrpcServletServices;
 import com.ibm.ws.http2.GrpcServletServices.ServiceInformation;
 import com.ibm.ws.security.authorization.util.RoleMethodAuthUtil;
 import com.ibm.ws.security.authorization.util.UnauthenticatedException;
 
+import io.grpc.BindableService;
 import io.grpc.Metadata;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerInterceptors;
+import io.grpc.servlet.ServletServerBuilder;
 
 public class GrpcServletUtils {
 
+	private static final TraceComponent tc = Tr.register(GrpcServletUtils.class);
+
 	public final static String LIBERTY_AUTH_KEY_STRING = "libertyAuthCheck";
-	public final static Map<String, Boolean> authMap = new ConcurrentHashMap<String, Boolean>();
+	private final static Map<String, Boolean> authMap = new ConcurrentHashMap<String, Boolean>();
 	public static final Metadata.Key<String> LIBERTY_AUTH_KEY = Metadata.Key.of(LIBERTY_AUTH_KEY_STRING,
 			Metadata.ASCII_STRING_MARSHALLER);
 
+	private static final LibertyAuthorizationInterceptor authInterceptor = new LibertyAuthorizationInterceptor();
+
 	/**
-	 * Helper method to add the "authorized" flag to the byte arrays that will get built into Metadata
+	 * Helper method to add the "authorized" flag to the byte arrays that will get
+	 * built into Metadata
 	 * 
 	 * @param byteArrays
 	 * @param req
@@ -48,6 +63,7 @@ public class GrpcServletUtils {
 		byteArrays.add(GrpcServletUtils.LIBERTY_AUTH_KEY.name().getBytes(StandardCharsets.US_ASCII));
 		byteArrays.add((String.valueOf(req.hashCode())).getBytes(StandardCharsets.US_ASCII));
 		authMap.put(String.valueOf(req.hashCode()), authorized);
+		System.out.println("addLibertyAuthHeader " + req.hashCode() + " authorized " + authorized);
 	}
 
 	/**
@@ -104,10 +120,11 @@ public class GrpcServletUtils {
 		}
 		return null;
 	}
-	
+
 	/**
-	 * Checks if a given request is authorized to access the requested method, by scanning the requested method 
-	 * for @DenyAll, @RolesAllowed, or @AllowAll and validating the request's Subject
+	 * Checks if a given request is authorized to access the requested method, by
+	 * scanning the requested method for @DenyAll, @RolesAllowed, or @AllowAll and
+	 * validating the request's Subject
 	 * 
 	 * @param req
 	 * @param res
@@ -145,7 +162,8 @@ public class GrpcServletUtils {
 		return false;
 	}
 
-	private static void handleMessage(HttpServletRequest req, String path) throws UnauthenticatedException, AccessDeniedException {
+	private static void handleMessage(HttpServletRequest req, String path)
+			throws UnauthenticatedException, AccessDeniedException {
 
 		Method method = GrpcServletUtils.getTargetMethod(path);
 		if (method == null) {
@@ -156,5 +174,78 @@ public class GrpcServletUtils {
 			return;
 		}
 		throw new AccessDeniedException("Unauthorized");
+	}
+
+	/**
+	 * 
+	 * @param key the LIBERTY_AUTH_KEY to check
+	 * @return the authorization value for the key in GrpcServletUtils.authMap, or
+	 *         false if the key is null
+	 */
+	public static boolean isAuthorized(String key) {
+		if (key == null) {
+			return false;
+		}
+		return authMap.remove(key);
+	}
+
+	/**
+	 * @param service name
+	 * @return the list of server interceptors registered for a given service, or an
+	 *         empty list if none are registered
+	 */
+	public static List<ServerInterceptor> getUserInterceptors(String service) {
+		List<ServerInterceptor> interceptors = new LinkedList<ServerInterceptor>();
+		String interceptorListString = GrpcServiceConfigHolder.getServiceInterceptors(service);
+
+		if (interceptorListString != null) {
+			// TODO: wildcard support
+			List<String> items = Arrays.asList(interceptorListString.split("\\s*,\\s*"));
+			if (!items.isEmpty()) {
+				for (String className : items) {
+					try {
+						// use the app classloader to load the interceptor
+						ClassLoader cl = Thread.currentThread().getContextClassLoader();
+						Class<?> clazz = Class.forName(className, true, cl);
+						ServerInterceptor interceptor = (ServerInterceptor) clazz.getDeclaredConstructor()
+								.newInstance();
+						interceptors.add(interceptor);
+					} catch (ClassNotFoundException | InstantiationException | IllegalAccessException
+							| IllegalArgumentException | InvocationTargetException | NoSuchMethodException
+							| SecurityException e) {
+						// TODO: proper warning message
+						Tr.warning(tc, "Could not load user-defined Interceptor", e);
+					}
+				}
+			}
+		}
+		return interceptors;
+	}
+
+	/**
+	 * Register grpc services with a ServletServerBuilder and apply liberty-specific
+	 * configurations
+	 * 
+	 * @param bindableServices
+	 * @param serverBuilder
+	 */
+	public static void addServices(List<? extends BindableService> bindableServices,
+			ServletServerBuilder serverBuilder) {
+		for (BindableService service : bindableServices) {
+			String name = service.bindService().getServiceDescriptor().getName();
+
+			// set any user-defined server interceptors and add the service
+			List<ServerInterceptor> interceptors = GrpcServletUtils.getUserInterceptors(name);
+			// add Liberty auth interceptor to every service
+			interceptors.add(authInterceptor);
+			serverBuilder.addService(ServerInterceptors.intercept(service, interceptors));
+
+			// set the max inbound msg size, if it's configured
+			// TODO: this should be done per service, rather than per server
+			int maxInboundMsgSize = GrpcServiceConfigHolder.getMaxInboundMessageSize(name);
+			if (maxInboundMsgSize != -1) {
+				serverBuilder.maxInboundMessageSize(maxInboundMsgSize);
+			}
+		}
 	}
 }

--- a/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/servlet/LibertyAuthorizationInterceptor.java
+++ b/dev/com.ibm.ws.grpc/src/com/ibm/ws/grpc/servlet/LibertyAuthorizationInterceptor.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package com.ibm.ws.grpc.servlet;
 
 import io.grpc.Metadata;
@@ -7,18 +17,27 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 
+/**
+ * Interceptor used to perform Liberty-specific authorization. If the backing
+ * request for the call was not authorized, this Interceptor will set the status
+ * to UNAUTHENTICATED.
+ */
 public class LibertyAuthorizationInterceptor implements ServerInterceptor {
 
+	/**
+	 * Grab the LIBERTY_AUTH_KEY from the headers on this call and use that key to
+	 * check the authorization map. If this call is not authorized, set the status
+	 * to UNAUTHENTICATED and stop the call chain
+	 */
 	@Override
 	public <ReqT, RespT> Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers,
 			ServerCallHandler<ReqT, RespT> next) {
-
 		String key = headers.get(GrpcServletUtils.LIBERTY_AUTH_KEY);
-		boolean isAuthorized = GrpcServletUtils.authMap.remove(key);
-		if (!isAuthorized) {
+		if (!GrpcServletUtils.isAuthorized(key)) {
 			call.close(Status.UNAUTHENTICATED.withDescription("Unauthorized"), headers);
 			// return no-op listener
-			return new ServerCall.Listener<ReqT>() {};
+			return new ServerCall.Listener<ReqT>() {
+			};
 		}
 		return next.startCall(call, headers);
 	}

--- a/dev/com.ibm.ws.grpc/src/io/grpc/servlet/GrpcServlet.java
+++ b/dev/com.ibm.ws.grpc/src/io/grpc/servlet/GrpcServlet.java
@@ -18,12 +18,10 @@ package io.grpc.servlet;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.ibm.websphere.ras.annotation.Trivial;
-import com.ibm.ws.grpc.servlet.LibertyAuthorizationInterceptor;
+import com.ibm.ws.grpc.servlet.GrpcServletUtils;
 
 import io.grpc.BindableService;
 import io.grpc.ExperimentalApi;
-import io.grpc.ServerInterceptor;
-import io.grpc.ServerInterceptors;
 
 import java.io.IOException;
 import java.util.List;
@@ -63,12 +61,7 @@ public class GrpcServlet extends HttpServlet {
 
   private static ServletAdapter loadServices(List<? extends BindableService> bindableServices) {
     ServletServerBuilder serverBuilder = new ServletServerBuilder();
-
-    // add Liberty auth interceptor to every service
-    for (BindableService service : bindableServices) {
-      serverBuilder.addService(ServerInterceptors.intercept(service, new LibertyAuthorizationInterceptor()));
-    }
-
+    GrpcServletUtils.addServices(bindableServices, serverBuilder);
     return serverBuilder.buildServletAdapter();
   }
 

--- a/dev/com.ibm.ws.grpc/src/io/grpc/servlet/ServletServerStream.java
+++ b/dev/com.ibm.ws.grpc/src/io/grpc/servlet/ServletServerStream.java
@@ -310,18 +310,21 @@ final class ServletServerStream extends AbstractServerStream {
         return; // let the servlet timeout, the container will sent RST_STREAM automatically
       }
       transportState.runOnTransportThread(() -> transportState.transportReportStatus(status));
+
+      // Liberty change: pass the actual status and skip countdown timer
+      close(status.withCause(status.asRuntimeException()), new Metadata());
       // There is no way to RST_STREAM with CANCEL code, so write trailers instead
-      close(Status.CANCELLED.withCause(status.asRuntimeException()), new Metadata());
-      CountDownLatch countDownLatch = new CountDownLatch(1);
+      //close(Status.CANCELLED.withCause(status.asRuntimeException()), new Metadata());
+//      CountDownLatch countDownLatch = new CountDownLatch(1);
       transportState.runOnTransportThread(() -> {
         asyncCtx.complete();
-        countDownLatch.countDown();
+//        countDownLatch.countDown();
       });
-      try {
-        countDownLatch.await(5, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
+//      try {
+//        countDownLatch.await(5, TimeUnit.SECONDS);
+//      } catch (InterruptedException e) {
+//        Thread.currentThread().interrupt();
+//      }
     }
   }
 

--- a/dev/com.ibm.ws.grpc/test/com/ibm/ws/grpc/config/GrpcServiceConfigTest.java
+++ b/dev/com.ibm.ws.grpc/test/com/ibm/ws/grpc/config/GrpcServiceConfigTest.java
@@ -71,21 +71,21 @@ public class GrpcServiceConfigTest {
 		// create and activate a property set
 		Map<String, Object> props = new HashMap<String, Object>();
 		props.put("prop1", "value1");
-		props.put(GrpcConfigConstants.SERVICE_NAME_PROP, "*");
+		props.put(GrpcConfigConstants.TARGET_PROP, "*");
 		GrpcServiceConfigImpl config1 = new GrpcServiceConfigImpl();
 		config1.activate(props);
 		Assert.assertTrue(GrpcServiceConfigHolder.getURIProps("uri").containsKey("prop1"));
 
 		// modify the property and make sure the new values are in use 
 		String serviceName = "ExplicitName";
-		props.put(GrpcConfigConstants.SERVICE_NAME_PROP, "ExplicitName");
+		props.put(GrpcConfigConstants.TARGET_PROP, "ExplicitName");
 		config1.modified(props);
 		Assert.assertNull(GrpcServiceConfigHolder.getURIProps("uri"));
 		Assert.assertTrue(GrpcServiceConfigHolder.getURIProps("ExplicitName").containsKey("prop1"));
 
 		// test some additional params
 		String fakeInterceptorClass = "com.fake.Class";
-		props.put(GrpcConfigConstants.SERVICE_INTERCEPTORS_PROP, fakeInterceptorClass);
+		props.put(GrpcConfigConstants.SERVER_INTERCEPTORS_PROP, fakeInterceptorClass);
 		props.put(GrpcConfigConstants.MAX_INBOUND_MSG_SIZE_PROP, "64");
 		config1.modified(props);
 		Assert.assertEquals(fakeInterceptorClass, GrpcServiceConfigHolder.getServiceInterceptors(serviceName));

--- a/dev/com.ibm.ws.grpc/test/com/ibm/ws/grpc/config/GrpcServiceConfigTest.java
+++ b/dev/com.ibm.ws.grpc/test/com/ibm/ws/grpc/config/GrpcServiceConfigTest.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.grpc.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.rules.TestRule;
+
+import com.ibm.ws.http2.GrpcServletServices;
+
+import test.common.SharedOutputManager;
+
+/**
+ * Basic unit tests for grpc-1.0 configuration
+ */
+public class GrpcServiceConfigTest {
+
+	private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
+
+	@Rule
+	public TestRule rule = outputMgr;
+
+	@Rule
+	public TestName name = new TestName();
+
+	@After
+	public void tearDown() {
+		GrpcServletServices.destroy();
+	}
+
+	/**
+	 * Verify that the application name map works as expected
+	 */
+	@Test
+	public void testApplicationMap() {
+		String app_name_1 = "APP1";
+		String app_name_2 = "APP2";
+		String app_name_3 = "APP3";
+		GrpcServiceConfigImpl config = new GrpcServiceConfigImpl();
+		GrpcServiceConfigImpl.addApplication(app_name_1);
+		GrpcServiceConfigImpl.addApplication(app_name_2);
+		GrpcServiceConfigImpl.addApplication(app_name_3);
+		GrpcServiceConfigImpl.removeApplication(app_name_1);
+		GrpcServiceConfigImpl.removeApplication(app_name_2);
+		Set<String> apps = config.getDependentApplications();
+		Assert.assertEquals(1, apps.size());
+		Assert.assertTrue(apps.contains(app_name_3));
+		Assert.assertEquals(0, config.getDependentApplications().size());
+	}
+	
+	/**
+	 * Verify that the application name map works as expected
+	 */
+	@Test
+	public void testModified() {
+		// create and activate a property set
+		Map<String, Object> props = new HashMap<String, Object>();
+		props.put("prop1", "value1");
+		props.put(GrpcConfigConstants.SERVICE_NAME_PROP, "*");
+		GrpcServiceConfigImpl config1 = new GrpcServiceConfigImpl();
+		config1.activate(props);
+		Assert.assertTrue(GrpcServiceConfigHolder.getURIProps("uri").containsKey("prop1"));
+
+		// modify the property and make sure the new values are in use 
+		String serviceName = "ExplicitName";
+		props.put(GrpcConfigConstants.SERVICE_NAME_PROP, "ExplicitName");
+		config1.modified(props);
+		Assert.assertNull(GrpcServiceConfigHolder.getURIProps("uri"));
+		Assert.assertTrue(GrpcServiceConfigHolder.getURIProps("ExplicitName").containsKey("prop1"));
+
+		// test some additional params
+		String fakeInterceptorClass = "com.fake.Class";
+		props.put(GrpcConfigConstants.SERVICE_INTERCEPTORS_PROP, fakeInterceptorClass);
+		props.put(GrpcConfigConstants.MAX_INBOUND_MSG_SIZE_PROP, "64");
+		config1.modified(props);
+		Assert.assertEquals(fakeInterceptorClass, GrpcServiceConfigHolder.getServiceInterceptors(serviceName));
+		Assert.assertEquals(64, GrpcServiceConfigHolder.getMaxInboundMessageSize(serviceName));
+		config1.deactivate();
+		Assert.assertNull(GrpcServiceConfigHolder.getURIProps(serviceName));
+	}
+}


### PR DESCRIPTION
Adds a new optional top-level server.xml element `<grpc/>`, which can be used to set properties for gRPC services managed via `grpc-1.0`.  A single `grpc` configuration can apply to one or many services.  Currently the following properties can be set:

* `target` = required string
    *  service used in proto, eg. `helloworld.Greeter` or just `*`
* `maxInboundMessageSize` = optional int
* `serverInterceptors` = optional string {list of fully qualified class names}
    * specify interceptors that should always be applied to this service
    * eg. `com.ibm.ws.grpc.HelloWorldServerInterceptor`

For #10088 and #10090