### PR TITLE
Repeat tests for jakarta ee9

### DIFF
--- a/dev/com.ibm.ws.transaction.core_fat/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat/bnd.bnd
@@ -34,7 +34,7 @@ tested.features:\
   jpa-2.2,\
   txtest-2.0,\
   servlet-5.0,\
-  jca-2.0
+  jdbc-4.3
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/com.ibm.ws.transaction.core_fat/fat/src/com/ibm/ws/transaction/test/RecoveryTest.java
+++ b/dev/com.ibm.ws.transaction.core_fat/fat/src/com/ibm/ws/transaction/test/RecoveryTest.java
@@ -12,6 +12,7 @@ package com.ibm.ws.transaction.test;
 
 import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
+import java.util.Arrays;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -25,11 +26,11 @@ import com.ibm.ws.transaction.web.RecoveryServlet;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
@@ -48,7 +49,6 @@ import componenttest.topology.utils.FATServletClient;
  */
 @Mode
 @RunWith(FATRunner.class)
-@SkipForRepeat({ SkipForRepeat.EE9_FEATURES })
 public class RecoveryTest extends FATServletClient {
 
     public static final String APP_NAME = "transaction";
@@ -66,6 +66,13 @@ public class RecoveryTest extends FATServletClient {
         // Exports the resulting application to the ${server.config.dir}/apps/ directory
         ShrinkHelper.defaultApp(server, APP_NAME, "com.ibm.ws.transaction.*");
 
+        // TODO: Revisit this after all features required by this FAT suite are available.
+        // The test-specific public features, txtest-x.y, are not in the repeatable EE feature
+        // set. And, the ejb-4.0 feature is not yet available. Enable jdbc-4.3 to enable transactions-2.0.
+        // The following sets the appropriate features for the EE9 repeatable tests.
+        if (JakartaEE9Action.isActive()) {
+            server.changeFeatures(Arrays.asList("jdbc-4.3", "txtest-2.0", "servlet-5.0", "componenttest-2.0", "osgiconsole-1.0", "jndi-1.0"));
+        }
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.transaction.core_fat/fat/src/com/ibm/ws/transaction/test/SimpleTest.java
+++ b/dev/com.ibm.ws.transaction.core_fat/fat/src/com/ibm/ws/transaction/test/SimpleTest.java
@@ -61,10 +61,10 @@ public class SimpleTest extends FATServletClient {
 
         // TODO: Revisit this after all features required by this FAT suite are available.
         // The test-specific public features, txtest-x.y, are not in the repeatable EE feature
-        // set. And, the ejb-4.0 feature is not yet available to enable transactions-2.0 and
-        // jdbc-4.3.  The following sets the appropriate features for the EE9 repeatable tests.
+        // set. And, the ejb-4.0 feature is not yet available. Enable jdbc-4.3 to enable transactions-2.0
+        // The following sets the appropriate features for the EE9 repeatable tests.
         if (JakartaEE9Action.isActive()) {
-            server.changeFeatures(Arrays.asList("jca-2.0", "txtest-2.0", "servlet-5.0", "componenttest-2.0", "osgiconsole-1.0", "jndi-1.0"));
+            server.changeFeatures(Arrays.asList("jdbc-4.3", "txtest-2.0", "servlet-5.0", "componenttest-2.0", "osgiconsole-1.0", "jndi-1.0"));
         }
 
         server.startServer();

--- a/dev/com.ibm.ws.transaction.core_fat/fat/src/com/ibm/ws/transaction/test/XAFlowTest.java
+++ b/dev/com.ibm.ws.transaction.core_fat/fat/src/com/ibm/ws/transaction/test/XAFlowTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.fail;
 
 import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
+import java.util.Arrays;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -28,9 +29,9 @@ import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.transaction.web.XAFlowServlet;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
@@ -47,7 +48,6 @@ import componenttest.topology.utils.FATServletClient;
  * servlet referenced by the annotation, and will be run whenever this test class runs.
  */
 @RunWith(FATRunner.class)
-@SkipForRepeat({ SkipForRepeat.EE9_FEATURES })
 public class XAFlowTest extends FATServletClient {
 
     public static final String APP_NAME = "transaction";
@@ -64,6 +64,14 @@ public class XAFlowTest extends FATServletClient {
         // Automatically includes resources under 'test-applications/APP_NAME/resources/' folder
         // Exports the resulting application to the ${server.config.dir}/apps/ directory
         ShrinkHelper.defaultApp(server, APP_NAME, "com.ibm.ws.transaction.*");
+
+        // TODO: Revisit this after all features required by this FAT suite are available.
+        // The test-specific public features, txtest-x.y, are not in the repeatable EE feature
+        // set. And, the ejb-4.0 feature is not yet available.
+        // The following sets the appropriate features for the EE9 repeatable tests.
+        if (JakartaEE9Action.isActive()) {
+            server.changeFeatures(Arrays.asList("jdbc-4.3", "txtest-2.0", "servlet-5.0", "componenttest-2.0", "osgiconsole-1.0", "jndi-1.0", "xaflow-1.0"));
+        }
 
         server.copyFileToLibertyInstallRoot("lib/features/", "features/xaflow-1.0.mf");
         assertTrue("Failed to install xaflow-1.0 manifest",

--- a/dev/com.ibm.ws.transaction.core_fat/fat/src/com/ibm/ws/transaction/test/XATest.java
+++ b/dev/com.ibm.ws.transaction.core_fat/fat/src/com/ibm/ws/transaction/test/XATest.java
@@ -12,6 +12,8 @@ package com.ibm.ws.transaction.test;
 
 import static org.junit.Assert.fail;
 
+import java.util.Arrays;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -26,6 +28,7 @@ import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
@@ -43,7 +46,6 @@ import componenttest.topology.utils.FATServletClient;
  * servlet referenced by the annotation, and will be run whenever this test class runs.
  */
 @RunWith(FATRunner.class)
-@SkipForRepeat({ SkipForRepeat.EE8_FEATURES, SkipForRepeat.EE9_FEATURES })
 public class XATest extends FATServletClient {
 
     public static final String APP_NAME = "transaction";
@@ -61,6 +63,14 @@ public class XATest extends FATServletClient {
         // Exports the resulting application to the ${server.config.dir}/apps/ directory
         ShrinkHelper.defaultApp(server, APP_NAME, "com.ibm.ws.transaction.*");
 
+        // TODO: Revisit this after all features required by this FAT suite are available.
+        // The test-specific public features, txtest-x.y, are not in the repeatable EE feature
+        // set. And, the ejb-4.0 feature is not yet available. Enable jdbc-4.3 to enable transactions-2.0.
+        // The following sets the appropriate features for the EE9 repeatable tests.
+        if (JakartaEE9Action.isActive()) {
+            server.changeFeatures(Arrays.asList("jdbc-4.3", "txtest-2.0", "servlet-5.0", "componenttest-2.0", "osgiconsole-1.0", "jndi-1.0"));
+        }
+
         server.startServer();
     }
 
@@ -70,6 +80,7 @@ public class XATest extends FATServletClient {
     }
 
     @Test
+    @SkipForRepeat({ SkipForRepeat.EE8_FEATURES, SkipForRepeat.EE9_FEATURES })
     public void testSetTransactionTimeoutReturnsTrue() throws Exception {
         server.setMarkToEndOfLog();
         runTest(server, SERVLET_NAME, testName.getMethodName());
@@ -79,6 +90,7 @@ public class XATest extends FATServletClient {
     }
 
     @Test
+    @SkipForRepeat({ SkipForRepeat.EE8_FEATURES, SkipForRepeat.EE9_FEATURES })
     public void testSetTransactionTimeoutReturnsFalse() throws Exception {
         server.setMarkToEndOfLog();
         runTest(server, SERVLET_NAME, testName.getMethodName());
@@ -88,6 +100,7 @@ public class XATest extends FATServletClient {
     }
 
     @Test
+    @SkipForRepeat({ SkipForRepeat.EE8_FEATURES, SkipForRepeat.EE9_FEATURES })
     @ExpectedFFDC(value = { "javax.transaction.xa.XAException" })
     public void testSetTransactionTimeoutThrowsException() throws Exception {
         server.setMarkToEndOfLog();

--- a/dev/com.ibm.ws.transaction.core_fat/test-applications/transaction/src/com/ibm/ws/transaction/web/SimpleServlet.java
+++ b/dev/com.ibm.ws.transaction.core_fat/test-applications/transaction/src/com/ibm/ws/transaction/web/SimpleServlet.java
@@ -25,19 +25,21 @@ import java.sql.Statement;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
+import javax.annotation.Resource;
+import javax.annotation.Resource.AuthenticationType;
 import javax.inject.Inject;
 import javax.naming.InitialContext;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
-import javax.transaction.NotSupportedException;
 import javax.transaction.RollbackException;
-import javax.transaction.Status;
-import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.UserTransaction;
+import javax.transaction.NotSupportedException;
+import javax.transaction.Transaction;
+import javax.transaction.Status;
 
 import org.junit.Test;
 
@@ -57,9 +59,8 @@ import componenttest.app.FATServlet;
 @WebServlet("/SimpleServlet")
 public class SimpleServlet extends FATServlet {
 
-// TODO: Reinstate When jdbc-4.x feature supports jakartaee9 and resource injection
-//    @Resource(name = "jdbc/derby", shareable = true, authenticationType = AuthenticationType.APPLICATION)
-//    DataSource ds;
+    @Resource(name = "jdbc/derby", shareable = true, authenticationType = AuthenticationType.APPLICATION)
+    DataSource ds;
 
     @Inject
     AsyncBean bean;
@@ -168,8 +169,6 @@ public class SimpleServlet extends FATServlet {
      * Test of basic database connectivity
      */
     @Test
-    // TODO: Remove skip when jdbc feature supports jakartaee9
-    @SkipForRepeat({ SkipForRepeat.EE9_FEATURES })
     public void testBasicConnection(HttpServletRequest request, HttpServletResponse response) throws Exception {
 
         String statusString = "";
@@ -180,7 +179,6 @@ public class SimpleServlet extends FATServlet {
             UserTransaction tran = (UserTransaction) context.lookup("java:comp/UserTransaction");
 
             statusString = statusString + "UserTransaction=" + tran + "<br>";
-            DataSource ds = (DataSource) context.lookup("java:comp/env/jdbc/derby");
             statusString = statusString + "DataSource=" + ds + "<br>";
             Connection con = ds.getConnection();
 
@@ -272,11 +270,8 @@ public class SimpleServlet extends FATServlet {
      * @throws Exception if an error occurs.
      */
     @Test
-    // TODO: Remove skip when jdbc feature supports jakartaee9
-    @SkipForRepeat({ SkipForRepeat.EE9_FEATURES })
     public void testTransactionEnlistment(HttpServletRequest request, HttpServletResponse response) throws Exception {
         InitialContext context = new InitialContext();
-        DataSource ds = (DataSource) context.lookup("java:comp/env/jdbc/derby");
         PrintWriter out = response.getWriter();
         Connection con = ds.getConnection();
         try {
@@ -376,11 +371,8 @@ public class SimpleServlet extends FATServlet {
      * LTC transaction.
      */
     @Test
-    // TODO: Remove skip when jdbc feature supports jakartaee9
-    @SkipForRepeat({ SkipForRepeat.EE9_FEATURES })
     public void testImplicitLTCCommit(HttpServletRequest request, HttpServletResponse response) throws Exception {
         InitialContext context = new InitialContext();
-        DataSource ds = (DataSource) context.lookup("java:comp/env/jdbc/derby");
         Connection con = ds.getConnection();
         try {
             // Set up table
@@ -422,12 +414,9 @@ public class SimpleServlet extends FATServlet {
     }
 
     @Test
-    // TODO: Remove skip when jdbc feature supports jakartaee9
-    @SkipForRepeat({ SkipForRepeat.EE9_FEATURES })
     @ExpectedFFDC(value = { "javax.transaction.NotSupportedException" })
     public void testNEW(HttpServletRequest request, HttpServletResponse response) throws Exception {
         InitialContext context = new InitialContext();
-        DataSource ds = (DataSource) context.lookup("java:comp/env/jdbc/derby");
         Connection con = ds.getConnection();
         try {
             // Set up table
@@ -480,12 +469,9 @@ public class SimpleServlet extends FATServlet {
     }
 
     @Test
-    // TODO: Remove skip when jdbc feature supports jakartaee9
-    @SkipForRepeat({ SkipForRepeat.EE9_FEATURES })
     @ExpectedFFDC(value = { "javax.transaction.NotSupportedException" })
     public void testNEW2(HttpServletRequest request, HttpServletResponse response) throws Exception {
         InitialContext context = new InitialContext();
-        DataSource ds = (DataSource) context.lookup("java:comp/env/jdbc/derby");
         Connection con = ds.getConnection();
         try {
             // Set up table
@@ -541,11 +527,8 @@ public class SimpleServlet extends FATServlet {
      * LTC transaction.
      */
     @Test
-    // TODO: Remove skip when jdbc feature supports jakartaee9
-    @SkipForRepeat({ SkipForRepeat.EE9_FEATURES })
     public void testExplicitLTCCommit(HttpServletRequest request, HttpServletResponse response) throws Exception {
         InitialContext context = new InitialContext();
-        DataSource ds = (DataSource) context.lookup("java:comp/env/jdbc/derby");
         Connection con = ds.getConnection();
         try {
             // Set up table
@@ -589,11 +572,8 @@ public class SimpleServlet extends FATServlet {
     }
 
     @Test
-    // TODO: Remove skip when jdbc feature supports jakartaee9
-    @SkipForRepeat({ SkipForRepeat.EE9_FEATURES })
     public void testLTCAfterGlobalTran(HttpServletRequest request, HttpServletResponse response) throws Exception {
         InitialContext context = new InitialContext();
-        DataSource ds = (DataSource) context.lookup("java:comp/env/jdbc/derby");
         UserTransaction tran = (UserTransaction) new InitialContext().lookup("java:comp/UserTransaction");
         Statement stmt;
         Connection con;

--- a/dev/com.ibm.ws.transaction.core_fat/test-applications/transaction/src/com/ibm/ws/transaction/web/SimpleServlet.java
+++ b/dev/com.ibm.ws.transaction.core_fat/test-applications/transaction/src/com/ibm/ws/transaction/web/SimpleServlet.java
@@ -33,13 +33,13 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
+import javax.transaction.NotSupportedException;
 import javax.transaction.RollbackException;
+import javax.transaction.Status;
+import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.UserTransaction;
-import javax.transaction.NotSupportedException;
-import javax.transaction.Transaction;
-import javax.transaction.Status;
 
 import org.junit.Test;
 
@@ -179,6 +179,7 @@ public class SimpleServlet extends FATServlet {
             UserTransaction tran = (UserTransaction) context.lookup("java:comp/UserTransaction");
 
             statusString = statusString + "UserTransaction=" + tran + "<br>";
+            //DataSource ds = (DataSource) context.lookup("java:comp/env/jdbc/derby");
             statusString = statusString + "DataSource=" + ds + "<br>";
             Connection con = ds.getConnection();
 
@@ -272,6 +273,7 @@ public class SimpleServlet extends FATServlet {
     @Test
     public void testTransactionEnlistment(HttpServletRequest request, HttpServletResponse response) throws Exception {
         InitialContext context = new InitialContext();
+        //DataSource ds = (DataSource) context.lookup("java:comp/env/jdbc/derby");
         PrintWriter out = response.getWriter();
         Connection con = ds.getConnection();
         try {
@@ -373,6 +375,7 @@ public class SimpleServlet extends FATServlet {
     @Test
     public void testImplicitLTCCommit(HttpServletRequest request, HttpServletResponse response) throws Exception {
         InitialContext context = new InitialContext();
+        //DataSource ds = (DataSource) context.lookup("java:comp/env/jdbc/derby");
         Connection con = ds.getConnection();
         try {
             // Set up table
@@ -417,6 +420,7 @@ public class SimpleServlet extends FATServlet {
     @ExpectedFFDC(value = { "javax.transaction.NotSupportedException" })
     public void testNEW(HttpServletRequest request, HttpServletResponse response) throws Exception {
         InitialContext context = new InitialContext();
+        //DataSource ds = (DataSource) context.lookup("java:comp/env/jdbc/derby");
         Connection con = ds.getConnection();
         try {
             // Set up table
@@ -472,6 +476,7 @@ public class SimpleServlet extends FATServlet {
     @ExpectedFFDC(value = { "javax.transaction.NotSupportedException" })
     public void testNEW2(HttpServletRequest request, HttpServletResponse response) throws Exception {
         InitialContext context = new InitialContext();
+        //DataSource ds = (DataSource) context.lookup("java:comp/env/jdbc/derby");
         Connection con = ds.getConnection();
         try {
             // Set up table
@@ -529,6 +534,7 @@ public class SimpleServlet extends FATServlet {
     @Test
     public void testExplicitLTCCommit(HttpServletRequest request, HttpServletResponse response) throws Exception {
         InitialContext context = new InitialContext();
+        //DataSource ds = (DataSource) context.lookup("java:comp/env/jdbc/derby");
         Connection con = ds.getConnection();
         try {
             // Set up table
@@ -574,6 +580,7 @@ public class SimpleServlet extends FATServlet {
     @Test
     public void testLTCAfterGlobalTran(HttpServletRequest request, HttpServletResponse response) throws Exception {
         InitialContext context = new InitialContext();
+        //DataSource ds = (DataSource) context.lookup("java:comp/env/jdbc/derby");
         UserTransaction tran = (UserTransaction) new InitialContext().lookup("java:comp/UserTransaction");
         Statement stmt;
         Connection con;


### PR DESCRIPTION
#11772

Continue the transaction FAT for ee9 in light of recent updates, including feature jdbc-4.3.  