### PR TITLE
MP GraphQL Authorization

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -643,6 +643,16 @@
     </dependency>
     <dependency>
       <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-graphql-client</artifactId>
+      <version>1.0.2</version>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-graphql-client-api</artifactId>
+      <version>1.0.2</version>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye</groupId>
       <artifactId>smallrye-graphql-schema-builder</artifactId>
       <version>1.0.2</version>
     </dependency>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -124,6 +124,8 @@ io.perfmark:perfmark-api:0.20.1
 io.projectreactor:reactor-core:3.1.8.RELEASE
 io.reactivex.rxjava2:rxjava:2.2.13
 io.smallrye:smallrye-graphql:1.0.2
+io.smallrye:smallrye-graphql-client:1.0.2
+io.smallrye:smallrye-graphql-client-api:1.0.2
 io.smallrye:smallrye-graphql-schema-builder:1.0.2
 io.smallrye:smallrye-graphql-schema-model:1.0.2
 io.smallrye:smallrye-graphql-servlet:1.0.2

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpGraphQL1.0-appSecurity-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpGraphQL1.0-appSecurity-3.0.feature
@@ -1,0 +1,12 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=com.ibm.websphere.appserver.mpGraphQL1.0-appSecurity3.0
+visibility=private
+singleton=true
+IBM-Provision-Capability: \
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpGraphQL-1.0))", \
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.appSecurity-2.0)(osgi.identity=com.ibm.websphere.appserver.appSecurity-3.0)))"
+-bundles=com.ibm.ws.microprofile.graphql.authorization,\
+  com.ibm.ws.security.authorization.util
+IBM-Install-Policy: when-satisfied
+kind=beta
+edition=core

--- a/dev/com.ibm.ws.io.smallrye.graphql/src/com/ibm/ws/io/smallrye/graphql/component/GraphQLServletContainerInitializer.java
+++ b/dev/com.ibm.ws.io.smallrye.graphql/src/com/ibm/ws/io/smallrye/graphql/component/GraphQLServletContainerInitializer.java
@@ -58,6 +58,9 @@ import org.jboss.jandex.IndexView;
 public class GraphQLServletContainerInitializer implements ServletContainerInitializer {
     private static final TraceComponent tc = Tr.register(GraphQLServletContainerInitializer.class);
 
+    public static final String EXECUTION_SERVLET_NAME = "ExecutionServlet";
+    public static final String SCHEMA_SERVLET_NAME = "SchemaServlet";
+
     @FFDCIgnore({Throwable.class})
     public void onStartup(Set<Class<?>> classes, ServletContext ctx) throws ServletException {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -168,10 +171,10 @@ public class GraphQLServletContainerInitializer implements ServletContainerIniti
                                         .filter(s -> {return s.replaceAll("/", "").length() > 0;})
                                         .orElse("graphql");
         ExecutionServlet execServlet = new ExecutionServlet(executionService, config);
-        ServletRegistration.Dynamic execServletReg = ctx.addServlet("ExecutionServlet", execServlet);
+        ServletRegistration.Dynamic execServletReg = ctx.addServlet(EXECUTION_SERVLET_NAME, execServlet);
         execServletReg.addMapping(path + "/*");
         SchemaPrinter printer = new SchemaPrinter(config);
-        ServletRegistration.Dynamic schemaServletReg = ctx.addServlet("SchemaServlet", new SchemaServlet(printer));
+        ServletRegistration.Dynamic schemaServletReg = ctx.addServlet(SCHEMA_SERVLET_NAME, new SchemaServlet(printer));
         schemaServletReg.addMapping(path + "/schema.graphql");
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {

--- a/dev/com.ibm.ws.io.smallrye.graphql/src/com/ibm/ws/io/smallrye/graphql/component/TracingInterceptor.java
+++ b/dev/com.ibm.ws.io.smallrye.graphql/src/com/ibm/ws/io/smallrye/graphql/component/TracingInterceptor.java
@@ -25,6 +25,7 @@ import org.eclipse.microprofile.graphql.GraphQLApi;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 @Trivial
 @Dependent
@@ -36,6 +37,7 @@ public class TracingInterceptor {
     private final static TraceComponent tc = Tr.register(TracingInterceptor.class);
 
     @AroundInvoke
+    @FFDCIgnore({Exception.class})
     public Object logInvocation(InvocationContext ctx) throws Exception {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Method m = ctx.getMethod();
@@ -44,6 +46,9 @@ public class TracingInterceptor {
             Object returnObj = null;
             try {
                 returnObj = ctx.proceed();
+            } catch (Exception e) {
+                Tr.debug(tc, "Caught exception", e);
+                throw e;
             } finally {
                 Tr.debug(tc, "Invoked: " + fqMethodName, returnObj);
             }

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/.classpath
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/.classpath
@@ -11,6 +11,7 @@
 	<classpathentry kind="src" path="test-applications/inputFieldsApp/src"/>
 	<classpathentry kind="src" path="test-applications/metricsApp/src"/>
 	<classpathentry kind="src" path="test-applications/outputFieldsApp/src"/>
+	<classpathentry kind="src" path="test-applications/rolesAuthApp/src"/>
 	<classpathentry kind="src" path="test-applications/typesApp/src"/>
 	<classpathentry kind="src" path="test-applications/voidQueryApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/bnd.bnd
@@ -23,6 +23,7 @@ src: \
   test-applications/metricsApp/src,\
   test-applications/inputFieldsApp/src,\
   test-applications/outputFieldsApp/src,\
+  test-applications/rolesAuthApp/src,\
   test-applications/typesApp/src,\
   test-applications/voidQueryApp/src
 
@@ -39,4 +40,5 @@ tested.features: mpMetrics-2.0
   com.ibm.websphere.org.eclipse.microprofile.graphql.1.0;version=latest,\
   com.ibm.websphere.org.eclipse.microprofile.rest.client.1.1;version=latest,\
   com.ibm.websphere.javaee.jsonp.1.1;version=latest,\
-  com.ibm.websphere.javaee.jsonb.1.0;version=latest
+  com.ibm.websphere.javaee.jsonb.1.0;version=latest,\
+  io.smallrye:smallrye-graphql-client-api;version=1.0.2

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/build.gradle
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/build.gradle
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+repositories {
+  if (isUsingArtifactory) {
+    maven {
+      credentials {
+        username userProps.getProperty("artifactory.download.user")
+        password userProps.getProperty("artifactory.download.token")
+      }
+      url ("https://na.artifactory.swg-devops.com/artifactory/wasliberty-maven-remote")
+    }
+  } else {
+    mavenCentral()
+  }
+}
+
+configurations {
+  smallryeGraphQLClient
+}
+
+configurations.smallryeGraphQLClient {
+  transitive = false
+}
+
+dependencies {
+  smallryeGraphQLClient 'io.smallrye:smallrye-graphql-client:1.0.2',
+    'io.smallrye:smallrye-graphql-client-api:1.0.2',
+    'org.slf4j:slf4j-api:1.7.7',
+	'org.slf4j:slf4j-jdk14:1.7.7'
+}
+
+task addSmallryeGraphQLClient(type: Copy) {
+  from configurations.smallryeGraphQLClient
+  into "${buildDir}/autoFVT/publish/shared/resources/smallryeGraphQLClient/"
+}
+
+addRequiredLibraries {
+  dependsOn addSmallryeGraphQLClient
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/FATSuite.java
@@ -10,9 +10,13 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.graphql.fat;
 
+import java.io.File;
+
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -27,7 +31,13 @@ import org.junit.runners.Suite.SuiteClasses;
                 InputFieldsTest.class,
                 MetricsTest.class,
                 OutputFieldsTest.class,
+                RolesAuthTest.class,
                 TypesTest.class,
                 VoidQueryTest.class
 })
-public class FATSuite {}
+public class FATSuite {
+    public static void addSmallRyeGraphQLClientLibraries(WebArchive webArchive) {
+        File libs = new File("publish/shared/resources/smallryeGraphQLClient/");
+        webArchive.addAsLibraries(libs.listFiles());
+    }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.rolesAuth/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.rolesAuth/bootstrap.properties
@@ -1,0 +1,4 @@
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.microprofile.graphql*=all:com.ibm.ws.io.smallrye.graphql.*=all
+com.ibm.ws.logging.max.file.size=0
+osgi.console=5678
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.rolesAuth/server.xml
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.rolesAuth/server.xml
@@ -1,0 +1,30 @@
+<server>
+   <featureManager>
+     <feature>componenttest-1.0</feature>
+     <feature>mpRestClient-1.2</feature>
+     <feature>mpGraphQL-1.0</feature>
+     <feature>jaxrsClient-2.1</feature>
+     <feature>jsonp-1.1</feature>
+     <feature>jsonb-1.0</feature>
+     <feature>appSecurity-3.0</feature>
+   </featureManager>
+
+    <include location="../fatTestPorts.xml"/>
+
+    <basicRegistry id="basic" realm="WebRealm">
+     <user name="user1" password="user1pwd" />
+     <user name="user2" password="user2pwd" />
+     <user name="user1a" password="user1pwd" />
+     <user name="user2a" password="user2pwd" />
+     <group name="Role1">
+       <member name="user1"/>
+     </group>
+     <group name="Role2">
+       <member name="user2"/>
+     </group>
+   </basicRegistry>
+
+    <!--  Required to read the server's port system property -->
+   <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
+
+  </server> 

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/rolesAuthApp/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/rolesAuthApp/resources/WEB-INF/web.xml
@@ -1,0 +1,38 @@
+<web-app
+    xmlns="http://java.sun.com/xml/ns/javaee" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee web-app_3_0.xsd"
+    version="3.0">
+
+  <display-name>rolesAuth</display-name>
+  <description>Test Case App for testing role-based authorization</description>
+
+    <security-constraint id="SecurityConstraint_1">
+        <web-resource-collection id="WebResourceCollection_1">
+            <web-resource-name>allResources</web-resource-name>
+            <description>Requiring authentication for all resources when appSecurity is enabled</description>
+            <url-pattern>/graphql/*</url-pattern>
+            <url-pattern>/graphiql.html</url-pattern>
+            <http-method>GET</http-method>
+            <http-method>POST</http-method>
+        </web-resource-collection>
+        <user-data-constraint id="UserDataConstraint_1">
+            <transport-guarantee>NONE</transport-guarantee>
+        </user-data-constraint>
+        <auth-constraint id="AuthConstraint_1">
+            <role-name>Role1</role-name>
+            <role-name>Role2</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>rolesAuthApp</realm-name>
+    </login-config>
+    <security-role id="SecurityRole_1">
+        <role-name>Role1</role-name>
+    </security-role>
+    <security-role id="SecurityRole_2">
+        <role-name>Role2</role-name>
+    </security-role>
+</web-app>

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/rolesAuthApp/resources/graphiql.html
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/rolesAuthApp/resources/graphiql.html
@@ -1,0 +1,142 @@
+<!--
+ *  Copyright (c) Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the license found in the
+ *  LICENSE file in the root directory of this source tree.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            height: 100%;
+            margin: 0;
+            width: 100%;
+            overflow: hidden;
+        }
+        #graphiql {
+            height: 100vh;
+        }
+    </style>
+
+    <!--
+      This GraphiQL example depends on Promise and fetch, which are available in
+      modern browsers, but can be "polyfilled" for older browsers.
+      GraphiQL itself depends on React DOM.
+      If you do not want to rely on a CDN, you can host these files locally or
+      include them directly in your favored resource bunder.
+    -->
+    <script src="//cdn.jsdelivr.net/es6-promise/4.0.5/es6-promise.auto.min.js"></script>
+    <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
+    <script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
+    <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
+
+    <!--
+      These two files can be found in the npm module, however you may wish to
+      copy them directly into your environment, or perhaps include them in your
+      favored resource bundler.
+     -->
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphiql@0.11.2/graphiql.css" />
+    <script src="//cdn.jsdelivr.net/npm/graphiql@0.11.2/graphiql.js"></script>
+
+</head>
+<body>
+<div id="graphiql">Loading...</div>
+<script>
+    /**
+     * This GraphiQL example illustrates how to use some of GraphiQL's props
+     * in order to enable reading and updating the URL parameters, making
+     * link sharing of queries a little bit easier.
+     *
+     * This is only one example of this kind of feature, GraphiQL exposes
+     * various React params to enable interesting integrations.
+     */
+        // Parse the search string to get url parameters.
+    var search = window.location.search;
+    var parameters = {};
+    search.substr(1).split('&').forEach(function (entry) {
+        var eq = entry.indexOf('=');
+        if (eq >= 0) {
+            parameters[decodeURIComponent(entry.slice(0, eq))] =
+                decodeURIComponent(entry.slice(eq + 1));
+        }
+    });
+    // if variables was provided, try to format it.
+    if (parameters.variables) {
+        try {
+            parameters.variables =
+                JSON.stringify(JSON.parse(parameters.variables), null, 2);
+        } catch (e) {
+            // Do nothing, we want to display the invalid JSON as a string, rather
+            // than present an error.
+        }
+    }
+    // When the query and variables string is edited, update the URL bar so
+    // that it can be easily shared
+    function onEditQuery(newQuery) {
+        parameters.query = newQuery;
+        updateURL();
+    }
+    function onEditVariables(newVariables) {
+        parameters.variables = newVariables;
+        updateURL();
+    }
+    function onEditOperationName(newOperationName) {
+        parameters.operationName = newOperationName;
+        updateURL();
+    }
+    function updateURL() {
+        var newSearch = '?' + Object.keys(parameters).filter(function (key) {
+                return Boolean(parameters[key]);
+            }).map(function (key) {
+                return encodeURIComponent(key) + '=' +
+                       encodeURIComponent(parameters[key]);
+            }).join('&');
+        history.replaceState(null, null, newSearch);
+    }
+    // Defines a GraphQL fetcher using the fetch API. You're not required to
+    // use fetch, and could instead implement graphQLFetcher however you like,
+    // as long as it returns a Promise or Observable.
+    function graphQLFetcher(graphQLParams) {
+        // This example expects a GraphQL server at the path /graphql.
+        // Change this to point wherever you host your GraphQL server.
+        // Changes by JJS to run on Payara
+        return fetch('graphql', {
+            method: 'post',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+                'Authorization': '5c54174535fc171980956533',
+            },
+            body: JSON.stringify(graphQLParams),
+            credentials: 'include',
+        }).then(function (response) {
+            return response.text();
+        }).then(function (responseBody) {
+            try {
+                return JSON.parse(responseBody);
+            } catch (error) {
+                return responseBody;
+            }
+        });
+    }
+    // Render <GraphiQL /> into the body.
+    // See the README in the top level of this module to learn more about
+    // how you can customize GraphiQL by providing different values or
+    // additional child elements.
+    ReactDOM.render(
+        React.createElement(GraphiQL, {
+            fetcher: graphQLFetcher,
+            query: parameters.query,
+            variables: parameters.variables,
+            operationName: parameters.operationName,
+            onEditQuery: onEditQuery,
+            onEditVariables: onEditVariables,
+            onEditOperationName: onEditOperationName
+        }),
+        document.getElementById('graphiql')
+    );
+</script>
+</body>
+</html>

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/rolesAuthApp/src/mpGraphQL10/rolesAuth/ClientInterface.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/rolesAuthApp/src/mpGraphQL10/rolesAuth/ClientInterface.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.rolesAuth;
+
+
+public interface ClientInterface {
+
+    String permitAll_unannotated();
+    String permitAll_permitAll();
+    String permitAll_denyAll();
+    String permitAll_rolesAllowed1();
+    String permitAll_rolesAllowed2();
+    
+    String denyAll_unannotated();
+    String denyAll_permitAll();
+    String denyAll_denyAll();
+    String denyAll_rolesAllowed1();
+    String denyAll_rolesAllowed2();
+    
+    String rolesAllowed1_unannotated();
+    String rolesAllowed1_permitAll();
+    String rolesAllowed1_denyAll();
+    String rolesAllowed1_rolesAllowed1();
+    String rolesAllowed1_rolesAllowed2();
+    
+    String rolesAllowed2_unannotated();
+    String rolesAllowed2_permitAll();
+    String rolesAllowed2_denyAll();
+    String rolesAllowed2_rolesAllowed1();
+    String rolesAllowed2_rolesAllowed2();
+    
+    String unannotated_unannotated();
+    String unannotated_permitAll();
+    String unannotated_denyAll();
+    String unannotated_rolesAllowed1();
+    String unannotated_rolesAllowed2();
+
+    // multiple annotations (generally an error condition...):
+    String denyAllAndPermitAll();
+    String denyAllAndRolesAllowed1();
+    String rolesAllowed1AndPermitAll();
+    String allThree();
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/rolesAuthApp/src/mpGraphQL10/rolesAuth/DenyAllApi.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/rolesAuthApp/src/mpGraphQL10/rolesAuth/DenyAllApi.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.rolesAuth;
+
+import static mpGraphQL10.rolesAuth.RolesAuthTestServlet.ACCESSED;
+
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Query;
+
+@DenyAll
+@GraphQLApi
+public class DenyAllApi {
+
+    @PermitAll
+    @Query("denyAll_permitAll")
+    public String permitAll() { return ACCESSED; }
+    
+    @Query("denyAll_unannotated")
+    public String unannotated() { return ACCESSED; }
+    
+    @DenyAll
+    @Query("denyAll_denyAll")
+    public String denyAll() { return ACCESSED; }
+    
+    @RolesAllowed("Role1")
+    @Query("denyAll_rolesAllowed1")
+    public String rolesAllowed1() { return ACCESSED; }
+    
+    @RolesAllowed("Role2")
+    @Query("denyAll_rolesAllowed2")
+    public String rolesAllowed2() { return ACCESSED; }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/rolesAuthApp/src/mpGraphQL10/rolesAuth/MultiAnnosApi.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/rolesAuthApp/src/mpGraphQL10/rolesAuth/MultiAnnosApi.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.rolesAuth;
+
+import static mpGraphQL10.rolesAuth.RolesAuthTestServlet.ACCESSED;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+
+import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.GraphQLApi;
+
+@GraphQLApi
+public class MultiAnnosApi {
+
+    @Query("denyAllAndPermitAll")
+    @DenyAll // should win
+    @PermitAll
+    public String denyAllAndPermitAll() { return ACCESSED; }
+
+    @Query("denyAllAndRolesAllowed1")
+    @DenyAll // should win
+    @RolesAllowed("Role1")
+    public String rolesAllowedAndDenyAllMethod() { return ACCESSED; }
+
+    @Query("rolesAllowed1AndPermitAll")
+    @PermitAll
+    @RolesAllowed("Role1") // should win
+    public String rolesAllowedAndPermitAllMethod() { return ACCESSED; }
+
+    @Query("allThree")
+    @DenyAll // should win
+    @PermitAll
+    @RolesAllowed("Role1")
+    public String allThree() { return ACCESSED; }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/rolesAuthApp/src/mpGraphQL10/rolesAuth/PermitAllApi.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/rolesAuthApp/src/mpGraphQL10/rolesAuth/PermitAllApi.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.rolesAuth;
+
+import static mpGraphQL10.rolesAuth.RolesAuthTestServlet.ACCESSED;
+
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Query;
+
+@PermitAll
+@GraphQLApi
+public class PermitAllApi {
+
+    @PermitAll
+    @Query("permitAll_permitAll")
+    public String permitAll() { return ACCESSED; }
+    
+    @Query("permitAll_unannotated")
+    public String unannotated() { return ACCESSED; }
+    
+    @DenyAll
+    @Query("permitAll_denyAll")
+    public String denyAll() { return ACCESSED; }
+    
+    @RolesAllowed("Role1")
+    @Query("permitAll_rolesAllowed1")
+    public String rolesAllowed1() { return ACCESSED; }
+    
+    @RolesAllowed("Role2")
+    @Query("permitAll_rolesAllowed2")
+    public String rolesAllowed2() { return ACCESSED; }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/rolesAuthApp/src/mpGraphQL10/rolesAuth/RolesAllowed1Api.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/rolesAuthApp/src/mpGraphQL10/rolesAuth/RolesAllowed1Api.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.rolesAuth;
+
+import static mpGraphQL10.rolesAuth.RolesAuthTestServlet.ACCESSED;
+
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Query;
+
+@RolesAllowed("Role1")
+@GraphQLApi
+public class RolesAllowed1Api {
+
+    @PermitAll
+    @Query("rolesAllowed1_permitAll")
+    public String permitAll() { return ACCESSED; }
+    
+    @Query("rolesAllowed1_unannotated")
+    public String unannotated() { return ACCESSED; }
+    
+    @DenyAll
+    @Query("rolesAllowed1_denyAll")
+    public String denyAll() { return ACCESSED; }
+    
+    @RolesAllowed("Role1")
+    @Query("rolesAllowed1_rolesAllowed1")
+    public String rolesAllowed1() { return ACCESSED; }
+    
+    @RolesAllowed("Role2")
+    @Query("rolesAllowed1_rolesAllowed2")
+    public String rolesAllowed2() { return ACCESSED; }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/rolesAuthApp/src/mpGraphQL10/rolesAuth/RolesAllowed2Api.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/rolesAuthApp/src/mpGraphQL10/rolesAuth/RolesAllowed2Api.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.rolesAuth;
+
+import static mpGraphQL10.rolesAuth.RolesAuthTestServlet.ACCESSED;
+
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Query;
+
+@RolesAllowed("Role2")
+@GraphQLApi
+public class RolesAllowed2Api {
+
+    @PermitAll
+    @Query("rolesAllowed2_permitAll")
+    public String permitAll() { return ACCESSED; }
+    
+    @Query("rolesAllowed2_unannotated")
+    public String unannotated() { return ACCESSED; }
+    
+    @DenyAll
+    @Query("rolesAllowed2_denyAll")
+    public String denyAll() { return ACCESSED; }
+    
+    @RolesAllowed("Role1")
+    @Query("rolesAllowed2_rolesAllowed1")
+    public String rolesAllowed1() { return ACCESSED; }
+    
+    @RolesAllowed("Role2")
+    @Query("rolesAllowed2_rolesAllowed2")
+    public String rolesAllowed2() { return ACCESSED; }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/rolesAuthApp/src/mpGraphQL10/rolesAuth/RolesAuthTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/rolesAuthApp/src/mpGraphQL10/rolesAuth/RolesAuthTestServlet.java
@@ -1,0 +1,267 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.rolesAuth;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Base64;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import componenttest.app.FATServlet;
+import io.smallrye.graphql.client.typesafe.api.GraphQlClientBuilder;
+import io.smallrye.graphql.client.typesafe.api.GraphQlClientException;
+import org.junit.Test;
+
+
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/RolesAuthTestServlet")
+public class RolesAuthTestServlet extends FATServlet {
+    Logger LOG = Logger.getLogger(RolesAuthTestServlet.class.getName());
+
+    static final String ACCESSED = "Accessed";
+    
+    ClientInterface role1Client;
+    ClientInterface role2Client;
+
+    private static String getSysProp(String key, String defaultValue) {
+        return AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty(key, defaultValue));
+    }
+
+    @FunctionalInterface
+    private static interface ThrowingSupplier<T> {
+        T getStringThatCouldThrowGraphQlClientException() throws GraphQlClientException;
+    }
+
+    private static void assertAuthorized(ThrowingSupplier<String> supplier) {
+        try {
+            assertEquals(ACCESSED, supplier.getStringThatCouldThrowGraphQlClientException());
+        } catch (Throwable t) {
+            t.printStackTrace();
+            fail("Caught unexpected exception when expected an authorized response, " + t);
+        }
+    }
+    private static void assertUnauthorized(ThrowingSupplier<String> supplier) {
+        try {
+            String s = supplier.getStringThatCouldThrowGraphQlClientException();
+            fail("Expected to be unauthorized, but was able to execute query and receive: " + s);
+        } catch (GraphQlClientException ex) {
+            assertNotNull(ex.getMessage());
+            assertTrue("Unexpected error message (expected \"Unauthorized\"): " + ex.getMessage(),
+                       ex.getMessage().contains("Unauthorized"));
+        }
+    }
+
+    @Override
+    public void init() throws ServletException {
+        String contextPath = getSysProp("com.ibm.ws.microprofile.graphql.fat.contextpath", "graphql");
+        String baseUriStr = "http://localhost:" + getSysProp("bvt.prop.HTTP_default", "8010") + "/rolesAuthApp/" + contextPath;
+        LOG.info("baseUrl = " + baseUriStr);
+        role1Client = GraphQlClientBuilder.newBuilder()
+                                          .endpoint(baseUriStr)
+                                          .header("Authorization", "Basic " + Base64.getEncoder().encodeToString(("user1:user1pwd").getBytes()))
+                                          .build(ClientInterface.class);
+        role2Client = GraphQlClientBuilder.newBuilder()
+                        .endpoint(baseUriStr)
+                        .header("Authorization", "Basic " + Base64.getEncoder().encodeToString(("user2:user2pwd").getBytes()))
+                        .build(ClientInterface.class);
+    }
+
+    @Test
+    public void permitAll_unannotated() {
+        assertAuthorized(() -> role1Client.permitAll_unannotated());
+        assertAuthorized(() -> role2Client.permitAll_unannotated());
+    }
+
+    @Test
+    public void permitAll_permitAll() {
+        assertAuthorized(() -> role1Client.permitAll_permitAll());
+        assertAuthorized(() -> role2Client.permitAll_permitAll());
+    }
+
+    @Test
+    public void permitAll_denyAll() {
+        assertUnauthorized(() -> role1Client.permitAll_denyAll());
+        assertUnauthorized(() -> role2Client.permitAll_denyAll());
+    }
+
+    @Test
+    public void permitAll_rolesAllowed1() {
+        assertAuthorized(() -> role1Client.permitAll_rolesAllowed1());
+        assertUnauthorized(() -> role2Client.permitAll_rolesAllowed1());
+    }
+
+    @Test
+    public void permitAll_rolesAllowed2() {
+        assertUnauthorized(() -> role1Client.permitAll_rolesAllowed2());
+        assertAuthorized(() -> role2Client.permitAll_rolesAllowed2());
+    }
+
+    @Test
+    public void denyAll_unannotated() {
+        assertUnauthorized(() -> role1Client.denyAll_unannotated());
+        assertUnauthorized(() -> role2Client.denyAll_unannotated());
+    }
+
+    @Test
+    public void denyAll_permitAll() {
+        assertAuthorized(() -> role1Client.denyAll_permitAll());
+        assertAuthorized(() -> role2Client.denyAll_permitAll());
+    }
+
+    @Test
+    public void denyAll_denyAll() {
+        assertUnauthorized(() -> role1Client.denyAll_denyAll());
+        assertUnauthorized(() -> role2Client.denyAll_denyAll());
+    }
+
+    @Test
+    public void denyAll_rolesAllowed1() {
+        assertAuthorized(() -> role1Client.denyAll_rolesAllowed1());
+        assertUnauthorized(() -> role2Client.denyAll_rolesAllowed1());
+    }
+
+    @Test
+    public void denyAll_rolesAllowed2() {
+        assertUnauthorized(() -> role1Client.denyAll_rolesAllowed2());
+        assertAuthorized(() -> role2Client.denyAll_rolesAllowed2());
+    }
+
+    @Test
+    public void rolesAllowed1_unannotated() {
+        assertAuthorized(() -> role1Client.rolesAllowed1_unannotated());
+        assertUnauthorized(() -> role2Client.rolesAllowed1_unannotated());
+    }
+
+    @Test
+    public void rolesAllowed1_permitAll() {
+        assertAuthorized(() -> role1Client.rolesAllowed1_permitAll());
+        assertAuthorized(() -> role2Client.rolesAllowed1_permitAll());
+    }
+
+    @Test
+    public void rolesAllowed1_denyAll() {
+        assertUnauthorized(() -> role1Client.rolesAllowed1_denyAll());
+        assertUnauthorized(() -> role2Client.rolesAllowed1_denyAll());
+    }
+
+    @Test
+    public void rolesAllowed1_rolesAllowed1() {
+        assertAuthorized(() -> role1Client.rolesAllowed1_rolesAllowed1());
+        assertUnauthorized(() -> role2Client.rolesAllowed1_rolesAllowed1());
+    }
+
+    @Test
+    public void rolesAllowed1_rolesAllowed2() {
+        assertUnauthorized(() -> role1Client.rolesAllowed1_rolesAllowed2());
+        assertAuthorized(() -> role2Client.rolesAllowed1_rolesAllowed2());
+    }
+
+    @Test
+    public void rolesAllowed2_unannotated() {
+        assertUnauthorized(() -> role1Client.rolesAllowed2_unannotated());
+        assertAuthorized(() -> role2Client.rolesAllowed2_unannotated());
+    }
+
+    @Test
+    public void rolesAllowed2_permitAll() {
+        assertAuthorized(() -> role1Client.rolesAllowed2_permitAll());
+        assertAuthorized(() -> role2Client.rolesAllowed2_permitAll());
+    }
+
+    @Test
+    public void rolesAllowed2_denyAll() {
+        assertUnauthorized(() -> role1Client.rolesAllowed2_denyAll());
+        assertUnauthorized(() -> role2Client.rolesAllowed2_denyAll());
+    }
+
+    @Test
+    public void rolesAllowed2_rolesAllowed1() {
+        assertAuthorized(() -> role1Client.rolesAllowed2_rolesAllowed1());
+        assertUnauthorized(() -> role2Client.rolesAllowed2_rolesAllowed1());
+    }
+
+    @Test
+    public void rolesAllowed2_rolesAllowed2() {
+        assertUnauthorized(() -> role1Client.rolesAllowed2_rolesAllowed2());
+        assertAuthorized(() -> role2Client.rolesAllowed2_rolesAllowed2());
+    }
+
+    @Test
+    public void unannotated_unannotated() {
+        assertAuthorized(() -> role1Client.unannotated_unannotated());
+        assertAuthorized(() -> role2Client.unannotated_unannotated());
+    }
+
+    @Test
+    public void unannotated_permitAll() {
+        assertAuthorized(() -> role1Client.unannotated_permitAll());
+        assertAuthorized(() -> role2Client.unannotated_permitAll());
+    }
+
+    @Test
+    public void unannotated_denyAll() {
+        assertUnauthorized(() -> role1Client.unannotated_denyAll());
+        assertUnauthorized(() -> role2Client.unannotated_denyAll());
+    }
+
+    @Test
+    public void unannotated_rolesAllowed1() {
+        assertAuthorized(() -> role1Client.unannotated_rolesAllowed1());
+        assertUnauthorized(() -> role2Client.unannotated_rolesAllowed1());
+    }
+
+    @Test
+    public void unannotated_rolesAllowed2() {
+        assertUnauthorized(() -> role1Client.unannotated_rolesAllowed2());
+        assertAuthorized(() -> role2Client.unannotated_rolesAllowed2());
+    }
+
+    @Test
+    public void denyAllAndPermitAll() {
+        assertUnauthorized(() -> role1Client.denyAllAndPermitAll());
+        assertUnauthorized(() -> role2Client.denyAllAndPermitAll());
+    }
+
+    @Test
+    public void denyAllAndRolesAllowed() {
+        assertUnauthorized(() -> role1Client.denyAllAndRolesAllowed1());
+        assertUnauthorized(() -> role2Client.denyAllAndRolesAllowed1());
+    }
+
+    @Test
+    public void rolesAllowed1AndPermitAll() {
+        assertAuthorized(() -> role1Client.rolesAllowed1AndPermitAll());
+        assertUnauthorized(() -> role2Client.rolesAllowed1AndPermitAll());
+    }
+
+    @Test
+    public void allThree() {
+        assertUnauthorized(() -> role1Client.allThree());
+        assertUnauthorized(() -> role2Client.allThree());
+    }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/rolesAuthApp/src/mpGraphQL10/rolesAuth/UnannotatedApi.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/rolesAuthApp/src/mpGraphQL10/rolesAuth/UnannotatedApi.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package mpGraphQL10.rolesAuth;
+
+import static mpGraphQL10.rolesAuth.RolesAuthTestServlet.ACCESSED;
+
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Query;
+
+@GraphQLApi
+public class UnannotatedApi {
+
+    @PermitAll
+    @Query("unannotated_permitAll")
+    public String permitAll() { return ACCESSED; }
+    
+    @Query("unannotated_unannotated")
+    public String unannotated() { return ACCESSED; }
+    
+    @DenyAll
+    @Query("unannotated_denyAll")
+    public String denyAll() { return ACCESSED; }
+    
+    @RolesAllowed("Role1")
+    @Query("unannotated_rolesAllowed1")
+    public String rolesAllowed1() { return ACCESSED; }
+    
+    @RolesAllowed("Role2")
+    @Query("unannotated_rolesAllowed2")
+    public String rolesAllowed2() { return ACCESSED; }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.authorization/.classpath
+++ b/dev/com.ibm.ws.microprofile.graphql.authorization/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/com.ibm.ws.microprofile.graphql.authorization/.project
+++ b/dev/com.ibm.ws.microprofile.graphql.authorization/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.ibm.ws.microprofile.graphql.authorization</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/com.ibm.ws.microprofile.graphql.authorization/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.microprofile.graphql.authorization/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.microprofile.graphql.authorization/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.microprofile.graphql.authorization/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/com.ibm.ws.microprofile.graphql.authorization/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.graphql.authorization/bnd.bnd
@@ -1,0 +1,41 @@
+#*******************************************************************************
+# Copyright (c) 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+Bundle-Name: MicroProfile Authorization Support for MP GraphQL
+Bundle-SymbolicName: com.ibm.ws.microprofile.graphql.authorization
+Bundle-Description: MicroProfile Authorization Support for MP GraphQL
+
+Export-Package: \
+  com.ibm.ws.microprofile.graphql.authorization.component;thread-context=true
+
+Include-Resource: \
+  META-INF=resources/META-INF
+
+src: src/
+
+-dsannotations: com.ibm.ws.microprofile.graphql.authorization.component.*
+
+-buildpath: \
+  com.ibm.websphere.javaee.annotation.1.3;version=latest, \
+  com.ibm.websphere.javaee.cdi.2.0;version=latest,\
+  com.ibm.websphere.javaee.interceptor.1.2;version=latest,\
+  com.ibm.websphere.javaee.servlet.4.0;version=latest,\
+  com.ibm.websphere.org.eclipse.microprofile.graphql.1.0;version=latest,\
+  com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+  com.ibm.ws.cdi.interfaces;version=latest,\
+  com.ibm.ws.io.smallrye.graphql;version=latest,\
+  com.ibm.ws.logging;version=latest,\
+  com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+  com.ibm.ws.security.authorization.util;version=latest
+ 

--- a/dev/com.ibm.ws.microprofile.graphql.authorization/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/dev/com.ibm.ws.microprofile.graphql.authorization/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+com.ibm.ws.microprofile.graphql.authorization.component.GraphQLAuthorizationExtension

--- a/dev/com.ibm.ws.microprofile.graphql.authorization/src/com/ibm/ws/microprofile/graphql/authorization/component/AuthorizationFilter.java
+++ b/dev/com.ibm.ws.microprofile.graphql.authorization/src/com/ibm/ws/microprofile/graphql/authorization/component/AuthorizationFilter.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.graphql.authorization.component;
+
+import java.io.IOException;
+import java.security.Principal;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+
+public class AuthorizationFilter extends HttpFilter {
+
+    private final static TraceComponent tc = Tr.register(AuthorizationFilter.class);
+    
+    private final static AuthorizationFilter INSTANCE = new AuthorizationFilter();
+
+    private final static ThreadLocal<HttpServletRequest> tlRequest = new ThreadLocal<>();
+    private final static ThreadLocal<HttpServletResponse> tlResponse = new ThreadLocal<>();
+
+    static AuthorizationFilter getInstance() {
+        return INSTANCE;
+    }
+
+    private AuthorizationFilter() {
+    }
+
+    @Override
+    protected void doFilter(HttpServletRequest req, HttpServletResponse res, FilterChain chain) 
+            throws IOException, ServletException {
+        try {
+            tlRequest.set(req);
+            tlResponse.set(res);
+            chain.doFilter(req, res);
+        } finally {
+            tlRequest.remove();
+            tlResponse.remove();
+        }
+    }
+
+    boolean authenticate() throws IOException, ServletException {
+        return getRequest().authenticate(getResponse());
+    }
+    Principal getUserPrincipal() {
+        return getRequest().getUserPrincipal();
+    }
+
+    boolean isUserInRole(String role) {
+        return getRequest().isUserInRole(role);
+    }
+
+    private HttpServletRequest getRequest() {
+        HttpServletRequest req = tlRequest.get();
+        if (req == null) {
+            throw new IllegalStateException("Not in the context of a servlet request");
+        }
+        return req;
+    }
+
+    private HttpServletResponse getResponse() {
+        HttpServletResponse res = tlResponse.get();
+        if (res == null) {
+            throw new IllegalStateException("Not in the context of a servlet request");
+        }
+        return res;
+    }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.authorization/src/com/ibm/ws/microprofile/graphql/authorization/component/AuthorizationInterceptor.java
+++ b/dev/com.ibm.ws.microprofile.graphql.authorization/src/com/ibm/ws/microprofile/graphql/authorization/component/AuthorizationInterceptor.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.graphql.authorization.component;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.Dependent;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.GraphQLException;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.security.authorization.util.RoleMethodAuthUtil;
+import com.ibm.ws.security.authorization.util.UnauthenticatedException;
+
+@Dependent
+@GraphQLApi
+@Interceptor
+@Priority(Interceptor.Priority.PLATFORM_BEFORE)
+public class AuthorizationInterceptor {
+
+    private final static TraceComponent tc = Tr.register(AuthorizationInterceptor.class);
+    private final static AuthorizationFilter AUTH_FILTER = AuthorizationFilter.getInstance();
+
+    @AroundInvoke
+    public Object checkAuthorized(InvocationContext ctx) throws Exception {
+
+        Method m = ctx.getMethod();
+        if (isAuthorized(m)) {
+            return ctx.proceed();
+        }
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "Unauthorized");
+        }
+        throw new GraphQLException("Unauthorized");
+    }
+
+    @FFDCIgnore({UnauthenticatedException.class})
+    private boolean isAuthorized(Method m) {
+        try {
+            return RoleMethodAuthUtil.parseMethodSecurity(m, 
+                    AUTH_FILTER.getUserPrincipal(), AUTH_FILTER::isUserInRole);
+        } catch (UnauthenticatedException ex) {
+            try {
+                return AUTH_FILTER.authenticate() && RoleMethodAuthUtil.parseMethodSecurity(m, 
+                        AUTH_FILTER.getUserPrincipal(), AUTH_FILTER::isUserInRole);
+            } catch (Throwable t) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Failed to authenticate or failed auth check", t);
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.authorization/src/com/ibm/ws/microprofile/graphql/authorization/component/GraphQLAuthorizationExtension.java
+++ b/dev/com.ibm.ws.microprofile.graphql.authorization/src/com/ibm/ws/microprofile/graphql/authorization/component/GraphQLAuthorizationExtension.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.graphql.authorization.component;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.BeforeBeanDiscovery;
+import javax.enterprise.inject.spi.Extension;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.cdi.CDIServiceUtils;
+import com.ibm.ws.cdi.extension.WebSphereCDIExtension;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+
+
+@Component(configurationPolicy = ConfigurationPolicy.IGNORE,
+immediate = true,
+property = { "api.classes=org.eclipse.microprofile.graphql.GraphQLApi",
+             "bean.defining.annotations=org.eclipse.microprofile.graphql.GraphQLApi",
+             "service.vendor=IBM" })
+public class GraphQLAuthorizationExtension implements Extension, WebSphereCDIExtension {
+    TraceComponent tc = Tr.register(GraphQLAuthorizationExtension.class);
+
+    @Trivial
+    public void beforeBeanDiscovery(@Observes BeforeBeanDiscovery beforeBeanDiscovery, BeanManager beanManager) {
+        //register the authorization interceptor binding and the interceptor itself
+        AnnotatedType<GraphQLApi> bindingType = beanManager.createAnnotatedType(GraphQLApi.class);
+        beforeBeanDiscovery.addInterceptorBinding(bindingType);
+        AnnotatedType<AuthorizationInterceptor> interceptorType = beanManager.createAnnotatedType(AuthorizationInterceptor.class);
+        beforeBeanDiscovery.addAnnotatedType(interceptorType, CDIServiceUtils.getAnnotatedTypeIdentifier(interceptorType, this.getClass()));
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "beforeBeanDiscovery - registered AuthorizingInterceptor");
+        }
+    }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.authorization/src/com/ibm/ws/microprofile/graphql/authorization/component/GraphQLAuthorizationServletContainerInitializer.java
+++ b/dev/com.ibm.ws.microprofile.graphql.authorization/src/com/ibm/ws/microprofile/graphql/authorization/component/GraphQLAuthorizationServletContainerInitializer.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.graphql.authorization.component;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.FilterRegistration;
+import javax.servlet.ServletContainerInitializer;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRegistration;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.io.smallrye.graphql.component.GraphQLServletContainerInitializer;
+
+import org.osgi.service.component.annotations.Component;
+
+@Component(property = { "service.vendor=IBM" })
+public class GraphQLAuthorizationServletContainerInitializer implements ServletContainerInitializer {
+    private static final TraceComponent tc = Tr.register(GraphQLAuthorizationServletContainerInitializer.class);
+    private static final String AUTH_FILTER_NAME = "AuthorizationFilter";
+
+    public void onStartup(Set<Class<?>> classes, ServletContext ctx) throws ServletException {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.entry(tc, "onStartup", new Object[] {classes, ctx, ctx.getServletContextName(), ctx.getContextPath()});
+        }
+
+        // add servlet filter for ExecutionServlet
+        FilterRegistration.Dynamic filterReg = ctx.addFilter(AUTH_FILTER_NAME, AuthorizationFilter.getInstance());
+        filterReg.addMappingForServletNames(EnumSet.of(DispatcherType.REQUEST), true, 
+                GraphQLServletContainerInitializer.EXECUTION_SERVLET_NAME);
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.exit(tc, "onStartup");
+        }
+    }
+}

--- a/dev/com.ibm.ws.microprofile.graphql.authorization/src/com/ibm/ws/microprofile/graphql/authorization/component/package-info.java
+++ b/dev/com.ibm.ws.microprofile.graphql.authorization/src/com/ibm/ws/microprofile/graphql/authorization/component/package-info.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+@TraceOptions(traceGroup = "GraphQL")
+package com.ibm.ws.microprofile.graphql.authorization.component;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;


### PR DESCRIPTION
Authorization checks for MP GraphQL.  Works similar to JAX-RS authorization where `@DenyAll`, `@PermitAll`, and `@RolesAllowed` annotations may be used on query/mutation methods (in classes annotated with `@GraphQLApi`).  This must be used in conjunction with the `appSecurity-2.0` or `appSecurity-3.0` feature, and requires configuration via the web container - usually with security constraints in the web.xml - see test case for example.