### PR TITLE
Avoid processing non-GraphQL apps

### DIFF
--- a/dev/com.ibm.ws.io.smallrye.graphql/src/com/ibm/ws/io/smallrye/graphql/component/GraphQLServletContainerInitializer.java
+++ b/dev/com.ibm.ws.io.smallrye.graphql/src/com/ibm/ws/io/smallrye/graphql/component/GraphQLServletContainerInitializer.java
@@ -161,6 +161,14 @@ public class GraphQLServletContainerInitializer implements ServletContainerIniti
             IndexInitializer indexInitializer = new IndexInitializer();
             IndexView index = indexInitializer.createIndex(Collections.singleton(webinfClassesUrl));
             Schema schema = SchemaBuilder.build(index);
+            if (schema == null || (!schema.hasQueries() && !schema.hasMutations())) {
+                // not a GraphQL app as far as we can tell - trace and exit:
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "No GraphQL components found in app: " + ctx.getServletContextName());
+                }
+                diagnostics.remove(ctx.getClassLoader());
+                return;
+            }
             diagBag.modelSchema = schema;
             graphQLSchema = Bootstrap.bootstrap(schema, config);
         } catch (Throwable t) {


### PR DESCRIPTION
Avoid any additional processing of non-GraphQL apps (i.e. apps with no `@GraphQLApi`, `@Query`, or `@Mutation` annotations) when the `mpGraphQL-1.0` feature is enabled.  This is really intended for multi-app servers where only some of the apps use GraphQL APIs.