### PR TITLE
Exclude javax.annotation import version from grpc bundles

### DIFF
--- a/dev/com.ibm.ws.grpc.client/bnd.bnd
+++ b/dev/com.ibm.ws.grpc.client/bnd.bnd
@@ -15,6 +15,9 @@ Bundle-Name: gRPC Client
 Bundle-SymbolicName: com.ibm.ws.grpc.client
 Bundle-Description: Liberty gRPC Client, version ${bVersion}
 
+# Using version=! in order to not have a version attached to the import for packages that were removed
+# from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
+# packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: !sun.*,\
   !com.google.code.gson,\
   !org.checkerframework,\
@@ -30,6 +33,7 @@ Import-Package: !sun.*,\
   !org.conscrypt,\
   !org.eclipse.jetty.*,\
   !org.jboss.*,\
+  javax.annotation;version=!,\
   *
 
 Export-Package: \

--- a/dev/com.ibm.ws.grpc.common/bnd.bnd
+++ b/dev/com.ibm.ws.grpc.common/bnd.bnd
@@ -15,10 +15,14 @@ Bundle-Name: gRPC Common Components
 Bundle-SymbolicName: com.ibm.ws.grpc.common
 Bundle-Description: gRPC Common Components, version ${bVersion}
 
+# Using version=! in order to not have a version attached to the import for packages that were removed
+# from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
+# packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: !sun.*,\
   !com.google.code.gson,\
   !org.checkerframework,\
   !com.google.*,\
+  javax.annotation;version=!,\
   *
 	
 Export-Package: com.ibm.ws.grpc,\

--- a/dev/com.ibm.ws.grpc/bnd.bnd
+++ b/dev/com.ibm.ws.grpc/bnd.bnd
@@ -20,9 +20,13 @@ Bundle-Description: Libery gRPC, version ${bVersion}
   com.ibm.ws.grpc.servlet.GrpcServerComponent,\
   com.ibm.ws.grpc.config.GrpcServiceConfigImpl
 
+# Using version=! in order to not have a version attached to the import for packages that were removed
+# from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
+# packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: !sun.*,\
   !com.google.code.gson,\
   !org.checkerframework,\
+  javax.annotation;version=!,\
   *
 
 Export-Package: io.grpc.servlet,\


### PR DESCRIPTION
The grpc bundles produced by the external contributor build are currently broken:
```
[ERROR   ] CWWKE0702E: Could not resolve module: com.ibm.ws.grpc.common [75]
  Unresolved requirement: Import-Package: javax.annotation; version="[3.0.0,4.0.0)"
```
This PR will add an explicit version exclude to that package.

Fixes #12368 
