### PR TITLE
Fix the tx ee9 fat from jdbc-4.3 to 4.2

### DIFF
--- a/dev/com.ibm.ws.transaction.core_fat/fat/src/com/ibm/ws/transaction/test/RecoveryTest.java
+++ b/dev/com.ibm.ws.transaction.core_fat/fat/src/com/ibm/ws/transaction/test/RecoveryTest.java
@@ -68,10 +68,10 @@ public class RecoveryTest extends FATServletClient {
 
         // TODO: Revisit this after all features required by this FAT suite are available.
         // The test-specific public features, txtest-x.y, are not in the repeatable EE feature
-        // set. And, the ejb-4.0 feature is not yet available. Enable jdbc-4.3 to enable transactions-2.0.
+        // set. And, the ejb-4.0 feature is not yet available. Enable jdbc-4.2 to enable transactions-2.0.
         // The following sets the appropriate features for the EE9 repeatable tests.
         if (JakartaEE9Action.isActive()) {
-            server.changeFeatures(Arrays.asList("jdbc-4.3", "txtest-2.0", "servlet-5.0", "componenttest-2.0", "osgiconsole-1.0", "jndi-1.0"));
+            server.changeFeatures(Arrays.asList("jdbc-4.2", "txtest-2.0", "servlet-5.0", "componenttest-2.0", "osgiconsole-1.0", "jndi-1.0"));
         }
         server.startServer();
     }

--- a/dev/com.ibm.ws.transaction.core_fat/fat/src/com/ibm/ws/transaction/test/SimpleTest.java
+++ b/dev/com.ibm.ws.transaction.core_fat/fat/src/com/ibm/ws/transaction/test/SimpleTest.java
@@ -61,10 +61,10 @@ public class SimpleTest extends FATServletClient {
 
         // TODO: Revisit this after all features required by this FAT suite are available.
         // The test-specific public features, txtest-x.y, are not in the repeatable EE feature
-        // set. And, the ejb-4.0 feature is not yet available. Enable jdbc-4.3 to enable transactions-2.0
+        // set. And, the ejb-4.0 feature is not yet available. Enable jdbc-4.2 to enable transactions-2.0
         // The following sets the appropriate features for the EE9 repeatable tests.
         if (JakartaEE9Action.isActive()) {
-            server.changeFeatures(Arrays.asList("jdbc-4.3", "txtest-2.0", "servlet-5.0", "componenttest-2.0", "osgiconsole-1.0", "jndi-1.0"));
+            server.changeFeatures(Arrays.asList("jdbc-4.2", "txtest-2.0", "servlet-5.0", "componenttest-2.0", "osgiconsole-1.0", "jndi-1.0"));
         }
 
         server.startServer();

--- a/dev/com.ibm.ws.transaction.core_fat/fat/src/com/ibm/ws/transaction/test/XAFlowTest.java
+++ b/dev/com.ibm.ws.transaction.core_fat/fat/src/com/ibm/ws/transaction/test/XAFlowTest.java
@@ -70,7 +70,7 @@ public class XAFlowTest extends FATServletClient {
         // set. And, the ejb-4.0 feature is not yet available.
         // The following sets the appropriate features for the EE9 repeatable tests.
         if (JakartaEE9Action.isActive()) {
-            server.changeFeatures(Arrays.asList("jdbc-4.3", "txtest-2.0", "servlet-5.0", "componenttest-2.0", "osgiconsole-1.0", "jndi-1.0", "xaflow-1.0"));
+            server.changeFeatures(Arrays.asList("jdbc-4.2", "txtest-2.0", "servlet-5.0", "componenttest-2.0", "osgiconsole-1.0", "jndi-1.0", "xaflow-1.0"));
         }
 
         server.copyFileToLibertyInstallRoot("lib/features/", "features/xaflow-1.0.mf");

--- a/dev/com.ibm.ws.transaction.core_fat/fat/src/com/ibm/ws/transaction/test/XATest.java
+++ b/dev/com.ibm.ws.transaction.core_fat/fat/src/com/ibm/ws/transaction/test/XATest.java
@@ -65,10 +65,10 @@ public class XATest extends FATServletClient {
 
         // TODO: Revisit this after all features required by this FAT suite are available.
         // The test-specific public features, txtest-x.y, are not in the repeatable EE feature
-        // set. And, the ejb-4.0 feature is not yet available. Enable jdbc-4.3 to enable transactions-2.0.
+        // set. And, the ejb-4.0 feature is not yet available. Enable jdbc-4.2 to enable transactions-2.0.
         // The following sets the appropriate features for the EE9 repeatable tests.
         if (JakartaEE9Action.isActive()) {
-            server.changeFeatures(Arrays.asList("jdbc-4.3", "txtest-2.0", "servlet-5.0", "componenttest-2.0", "osgiconsole-1.0", "jndi-1.0"));
+            server.changeFeatures(Arrays.asList("jdbc-4.2", "txtest-2.0", "servlet-5.0", "componenttest-2.0", "osgiconsole-1.0", "jndi-1.0"));
         }
 
         server.startServer();


### PR DESCRIPTION
Change the transactions ee9 FAT to use jdbc-4.2 rather than jdbc-4.3, because jdbc-4.3 requires java11 and Jakarta EE 9 must work with Java 8.

