### PR TITLE
Issue 12328: Add new Acme Cert Checker tests

### DIFF
--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeCertCheckerTask.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeCertCheckerTask.java
@@ -80,6 +80,8 @@ public class AcmeCertCheckerTask implements Runnable {
 								+ ", isRevocationCheckerEnabled: "
 								+ acmeProviderImpl.getAcmeConfig().isRevocationCheckerEnabled());
 			}
+			Tr.info(tc, "CWPKI2069I");
+
 			return;
 		}
 

--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeConfig.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeConfig.java
@@ -669,9 +669,9 @@ public class AcmeConfig {
 		if (certCheckerScheduler != null) {
 			if (certCheckerScheduler <= 0) {
 				/*
-				 * Cert Checker is disabled
+				 * Cert Checker is disabled. Message is logged in 
+				 * AcmeCertCheckerTask.startCertificateChecker
 				 */
-				Tr.info(tc, "CWPKI2069I");
 				this.certCheckerScheduler = 0L;
 			} else if (certCheckerScheduler < AcmeConstants.RENEW_CERT_MIN) {
 				/*

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeCaRestHandlerTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeCaRestHandlerTest.java
@@ -80,8 +80,8 @@ public class AcmeCaRestHandlerTest {
 	private static final String ACCOUNT_ENDPOINT = "/ibm/api" + AcmeCaRestHandler.PATH_ACCOUNT;
 	private static final String CERTIFICATE_ENDPOINT = "/ibm/api" + AcmeCaRestHandler.PATH_CERTIFICATE;
 
-	private static final String ADMIN_USER = "administrator";
-	private static final String ADMIN_PASS = "adminpass";
+	private static final String ADMIN_USER = AcmeFatUtils.ADMIN_USER;
+	private static final String ADMIN_PASS = AcmeFatUtils.ADMIN_PASS;
 	private static final String READER_USER = "reader";
 	private static final String READER_PASS = "readerpass";
 	private static final String UNAUTHORIZED_USER = "unauthorized";

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeDisableTriggerSimpleTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeDisableTriggerSimpleTest.java
@@ -1,0 +1,415 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.acme.fat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import java.math.BigInteger;
+import java.security.SignatureException;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.SSLHandshakeException;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.conn.HttpHostConnectException;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.security.acme.docker.CAContainer;
+import com.ibm.ws.security.acme.docker.pebble.PebbleContainer;
+import com.ibm.ws.security.acme.internal.util.AcmeConstants;
+import com.ibm.ws.security.acme.utils.AcmeFatUtils;
+
+import componenttest.annotation.CheckForLeakedPasswords;
+import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.MinimumJavaLevel;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * Disables the keystore trigger. Select a few tests from
+ * AcmeSimpleTest to run.
+ * 
+ */
+@RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
+public class AcmeDisableTriggerSimpleTest {
+	
+	@Server("com.ibm.ws.security.acme.fat.trigger")
+	public static LibertyServer server;
+	
+	protected static ServerConfiguration ORIGINAL_CONFIG;
+
+	/*
+	 * Domains that are configured and cleared before and after the class.
+	 */
+	private static final String[] DOMAINS_ALL = { "domain1.com", "domain2.com", "domain3.com" };
+	private static final String[] DOMAINS_1 = { "domain1.com" };
+	private static final String[] DOMAINS_2 = { "domain1.com", "domain2.com", "domain3.com" };
+	private static final String[] DOMAINS_3 = { "domain1.com", "domain2.com" };
+	private static final String[] DOMAINS_4 = { "domain2.com" };
+
+	public static CAContainer caContainer;
+
+	@Rule
+	public TestName testName = new TestName();
+
+	@BeforeClass
+	public static void beforeClass() throws Exception {
+		ORIGINAL_CONFIG = server.getServerConfiguration();
+		caContainer = new PebbleContainer();
+		AcmeFatUtils.checkPortOpen(caContainer.getHttpPort(), 60000);
+	}
+
+	@AfterClass
+	public static void afterClass() throws Exception {
+		if (caContainer != null) {
+			caContainer.stop();
+		}
+	}
+
+	@After
+	public void afterTest() throws Exception {
+		/*
+		 * Clear the DNS records for the domain. Required since a few of the
+		 * tests setup invalid A records to test failure scenarios.
+		 */
+		AcmeFatUtils.clearDnsForDomains(caContainer, DOMAINS_ALL);
+
+		/*
+		 * Cleanup any generated ACME files.
+		 */
+		AcmeFatUtils.deleteAcmeFiles(server);
+	}
+
+	
+	
+	@Test
+	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
+	public void update_domains() throws Exception {
+
+		/*
+		 * Configure the acmeCA-2.0 feature.
+		 */
+		AcmeFatUtils.configureAcmeCA(server, caContainer, ORIGINAL_CONFIG, false, DOMAINS_1);
+
+		try {
+
+			/*
+			 * Start the server and wait for the certificate to be installed.
+			 */
+			server.startServer();
+			AcmeFatUtils.waitForAcmeToCreateCertificate(server);
+			AcmeFatUtils.waitForSslToCreateKeystore(server);
+			AcmeFatUtils.waitForSslEndpoint(server);
+
+			/*
+			 * Verify that the server is now using a certificate signed by the
+			 * CA.
+			 */
+			Certificate[] certificates1 = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			/***********************************************************************
+			 * 
+			 * TEST 1: Add more domains. This should result in a refreshed
+			 * certificate.
+			 * 
+			 **********************************************************************/
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 1: START");
+			AcmeFatUtils.configureAcmeCA(server, caContainer, ORIGINAL_CONFIG, false, DOMAINS_2);
+			AcmeFatUtils.waitForAcmeToCreateCertificate(server);
+
+			/*
+			 * Verify that the server is now using a certificate signed by the
+			 * CA.
+			 */
+			Certificate[] certificates2 = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			BigInteger serial1 = ((X509Certificate) certificates1[0]).getSerialNumber();
+			BigInteger serial2 = ((X509Certificate) certificates2[0]).getSerialNumber();
+			assertFalse("Expected new certificate after adding new domain.", serial1.equals(serial2));
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 1: FINISH");
+
+			/***********************************************************************
+			 * 
+			 * TEST 2: Remove a domain that IS NOT the subject CN. We SHOULD NOT
+			 * refresh the certificate.
+			 * 
+			 **********************************************************************/
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 2: START");
+			AcmeFatUtils.configureAcmeCA(server, caContainer, ORIGINAL_CONFIG, false, DOMAINS_3);
+			AcmeFatUtils.waitForAcmeToNoOp(server);
+
+			/*
+			 * Verify that the server is now using a certificate signed by the
+			 * CA.
+			 */
+			Certificate[] certificates3 = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			serial1 = ((X509Certificate) certificates2[0]).getSerialNumber();
+			serial2 = ((X509Certificate) certificates3[0]).getSerialNumber();
+			assertEquals("Expected same certificate after removing non-CN domain.", serial1, serial2);
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 2: FINISH");
+
+			/***********************************************************************
+			 * 
+			 * TEST 3: Remove a domain that IS the subject CN. We SHOULD refresh
+			 * the certificate.
+			 * 
+			 **********************************************************************/
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 3: START");
+			AcmeFatUtils.configureAcmeCA(server, caContainer, ORIGINAL_CONFIG, false, DOMAINS_4);
+			AcmeFatUtils.waitForAcmeToCreateCertificate(server);
+
+			/*
+			 * Verify that the server is now using a certificate signed by the
+			 * CA.
+			 */
+			Certificate[] certificates4 = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			serial1 = ((X509Certificate) certificates3[0]).getSerialNumber();
+			serial2 = ((X509Certificate) certificates4[0]).getSerialNumber();
+			assertFalse("Expected new certificate after adding new domain.", serial1.equals(serial2));
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 3: FINISH");
+
+		} finally {
+			/*
+			 * Stop the server.
+			 */
+			server.stopServer();
+		}
+	}
+	
+	/**
+	 * This test will verify that even when the ACME CA server fails to validate
+	 * our domain on startup due to configuration issues that can't be validated
+	 * before requesting the certificate, we can recover by updating
+	 * configuration.
+	 * 
+	 * <p/>
+	 * NOTE: This does not cover errors that are not due to configuration issues
+	 * (for example, when the DNS record for the domain does not point at your
+	 * server). Those will require a restart of the server.
+	 * 
+	 * @throws Exception
+	 *             if the test fails for some unforeseen reason.
+	 */
+	@Test
+	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
+	@ExpectedFFDC({ "com.ibm.ws.security.acme.AcmeCaException" })
+	@MinimumJavaLevel(javaLevel = 9)
+	/* Minimum Java Level to avoid a known/fixed IBM Java 8 bug with an empty keystore, IJ19292. When the builds move to 8SR6, we can run this test again */
+	public void startup_failure_recover() throws Exception {
+
+		ServerConfiguration configuration = ORIGINAL_CONFIG.clone();
+
+		/*
+		 * Configure the acmeCA-2.0 feature. Point domain2.com to an invalid
+		 * address. Any attempt to validate ownership of this domain is going to
+		 * fail.
+		 */
+		AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, false, DOMAINS_2);
+		caContainer.addDnsARecord("domain2.com", "127.0.0.1");
+
+		try {
+			/***********************************************************************
+			 * 
+			 * Start the server. The domain2.com domain will fail to validate.
+			 * 
+			 **********************************************************************/
+			Log.info(AcmeSimpleTest.class, testName.getMethodName(), "Starting server.");
+			server.startServer();
+			server.waitForStringInLog("CWPKI2001E.*authorization challenge failed for the domain2.com domain");
+			AcmeFatUtils.waitForSslEndpoint(server);
+
+			/*
+			 * Try and connect to Liberty's HTTPS port. We should fail as there
+			 * is no cert.
+			 */
+			try (CloseableHttpClient httpclient = AcmeFatUtils.getInsecureHttpsClient()) {
+
+				/*
+				 * Create a GET request to the Liberty server.
+				 */
+				HttpGet httpGet = new HttpGet("https://localhost:" + server.getHttpDefaultSecurePort());
+
+				/*
+				 * Send the GET request and process the response.
+				 */
+				try (final CloseableHttpResponse response = httpclient.execute(httpGet)) {
+					fail("Expected HttpHostConnectException.");
+				} catch (HttpHostConnectException e) {
+					// Expected if the HTTPS endpoint is NOT up.
+				} catch (SSLHandshakeException e) {
+					// Expected if we wait for the HTTPS endpoint to come up.
+				}
+			}
+
+			/***********************************************************************
+			 * 
+			 * Update the domains so that domain2.com is no longer in the
+			 * configuration.
+			 * 
+			 **********************************************************************/
+			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, false, DOMAINS_1);
+			AcmeFatUtils.waitForAcmeToCreateCertificate(server);
+			AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+		} finally {
+			server.stopServer("CWPKI2001E", "CWPKI0804E", "CWWKO0801E");
+		}
+	}
+	
+	@Test
+	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
+	public void toggle_acme_feature() throws Exception {
+
+		/*
+		 * Modify the configuration so that transportSecurity-1.0 feature is
+		 * enabled, but acmeCA-2.0 is not enabled. Also enable servlet-4.0 so
+		 * the HTTPS end-point comes up.
+		 */
+		ServerConfiguration configuration = ORIGINAL_CONFIG.clone();
+		configuration.getFeatureManager().getFeatures().remove("acmeCA-2.0");
+		configuration.getFeatureManager().getFeatures().add("transportSecurity-1.0");
+		configuration.getFeatureManager().getFeatures().add("servlet-4.0");
+		configuration.getAcmeCA().setCertCheckerSchedule(AcmeConstants.RENEW_CERT_MIN + "ms");
+		AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, false, DOMAINS_1);
+
+		try {
+
+			/*
+			 * Start the server and wait for the (self-signed) certificate to be
+			 * installed.
+			 */
+			server.startServer();
+			AcmeFatUtils.waitForSslToCreateKeystore(server);
+			AcmeFatUtils.waitForSslEndpoint(server);
+
+			/*
+			 * Verify that the server is NOT using a certificate signed by the
+			 * ACME CA.
+			 */
+			try {
+				AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+				fail("Expected SignatureException.");
+			} catch (SignatureException e) {
+				assertEquals("Expected error message was not found.", "Signature does not match.", e.getMessage());
+			}
+
+			/***********************************************************************
+			 * 
+			 * TEST 1: Add the acmeCA-2.0 feature. This will generate a new ACME
+			 * CA certificate.
+			 * 
+			 **********************************************************************/
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 1: START");
+			configuration = configuration.clone();
+			configuration.getFeatureManager().getFeatures().add("acmeCA-2.0");
+			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, false, DOMAINS_1);
+			AcmeFatUtils.waitForAcmeToCreateCertificate(server);
+
+			/*
+			 * Verify that the server is now using a certificate signed by the CA. We may
+			 * need to a wait a short bit at the SSL config completes the update and clears
+			 * the cache.
+			 */
+			Certificate[] certificates1 = AcmeFatUtils.waitForAcmeCert(server, caContainer, 10000);
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 1: FINISH");
+
+			/***********************************************************************
+			 * 
+			 * TEST 2: Remove the acmeCA-2.0 feature. Certificate should not
+			 * change.
+			 * 
+			 **********************************************************************/
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 2: START");
+			configuration = configuration.clone();
+			configuration.getFeatureManager().getFeatures().remove("acmeCA-2.0");
+			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, false, DOMAINS_1);
+			AcmeFatUtils.waitAcmeFeatureUninstall(server);
+
+			long timeElapsed = System.currentTimeMillis();
+
+			/*
+			 * Verify that the server is still using a certificate signed by the
+			 * CA. The default certificate generator doesn't update the
+			 * certificate.
+			 */
+			Certificate[] certificates2 = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			BigInteger serial1 = ((X509Certificate) certificates1[0]).getSerialNumber();
+			BigInteger serial2 = ((X509Certificate) certificates2[0]).getSerialNumber();
+			assertEquals("Expected same certificate after removing acmeCA-2.0 feature.", serial1, serial2);
+			
+			/*
+			 * Check log for the amount of time it would take to wake up/run the scheduler
+			 */
+			assertNull("Should not have found the cert checker waking up: " + AcmeFatUtils.ACME_CHECKER_TRACE,
+					server.waitForStringInTrace(AcmeFatUtils.ACME_CHECKER_TRACE, AcmeConstants.RENEW_CERT_MIN - timeElapsed + 1000));
+			
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 2: FINISH");
+
+			/***********************************************************************
+			 * 
+			 * TEST 3: Add the acmeCA-2.0 feature back, again. Certificate
+			 * should not change.
+			 * 
+			 **********************************************************************/
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 3: START");
+			configuration = configuration.clone();
+			configuration.getFeatureManager().getFeatures().add("acmeCA-2.0");
+			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, false, DOMAINS_1);
+			AcmeFatUtils.waitForAcmeToNoOp(server);
+
+			/*
+			 * Verify that the server is now using a certificate signed by the
+			 * CA.
+			 */
+			Certificate[] certificates3 = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			serial1 = ((X509Certificate) certificates2[0]).getSerialNumber();
+			serial2 = ((X509Certificate) certificates3[0]).getSerialNumber();
+			assertEquals("Expected same certificate after re-adding the acmeCA-2.0 feature.", serial1, serial2);
+
+			/**
+			 * Make sure the scheduler started again
+			 */
+			assertNotNull("Should have found the cert checker waking up: " + AcmeFatUtils.ACME_CHECKER_TRACE,
+					server.waitForStringInTrace(AcmeFatUtils.ACME_CHECKER_TRACE));
+
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 3: FINISH");
+
+		} finally {
+			/*
+			 * Stop the server.
+			 */
+			server.stopServer("CWPKI2058W");
+		}
+	}
+
+}

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeValidityAndRenewTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeValidityAndRenewTest.java
@@ -23,6 +23,15 @@ import static org.junit.Assert.assertTrue;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 
+import javax.xml.bind.DatatypeConverter;
+
+import org.apache.http.Header;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.util.EntityUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -32,10 +41,12 @@ import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.websphere.simplicity.config.AcmeCA.AcmeRevocationChecker;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.acme.docker.CAContainer;
 import com.ibm.ws.security.acme.docker.pebble.PebbleContainer;
 import com.ibm.ws.security.acme.internal.util.AcmeConstants;
+import com.ibm.ws.security.acme.internal.web.AcmeCaRestHandler;
 import com.ibm.ws.security.acme.utils.AcmeFatUtils;
 
 import componenttest.annotation.AllowedFFDC;
@@ -54,7 +65,7 @@ import componenttest.topology.impl.LibertyServer;
 @Mode(TestMode.FULL)
 public class AcmeValidityAndRenewTest {
 
-	@Server("com.ibm.ws.security.acme.fat.simple")
+	@Server("com.ibm.ws.security.acme.fat.renew")
 	public static LibertyServer server;
 
 	private static ServerConfiguration ORIGINAL_CONFIG;
@@ -62,7 +73,7 @@ public class AcmeValidityAndRenewTest {
 
 	public static CAContainer caContainer;
 
-	public static final long timeBufferToExpire = 30000L; // milliseconds
+	public static final long TIME_BUFFER_BEFORE_EXPIRE = 30000L; // milliseconds
 
 	public static final int CHECKER_SECONDS = 1000;
 
@@ -322,7 +333,7 @@ public class AcmeValidityAndRenewTest {
 			long extraBuffer = serverTime - notBefore;
 			// check if the certificate is slightly in the future to make sure we wait long
 			// enough.
-			long totalBuffer = (extraBuffer > 0 ? extraBuffer : 0) + timeBufferToExpire;
+			long totalBuffer = (extraBuffer > 0 ? extraBuffer : 0) + TIME_BUFFER_BEFORE_EXPIRE;
 
 			Log.info(this.getClass(), testName.getMethodName(),
 					"Not before: " + notBefore + ", extra buffer " + extraBuffer);
@@ -331,7 +342,7 @@ public class AcmeValidityAndRenewTest {
 			 * Set a renew time just shy of default Pebble validity period) so we will
 			 * request a new certificate on restart)
 			 */
-			 justShyOfValidityPeriod = (notAfter - notBefore) - timeBufferToExpire;
+			justShyOfValidityPeriod = (notAfter - notBefore) - TIME_BUFFER_BEFORE_EXPIRE;
 			Log.info(this.getClass(), testName.getMethodName(), "Time configured: " + justShyOfValidityPeriod);
 
 			/*
@@ -383,9 +394,10 @@ public class AcmeValidityAndRenewTest {
 					"TEST 3: Restart with renew time close to validity period and short cert checker.");
 
 			configuration.getAcmeCA().setRenewBeforeExpiration((justShyOfValidityPeriod +5000) + "ms");
-			configuration.getAcmeCA().setCertCheckerSchedule((timeBufferToExpire + 1000) + "ms");
-			configuration.getAcmeCA().setCertCheckerSchedule(AcmeConstants.RENEW_CERT_MIN + "ms");
+			configuration.getAcmeCA().setCertCheckerSchedule((TIME_BUFFER_BEFORE_EXPIRE + 1000) + "ms");
 
+			configuration.getAcmeCA().setCertCheckerSchedule(AcmeConstants.RENEW_CERT_MIN + "ms");
+			configuration.getAcmeCA().setDisableMinRenewWindow(true);
 			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, DOMAINS1);
 
 			server.startServer();
@@ -407,22 +419,40 @@ public class AcmeValidityAndRenewTest {
 			/*
 			 * The certificate checker should automatically renew the certificate.
 			 */
-			AcmeFatUtils.waitForNewCert(server, caContainer, startingCertificateChain, timeBufferToExpire * 4);
+			AcmeFatUtils.waitForNewCert(server, caContainer, startingCertificateChain, TIME_BUFFER_BEFORE_EXPIRE * 2);
 
 			assertNotNull("Should log message that the certificate was renewed",
 					server.waitForStringInLogUsingMark("CWPKI2052I"));
-			
+
 			/**
 			 * Run "load" while the certificate checkers runs in the background and renews the cert
 			 */
 			long now = System.currentTimeMillis();
 			Log.info(this.getClass(), testName.getMethodName(), "Run https load to make sure certificate renew happens cleanly.");
-			while (System.currentTimeMillis() - now < timeBufferToExpire * 2) {
+			while (System.currentTimeMillis() - now < TIME_BUFFER_BEFORE_EXPIRE * 2) {
 				AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
 			}
 			
 			assertTrue("Should not find CWPKI0033E", server.findStringsInLogs("CWPKI0033E").isEmpty());
 			assertTrue("Should not find CWPKI0809W", server.findStringsInLogs("CWPKI0809W").isEmpty());
+
+			startingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+			
+			// Run a bunch of requests while the cert checker runs in the background
+			long expireTime = System.currentTimeMillis() + (TIME_BUFFER_BEFORE_EXPIRE * 2);
+			while (expireTime >  System.currentTimeMillis()) {
+				renewCertificate();
+				AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+			}
+
+			/*
+			 * Should definitely have a new certificate
+			 */
+			endingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			serial1 = ((X509Certificate) startingCertificateChain[0]).getSerialNumber().toString(16);
+			serial2 = ((X509Certificate) endingCertificateChain[0]).getSerialNumber().toString(16);
+			assertThat("The certificate should have been marked as expired and renewed.", serial1, not(equalTo(serial2)));	
 
 		} finally {
 			Log.info(this.getClass(), testName.getMethodName(), "TEST 3: Shutdown.");
@@ -499,14 +529,14 @@ public class AcmeValidityAndRenewTest {
 	}
 
 	/**
-	 * This test will verify that the server starts up and requests a new
-	 * certificate from the ACME server when required.
+	 * This test will verify that the cert checker starts and stops as it is disabled and
+	 * enabled.
 	 * 
 	 * @throws Exception If the test failed for some reason.
 	 */
 	@Test
 	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
-	public void certCheckerDisabled() throws Exception {
+	public void certCheckerToggle() throws Exception {
 
 		Certificate[] startingCertificateChain = null, endingCertificateChain = null;
 
@@ -519,14 +549,16 @@ public class AcmeValidityAndRenewTest {
 		configuration.getAcmeCA().setRenewBeforeExpiration("0ms");
 		AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, DOMAINS1);
 
-		/***********************************************************************
-		 * 
-		 * TEST 1: The server will start up without the specified keystore available. It
-		 * should generate a new keystore with a certificate retrieved from the ACME CA
-		 * server.
-		 * 
-		 **********************************************************************/
+		
 		try {
+			
+			/***********************************************************************
+			 * 
+			 * TEST 1: The server will start and
+			 * should generate a new keystore with a certificate retrieved from the ACME CA
+			 * server. The cert checker should run, but the renew option is disabled.
+			 * 
+			 **********************************************************************/
 			Log.info(this.getClass(), testName.getMethodName(), "TEST 1: Start");
 
 			/*
@@ -538,11 +570,50 @@ public class AcmeValidityAndRenewTest {
 			AcmeFatUtils.waitForSslEndpoint(server);
 
 			/*
-			 * Verify that the server is now using a certificate signed by the CA.
+			 * Verify that the server is now using a certificate signed by the CA
+			 * The cert checker will run
+			 */
+			startingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+			assertNotNull("Should have found the cert checker waking up: " + AcmeFatUtils.ACME_CHECKER_TRACE,
+					server.waitForStringInTraceUsingMark(AcmeFatUtils.ACME_CHECKER_TRACE, AcmeConstants.RENEW_CERT_MIN + 5000));
+
+			/*
+			 * Should have the same certificate
+			 */
+			endingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			assertEquals("The certificate should be the same.",
+					((X509Certificate) startingCertificateChain[0]).getSerialNumber(),
+					((X509Certificate) endingCertificateChain[0]).getSerialNumber());
+
+			/*
+			 * Auto renew is disabled
+			 */
+
+			assertFalse("Should log disabled message", server.findStringsInLogsAndTraceUsingMark("Auto renewal of the certificate is disabled").isEmpty());
+
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 1: Finish.");
+
+			/***********************************************************************
+			 * 
+			 * TEST 2: The cert checker is disabled and should not run.
+			 * 
+			 **********************************************************************/
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 2: Start");
+
+			configuration = ORIGINAL_CONFIG.clone();
+			configuration.getAcmeCA().setCertCheckerSchedule(0 + "ms");
+			configuration.getAcmeCA().setRenewBeforeExpiration("7d");
+			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, DOMAINS1);
+			AcmeFatUtils.waitForAcmeToNoOp(server);
+			server.setMarkToEndOfLog(server.getDefaultTraceFile());
+			
+			/*
+			 * The cert checker should not run
 			 */
 			startingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
 			assertNull("Should not have found the cert checker waking up: " + AcmeFatUtils.ACME_CHECKER_TRACE,
-					server.waitForStringInTrace(AcmeFatUtils.ACME_CHECKER_TRACE, CHECKER_SECONDS + 5000));
+					server.waitForStringInTraceUsingMark(AcmeFatUtils.ACME_CHECKER_TRACE, CHECKER_SECONDS + 5000));
 
 			/*
 			 * Should have the same certificate
@@ -553,9 +624,179 @@ public class AcmeValidityAndRenewTest {
 					((X509Certificate) startingCertificateChain[0]).getSerialNumber(),
 					((X509Certificate) endingCertificateChain[0]).getSerialNumber());
 			
-			assertNotNull("Should log disabled message", server.findStringsInLogs("CWPKI2069I"));
+			assertFalse("Should log disabled message", server.findStringsInLogsAndTraceUsingMark("CWPKI2069I").isEmpty());
+			
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 2: Finish.");
+			
+			/***********************************************************************
+			 * 
+			 * TEST 3: The cert checker is enabled again.
+			 * 
+			 **********************************************************************/
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 3: Start");
+
+			configuration = ORIGINAL_CONFIG.clone();
+			configuration.getAcmeCA().setCertCheckerSchedule(AcmeConstants.RENEW_CERT_MIN + "ms");
+			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, DOMAINS1);
+			AcmeFatUtils.waitForAcmeToNoOp(server);
+			server.setMarkToEndOfLog(server.getDefaultTraceFile());
+
+			/*
+			 * The cert checker should run
+			 */
+			startingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+			assertNotNull("Should have found the cert checker waking up: " + AcmeFatUtils.ACME_CHECKER_TRACE,
+					server.waitForStringInTraceUsingMark(AcmeFatUtils.ACME_CHECKER_TRACE, AcmeConstants.RENEW_CERT_MIN + 5000));
+
+			/*
+			 * Should have the same certificate -- not expiring
+			 */
+			endingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			assertEquals("The certificate should be the same after the cert checker runs.",
+					((X509Certificate) startingCertificateChain[0]).getSerialNumber(),
+					((X509Certificate) endingCertificateChain[0]).getSerialNumber());
+
+			assertTrue("Should not log disabled message", server.findStringsInLogsAndTraceUsingMark("CWPKI2069I").isEmpty());
+
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 3: Finish.");
+
+			/***********************************************************************
+			 * 
+			 * TEST 4: The cert check is disabled again.
+			 * 
+			 **********************************************************************/
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 4: Start");
+
+			configuration = ORIGINAL_CONFIG.clone();
+			configuration.getAcmeCA().setCertCheckerSchedule(0 + "ms");
+			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, DOMAINS1);
+			AcmeFatUtils.waitForAcmeToNoOp(server);
+			server.setMarkToEndOfLog(server.getDefaultTraceFile());
+			/*
+			 * Check that the cert checker does not run
+			 */
+			startingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+			assertNull("Should not have found the cert checker waking up: " + AcmeFatUtils.ACME_CHECKER_TRACE,
+					server.waitForStringInTraceUsingMark(AcmeFatUtils.ACME_CHECKER_TRACE, AcmeConstants.RENEW_CERT_MIN + 5000));
+
+			/*
+			 * Should have the same certificate
+			 */
+			endingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			assertEquals("The certificate should be the same after the cert checker runs.",
+					((X509Certificate) startingCertificateChain[0]).getSerialNumber(),
+					((X509Certificate) endingCertificateChain[0]).getSerialNumber());
+
+			assertFalse("Should log disabled message", server.findStringsInLogsAndTraceUsingMark("CWPKI2069I").isEmpty());
+
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 4: Finish.");
+
+			/***********************************************************************
+			 * 
+			 * TEST 5: The cert check is enabled again.
+			 * 
+			 **********************************************************************/
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 5: Start");
+
+			configuration = ORIGINAL_CONFIG.clone();
+			configuration.getAcmeCA().setCertCheckerSchedule(AcmeConstants.RENEW_CERT_MIN + "ms");
+			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, DOMAINS1);
+			AcmeFatUtils.waitForAcmeToNoOp(server);
+			server.setMarkToEndOfLog(server.getDefaultTraceFile());
+
+			/*
+			 * The cert checker should run
+			 */
+			startingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+			assertNotNull("Should have found the cert checker waking up: " + AcmeFatUtils.ACME_CHECKER_TRACE,
+					server.waitForStringInTraceUsingMark(AcmeFatUtils.ACME_CHECKER_TRACE, AcmeConstants.RENEW_CERT_MIN + 5000));
+
+			/*
+			 * Should have the same certificate -- not expiring
+			 */
+			endingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			assertEquals("The certificate should be the same after the cert checker runs.",
+					((X509Certificate) startingCertificateChain[0]).getSerialNumber(),
+					((X509Certificate) endingCertificateChain[0]).getSerialNumber());
+
+			assertTrue("Should not log disabled message", server.findStringsInLogsAndTraceUsingMark("CWPKI2069I").isEmpty());
+
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 5: Finish.");
+
+			/***********************************************************************
+			 * 
+			 * TEST 6: The cert check is disabled indirectly by turning off renew and revocation.
+			 * 
+			 **********************************************************************/
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 6: Start");
+
+			configuration = ORIGINAL_CONFIG.clone();
+			
+			configuration.getAcmeCA().setRenewBeforeExpiration("0ms");
+			AcmeRevocationChecker acmeRevocationChecker = new AcmeRevocationChecker();
+			acmeRevocationChecker.setEnabled(false);
+			configuration.getAcmeCA().setAcmeRevocationChecker(acmeRevocationChecker);
+			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, DOMAINS1);
+			AcmeFatUtils.waitForAcmeToNoOp(server);
+			server.setMarkToEndOfLog(server.getDefaultTraceFile());
+
+			/*
+			 * Check that the cert checker does not run
+			 */
+			startingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+			assertNull("Should not have found the cert checker waking up: " + AcmeFatUtils.ACME_CHECKER_TRACE,
+					server.waitForStringInTraceUsingMark(AcmeFatUtils.ACME_CHECKER_TRACE, AcmeConstants.RENEW_CERT_MIN + 5000));
+
+			/*
+			 * Should have the same certificate
+			 */
+			endingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			assertEquals("The certificate should be the same after the cert checker runs.",
+					((X509Certificate) startingCertificateChain[0]).getSerialNumber(),
+					((X509Certificate) endingCertificateChain[0]).getSerialNumber());
+
+			assertFalse("Should log disabled message", server.findStringsInLogsAndTraceUsingMark("CWPKI2069I").isEmpty());
+
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 6: Finish.");
+
+			/***********************************************************************
+			 * 
+			 * TEST 7: The cert check is enabled again by enabling renew and revocation
+			 * 
+			 **********************************************************************/
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 7: Start");
+
+			configuration = ORIGINAL_CONFIG.clone();
+			configuration.getAcmeCA().setCertCheckerSchedule(AcmeConstants.RENEW_CERT_MIN + "ms");
+			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, DOMAINS1);
+			AcmeFatUtils.waitForAcmeToNoOp(server);
+			server.setMarkToEndOfLog(server.getDefaultTraceFile());
+
+			/*
+			 * The cert checker should run
+			 */
+			startingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+			assertNotNull("Should have found the cert checker waking up: " + AcmeFatUtils.ACME_CHECKER_TRACE,
+					server.waitForStringInTraceUsingMark(AcmeFatUtils.ACME_CHECKER_TRACE, AcmeConstants.RENEW_CERT_MIN + 5000));
+
+			/*
+			 * Should have the same certificate -- not expiring
+			 */
+			endingCertificateChain = AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			assertEquals("The certificate should be the same after the cert checker runs.",
+					((X509Certificate) startingCertificateChain[0]).getSerialNumber(),
+					((X509Certificate) endingCertificateChain[0]).getSerialNumber());
+
+			assertTrue("Should not log disabled message", server.findStringsInLogsAndTraceUsingMark("CWPKI2069I").isEmpty());
+
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 7: Finish.");
 		} finally {
-			Log.info(this.getClass(), testName.getMethodName(), "TEST 1: Shutdown.");
+			Log.info(this.getClass(), testName.getMethodName(), "TEST: Shutdown.");
 
 			/*
 			 * Stop the server.
@@ -610,12 +851,12 @@ public class AcmeValidityAndRenewTest {
 			 */
 			long notAfter = ((X509Certificate) startingCertificateChain[0]).getNotAfter().getTime();
 			long notBefore = ((X509Certificate) startingCertificateChain[0]).getNotBefore().getTime();
-			long justShyOfValidityPeriod = (notAfter - notBefore) - timeBufferToExpire;
+			long justShyOfValidityPeriod = (notAfter - notBefore) - TIME_BUFFER_BEFORE_EXPIRE;
 			Log.info(this.getClass(), testName.getMethodName(), "Time configured: " + justShyOfValidityPeriod);
 
 			configuration.getAcmeCA().setRenewBeforeExpiration(justShyOfValidityPeriod + "ms");
 			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, DOMAINS1);
-			configuration.getAcmeCA().setCertCheckerSchedule((timeBufferToExpire + 1000) + "ms");
+			configuration.getAcmeCA().setCertCheckerSchedule((TIME_BUFFER_BEFORE_EXPIRE + 1000) + "ms");
 			configuration.getAcmeCA().setCertCheckerErrorSchedule(AcmeConstants.RENEW_CERT_MIN + "ms");
 
 			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, DOMAINS1);
@@ -623,7 +864,7 @@ public class AcmeValidityAndRenewTest {
 			/*
 			 * The certificate checker should automatically renew the certificate.
 			 */
-			AcmeFatUtils.waitForNewCert(server, caContainer, startingCertificateChain, timeBufferToExpire * 2);
+			AcmeFatUtils.waitForNewCert(server, caContainer, startingCertificateChain, TIME_BUFFER_BEFORE_EXPIRE * 2);
 
 			assertNotNull("Should log message that the certificate was renewed",
 					server.waitForStringInLogUsingMark("CWPKI2052I"));
@@ -644,7 +885,7 @@ public class AcmeValidityAndRenewTest {
 			 * DNS info can be cached, give more time for cache to expire
 			 */
 			assertNotNull("Should log message that the certificate renew failed",
-					server.waitForStringInLogUsingMark("CWPKI2065W", timeBufferToExpire * 8));
+					server.waitForStringInLogUsingMark("CWPKI2065W", TIME_BUFFER_BEFORE_EXPIRE * 8));
 
 			/*
 			 * Clear the bad DNS record and the cert checker should recover and fetch a new
@@ -655,7 +896,7 @@ public class AcmeValidityAndRenewTest {
 
 			assertNotNull("Should log message that the certificate was renewed after restarting the challenge server",
 					server.waitForStringInLogUsingMark("CWPKI2007I", (AcmeConstants.RENEW_CERT_MIN * 6)));
-			AcmeFatUtils.waitForNewCert(server, caContainer, startingCertificateChain, timeBufferToExpire);
+			AcmeFatUtils.waitForNewCert(server, caContainer, startingCertificateChain, TIME_BUFFER_BEFORE_EXPIRE);
 
 		} finally {
 			Log.info(this.getClass(), testName.getMethodName(), "TEST Shutdown.");
@@ -664,6 +905,53 @@ public class AcmeValidityAndRenewTest {
 			 * Stop the server.
 			 */
 			server.stopServer("CWPKI2049W", "CWPKI2065W");
+		}
+	}
+
+	/**
+	 * Issue a POST request to the ACME REST API to renew the certificate
+	 * 
+	 * @return The JSON response.
+	 * @throws Exception
+	 *             if the request failed.
+	 */
+	private static String renewCertificate() throws Exception {
+		final String methodName = "renewCertificate()";
+
+		try (CloseableHttpClient httpclient = AcmeFatUtils.getInsecureHttpsClient()) {
+
+			/*
+			 * Create a POST request to the Liberty server.
+			 */
+			HttpPost httpPost = new HttpPost("https://localhost:" + server.getHttpDefaultSecurePort() + "/ibm/api"
+					+ AcmeCaRestHandler.PATH_CERTIFICATE);
+			httpPost.setHeader("Authorization",
+					"Basic " + DatatypeConverter.printBase64Binary((AcmeFatUtils.ADMIN_USER + ":" + AcmeFatUtils.ADMIN_PASS).getBytes()));
+			httpPost.setHeader("Content-Type", "application/json");
+			httpPost.setEntity(new StringEntity("{\"operation\":\"renewCertificate\"}"));
+
+			/*
+			 * Send the POST request and process the response.
+			 */
+			try (final CloseableHttpResponse response = httpclient.execute(httpPost)) {
+				AcmeFatUtils.logHttpResponse(AcmeRevocationTest.class, methodName, httpPost, response);
+
+				StatusLine statusLine = response.getStatusLine();
+				assertEquals("Unexpected status code response.", 200, statusLine.getStatusCode());
+
+				/*
+				 * Check content type header.
+				 */
+				Header[] headers = response.getHeaders("content-type");
+				assertNotNull("Expected content type header.", headers);
+				assertEquals("Expected 1 content type header.", 1, headers.length);
+				assertEquals("Unexpected content type.", "application/json", headers[0].getValue());
+
+				String contentString = EntityUtils.toString(response.getEntity());
+				Log.info(AcmeValidityAndRenewTest.class, methodName, "HTTP post contents: \n" + contentString);
+
+				return contentString;
+			}
 		}
 	}
 

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/FATSuite.java
@@ -23,7 +23,8 @@ import componenttest.topology.utils.ExternalTestServiceDockerClientStrategy;
 	AcmeCaRestHandlerTest.class,
 	AcmeSwapDirectoriesTest.class,
 	AcmeValidityAndRenewTest.class,
-	AcmeRevocationTest.class
+	AcmeRevocationTest.class,
+	AcmeDisableTriggerSimpleTest.class
 	 })
 public class FATSuite {
 

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
@@ -78,6 +78,9 @@ public class AcmeFatUtils {
 	private static final long SCHEDULE_TIME = 30000;
 	public static final String ACME_CHECKER_TRACE = "ACME automatic certificate checker verified";
 
+	public static final String ADMIN_USER = "administrator";
+	public static final String ADMIN_PASS = "adminpass";
+
 	/**
 	 * Get an X.509 certificate from a PEM certificate.
 	 * 

--- a/dev/com.ibm.ws.security.acme_fat/publish/servers/com.ibm.ws.security.acme.fat.renew/bootstrap.properties
+++ b/dev/com.ibm.ws.security.acme_fat/publish/servers/com.ibm.ws.security.acme.fat.renew/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info=enabled:ACME=all:com.ibm.ws.ssl.*=all

--- a/dev/com.ibm.ws.security.acme_fat/publish/servers/com.ibm.ws.security.acme.fat.renew/server.xml
+++ b/dev/com.ibm.ws.security.acme_fat/publish/servers/com.ibm.ws.security.acme.fat.renew/server.xml
@@ -1,0 +1,30 @@
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+	<featureManager>
+		<feature>acmeCA-2.0</feature>
+		<feature>appSecurity-3.0</feature>
+	</featureManager>
+
+ 	<include location="../fatTestCommon.xml" />
+	
+	<keyStore id="defaultKeyStore" password="acmepassword"/>
+
+	<basicRegistry realm="basicRealm">
+		<user name="administrator" password="adminpass" />
+	</basicRegistry>
+
+	<administrator-role>
+		<user>administrator</user>
+	</administrator-role>
+
+</server>

--- a/dev/com.ibm.ws.security.acme_fat/publish/servers/com.ibm.ws.security.acme.fat.trigger/bootstrap.properties
+++ b/dev/com.ibm.ws.security.acme_fat/publish/servers/com.ibm.ws.security.acme.fat.trigger/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info=enabled:ACME=all:com.ibm.ws.ssl.*=all

--- a/dev/com.ibm.ws.security.acme_fat/publish/servers/com.ibm.ws.security.acme.fat.trigger/server.xml
+++ b/dev/com.ibm.ws.security.acme_fat/publish/servers/com.ibm.ws.security.acme.fat.trigger/server.xml
@@ -1,0 +1,21 @@
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+	<featureManager>
+		<feature>acmeCA-2.0</feature>
+	</featureManager>
+
+ 	<include location="../fatTestCommon.xml" />
+	
+	<keyStore id="defaultKeyStore" password="acmepassword" updateTrigger="disabled"/>
+
+</server>


### PR DESCRIPTION
Fixes #12328 and #12393

Added/updated 3 tests described in linked Issues

Updated the BoulderContainer again -- undid the changes to bluenet as they caused and NPE on retry.

Code change: I moved where we log the certchecker is disabled message so it would applied either to the certcheckerschedule being set to 0 or the renew and revoke both being disabled.