### PR TITLE
Wait for LTPA keys to be created/check if LTPA keys exist in MetricsAuthenticationTest

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsAuthenticationTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsAuthenticationTest.java
@@ -81,7 +81,8 @@ public class MetricsAuthenticationTest {
         assertNotNull("[/metrics] failed to initialize", server.waitForStringInLogUsingMark("SRVE0242I.*/metrics.*"));
     }
 
-    private void waitForTCPChannels(LibertyServer server) throws Exception {
+    private void waitForSecurityPrerequisites(LibertyServer server) throws Exception {
+        assertNotNull("LTPA keys are not created/ready within timeout period of " + TIMEOUT + "ms.", server.waitForStringInLog("CWWKS4104A.*|CWWKS4105I.*", TIMEOUT));
         assertNotNull("TCP Channel defaultHttpEndpoint has not started", server.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint"));
         assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started", server.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl"));
     }
@@ -101,7 +102,7 @@ public class MetricsAuthenticationTest {
         // wait for metrics installations to complete before running test
         waitForMetricsFeature(server);
         // wait for TCP Channels to start listening
-        waitForTCPChannels(server);
+        waitForSecurityPrerequisites(server);
 
         //1. When authentication is not explicitly set in server.xml, it defaults to private,
         //  i.e. requires authentication into metrics endpoint


### PR DESCRIPTION
Fixes #12292 
Test hits URL without waiting for LTPA keys to be created.