### PR TITLE
prepare JDBC 4.3 test bucket for Jakarta

### DIFF
--- a/dev/com.ibm.ws.jdbc.4.2/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc.4.2/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jdbc_fat_v43/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_v43/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -35,3 +35,5 @@ fat.project: true
 	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
 	com.ibm.tx.core;version=latest,\
 	org.apache.derby:derby;version=10.11.1.1
+
+tested.features: servlet-5.0

--- a/dev/com.ibm.ws.jdbc_fat_v43/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_v43/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,3 +10,4 @@
  *******************************************************************************/
 
 addRequiredLibraries.dependsOn addDerby
+addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/com.ibm.ws.jdbc_fat_v43/fat/src/com/ibm/ws/jdbc/fat/v43/JDBC43Test.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/fat/src/com/ibm/ws/jdbc/fat/v43/JDBC43Test.java
@@ -17,6 +17,7 @@ import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.test.d43.jdbc.D43Driver;
@@ -29,6 +30,8 @@ import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import jdbc.fat.v43.web.HandleListTestServlet;
@@ -37,6 +40,11 @@ import jdbc.fat.v43.web.JDBC43TestServlet;
 @RunWith(FATRunner.class)
 public class JDBC43Test extends FATServletClient {
     public static final String APP_NAME = "app43";
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests
+                    .withoutModification()
+                    ;// TODO .andWith(new JakartaEE9Action());
 
     @Server("com.ibm.ws.jdbc.fat.v43")
     @TestServlets({

--- a/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v43/publish/servers/com.ibm.ws.jdbc.fat.v43/server.xml
@@ -81,7 +81,7 @@
   <javaPermission codebase="${server.config.dir}/drivers/d43driver.jar" className="java.security.AllPermission"/>
   <javaPermission codebase="${server.config.dir}/apps/app43.war" className="java.sql.SQLPermission" name="callAbort"/>
   <javaPermission codebase="${server.config.dir}/apps/app43.war" className="java.lang.RuntimePermission" name="modifyThread"/>
- 
+  <javaPermission codebase="${server.config.dir}/apps/app43.war" className="java.util.PropertyPermission" name="java.util.concurrent.ForkJoinPool.*" actions="read"/>
 
   <variable name="onError" value="FAIL"/>
 </server>

--- a/dev/com.ibm.ws.jdbc_fat_v43/test-applications/app43/src/jdbc/fat/v43/web/JDBC43TestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/test-applications/app43/src/jdbc/fat/v43/web/JDBC43TestServlet.java
@@ -19,6 +19,8 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.security.AccessController;
+import java.security.PrivilegedExceptionAction;
 import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.ConnectionBuilder;
@@ -194,8 +196,9 @@ public class JDBC43TestServlet extends FATServlet {
      */
     public void testCompletionStageCachesUnsharedAutocommitConnectionAcrossServletBoundaryPart1() throws Exception {
         final Connection con = unsharablePool1DataSource.getConnection();
-        CompletableFuture<Statement> stage = CompletableFuture
-                        .completedFuture(con.createStatement())
+        CompletableFuture<Statement> creationStage = AccessController
+                        .doPrivileged((PrivilegedExceptionAction<CompletableFuture<Statement>>) () -> CompletableFuture.completedFuture(con.createStatement()));
+        CompletableFuture<Statement> stage = creationStage
                         .thenApply(s -> {
                             try {
                                 s.executeUpdate("INSERT INTO STREETS VALUES ('Meadow Crossing Road SW', 'Rochester', 'MN')");
@@ -264,8 +267,9 @@ public class JDBC43TestServlet extends FATServlet {
     public void testCompletionStageCachesUnsharedManualCommitConnectionAcrossServletBoundaryPart1() throws Exception {
         final Connection con = unsharablePool1DataSource.getConnection();
         con.setAutoCommit(false);
-        CompletableFuture<Statement> stage = CompletableFuture
-                        .completedFuture(con.createStatement())
+        CompletableFuture<Statement> creationStage = AccessController
+                        .doPrivileged((PrivilegedExceptionAction<CompletableFuture<Statement>>) () -> CompletableFuture.completedFuture(con.createStatement()));
+        CompletableFuture<Statement> stage = creationStage
                         .thenApply(s -> {
                             try {
                                 s.executeUpdate("INSERT INTO STREETS VALUES ('Century Valley Road NE', 'Rochester', 'MN')");


### PR DESCRIPTION
Prepare the JDBC 4.3 test bucket to run with Jakarta, but don't enable it for this yet. Enablement is blocked by work that is being done to force the proper transaction feature to be used in combination with Jakarta features.