### PR TITLE
prepare JDBC 4.1 test bucket for Jakarta

### DIFF
--- a/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/JPATest.java
+++ b/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/JPATest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.injection.fat;
 
+import java.util.Set;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -19,6 +21,7 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.ws.injection.jpa.web.AdvJPAPersistenceServlet;
 import com.ibm.ws.injection.jpa.web.BasicJPAPersistenceContextServlet;
 import com.ibm.ws.injection.jpa.web.BasicJPAPersistenceUnitServlet;
@@ -67,6 +70,13 @@ public class JPATest extends FATServletClient {
         JPAInjectionTest.addAsModule(JPAInjectionWeb);
 
         ShrinkHelper.exportDropinAppToServer(server, JPAInjectionTest);
+
+        // When repeated with EE 8 features, jpa-2.2 requires jdbc-4.2 instead of jdbc-4.1
+        ServerConfiguration config = server.getServerConfiguration();
+        Set<String> features = config.getFeatureManager().getFeatures();
+        if (features.contains("jpa-2.2") && features.remove("jdbc-4.1"))
+            features.add("jdbc-4.2");
+        server.updateServerConfiguration(config);
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.jdbc_fat_v41/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_v41/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -17,6 +17,8 @@ src: \
 	test-applications/slowdriver/src
 
 fat.project: true
+
+tested.features: servlet-5.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\

--- a/dev/com.ibm.ws.jdbc_fat_v41/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_v41/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,4 +35,5 @@ task addDerby40ToServerDir(type: Copy) {
 addRequiredLibraries {
   dependsOn addDerbyToServerDir
   dependsOn addDerby40ToServerDir
+  dependsOn addJakartaTransformer
 }

--- a/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,12 +14,15 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
+import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
@@ -29,9 +32,13 @@ import componenttest.topology.impl.LibertyServerFactory;
                 JDBC41Test.class
 })
 public class FATSuite {
-
     public static final String appName = "basicfat";
     public static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.jdbc.fat.v41");
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests
+                    .withoutModification()
+                    ;// TODO .andWith(new JakartaEE9Action());
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/JDBC41Test.java
+++ b/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/JDBC41Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -61,13 +61,13 @@ public class JDBC41Test extends FATServletClient {
      */
     @Test
     public void testAbortedConnectionDestroyed() throws Exception {
-        FATServletClient.runTest(server, appName + '/' + "BasicTestServlet", testName.getMethodName());
+        FATServletClient.runTest(server, appName + '/' + "BasicTestServlet", "testAbortedConnectionDestroyed");
         FATServletClient.runTest(server, appName + '/' + "BasicTestServlet", "getSingleConnectionAfterAbort");
     }
 
     @Test
     public void testJDBCVersionLimiting() throws Exception {
-        FATServletClient.runTest(server, appName + '/' + "BasicTestServlet", testName.getMethodName() + "&expectedVersion=4.1");
+        FATServletClient.runTest(server, appName + '/' + "BasicTestServlet", "testJDBCVersionLimiting&expectedVersion=4.1");
     }
 
 }

--- a/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/JDBC41UpgradeTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/JDBC41UpgradeTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,11 +19,13 @@ import org.junit.runner.RunWith;
 
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 public class JDBC41UpgradeTest extends FATServletClient {
     private static final String servlet_basic = "BasicTestServlet";
 

--- a/dev/com.ibm.ws.jdbc_fat_v41/publish/files/server_derby40.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v41/publish/files/server_derby40.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017,2020 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -15,7 +15,6 @@
       <feature>localConnector-1.0</feature>
       <feature>jdbc-4.1</feature>
       <feature>jndi-1.0</feature>
-      <feature>jsp-2.2</feature>
     </featureManager>
     
     <include location="../fatTestPorts.xml"/>

--- a/dev/com.ibm.ws.jdbc_fat_v41/publish/servers/com.ibm.ws.jdbc.fat.v41/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v41/publish/servers/com.ibm.ws.jdbc.fat.v41/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017,2020 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -15,7 +15,6 @@
         <feature>localConnector-1.0</feature>
         <feature>jdbc-4.1</feature>
         <feature>jndi-1.0</feature>
-        <feature>jsp-2.2</feature>
     </featureManager>
     
     <include location="../fatTestPorts.xml"/>

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EE7FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EE7FeatureReplacementAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,7 @@ public class EE7FeatureReplacementAction extends FeatureReplacementAction {
 
     public static final String ID = "EE7_FEATURES";
 
-    static final String[] EE7_FEATURES_ARRAY = { "javaee-7.0", "webProfile-7.0", "javaeeClient-7.0", "servlet-3.1", "jdbc-4.1", "javaMail-1.5", "cdi-1.2", "jpa-2.1",
+    static final String[] EE7_FEATURES_ARRAY = { "javaee-7.0", "webProfile-7.0", "javaeeClient-7.0", "servlet-3.1", "javaMail-1.5", "cdi-1.2", "jpa-2.1",
                                                  "beanValidation-1.1", "jaxrs-2.0", "jaxrsClient-2.0", "jsf-2.2", "appSecurity-2.0", "jsonp-1.0",
                                                  "jsp-2.3", "el-3.0", "concurrent-1.0" };
     public static final Set<String> EE7_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE7_FEATURES_ARRAY)));

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EE8FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EE8FeatureReplacementAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,7 @@ public class EE8FeatureReplacementAction extends FeatureReplacementAction {
 
     public static final String ID = "EE8_FEATURES";
 
-    static final String[] EE8_FEATURES_ARRAY = { "javaee-8.0", "webProfile-8.0", "javaeeClient-8.0", "servlet-4.0", "jdbc-4.2", "javaMail-1.6", "cdi-2.0", "jpa-2.2",
+    static final String[] EE8_FEATURES_ARRAY = { "javaee-8.0", "webProfile-8.0", "javaeeClient-8.0", "servlet-4.0", "javaMail-1.6", "cdi-2.0", "jpa-2.2",
                                                  "beanValidation-2.0", "jaxrs-2.1", "jaxrsClient-2.1", "jsf-2.3", "appSecurity-3.0", "jsonp-1.1", "jsonb-1.0", "jsonpContainer-1.1",
                                                  "jsonbContainer-1.0", "el-3.0", "jsp-2.3", "concurrent-1.0" };
     public static final Set<String> EE8_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE8_FEATURES_ARRAY)));


### PR DESCRIPTION
Updates to prepare the JDBC 4.1 test bucket to run with Jakarta specs.
This pull does not enable the testing with Jakarta yet due to an unresolved issue with determining the correct transaction version.