### PR TITLE
Only destroy TCCL if we created it - BV 1.1 projects

### DIFF
--- a/dev/com.ibm.ws.beanvalidation.core/src/com/ibm/ws/beanvalidation/ValidatorFactoryAccessor.java
+++ b/dev/com.ibm.ws.beanvalidation.core/src/com/ibm/ws/beanvalidation/ValidatorFactoryAccessor.java
@@ -241,9 +241,7 @@ public class ValidatorFactoryAccessor {
                     Tr.debug(tc, "Set Class loader back to " + oldClassLoader);
                 }
             }
-            if (tuple != null && tuple.wasCreatedViaClassLoadingService) {
-                AbstractBeanValidation.instance().releaseLoader(tuple);
-            }
+            AbstractBeanValidation.instance().releaseLoader(tuple);
         }
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
             Tr.exit(tc, "getValidatorFactory", factory);

--- a/dev/com.ibm.ws.beanvalidation.v11.cdi/src/com/ibm/ws/beanvalidation/v11/cdi/internal/BValExtensionBean.java
+++ b/dev/com.ibm.ws.beanvalidation.v11.cdi/src/com/ibm/ws/beanvalidation/v11/cdi/internal/BValExtensionBean.java
@@ -112,9 +112,7 @@ public class BValExtensionBean implements Bean<BValExtension>, PassivationCapabl
                     Tr.debug(TC, "Set Class loader back to " + oldClassLoader);
                 }
             }
-            if (setClassLoader != null && setClassLoader.wasChanged) {
-                ValidationExtensionService.instance().releaseLoader(classLoader);
-            }
+
         }
         return bValExtension;
     }


### PR DESCRIPTION
This is a followup to PR #12462 - it removes a duplicate check and uses
the same patterns for the 1.1 BV/CDI project.