### PR TITLE
Updating the WIM SSL tests to use Unboundid instead of the embedded LDAP server

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/build.gradle
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/build.gradle
@@ -146,6 +146,7 @@ autoFVT.doLast {
   servers = [
     'com.ibm.ws.security.wim.adapter.ldap.fat.tds.ssl',
     'com.ibm.ws.security.wim.adapter.ldap.fat.ad.ssl',
+    'com.ibm.ws.security.registry.ldap.fat.ids.ssl.trustonly',
     'com.ibm.ws.security.registry.ldap.fat.ids.ssl'
   ]
   servers.each { server ->

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.ids.ssl.trustonly/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.registry.ldap.fat.ids.ssl.trustonly/server.xml
@@ -43,7 +43,7 @@
 
 	<sslDefault sslRef="LDAPSSLSettings" />
 	<ssl id="LDAPSSLSettings" keyStoreRef="LDAPTrustStore" />
-	<keyStore id="LDAPTrustStore" location="${server.config.dir}/LdapSSLTrustStore.jks" type="JKS" password="{xor}CDo9Hgw=" />
+	<keyStore id="LDAPTrustStore" location="${server.config.dir}/truststore.p12" type="PKCS12" password="LDAPpassword" />
 
 	<include location="../fatTestPorts.xml"/>
 


### PR DESCRIPTION
fixes #12308 