### PR TITLE
Issue 12323: Limit the HTTP methods returned from OAuth endpoints

### DIFF
--- a/dev/com.ibm.ws.security.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.common/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,8 @@ WS-TraceGroup: SecurityCommon
 Export-Package: \
     !com.ibm.ws.security.common.internal.*, \
     !com.ibm.ws.security.common.*.internal.*, \
-    com.ibm.ws.security.common.*
+    com.ibm.ws.security.common.*, \
+    io.openliberty.security.common.*
     
 # 238871
 Import-Package: \

--- a/dev/com.ibm.ws.security.common/src/io/openliberty/security/common/http/SupportedHttpMethodHandler.java
+++ b/dev/com.ibm.ws.security.common/src/io/openliberty/security/common/http/SupportedHttpMethodHandler.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.common.http;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class SupportedHttpMethodHandler {
+
+    public static enum HttpMethod {
+        GET, HEAD, POST, DELETE, PUT, TRACE, OPTIONS
+    }
+
+    protected HttpServletRequest request;
+    protected HttpServletResponse response;
+
+    public SupportedHttpMethodHandler(HttpServletRequest request, HttpServletResponse response) {
+        this.request = request;
+        this.response = response;
+    }
+
+    public boolean isValidHttpMethodForRequest(HttpMethod requestMethod) {
+        return true;
+    };
+
+    public void sendHttpOptionsResponse() throws IOException {
+        Set<HttpMethod> supportedMethods = getAllHttpMethods();
+        setAllowHeaderAndSendResponse(supportedMethods);
+    }
+
+    public void sendUnsupportedMethodResponse() throws IOException {
+        response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+    }
+
+    protected void setAllowHeaderAndSendResponse(Set<HttpMethod> supportedMethods) {
+        String allowHeaderValue = buildHeaderValue(supportedMethods);
+        if (allowHeaderValue != null) {
+            response.setHeader("Allow", allowHeaderValue);
+        }
+        response.setStatus(HttpServletResponse.SC_OK);
+    }
+
+    String buildHeaderValue(Set<HttpMethod> supportedMethods) {
+        if (supportedMethods == null) {
+            return null;
+        }
+        String allowHeaderValue = "";
+        Iterator<HttpMethod> iter = supportedMethods.iterator();
+        while (iter.hasNext()) {
+            allowHeaderValue += iter.next();
+            if (iter.hasNext()) {
+                allowHeaderValue += ", ";
+            }
+        }
+        return allowHeaderValue;
+    }
+
+    private Set<HttpMethod> getAllHttpMethods() {
+        Set<HttpMethod> allMethods = new HashSet<HttpMethod>();
+        HttpMethod[] allMethodsArray = HttpMethod.values();
+        for (HttpMethod method : allMethodsArray) {
+            allMethods.add(method);
+        }
+        return allMethods;
+    }
+
+}

--- a/dev/com.ibm.ws.security.common/src/io/openliberty/security/common/http/package-info.java
+++ b/dev/com.ibm.ws.security.common/src/io/openliberty/security/common/http/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+package io.openliberty.security.common.http;

--- a/dev/com.ibm.ws.security.common/test/io/openliberty/security/common/http/SupportedHttpMethodHandlerTest.java
+++ b/dev/com.ibm.ws.security.common/test/io/openliberty/security/common/http/SupportedHttpMethodHandlerTest.java
@@ -1,0 +1,160 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.common.http;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jmock.Expectations;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import io.openliberty.security.common.http.SupportedHttpMethodHandler.HttpMethod;
+import test.common.SharedOutputManager;
+
+public class SupportedHttpMethodHandlerTest extends CommonTestClass {
+
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("io.openliberty.security.common.*=all");
+
+    private final HttpServletRequest request = mockery.mock(HttpServletRequest.class);
+    private final HttpServletResponse response = mockery.mock(HttpServletResponse.class);
+
+    private SupportedHttpMethodHandler handler;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        System.out.println("Entering test: " + testName.getMethodName());
+        handler = new SupportedHttpMethodHandler(request, response);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.out.println("Exiting test: " + testName.getMethodName());
+        mockery.assertIsSatisfied();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    @Test
+    public void test_isValidHttpMethodForRequest() throws IOException {
+        assertTrue("Default behavior should be to allow all HTTP methods for request.", handler.isValidHttpMethodForRequest(HttpMethod.GET));
+    }
+
+    @Test
+    public void test_sendUnsupportedMethodResponse() throws IOException {
+        mockery.checking(new Expectations() {
+            {
+                one(response).sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+            }
+        });
+        handler.sendUnsupportedMethodResponse();
+    }
+
+    @Test
+    public void test_setAllowHeaderAndSendResponse_nullSupportedMethods() {
+        mockery.checking(new Expectations() {
+            {
+                one(response).setStatus(HttpServletResponse.SC_OK);
+            }
+        });
+        handler.setAllowHeaderAndSendResponse(null);
+    }
+
+    @Test
+    public void test_setAllowHeaderAndSendResponse_noSupportedMethods() {
+        Set<HttpMethod> supportedMethods = new HashSet<HttpMethod>();
+        mockery.checking(new Expectations() {
+            {
+                one(response).setHeader("Allow", "");
+                one(response).setStatus(HttpServletResponse.SC_OK);
+            }
+        });
+        handler.setAllowHeaderAndSendResponse(supportedMethods);
+    }
+
+    @Test
+    public void test_setAllowHeaderAndSendResponse() {
+        Set<HttpMethod> supportedMethods = new HashSet<HttpMethod>();
+        supportedMethods.add(HttpMethod.GET);
+        mockery.checking(new Expectations() {
+            {
+                one(response).setHeader("Allow", "GET");
+                one(response).setStatus(HttpServletResponse.SC_OK);
+            }
+        });
+        handler.setAllowHeaderAndSendResponse(supportedMethods);
+    }
+
+    @Test
+    public void test_buildHeaderValue_nullInput() {
+        String result = handler.buildHeaderValue(null);
+        assertNull("Result should have been null but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_buildHeaderValue_emptySet() {
+        Set<HttpMethod> input = new HashSet<HttpMethod>();
+        String result = handler.buildHeaderValue(input);
+        assertNotNull("Result should not have been null but was.", result);
+        assertTrue("Header value should have been an empty string but was [" + result + "].", result.isEmpty());
+    }
+
+    @Test
+    public void test_buildHeaderValue_singleEntry() {
+        Set<HttpMethod> input = new HashSet<HttpMethod>();
+        input.add(HttpMethod.GET);
+        String result = handler.buildHeaderValue(input);
+        assertNotNull("Result should not have been null but was.", result);
+        assertEquals("Header value did not match the expected value.", "GET", result);
+    }
+
+    @Test
+    public void test_buildHeaderValue_multipleEntries() {
+        Set<HttpMethod> input = new HashSet<HttpMethod>();
+        input.add(HttpMethod.GET);
+        input.add(HttpMethod.HEAD);
+        input.add(HttpMethod.POST);
+        String result = handler.buildHeaderValue(input);
+        assertNotNull("Result should not have been null but was.", result);
+        String possibleValue1 = "GET, HEAD, POST";
+        String possibleValue2 = "GET, POST, HEAD";
+        String possibleValue3 = "HEAD, GET, POST";
+        String possibleValue4 = "HEAD, POST, GET";
+        String possibleValue5 = "POST, HEAD, GET";
+        String possibleValue6 = "POST, GET, HEAD";
+        assertTrue("Header value did not match one of the expected values. Result was: [" + result + "]",
+                possibleValue1.equals(result) || possibleValue2.equals(result) || possibleValue3.equals(result) || possibleValue4.equals(result) || possibleValue5.equals(result) || possibleValue6.equals(result));
+    }
+
+}

--- a/dev/com.ibm.ws.security.oauth/bnd.bnd
+++ b/dev/com.ibm.ws.security.oauth/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -44,7 +44,8 @@ Export-Package: \
  com.ibm.oauth.core.*, \
  com.ibm.wsspi.security.oauth20.token, \
  com.ibm.ws.security.oauth20.*, \
- com.ibm.ws.security.common.claims
+ com.ibm.ws.security.common.claims, \
+ io.openliberty.security.oauth20.*
  
 # com.ibm.ws.security.common.* #238871
 

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/oauth/core/internal/oauth20/OAuth20ComponentImpl.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/oauth/core/internal/oauth20/OAuth20ComponentImpl.java
@@ -1776,7 +1776,7 @@ public class OAuth20ComponentImpl extends OAuthComponentImpl implements
         int lastSlashIndex = path.lastIndexOf("/");
         String issuerIdentifier = scheme + "://" + hostname + ":" + port + path.substring(0, lastSlashIndex);
         addParameterToAttributeList(OAuth20Constants.ISSUER_IDENTIFIER, OAuth20Constants.ATTRTYPE_REQUEST, issuerIdentifier, attributeList);
-        if (request.getAttribute("OidcRequest") != null) {
+        if (request.getAttribute(OAuth20Constants.OIDC_REQUEST_OBJECT_ATTR_NAME) != null) {
             addParameterToAttributeList(OAuth20Constants.REQUEST_FEATURE, OAuth20Constants.ATTRTYPE_REQUEST, OAuth20Constants.REQUEST_FEATURE_OIDC, attributeList);
         }
         _log.exiting(CLASS, methodName);

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/oauth/core/internal/oauth20/OAuth20Constants.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/oauth/core/internal/oauth20/OAuth20Constants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -87,6 +87,10 @@ public interface OAuth20Constants extends OAuthConstants {
     public static final String ISSUER_IDENTIFIER = "issuerIdentifier";
     public static final String REFRESH_TOKEN_KEY = "refresh_key";
     public static final String OLD_REFRESH_TOKEN_KEY = "old_refresh_key";
+
+    public static final String OAUTH_REQUEST_OBJECT_ATTR_NAME = "OAuth20Request";
+    public static final String OIDC_REQUEST_OBJECT_ATTR_NAME = "OidcRequest";
+
     /*
      * Token types, subtypes, and token map data
      */

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/ClientAuthorization.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/ClientAuthorization.java
@@ -264,7 +264,7 @@ public class ClientAuthorization {
      * @throws OAuth20Exception
      */
     private void validateScopes(HttpServletRequest request, AttributeList attrList, OidcBaseClient client, String clientId) throws OAuth20Exception {
-        if (request.getAttribute("OidcRequest") != null) {
+        if (request.getAttribute(OAuth20Constants.OIDC_REQUEST_OBJECT_ATTR_NAME) != null) {
             checkForMissingScopeInTheRequest(request);
             checkForEmptyRegisteredScopeSet(client, clientId);
         }
@@ -372,7 +372,7 @@ public class ClientAuthorization {
                 return retVal;
             }
 
-            if (request.getAttribute("OidcRequest") == null) {
+            if (request.getAttribute(OAuth20Constants.OIDC_REQUEST_OBJECT_ATTR_NAME) == null) {
                 if (tc.isDebugEnabled()) {
                     Tr.debug(tc, "This is an OAuth20 request");
                 }

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/OAuth20ClientMetatypeService.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/OAuth20ClientMetatypeService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -138,7 +138,7 @@ public class OAuth20ClientMetatypeService {
     }
 
     private boolean isSupportedHttpMethod(String requestMethod) {
-        return "GET".equalsIgnoreCase(requestMethod);
+        return "GET".equalsIgnoreCase(requestMethod) || "HEAD".equalsIgnoreCase(requestMethod);
     }
 
     private List<String> getRequestLocales(HttpServletRequest request) {

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/OAuth20EndpointServices.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/OAuth20EndpointServices.java
@@ -213,9 +213,9 @@ public class OAuth20EndpointServices {
         }
         if (tc.isDebugEnabled()) {
             if (oauth20Provider != null) {
-              Tr.debug(tc, "OAUTH20 _SSO OP PROCESS HAS ENDED.");
+                Tr.debug(tc, "OAUTH20 _SSO OP PROCESS HAS ENDED.");
             } else {
-              Tr.debug(tc, "OAUTH20 _SSO OP WILL NOT PROCESS THE REQUEST");
+                Tr.debug(tc, "OAUTH20 _SSO OP WILL NOT PROCESS THE REQUEST");
             }
         }
     }
@@ -743,7 +743,7 @@ public class OAuth20EndpointServices {
             return createTokenLimitResult(attrs, request, clientId);
         }
 
-        if (request.getAttribute("OidcRequest") != null) {
+        if (request.getAttribute(OAuth20Constants.OIDC_REQUEST_OBJECT_ATTR_NAME) != null) {
             // Ensure that the reduced scopes list is not empty
             oauthResult = clientAuthorization.checkForEmptyScopeSetAfterConsent(reducedScopes, oauthResult, request, provider, clientId);
             if (oauthResult != null && oauthResult.getStatus() != OAuthResult.STATUS_OK) {
@@ -1047,12 +1047,12 @@ public class OAuth20EndpointServices {
     }
 
     private OAuth20Request getAuth20Request(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        OAuth20Request oauth20Request = (OAuth20Request) request.getAttribute("OAuth20Request");
+        OAuth20Request oauth20Request = (OAuth20Request) request.getAttribute(OAuth20Constants.OAUTH_REQUEST_OBJECT_ATTR_NAME);
         if (oauth20Request == null) {
             String errorMsg = TraceNLS.getFormattedMessage(this.getClass(),
                     MESSAGE_BUNDLE,
                     "OAUTH_REQUEST_ATTRIBUTE_MISSING",
-                    new Object[] { request.getRequestURI(), "OAuth20Request" },
+                    new Object[] { request.getRequestURI(), OAuth20Constants.OAUTH_REQUEST_OBJECT_ATTR_NAME },
                     "CWWKS1412E: The request endpoint {0} does not have attribute {1}.");
             Tr.error(tc, errorMsg);
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
@@ -1066,7 +1066,7 @@ public class OAuth20EndpointServices {
             String errorMsg = TraceNLS.getFormattedMessage(this.getClass(),
                     MESSAGE_BUNDLE,
                     "OAUTH_PROVIDER_OBJECT_NULL",
-                    new Object[] { oauth20Request.getProviderName(), "OAuth20Request" },
+                    new Object[] { oauth20Request.getProviderName(), OAuth20Constants.OAUTH_REQUEST_OBJECT_ATTR_NAME },
                     "CWWKS1413E: The OAuth20Provider object is null for OAuth provider {0}.");
             Tr.error(tc, errorMsg);
             response.sendError(HttpServletResponse.SC_NOT_FOUND);

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/OAuth20EndpointServlet.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/OAuth20EndpointServlet.java
@@ -23,9 +23,13 @@ import org.osgi.framework.ServiceReference;
 
 import com.ibm.ejs.ras.TraceNLS;
 
+import io.openliberty.security.common.http.SupportedHttpMethodHandler.HttpMethod;
+import io.openliberty.security.oauth20.web.OAuthSupportedHttpMethodHandler;
+
 /**
  * Servlet implementation class OAuth20EndpointServlet
  */
+@SuppressWarnings("restriction")
 public class OAuth20EndpointServlet extends HttpServlet {
     private static final String MESSAGE_BUNDLE = "com.ibm.ws.security.oauth20.internal.resources.OAuthMessages";
 
@@ -43,6 +47,7 @@ public class OAuth20EndpointServlet extends HttpServlet {
         super();
     }
 
+    @Override
     public void init() {
         servletContext = getServletContext();
         bundleContext = (BundleContext) servletContext.getAttribute("osgi-bundlecontext");
@@ -50,46 +55,77 @@ public class OAuth20EndpointServlet extends HttpServlet {
     }
 
     /**
-     * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse
-     *      response)
+     * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response)
      */
-    protected void doGet(HttpServletRequest request,
-            HttpServletResponse response) throws ServletException, IOException {
-        this.doPost(request, response);
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        if (!isValidHttpMethodForRequest(request, response, HttpMethod.GET)) {
+            return;
+        }
+        handleRequest(request, response);
     }
 
     /**
-     * @see HttpServlet#doHead(HttpServletRequest request, HttpServletResponse
-     *      response)
+     * @see HttpServlet#doHead(HttpServletRequest request, HttpServletResponse response)
      */
-    protected void doHead(HttpServletRequest request,
-            HttpServletResponse response) throws ServletException, IOException {
-        this.doPost(request, response);
+    @Override
+    protected void doHead(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        if (!isValidHttpMethodForRequest(request, response, HttpMethod.HEAD)) {
+            return;
+        }
+        handleRequest(request, response);
     }
 
     /**
-     * @see HttpServlet#doDelete(HttpServletRequest request, HttpServletResponse
-     *      response)
+     * @see HttpServlet#doDelete(HttpServletRequest request, HttpServletResponse response)
      */
-    protected void doDelete(HttpServletRequest request,
-            HttpServletResponse response) throws ServletException, IOException {
-        this.doPost(request, response);
+    @Override
+    protected void doDelete(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        if (!isValidHttpMethodForRequest(request, response, HttpMethod.DELETE)) {
+            return;
+        }
+        handleRequest(request, response);
     }
 
     /**
-     * @see HttpServlet#doPut(HttpServletRequest request, HttpServletResponse
-     *      response)
+     * @see HttpServlet#doPut(HttpServletRequest request, HttpServletResponse response)
      */
-    protected void doPut(HttpServletRequest request,
-            HttpServletResponse response) throws ServletException, IOException {
-        this.doPost(request, response);
+    @Override
+    protected void doPut(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        if (!isValidHttpMethodForRequest(request, response, HttpMethod.PUT)) {
+            return;
+        }
+        handleRequest(request, response);
     }
 
     /**
-     * @see HttpServlet#doPost(HttpServletRequest request, HttpServletResponse
-     *      response)
+     * @see HttpServlet#doPost(HttpServletRequest request, HttpServletResponse response)
      */
+    @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        if (!isValidHttpMethodForRequest(request, response, HttpMethod.POST)) {
+            return;
+        }
+        handleRequest(request, response);
+    }
+
+    @Override
+    protected void doTrace(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        OAuthSupportedHttpMethodHandler optionsRequestHandler = getOAuthSupportedHttpMethodHandler(request, response);
+        optionsRequestHandler.sendUnsupportedMethodResponse();
+    }
+
+    @Override
+    protected void doOptions(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        OAuthSupportedHttpMethodHandler optionsRequestHandler = getOAuthSupportedHttpMethodHandler(request, response);
+        optionsRequestHandler.sendHttpOptionsResponse();
+    }
+
+    OAuthSupportedHttpMethodHandler getOAuthSupportedHttpMethodHandler(HttpServletRequest request, HttpServletResponse response) {
+        return new OAuthSupportedHttpMethodHandler(request, response);
+    }
+
+    protected void handleRequest(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         getOAuthEndpointServices();
         oauthEndpointServices.handleOAuthRequest(request, response, servletContext);
     }
@@ -107,4 +143,14 @@ public class OAuth20EndpointServlet extends HttpServlet {
         }
         return oauthEndpointServices;
     }
+
+    private boolean isValidHttpMethodForRequest(HttpServletRequest request, HttpServletResponse response, HttpMethod requestMethod) throws IOException {
+        OAuthSupportedHttpMethodHandler optionsRequestHandler = getOAuthSupportedHttpMethodHandler(request, response);
+        if (!optionsRequestHandler.isValidHttpMethodForRequest(requestMethod)) {
+            optionsRequestHandler.sendUnsupportedMethodResponse();
+            return false;
+        }
+        return true;
+    }
+
 }

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/OAuth20RequestFilter.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/OAuth20RequestFilter.java
@@ -11,6 +11,7 @@
 package com.ibm.ws.security.oauth20.web;
 
 import java.io.IOException;
+import java.util.Enumeration;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -108,7 +109,7 @@ public class OAuth20RequestFilter implements Filter {
      */
     public void setEndpointRequest(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Matcher matcher) throws IOException, ServletException {
         OAuth20Request oauth20Request = new OAuth20Request(getProviderNameFromUrl(matcher), getEndpointTypeFromUrl(matcher), request);
-        request.setAttribute("OAuth20Request", oauth20Request);
+        request.setAttribute(OAuth20Constants.OAUTH_REQUEST_OBJECT_ATTR_NAME, oauth20Request);
         chain.doFilter(request, response);
     }
 

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/UserAuthentication.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/UserAuthentication.java
@@ -168,7 +168,7 @@ public class UserAuthentication {
                 return processPostAuthentication(request, response, requiredRole, al, authResult);
             } else if (authResult.getStatus() == AuthResult.FAILURE || authResult.getStatus() == AuthResult.SEND_401) {
                 setAuthTypeAndPrintError(provider, al, authResult, authnType);
-                boolean bOAuth = request.getAttribute("OidcRequest") == null;
+                boolean bOAuth = request.getAttribute(OAuth20Constants.OIDC_REQUEST_OBJECT_ATTR_NAME) == null;
                 if (bOAuth || !prompt.hasNone()) {
                     response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
                     return new OAuthResultImpl(OAuthResult.STATUS_FAILED, al,

--- a/dev/com.ibm.ws.security.oauth/src/io/openliberty/security/oauth20/web/OAuthSupportedHttpMethodHandler.java
+++ b/dev/com.ibm.ws.security.oauth/src/io/openliberty/security/oauth20/web/OAuthSupportedHttpMethodHandler.java
@@ -76,9 +76,6 @@ public class OAuthSupportedHttpMethodHandler extends SupportedHttpMethodHandler 
     EndpointType getEndpointType() throws IOException {
         OAuth20Request oauth20Request = getOAuth20RequestAttribute();
         if (oauth20Request == null) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Failed to find OAuth20Request information from the inbound request (constructor)");
-            }
             return null;
         }
         return oauth20Request.getType();
@@ -93,6 +90,8 @@ public class OAuthSupportedHttpMethodHandler extends SupportedHttpMethodHandler 
             supportedMethods.add(HttpMethod.HEAD);
             supportedMethods.add(HttpMethod.POST);
         } else if (endpointType == EndpointType.introspect) {
+            supportedMethods.add(HttpMethod.GET);
+            supportedMethods.add(HttpMethod.HEAD);
             supportedMethods.add(HttpMethod.POST);
         } else if (endpointType == EndpointType.revoke) {
             supportedMethods.add(HttpMethod.POST);

--- a/dev/com.ibm.ws.security.oauth/src/io/openliberty/security/oauth20/web/OAuthSupportedHttpMethodHandler.java
+++ b/dev/com.ibm.ws.security.oauth/src/io/openliberty/security/oauth20/web/OAuthSupportedHttpMethodHandler.java
@@ -1,0 +1,160 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oauth20.web;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.ibm.oauth.core.internal.oauth20.OAuth20Constants;
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.security.oauth20.web.EndpointUtils;
+import com.ibm.ws.security.oauth20.web.OAuth20Request;
+import com.ibm.ws.security.oauth20.web.OAuth20Request.EndpointType;
+
+import io.openliberty.security.common.http.SupportedHttpMethodHandler;
+
+@SuppressWarnings("restriction")
+public class OAuthSupportedHttpMethodHandler extends SupportedHttpMethodHandler {
+
+    private static TraceComponent tc = Tr.register(OAuthSupportedHttpMethodHandler.class);
+
+    EndpointUtils endpointUtils = new EndpointUtils();
+
+    public OAuthSupportedHttpMethodHandler(HttpServletRequest request, HttpServletResponse response) {
+        super(request, response);
+    }
+
+    @Override
+    @FFDCIgnore(IOException.class)
+    public boolean isValidHttpMethodForRequest(HttpMethod requestMethod) {
+        try {
+            EndpointType endpointType = getEndpointType();
+            if (endpointType == null) {
+                return false;
+            }
+            Set<HttpMethod> supportedMethods = getSupportedMethodsForEndpoint(endpointType);
+            if (supportedMethods != null && supportedMethods.contains(requestMethod)) {
+                return true;
+            }
+        } catch (IOException e) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Caught an exception determing whether the HTTP method is supported for endpoint: " + e);
+            }
+            return false;
+        }
+        return false;
+    }
+
+    @Override
+    public void sendHttpOptionsResponse() throws IOException {
+        EndpointType endpointType = getEndpointType();
+        if (endpointType == null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Failed to find a known endpoint type from the inbound request");
+            }
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+        Set<HttpMethod> supportedMethods = getSupportedMethodsForEndpoint(endpointType);
+        setAllowHeaderAndSendResponse(supportedMethods);
+    }
+
+    EndpointType getEndpointType() throws IOException {
+        OAuth20Request oauth20Request = getOAuth20RequestAttribute();
+        if (oauth20Request == null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Failed to find OAuth20Request information from the inbound request (constructor)");
+            }
+            return null;
+        }
+        return oauth20Request.getType();
+    }
+
+    Set<HttpMethod> getSupportedMethodsForEndpoint(EndpointType endpointType) throws IOException {
+        Set<HttpMethod> supportedMethods = new HashSet<HttpMethod>();
+        supportedMethods.add(HttpMethod.OPTIONS);
+
+        if (endpointType == EndpointType.authorize) {
+            supportedMethods.add(HttpMethod.GET);
+            supportedMethods.add(HttpMethod.HEAD);
+            supportedMethods.add(HttpMethod.POST);
+        } else if (endpointType == EndpointType.introspect) {
+            supportedMethods.add(HttpMethod.POST);
+        } else if (endpointType == EndpointType.revoke) {
+            supportedMethods.add(HttpMethod.POST);
+        } else if (endpointType == EndpointType.token) {
+            supportedMethods.add(HttpMethod.POST);
+        } else if (endpointType == EndpointType.coverage_map) {
+            supportedMethods.add(HttpMethod.GET);
+            supportedMethods.add(HttpMethod.HEAD);
+        } else if (endpointType == EndpointType.registration) {
+            supportedMethods.add(HttpMethod.GET);
+            supportedMethods.add(HttpMethod.HEAD);
+            supportedMethods.add(HttpMethod.POST);
+            supportedMethods.add(HttpMethod.DELETE);
+            supportedMethods.add(HttpMethod.PUT);
+        } else if (endpointType == EndpointType.logout) {
+            supportedMethods.add(HttpMethod.GET);
+            supportedMethods.add(HttpMethod.HEAD);
+            supportedMethods.add(HttpMethod.POST);
+            supportedMethods.add(HttpMethod.DELETE);
+            supportedMethods.add(HttpMethod.PUT);
+        } else if (endpointType == EndpointType.app_password) {
+            supportedMethods.add(HttpMethod.GET);
+            supportedMethods.add(HttpMethod.HEAD);
+            supportedMethods.add(HttpMethod.POST);
+            supportedMethods.add(HttpMethod.DELETE);
+        } else if (endpointType == EndpointType.app_token) {
+            supportedMethods.add(HttpMethod.GET);
+            supportedMethods.add(HttpMethod.HEAD);
+            supportedMethods.add(HttpMethod.POST);
+            supportedMethods.add(HttpMethod.DELETE);
+        } else if (endpointType == EndpointType.clientManagement) {
+            supportedMethods.add(HttpMethod.GET);
+            supportedMethods.add(HttpMethod.HEAD);
+        } else if (endpointType == EndpointType.personalTokenManagement) {
+            supportedMethods.add(HttpMethod.GET);
+            supportedMethods.add(HttpMethod.HEAD);
+        } else if (endpointType == EndpointType.usersTokenManagement) {
+            supportedMethods.add(HttpMethod.GET);
+            supportedMethods.add(HttpMethod.HEAD);
+        } else if (endpointType == EndpointType.clientMetatype) {
+            supportedMethods.add(HttpMethod.GET);
+            supportedMethods.add(HttpMethod.HEAD);
+        } else {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Received a request for an unknown OAuth endpoint: [" + endpointType + "]");
+            }
+        }
+        return supportedMethods;
+    }
+
+    OAuth20Request getOAuth20RequestAttribute() {
+        OAuth20Request oauth20Request = (OAuth20Request) request.getAttribute(OAuth20Constants.OAUTH_REQUEST_OBJECT_ATTR_NAME);
+        if (oauth20Request == null) {
+            oauth20Request = (OAuth20Request) request.getAttribute(OAuth20Constants.OIDC_REQUEST_OBJECT_ATTR_NAME);
+            if (oauth20Request == null) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Failed to find OAuth20Request information from the inbound request");
+                }
+                return null;
+            }
+        }
+        return oauth20Request;
+    }
+
+}

--- a/dev/com.ibm.ws.security.oauth/src/io/openliberty/security/oauth20/web/package-info.java
+++ b/dev/com.ibm.ws.security.oauth/src/io/openliberty/security/oauth20/web/package-info.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+@TraceOptions(traceGroup = "OAUTH", messageBundle = "com.ibm.ws.security.oauth20.resources.ProviderMsgs")
+package io.openliberty.security.oauth20.web;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/web/ClientAuthorizationTest.java
+++ b/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/web/ClientAuthorizationTest.java
@@ -282,7 +282,7 @@ public class ClientAuthorizationTest {
     private void oidcRequestExpectation(final String oidcRequestAttr) {
         mock.checking(new Expectations() {
             {
-                one(request).getAttribute("OidcRequest");
+                one(request).getAttribute(OAuth20Constants.OIDC_REQUEST_OBJECT_ATTR_NAME);
                 will(returnValue(oidcRequestAttr));
             }
         });

--- a/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/web/OAuth20EndpointServicesTest.java
+++ b/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/web/OAuth20EndpointServicesTest.java
@@ -723,7 +723,7 @@ public class OAuth20EndpointServicesTest {
         final OAuth20Request oauth20Request = new OAuth20Request("providerThatDoesNotExist", EndpointType.authorize, req);
         mock.checking(new Expectations() {
             {
-                one(req).getAttribute("OAuth20Request");
+                one(req).getAttribute(OAuth20Constants.OAUTH_REQUEST_OBJECT_ATTR_NAME);
                 will(returnValue(oauth20Request));
             }
         });

--- a/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/web/OAuth20EndpointServletTest.java
+++ b/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/web/OAuth20EndpointServletTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,12 +29,15 @@ import org.junit.rules.TestRule;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 
+import io.openliberty.security.common.http.SupportedHttpMethodHandler.HttpMethod;
+import io.openliberty.security.oauth20.web.OAuthSupportedHttpMethodHandler;
 import test.common.SharedOutputManager;
 
 /*
- * 
+ *
  */
 
+@SuppressWarnings("restriction")
 public class OAuth20EndpointServletTest {
     static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
     @Rule
@@ -53,9 +56,19 @@ public class OAuth20EndpointServletTest {
     @SuppressWarnings("unchecked")
     private final ServiceReference<OAuth20EndpointServices> sr = context.mock(ServiceReference.class);
     private final OAuth20EndpointServices oes = context.mock(OAuth20EndpointServices.class);
+    private final OAuthSupportedHttpMethodHandler supportedHttpMethodHandler = context.mock(OAuthSupportedHttpMethodHandler.class);
+
+    @SuppressWarnings("serial")
+    private class MockedOAuth20EndpointServlet extends OAuth20EndpointServlet {
+        @Override
+        OAuthSupportedHttpMethodHandler getOAuthSupportedHttpMethodHandler(HttpServletRequest request, HttpServletResponse response) {
+            return supportedHttpMethodHandler;
+        }
+    };
 
     @Before
-    public void setUp() {}
+    public void setUp() {
+    }
 
     private void setupNormalExpectations() throws Exception {
         context.checking(new Expectations() {
@@ -82,7 +95,13 @@ public class OAuth20EndpointServletTest {
 
         try {
             setupNormalExpectations();
-            OAuth20EndpointServlet oeservlet = new OAuth20EndpointServlet();
+            OAuth20EndpointServlet oeservlet = new MockedOAuth20EndpointServlet();
+            context.checking(new Expectations() {
+                {
+                    one(supportedHttpMethodHandler).isValidHttpMethodForRequest(HttpMethod.GET);
+                    will(returnValue(true));
+                }
+            });
             oeservlet.init(scfg);
             oeservlet.init();
             oeservlet.doGet(request, response);
@@ -101,7 +120,13 @@ public class OAuth20EndpointServletTest {
 
         try {
             setupNormalExpectations();
-            OAuth20EndpointServlet oeservlet = new OAuth20EndpointServlet();
+            OAuth20EndpointServlet oeservlet = new MockedOAuth20EndpointServlet();
+            context.checking(new Expectations() {
+                {
+                    one(supportedHttpMethodHandler).isValidHttpMethodForRequest(HttpMethod.HEAD);
+                    will(returnValue(true));
+                }
+            });
             oeservlet.init(scfg);
             oeservlet.init();
             oeservlet.doHead(request, response);
@@ -119,8 +144,14 @@ public class OAuth20EndpointServletTest {
     public void testDoDeleteValid() {
 
         try {
+            OAuth20EndpointServlet oeservlet = new MockedOAuth20EndpointServlet();
+            context.checking(new Expectations() {
+                {
+                    one(supportedHttpMethodHandler).isValidHttpMethodForRequest(HttpMethod.DELETE);
+                    will(returnValue(true));
+                }
+            });
             setupNormalExpectations();
-            OAuth20EndpointServlet oeservlet = new OAuth20EndpointServlet();
             oeservlet.init(scfg);
             oeservlet.init();
             oeservlet.doDelete(request, response);
@@ -139,7 +170,13 @@ public class OAuth20EndpointServletTest {
 
         try {
             setupNormalExpectations();
-            OAuth20EndpointServlet oeservlet = new OAuth20EndpointServlet();
+            OAuth20EndpointServlet oeservlet = new MockedOAuth20EndpointServlet();
+            context.checking(new Expectations() {
+                {
+                    one(supportedHttpMethodHandler).isValidHttpMethodForRequest(HttpMethod.PUT);
+                    will(returnValue(true));
+                }
+            });
             oeservlet.init(scfg);
             oeservlet.init();
             oeservlet.doPut(request, response);
@@ -171,7 +208,13 @@ public class OAuth20EndpointServletTest {
                 }
             });
 
-            OAuth20EndpointServlet oeservlet = new OAuth20EndpointServlet();
+            OAuth20EndpointServlet oeservlet = new MockedOAuth20EndpointServlet();
+            context.checking(new Expectations() {
+                {
+                    one(supportedHttpMethodHandler).isValidHttpMethodForRequest(HttpMethod.GET);
+                    will(returnValue(true));
+                }
+            });
             oeservlet.init(scfg);
             oeservlet.init();
             oeservlet.doGet(request, response);

--- a/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/web/UserAuthenticationTest.java
+++ b/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/oauth20/web/UserAuthenticationTest.java
@@ -1040,7 +1040,7 @@ public class UserAuthenticationTest {
                     will(returnValue(new SSOCookieHelperImpl(config)));
                     allowing(config).createReferrerURLCookieHandler();
                     will(returnValue(new ReferrerURLCookieHandler(config)));
-                    one(request).getAttribute("OidcRequest");
+                    one(request).getAttribute(OAuth20Constants.OIDC_REQUEST_OBJECT_ATTR_NAME);
                     will(returnValue(null));
                     one(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
                 }

--- a/dev/com.ibm.ws.security.oauth/test/io/openliberty/security/oauth20/web/OAuthSupportedHttpMethodHandlerTest.java
+++ b/dev/com.ibm.ws.security.oauth/test/io/openliberty/security/oauth20/web/OAuthSupportedHttpMethodHandlerTest.java
@@ -1,0 +1,246 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oauth20.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jmock.Expectations;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.oauth.core.internal.oauth20.OAuth20Constants;
+import com.ibm.ws.security.oauth20.web.EndpointUtils;
+import com.ibm.ws.security.oauth20.web.OAuth20Request;
+import com.ibm.ws.security.oauth20.web.OAuth20Request.EndpointType;
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import io.openliberty.security.common.http.SupportedHttpMethodHandler.HttpMethod;
+import test.common.SharedOutputManager;
+
+@SuppressWarnings("restriction")
+public class OAuthSupportedHttpMethodHandlerTest extends CommonTestClass {
+
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("io.openliberty.security.oauth.*=all:com.ibm.ws.security.oauth*=all");
+
+    private final HttpServletRequest request = mockery.mock(HttpServletRequest.class);
+    private final HttpServletResponse response = mockery.mock(HttpServletResponse.class);
+    private final EndpointUtils endpointUtils = mockery.mock(EndpointUtils.class);
+    private final OAuth20Request oauth20Request = mockery.mock(OAuth20Request.class);
+
+    private OAuthSupportedHttpMethodHandler handler;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        System.out.println("Entering test: " + testName.getMethodName());
+        handler = new OAuthSupportedHttpMethodHandler(request, response);
+        handler.endpointUtils = endpointUtils;
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.out.println("Exiting test: " + testName.getMethodName());
+        mockery.assertIsSatisfied();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    @Test
+    public void test_isValidHttpMethodForRequest_missingOAuth20RequestInfo() throws IOException {
+        mockery.checking(new Expectations() {
+            {
+                one(request).getAttribute(OAuth20Constants.OAUTH_REQUEST_OBJECT_ATTR_NAME);
+                will(returnValue(null));
+                one(request).getAttribute(OAuth20Constants.OIDC_REQUEST_OBJECT_ATTR_NAME);
+                will(returnValue(null));
+            }
+        });
+        boolean result = handler.isValidHttpMethodForRequest(HttpMethod.GET);
+        assertFalse("Should not have been a valid HTTP method for a request missing OAuth20Request information.", result);
+    }
+
+    @Test
+    public void test_isValidHttpMethodForRequest_unknownEndpoint() throws IOException {
+        mockery.checking(new Expectations() {
+            {
+                one(request).getAttribute(OAuth20Constants.OAUTH_REQUEST_OBJECT_ATTR_NAME);
+                will(returnValue(oauth20Request));
+                one(oauth20Request).getType();
+                will(returnValue(null));
+            }
+        });
+        boolean result = handler.isValidHttpMethodForRequest(HttpMethod.GET);
+        assertFalse("Should not have been a valid HTTP method for an unknown endpoint.", result);
+    }
+
+    @Test
+    public void test_isValidHttpMethodForRequest_knownEndpoint_unsupportedHttpMethod() throws IOException {
+        final EndpointType endpoint = EndpointType.introspect;
+        final HttpMethod requestMethod = HttpMethod.GET;
+        mockery.checking(new Expectations() {
+            {
+                one(request).getAttribute(OAuth20Constants.OAUTH_REQUEST_OBJECT_ATTR_NAME);
+                will(returnValue(oauth20Request));
+                one(oauth20Request).getType();
+                will(returnValue(endpoint));
+            }
+        });
+        boolean result = handler.isValidHttpMethodForRequest(requestMethod);
+        assertFalse("HTTP method [" + requestMethod + "] should not have been supported for endpoint [" + endpoint + "].", result);
+    }
+
+    @Test
+    public void test_isValidHttpMethodForRequest_knownEndpoint_ssupportedHttpMethod() throws IOException {
+        final EndpointType endpoint = EndpointType.authorize;
+        final HttpMethod requestMethod = HttpMethod.GET;
+        mockery.checking(new Expectations() {
+            {
+                one(request).getAttribute(OAuth20Constants.OAUTH_REQUEST_OBJECT_ATTR_NAME);
+                will(returnValue(oauth20Request));
+                one(oauth20Request).getType();
+                will(returnValue(endpoint));
+            }
+        });
+        boolean result = handler.isValidHttpMethodForRequest(requestMethod);
+        assertTrue("HTTP method [" + requestMethod + "] should have been supported for endpoint [" + endpoint + "].", result);
+    }
+
+    @Test
+    public void test_sendHttpOptionsResponse_missingOAuth20RequestInfo() throws IOException {
+        mockery.checking(new Expectations() {
+            {
+                one(request).getAttribute(OAuth20Constants.OAUTH_REQUEST_OBJECT_ATTR_NAME);
+                will(returnValue(null));
+                one(request).getAttribute(OAuth20Constants.OIDC_REQUEST_OBJECT_ATTR_NAME);
+                will(returnValue(null));
+                one(response).sendError(HttpServletResponse.SC_NOT_FOUND);
+            }
+        });
+        handler.sendHttpOptionsResponse();
+    }
+
+    @Test
+    public void test_sendHttpOptionsResponse_unknownEndpoint() throws IOException {
+        mockery.checking(new Expectations() {
+            {
+                one(request).getAttribute(OAuth20Constants.OAUTH_REQUEST_OBJECT_ATTR_NAME);
+                will(returnValue(oauth20Request));
+                one(oauth20Request).getType();
+                will(returnValue(null));
+                one(response).sendError(HttpServletResponse.SC_NOT_FOUND);
+            }
+        });
+        handler.sendHttpOptionsResponse();
+    }
+
+    @Test
+    public void test_sendHttpOptionsResponse_knownEndpoint() throws IOException {
+        mockery.checking(new Expectations() {
+            {
+                one(request).getAttribute(OAuth20Constants.OAUTH_REQUEST_OBJECT_ATTR_NAME);
+                will(returnValue(oauth20Request));
+                one(oauth20Request).getType();
+                will(returnValue(EndpointType.introspect));
+                // There are multiple supported methods, so we can't know in which order they'll be output
+                one(response).setHeader(with(any(String.class)), with(any(String.class)));
+                one(response).setStatus(HttpServletResponse.SC_OK);
+            }
+        });
+        handler.sendHttpOptionsResponse();
+    }
+
+    @Test
+    public void test_getEndpointType_missingOAuthRequestInfo() throws IOException {
+        mockery.checking(new Expectations() {
+            {
+                one(request).getAttribute(OAuth20Constants.OAUTH_REQUEST_OBJECT_ATTR_NAME);
+                will(returnValue(null));
+                one(request).getAttribute(OAuth20Constants.OIDC_REQUEST_OBJECT_ATTR_NAME);
+                will(returnValue(null));
+            }
+        });
+        EndpointType endpoint = handler.getEndpointType();
+        assertNull("Expected endpoint to be null but was [" + endpoint + "].", endpoint);
+    }
+
+    @Test
+    public void test_getEndpointType_nullEndpointType() throws IOException {
+        mockery.checking(new Expectations() {
+            {
+                one(request).getAttribute(OAuth20Constants.OAUTH_REQUEST_OBJECT_ATTR_NAME);
+                will(returnValue(oauth20Request));
+                one(oauth20Request).getType();
+                will(returnValue(null));
+            }
+        });
+        EndpointType endpoint = handler.getEndpointType();
+        assertNull("Expected endpoint to be null but was [" + endpoint + "].", endpoint);
+    }
+
+    @Test
+    public void test_getEndpointType() throws IOException {
+        final EndpointType expectedEndpoint = EndpointType.introspect;
+        mockery.checking(new Expectations() {
+            {
+                one(request).getAttribute(OAuth20Constants.OAUTH_REQUEST_OBJECT_ATTR_NAME);
+                will(returnValue(oauth20Request));
+                one(oauth20Request).getType();
+                will(returnValue(expectedEndpoint));
+            }
+        });
+        EndpointType endpoint = handler.getEndpointType();
+        assertEquals("Returned endpoint did not match expected value.", expectedEndpoint, endpoint);
+    }
+
+    @Test
+    public void test_getSupportedMethodsForEndpoint_authorize() throws IOException {
+        Set<HttpMethod> supportedMethods = handler.getSupportedMethodsForEndpoint(EndpointType.authorize);
+        assertNotNull("Set of supported methods should not have been null but was.", supportedMethods);
+        HttpMethod[] expectedMethods = new HttpMethod[] { HttpMethod.OPTIONS, HttpMethod.GET, HttpMethod.HEAD, HttpMethod.POST };
+        assertEquals("Did not find the expected number of supported HTTP methods.", expectedMethods.length, supportedMethods.size());
+        for (HttpMethod expectedMethod : expectedMethods) {
+            assertTrue("Did not find " + expectedMethod + " in the set of supported HTTP methods.", supportedMethods.contains(expectedMethod));
+        }
+    }
+
+    @Test
+    public void test_getSupportedMethodsForEndpoint_token() throws IOException {
+        Set<HttpMethod> supportedMethods = handler.getSupportedMethodsForEndpoint(EndpointType.token);
+        assertNotNull("Set of supported methods should not have been null but was.", supportedMethods);
+        HttpMethod[] expectedMethods = new HttpMethod[] { HttpMethod.OPTIONS, HttpMethod.POST };
+        assertEquals("Did not find the expected number of supported HTTP methods.", expectedMethods.length, supportedMethods.size());
+        for (HttpMethod expectedMethod : expectedMethods) {
+            assertTrue("Did not find " + expectedMethod + " in the set of supported HTTP methods.", supportedMethods.contains(expectedMethod));
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.security.oauth/test/io/openliberty/security/oauth20/web/OAuthSupportedHttpMethodHandlerTest.java
+++ b/dev/com.ibm.ws.security.oauth/test/io/openliberty/security/oauth20/web/OAuthSupportedHttpMethodHandlerTest.java
@@ -104,7 +104,7 @@ public class OAuthSupportedHttpMethodHandlerTest extends CommonTestClass {
 
     @Test
     public void test_isValidHttpMethodForRequest_knownEndpoint_unsupportedHttpMethod() throws IOException {
-        final EndpointType endpoint = EndpointType.introspect;
+        final EndpointType endpoint = EndpointType.token;
         final HttpMethod requestMethod = HttpMethod.GET;
         mockery.checking(new Expectations() {
             {

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/OidcEndpointServices.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/OidcEndpointServices.java
@@ -309,12 +309,12 @@ public class OidcEndpointServices extends OAuth20EndpointServices {
     }
 
     private OidcRequest getOidcRequest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        OidcRequest oidcRequest = (OidcRequest) request.getAttribute("OidcRequest");
+        OidcRequest oidcRequest = (OidcRequest) request.getAttribute(OAuth20Constants.OIDC_REQUEST_OBJECT_ATTR_NAME);
         if (oidcRequest == null) {
             String errorMsg = TraceNLS.getFormattedMessage(this.getClass(),
                                                            TraceConstants.MESSAGE_BUNDLE,
                                                            "OIDC_REQUEST_ATTRIBUTE_MISSING",
-                                                           new Object[] { request.getRequestURI(), "OidcRequest" },
+                                                           new Object[] { request.getRequestURI(), OAuth20Constants.OIDC_REQUEST_OBJECT_ATTR_NAME },
                                                            "CWWKS1634E: The request endpoint {0} does not have attribute {1}.");
             Tr.error(tc, errorMsg);
             response.sendError(HttpServletResponse.SC_NOT_FOUND, errorMsg);

--- a/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/OidcEndpointServlet.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/src/com/ibm/ws/security/openidconnect/web/OidcEndpointServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,13 +20,11 @@ import javax.servlet.http.HttpServletResponse;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 
-import com.ibm.ws.security.oauth20.web.OAuth20EndpointServlet;
-
 import com.ibm.ejs.ras.TraceNLS;
+import com.ibm.ws.security.oauth20.web.OAuth20EndpointServlet;
 import com.ibm.ws.security.openidconnect.server.TraceConstants;
 
-public class OidcEndpointServlet extends OAuth20EndpointServlet
-{
+public class OidcEndpointServlet extends OAuth20EndpointServlet {
     private transient OidcEndpointServices oidcEndpointServices = null;
     private transient ServletContext servletContext = null;
     private transient BundleContext bundleContext = null;
@@ -38,19 +36,25 @@ public class OidcEndpointServlet extends OAuth20EndpointServlet
         super();
     }
 
+    @Override
     public void init() {
         servletContext = getServletContext();
         bundleContext = (BundleContext) servletContext.getAttribute("osgi-bundlecontext");
         oidcEndPointServicesRef = bundleContext.getServiceReference(OidcEndpointServices.class);
     }
 
-    protected void doGet(HttpServletRequest request, HttpServletResponse response)
-                    throws ServletException, IOException {
-        this.doPost(request, response);
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        handleRequest(request, response);
     }
 
-    protected void doPost(HttpServletRequest request, HttpServletResponse response)
-                    throws ServletException, IOException {
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        handleRequest(request, response);
+    }
+
+    @Override
+    protected void handleRequest(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         getOidcEndpointServices();
         oidcEndpointServices.handleOidcRequest(request, response, servletContext);
     }

--- a/dev/com.ibm.ws.security.openidconnect.server/test/com/ibm/ws/security/openidconnect/web/OidcEndpointServicesTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.server/test/com/ibm/ws/security/openidconnect/web/OidcEndpointServicesTest.java
@@ -1350,7 +1350,7 @@ public class OidcEndpointServicesTest {
                 //screw up if we hardcode the parameter map
                 allowing(request).getQueryString(); //for trace
                 will(returnValue(TEST_QUERY));
-                allowing(request).getAttribute("OidcRequest");
+                allowing(request).getAttribute(OAuth20Constants.OIDC_REQUEST_OBJECT_ATTR_NAME);
                 will(returnValue(oidcRequest));
             }
         });


### PR DESCRIPTION
Limits the HTTP methods that are supported by the OAuth endpoints that Liberty supports. Each endpoint handled by `OAuth20EndpointServices.handleEndpointRequest()` now has a tailored set of HTTP methods that are considered supported, based off of either spec-defined behavior or the behavior as defined by the current structure of the Liberty code. HTTP `OPTIONS` requests to each endpoint will return that set of supported HTTP methods. HTTP requests of any type other than one of the methods supported will return a 405.

Related to #12323