### PR TITLE
test precedence of Jakarta transaction context

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_db/test-applications/concurrentdbtest/src/concurrent/fat/db/web/ConcurrentDBTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_db/test-applications/concurrentdbtest/src/concurrent/fat/db/web/ConcurrentDBTestServlet.java
@@ -15,6 +15,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Collections;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
@@ -352,6 +354,58 @@ public class ConcurrentDBTestServlet extends FATDatabaseServlet {
                 throw new Exception("Updates should have been rolled back");
         } finally {
             con.commit();
+            con.close();
+        }
+    }
+
+    /**
+     * If the user specifies the ManagedtTask.TRANSACTION constant from both specs with conflicting values,
+     * the one from Jakarta Concurrency must take precedence when Jakarta Concurrency is enabled.
+     */
+    @Test
+    public void testPrecedenceOfTransactionConstant() throws Exception {
+        Map<String, String> execProps = new TreeMap<String, String>();
+        execProps.put(ManagedTask.TRANSACTION.replace("jakarta", "javax"), ManagedTask.SUSPEND);
+        execProps.put(ManagedTask.TRANSACTION, ManagedTask.USE_TRANSACTION_OF_EXECUTION_THREAD); // enabled spec must take precedence
+
+        Connection con = dataSource.getConnection();
+        try {
+            con.setAutoCommit(false);
+            con.createStatement().executeUpdate("INSERT INTO MYTABLE VALUES ('testPrecedenceOfTransactionConstant', 27)");
+        } finally {
+            // don't commit or roll back yet
+            con.close();
+        }
+
+        // In order for the following update of the same entry to be permitted, the same transaction must be used,
+        // showing that USE_TRANSACTION_OF_EXECUTION_THREAD is honored rather than SUSPEND.
+        int count = (Integer) contextService.createContextualProxy(new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                Connection con = dataSource.getConnection();
+                try {
+                    return con.createStatement().executeUpdate("UPDATE MYTABLE SET MYVALUE = 28 where MYKEY = 'testPrecedenceOfTransactionConstant'");
+                } finally {
+                    // don't commit or roll back yet
+                    con.close();
+                }
+            }
+        }, execProps, Callable.class)
+                        .call();
+
+        if (count != 1)
+            throw new Exception("Update was not visible to contextual proxy. Count: " + count);
+
+        // roll back both updates
+        con = dataSource.getConnection();
+        con.rollback();
+        con.setAutoCommit(true);
+
+        try {
+            ResultSet result = con.createStatement().executeQuery("SELECT MYVALUE FROM MYTABLE WHERE MYKEY = 'testPrecedenceOfTransactionConstant'");
+            if (result.next())
+                throw new Exception("Should have been rolled back. " + result.getInt(1));
+        } finally {
             con.close();
         }
     }


### PR DESCRIPTION
When Java EE and Jakarta constant values are both specified, give precedence to the enabled spec.