### PR TITLE
Publicize the APIs for JAXRS PMI/Metrics

### DIFF
--- a/dev/com.ibm.websphere.appserver.api.jaxrs20/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.api.jaxrs20/bnd.bnd
@@ -17,6 +17,8 @@ Bundle-SymbolicName: com.ibm.websphere.appserver.api.jaxrs20
 
 Import-Package: com.ibm.websphere.jaxrs.providers.json4j, \
 		com.ibm.websphere.jaxrs20.multipart, \
+		com.ibm.websphere.jaxrs.monitor;resolution:=optional, \
+		com.ibm.websphere.monitor.jmx;resolution:=optional, \
 		javax.activation, \
 		javax.ws.rs, \
 		javax.ws.rs.client, \
@@ -25,7 +27,7 @@ Import-Package: com.ibm.websphere.jaxrs.providers.json4j, \
 		javax.ws.rs.ext, \
 		javax.ws.rs.sse;resolution:=optional
 
-Export-Package: com.ibm.websphere.jaxrs.providers.json4j,com.ibm.websphere.jaxrs20.multipart
+Export-Package: com.ibm.websphere.jaxrs.providers.json4j,com.ibm.websphere.jaxrs20.multipart,com.ibm.websphere.jaxrs.monitor
 
 -includeresource: {META-INF/maven/com.ibm.websphere.appserver.api/com.ibm.websphere.appserver.api.jaxrs20/pom.xml=com.ibm.websphere.appserver.api.jaxrs20.pom}
 
@@ -33,4 +35,5 @@ publish.wlp.jar.suffix: dev/api/ibm
 
 -buildpath: \
 	com.ibm.ws.jaxrs.2.0.common;version=latest, \
+	com.ibm.ws.jaxrs.2.x.monitor;version=latest, \
 	com.ibm.ws.jaxrs.2.x.config;version=latest


### PR DESCRIPTION
This change should have been included in PR #9202.   It is needed to publicize the jaxrs monitor api. 