### PR TITLE
Removed EE9 from description

### DIFF
--- a/dev/io.openliberty.jakarta.el.4.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.el.4.0/bnd.bnd
@@ -12,7 +12,7 @@
 bVersion=1.0
 
 Bundle-SymbolicName: io.openliberty.jakarta.el.4.0; singleton:=true
-Bundle-Description: Jakarta Expression Language EE9, version 4.0
+Bundle-Description: Jakarta Expression Language, version 4.0
 
 Export-Package: \
  jakarta.el;thread-context=true; version="4.0.0", \

--- a/dev/io.openliberty.jakarta.jsp.3.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.jsp.3.0/bnd.bnd
@@ -12,7 +12,7 @@
 bVersion=1.0
 
 Bundle-SymbolicName: io.openliberty.jakarta.jsp.3.0; singleton:=true
-Bundle-Description: Jakarta Server Pages EE9, version 3.0
+Bundle-Description: Jakarta Server Pages, version 3.0
 
 Export-Package: \
 	jakarta.servlet.jsp; version="3.0.0",\

--- a/dev/io.openliberty.jakarta.jstl.2.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.jstl.2.0/bnd.bnd
@@ -12,7 +12,7 @@
 bVersion=1.0
 
 Bundle-SymbolicName: io.openliberty.jakarta.jstl.2.0; singleton:=true
-Bundle-Description: Jakarta Standard Tag Library EE9, version 2.0
+Bundle-Description: Jakarta Standard Tag Library, version 2.0
 
 Export-Package: \
 	jakarta.servlet.jsp.jstl.core,\

--- a/dev/io.openliberty.jakarta.servlet.5.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.servlet.5.0/bnd.bnd
@@ -13,7 +13,7 @@
 bVersion=1.0
 
 Bundle-SymbolicName: io.openliberty.jakarta.servlet.5.0; singleton:=true
-Bundle-Description: Jakarta Servlet EE9, version 5.0
+Bundle-Description: Jakarta Servlet, version 5.0
 
 Export-Package: \
    	jakarta.servlet;uses:="jakarta.servlet.annotation,jakarta.servlet.descriptor";version="5.0.0",\


### PR DESCRIPTION
Subspecs are the same for each EE version so having EE9 in the description is unnecessary 