### PR TITLE
Only destroy the TCCL if we created it

### DIFF
--- a/dev/com.ibm.ws.beanvalidation.core/src/com/ibm/ws/beanvalidation/AbstractBeanValidation.java
+++ b/dev/com.ibm.ws.beanvalidation.core/src/com/ibm/ws/beanvalidation/AbstractBeanValidation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2016 IBM Corporation and others.
+ * Copyright (c) 2012, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -145,12 +145,24 @@ public abstract class AbstractBeanValidation implements BeanValidation
         return moduleValidationXMLs.get(mmd);
     }
 
-    public abstract ClassLoader configureBvalClassloader(ClassLoader cl);
+    public abstract ClassLoaderTuple configureBvalClassloader(ClassLoader cl);
 
-    public abstract void releaseLoader(ClassLoader cl);
+    public abstract void releaseLoader(ClassLoaderTuple tuple);
 
     @Override
     public abstract void registerValidatorFactory(ModuleMetaData mmd, ClassLoader cl, ValidatorFactory validatorFactory);
 
     public abstract ConstraintValidatorFactory getConstraintValidatorFactory(Configuration<?> config);
+
+    public static class ClassLoaderTuple {
+        public ClassLoader classLoader;
+        public boolean wasCreatedViaClassLoadingService;
+
+        public static ClassLoaderTuple of(ClassLoader classLoader, boolean wasCreatedViaClassLoadingService) {
+            ClassLoaderTuple tuple = new ClassLoaderTuple();
+            tuple.classLoader = classLoader;
+            tuple.wasCreatedViaClassLoadingService = wasCreatedViaClassLoadingService;
+            return tuple;
+        }
+    }
 }

--- a/dev/com.ibm.ws.beanvalidation.v20.cdi/src/com/ibm/ws/beanvalidation/v20/cdi/internal/LibertyHibernateValidatorExtension.java
+++ b/dev/com.ibm.ws.beanvalidation.v20.cdi/src/com/ibm/ws/beanvalidation/v20/cdi/internal/LibertyHibernateValidatorExtension.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -40,6 +40,7 @@ import org.osgi.service.component.annotations.Reference;
 import com.ibm.ejs.util.dopriv.SetContextClassLoaderPrivileged;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.beanvalidation.AbstractBeanValidation.ClassLoaderTuple;
 import com.ibm.ws.beanvalidation.service.Validation20ClassLoader;
 import com.ibm.ws.cdi.CDIService;
 import com.ibm.ws.cdi.extension.WebSphereCDIExtension;
@@ -232,17 +233,5 @@ public class LibertyHibernateValidatorExtension implements Extension, WebSphereC
 
     private ClassLoader createTCCL(ClassLoader parentCL) {
         return AccessController.doPrivileged((PrivilegedAction<ClassLoader>) () -> getClassLoadingService().createThreadContextClassLoader(parentCL));
-    }
-
-    private static class ClassLoaderTuple {
-        ClassLoader classLoader;
-        boolean wasCreatedViaClassLoadingService;
-
-        static ClassLoaderTuple of(ClassLoader classLoader, boolean wasCreatedViaClassLoadingService) {
-            ClassLoaderTuple tuple = new ClassLoaderTuple();
-            tuple.classLoader = classLoader;
-            tuple.wasCreatedViaClassLoadingService = wasCreatedViaClassLoadingService;
-            return tuple;
-        }
     }
 }

--- a/dev/com.ibm.ws.beanvalidation.v20/src/com/ibm/ws/beanvalidation/v20/ValidatorFactoryBuilderImpl.java
+++ b/dev/com.ibm.ws.beanvalidation.v20/src/com/ibm/ws/beanvalidation/v20/ValidatorFactoryBuilderImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -32,6 +32,7 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 import com.ibm.ejs.util.dopriv.SetContextClassLoaderPrivileged;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.beanvalidation.AbstractBeanValidation.ClassLoaderTuple;
 import com.ibm.ws.beanvalidation.service.BvalManagedObjectBuilder;
 import com.ibm.ws.beanvalidation.service.Validation20ClassLoader;
 import com.ibm.ws.beanvalidation.service.ValidatorFactoryBuilder;
@@ -149,17 +150,5 @@ public class ValidatorFactoryBuilderImpl implements ValidatorFactoryBuilder {
 
     protected void unsetBvalManagedObjectBuilder(ServiceReference<BvalManagedObjectBuilder> builderRef) {
         bvalManagedObjectBuilderSR.unsetReference(builderRef);
-    }
-
-    private static class ClassLoaderTuple {
-        ClassLoader classLoader;
-        boolean wasCreatedViaClassLoadingService;
-
-        static ClassLoaderTuple of(ClassLoader classLoader, boolean wasCreatedViaClassLoadingService) {
-            ClassLoaderTuple tuple = new ClassLoaderTuple();
-            tuple.classLoader = classLoader;
-            tuple.wasCreatedViaClassLoadingService = wasCreatedViaClassLoadingService;
-            return tuple;
-        }
     }
 }

--- a/dev/com.ibm.ws.beanvalidation/bnd.bnd
+++ b/dev/com.ibm.ws.beanvalidation/bnd.bnd
@@ -19,6 +19,7 @@ Bundle-Description: Bean Validation Container; version=${bVersion}
 WS-TraceGroup: BeanValidation
 
 Export-Package: \
+  com.ibm.ws.beanvalidation,\
   com.ibm.ws.beanvalidation.service;provide:=true, \
   com.ibm.ws.beanvalidation.config,\
   com.ibm.ws.beanvalidation.accessor


### PR DESCRIPTION
Fixes an issue where bean validation might inadvertantly call `destroyThreadContextClassLoader` when it never created one. This can happen if somebody has already created a TCCL and put it on the current thread.  Then BV would not create a new one, but would call destroy.  This will lead to the reference count being off by one, which could cause the classloading service to uninstall the TCCL's gateway bundle when it is still in use.