### PR TITLE
274647 Fix transaction feature affinity with eeCompatible versions

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-1.1.feature
@@ -22,7 +22,7 @@ IBM-API-Service: com.ibm.wsspi.uow.UOWManager, \
  com.ibm.websphere.appserver.javaeedd-1.0, \
  com.ibm.websphere.appserver.containerServices-1.0, \
  com.ibm.websphere.appserver.anno-1.0, \
- com.ibm.websphere.appserver.eeCompatible-7.0; ibm.tolerates:="6.0,8.0"
+ com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0,8.0"
 -bundles=com.ibm.ws.tx.jta.extensions, \
  com.ibm.ws.transaction; start-phase:=CONTAINER_LATE, \
  com.ibm.tx.jta, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-1.2.feature
@@ -24,7 +24,7 @@ IBM-API-Service: com.ibm.wsspi.uow.UOWManager, \
  com.ibm.websphere.appserver.containerServices-1.0, \
  com.ibm.websphere.appserver.javax.annotation-1.2; ibm.tolerates:=1.3; apiJar=false, \
  com.ibm.websphere.appserver.anno-1.0, \
- com.ibm.websphere.appserver.eeCompatible-8.0; ibm.tolerates:="6.0,7.0"
+ com.ibm.websphere.appserver.eeCompatible-7.0; ibm.tolerates:="6.0,8.0"
 -bundles=com.ibm.ws.tx.jta.extensions, \
  com.ibm.ws.transaction; start-phase:=CONTAINER_LATE, \
  com.ibm.tx.jta, \


### PR DESCRIPTION
Change javaee transaction-x.0 feature dependencies to the appropriate ee release versions.  This will ensure the feature resolver attempts to select most appropriate transaction-x.0 feature to match the other javaee features in the server configuration. 