### PR TITLE
Issue #12482: Extra Slash in error msg path when <include location> r…

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/XMLConfigParser.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/XMLConfigParser.java
@@ -669,7 +669,7 @@ public class XMLConfigParser {
             return locationService.resolveString(path);
         }
 
-        return path;
+        return PathUtils.normalize(path);
     }
 
     public void handleParseError(ConfigParserException e, Bundle bundle) {


### PR DESCRIPTION
#build 
fixes #12482 