### PR TITLE
Do not cache variable lookups from expressions

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/VariableEvaluator.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/VariableEvaluator.java
@@ -183,7 +183,7 @@ public class VariableEvaluator {
                         context.addDefinedVariable(variable, realValue);
                 }
 
-                if (realValue == null) {
+                if (realValue == null && useEnvironment) {
                     // If the value is null, add it to the context so that we don't try to evaluate it again.
                     // If the value is not null here, it is either:
                     // 1) An environment variable or mangled variable, in which case we added it above, or


### PR DESCRIPTION
We are currently caching variables looked up during the evaluation of expressions like servicePidOrFilter despite the fact that they always come from configuration. This can result in cached configuration not being used on restart even though nothing has changed. 