### PR TITLE
Issue #11967: Jakarta 9 Injection FAT part 2

### DIFF
--- a/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/ResRefTest.java
+++ b/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/ResRefTest.java
@@ -28,6 +28,7 @@ import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -55,7 +56,7 @@ public class ResRefTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.injection.fat.ResRefServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.injection.fat.ResRefServer"));
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.injection.fat.ResRefServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.injection.fat.ResRefServer")).andWith(new JakartaEE9Action().forServers("com.ibm.ws.injection.fat.ResRefServer"));
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/ServiceLookupTest.java
+++ b/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/ServiceLookupTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2018 IBM Corporation and others.
+ * Copyright (c) 2012, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,6 +23,7 @@ import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -34,7 +35,7 @@ public class ServiceLookupTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.injection.fat.ServiceLookupServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.injection.fat.ServiceLookupServer"));
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.injection.fat.ServiceLookupServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.injection.fat.ServiceLookupServer")).andWith(new JakartaEE9Action().forServers("com.ibm.ws.injection.fat.ServiceLookupServer"));
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/TranTest.java
+++ b/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/TranTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,6 +28,7 @@ import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -57,7 +58,7 @@ public class TranTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.injection.fat.TranServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.injection.fat.TranServer"));
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.injection.fat.TranServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.injection.fat.TranServer")).andWith(new JakartaEE9Action().forServers("com.ibm.ws.injection.fat.TranServer"));
 
     @BeforeClass
     public static void setUp() throws Exception {


### PR DESCRIPTION
Enabled Injection FAT that relies on transactions/jdbc
to run with the Jakarta 9 repeat action.

RepeatableTranTest needed to manually convert the app, since
it isn't built with shrinkwrap.  Also, switched to JDBC 4.1
as the current repeat action strips out jdbc-4.0 without
adding jdbc-4.2.

fixes #11967 