### PR TITLE
Issue 12133: Check both serverA and serverB for the destruction of timed out sessions

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/SharedPool.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/SharedPool.java
@@ -585,7 +585,7 @@ public final class SharedPool {
 
         synchronized (sharedLockObject) {
 
-            sizeDifference = mcWrapperListSize; //set to the orginal size
+            sizeDifference = mcWrapperListSize; //set to the original size
             if (mcWrapperListSize == 1) {
                 /*
                  * If there is only one mcWrapper in the list, the odds of it


### PR DESCRIPTION
fixes #12133 

When testing the timeout of a session with two Liberty servers connected to a single Infinispan server for session caching, the session isn't always destroyed from the same Liberty server that created it.  The test has been updated to check the messages log of both serverA and serverB.