### PR TITLE
Cleanup features and bundles in kernel feature FAT

### DIFF
--- a/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/FATTest.java
+++ b/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/FATTest.java
@@ -847,6 +847,8 @@ public class FATTest extends AbstractAppManagerTest {
         } finally {
             pathsToCleanup.add(server.getServerRoot() + "/" + DROPINS_FISH_DIR);
             server.stopServer("CWWKZ0005E");
+            server.uninstallSystemFeature("test.app.notifications");
+            server.uninstallSystemBundle("test.app.notifications");
         }
     }
 

--- a/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/FeatureAPITest.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/FeatureAPITest.java
@@ -83,7 +83,7 @@ public class FeatureAPITest {
     public static void uninstallSystemFeature() throws Exception {
         server.uninstallSystemFeature("test.feature.api.internal-1.0");
         server.uninstallSystemFeature("test.feature.api-1.0");
-        server.uninstallSystemBundle("test.feature.api_1.0.0");
+        server.uninstallSystemBundle("test.feature.api");
     }
 
     @After

--- a/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/FeatureTest.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/FeatureTest.java
@@ -32,7 +32,6 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
-import com.ibm.ws.kernel.feature.fat.TestUtils;
 
 @RunWith(FATRunner.class)
 public class FeatureTest {
@@ -121,6 +120,7 @@ public class FeatureTest {
         server.deleteFileFromLibertyInstallRoot("lib/bundleJavaEight_1.0.0.jar");
         server.deleteFileFromLibertyInstallRoot("lib/bundleJavaNine_1.0.0.jar");
 
+        server.deleteFileFromLibertyInstallRoot("lib/features/includeClientFeature-1.0.mf");
         Log.exiting(c, METHOD_NAME);
     }
 

--- a/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/SPIIsolationTest.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/SPIIsolationTest.java
@@ -89,13 +89,13 @@ public class SPIIsolationTest {
         //copy the isolation test runtime feature into the server features location
         server.deleteFileFromLibertyInstallRoot("lib/features/isolation.Runtime.Test.Feature-1.0.mf");
         //copy the isolation test runtime bundles into the server lib location
-        server.deleteFileFromLibertyInstallRoot("lib/bundles/test.feature.isolation.L1_1.0.0.jar");
-        server.deleteFileFromLibertyInstallRoot("lib/bundles/test.feature.isolation.L2_1.0.0.jar");
-        server.deleteFileFromLibertyInstallRoot("lib/bundles/test.feature.isolation.L3_1.0.0.jar");
+        server.deleteFileFromLibertyInstallRoot("lib/test.feature.isolation.L1_1.0.0.jar");
+        server.deleteFileFromLibertyInstallRoot("lib/test.feature.isolation.L2_1.0.0.jar");
+        server.deleteFileFromLibertyInstallRoot("lib/test.feature.isolation.L3_1.0.0.jar");
 
         //copy the negative runtime feature and bundle
         server.deleteFileFromLibertyInstallRoot("lib/features/isolation.Runtime.Test.Feature.Negative-1.0.mf");
-        server.deleteFileFromLibertyInstallRoot("lib/bundles/test.feature.isolation.L8_1.0.0.jar");
+        server.deleteFileFromLibertyInstallRoot("lib/test.feature.isolation.L8_1.0.0.jar");
 
         //install the user (different product isolation space) feature and bundles
         server.uninstallUserFeature("isolation.Product.Test.Feature-1.0");


### PR DESCRIPTION
The kernel feature FAT isn't cleaning up a few bundles and a system feature. If these are left around it can cause other FAT buckets to fail. 