### PR TITLE
Update xpoweredby header value for the servlet-5.0 feature

### DIFF
--- a/dev/com.ibm.ws.security.mp.jwt/bnd.bnd
+++ b/dev/com.ibm.ws.security.mp.jwt/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -108,4 +108,5 @@ Include-Resource: \
     com.ibm.ws.container.service;version=latest,\
     com.ibm.ws.injection.core;version=latest,\
     com.ibm.websphere.appserver.spi.servlet;version=latest, \
-    com.ibm.ws.anno;version=latest
+    com.ibm.ws.anno;version=latest, \
+    com.ibm.ws.threading;version=latest

--- a/dev/com.ibm.ws.security.openidconnect.client/bnd.bnd
+++ b/dev/com.ibm.ws.security.openidconnect.client/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -132,7 +132,8 @@ Include-Resource: \
 	joda-time;version=latest,\
 	com.ibm.ws.org.slf4j.api.1.7.7;version=latest,\
 	com.ibm.ws.org.apache.commons.codec.1.4;version=latest,\
-    
-    
-    
+	com.ibm.ws.container.service;version=latest,\
+	com.ibm.ws.threading;version=latest,\
+	com.ibm.ws.injection.core;version=latest,\
+
 instrument.classesExcludes: com/ibm/ws/security/openidconnect/client/internal/resources/OidcClientMessages*.class

--- a/dev/com.ibm.ws.security.saml.sso/bnd.bnd
+++ b/dev/com.ibm.ws.security.saml.sso/bnd.bnd
@@ -163,4 +163,7 @@ instrument.classesExcludes: com/ibm/ws/security/saml/sso20/internal/resources/Sa
     org.slf4j:slf4j-jdk14;version=1.7.7, \
     com.ibm.ws.org.apache.commons.fileupload;version=latest, \
     com.ibm.ws.org.apache.commons.codec.1.4;version=latest, \
-    com.ibm.ws.security.common;version=latest
+    com.ibm.ws.security.common;version=latest, \
+    com.ibm.ws.container.service;version=latest, \
+    com.ibm.ws.threading;version=latest, \
+    com.ibm.ws.injection.core;version=latest

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/bnd.bnd
@@ -91,5 +91,6 @@ Import-Package: \
     com.ibm.ws.org.apache.commons.fileupload;version=latest,\
     com.ibm.ws.org.apache.commons.io;version=latest,\
     com.ibm.ws.channelfw;version=latest,\
-    com.ibm.ws.anno;version=latest
+    com.ibm.ws.anno;version=latest,\
+    com.ibm.ws.threading;version=latest
 

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/osgi/osgi/WebContainerConstants.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/osgi/osgi/WebContainerConstants.java
@@ -22,5 +22,6 @@ public class WebContainerConstants {
     static String PARAMETER_ASSIGNMENT = "=";
 
     public static final String X_POWERED_BY_DEFAULT_VALUE40 = "Servlet/4.0";
+    public static final String X_POWERED_BY_DEFAULT_VALUE50 = "Servlet/5.0";
 
 }

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/srt/SRTServletResponse40.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/srt/SRTServletResponse40.java
@@ -24,6 +24,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.servlet.request.IRequest;
 import com.ibm.websphere.servlet.response.IResponse;
 import com.ibm.websphere.servlet40.IResponse40;
+import com.ibm.ws.webcontainer.osgi.WebContainer;
 import com.ibm.ws.webcontainer.webapp.WebApp;
 import com.ibm.ws.webcontainer.webapp.WebAppDispatcherContext;
 import com.ibm.ws.webcontainer31.srt.SRTServletResponse31;
@@ -72,7 +73,15 @@ public class SRTServletResponse40 extends SRTServletResponse31 implements HttpSe
      */
     @Override
     protected String getXPoweredbyHeader() {
-        return WebContainerConstants.X_POWERED_BY_DEFAULT_VALUE40;
+        String xPoweredBy = WebContainerConstants.X_POWERED_BY_DEFAULT_VALUE40;
+
+        // The Servlet 4.0 feature is transformed from javax->jakarta and therefore we need
+        // to add a check here to determine the proper X-Powered-By header value.
+        if (WebContainer.getServletContainerSpecLevel() == WebContainer.SPEC_LEVEL_50) {
+            xPoweredBy = WebContainerConstants.X_POWERED_BY_DEFAULT_VALUE50;
+        }
+
+        return xPoweredBy;
     }
 
     @Override

--- a/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype.properties
@@ -125,7 +125,7 @@ xPoweredBy.name=X-Powered-By
 xPoweredBy.desc=Alternative string for the X-Powered-By header setting. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.xpoweredby. There is no default value for this property. If the property is not set, the value of the X-Powered-By header is set to Servlet/<servlet spec version>, as defined by the Servlet specification.
 
 disableXPoweredBy.name=Disable the X-Powered-By header
-disableXPoweredBy.desc=Disable setting the X-Powered-By header. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.disablexpoweredby.
+disableXPoweredBy.desc=Disable setting the X-Powered-By header. The equivalent custom property in the full application server profile is com.ibm.ws.webcontainer.disablexpoweredby. For servlet-5.0 and newer Servlet features, the default value is true.
 
 deferServletLoad.name=Defer servlet load
 deferServletLoad.desc=Defer servlet loading from application server startup.

--- a/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/metatype/metatype.xml
@@ -224,7 +224,7 @@
         <AD id="disableXPoweredBy"
             name="%disableXPoweredBy.name" 
             description="%disableXPoweredBy.desc" 
-            required="false" type="Boolean" default="false" />
+            required="false" type="Boolean" />
             
         <AD id="deferServletLoad"
             name="%deferServletLoad.name" 

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/WCCustomProperties.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/WCCustomProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2019 IBM Corporation and others.
+ * Copyright (c) 1997, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -639,7 +639,13 @@ public class WCCustomProperties {
         TOLERATE_SYMBOLIC_LINKS = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.toleratesymboliclinks")).booleanValue();
 
         X_POWERED_BY = WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.xpoweredby");
-        DISABLE_X_POWERED_BY = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.disablexpoweredby")).booleanValue();
+
+        // Set DISABLE_X_POWERED_BY to true by default for Servlet 5.0 +
+        if(com.ibm.ws.webcontainer.osgi.WebContainer.getServletContainerSpecLevel() >= com.ibm.ws.webcontainer.osgi.WebContainer.SPEC_LEVEL_50) {
+            DISABLE_X_POWERED_BY = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.disablexpoweredby","true")).booleanValue();
+        } else {
+            DISABLE_X_POWERED_BY = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.disablexpoweredby","false")).booleanValue();
+        }
 
         DISABLE_SCI_FOR_PRE_V8_APPS = Boolean.valueOf(
                                                       WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.disableservletcontainerinitializersonprev8apps")).booleanValue();
@@ -803,7 +809,6 @@ public class WCCustomProperties {
 
             Tr.debug(tc, "servletpathfordefaultmapping = " + SERVLET_PATH_FOR_DEFAULT_MAPPING);
         }
-
-}
+    }
 
 }


### PR DESCRIPTION
fixes #12022

Since the following is in a static block and we've added code that now depends on `com.ibm.ws.webcontainer.osgi.WebContainer` in the method called multiple sets of unit tests require some additional projects on their  classpaths to work properly:

`    static {
        setCustomPropertyVariables(); //initilizes all the variables
    }`