### PR TITLE
Improve resource injection trace

### DIFF
--- a/dev/com.ibm.ws.injection.core/src/com/ibm/ws/injectionengine/AbstractInjectionEngine.java
+++ b/dev/com.ibm.ws.injection.core/src/com/ibm/ws/injectionengine/AbstractInjectionEngine.java
@@ -919,11 +919,10 @@ public abstract class AbstractInjectionEngine implements InternalInjectionEngine
 
                 if (!ivProcessorProviders.containsKey(annotation)) {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                        Tr.debug(tc, "registerObjectFactory: An injection processor " +
-                                     "does not exist for the specified annotation: " +
-                                     annotation.getName());
+                        Tr.debug(tc, "registerObjectFactory: An injection processor does not exist for the specified annotation: " +
+                                     annotation.getName() + ". Object factory " + objectFactory.getName() + " not registered for the " + type.getName() + " type.");
                     throw new InjectionException("An injection processor does not exist for the specified annotation: " +
-                                                 annotation.getName());
+                                                 annotation.getName() + ". Object factory " + objectFactory.getName() + " not registered for the " + type.getName() + " type.");
                 }
 
                 factories = new HashMap<Class<?>, ObjectFactoryInfo>();
@@ -1012,11 +1011,10 @@ public abstract class AbstractInjectionEngine implements InternalInjectionEngine
             if (factories == null) {
                 if (!ivProcessorProviders.containsKey(annotation)) {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                        Tr.debug(tc, "registerOverrideReferenceFactory: An injection " +
-                                     "processor does not exist for the specified annotation: " +
-                                     annotation.getName());
+                        Tr.debug(tc, "registerOverrideReferenceFactory: An injection processor does not exist for the specified annotation: " +
+                                     annotation.getName() + ". Factory " + factory.getClass().getName() + " not registered.");
                     throw new InjectionException("An injection processor does not exist for the specified annotation: " +
-                                                 annotation.getName());
+                                                 annotation.getName() + ". Factory " + factory.getClass().getName() + " not registered.");
                 }
 
                 factories = new OverrideReferenceFactory[1];

--- a/dev/com.ibm.ws.injection.core/src/com/ibm/ws/injectionengine/InjectionProcessorManager.java
+++ b/dev/com.ibm.ws.injection.core/src/com/ibm/ws/injectionengine/InjectionProcessorManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 IBM Corporation and others.
+ * Copyright (c) 2013, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -324,13 +324,16 @@ public class InjectionProcessorManager
                                                                                        Class<?> klass)
                     throws InjectionException
     {
+        final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
         Class<A> annClass = provider.getAnnotationClass();
+        if (isTraceOn && tc.isDebugEnabled())
+            Tr.debug(tc, "looking for annotation : " + annClass);
         if (annClass != null)
         {
             A ann = klass.getAnnotation(annClass);
             if (ann != null)
             {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                if (isTraceOn && tc.isDebugEnabled())
                     Tr.debug(tc, "found class annotation " + toStringSecure(ann));
 
                 InjectionProcessor<A, AS> processor = getProcessor(processorIndex, provider);
@@ -338,6 +341,8 @@ public class InjectionProcessorManager
             }
 
             Class<AS> pluralAnnClass = provider.getAnnotationsClass();
+            if (isTraceOn && tc.isDebugEnabled())
+                Tr.debug(tc, "looking for annotation(s) : " + pluralAnnClass);
             if (pluralAnnClass != null)
             {
                 AS pluralAnn = klass.getAnnotation(pluralAnnClass);
@@ -350,7 +355,7 @@ public class InjectionProcessorManager
                     {
                         for (A singleAnn : singleAnns)
                         {
-                            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                            if (isTraceOn && tc.isDebugEnabled())
                                 Tr.debug(tc, "found plural class annotation " + toStringSecure(singleAnn));
                             addOrMergeInjectionBinding(processorIndex, processor, klass, null, singleAnn);
                         }


### PR DESCRIPTION
Since supporting Object Factories are injected into the injection
engine, it can be difficult to tell which component is injecting
an object factory where there is a failure.

Include the name of the object factory in trace and the exception
message when an error occurs in registration.

Also improve trace when processing class annotations.
