### PR TITLE
Add jsp-3.0/el-4.0/servlet-5.0 features to beta

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.anno-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.anno-2.0.feature
@@ -18,5 +18,5 @@ IBM-Process-Types: server, \
 -jars=com.ibm.websphere.appserver.spi.anno; location:=dev/spi/ibm/
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.anno_1.1-javadoc.zip
 kind=beta
-edition=full
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.anno-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.anno-2.0.feature
@@ -17,6 +17,6 @@ IBM-Process-Types: server, \
 -bundles=com.ibm.ws.anno
 -jars=com.ibm.websphere.appserver.spi.anno; location:=dev/spi/ibm/
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.anno_1.1-javadoc.zip
-kind=noship
+kind=beta
 edition=full
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.eeCompatible-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.eeCompatible-9.0.feature
@@ -4,6 +4,6 @@ visibility=private
 singleton=true
 Subsystem-Version: 9.0.0
 -bundles=com.ibm.ws.javaee.version
-kind=noship
+kind=beta
 edition=full
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.eeCompatible-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.eeCompatible-9.0.feature
@@ -5,5 +5,5 @@ singleton=true
 Subsystem-Version: 9.0.0
 -bundles=com.ibm.ws.javaee.version
 kind=beta
-edition=full
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.injection-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.injection-2.0.feature
@@ -6,5 +6,5 @@ IBM-Process-Types: client, \
  com.ibm.websphere.appserver.anno-2.0
 -bundles=com.ibm.ws.injection.jakarta
 kind=beta
-edition=full
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.injection-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.injection-2.0.feature
@@ -5,6 +5,6 @@ IBM-Process-Types: client, \
 -features=com.ibm.websphere.appserver.containerServices-1.0, \
  com.ibm.websphere.appserver.anno-2.0
 -bundles=com.ibm.ws.injection.jakarta
-kind=noship
+kind=beta
 edition=full
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jakarta.annotation-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jakarta.annotation-2.0.feature
@@ -4,6 +4,6 @@ singleton=true
 IBM-Process-Types: server, \
  client
 -bundles=io.openliberty.jakarta.annotation.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.annotation:jakarta.annotation-api:2.0.0-RC1"
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jakarta.el-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jakarta.el-4.0.feature
@@ -2,6 +2,6 @@
 symbolicName=com.ibm.websphere.appserver.jakarta.el-4.0
 singleton=true
 -bundles=com.ibm.websphere.jakartaee.el.4.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.el:jakarta.el-api:4.0.0"
-kind=noship
+kind=beta
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jakarta.jsp-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jakarta.jsp-3.0.feature
@@ -4,6 +4,6 @@ singleton=true
 -features=com.ibm.websphere.appserver.jakarta.el-4.0; apiJar=false, \
  com.ibm.websphere.appserver.jakarta.servlet-5.0; apiJar=false
 -bundles=com.ibm.websphere.jakartaee.jsp.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.servlet.jsp:jakarta.servlet.jsp-api:3.0.0"
-kind=noship
+kind=beta
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jakarta.servlet-5.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jakarta.servlet-5.0.feature
@@ -2,6 +2,6 @@
 symbolicName=com.ibm.websphere.appserver.jakarta.servlet-5.0
 singleton=true
 -bundles=com.ibm.websphere.jakartaee.servlet.5.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.servlet:jakarta.servlet-api:5.0.0"
-kind=noship
+kind=beta
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/el-4.0/com.ibm.websphere.appserver.el-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/el-4.0/com.ibm.websphere.appserver.el-4.0.feature
@@ -14,6 +14,6 @@ Subsystem-Version: 4.0.0
 Subsystem-Name: Jakarta Expression Language 4.0
 -features=com.ibm.websphere.appserver.jakarta.el-4.0
 -bundles=com.ibm.ws.org.apache.jasper.el.3.0.jakarta
-kind=noship
+kind=beta
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-3.0/com.ibm.websphere.appserver.jsp-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-3.0/com.ibm.websphere.appserver.jsp-3.0.feature
@@ -45,5 +45,5 @@ Subsystem-Name: Jakarta Server Pages 3.0
  com.ibm.websphere.javaee.jsp.tld.2.2.jakarta; location:=dev/api/spec/
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.jsp_1.0-javadoc.zip
 kind=beta
-edition=full
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-3.0/com.ibm.websphere.appserver.jsp-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-3.0/com.ibm.websphere.appserver.jsp-3.0.feature
@@ -44,6 +44,6 @@ Subsystem-Name: Jakarta Server Pages 3.0
 -jars=com.ibm.websphere.appserver.spi.jsp; location:=dev/spi/ibm/, \
  com.ibm.websphere.javaee.jsp.tld.2.2.jakarta; location:=dev/api/spec/
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.jsp_1.0-javadoc.zip
-kind=noship
+kind=beta
 edition=full
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/servlet-5.0/com.ibm.websphere.appserver.servlet-5.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/servlet-5.0/com.ibm.websphere.appserver.servlet-5.0.feature
@@ -69,6 +69,6 @@ Subsystem-Category: JakartaEE9Application
  bin/pluginUtility.bat, \
  dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.servlet_1.1-javadoc.zip
 Subsystem-Name: Jakarta Servlets 5.0
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel


### PR DESCRIPTION
fixes #12265
fixes #12269
fixes #12258

Making the public servlet/el/jsp jakarta features beta gives the following error showing what else we need to change:

> Found issues with Feature: [com.ibm.websphere.appserver.jsp-3.0]   Edition: [full]   Kind: [beta]
>      It provisions less visible features: 
>      Feature: [com.ibm.websphere.appserver.jakarta.annotation-2.0]   Edition: [full]   Kind: [noship]
>      Feature: [com.ibm.websphere.appserver.eeCompatible-9.0]   Edition: [full]   Kind: [noship]
>      Feature: [com.ibm.websphere.appserver.injection-2.0]   Edition: [full]   Kind: [noship]
>      Feature: [com.ibm.websphere.appserver.anno-2.0]   Edition: [full]   Kind: [noship]
>      Feature: [com.ibm.websphere.appserver.jakarta.jsp-3.0]   Edition: [core]   Kind: [noship]
>      Feature: [com.ibm.websphere.appserver.jakarta.servlet-5.0]   Edition: [core]   Kind: [noship]
>      Feature: [com.ibm.websphere.appserver.jakarta.el-4.0]   Edition: [core]   Kind: [noship]
> Found issues with Feature: [com.ibm.websphere.appserver.servlet-5.0]   Edition: [full]   Kind: [beta]
>      It provisions less visible features: 
>      Feature: [com.ibm.websphere.appserver.jakarta.annotation-2.0]   Edition: [full]   Kind: [noship]
>      Feature: [com.ibm.websphere.appserver.eeCompatible-9.0]   Edition: [full]   Kind: [noship]
>      Feature: [com.ibm.websphere.appserver.injection-2.0]   Edition: [full]   Kind: [noship]
>      Feature: [com.ibm.websphere.appserver.anno-2.0]   Edition: [full]   Kind: [noship]
>      Feature: [com.ibm.websphere.appserver.jakarta.servlet-5.0]   Edition: [core]   Kind: [noship]
> Found issues with Feature: [com.ibm.websphere.appserver.el-4.0]   Edition: [core]   Kind: [beta]
>      It provisions less visible features: 
>      Feature: [com.ibm.websphere.appserver.jakarta.el-4.0]   Edition: [core]   Kind: [noship]