### PR TITLE
Update Servlet Version & MajorVersion for Servlet-5.0

### DIFF
--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/osgi/webapp/WebApp40.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/osgi/webapp/WebApp40.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 IBM Corporation and others.
+ * Copyright (c) 2011, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.managedobject.ManagedObjectService;
 import com.ibm.ws.session.SessionManager;
 import com.ibm.ws.webcontainer.osgi.webapp.WebAppConfiguration;
+import com.ibm.ws.webcontainer.osgi.WebContainer;
 import com.ibm.ws.webcontainer.webapp.WebApp;
 import com.ibm.ws.webcontainer.webapp.WebAppDispatcherContext;
 import com.ibm.ws.webcontainer.webapp.WebAppRequestDispatcher;
@@ -72,7 +73,7 @@ public class WebApp40 extends com.ibm.ws.webcontainer31.osgi.webapp.WebApp31 imp
      */
     @Override
     public int getMajorVersion() {
-        return 4;
+        return WebContainer.getServletContainerSpecLevel() == WebContainer.SPEC_LEVEL_50 ? 5 : 4;
     }
 
     /*

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCServerTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCServerTest.java
@@ -27,6 +27,7 @@ import com.ibm.ws.fat.util.browser.WebResponse;
 import com.ibm.ws.fat.wc.WCApplicationHelper;
 
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE9Action;
 
 /**
  * All Servlet 4.0 tests with all applicable server features enabled.
@@ -118,7 +119,11 @@ public class WCServerTest extends LoggingTest {
 
     @Test
     public void testServletContextMajorMinorVersion() throws Exception {
-        this.verifyResponse("/TestServlet40/MyServlet?TestMajorMinorVersion=true", "majorVersion: 4");
+        String majorVersionExpectedResult = "majorVersion: 4";
+        if (JakartaEE9Action.isActive()) {
+            majorVersionExpectedResult = "majorVersion: 5";
+        }
+        this.verifyResponse("/TestServlet40/MyServlet?TestMajorMinorVersion=true", majorVersionExpectedResult);
 
         this.verifyResponse("/TestServlet40/MyServlet?TestMajorMinorVersion=true", "minorVersion: 0");
     }

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/WebContainer.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/WebContainer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2015 IBM Corporation and others.
+ * Copyright (c) 2010, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1557,6 +1557,7 @@ public class WebContainer extends com.ibm.ws.webcontainer.WebContainer implement
     public static final int SPEC_LEVEL_30 = 30;
     public static final int SPEC_LEVEL_31 = 31;
     public static final int SPEC_LEVEL_40 = 40;
+    public static final int SPEC_LEVEL_50 = 50;
     private static final int DEFAULT_SPEC_LEVEL = 30;
     
     private static int loadedContainerSpecLevel = SPEC_LEVEL_UNLOADED;

--- a/dev/wlp-jakartaee-transform/rules/jakarta-servletVersion.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-servletVersion.properties
@@ -1,0 +1,4 @@
+# Change version (occurs with all references within the file)
+40=50
+# Change name attribute back to original (should not change)
+com.ibm.ws.webcontainer.v50.dd=com.ibm.ws.webcontainer.v40.dd

--- a/dev/wlp-jakartaee-transform/rules/jakarta-xml-master.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-xml-master.properties
@@ -5,3 +5,4 @@ TransactionJavaColonHelper.xml=jakarta-userTransaction.properties
 com.ibm.ws.transaction.services.RemoteTransactionControllerService.xml=jakarta-transactionManager.properties
 com.ibm.ws.transaction.services.TransactionSynchronizationRegistryService.xml=jakarta-transactionSynchronizationRegistry.properties
 com.ibm.ws.transaction.services.UserTransactionService.xml=jakarta-userTransaction.properties
+com.ibm.ws.webcontainer.v40.dd.xml=jakarta-servletVersion.properties


### PR DESCRIPTION
1) Fixes #12021  Transformed servlet specVersion  to 50 using transformer tool. 

2)  Fixes part of #12105   -- Updated webcontainer servlet 4 code to return 5 as the MajorVersion when the spec level is 50. 

3)  Corrected the testServletContextMajorMinorVersion test during the EE9_FEATURES run.  (Also part of #12105 ) 
