### PR TITLE
Upgrade to bnd 5.0.1

### DIFF
--- a/dev/gradle.properties
+++ b/dev/gradle.properties
@@ -13,7 +13,7 @@ bnd_cnf=cnf
 
 # bnd_plugin is the dependency declaration for the bnd gradle plugin
 #bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:+
-bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:4.3.1
+bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:5.0.1
 
 # The URL to the bnd build repo.
 bnd_repourl=https://repo1.maven.org/maven2


### PR DESCRIPTION
Brief description of the types of differences:
- Private-Package entry in MANIFEST.MF differs because packages are ordered differently.
For example, before:
```
Private-Package: com.ibm.json;version="1.0.0",com.ibm.json.java;versio
 n="1.0.0",com.ibm.json.java.internal,com.ibm.json.xml;version="1.0.0"
 ,com.ibm.json.xml.internal,com.ibm.websphere.jmx.connector.rest;versi
 on="1.4",com.ibm.ws.jmx.connector.client.rest;version="1.4.0",com.ibm
 .ws.jmx.connector.client.rest.internal;version="1.0",com.ibm.ws.jmx.c
 onnector.client.rest.internal.resources,com.ibm.ws.jmx.connector.conv
 erter;version="1.0",com.ibm.ws.jmx.connector.datatypes;version="1.0"
```
After:
```
Private-Package: com.ibm.json.xml;version="1.0.0",com.ibm.json.java;ve
 rsion="1.0.0",com.ibm.json.xml.internal,com.ibm.json;version="1.0.0",
 com.ibm.json.java.internal,com.ibm.websphere.jmx.connector.rest;versi
 on="1.4",com.ibm.ws.jmx.connector.client.rest.internal;version="1.0",
 com.ibm.ws.jmx.connector.client.rest;version="1.4.0",com.ibm.ws.jmx.c
 onnector.client.rest.internal.resources,com.ibm.ws.jmx.connector.conv
 erter;version="1.0",com.ibm.ws.jmx.connector.datatypes;version="1.0"
```

- Service Component XMLs differ because properties are ordered differently.
For example, before:
```
  <property name="service.ranking" type="Integer" value="20"/>
  <property name="persistenceType" type="String" value="JPA"/>
```
After:
```
  <property name="persistenceType" type="String" value="JPA"/>
  <property name="service.ranking" type="Integer" value="20"/>
```