### PR TITLE
enable JDBC 4.1 tests with Jakarta and prepare for 4.2

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,3 +9,4 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 addRequiredLibraries.dependsOn addDerby
+addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
@@ -18,6 +18,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -26,6 +27,8 @@ import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import web.derby.DerbyLoadFromAppServlet;
@@ -37,6 +40,10 @@ import web.other.LoadFromAppServlet;
  */
 @RunWith(FATRunner.class)
 public class JDBCLoadFromAppTest extends FATServletClient {
+    @ClassRule
+    public static RepeatTests r = RepeatTests
+                    .withoutModification()
+                    ;//.andWith(new JakartaEE9Action()); TODO uncomment once JCA (and possibly other) features are ready for Jakarta
 
     @Server("com.ibm.ws.jdbc.fat.loadfromapp")
     @TestServlets(value = {

--- a/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/FATSuite.java
@@ -38,7 +38,7 @@ public class FATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests
                     .withoutModification()
-                    ;// TODO .andWith(new JakartaEE9Action());
+                    .andWith(new JakartaEE9Action());
 
     @BeforeClass
     public static void setup() throws Exception {


### PR DESCRIPTION
Enable the jdbc 4.1 test bucket to run with Jakarta.
Also, take some steps to prepare a bucket that uses jdbc 4.2, however, that bucket must remain disabled until the jca-2.0 feature (Jakarta Connectors) is ready.