### PR TITLE
Issue 12542: Allow CWPKI2045W on acme fats

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/docker/boulder/BoulderContainer.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/docker/boulder/BoulderContainer.java
@@ -158,20 +158,27 @@ public class BoulderContainer extends CAContainer {
 		for (int i = 1; i < NUM_RESTART_ATTEMPTS_ON_EXCEPTION + 1; i++) {
 			try {
 				bmysql.start();
-				break;
+
+				if (bmysql.isRunning()) {
+					break;
+				}
+				Log.info(BoulderContainer.class, "start", "Failed to start bmysql, marked as not running.");
 			} catch (Throwable t) {
 				Log.info(BoulderContainer.class, "start", "Failed to start bmysql, try again. " + t);
-				bmysql.stop();
-				initSQL();
+			}
 
-				Log.error(BoulderContainer.class, "start", t, "Hit an exception, trying a long sleep and retry");
-				try {
-					Thread.sleep(30000);
-				} catch (InterruptedException e) {
-				}
+			bmysql.stop();
+			initSQL();
+
+			try {
+				Thread.sleep(30000);
+			} catch (InterruptedException e) {
 			}
 		}
 		if (!bmysql.isRunning()) {
+			/*
+			 * One more try
+			 */
 			bmysql.start();
 		}
 		

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeCaRestHandlerTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeCaRestHandlerTest.java
@@ -135,7 +135,7 @@ public class AcmeCaRestHandlerTest {
 		/*
 		 * Stop the server.
 		 */
-		server.stopServer("CWPKI2058W");
+		AcmeFatUtils.stopServer(server, "CWPKI2058W");
 	}
 
 	@Test

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeDisableTriggerSimpleTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeDisableTriggerSimpleTest.java
@@ -201,7 +201,7 @@ public class AcmeDisableTriggerSimpleTest {
 			/*
 			 * Stop the server.
 			 */
-			server.stopServer();
+			stopServer();
 		}
 	}
 	
@@ -280,7 +280,7 @@ public class AcmeDisableTriggerSimpleTest {
 			AcmeFatUtils.waitForAcmeToCreateCertificate(server);
 			AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
 		} finally {
-			server.stopServer("CWPKI2001E", "CWPKI0804E", "CWWKO0801E");
+			stopServer("CWPKI2001E", "CWPKI0804E", "CWWKO0801E");
 		}
 	}
 	
@@ -408,8 +408,11 @@ public class AcmeDisableTriggerSimpleTest {
 			/*
 			 * Stop the server.
 			 */
-			server.stopServer("CWPKI2058W");
+			stopServer("CWPKI2058W");
 		}
 	}
 
+	private void stopServer(String...msgs) throws Exception {
+		AcmeFatUtils.stopServer(server, msgs);
+	}
 }

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeRevocationTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeRevocationTest.java
@@ -165,7 +165,7 @@ public class AcmeRevocationTest {
 			 * status as revoked. Cycle the server and we should now see that
 			 * the certificate is replaced since it was revoked.
 			 */
-			server.stopServer();
+			stopServer();
 			server.startServer();
 			server.waitForStringInLog("CWPKI2059I"); // Detected cert revoked!
 			AcmeFatUtils.waitForAcmeToCreateCertificate(server);
@@ -180,7 +180,7 @@ public class AcmeRevocationTest {
 			assertThat("Expected new certificate.", serial1, not(equalTo(serial2)));
 
 		} finally {
-			server.stopServer();
+			stopServer();
 		}
 	}
 
@@ -225,7 +225,7 @@ public class AcmeRevocationTest {
 			 * status as revoked. Cycle the server. This time we will not
 			 * perform the revocation check since it is disabled.
 			 */
-			server.stopServer();
+			stopServer();
 			server.startServer();
 			AcmeFatUtils.waitForSslEndpoint(server);
 			Certificate[] certificates2 = AcmeFatUtils.assertAndGetServerCertificate(server, boulder);
@@ -238,7 +238,7 @@ public class AcmeRevocationTest {
 			assertThat("Expected same certificate.", serial1, equalTo(serial2));
 
 		} finally {
-			server.stopServer();
+			stopServer();
 		}
 	}
 
@@ -286,7 +286,7 @@ public class AcmeRevocationTest {
 			 * revoked. We treat this as a soft failure since it is possible it
 			 * may be a network glitch. A warning will be written to logs.
 			 */
-			server.stopServer();
+			stopServer();
 			server.startServer();
 			server.waitForStringInLog("CWPKI2058W"); // Soft failures...
 			AcmeFatUtils.waitForSslEndpoint(server);
@@ -300,7 +300,7 @@ public class AcmeRevocationTest {
 			assertThat("Expected same certificate.", serial1, equalTo(serial2));
 
 		} finally {
-			server.stopServer("CWPKI2058W");
+			stopServer("CWPKI2058W");
 		}
 	}
 
@@ -433,7 +433,7 @@ public class AcmeRevocationTest {
 			/*
 			 * Stop the server.
 			 */
-			server.stopServer();
+			stopServer();
 		}
 	}
 	
@@ -492,7 +492,7 @@ public class AcmeRevocationTest {
 			assertJsonResponse(jsonResponse, 200);
 
 		} finally {
-			server.stopServer();
+			stopServer();
 		}
 	}
 
@@ -587,4 +587,7 @@ public class AcmeRevocationTest {
 		}
 	}
 
+	private void stopServer(String...msgs) throws Exception {
+		AcmeFatUtils.stopServer(server, msgs);
+	}
 }

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSimpleTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSimpleTest.java
@@ -1058,6 +1058,6 @@ public class AcmeSimpleTest {
 	}
 	
 	protected void stopServer(String ...msgs) throws Exception {
-		server.stopServer(msgs);
+		AcmeFatUtils.stopServer(server, msgs);
 	}
 }

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSwapDirectoriesTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSwapDirectoriesTest.java
@@ -189,7 +189,7 @@ public class AcmeSwapDirectoriesTest {
 			 * 
 			 **********************************************************************/			
 			Log.info(this.getClass(), testName.getMethodName(), "TEST 3: START");
-			server.stopServer();
+			stopServer();
 			AcmeFatUtils.configureAcmeCA(server, caContainer, ORIGINAL_CONFIG, false, false, false, DOMAINS_1);
 			server.startServer();
 			AcmeFatUtils.waitForAcmeAppToStart(server);
@@ -218,7 +218,7 @@ public class AcmeSwapDirectoriesTest {
 			/*
 			 * Stop the server.
 			 */
-			server.stopServer("CWPKI2038W");
+			stopServer("CWPKI2038W");
 		}
 	}
 	/**
@@ -318,7 +318,7 @@ public class AcmeSwapDirectoriesTest {
 			/*
 			 * Stop the server.
 			 */
-			server.stopServer("CWPKI2038W", "CWPKI2072W");
+			stopServer("CWPKI2038W", "CWPKI2072W");
 		}
 	}
 	/**
@@ -393,7 +393,11 @@ public class AcmeSwapDirectoriesTest {
 			/*
 			 * Stop the server.
 			 */
-			server.stopServer("CWPKI2038W");
+			stopServer("CWPKI2038W");
 		}
+	}
+	
+	private void stopServer(String...msgs) throws Exception {
+		AcmeFatUtils.stopServer(server, msgs);
 	}
 }

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeURISimpleTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeURISimpleTest.java
@@ -16,6 +16,8 @@ import java.util.List;
 
 import org.junit.runner.RunWith;
 
+import com.ibm.ws.security.acme.utils.AcmeFatUtils;
+
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -37,7 +39,7 @@ public class AcmeURISimpleTest extends AcmeSimpleTest {
 	@Override
 	protected void stopServer(String... msgs) throws Exception {
 		if (JavaInfo.JAVA_VERSION > 8) {
-			server.stopServer(msgs);
+			AcmeFatUtils.stopServer(server, msgs);
 		} else {
 			/*
 			 * HttpConnector.config runs oddly slow on Java 8 and can trigger the update
@@ -45,7 +47,7 @@ public class AcmeURISimpleTest extends AcmeSimpleTest {
 			 */
 			List<String> tempList = new ArrayList<String>(Arrays.asList(msgs));
 			tempList.add("CWWKG0027W");
-			server.stopServer(tempList.toArray(new String[tempList.size()]));
+			AcmeFatUtils.stopServer(server, tempList.toArray(new String[tempList.size()]));
 		}
 	}
 }

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeValidityAndRenewTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeValidityAndRenewTest.java
@@ -153,7 +153,7 @@ public class AcmeValidityAndRenewTest {
 			/*
 			 * Stop the server.
 			 */
-			server.stopServer("CWPKI2051W");
+			stopServer("CWPKI2051W");
 		}
 	}
 
@@ -205,7 +205,7 @@ public class AcmeValidityAndRenewTest {
 			/*
 			 * Stop the server.
 			 */
-			server.stopServer("CWPKI2055W");
+			stopServer("CWPKI2055W");
 		}
 
 	}
@@ -259,7 +259,7 @@ public class AcmeValidityAndRenewTest {
 			/*
 			 * Stop the server.
 			 */
-			server.stopServer("CWPKI2054W");
+			stopServer("CWPKI2054W");
 		}
 
 	}
@@ -314,7 +314,7 @@ public class AcmeValidityAndRenewTest {
 			/*
 			 * Stop the server.
 			 */
-			server.stopServer();
+			stopServer();
 		}
 
 		/***********************************************************************
@@ -380,7 +380,7 @@ public class AcmeValidityAndRenewTest {
 			/*
 			 * Stop the server.
 			 */
-			server.stopServer("CWPKI2055W"); // we are running with and intentionally short renewBeforeExpiration.
+			stopServer("CWPKI2055W"); // we are running with an intentionally short renewBeforeExpiration.
 		}
 
 		/***********************************************************************
@@ -460,7 +460,7 @@ public class AcmeValidityAndRenewTest {
 			/*
 			 * Stop the server.
 			 */
-			server.stopServer("CWPKI2049W");
+			stopServer("CWPKI2049W");
 		}
 	}
 
@@ -524,7 +524,7 @@ public class AcmeValidityAndRenewTest {
 			/*
 			 * Stop the server.
 			 */
-			server.stopServer();
+			stopServer();
 		}
 	}
 
@@ -801,7 +801,7 @@ public class AcmeValidityAndRenewTest {
 			/*
 			 * Stop the server.
 			 */
-			server.stopServer();
+			stopServer();
 		}
 	}
 
@@ -904,7 +904,7 @@ public class AcmeValidityAndRenewTest {
 			/*
 			 * Stop the server.
 			 */
-			server.stopServer("CWPKI2049W", "CWPKI2065W");
+			stopServer("CWPKI2049W", "CWPKI2065W");
 		}
 	}
 
@@ -953,6 +953,10 @@ public class AcmeValidityAndRenewTest {
 				return contentString;
 			}
 		}
+	}
+	
+	private void stopServer(String...msgs) throws Exception {
+		AcmeFatUtils.stopServer(server, msgs);
 	}
 
 }

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
@@ -826,4 +826,23 @@ public class AcmeFatUtils {
  		}
  		return false;
  	}
+ 	
+ 	/**
+ 	 * Handle adding CWPKI2045W as an allowed warning message to all stopServer requests.
+ 	 * 
+ 	 * @param server
+ 	 * @param msgs
+ 	 * @throws Exception
+ 	 */
+ 	public static void stopServer(LibertyServer server, String...msgs) throws Exception{
+ 		/*
+ 		 * If the test Pebble or Boulder container is slightly ahead of our test machine, we can
+ 		 * get a certificate that is in "the future" and that will produce a warning message.
+ 		 */
+ 		String alwaysAdd = "CWPKI2045W";
+ 		
+ 		List<String> tempList = new ArrayList<String>(Arrays.asList(msgs));
+		tempList.add(alwaysAdd);
+		server.stopServer(tempList.toArray(new String[tempList.size()]));
+ 	}
 }


### PR DESCRIPTION
Fixes #12542 

Wrapped all of our stop methods so we could always allow the warning message about a future certificate.
For example, `CWPKI2045W: The certificate with 2d38e93caa3cb01f serial number that is signed by the ACME certificate authority at the https://host_name:43033/dir URI is not valid until 2020-06-08T09:54:13Z.`

Also added a new attempt to retry on Boulder failure to avoid this NPE that the previous restart of `bmysql` was hitting.

```
Caused by: org.testcontainers.containers.ContainerLaunchException: Container startup failed
	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:320)
	at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:300)
	at com.ibm.ws.security.acme.docker.boulder.BoulderContainer.start(BoulderContainer.java:175)
	at com.ibm.ws.security.acme.docker.boulder.BoulderContainer.<init>(BoulderContainer.java:93)
	at com.ibm.ws.security.acme.fat.AcmeRevocationTest.<clinit>(AcmeRevocationTest.java:79)
Caused by: org.rnorth.ducttape.RetryCountExceededException: Retry limit hit with exception
	at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:83)
	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:313)
Caused by: org.testcontainers.containers.ContainerLaunchException: Could not create/start container
	at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:488)
	at org.testcontainers.containers.GenericContainer.lambda$doStart$0(GenericContainer.java:315)
	at org.testcontainers.containers.GenericContainer$$Lambda$140/0000000000000000.call(Unknown Source)
	at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:76)
Caused by: java.lang.NullPointerException: networkMode was not specified
	at java.base/java.util.Objects.requireNonNull(Objects.java:246)
```