### PR TITLE
javaeeCompatible -> eeCompatible

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxrs-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxrs-3.0.feature
@@ -12,7 +12,7 @@ Subsystem-Name: Internal Java RESTful Services 3.0
  com.ibm.websphere.appserver.servlet-4.0, \
  com.ibm.websphere.appserver.classloading-1.0, \
  com.ibm.websphere.appserver.globalhandler-1.0, \
- com.ibm.websphere.appserver.javaeeCompatible-8.0, \
+ com.ibm.websphere.appserver.eeCompatible-8.0, \
  com.ibm.websphere.appserver.internal.optional.jaxb-2.2; ibm.tolerates:=2.3, \
  com.ibm.websphere.appserver.internal.optional.jaxws-2.2; ibm.tolerates:=2.3, \
  com.ibm.websphere.appserver.org.eclipse.microprofile.config-1.4, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jaxrs-3.0/com.ibm.websphere.appserver.jaxrs-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jaxrs-3.0/com.ibm.websphere.appserver.jaxrs-3.0.feature
@@ -9,7 +9,7 @@ Subsystem-Name: Java RESTful Services 3.0
 -features=\
  com.ibm.websphere.appserver.internal.jaxrs-3.0, \
  com.ibm.websphere.appserver.jaxrsClient-3.0, \
- com.ibm.websphere.appserver.javaeeCompatible-8.0, \
+ com.ibm.websphere.appserver.eeCompatible-8.0, \
  com.ibm.websphere.appserver.cdi-2.0
 kind=noship
 edition=full


### PR DESCRIPTION
Fix a timing issue where `javaeeCompatible-8.0` was renamed to `eeCompatible-8.0` at the same time that the jaxrs-3.0 feature was merged using the `javaeeCompatible-8.0` feature.