### PR TITLE
Update Monitor SimpleTimer and the REST Stat Mbean to track high/low time durations effectively

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.x.monitor/src/com/ibm/websphere/jaxrs/monitor/RestStatsMXBean.java
+++ b/dev/com.ibm.ws.jaxrs.2.x.monitor/src/com/ibm/websphere/jaxrs/monitor/RestStatsMXBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,61 +14,128 @@ import com.ibm.websphere.monitor.jmx.Counter;
 import com.ibm.websphere.monitor.jmx.StatisticsMeter;
 
 /**
- * Management12 interface for MBeans with names of the form "WebSphere:type=RestStats,name=*"
- * where * is the name of a RESTful resource method within an application under the Liberty profile of the form <appName>.<resourceMethodName>. For example, myApp.DemoResource. One such MBean for each resource method in the system is available
- * from the Liberty profile platform MBean server when the monitor-1.0 feature is enabled. This interface can be used to request a proxy object via the {@link javax.management.JMX#newMMBeanProxy} method.
+ * Management12 interface for MBeans with names of the form
+ * "WebSphere:type=RestStats,name=*" where * is the name of a RESTful resource
+ * method within an application under the Liberty profile of the form
+ * <appName>.<resourceMethodName>. For example, myApp.DemoResource. One such
+ * MBean for each resource method in the system is available from the Liberty
+ * profile platform MBean server when the monitor-1.0 feature is enabled. This
+ * interface can be used to request a proxy object via the
+ * {@link javax.management.JMX#newMMBeanProxy} method.
  * 
  * @ibm-api
  */
 public interface RestStatsMXBean {
 
-    /**
-     * Retrieves the value of the read-only attribute Description, which is a description of the MBean itself.
-     * 
-     * @return description
-     */
-    public String getDescription();
+	/**
+	 * Retrieves the value of the read-only attribute Description, which is a
+	 * description of the MBean itself.
+	 * 
+	 * @return description
+	 */
+	public String getDescription();
 
-    /**
-     * Retrieves the value of the read-only attribute MethodName, the name of the resource method as specified in the deployment descriptor.
-     * 
-     * @return method name
-     */
-    public String getMethodName();
+	/**
+	 * Retrieves the value of the read-only attribute MethodName, the name of the
+	 * resource method as specified in the deployment descriptor.
+	 * 
+	 * @return method name
+	 */
+	public String getMethodName();
 
-    /**
-     * Retrieves the value of the read-only attribute RequestCount, the number of requests the server has received for this resource method.
-     * 
-     * @return request count
-     */
-    public long getRequestCount();
+	/**
+	 * Retrieves the value of the read-only attribute RequestCount, the number of
+	 * requests the server has received for this resource method.
+	 * 
+	 * @return request count
+	 */
+	public long getRequestCount();
 
-    /**
-     * Retrieves the value of the read-only attribute RequestCountDetails, which provides other details on the request count.
-     * 
-     * @return request count details
-     */
-    public Counter getRequestCountDetails();
+	/**
+	 * Retrieves the value of the read-only attribute RequestCountDetails, which
+	 * provides other details on the request count.
+	 * 
+	 * @return request count details
+	 */
+	public Counter getRequestCountDetails();
 
-    /**
-     * Retrieves the value of the read-only attribute ResponseTime, which is the average (mean) time spent responding to each request for the resource method.
-     * 
-     * @return response time
-     */
-    public double getResponseTime();
+	/**
+	 * Retrieves the value of the read-only attribute ResponseTime, which is the
+	 * average (mean) time spent responding to each request for the resource method.
+	 * 
+	 * @return response time
+	 */
+	public double getResponseTime();
 
-    /**
-     * Retrieves the value of the read-only attribute ResponseCountDetails, which provides statistical details on the response time.
-     * 
-     * @return response time details
-     */
-    public StatisticsMeter getResponseTimeDetails();
+	/**
+	 * Retrieves the value of the read-only attribute ResponseCountDetails, which
+	 * provides statistical details on the response time.
+	 * 
+	 * @return response time details
+	 */
+	public StatisticsMeter getResponseTimeDetails();
 
-    /**
-     * Retrieves the value of the read-only attribute AppName, the name of the application of which the resource method belongs.
-     * 
-     * @return app name
-     */
-    public String getAppName();
+	/**
+	 * Retrieves the value of the read-only attribute MinuteLatestMinimumDuration,
+	 * which provides details of the minimum duration of the latest, most-recently,
+	 * recorded complete minute (latest minute can be on-going and not "complete" 
+	 * if mbean is being updated in the current minute).
+	 * 
+	 * @return minimum elapsed duration of the latest minute
+	 */
+	public long getMinuteLatestMinimumDuration();
+
+	/**
+	 * Retrieves the value of the read-only attribute MinuteLatestMaximumDuration,
+	 * which provides details of the maximum duration of the latest, most-recently,
+	 * recorded complete minute. (latest minute can be on-going and not "complete" 
+	 * if mbean is being updated in the current minute).
+	 * 
+	 * @return maximum elapsed duration of the latest minute
+	 */
+	public long getMinuteLatestMaximumDuration();
+
+	/**
+	 * Retrieves the value of the read-only attribute of the latest, most-recently,
+	 * recorded complete minute. (latest minute can be on-going and not "complete"
+	 * if mbean is being updated in the current minute).
+	 * 
+	 * @return latest minute recorded (value in minute since epoch)
+	 */
+	public long getMinuteLatest();
+
+	/**
+	 * Retrieves the value of the read-only attribute MinutePreviousMinimumDuration,
+	 * which provides details of the minimum duration of the previous, second most-recently,
+	 * recorded complete minute
+	 * 
+	 * @return minimum elapsed duration of the previous minute
+	 */
+	public long getMinutePreviousMinimumDuration();
+
+	/**
+	 * Retrieves the value of the read-only attribute MinutePreviousMaximumDuration,
+	 * which provides details of the minimum duration of the previous, second most-recently,
+	 * recorded complete minute
+	 * 
+	 * @return maximum elapsed duration of the previous minute
+	 */
+	public long getMinutePreviousMaximumDuration();
+
+	/**
+	 * Retrieves the value of the read-only attribute of the previous, second most-recently,
+	 * recorded complete minute
+	 * 
+	 * @return previous minute (prior to latest minute) recorded (value in minute since epoch)
+	 */
+	public long getMinutePrevious();
+
+	/**
+	 * Retrieves the value of the read-only attribute AppName, the name of the
+	 * application of which the resource method belongs.
+	 * 
+	 * @return app name
+	 */
+	public String getAppName();
 
 }

--- a/dev/com.ibm.ws.jaxrs.2.x.monitor/src/com/ibm/websphere/jaxrs/monitor/package-info.java
+++ b/dev/com.ibm.ws.jaxrs.2.x.monitor/src/com/ibm/websphere/jaxrs/monitor/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 /**
- * @version 1.0
+ * @version 1.1
  */
-@org.osgi.annotation.versioning.Version("1.0")
+@org.osgi.annotation.versioning.Version("1.1")
 package com.ibm.websphere.jaxrs.monitor;

--- a/dev/com.ibm.ws.jaxrs.2.x.monitor/src/com/ibm/ws/jaxrs/monitor/RestStatsMXBean.java
+++ b/dev/com.ibm.ws.jaxrs.2.x.monitor/src/com/ibm/ws/jaxrs/monitor/RestStatsMXBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,4 +24,22 @@ public interface RestStatsMXBean extends com.ibm.websphere.jaxrs.monitor.RestSta
 
     @Override
     public StatisticsMeter getResponseTimeDetails();
+    
+    @Override
+    public long getMinuteLatestMinimumDuration();
+    
+    @Override
+    public long getMinuteLatestMaximumDuration();
+    
+    @Override
+    public long getMinuteLatest();
+    
+    @Override
+    public long getMinutePreviousMinimumDuration();
+    
+    @Override
+    public long getMinutePreviousMaximumDuration();
+    
+    @Override
+    public long getMinutePrevious();
 }


### PR DESCRIPTION
Definition:

**Latest minute -** The latest minute is the latest/last, most-recent, minute in which values were recorded. It can be the current-instantaneous minute or a complete minute **x-minutes ago (x >= 1)**.
**Previous minute -** The previous minute is the minute previous to the latest minute. It can be y minutes prior to the latest minute). **(y >= 1)**

--------------------------------------------------------------


Metrics-Monitor / MBean behavious:

The mechanism behind the metrics monitor bundle (i.e for vendor metrics (and REST base metrics)) is to utilize MBeans. The metrics-monitor bundle implements their own versions of the metric interfaces which retrieve value by querying the appropriate MBeans when the metrics endpoint is queried. The update of Mbean values and the querying of the metric values are not synchronized. They can be dramatically staggered or imbalanced.

-------------------------------------------------------------------------------------------
This PR serves to introduce the minimum and maximum elapsed time duration tracking for the REST stat metrics. This is a feature of the simple timer that the MP Metrics 3.0 specification has defined. It will display the min/max of the previous complete minute for a duration of one complete minute as well.

Note that the last and most recent complete minute does not necessarily mean the minute immediately prior to the "current/instantaneous" one. It is a recorded minute that is "complete" (i.e 12:00:00 - 12:00:59) that is prior to the current/instantaneous minute.  This is similar to the high/low - min/max behavior of concurrent gauge. The previous complete minute is not necessary the current minute - 1. This is so that whatever monitoring tool is running can get the most recent data whenever it queries (potentially 2 or more minutes after).

The REST Mbean is now  introduced with the `latest` and `previous` min/max values. Ideally the Mbean is constantly updated so that the latest value is the _current _minute's__ value and the previous value is the last complete minute. Ideally we will always query the "previous" value. Also ideally, the `/metrics` endpoint is queried constantly enough that we do not lose a _previous_ value in reporting.

But however, due to high probability of imbalanced updating (i.e REST endpoint hit at various times) and the `/metrics` endpoint being queried at irregular times this poses an issue for retrieving and displaying the SimpleTimer's minimum and maximum recorded values of the most recent complete minute. 

The main issue that arises is that the Mbean (i.e REST endpoint) is only ever updated once (REST endpoint hit once) and we need to account for that by obtaining that "latest" value when appropriate.

A variation of that is that the last REST hit and subsequent Mbean  update needs to be presented on the `/metrics` endpoint at the appropriate time (i.e after the complete minute is finished and the subsequent metrics query is invoked)

Another issue that can arise is if we're using the Mbean's _latest_ value as it is now the most recent complete minute and the Mbean is updated. We will need to account for the value shift and still report the value until the minute is complete.

The logic to handle this is purely in the `MonitorSimpleTimer.java`. The REST/JAX-RS code purely updates the latest and previous values as appropriate.

