### PR TITLE
Issue 12536: Remove extra messages check in Acme rest test

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeCaRestHandlerTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeCaRestHandlerTest.java
@@ -283,7 +283,6 @@ public class AcmeCaRestHandlerTest {
 				CONTENT_TYPE_JSON, JSON_CERT_REGEN);
 		assertJsonResponse(jsonResponse, 200);
 		AcmeFatUtils.waitForAcmeToCreateCertificate(server);
-		AcmeFatUtils.waitForSslEndpoint(server);
 
 		/*
 		 * Compare the new certificate to the old certificate.


### PR DESCRIPTION
Fixes #12536 

Remove extra `AcmeFatUtils.waitForSslEndpoint(server);` as it can cause an error if a test that resets the log marks runs first.