### PR TITLE
 Issue 12395: Add retry on checking for acme cert after feature enabled

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSimpleTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSimpleTest.java
@@ -12,11 +12,11 @@ package com.ibm.ws.security.acme.fat;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -406,10 +406,11 @@ public class AcmeSimpleTest {
 			AcmeFatUtils.waitForAcmeToCreateCertificate(server);
 
 			/*
-			 * Verify that the server is now using a certificate signed by the
-			 * CA.
+			 * Verify that the server is now using a certificate signed by the CA. We may
+			 * need to a wait a short bit at the SSL config completes the update and clears
+			 * the cache.
 			 */
-			Certificate[] certificates1 = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+			Certificate[] certificates1 = AcmeFatUtils.waitForAcmeCert(server, caContainer, 10000);
 			Log.info(this.getClass(), testName.getMethodName(), "TEST 1: FINISH");
 
 			/***********************************************************************

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
@@ -11,7 +11,6 @@
 
 package com.ibm.ws.security.acme.utils;
 
-import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
@@ -596,6 +595,30 @@ public class AcmeFatUtils {
 				return certificates;
 			}
 		}
+	}
+
+	/**
+	 * Wait for assertAndGetServerCertificate to complete without errors. If it
+	 * fails until the timeout, run again to throw the exception back to the caller.
+	 * 
+	 * @param server
+	 * @param container
+	 * @param timeout
+	 * @return
+	 * @throws Exception
+	 */
+	public static final <assertAndGetServerCertificate> Certificate[] waitForAcmeCert(LibertyServer server,
+			CAContainer container, long timeout) throws Exception {
+		long startTime = System.currentTimeMillis();
+		while (System.currentTimeMillis() < startTime + timeout) {
+			Log.info(AcmeFatUtils.class, "waitForAcmeCert", "Cert checking to swap from self signed to acme ");
+			try {
+				return assertAndGetServerCertificate(server, container);
+			} catch (Exception e) {
+				Thread.sleep(1000);
+			}
+		}
+		return assertAndGetServerCertificate(server, container);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #12395

Add retry while fetching the acme certificate after the acmeCA feature is enabled and we will switch from the self signed to the acme certificate. Depending on the timing, there is some additional SSL processing after the `CWPKI2007I` message is printed.