### PR TITLE
Enable MP Metrics 2.3 Support for MP GraphQL

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpGraphQL1.0-mpMetrics2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpGraphQL1.0-mpMetrics2.3.feature
@@ -1,0 +1,11 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=com.ibm.websphere.appserver.mpGraphQL1.0-metrics2.3
+visibility=private
+singleton=true
+IBM-Provision-Capability: \
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpGraphQL-1.0))", \
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-2.3))"
+-bundles=com.ibm.ws.microprofile.graphql.metrics.1.0
+IBM-Install-Policy: when-satisfied
+kind=beta
+edition=core

--- a/dev/com.ibm.ws.io.smallrye.graphql/bnd.bnd
+++ b/dev/com.ibm.ws.io.smallrye.graphql/bnd.bnd
@@ -18,8 +18,8 @@ Bundle-Description: SmallRye implementation of MicroProfile GraphQL
 
 Import-Package: \
   graphql.util,\
+  org.eclipse.microprofile.metrics;resolution:=optional,\
   !io.smallrye.metrics,\
-  !org.eclipse.microprofile.metrics,\
   *
 
 Export-Package: \

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/FATSuite.java
@@ -25,7 +25,7 @@ import org.junit.runners.Suite.SuiteClasses;
                 IfaceTest.class,
                 IgnoreTest.class,
                 InputFieldsTest.class,
-                //MetricsTest.class, // temporary - Metrics module being replaced in SmallRye
+                MetricsTest.class,
                 OutputFieldsTest.class,
                 TypesTest.class,
                 VoidQueryTest.class

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/MetricsTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/MetricsTestServlet.java
@@ -110,7 +110,7 @@ public class MetricsTestServlet extends FATServlet {
         assertEquals("Count", widget.getName());
         assertEquals(3, widget.getCount());
         
-        Stats stats = statsBuilder.build(StatsClient.class).getVendorStats();
+        Stats stats = statsBuilder.register(LoggingFilter.class).build(StatsClient.class).getVendorStats();
         assertNotNull(stats);
         assertEquals(3, stats.getCount().getCount());
     }

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/Stats.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/Stats.java
@@ -32,9 +32,9 @@ public class Stats {
         }
     }
 
-    @JsonbProperty("mp_graphql_mpGraphQL10.metrics.MyGraphQLEndpoint.getCountWidget")
+    @JsonbProperty("mp_graphql_Query_getCountWidget")
     private SimpleTimerStat count;
-    @JsonbProperty("mp_graphql_mpGraphQL10.metrics.MyGraphQLEndpoint.getTimeWidget")
+    @JsonbProperty("mp_graphql_Query_getTimeWidget")
     private SimpleTimerStat time;
 
     public SimpleTimerStat getCount() {

--- a/dev/com.ibm.ws.microprofile.graphql.metrics.1.0/.classpath
+++ b/dev/com.ibm.ws.microprofile.graphql.metrics.1.0/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/com.ibm.ws.microprofile.graphql.metrics.1.0/.project
+++ b/dev/com.ibm.ws.microprofile.graphql.metrics.1.0/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.ibm.ws.microprofile.graphql.metrics.1.0</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/com.ibm.ws.microprofile.graphql.metrics.1.0/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.microprofile.graphql.metrics.1.0/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.microprofile.graphql.metrics.1.0/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.microprofile.graphql.metrics.1.0/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/com.ibm.ws.microprofile.graphql.metrics.1.0/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.graphql.metrics.1.0/bnd.bnd
@@ -1,0 +1,41 @@
+#*******************************************************************************
+# Copyright (c) 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+Bundle-Name: MicroProfile Metrics Support for MP GraphQL
+Bundle-SymbolicName: com.ibm.ws.microprofile.graphql.metrics.1.0
+Bundle-Description: MicroProfile Metrics Support for MP GraphQL
+
+Export-Package: \
+  com.ibm.ws.microprofile.graphql.metrics.component;thread-context=true
+
+Include-Resource: \
+  META-INF=resources/META-INF
+
+src: src/
+
+
+Service-Component: \
+  com.ibm.ws.io.smallrye.graphql.ResourceProvider; \
+    implementation:=com.ibm.wsspi.classloading.ResourceProvider; \
+    provide:=com.ibm.wsspi.classloading.ResourceProvider; \
+    configuration-policy:=optional; \
+    properties:="resources=META-INF/services/io.smallrye.graphql.spi.MetricsService"
+
+-buildpath: \
+  io.smallrye:smallrye-graphql;strategy=exact;version=1.0.2,\
+  com.ibm.websphere.org.eclipse.microprofile.metrics.2.3;version=latest,\
+  com.ibm.ws.logging;version=latest,\
+  com.ibm.ws.microprofile.metrics.cdi.2.3,\
+  com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+ 

--- a/dev/com.ibm.ws.microprofile.graphql.metrics.1.0/resources/META-INF/services/io.smallrye.graphql.spi.MetricsService
+++ b/dev/com.ibm.ws.microprofile.graphql.metrics.1.0/resources/META-INF/services/io.smallrye.graphql.spi.MetricsService
@@ -1,0 +1,1 @@
+com.ibm.ws.microprofile.graphql.metrics.component.MetricsServiceImpl

--- a/dev/com.ibm.ws.microprofile.graphql.metrics.1.0/src/com/ibm/ws/microprofile/graphql/metrics/component/MetricsServiceImpl.java
+++ b/dev/com.ibm.ws.microprofile.graphql.metrics.1.0/src/com/ibm/ws/microprofile/graphql/metrics/component/MetricsServiceImpl.java
@@ -1,0 +1,25 @@
+package com.ibm.ws.microprofile.graphql.metrics.component;
+
+import com.ibm.ws.microprofile.metrics.cdi23.producer.MetricRegistryFactory;
+
+import io.smallrye.graphql.spi.MetricsService;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
+
+public class MetricsServiceImpl implements MetricsService {
+
+    @Override
+    public String getName() {
+        return "Liberty MetricsServiceImpl";
+    }
+
+    @Override
+    public MetricRegistry getMetricRegistry(MetricRegistry.Type type) {
+        switch (type) {
+            case VENDOR: return MetricRegistryFactory.getVendorRegistry();
+            case BASE: return MetricRegistryFactory.getBaseRegistry();
+            case APPLICATION: return MetricRegistryFactory.getApplicationRegistry();
+            default: throw new IllegalArgumentException("Unexpected MetricRegistry.Type, " + type);
+        }
+    }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.metrics.1.0/src/com/ibm/ws/microprofile/graphql/metrics/component/package-info.java
+++ b/dev/com.ibm.ws.microprofile.graphql.metrics.1.0/src/com/ibm/ws/microprofile/graphql/metrics/component/package-info.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+@TraceOptions(traceGroup = "GraphQL")
+package com.ibm.ws.microprofile.graphql.metrics.component;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;


### PR DESCRIPTION
Building on PR #12060 (part of Epic Issue #7956), this PR adds support for MP Metrics 2.3 to MP GraphQL.  

When enabled and when executing a GraphQL query or mutation, the SmallRye GraphQL implementation will track stats in the following form (Prometheus):

```
# TYPE vendor_mp_graphql_Mutation_reset_total counter
vendor_mp_graphql_Mutation_reset_total 1
# TYPE vendor_mp_graphql_Mutation_reset_elapsedTime_seconds gauge
vendor_mp_graphql_Mutation_reset_elapsedTime_seconds 0.035550527000000005
# TYPE vendor_mp_graphql_Query_currentConditions_total counter
vendor_mp_graphql_Query_currentConditions_total 9
# TYPE vendor_mp_graphql_Query_currentConditions_elapsedTime_seconds gauge
vendor_mp_graphql_Query_currentConditions_elapsedTime_seconds 0.007973887
```

or JSON:
```
{
  ...
  "mp_graphql_Query_currentConditions": {
    "count":9,
    "elapsedTime":7973887
  },
  "mp_graphql_Mutation_reset":{
    "count":1,
    "elapsedTime":35550527
  },
  ...
}
```

Includes auto-feature code and FAT tests.

Supersedes PR #12064.