### PR TITLE
Issue 12345 and 12400: Add read/write for WSKeyStore, merge REST revoke test into Boulder tests

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/docker/CAContainer.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/docker/CAContainer.java
@@ -52,6 +52,16 @@ public abstract class CAContainer extends GenericContainer<CAContainer> {
 	 * reachable.
 	 */
 	private final int dnsManagementPort;
+	
+	/**
+	 * Number of attemps to start containers again after catch an exception
+	 */
+	protected final static int NUM_RESTART_ATTEMPTS_ON_EXCEPTION = 3;
+	
+	/**
+	 * Value to put into withStartupAttempts on container config
+	 */
+	protected final static int WITH_STARTUP_ATTEMPTS = 20;
 
 	/**
 	 * Instantiate a new {@link CAContainer} instance.

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/docker/pebble/PebbleContainer.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/docker/pebble/PebbleContainer.java
@@ -13,6 +13,7 @@ package com.ibm.ws.security.acme.docker.pebble;
 
 import static junit.framework.Assert.fail;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,6 +26,7 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
+import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.ContainerNetwork;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.acme.docker.CAContainer;
@@ -80,8 +82,49 @@ public class PebbleContainer extends CAContainer {
 						.copy("pebble-config.json", "/test/config/pebble-config.json").build())
 				.withFileFromFile("pebble-config.json", new File("lib/LibertyFATTestFiles/pebble-config.json")), 5002,
 				14000, 15000);
+		challtestsrv.withStartupAttempts(20);
+		challtestsrv.withStartupTimeout(Duration.ofSeconds(60));
 
-		challtestsrv.start();
+		for (int i = 1; i < NUM_RESTART_ATTEMPTS_ON_EXCEPTION + 1; i ++) {
+			try {
+				challtestsrv.start();
+				Log.info(PebbleContainer.class, "PebbleContainer", "challtestsrv started");
+				break;
+			} catch (Throwable t) {
+				Log.info(PebbleContainer.class, "PebbleContainer", "Failed to start challtestsrv, try again. " + t);
+				challtestsrv.stop();
+				Throwable cause = t.getCause();
+				while (cause != null) {
+					if (t instanceof DockerException) {
+						Log.info(PebbleContainer.class, "PebbleContainer", "Hit a Docker exception, trying a long sleep and retry");
+						try {
+							Thread.sleep(120000);
+						} catch (InterruptedException e) {
+						}
+						break;
+					}
+					cause = cause.getCause();
+				}
+
+				if (cause == null) { // do a short sleep and retry
+					try {
+						Thread.sleep(1000);
+					} catch (InterruptedException e) {
+					}
+				}
+			}
+		}
+		if (!challtestsrv.isRunning()) {
+			challtestsrv.start();
+			Log.info(PebbleContainer.class, "PebbleContainer", "challtestsrv started");
+			
+			/**
+			 * Intermittently getting a null calling getIntraContainerIP, determine what is null
+			 */
+			assertNotNull("challtestsrv.getContainerInfo()", challtestsrv.getContainerInfo());
+			assertNotNull("challtestsrv.getContainerInfo().getNetworkSettings()", challtestsrv.getContainerInfo().getNetworkSettings());
+			assertNotNull("challtestsrv.getContainerInfo().getNetworkSettings().getNetworks().entrySet()", challtestsrv.getContainerInfo().getNetworkSettings().getNetworks().entrySet());
+		}
 
 		String dnsServer = getIntraContainerIP() + ":" + DNS_PORT;
 
@@ -90,12 +133,43 @@ public class PebbleContainer extends CAContainer {
 		this.withExposedPorts(getDnsManagementPort(), getAcmeListenPort());
 		this.withNetwork(network);
 		this.withLogConsumer(PebbleContainer::log);
-		this.withStartupAttempts(3);
+		this.withStartupAttempts(20);
 		this.withStartupTimeout(Duration.ofSeconds(60));
 
 		Testcontainers.exposeHostPorts(5002);
 
-		start();
+		for (int i = 1; i < NUM_RESTART_ATTEMPTS_ON_EXCEPTION + 1; i ++) {
+			try {
+				start();
+				break;
+			} catch (Throwable t) {
+				Log.info(PebbleContainer.class, "PebbleContainer", "Failed to start pebble, try again. " + t);
+				super.stop();
+				Throwable cause = t.getCause();
+				while (cause != null) {
+					if (t instanceof DockerException) {
+						Log.info(PebbleContainer.class, "PebbleContainer", "Hit a Docker exception, trying a long sleep and retry");
+						try {
+							Thread.sleep(120000);
+						} catch (InterruptedException e) {
+						}
+						break;
+					}
+					cause = cause.getCause();
+				}
+
+				if (cause == null) { // do a short sleep and retry
+					try {
+						Thread.sleep(1000);
+					} catch (InterruptedException e) {
+					}
+				}
+			}
+		}
+		
+		if (!isRunning()) {
+			start();
+		}
 
 		try {
 			/*
@@ -115,6 +189,7 @@ public class PebbleContainer extends CAContainer {
 
 		Log.info(PebbleContainer.class, "PebbleContainer", "ContainerIpAddress: " + getContainerIpAddress());
 		Log.info(PebbleContainer.class, "PebbleContainer", "DockerImageName:    " + getDockerImageName());
+		assertNotNull("getContainerInfo()", getContainerInfo());
 		Log.info(PebbleContainer.class, "PebbleContainer", "ContainerInfo:      " + getContainerInfo());
 	}
 

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeCaRestHandlerTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeCaRestHandlerTest.java
@@ -53,7 +53,6 @@ import org.shredzone.acme4j.util.KeyPairUtils;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.acme.docker.CAContainer;
-import com.ibm.ws.security.acme.docker.boulder.BoulderContainer;
 import com.ibm.ws.security.acme.docker.pebble.PebbleContainer;
 import com.ibm.ws.security.acme.internal.util.AcmeConstants;
 import com.ibm.ws.security.acme.internal.web.AcmeCaRestHandler;
@@ -89,7 +88,7 @@ public class AcmeCaRestHandlerTest {
 	private static final String UNAUTHORIZED_PASS = "unauthorizedpass";
 
 	@ClassRule
-	public static CAContainer boulder = new BoulderContainer();
+	public static CAContainer pebble = new PebbleContainer();
 
 	private static final String JSON_ACCOUNT_REGEN_KEYPAIR_VALID = "{\"" + AcmeCaRestHandler.OP_KEY + "\":\""
 			+ AcmeCaRestHandler.OP_RENEW_ACCT_KEY_PAIR + "\"}";
@@ -100,13 +99,6 @@ public class AcmeCaRestHandlerTest {
 	private static final String JSON_CERT_REGEN = "{\"" + AcmeCaRestHandler.OP_KEY + "\":\""
 			+ AcmeCaRestHandler.OP_RENEW_CERT + "\"}";
 	private static final String JSON_CERT_INVALID_OP = "{\"" + AcmeCaRestHandler.OP_KEY + "\":\"invalid\"}";
-
-	private static final String JSON_CERT_REVOKE_DEFAULT_REASON = "{\"" + AcmeCaRestHandler.OP_KEY + "\":\""
-			+ AcmeCaRestHandler.OP_REVOKE_CERT + "\"}";
-	private static final String JSON_CERT_REVOKE_VALID_REASON = "{\"" + AcmeCaRestHandler.OP_KEY + "\":\""
-			+ AcmeCaRestHandler.OP_REVOKE_CERT + "\",\"" + AcmeCaRestHandler.REASON_KEY + "\":\"superseded\"}";
-	private static final String JSON_CERT_REVOKE_INVALID_REASON = "{\"" + AcmeCaRestHandler.OP_KEY + "\":\""
-			+ AcmeCaRestHandler.OP_REVOKE_CERT + "\",\"" + AcmeCaRestHandler.REASON_KEY + "\":\"invalid\"}";
 
 	private static final String CONTENT_TYPE_HTML = "text/html";
 	private static final String CONTENT_TYPE_JSON = "application/json";
@@ -125,12 +117,12 @@ public class AcmeCaRestHandlerTest {
 		/*
 		 * Make sure the HTTP port is open.
 		 */
-		AcmeFatUtils.checkPortOpen(boulder.getHttpPort(), 60000);
+		AcmeFatUtils.checkPortOpen(pebble.getHttpPort(), 60000);
 
 		/*
 		 * Configure the acmeCA-2.0 feature.
 		 */
-		AcmeFatUtils.configureAcmeCA(server, boulder, ORIGINAL_CONFIG, false, true, DOMAINS);
+		AcmeFatUtils.configureAcmeCA(server, pebble, ORIGINAL_CONFIG, false, true, DOMAINS);
 
 		server.startServer();
 		AcmeFatUtils.waitForAcmeToCreateCertificate(server);
@@ -301,39 +293,6 @@ public class AcmeCaRestHandlerTest {
 		String serial1 = getLeafSerialFromHtml(html1);
 		String serial2 = getLeafSerialFromHtml(html2);
 		assertThat("Certificates should have been different.", serial2, not(equalTo(serial1)));
-	}
-
-	@Test
-	public void certificate_endpoint_post_revoke_certificate() throws Exception {
-		/*
-		 * Revoke with invalid reason.
-		 */
-		String jsonResponse = performPost(CERTIFICATE_ENDPOINT, 400, CONTENT_TYPE_JSON, ADMIN_USER, ADMIN_PASS,
-				CONTENT_TYPE_JSON, JSON_CERT_REVOKE_INVALID_REASON);
-		assertJsonResponse(jsonResponse, 400);
-
-		/*
-		 * Revoke with unspecified / default reason.
-		 */
-		jsonResponse = performPost(CERTIFICATE_ENDPOINT, 200, CONTENT_TYPE_JSON, ADMIN_USER, ADMIN_PASS,
-				CONTENT_TYPE_JSON, JSON_CERT_REVOKE_DEFAULT_REASON);
-		assertJsonResponse(jsonResponse, 200);
-
-		/*
-		 * Request a new certificate.
-		 */
-		jsonResponse = performPost(CERTIFICATE_ENDPOINT, 200, CONTENT_TYPE_JSON, ADMIN_USER, ADMIN_PASS,
-				CONTENT_TYPE_JSON, JSON_CERT_REGEN);
-		assertJsonResponse(jsonResponse, 200);
-		AcmeFatUtils.waitForAcmeToCreateCertificate(server);
-		AcmeFatUtils.waitForSslEndpoint(server);
-
-		/*
-		 * Revoke with a valid reason.
-		 */
-		jsonResponse = performPost(CERTIFICATE_ENDPOINT, 200, CONTENT_TYPE_JSON, ADMIN_USER, ADMIN_PASS,
-				CONTENT_TYPE_JSON, JSON_CERT_REVOKE_VALID_REASON);
-		assertJsonResponse(jsonResponse, 200);
 	}
 
 	@Test
@@ -848,12 +807,12 @@ public class AcmeCaRestHandlerTest {
 			/*
 			 * First renew request should update.
 			 */
-			startingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, boulder);
+			startingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, pebble);
 
 			String jsonResponse = performPost(AcmeCaRestHandlerTest.CERTIFICATE_ENDPOINT, 200, AcmeCaRestHandlerTest.CONTENT_TYPE_JSON, AcmeCaRestHandlerTest.ADMIN_USER, AcmeCaRestHandlerTest.ADMIN_PASS,
 					AcmeCaRestHandlerTest.CONTENT_TYPE_JSON, AcmeCaRestHandlerTest.JSON_CERT_REGEN);
 			assertJsonResponse(jsonResponse, 200);
-			AcmeFatUtils.waitForNewCert(server, boulder, startingCertificateChain);
+			AcmeFatUtils.waitForNewCert(server, pebble, startingCertificateChain);
 			
 			/*
 			 * Do back to back renew requests, we should be blocked from renewing
@@ -863,7 +822,7 @@ public class AcmeCaRestHandlerTest {
 				
 				Log.info(this.getClass(), testName.getMethodName(), "Renew round " + i);
 				
-				startingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, boulder);
+				startingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, pebble);
 
 				jsonResponse = performPost(AcmeCaRestHandlerTest.CERTIFICATE_ENDPOINT, 429, AcmeCaRestHandlerTest.CONTENT_TYPE_JSON, AcmeCaRestHandlerTest.ADMIN_USER, AcmeCaRestHandlerTest.ADMIN_PASS,
 						AcmeCaRestHandlerTest.CONTENT_TYPE_JSON, AcmeCaRestHandlerTest.JSON_CERT_REGEN);
@@ -873,7 +832,7 @@ public class AcmeCaRestHandlerTest {
 				
 				Log.info(this.getClass(), methodName, "Response received: " + jsonResponse);
 				
-				endingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, boulder);
+				endingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, pebble);
 
 				assertEquals("The certificate should not renew after REST request.",
 						((X509Certificate) startingCertificateChain[0]).getSerialNumber(),
@@ -885,13 +844,13 @@ public class AcmeCaRestHandlerTest {
 			 */
 			Thread.sleep(AcmeConstants.RENEW_CERT_MIN + 2000);
 			
-			startingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, boulder);
+			startingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, pebble);
 
 			jsonResponse = performPost(AcmeCaRestHandlerTest.CERTIFICATE_ENDPOINT, 200, AcmeCaRestHandlerTest.CONTENT_TYPE_JSON, AcmeCaRestHandlerTest.ADMIN_USER, AcmeCaRestHandlerTest.ADMIN_PASS,
 					AcmeCaRestHandlerTest.CONTENT_TYPE_JSON, AcmeCaRestHandlerTest.JSON_CERT_REGEN);
 			assertJsonResponse(jsonResponse, 200);
 			
-			AcmeFatUtils.waitForNewCert(server, boulder, startingCertificateChain);
+			AcmeFatUtils.waitForNewCert(server, pebble, startingCertificateChain);
 
 		} finally {
 			/*

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeRevocationTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeRevocationTest.java
@@ -13,11 +13,14 @@ package com.ibm.ws.security.acme.fat;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertThat;
 
+import java.io.File;
+import java.io.FileFilter;
 import java.math.BigInteger;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
@@ -84,6 +87,21 @@ public class AcmeRevocationTest {
 	private static final String DOMAIN = "domain1.com"; // Set to domain1.com as it has a high rate limit on certificate requests
 	
 	public static final long SCHEDULE_TIME = AcmeConstants.RENEW_CERT_MIN + 2000;
+	
+	private static final String CERTIFICATE_ENDPOINT = "/ibm/api" + AcmeCaRestHandler.PATH_CERTIFICATE;
+	
+	private static final String JSON_CERT_REGEN = "{\"" + AcmeCaRestHandler.OP_KEY + "\":\""
+			+ AcmeCaRestHandler.OP_RENEW_CERT + "\"}";
+	private static final String JSON_CERT_INVALID_OP = "{\"" + AcmeCaRestHandler.OP_KEY + "\":\"invalid\"}";
+
+	private static final String JSON_CERT_REVOKE_DEFAULT_REASON = "{\"" + AcmeCaRestHandler.OP_KEY + "\":\""
+			+ AcmeCaRestHandler.OP_REVOKE_CERT + "\"}";
+	private static final String JSON_CERT_REVOKE_VALID_REASON = "{\"" + AcmeCaRestHandler.OP_KEY + "\":\""
+			+ AcmeCaRestHandler.OP_REVOKE_CERT + "\",\"" + AcmeCaRestHandler.REASON_KEY + "\":\"superseded\"}";
+	private static final String JSON_CERT_REVOKE_INVALID_REASON = "{\"" + AcmeCaRestHandler.OP_KEY + "\":\""
+			+ AcmeCaRestHandler.OP_REVOKE_CERT + "\",\"" + AcmeCaRestHandler.REASON_KEY + "\":\"invalid\"}";
+
+	private static final String CONTENT_TYPE_JSON = "application/json";
 
 	@Rule
 	public TestName testName = new TestName();
@@ -416,6 +434,156 @@ public class AcmeRevocationTest {
 			 * Stop the server.
 			 */
 			server.stopServer();
+		}
+	}
+	
+	/**
+	 * Test the REST revoke endpoint, provide valid and invalid reasons for the revoke
+	 * @throws Exception
+	 */
+	@Test
+	public void certificate_endpoint_post_revoke_certificate() throws Exception {
+		/*
+		 * Configure the acmeCA-2.0 feature.
+		 */
+		ServerConfiguration configuration = originalServerConfig.clone();
+		configureAcmeRevocation(configuration, true);
+		AcmeFatUtils.configureAcmeCA(server, boulder, configuration, false, true, DOMAIN);
+
+		try {
+
+			/*
+			 * Startup the server.
+			 */
+			Log.info(this.getClass(), testName.getMethodName(), "Rest revokation test.");
+			server.startServer();
+			AcmeFatUtils.waitForSslToCreateKeystore(server);
+			AcmeFatUtils.waitForSslEndpoint(server);
+
+
+			/*
+			 * Revoke with invalid reason.
+			 */
+			String jsonResponse = performPost(CERTIFICATE_ENDPOINT, 400, CONTENT_TYPE_JSON, ADMIN_USER, ADMIN_PASS,
+					CONTENT_TYPE_JSON, JSON_CERT_REVOKE_INVALID_REASON);
+			assertJsonResponse(jsonResponse, 400);
+
+			/*
+			 * Revoke with unspecified / default reason.
+			 */
+			jsonResponse = performPost(CERTIFICATE_ENDPOINT, 200, CONTENT_TYPE_JSON, ADMIN_USER, ADMIN_PASS,
+					CONTENT_TYPE_JSON, JSON_CERT_REVOKE_DEFAULT_REASON);
+			assertJsonResponse(jsonResponse, 200);
+
+			/*
+			 * Request a new certificate.
+			 */
+			jsonResponse = performPost(CERTIFICATE_ENDPOINT, 200, CONTENT_TYPE_JSON, ADMIN_USER, ADMIN_PASS,
+					CONTENT_TYPE_JSON, JSON_CERT_REGEN);
+			assertJsonResponse(jsonResponse, 200);
+			AcmeFatUtils.waitForAcmeToCreateCertificate(server);
+			AcmeFatUtils.waitForSslEndpoint(server);
+
+			/*
+			 * Revoke with a valid reason.
+			 */
+			jsonResponse = performPost(CERTIFICATE_ENDPOINT, 200, CONTENT_TYPE_JSON, ADMIN_USER, ADMIN_PASS,
+					CONTENT_TYPE_JSON, JSON_CERT_REVOKE_VALID_REASON);
+			assertJsonResponse(jsonResponse, 200);
+
+		} finally {
+			server.stopServer();
+		}
+	}
+
+	/**
+	 * Make a POST call to the REST endpoint.
+	 * 
+	 * @param endpoint            The endpoint to call.
+	 * @param expectedStatus      The expected HTTP return code.
+	 * @param expectedContentType The expected response content type.
+	 * @param user                The user to make the call with.
+	 * @param password            The password to make the call with.
+	 * @return the response in the form of a string.
+	 * @throws Exception If the call failed.
+	 */
+	private static String performPost(String endpoint, int expectedStatus, String expectedContentType, String user,
+			String password, String contentType, String content) throws Exception {
+		String methodName = "performPost()";
+
+		try (CloseableHttpClient httpclient = AcmeFatUtils.getInsecureHttpsClient()) {
+
+			/*
+			 * Create a POST request to the Liberty server.
+			 */
+			HttpPost httpPost = new HttpPost("https://localhost:" + server.getHttpDefaultSecurePort() + endpoint);
+			httpPost.setHeader("Authorization",
+					"Basic " + DatatypeConverter.printBase64Binary((user + ":" + password).getBytes()));
+			if (contentType != null && !contentType.isEmpty()) {
+				httpPost.setHeader("Content-Type", contentType);
+			}
+			if (content != null && !content.isEmpty()) {
+				httpPost.setEntity(new StringEntity(content));
+			}
+
+			/*
+			 * Send the POST request and process the response.
+			 */
+			try (final CloseableHttpResponse response = httpclient.execute(httpPost)) {
+				AcmeFatUtils.logHttpResponse(PebbleContainer.class, methodName, httpPost, response);
+
+				StatusLine statusLine = response.getStatusLine();
+				assertEquals("Unexpected status code response.", expectedStatus, statusLine.getStatusCode());
+
+				/*
+				 * Check content type header.
+				 */
+				if (expectedContentType != null) {
+					Header[] headers = response.getHeaders("content-type");
+					assertNotNull("Expected content type header.", headers);
+					assertEquals("Expected 1 content type header.", 1, headers.length);
+					assertEquals("Unexpected content type.", expectedContentType, headers[0].getValue());
+				}
+
+				String contentString = EntityUtils.toString(response.getEntity());
+				Log.info(AcmeRevocationTest.class, methodName, "HTTP post contents: \n" + contentString);
+
+				return contentString;
+			}
+		}
+	}
+
+	/**
+	 * Find all files in the directory whose file name matches the given pattern.
+	 * 
+	 * @param dir     The directory to search.
+	 * @param pattern The pattern to check file names against.
+	 * @return The array of files that match.
+	 */
+	public static File[] findFilesThatMatch(String dir, final String pattern) {
+		File searchDir = new File(dir);
+
+		return searchDir.listFiles(new FileFilter() {
+			public boolean accept(File pathname) {
+				return pathname.getName().matches(pattern);
+			}
+		});
+	}
+
+	/**
+	 * Assert that the expected JSON response is returned.
+	 * 
+	 * @param jsonResponse       The actual JSON response.
+	 * @param expectedStatusCode The expected status code.
+	 */
+	private static void assertJsonResponse(String jsonResponse, int expectedStatusCode) {
+		assertThat("Unexpected HTTP status code returned in JSON response.", jsonResponse,
+				containsString("\"httpCode\":" + expectedStatusCode));
+		if (expectedStatusCode == 200) {
+			assertThat("Expected no error message in JSON response.", jsonResponse,
+					not(containsString("\"message\":")));
+		} else {
+			assertThat("Expected error message in JSON response.", jsonResponse, containsString("\"message\":"));
 		}
 	}
 

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/WSKeyStore.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/WSKeyStore.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.ssl.config;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -38,12 +40,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import com.ibm.websphere.crypto.InvalidPasswordDecodingException;
 import com.ibm.websphere.crypto.PasswordUtil;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.websphere.ssl.Constants;
 import com.ibm.websphere.ssl.JSSEProvider;
 import com.ibm.websphere.ssl.SSLException;
@@ -117,6 +122,9 @@ public class WSKeyStore extends Properties {
     private static final String SUNPKCS11_PROVIDER_NAME = "SunPKCS11";
 
     private final Map<String, SerializableProtectedString> certAliasInfo = new HashMap<String, SerializableProtectedString>();
+
+    /** Read/Write lock to prevent multiple processes writing the keystore file at the same time, or reading while we are writing. Added for acmeCA feature. **/
+    private final ReadWriteLock rwKeyStoreLock = new ReentrantReadWriteLock();
 
     /**
      * Default constructor, will initialize default values.
@@ -745,7 +753,7 @@ public class WSKeyStore extends Properties {
      * @return KeyStore
      * @throws Exception
      */
-    public synchronized KeyStore do_getKeyStore(boolean reinitialize, boolean createIfNotPresent) throws Exception {
+    private synchronized KeyStore do_getKeyStore(boolean reinitialize, boolean createIfNotPresent) throws Exception {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
             Tr.entry(tc, "do_getKeyStore", new Object[] { Boolean.valueOf(reinitialize), Boolean.valueOf(createIfNotPresent) });
 
@@ -1002,11 +1010,16 @@ public class WSKeyStore extends Properties {
      * @throws Exception
      */
     public KeyStore getKeyStore(boolean reinitialize, boolean createIfNotPresent) throws Exception {
-        if (myKeyStore == null || reinitialize) {
-            myKeyStore = do_getKeyStore(reinitialize, createIfNotPresent);
-        }
+        acquireReadLock();
+        try {
+            if (myKeyStore == null || reinitialize) {
+                myKeyStore = do_getKeyStore(reinitialize, createIfNotPresent);
+            }
 
-        return myKeyStore;
+            return myKeyStore;
+        } finally {
+            releaseReadLock();
+        }
     }
 
     /**
@@ -1017,6 +1030,8 @@ public class WSKeyStore extends Properties {
     public void store() throws Exception {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
             Tr.entry(tc, "store");
+
+        acquireWriteLock();
 
         try {
             String name = getProperty(Constants.SSLPROP_KEY_STORE_NAME);
@@ -1067,6 +1082,8 @@ public class WSKeyStore extends Properties {
                 Tr.debug(tc, "Exception storing KeyStore; " + e);
             FFDCFilter.processException(e, getClass().getName(), "store", this);
             throw e;
+        } finally {
+            releaseWriteLock();
         }
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
@@ -1276,9 +1293,9 @@ public class WSKeyStore extends Properties {
      * @param alias
      * @param cert
      * @throws KeyStoreException
-     *             - if the store is read only or not found
+     *                               - if the store is read only or not found
      * @throws KeyException
-     *             - if an error happens updating the store with the cert
+     *                               - if an error happens updating the store with the cert
      */
     public void setCertificateEntry(String alias, Certificate cert) throws KeyStoreException, KeyException {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
@@ -1362,9 +1379,9 @@ public class WSKeyStore extends Properties {
      * @param password
      * @param chain
      * @throws KeyStoreException
-     *             - if the store is read only or not found
+     *                               - if the store is read only or not found
      * @throws KeyException
-     *             - if an error happens updating the store with the cert
+     *                               - if an error happens updating the store with the cert
      */
     @Sensitive
     public void setKeyEntry(String alias, Key key, Certificate[] chain) throws KeyStoreException, KeyException {
@@ -1546,15 +1563,15 @@ public class WSKeyStore extends Properties {
     }
 
     /**
-     * Set a new certificate into the keystore and save the updated store.
+     * Set a new certificate into the keystore
      *
      * @param alias
      *
      * @param cert
      * @throws KeyStoreException
-     *             - if the store is read only or not found
+     *                               - if the store is read only or not found
      * @throws KeyException
-     *             - if an error happens updating the store with the cert
+     *                               - if an error happens updating the store with the cert
      */
     private void setCertificateEntryNoStore(String alias, Certificate cert) throws KeyStoreException, KeyException {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
@@ -1582,7 +1599,12 @@ public class WSKeyStore extends Properties {
     protected void clearJavaKeyStore() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(tc, "clearJavaKeyStore");
-        myKeyStore = null;
+        acquireWriteLock();
+        try {
+            myKeyStore = null;
+        } finally {
+            releaseWriteLock();
+        }
     }
 
     public static String getCannonicalPath(String location, Boolean fileBased) {
@@ -1628,4 +1650,62 @@ public class WSKeyStore extends Properties {
         return (ext);
     }
 
+    /**
+     * Acquire the writer lock. To be used to prevent concurrent keystore
+     * fetching and storing. Must be used with releaseWriteLock
+     */
+    @Trivial
+    void acquireWriteLock() {
+        rwKeyStoreLock.writeLock().lock();
+    }
+
+    /**
+     * Release the writer lock. To be used to prevent concurrent keystore
+     * fetching and storing. Must be used with acquireWriteLock
+     */
+    @Trivial
+    void releaseWriteLock() {
+        rwKeyStoreLock.writeLock().unlock();
+    }
+
+    /**
+     * Acquire the reader lock. To be used to prevent concurrent keystore
+     * fetching and storing. Must be used with releaseReadLock
+     */
+    @Trivial
+    void acquireReadLock() {
+        rwKeyStoreLock.readLock().lock();
+    }
+
+    /**
+     * Release the read lock. To be used to prevent concurrent keystore
+     * fetching and storing. Must be used with acquireReadLock
+     */
+    @Trivial
+    void releaseReadLock() {
+        rwKeyStoreLock.readLock().unlock();
+    }
+
+    /**
+     * Clone the keystore. If an exception occurs, return the original
+     * keystore as "best effort" instead of failing.
+     *
+     * @param original
+     * @return
+     */
+    @Trivial
+    private KeyStore cloneKeystore(KeyStore original) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            original.store(baos, password.getChars());
+            KeyStore clone = JSSEProviderFactory.getInstance().getKeyStoreInstance(type, provider);
+            clone.load(new ByteArrayInputStream(baos.toByteArray()), password.getChars());
+            return clone;
+        } catch (Throwable t) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
+                Tr.event(tc, "cloneKeystore hit an exception, will return original keystore.", t);
+            }
+        }
+        return original;
+    }
 }

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/internal/KeyStoreServiceImpl.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/internal/KeyStoreServiceImpl.java
@@ -345,10 +345,7 @@ public class KeyStoreServiceImpl implements KeyStoreService {
                 throw new KeyStoreException("The keystore [" + keyStoreName + "] is not present in the configuration");
             } else {
                 wks.setCertificateEntry(alias, certificate);
-                wks.store();
             }
-        } catch (CertificateException e) {
-            throw e;
         } catch (KeyStoreException e) {
             throw e;
         } catch (Exception e) {
@@ -365,10 +362,7 @@ public class KeyStoreServiceImpl implements KeyStoreService {
                 throw new KeyStoreException("The keystore [" + keyStoreName + "] is not present in the configuration");
             } else {
                 wks.setKeyEntry(alias, key, chain);
-                wks.store();
             }
-        } catch (CertificateException e) {
-            throw e;
         } catch (KeyStoreException e) {
             throw e;
         } catch (Exception e) {


### PR DESCRIPTION
Fixes #12345 and #12400 -- got a bit of feature creep going on as I fixed one thing, it led to another.

Remove revoke test from `AcmeCaRestHandlerTest` and swap to the `AcmeRevocationTest` to consolidate Boulder tests. Change `AcmeCaRestHandlerTest`  back to being a Pebble test.

Add more retries to starting both Pebble and Boulder, both internal and external try/catch. This is both to help with remote Docker problems on builds and my local Windows run which hit intermittent problems.

Resolve thread problem with getting and store the KeyStore by adding read/write lock.

Removed extra store() calls on KeyStore

Added onto `AcmeValidityAndRenewTest.autoRenewOnRestartAndCertChecker` to test the threading problem with WSKeyStore. Added more time to the `autoRenewWithErrorAndRecovery` because it intermittently failed on PBs.

Fixed exception happening when the certchecker was running after the server was stopping.

ToDo: Clone/copy on getKeyStore, further stabilization of Boulder/Pebble.