### PR TITLE
Code review comment

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/message/MessageImpl.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/message/MessageImpl.java
@@ -1400,9 +1400,13 @@ public class MessageImpl extends StringMapImpl implements Message {
             }
         }
         try {
-            forEach((k, v) -> { sb.append(k).append("=").append(v).append(", "); });
+            super.forEach((k, v) -> { sb.append(k).append("=").append(v).append(", "); });
         } catch (ConcurrentModificationException ex) {
             sb.append(" ConcurrentModificationException caught!");
+        }
+        int len = sb.length();
+        if (len > 3) {
+            sb.setLength(len-2); //remove trailing comma and space
         }
         sb.append("}");
         return sb.toString();

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/test/com/ibm/ws/jaxrs/test/MessageImplTest.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/test/com/ibm/ws/jaxrs/test/MessageImplTest.java
@@ -101,6 +101,29 @@ public class MessageImplTest {
         }
     }    
  
+    @Test
+    public void testToString() {
+        // propertyValues entry
+        MessageImpl m = new MessageImpl();
+        m.setSseEventSink("foo");
+        assertEquals("{javax.ws.rs.sse.SseEventSink=foo}", m.toString());
+        
+        // custom entry
+        m = new MessageImpl();
+        m.put("hello", "world");
+        assertEquals("{hello=world}", m.toString());
+        
+        // entries of each type (propertyValues entries should always precede other entries)
+        m = new MessageImpl();
+        m.put("hello2", "world2");
+        m.setSseEventSink("bar");
+        assertEquals("{javax.ws.rs.sse.SseEventSink=bar, hello2=world2}", m.toString());
+        
+        // empty message impl
+        m = new MessageImpl();
+        assertEquals("{}", m.toString());
+    }
+
     @SuppressWarnings({ "unchecked", "serial" })
     private void exerciseMethods(MessageImpl message, String propertyKey, Method getter, Method setter, Method remove, Method contains, Class<?> type) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
         assertNull(message.get(propertyKey));


### PR DESCRIPTION
Tweak to PR #12157 - avoid duplicating propertyValue fields by using `super.forEach` and remove trailing comma.