### PR TITLE
11207 - fix cdi constructor injection in Jaxrs resource methods

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/Basic12Test.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/fat/src/com/ibm/ws/jaxrs20/cdi12/fat/test/Basic12Test.java
@@ -228,5 +228,10 @@ public class Basic12Test extends AbstractTest {
         assertTrue(result.indexOf(str) == result.lastIndexOf(str));
     }
 
-
+    @Test
+    public void testCdiConstructorInjectionInResource() throws IOException {
+        String result = runGetMethod("/rest/cdiresource/get", 200, "", false).toString();
+        System.out.println("testCdiConstructorInjectionInResource Result: " + result);
+        assertTrue(result.contains("Hello World!"));
+    } 
 }

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/basic/src/com/ibm/ws/jaxrs20/cdi12/fat/basic/CdiConstructorInjectionResource.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/basic/src/com/ibm/ws/jaxrs20/cdi12/fat/basic/CdiConstructorInjectionResource.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs20.cdi12.fat.basic;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+
+@Path("cdiresource")
+public class CdiConstructorInjectionResource {
+
+    private InjectedClass injectedClass;
+    
+    public CdiConstructorInjectionResource() {}
+    
+    @Inject
+    public CdiConstructorInjectionResource(InjectedClass injectedClass) {
+        this.injectedClass = injectedClass;
+    }
+    
+    @GET
+    @Path("get")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response get() {
+        System.out.println(injectedClass.message());
+        return Response.ok().entity(injectedClass.message()).build();
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/basic/src/com/ibm/ws/jaxrs20/cdi12/fat/basic/HelloWorldApplication.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/basic/src/com/ibm/ws/jaxrs20/cdi12/fat/basic/HelloWorldApplication.java
@@ -48,6 +48,7 @@ public class HelloWorldApplication extends Application {
         classes.add(HelloWorldResourceForT2.class);
         classes.add(HelloWorldResourceForT3.class);
         classes.add(HelloWorldResource3Child.class);
+        classes.add(CdiConstructorInjectionResource.class);
         return classes;
     }
 

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/basic/src/com/ibm/ws/jaxrs20/cdi12/fat/basic/InjectedClass.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/test-applications/basic/src/com/ibm/ws/jaxrs20/cdi12/fat/basic/InjectedClass.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs20.cdi12.fat.basic;
+
+import javax.enterprise.context.Dependent;
+
+@Dependent
+public class InjectedClass {
+
+    public InjectedClass() {}
+    
+    public String message() {
+            return "Hello World!";
+    }
+}

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi/src/com/ibm/ws/jaxrs20/cdi/component/JaxRsFactoryImplicitBeanCDICustomizer.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi/src/com/ibm/ws/jaxrs20/cdi/component/JaxRsFactoryImplicitBeanCDICustomizer.java
@@ -250,7 +250,12 @@ public class JaxRsFactoryImplicitBeanCDICustomizer implements JaxRsFactoryBeanCu
         //end temp fix
         Map<Class<?>, ManagedObject<?>> newContext = (Map<Class<?>, ManagedObject<?>>) (context);
 
-        ManagedObject<T> newServiceObject = (ManagedObject<T>) getClassFromServiceObject(clazz, serviceObject);
+        ManagedObject<T> newServiceObject = null;
+        if (cdiService.isWeldProxy(clazz)) {
+            newServiceObject = (ManagedObject<T>) getClassFromServiceObject(clazz, serviceObject);
+        } else {
+            newServiceObject = (ManagedObject<T>) getClassFromManagedObject(clazz);
+        }
         if (newServiceObject != null) {
 
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {


### PR DESCRIPTION
Added an if statement to get the managed object the "old" way if the class is not a Weld proxy.