### PR TITLE
Issues #11673, #11247, #11245: Add retry until logic in AcmeClient or…

### DIFF
--- a/dev/com.ibm.ws.security.acme/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.acme/resources/OSGI-INF/l10n/metatype.properties
@@ -28,17 +28,11 @@ validFor.desc=The duration of time that the certificate signing request specifie
 subjectDN=Subject distinguished name
 subjectDN.desc=Subject distinguished name (DN) to use for the certificate. The DN can include the following relative distinguished name (RDN) types: cn, c, st, l, o and ou. If the cn RDN type is defined, it must be one of the domains defined by the domain configuration element and it must be the first RDN in the DN. If the cn RDN type is not defined, the first domain defined by the domain configuration element is used as the cn RDN value.
 
-challengeRetries=Challenge retries
-challengeRetries.desc=The number of times to retry updating the challenge status before aborting the challenge.
+challengePollTimeout=Challenge poll timeout
+challengePollTimeout.desc=The amount of time to spend polling the status of an ACME challenge before polling discontinues and treats the challenge as failed. A value of 0 indicates to poll indefinitely.
 
-challengeRetryWait=Challenge retry wait
-challengeRetryWait.desc=The amount of time to wait before retrying to refresh the status of a challenge.
-
-orderRetries=Order retries
-orderRetries.desc=The number of times to retry updating the order status before aborting the order.
-
-orderRetryWait=Order retry wait
-orderRetryWait.desc=The amount of time to wait before retrying to refresh the status of an order.
+orderPollTimeout=Order poll timeout
+orderPollTimeout.desc=The amount of time to spend polling the status of an ACME order before polling discontinues and treats the order as failed. A value of 0 indicates to poll indefinitely.
 
 accountContact=Account contact
 accountContact.desc=A contact URL the ACME server can use to contact the client for issues related this the ACME account.

--- a/dev/com.ibm.ws.security.acme/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.acme/resources/OSGI-INF/metatype/metatype.xml
@@ -29,10 +29,8 @@
    <AD id="subjectDN"             name="internal" description="internal use only" type="String"  required="false" />
   
    <!-- Challenge and order related fields. -->
-   <AD id="challengeRetries"      name="internal" description="internal use only" type="Integer" required="false" default="10" />
-   <AD id="challengeRetryWait"    name="internal" description="internal use only" type="String"  required="false" ibm:type="duration" default="5s" />
-   <AD id="orderRetries"          name="internal" description="internal use only" type="Integer" required="false" default="10" />
-   <AD id="orderRetryWait"        name="internal" description="internal use only" type="String"  required="false" ibm:type="duration" default="3s" />
+   <AD id="challengePollTimeout"  name="%challengePollTimeout" description="%challengePollTimeout.desc" type="String"  required="false" ibm:type="duration" default="120s" />
+   <AD id="orderPollTimeout"      name="%orderPollTimeout"     description="%orderPollTimeout.desc"     type="String"  required="false" ibm:type="duration" default="120s" />
 
    <!-- ACME account related fields. -->
    <AD id="accountKeyFile"        name="internal" description="internal use only" type="String"  required="false" default="${server.output.dir}/resources/security/acmeAccountKey.pem" />

--- a/dev/com.ibm.ws.security.acme/resources/com/ibm/ws/security/acme/resources/AcmeMessages.nlsprops
+++ b/dev/com.ibm.ws.security.acme/resources/com/ibm/ws/security/acme/resources/AcmeMessages.nlsprops
@@ -285,3 +285,11 @@ CWPKI2061E.useraction=Ensure that the certificate is a valid X.509 certificate. 
 CWPKI2062E=CWPKI2062E: The {0} OCSP responder URL defined in the server configuration is not a valid URI. If defined, it must be a valid URI to override the OSCP responder URL contained in the certificate.
 CWPKI2062E.explanation=Certificate revocation checking requires a valid OCSP responder URL.
 CWPKI2062E.useraction=Provide a valid OCSP responder URL in the server configuration.
+
+CWPKI2063E=CWPKI2063E: The ACME certificate authority at the {0} URI updated its terms of service and now requires the user to agree to the new terms of service at the following URI before it processes any further requests: {1}
+CWPKI2063E.explanation=The certificate authority updated its terms of service and requires user interaction.
+CWPKI2063E.useraction=Review the provided terms of service.
+
+CWPKI2064I=CWPKI2064I: The ACME service retrieved the certificate with the {0} serial number from the {1} URI in {2} seconds.
+CWPKI2064I.explanation=The ACME service successfully requested a certificate.
+CWPKI2064I.useraction=No action is required.

--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeClient.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeClient.java
@@ -44,6 +44,7 @@ import javax.naming.ldap.Rdn;
 import org.shredzone.acme4j.Account;
 import org.shredzone.acme4j.Account.EditableAccount;
 import org.shredzone.acme4j.AccountBuilder;
+import org.shredzone.acme4j.AcmeResource;
 import org.shredzone.acme4j.Authorization;
 import org.shredzone.acme4j.Certificate;
 import org.shredzone.acme4j.Login;
@@ -58,6 +59,7 @@ import org.shredzone.acme4j.exception.AcmeException;
 import org.shredzone.acme4j.exception.AcmeProtocolException;
 import org.shredzone.acme4j.exception.AcmeRetryAfterException;
 import org.shredzone.acme4j.exception.AcmeServerException;
+import org.shredzone.acme4j.exception.AcmeUserActionRequiredException;
 import org.shredzone.acme4j.util.CSRBuilder;
 import org.shredzone.acme4j.util.KeyPairUtils;
 
@@ -101,6 +103,11 @@ public class AcmeClient {
 	 * to be regenerated.
 	 */
 	private final static ReadWriteLock accountKeyPairFileRWLock = new ReentrantReadWriteLock();
+
+	/**
+	 * The time to sleep between polls for the challenge and order status.
+	 */
+	private final long POLL_SLEEP = 500;
 
 	/**
 	 * Create a new {@link AcmeClient} instance.
@@ -153,51 +160,97 @@ public class AcmeClient {
 			try {
 				challenge.trigger();
 			} catch (AcmeException e) {
-				throw new AcmeCaException(
-						Tr.formatMessage(tc, "CWPKI2009E", acmeConfig.getDirectoryURI(), e.getMessage()), e);
+				throw handleAcmeException(e,
+						Tr.formatMessage(tc, "CWPKI2009E", acmeConfig.getDirectoryURI(), e.getMessage()));
 			}
 
 			/*
 			 * Poll for the challenge to complete.
+			 * 
+			 * Determine how long to poll. If the poll timeout is <= 0, then we
+			 * will pull indefinitely.
 			 */
-			int attempts = acmeConfig.getChallengeRetries() + 1;
-			while (challenge.getStatus() != Status.VALID && attempts-- > 0) {
-				// Did the authorization fail?
-				if (challenge.getStatus() == Status.INVALID) {
-					String msg = Tr.formatMessage(tc, "CWPKI2001E", acmeConfig.getDirectoryURI(),
-							authorization.getIdentifier().getDomain(), challenge.getStatus().toString(),
-							challenge.getError().toString());
-					throw new AcmeCaException(msg);
+			Long pollTimeoutMs = acmeConfig.getChallengePollTimeoutMs();
+			long pollUntil = (pollTimeoutMs <= 0) ? 0 : System.currentTimeMillis() + pollTimeoutMs;
+			boolean retryAfterRequested = false;
+			while (retryAfterRequested || pollUntil == 0 || pollUntil >= System.currentTimeMillis()) {
+				if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+					Tr.debug(tc, "Challenge status poll loop: " + challenge.getStatus() + ", " + retryAfterRequested
+							+ ", " + pollUntil + ", " + System.currentTimeMillis());
+				}
+
+				/*
+				 * Do we have a concrete status - valid or invalid? If so, quit
+				 * polling.
+				 */
+				if (challenge.getStatus() == Status.INVALID || challenge.getStatus() == Status.VALID) {
+					break;
 				}
 
 				/*
 				 * Wait to update the status.
+				 * 
+				 * Don't sleep if we waited to retry at the ACME servers
+				 * request, as we already slept.
 				 */
-				sleep(acmeConfig.getChallengeRetryWaitMs());
+				if (!retryAfterRequested) {
+					sleep(POLL_SLEEP, pollUntil);
+				}
 
 				/*
-				 * Then update the status
+				 * Get updated status from the ACME server.
 				 */
 				try {
+					if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+						Tr.debug(tc, "Challenge status poll loop: updating challenge status.");
+					}
+					retryAfterRequested = false;
 					challenge.update();
 				} catch (AcmeRetryAfterException e) {
-					// TODO Wait until the moment defined in the returned
-					// Instant.
-					// Instant when = e.getRetryAfter();
+					if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+						Tr.debug(tc, "Challenge status poll loop: server requested us to retry again later at "
+								+ e.getRetryAfter());
+					}
+
+					/*
+					 * ACME server is asking us to wait until the specified time
+					 * to poll again.
+					 */
+					long current = System.currentTimeMillis();
+					if (pollUntil != 0 && current >= pollUntil) {
+						/*
+						 * We have run out of time.
+						 */
+						break;
+					}
+
+					/*
+					 * Wait until either when the server has 1) requested OR 2)
+					 * until our poll timeout would occur. In the case of 2), we
+					 * will poll one last time even if it is before the retry
+					 * after time just to do a best effort / optimistic check.
+					 */
+					retryAfterRequested = true;
+					sleep(e.getRetryAfter().toEpochMilli() - current, pollUntil);
 				} catch (AcmeException e) {
-					throw new AcmeCaException(
-							Tr.formatMessage(tc, "CWPKI2010E", acmeConfig.getDirectoryURI(), e.getMessage()), e);
+					throw handleAcmeException(e,
+							Tr.formatMessage(tc, "CWPKI2010E", acmeConfig.getDirectoryURI(), e.getMessage()));
 				}
 			}
 
 			/*
-			 * All re-attempts are used up and there is still no valid
-			 * authorization?
+			 * Check whether we failed the challenge (invalid) or whether we
+			 * timed out polling for the status of the challenge.
 			 */
-			if (challenge.getStatus() != Status.VALID) {
+			if (challenge.getStatus() == Status.INVALID) {
+				String msg = Tr.formatMessage(tc, "CWPKI2001E", acmeConfig.getDirectoryURI(),
+						authorization.getIdentifier().getDomain(), challenge.getStatus().toString(),
+						challenge.getError().toString());
+				throw new AcmeCaException(msg);
+			} else if (challenge.getStatus() != Status.VALID) {
 				String msg = Tr.formatMessage(tc, "CWPKI2002E", acmeConfig.getDirectoryURI(),
 						authorization.getIdentifier().getDomain(), challenge.getStatus().toString(),
-						(acmeConfig.getChallengeRetries() * acmeConfig.getChallengeRetryWaitMs()) + "ms");
+						pollTimeoutMs + "ms");
 				throw new AcmeCaException(msg);
 			}
 
@@ -226,6 +279,8 @@ public class AcmeClient {
 	 */
 	@FFDCIgnore({ IOException.class, AcmeException.class, AcmeRetryAfterException.class })
 	public AcmeCertificate fetchCertificate(boolean dryRun) throws AcmeCaException {
+
+		long beginTimeMs = System.currentTimeMillis();
 
 		/*
 		 * Load the account key file. If there is no key file, create a new one.
@@ -266,8 +321,8 @@ public class AcmeClient {
 		try {
 			order = orderBuilder.create();
 		} catch (AcmeException e) {
-			throw new AcmeCaException(Tr.formatMessage(tc, "CWPKI2011E", acmeConfig.getDirectoryURI(), e.getMessage()),
-					e);
+			throw handleAcmeException(e,
+					Tr.formatMessage(tc, "CWPKI2011E", acmeConfig.getDirectoryURI(), e.getMessage()));
 		}
 
 		/*
@@ -324,53 +379,98 @@ public class AcmeClient {
 		try {
 			order.execute(csrb.getEncoded());
 		} catch (AcmeException e) {
-			throw new AcmeCaException(Tr.formatMessage(tc, "CWPKI2013E", acmeConfig.getDirectoryURI(), e.getMessage()),
-					e);
+			throw handleAcmeException(e,
+					Tr.formatMessage(tc, "CWPKI2013E", acmeConfig.getDirectoryURI(), e.getMessage()));
 		} catch (IOException e) {
 			throw new AcmeCaException(Tr.formatMessage(tc, "CWPKI2014E", acmeConfig.getDirectoryURI(), e.getMessage()),
 					e);
 		}
 
 		/*
-		 * Wait for the order to complete
+		 * Poll for the order to complete.
+		 * 
+		 * Determine how long to poll. If the poll timeout is <= 0, then we will
+		 * pull indefinitely.
 		 */
-		int attempts = acmeConfig.getOrderRetries() + 1;
-		while (order.getStatus() != Status.VALID && attempts-- > 0) {
+		Long pollTimeoutMs = acmeConfig.getOrderPollTimeoutMs();
+		long pollUntil = (pollTimeoutMs <= 0) ? 0 : System.currentTimeMillis() + pollTimeoutMs;
+		boolean retryAfterRequested = false;
+		while (retryAfterRequested || pollUntil == 0 || pollUntil >= System.currentTimeMillis()) {
+			if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+				Tr.debug(tc, "Order status poll loop: " + order.getStatus() + ", " + retryAfterRequested + ", "
+						+ pollUntil + ", " + System.currentTimeMillis());
+			}
+
 			/*
-			 * Did the order fail?
+			 * Do we have a concrete status - valid or invalid? If so, quit
+			 * polling.
 			 */
-			if (order.getStatus() == Status.INVALID) {
-				String msg = Tr.formatMessage(tc, "CWPKI2001E", acmeConfig.getDirectoryURI(), acmeConfig.getDomains(),
-						order.getStatus().toString(), order.getError().toString());
-				throw new AcmeCaException(msg);
+			if (order.getStatus() == Status.INVALID || order.getStatus() == Status.VALID) {
+				break;
 			}
 
 			/*
 			 * Wait to update the status.
+			 * 
+			 * Don't sleep if we waited to retry at the ACME servers request, as
+			 * we already slept.
 			 */
-			sleep(acmeConfig.getOrderRetryWaitMs());
+			if (!retryAfterRequested) {
+				sleep(POLL_SLEEP, pollUntil);
+			}
 
 			/*
-			 * Then update the status
+			 * Update the status.
 			 */
 			try {
+				if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+					Tr.debug(tc, "Order status poll loop: updating challenge status.");
+				}
+				retryAfterRequested = false;
 				order.update();
 			} catch (AcmeRetryAfterException e) {
-				// TODO Wait until the moment defined in the returned Instant.
-				// Instant when = e.getRetryAfter();
+				if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+					Tr.debug(tc,
+							"Order status poll loop: server requested us to retry again later at " + e.getRetryAfter());
+				}
+
+				/*
+				 * ACME server is asking us to wait until the specified time to
+				 * poll again.
+				 */
+				long current = System.currentTimeMillis();
+				if (pollUntil != 0 && current >= pollUntil) {
+					/*
+					 * We have run out of time.
+					 */
+					break;
+				}
+
+				/*
+				 * Wait until either when the server has 1) requested OR 2)
+				 * until our poll timeout would occur. In the case of 2), we
+				 * will poll one last time even if it is before the retry after
+				 * time just to do a best effort / optimistic check.
+				 */
+				retryAfterRequested = true;
+				sleep(e.getRetryAfter().toEpochMilli() - current, pollUntil);
 			} catch (AcmeException e) {
-				throw new AcmeCaException(
-						Tr.formatMessage(tc, "CWPKI2015E", acmeConfig.getDirectoryURI(), e.getMessage()), e);
+				throw handleAcmeException(e,
+						Tr.formatMessage(tc, "CWPKI2015E", acmeConfig.getDirectoryURI(), e.getMessage()));
 			}
 		}
 
 		/*
-		 * All re-attempts are used up and there is still no valid order?
+		 * Check whether we failed the challenge (invalid) or whether we timed
+		 * out polling for the status of the challenge.
 		 */
-		if (order.getStatus() != Status.VALID) {
+		if (order.getStatus() == Status.INVALID) {
+			String msg = Tr.formatMessage(tc, "CWPKI2001E", acmeConfig.getDirectoryURI(), acmeConfig.getDomains(),
+					order.getStatus().toString(), order.getError().toString());
+			throw new AcmeCaException(msg);
+		} else if (order.getStatus() != Status.VALID) {
 			String msg = Tr.formatMessage(tc, "CWPKI2004E", acmeConfig.getDirectoryURI(), acmeConfig.getDomains(),
-					order.getStatus().toString(),
-					(acmeConfig.getOrderRetries() * acmeConfig.getOrderRetryWaitMs()) + "ms");
+					order.getStatus().toString(), pollTimeoutMs + "ms");
 			throw new AcmeCaException(msg);
 		}
 
@@ -393,6 +493,12 @@ public class AcmeClient {
 		checkRenewTimeAgainstCertValidityPeriod(certificate.getCertificate().getNotBefore(),
 				certificate.getCertificate().getNotAfter(),
 				certificate.getCertificate().getSerialNumber().toString(16));
+
+		if (TraceComponent.isAnyTracingEnabled() && tc.isAuditEnabled()) {
+			String msg = Tr.formatMessage(tc, "CWPKI2064I", x509Cert.getSerialNumber().toString(16),
+					acmeConfig.getDirectoryURI(), (System.currentTimeMillis() - beginTimeMs) / 1000.0);
+			Tr.audit(tc, msg);
+		}
 
 		return new AcmeCertificate(domainKeyPair, x509Cert, certificate.getCertificateChain());
 	}
@@ -502,8 +608,8 @@ public class AcmeClient {
 			try {
 				tosURI = session.getMetadata().getTermsOfService();
 			} catch (AcmeException e) {
-				throw new AcmeCaException(
-						Tr.formatMessage(tc, "CWPKI2017E", acmeConfig.getDirectoryURI(), e.getMessage()), e);
+				throw handleAcmeException(e,
+						Tr.formatMessage(tc, "CWPKI2017E", acmeConfig.getDirectoryURI(), e.getMessage()));
 			}
 
 			/*
@@ -538,8 +644,8 @@ public class AcmeClient {
 			try {
 				account = accountBuilder.create(session);
 			} catch (AcmeException e) {
-				throw new AcmeCaException(
-						Tr.formatMessage(tc, "CWPKI2018E", acmeConfig.getDirectoryURI(), e.getMessage()), e);
+				throw handleAcmeException(e,
+						Tr.formatMessage(tc, "CWPKI2018E", acmeConfig.getDirectoryURI(), e.getMessage()));
 			}
 		}
 
@@ -855,8 +961,8 @@ public class AcmeClient {
 				Certificate.revoke(login, certificate, revocationReason);
 				Tr.info(tc, Tr.formatMessage(tc, "CWPKI2038I", certificate.getSerialNumber().toString(16)));
 			} catch (AcmeException e) {
-				throw new AcmeCaException(Tr.formatMessage(tc, "CWPKI2024E", acmeConfig.getDirectoryURI(),
-						certificate.getSerialNumber().toString(16), e.getMessage()), e);
+				throw handleAcmeException(e, Tr.formatMessage(tc, "CWPKI2024E", acmeConfig.getDirectoryURI(),
+						certificate.getSerialNumber().toString(16), e.getMessage()));
 			}
 		} else {
 			throw new AcmeCaException(Tr.formatMessage(tc, "CWPKI2026W", acmeConfig.getDirectoryURI()));
@@ -864,15 +970,29 @@ public class AcmeClient {
 	}
 
 	/**
-	 * Call {@link Thread#sleep(long)} while handling interrupts.
+	 * Call {@link Thread#sleep(long)} while handling interrupts. This will
+	 * sleep <code>sleepMs</code> ms or until <code>orUntil</code>, whichever
+	 * occurs first.
 	 * 
 	 * @param sleepMs
 	 *            The number of milliseconds to sleep.
+	 * @param orUntil
+	 *            The time in ms since the epoch to sleep until. If 0, the
+	 *            method will sleep until <code>sleepMs</code> from now.
 	 */
 	@FFDCIgnore(InterruptedException.class)
-	private static void sleep(long sleepMs) {
+	private static void sleep(long sleepMs, long orUntil) {
 
-		long current, terminate = System.currentTimeMillis() + sleepMs;
+		long current = System.currentTimeMillis();
+
+		long terminate;
+		if (orUntil != 0) {
+			terminate = Math.min(current + sleepMs, orUntil);
+		} else {
+			terminate = current + sleepMs;
+		}
+
+		Tr.debug(tc, "sleep: " + terminate);
 		while ((current = System.currentTimeMillis()) < terminate) {
 			try {
 				Thread.sleep(terminate - current);
@@ -1036,7 +1156,8 @@ public class AcmeClient {
 						 */
 						Tr.error(tc, "CWPKI2049E", acmeConfig.getAccountKeyFile(), backupFile.getAbsolutePath());
 					}
-					throw new AcmeCaException(Tr.formatMessage(tc, "CWPKI2047E", e.getMessage()), e);
+
+					throw handleAcmeException(e, Tr.formatMessage(tc, "CWPKI2047E", e.getMessage()));
 				}
 
 				Tr.info(tc, Tr.formatMessage(tc, "CWPKI2048I", backupFile.getAbsolutePath()));
@@ -1168,8 +1289,8 @@ public class AcmeClient {
 
 					editableAcct.commit();
 				} catch (AcmeException e) {
-					throw new AcmeCaException(Tr.formatMessage(tc, "CWPKI2033E", acct.getLocation(),
-							acmeConfig.getDirectoryURI(), e.getMessage()), e);
+					throw handleAcmeException(e, Tr.formatMessage(tc, "CWPKI2033E", acct.getLocation(),
+							acmeConfig.getDirectoryURI(), e.getMessage()));
 				}
 			}
 		} else {
@@ -1262,10 +1383,10 @@ public class AcmeClient {
 			return super.toString() + "{" + account.getLocation() + "}";
 		}
 	}
-	
+
 	/**
-	 * Check that the valid period of the certificate works with the configured renewBeforeExpiration. Adjust the
-	 * renew timing if necessary.
+	 * Check that the valid period of the certificate works with the configured
+	 * renewBeforeExpiration. Adjust the renew timing if necessary.
 	 * 
 	 * @param notBefore
 	 * @param notAfter
@@ -1276,29 +1397,72 @@ public class AcmeClient {
 		long notAfterms = notAfter.getTime();
 
 		long validityPeriod = notAfterms - notBeforems;
-		
+
 		long renewBeforeExpirationMs = acmeConfig.getRenewBeforeExpirationMs();
 		if (tc.isDebugEnabled()) {
-			Tr.debug(tc, "Validity versus renew check", notBeforems, notAfterms, validityPeriod, renewBeforeExpirationMs);
+			Tr.debug(tc, "Validity versus renew check", notBeforems, notAfterms, validityPeriod,
+					renewBeforeExpirationMs);
 		}
-		
+
 		/*
-		 * If the renewBeforeExpirationMs is longer than the validityPeriod, reset it so we can make a best effort at fetching a new
-		 * certificate prior to expiration.
+		 * If the renewBeforeExpirationMs is longer than the validityPeriod,
+		 * reset it so we can make a best effort at fetching a new certificate
+		 * prior to expiration.
 		 */
 		if (validityPeriod <= renewBeforeExpirationMs) {
-			if (validityPeriod <= AcmeConstants.RENEW_CERT_MIN) { // less than the minimum renew, reset to min.
-				Tr.warning(tc, "CWPKI2056W", serialNumber,  AcmeConstants.RENEW_CERT_MIN + "ms", validityPeriod, AcmeConstants.RENEW_CERT_MIN + "ms");
+			if (validityPeriod <= AcmeConstants.RENEW_CERT_MIN) {
+				/*
+				 * less than the minimum renew, reset to min.
+				 */
+				Tr.warning(tc, "CWPKI2056W", serialNumber, AcmeConstants.RENEW_CERT_MIN + "ms", validityPeriod,
+						AcmeConstants.RENEW_CERT_MIN + "ms");
 				acmeConfig.setRenewBeforeExpirationMs(AcmeConstants.RENEW_CERT_MIN, false);
-			} else if (validityPeriod <= AcmeConstants.RENEW_DEFAULT_MS) { // less than the default period, reset to half the time.
+			} else if (validityPeriod <= AcmeConstants.RENEW_DEFAULT_MS) {
+				/*
+				 * less than the default period, reset to half the time.
+				 */
 				long resetRenew = Math.round(validityPeriod * AcmeConstants.RENEW_DIVISOR);
 				long priorRenew = renewBeforeExpirationMs;
-				acmeConfig.setRenewBeforeExpirationMs(resetRenew <= AcmeConstants.RENEW_CERT_MIN ? AcmeConstants.RENEW_CERT_MIN : resetRenew, false); // floor is still the min renew
-				Tr.warning(tc, "CWPKI2054W", priorRenew  +"ms", serialNumber, validityPeriod, renewBeforeExpirationMs+ "ms");
-			} else { // reset to the default renew time.
-				Tr.warning(tc, "CWPKI2054W", renewBeforeExpirationMs +"ms", serialNumber, validityPeriod + "ms", AcmeConstants.RENEW_DEFAULT_MS + "ms");
+				/*
+				 * floor is still the min renew
+				 */
+				acmeConfig.setRenewBeforeExpirationMs(
+						resetRenew <= AcmeConstants.RENEW_CERT_MIN ? AcmeConstants.RENEW_CERT_MIN : resetRenew, false);
+				Tr.warning(tc, "CWPKI2054W", priorRenew + "ms", serialNumber, validityPeriod,
+						renewBeforeExpirationMs + "ms");
+			} else {
+				/*
+				 * reset to the default renew time.
+				 */
+				Tr.warning(tc, "CWPKI2054W", renewBeforeExpirationMs + "ms", serialNumber, validityPeriod + "ms",
+						AcmeConstants.RENEW_DEFAULT_MS + "ms");
 				acmeConfig.setRenewBeforeExpirationMs(AcmeConstants.RENEW_DEFAULT_MS, false);
 			}
 		}
+	}
+
+	/**
+	 * Wrap an {@link AcmeException} in a {@link AcmeCaException}. This should
+	 * be done for all {@link AcmeException} catch blocks.
+	 * 
+	 * @param acmeException
+	 *            The returned exception from acme4j.
+	 * @param message
+	 *            The message to put in the new {@link AcmeCaException}.
+	 * @return The new exception instance.
+	 */
+	@Trivial
+	private AcmeCaException handleAcmeException(AcmeException acmeException, String message) {
+		/*
+		 * Log an error if an AcmeUserActionRequiredException is thrown as it
+		 * will require the user to manually visit the URI and agree to the
+		 * terms of service.
+		 */
+		if (acmeException instanceof AcmeUserActionRequiredException) {
+			AcmeUserActionRequiredException uae = ((AcmeUserActionRequiredException) acmeException);
+			Tr.error(tc, "CWPKI2063E", acmeConfig.getDirectoryURI(), uae.getTermsOfServiceUri());
+		}
+
+		return new AcmeCaException(message, acmeException);
 	}
 }

--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeProviderImpl.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeProviderImpl.java
@@ -56,7 +56,6 @@ import com.ibm.ws.security.acme.AcmeCaException;
 import com.ibm.ws.security.acme.AcmeCertificate;
 import com.ibm.ws.security.acme.AcmeProvider;
 import com.ibm.ws.security.acme.internal.AcmeClient.AcmeAccount;
-import com.ibm.ws.security.acme.internal.util.AcmeConstants;
 import com.ibm.ws.ssl.JSSEProviderFactory;
 import com.ibm.ws.ssl.KeyStoreService;
 

--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/util/AcmeConstants.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/util/AcmeConstants.java
@@ -27,10 +27,8 @@ public class AcmeConstants {
 	public static final String SUBJECT_DN = "subjectDN";
 
 	// Challenge and order related fields.
-	public static final String CHALL_RETRIES = "challengeRetries";
-	public static final String CHALL_RETRY_WAIT = "challengeRetryWait";
-	public static final String ORDER_RETRIES = "orderRetries";
-	public static final String ORDER_RETRY_WAIT = "orderRetryWait";
+	public static final String CHALL_POLL_TIMEOUT = "challengePollTimeout";
+	public static final String ORDER_POLL_TIMEOUT = "orderPollTimeout";
 
 	// ACME account related fields.
 	public static final String ACCOUNT_KEY_FILE = "accountKeyFile";
@@ -75,5 +73,7 @@ public class AcmeConstants {
 	public static final int RENEW_DEFAULT_DAYS = 7;
 	public static final Long RENEW_DEFAULT_MS = TimeUnit.DAYS.toMillis(RENEW_DEFAULT_DAYS);  // 604800000L; 
 	public static final double RENEW_DIVISOR = .5;
+	public static final long CHALLENGE_POLL_DEFAULT = 120000l;
+	public static final long ORDER_POLL_DEFAULT = 120000l;
 
 }

--- a/dev/com.ibm.ws.security.acme/test/com/ibm/ws/security/acme/internal/AcmeConfigTest.java
+++ b/dev/com.ibm.ws.security.acme/test/com/ibm/ws/security/acme/internal/AcmeConfigTest.java
@@ -327,13 +327,11 @@ public class AcmeConfigTest {
 		Map<String, Object> properties = new HashMap<String, Object>();
 		properties.put(AcmeConstants.ACCOUNT_CONTACT, new String[] { "mailto://pacman@mail.com" });
 		properties.put(AcmeConstants.ACCOUNT_KEY_FILE, "account.key");
-		properties.put(AcmeConstants.CHALL_RETRIES, 1);
-		properties.put(AcmeConstants.CHALL_RETRY_WAIT, 2L);
+		properties.put(AcmeConstants.CHALL_POLL_TIMEOUT, 2L);
 		properties.put(AcmeConstants.DIR_URI, "https://localhost:443/dir");
 		properties.put(AcmeConstants.DOMAIN_KEY_FILE, "domain.key");
 		properties.put(AcmeConstants.DOMAIN, new String[] { "domain1.com", "domain2.com" });
-		properties.put(AcmeConstants.ORDER_RETRIES, 3);
-		properties.put(AcmeConstants.ORDER_RETRY_WAIT, 4L);
+		properties.put(AcmeConstants.ORDER_POLL_TIMEOUT, 4L);
 		properties.put(AcmeConstants.SUBJECT_DN, "cn=domain1.com,ou=liberty,o=ibm.com");
 		properties.put(AcmeConstants.TRANSPORT_CONFIG + ".0." + AcmeConstants.TRANSPORT_PROTOCOL, "SSL");
 		properties.put(AcmeConstants.TRANSPORT_CONFIG + ".0." + AcmeConstants.TRANSPORT_TRUST_STORE, "truststore.p12");
@@ -346,7 +344,8 @@ public class AcmeConfigTest {
 				"http://localhost:4001");
 		properties.put(AcmeConstants.REVOCATION_CHECKER + ".0." + AcmeConstants.REVOCATION_PREFER_CRLS, true);
 		properties.put(AcmeConstants.VALID_FOR, 5L);
-		properties.put(AcmeConstants.RENEW_BEFORE_EXPIRATION, 691200000L); // 8 days
+		properties.put(AcmeConstants.RENEW_BEFORE_EXPIRATION, 691200000L); // 8
+																			// days
 
 		/*
 		 * Instantiate the ACME configuration.
@@ -358,14 +357,12 @@ public class AcmeConfigTest {
 		 */
 		assertEquals("mailto://pacman@mail.com", acmeConfig.getAccountContacts().get(0));
 		assertEquals("account.key", acmeConfig.getAccountKeyFile());
-		assertEquals(1, acmeConfig.getChallengeRetries().intValue());
-		assertEquals(2L, acmeConfig.getChallengeRetryWaitMs().longValue());
+		assertEquals(2L, acmeConfig.getChallengePollTimeoutMs().longValue());
 		assertEquals("https://localhost:443/dir", acmeConfig.getDirectoryURI());
 		assertEquals("domain.key", acmeConfig.getDomainKeyFile());
 		assertEquals("domain1.com", acmeConfig.getDomains().get(0));
 		assertEquals("domain2.com", acmeConfig.getDomains().get(1));
-		assertEquals(3, acmeConfig.getOrderRetries().intValue());
-		assertEquals(4L, acmeConfig.getOrderRetryWaitMs().intValue());
+		assertEquals(4L, acmeConfig.getOrderPollTimeoutMs().intValue());
 
 		SSLConfig sslConfig = acmeConfig.getSSLConfig();
 		assertEquals("SSL", sslConfig.getProperty(Constants.SSLPROP_PROTOCOL));
@@ -377,7 +374,7 @@ public class AcmeConfigTest {
 		assertEquals("ou=liberty", acmeConfig.getSubjectDN().get(1).toString());
 		assertEquals("o=ibm.com", acmeConfig.getSubjectDN().get(2).toString());
 		assertEquals(5L, acmeConfig.getValidForMs().longValue());
-		
+
 		assertEquals(691200000L, acmeConfig.getRenewBeforeExpirationMs().longValue());
 		assertTrue("Auto-renewal should be enabled", acmeConfig.isAutoRenewOnExpiration());
 
@@ -386,7 +383,7 @@ public class AcmeConfigTest {
 		assertEquals(URI.create("http://localhost:4001"), acmeConfig.getOcspResponderUrl());
 		assertTrue(acmeConfig.isPreferCrls());
 	}
-	
+
 	@Test
 	public void constructor_validConfig_disableRenew() throws Exception {
 
@@ -394,7 +391,6 @@ public class AcmeConfigTest {
 		 * Create a properties map.
 		 */
 		Map<String, Object> properties = getBasicConfig();
-
 		properties.put(AcmeConstants.RENEW_BEFORE_EXPIRATION, -1L);
 
 		/*
@@ -405,7 +401,7 @@ public class AcmeConfigTest {
 		/*
 		 * Verify values. A negative or zero renew disables auto-renew
 		 */
-		
+
 		assertEquals(0L, acmeConfig.getRenewBeforeExpirationMs().longValue());
 		assertFalse("Auto-renewal should be disabled", acmeConfig.isAutoRenewOnExpiration());
 	}
@@ -418,13 +414,11 @@ public class AcmeConfigTest {
 		 */
 		Map<String, Object> properties = new HashMap<String, Object>();
 		properties.put(AcmeConstants.ACCOUNT_KEY_FILE, "account.key");
-		properties.put(AcmeConstants.CHALL_RETRIES, -1);
-		properties.put(AcmeConstants.CHALL_RETRY_WAIT, -2L);
+		properties.put(AcmeConstants.CHALL_POLL_TIMEOUT, -2L);
 		properties.put(AcmeConstants.DIR_URI, "https://localhost:443/dir");
 		properties.put(AcmeConstants.DOMAIN_KEY_FILE, "domain.key");
 		properties.put(AcmeConstants.DOMAIN, new String[] { "domain1.com", "domain2.com" });
-		properties.put(AcmeConstants.ORDER_RETRIES, -3);
-		properties.put(AcmeConstants.ORDER_RETRY_WAIT, -4L);
+		properties.put(AcmeConstants.ORDER_POLL_TIMEOUT, -4L);
 		properties.put(AcmeConstants.VALID_FOR, -5L);
 		properties.put(AcmeConstants.RENEW_BEFORE_EXPIRATION, AcmeConstants.RENEW_CERT_MIN - 10);
 
@@ -436,15 +430,13 @@ public class AcmeConfigTest {
 		/*
 		 * Verify values.
 		 */
-		assertEquals(10, acmeConfig.getChallengeRetries().intValue());
-		assertEquals(5000L, acmeConfig.getChallengeRetryWaitMs().longValue());
-		assertEquals(10, acmeConfig.getOrderRetries().intValue());
-		assertEquals(3000L, acmeConfig.getOrderRetryWaitMs().intValue());
+		assertEquals(0L, acmeConfig.getChallengePollTimeoutMs().longValue());
+		assertEquals(0L, acmeConfig.getOrderPollTimeoutMs().intValue());
 		assertEquals(null, acmeConfig.getValidForMs());
 		assertEquals(AcmeConstants.RENEW_CERT_MIN, acmeConfig.getRenewBeforeExpirationMs().longValue());
 		assertTrue("Auto-renewal should be enabled", acmeConfig.isAutoRenewOnExpiration());
 	}
-	
+
 	private Map<String, Object> getBasicConfig() {
 		Map<String, Object> properties = new HashMap<String, Object>();
 		properties.put(AcmeConstants.ACCOUNT_KEY_FILE, "account.key");

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
@@ -397,6 +397,7 @@ public class AcmeFatUtils {
 	 *            The server to check.
 	 */
 	public static final void waitForAcmeToCreateCertificate(LibertyServer server) {
+		assertNotNull("ACME did not fetch the certificate.", server.waitForStringInLog("CWPKI2064I"));
 		assertNotNull("ACME did not create the certificate.", server.waitForStringInLog("CWPKI2007I"));
 	}
 


### PR DESCRIPTION
…der and challenge processing. Add message to denote how long it took to retrieve the certificate from the ACME server. Add message when terms of service requires manual intervention.

fixes #11673
fixes #11247
fixes #11245 