### PR TITLE
11772 Set EE platform dependencies for transaction features

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-1.1.feature
@@ -21,7 +21,8 @@ IBM-API-Service: com.ibm.wsspi.uow.UOWManager, \
  com.ibm.websphere.appserver.artifact-1.0, \
  com.ibm.websphere.appserver.javaeedd-1.0, \
  com.ibm.websphere.appserver.containerServices-1.0, \
- com.ibm.websphere.appserver.anno-1.0
+ com.ibm.websphere.appserver.anno-1.0, \
+ com.ibm.websphere.appserver.javaeeCompatible-7.0; ibm.tolerates:="6.0,8.0"
 -bundles=com.ibm.ws.tx.jta.extensions, \
  com.ibm.ws.transaction; start-phase:=CONTAINER_LATE, \
  com.ibm.tx.jta, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-1.2.feature
@@ -23,7 +23,8 @@ IBM-API-Service: com.ibm.wsspi.uow.UOWManager, \
  com.ibm.websphere.appserver.javaeedd-1.0, \
  com.ibm.websphere.appserver.containerServices-1.0, \
  com.ibm.websphere.appserver.javax.annotation-1.2; ibm.tolerates:=1.3; apiJar=false, \
- com.ibm.websphere.appserver.anno-1.0
+ com.ibm.websphere.appserver.anno-1.0, \
+ com.ibm.websphere.appserver.javaeeCompatible-8.0; ibm.tolerates:="6.0,7.0"
 -bundles=com.ibm.ws.tx.jta.extensions, \
  com.ibm.ws.transaction; start-phase:=CONTAINER_LATE, \
  com.ibm.tx.jta, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-2.0.feature
@@ -23,7 +23,8 @@ IBM-API-Service: com.ibm.wsspi.uow.UOWManager, \
  com.ibm.websphere.appserver.javaeedd-1.0, \
  com.ibm.websphere.appserver.containerServices-1.0, \
  com.ibm.websphere.appserver.jakarta.annotation-2.0; apiJar=false, \
- com.ibm.websphere.appserver.anno-2.0
+ com.ibm.websphere.appserver.anno-2.0, \
+ com.ibm.websphere.appserver.eeCompatible-9.0
 -bundles=com.ibm.ws.tx.jta.extensions.jakarta, \
  com.ibm.ws.transaction.jakarta; start-phase:=CONTAINER_LATE, \
  com.ibm.tx.jta.jakarta, \


### PR DESCRIPTION
#11772 

Establish the EE platform affinity and tolerance for all the transaction-x.y features to ensure the feature manager rejects (i.e. prevents from resolving) invalid combinations of features dependent on transaction-x.y, and to enable the feature manager to resolve the appropriate transaction-x.y feature dependency for non-public features.

The feature manager may resolve transaction-1.x for dependent javaee features, and must resolve transaction-2.0 for dependent jakarta features, and must reject any combination of features dependent on both transaction-1.x and transaction-2.0.  