### PR TITLE
Issue 11962: Make ACME CA config properties public

### DIFF
--- a/dev/com.ibm.ws.security.acme/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.acme/resources/OSGI-INF/l10n/metatype.properties
@@ -16,6 +16,9 @@
 
 # ACME configuration
 
+acmeCA.config=ACME Certificate Authority
+acmeCA.config.desc=Configuration for the ACME Certificate Authority.
+
 directoryURI=ACME server directory URI
 directoryURI.desc=The URI to the ACME CA server's directory object.
 
@@ -43,8 +46,9 @@ accountKeyFile.desc=A path to the file containing a key identifier for a registe
 domainKeyFile=Domain key file
 domainKeyFile.desc=A path to the file containing a key identifier for a domain. If the file does not exist, a new key is generated and written to this file. Back this file up to maintain control of the domain. 
 
-acmeTransportConfig=ACME transport configuration
-acmeTransportConfig.desc=ACME transport layer configuration.
+acmeTransport=ACME Transport
+acmeTransport.desc=ACME transport layer.
+acmeTransport$Ref=ACME transport reference
 
 sslProtocol=SSL protocol
 sslProtocol.desc=The SSL handshake protocol. Protocol values can be found in the documentation for the Java Secure Socket Extension (JSSE) provider of the underlying JRE.  When using the IBM JRE the default value is SSL_TLSv2 and when using the Oracle JRE the default value is SSL.
@@ -61,8 +65,9 @@ trustStoreType.desc=The keystore type for the truststore. Supported types are JK
 renewBeforeExpiration=Renew time before expiration
 renewBeforeExpiration.desc=Time period before the expiration date of the certificate to request a new certificate. If the first request doesn't work, the certificate renewal request continues until a new certificate is received. For example, if the renewBeforeExpiration property is set to seven days, the ACME service requests a new certificate seven days before the expiration date of the current certificate. Setting the renewBeforeExpiration property to zero or a negative value disables automatic certificate renewal.
 
-acmeRevocationChecker=ACME certificate revocation checker
+acmeRevocationChecker=ACME Certificate Revocation Checker
 acmeRevocationChecker.desc=Configuration for checking the revocation status of certificates with the Online Certificate Status Protocol (OCSP) or Certificate Revocation Lists (CRLs).
+acmeRevocationChecker$Ref=ACME certificate revocation checker reference
 
 enabled=Certificate revocation checking enabled
 enabled.desc=Verifies whether certificate revocation checking is enabled for the ACME CA service. The default is true.

--- a/dev/com.ibm.ws.security.acme/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.acme/resources/OSGI-INF/metatype/metatype.xml
@@ -19,32 +19,32 @@
    <Object ocdref="com.ibm.ws.security.acme.config.metatype"/>
  </Designate>
 
- <OCD id="com.ibm.ws.security.acme.config.metatype" ibm:alias="acmeCA" name="internal" description="internal use only">
+ <OCD id="com.ibm.ws.security.acme.config.metatype" ibm:alias="acmeCA" name="%acmeCA.config" description="%acmeCA.config.desc">
  
-   <AD id="directoryURI"          name="internal" description="internal use only" type="String"  required="true" />
+   <AD id="directoryURI"          name="%directoryURI" description="%directoryURI.desc" type="String"  required="true" />
 
    <!-- CSR related fields. -->
-   <AD id="domain"                name="internal" description="internal use only" type="String"  required="true"  cardinality="2147483647" />
-   <AD id="validFor"              name="internal" description="internal use only" type="String"  required="false" ibm:type="duration" />
-   <AD id="subjectDN"             name="internal" description="internal use only" type="String"  required="false" />
+   <AD id="domain"                name="%domain" description="%domain.desc" type="String"  required="true"  cardinality="2147483647" />
+   <AD id="validFor"              name="%validFor" description="%validFor.desc" type="String"  required="false" ibm:type="duration" />
+   <AD id="subjectDN"             name="%subjectDN" description="%subjectDN.desc" type="String"  required="false" />
   
    <!-- Challenge and order related fields. -->
    <AD id="challengePollTimeout"  name="%challengePollTimeout" description="%challengePollTimeout.desc" type="String"  required="false" ibm:type="duration" default="120s" />
    <AD id="orderPollTimeout"      name="%orderPollTimeout"     description="%orderPollTimeout.desc"     type="String"  required="false" ibm:type="duration" default="120s" />
 
    <!-- ACME account related fields. -->
-   <AD id="accountKeyFile"        name="internal" description="internal use only" type="String"  required="false" default="${server.output.dir}/resources/security/acmeAccountKey.pem" />
-   <AD id="accountContact"        name="internal" description="internal use only" type="String"  required="false" cardinality="2147483647" />
-   <AD id="domainKeyFile"         name="internal" description="internal use only" type="String"  required="false" default="${server.output.dir}/resources/security/acmeDomainKey.pem" />
+   <AD id="accountKeyFile"        name="%accountKeyFile" description="%accountKeyFile.desc" type="String"  required="false" default="${server.output.dir}/resources/security/acmeAccountKey.pem" />
+   <AD id="accountContact"        name="%accountContact" description="%accountContact.desc" type="String"  required="false" cardinality="2147483647" />
+   <AD id="domainKeyFile"         name="%domainKeyFile" description="%domainKeyFile.desc" type="String"  required="false" default="${server.output.dir}/resources/security/acmeDomainKey.pem" />
 
    <!-- Transport configuration. -->
-   <AD id="acmeTransportConfig"   name="internal" description="internal use only" type="String"  required="false" ibm:flat="true" ibm:type="pid" ibm:reference="com.ibm.ws.security.acme.transport" />
-
-   <!-- Renewal configuration options -->
-   <AD id="renewBeforeExpiration" name="internal" description="internal use only" type="String" required="false" ibm:type="duration" default="7d" />
+   <AD id="acmeTransportConfig"   name="%acmeTransportConfig" description="%acmeTransportConfig.desc" type="String"  required="false" ibm:flat="true" ibm:type="pid" ibm:reference="com.ibm.ws.security.acme.transport" />
   
+   <!-- Renewal configuration options -->
+   <AD id="renewBeforeExpiration" name="%renewBeforeExpiration" description="%renewBeforeExpiration" type="String" required="false" ibm:type="duration" default="7d" />
+
    <!-- Revocation checker configuration. -->
-   <AD id="acmeRevocationChecker" name="internal" description="internal use only" type="String"  required="false" ibm:flat="true" ibm:type="pid" ibm:reference="com.ibm.ws.security.acme.revocation" />
+   <AD id="acmeRevocationChecker" name="%acmeRevocationChecker" description="%acmeRevocationChecker.desc" type="String"  required="false" ibm:flat="true" ibm:type="pid" ibm:reference="com.ibm.ws.security.acme.revocation" />
   
  </OCD>
   


### PR DESCRIPTION
Fixes #11962 

First pass at making acmeConfig properties public. The feature is still non-GA.

This does not include properties from #12016

Based on how the verification checks run, I think we'll have to do the AcmeTransport and Revocation in after the Refs are translated.

For #9017