### PR TITLE
Issue #12102: Ignore Token error on server stop

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.async_fat/fat/src/com/ibm/ws/ejbcontainer/async/fat/tests/AsyncSecureTests.java
+++ b/dev/com.ibm.ws.ejbcontainer.async_fat/fat/src/com/ibm/ws/ejbcontainer/async/fat/tests/AsyncSecureTests.java
@@ -51,14 +51,6 @@ public class AsyncSecureTests extends AbstractTest {
     public static void beforeClass() throws Exception {
         // Use ShrinkHelper to build the Ears & Wars
 
-        //#################### InitTxRecoveryLogApp.ear (Automatically initializes transaction recovery logs)
-        JavaArchive InitTxRecoveryLogEJBJar = ShrinkHelper.buildJavaArchive("InitTxRecoveryLogEJB.jar", "com.ibm.ws.ejbcontainer.init.recovery.ejb.");
-
-        EnterpriseArchive InitTxRecoveryLogApp = ShrinkWrap.create(EnterpriseArchive.class, "InitTxRecoveryLogApp.ear");
-        InitTxRecoveryLogApp.addAsModule(InitTxRecoveryLogEJBJar);
-
-        ShrinkHelper.exportDropinAppToServer(server, InitTxRecoveryLogApp);
-
         //#################### AsyncSecureTestApp.ear
         JavaArchive AsyncSecureTestEJB = ShrinkHelper.buildJavaArchive("AsyncSecureTestEJB.jar", "com.ibm.ws.ejbcontainer.async.fat.secure.ejb.");
         WebArchive AsyncSecureTestWeb = ShrinkHelper.buildDefaultApp("AsyncSecureTestWeb.war", "com.ibm.ws.ejbcontainer.async.fat.secure.web.");
@@ -75,6 +67,16 @@ public class AsyncSecureTests extends AbstractTest {
         // verify the appSecurity-2.0 feature is ready
         assertNotNull("Security service did not report it was ready", server.waitForStringInLogUsingMark("CWWKS0008I"));
         assertNotNull("LTPA configuration did not report it was ready", server.waitForStringInLogUsingMark("CWWKS4105I"));
+
+        //#################### InitTxRecoveryLogApp.ear (Automatically initializes transaction recovery logs)
+        JavaArchive InitTxRecoveryLogEJBJar = ShrinkHelper.buildJavaArchive("InitTxRecoveryLogEJB.jar", "com.ibm.ws.ejbcontainer.init.recovery.ejb.");
+
+        EnterpriseArchive InitTxRecoveryLogApp = ShrinkWrap.create(EnterpriseArchive.class, "InitTxRecoveryLogApp.ear");
+        InitTxRecoveryLogApp.addAsModule(InitTxRecoveryLogEJBJar);
+
+        // Only after the server has started and appSecurity-2.0 feature is ready,
+        // then allow the @Startup InitTxRecoveryLog bean to start.
+        ShrinkHelper.exportDropinAppToServer(server, InitTxRecoveryLogApp);
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.ejbcontainer.remote.client_fat/fat/src/com/ibm/ws/ejbcontainer/remote/client/fat/tests/EjbLinkTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote.client_fat/fat/src/com/ibm/ws/ejbcontainer/remote/client/fat/tests/EjbLinkTest.java
@@ -53,14 +53,6 @@ public class EjbLinkTest extends FATServletClient {
     public static void beforeClass() throws Exception {
         // Use ShrinkHelper to build the Ears & Wars
 
-        //#################### InitTxRecoveryLogApp.ear (Automatically initializes transaction recovery logs)
-        JavaArchive InitTxRecoveryLogEJBJar = ShrinkHelper.buildJavaArchive("InitTxRecoveryLogEJB.jar", "com.ibm.ws.ejbcontainer.init.recovery.ejb.");
-
-        EnterpriseArchive InitTxRecoveryLogApp = ShrinkWrap.create(EnterpriseArchive.class, "InitTxRecoveryLogApp.ear");
-        InitTxRecoveryLogApp.addAsModule(InitTxRecoveryLogEJBJar);
-
-        ShrinkHelper.exportDropinAppToServer(server, InitTxRecoveryLogApp);
-
         //#################### StatefulAnnRemoteTest.ear
         JavaArchive EjbLinkBean = ShrinkHelper.buildJavaArchive("EjbLinkBean.jar", "com.ibm.ws.ejbcontainer.ejblink.ejb.");
         EjbLinkBean = (JavaArchive) ShrinkHelper.addDirectory(EjbLinkBean, "test-applications/EjbLinkBean.jar/resources");
@@ -92,6 +84,16 @@ public class EjbLinkTest extends FATServletClient {
         // verify the appSecurity-2.0 feature is ready
         assertNotNull("Security service did not report it was ready", server.waitForStringInLogUsingMark("CWWKS0008I"));
         assertNotNull("LTPA configuration did not report it was ready", server.waitForStringInLogUsingMark("CWWKS4105I"));
+
+        //#################### InitTxRecoveryLogApp.ear (Automatically initializes transaction recovery logs)
+        JavaArchive InitTxRecoveryLogEJBJar = ShrinkHelper.buildJavaArchive("InitTxRecoveryLogEJB.jar", "com.ibm.ws.ejbcontainer.init.recovery.ejb.");
+
+        EnterpriseArchive InitTxRecoveryLogApp = ShrinkWrap.create(EnterpriseArchive.class, "InitTxRecoveryLogApp.ear");
+        InitTxRecoveryLogApp.addAsModule(InitTxRecoveryLogEJBJar);
+
+        // Only after the server has started and appSecurity-2.0 feature is ready,
+        // then allow the @Startup InitTxRecoveryLog bean to start.
+        ShrinkHelper.exportDropinAppToServer(server, InitTxRecoveryLogApp);
 
         client.addIgnoreErrors("CWWKC0105W");
         client.startClient();


### PR DESCRIPTION
Despite the test waiting for messages indicating security has started,
occasionally it hasn't fully started and this results in the error:

CWWKS4000E - The requested TokenService instance of type Ltpa2 could not be found.

This does not effect the successful completion of the test and may be ignored.

fixes #12102 