### PR TITLE
Update .classpath and bnd files for RESTEasy components

### DIFF
--- a/dev/com.ibm.ws.org.jboss.resteasy.resteasy.client.api/.classpath
+++ b/dev/com.ibm.ws.org.jboss.resteasy.resteasy.client.api/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.org.jboss.resteasy.resteasy.client.api/bnd.bnd
+++ b/dev/com.ibm.ws.org.jboss.resteasy.resteasy.client.api/bnd.bnd
@@ -12,10 +12,6 @@
 bVersion=1.0
 
 Bundle-SymbolicName: com.ibm.ws.org.jboss.resteasy.resteasy.client.api
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
-
-javac.source: 1.8
-javac.target: 1.8
 
 Export-Package: \
   org.jboss.resteasy.client.jaxrs;version=4.5.2.Final, \

--- a/dev/com.ibm.ws.org.jboss.resteasy.resteasy.client/.classpath
+++ b/dev/com.ibm.ws.org.jboss.resteasy.resteasy.client/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.org.jboss.resteasy.resteasy.client/bnd.bnd
+++ b/dev/com.ibm.ws.org.jboss.resteasy.resteasy.client/bnd.bnd
@@ -12,10 +12,6 @@
 bVersion=1.0
 
 Bundle-SymbolicName: com.ibm.ws.org.jboss.resteasy.resteasy.client
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
-
-javac.source: 1.8
-javac.target: 1.8
 
 Service-Component: \
   com.ibm.ws.org.jboss.resteasy.client.clientbuilder; \

--- a/dev/com.ibm.ws.org.jboss.resteasy.resteasy.core.spi/.classpath
+++ b/dev/com.ibm.ws.org.jboss.resteasy.resteasy.core.spi/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.org.jboss.resteasy.resteasy.core.spi/bnd.bnd
+++ b/dev/com.ibm.ws.org.jboss.resteasy.resteasy.core.spi/bnd.bnd
@@ -12,10 +12,6 @@
 bVersion=1.0
 
 Bundle-SymbolicName: com.ibm.ws.org.jboss.resteasy.resteasy.core.spi
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
-
-javac.source: 1.8
-javac.target: 1.8
 
 Export-Package: \
   org.jboss.resteasy.annotations;version=4.5.2.Final, \

--- a/dev/com.ibm.ws.org.jboss.resteasy.resteasy.core/.classpath
+++ b/dev/com.ibm.ws.org.jboss.resteasy.resteasy.core/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.org.jboss.resteasy.resteasy.core/bnd.bnd
+++ b/dev/com.ibm.ws.org.jboss.resteasy.resteasy.core/bnd.bnd
@@ -12,10 +12,6 @@
 bVersion=1.0
 
 Bundle-SymbolicName: com.ibm.ws.org.jboss.resteasy.resteasy.core
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
-
-javac.source: 1.8
-javac.target: 1.8
 
 Export-Package: \
   org.jboss.resteasy.core;version=4.5.2.Final, \

--- a/dev/com.ibm.ws.org.jboss.resteasy.resteasy.servlet.initializer/.classpath
+++ b/dev/com.ibm.ws.org.jboss.resteasy.resteasy.servlet.initializer/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.org.jboss.resteasy.resteasy.servlet.initializer/bnd.bnd
+++ b/dev/com.ibm.ws.org.jboss.resteasy.resteasy.servlet.initializer/bnd.bnd
@@ -12,10 +12,6 @@
 bVersion=1.0
 
 Bundle-SymbolicName: com.ibm.ws.org.jboss.resteasy.resteasy.servlet.initializer
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
-
-javac.source: 1.8
-javac.target: 1.8
 
 Service-Component: \
   com.ibm.ws.org.jboss.resteasy.servlet.initializer; \

--- a/dev/com.ibm.ws.org.jboss.resteasy.resteasy.tracing.api/.classpath
+++ b/dev/com.ibm.ws.org.jboss.resteasy.resteasy.tracing.api/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.org.jboss.resteasy.resteasy.tracing.api/bnd.bnd
+++ b/dev/com.ibm.ws.org.jboss.resteasy.resteasy.tracing.api/bnd.bnd
@@ -12,10 +12,6 @@
 bVersion=1.0
 
 Bundle-SymbolicName: com.ibm.ws.org.jboss.resteasy.resteasy.tracing.api
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
-
-javac.source: 1.8
-javac.target: 1.8
 
 Export-Package: \
   org.jboss.resteasy.tracing.api;version=1.0.0, \


### PR DESCRIPTION
- Update .classpath files to remove src directory since it does not have anything in it
- Update bnd files to remove the Java 8 settings since that is the default now.
