### PR TITLE
Fix failing FAT #11945

### DIFF
--- a/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/CommonTasks.java
+++ b/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/CommonTasks.java
@@ -27,7 +27,9 @@ package com.ibm.ws.logging.hpel.fat;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.util.Properties;
 import java.util.Set;
@@ -379,7 +381,9 @@ public class CommonTasks {
             return false;
         }
         Properties bootstrapProps = new Properties();
-        bootstrapProps.load(bootstrapFile.openForReading());
+        InputStream is = bootstrapFile.openForReading();
+        bootstrapProps.load(is);
+        is.close();
         String logProvider = bootstrapProps.getProperty("websphere.log.provider");
         return logProvider != null && logProvider.startsWith("binaryLogging-");
 //        if (getUnifiedLoggingService(aServer) == null) {
@@ -902,7 +906,9 @@ public class CommonTasks {
         RemoteFile bootstrapFile = server.getServerBootstrapPropertiesFile();
         Properties bootstrapProps = new Properties();
         bootstrapProps.setProperty(propertyName, propertyValue);
-        bootstrapProps.store(bootstrapFile.openForWriting(true), null);
+        OutputStream os = bootstrapFile.openForWriting(true);
+        bootstrapProps.store(os, null);
+        os.close();
 
     }
 

--- a/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/HpelPurgeMaxSizeIgnoreTest_2.java
+++ b/dev/com.ibm.ws.logging.hpel_fat/fat/src/com/ibm/ws/logging/hpel/fat/HpelPurgeMaxSizeIgnoreTest_2.java
@@ -95,8 +95,7 @@ public class HpelPurgeMaxSizeIgnoreTest_2 {
         NumberFormat nf = NumberFormat.getInstance();
 
         CommonTasks.addBootstrapProperty(server, "com.ibm.hpel.trace.purgeMaxSize", "91");
-        //restart?
-//        server.restartServer();
+
         if (!server.isStarted()) {
             server.startServer();
         }
@@ -244,7 +243,6 @@ public class HpelPurgeMaxSizeIgnoreTest_2 {
         RemoteFile[] allBinaryLogFiles = dirToCheck.list(true);
         for (RemoteFile i : allBinaryLogFiles) {
             totalBinaryLogRepositorySize += i.length();
-//            }
         }
         return totalBinaryLogRepositorySize;
     }


### PR DESCRIPTION
Bootstrap.properties file cannot be deleted on Windows builds.
Fixes #11945 