### PR TITLE
Issue 12235: Skip error path test on Java 8 due to java bug

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSimpleTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSimpleTest.java
@@ -53,6 +53,7 @@ import com.ibm.ws.security.acme.utils.AcmeFatUtils;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.CheckForLeakedPasswords;
 import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -818,6 +819,8 @@ public class AcmeSimpleTest {
 	@Test
 	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
 	@ExpectedFFDC({ "com.ibm.ws.security.acme.AcmeCaException" })
+	@MinimumJavaLevel(javaLevel = 9)
+	/* Minimum Java Level to avoid a known/fixed IBM Java 8 bug with an empty keystore, IJ19292. When the builds move to 8SR6, we can run this test again */
 	public void startup_failure_recover() throws Exception {
 
 		ServerConfiguration configuration = ORIGINAL_CONFIG.clone();
@@ -894,6 +897,8 @@ public class AcmeSimpleTest {
 	 */
 	@Test
 	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
+	@MinimumJavaLevel(javaLevel = 9)
+	/* Minimum Java Level to avoid a known/fixed IBM Java 8 bug with an empty keystore, IJ19292. When the builds move to 8SR6, we can run this test again */
 	public void keystore_exists_without_default_alias() throws Exception {
 
 		ServerConfiguration configuration = ORIGINAL_CONFIG.clone();


### PR DESCRIPTION
Fixes #12235 

Skip `startup_failure_recover` adn `keystore_exists_without_default_alias` on Java 8 tests to avoid the NPE from Java. If we move up to Java8SR6, we can re-enable the test.

For #9017 