### PR TITLE
Rename Jakarta API features and move concurrent 2.0 API to lib

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jakarta-connectionManagement-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jakarta-connectionManagement-1.0.feature
@@ -4,7 +4,7 @@ IBM-Provision-Capability:\
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.transaction-2.0)))", \
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.connectionManagement-1.0))"
 IBM-Install-Policy: when-satisfied
--features=com.ibm.websphere.appserver.jakarta.connector-2.0
+-features=io.openliberty.connector-2.0
 -bundles=com.ibm.ws.jca.cm.jakarta
 kind=beta
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.cdi3.0-servlet5.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.cdi3.0-servlet5.0.feature
@@ -5,7 +5,7 @@ IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.servlet-5.0))"
 -bundles=com.ibm.ws.cdi.2.0.web.jakarta, \
  com.ibm.ws.cdi.web.jakarta
--features=com.ibm.websphere.appserver.jakarta.jsp-3.0; apiJar=false
+-features=io.openliberty.jakarta.jsp-3.0; apiJar=false
 IBM-Install-Policy: when-satisfied
 kind=noship
 edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.anno-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.anno-2.0.feature
@@ -13,7 +13,7 @@ Manifest-Version: 1.0
 IBM-Process-Types: server, \
  client
 -features=com.ibm.websphere.appserver.artifact-1.0, \
- com.ibm.websphere.appserver.jakarta.annotation-2.0
+ io.openliberty.jakarta.annotation-2.0
 -bundles=com.ibm.ws.anno
 -jars=com.ibm.websphere.appserver.spi.anno; location:=dev/spi/ibm/
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.anno_1.1-javadoc.zip

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.concurrent.mp-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.concurrent.mp-1.0.feature
@@ -5,7 +5,7 @@ singleton=true
 -features=\
   com.ibm.websphere.appserver.contextService-1.0, \
   com.ibm.websphere.appserver.concurrencyPolicy-1.0, \
-  com.ibm.websphere.appserver.jakarta.concurrency-2.0, \
+  io.openliberty.jakarta.concurrency-2.0, \
   com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.0 
 -bundles=\
   com.ibm.ws.javaee.platform.defaultresource, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.concurrent.mp-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.concurrent.mp-1.0.feature
@@ -5,7 +5,7 @@ singleton=true
 -features=\
   com.ibm.websphere.appserver.contextService-1.0, \
   com.ibm.websphere.appserver.concurrencyPolicy-1.0, \
-  io.openliberty.jakarta.concurrency-2.0, \
+  io.openliberty.jakarta.concurrency-2.0; apiJar=false, \
   com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.0 
 -bundles=\
   com.ibm.ws.javaee.platform.defaultresource, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.concurrent.mp-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.concurrent.mp-1.1.feature
@@ -5,7 +5,7 @@ singleton=true
 -features=\
   com.ibm.websphere.appserver.contextService-1.0, \
   com.ibm.websphere.appserver.concurrencyPolicy-1.0, \
-  io.openliberty.jakarta.concurrency-2.0, \
+  io.openliberty.jakarta.concurrency-2.0; apiJar=false, \
   com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.1 
 -bundles=\
   com.ibm.ws.javaee.platform.defaultresource, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.concurrent.mp-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.concurrent.mp-1.1.feature
@@ -5,7 +5,7 @@ singleton=true
 -features=\
   com.ibm.websphere.appserver.contextService-1.0, \
   com.ibm.websphere.appserver.concurrencyPolicy-1.0, \
-  com.ibm.websphere.appserver.jakarta.concurrency-2.0, \
+  io.openliberty.jakarta.concurrency-2.0, \
   com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.1 
 -bundles=\
   com.ibm.ws.javaee.platform.defaultresource, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jakarta.activation-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jakarta.activation-2.0.feature
@@ -1,8 +1,0 @@
--include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jakarta.activation-2.0
-singleton=true
--bundles=\
-  io.openliberty.jakarta.activation.2.0; location:="dev/api/spec/,lib/";mavenCoordinates="jakarta.activation:jakarta.activation-api:2.0"
-kind=noship
-edition=full
-WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jakarta.connector.internal-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jakarta.connector.internal-2.0.feature
@@ -1,7 +1,0 @@
--include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jakarta.connector.internal-2.0
-singleton=true
--bundles=io.openliberty.jakarta.connector.2.0; apiJar=false; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.resource:jakarta.resource-api:2.0.0-RC1"
-kind=beta
-edition=core
-WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.annotation-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.annotation-2.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jakarta.annotation-2.0
+symbolicName=io.openliberty.jakarta.annotation-2.0
 singleton=true
 IBM-Process-Types: server, \
  client

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.cdi-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.cdi-3.0.feature
@@ -1,8 +1,8 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.jakarta.cdi-3.0
 singleton=true
--features=com.ibm.websphere.appserver.jakarta.el-4.0; apiJar=false, \
- com.ibm.websphere.appserver.jakarta.interceptor-2.0
+-features=io.openliberty.jakarta.el-4.0; apiJar=false, \
+ io.openliberty.jakarta.interceptor-2.0
 -bundles=io.openliberty.jakarta.cdi.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.enterprise:jakarta.enterprise.cdi-api:3.0.0"
 kind=noship
 edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.concurrency-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.concurrency-2.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jakarta.concurrency-2.0
+symbolicName=io.openliberty.jakarta.concurrency-2.0
 visibility=private
 singleton=true
 -bundles=io.openliberty.jakarta.concurrency.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:2.0.0-RC1"

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.connector-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.connector-2.0.feature
@@ -1,0 +1,7 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.jakarta.connector-2.0
+singleton=true
+-bundles=io.openliberty.jakarta.connector.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.resource:jakarta.resource-api:2.0.0-RC1"
+kind=beta
+edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.ejb-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.ejb-4.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jakarta.ejb-4.0
+symbolicName=io.openliberty.jakarta.ejb-4.0
 singleton=true
 -bundles=io.openliberty.jakarta.ejb.4.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.ejb:jakarta.ejb-api:4.0.0-RC2"
 kind=noship

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.el-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.el-4.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jakarta.el-4.0
+symbolicName=io.openliberty.jakarta.el-4.0
 singleton=true
 -bundles=io.openliberty.jakarta.el.4.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.el:jakarta.el-api:4.0.0"
 kind=beta

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.interceptor-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.interceptor-2.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jakarta.interceptor-2.0
+symbolicName=io.openliberty.jakarta.interceptor-2.0
 singleton=true
 -bundles=io.openliberty.jakarta.interceptor.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.interceptor:jakarta.interceptor-api:2.0.0"
 kind=noship

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.jsp-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.jsp-3.0.feature
@@ -1,8 +1,8 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jakarta.jsp-3.0
+symbolicName=io.openliberty.jakarta.jsp-3.0
 singleton=true
--features=com.ibm.websphere.appserver.jakarta.el-4.0; apiJar=false, \
- com.ibm.websphere.appserver.jakarta.servlet-5.0; apiJar=false
+-features=io.openliberty.jakarta.el-4.0; apiJar=false, \
+ io.openliberty.jakarta.servlet-5.0; apiJar=false
 -bundles=io.openliberty.jakarta.jsp.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.servlet.jsp:jakarta.servlet.jsp-api:3.0.0"
 kind=beta
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.persistence-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.persistence-3.0.feature
@@ -1,9 +1,9 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jakarta.persistence-3.0
+symbolicName=io.openliberty.jakarta.persistence-3.0
 singleton=true
 IBM-Process-Types: server, \
  client
--features=com.ibm.websphere.appserver.jakarta.persistence.base-3.0
+-features=io.openliberty.jakarta.persistence.base-3.0
 -bundles=com.ibm.ws.jakartaee.persistence.api.3.0
 -jars=io.openliberty.jakarta.persistence.3.0; location:=dev/api/spec/; mavenCoordinates="jakarta.persistence:jakarta.persistence-api:3.0-RC1"
 kind=noship

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.persistence.base-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.persistence.base-3.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jakarta.persistence.base-3.0
+symbolicName=io.openliberty.jakarta.persistence.base-3.0
 singleton=true
 IBM-Process-Types: server, \
  client

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.servlet-5.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.servlet-5.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jakarta.servlet-5.0
+symbolicName=io.openliberty.jakarta.servlet-5.0
 singleton=true
 -bundles=io.openliberty.jakarta.servlet.5.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.servlet:jakarta.servlet-api:5.0.0"
 kind=beta

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakartaeePlatform-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakartaeePlatform-9.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jakartaeePlatform-9.0
+symbolicName=io.openliberty.jakartaeePlatform-9.0
 IBM-Process-Types: client, server
 -bundles=com.ibm.ws.jakartaee.platform.v9, \
  com.ibm.ws.javaee.version

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-2.0.feature
@@ -14,15 +14,15 @@ IBM-SPI-Package: com.ibm.wsspi.tx
 IBM-API-Service: com.ibm.wsspi.uow.UOWManager, \
  jakarta.transaction.TransactionSynchronizationRegistry, \
  jakarta.transaction.UserTransaction
--features=com.ibm.websphere.appserver.jakarta.connector.internal-2.0, \
+-features=io.openliberty.jakarta.connector-2.0, \
  io.openliberty.jakarta.cdi-3.0; apiJar=false, \
  com.ibm.websphere.appserver.jta-2.0, \
  com.ibm.websphere.appserver.injection-2.0, \
- com.ibm.websphere.appserver.jakarta.servlet-5.0; apiJar=false, \
+ io.openliberty.jakarta.servlet-5.0; apiJar=false, \
  com.ibm.websphere.appserver.artifact-1.0, \
  com.ibm.websphere.appserver.javaeedd-1.0, \
  com.ibm.websphere.appserver.containerServices-1.0, \
- com.ibm.websphere.appserver.jakarta.annotation-2.0; apiJar=false, \
+ io.openliberty.jakarta.annotation-2.0; apiJar=false, \
  com.ibm.websphere.appserver.anno-2.0, \
  com.ibm.websphere.appserver.eeCompatible-9.0
 -bundles=com.ibm.ws.tx.jta.extensions.jakarta, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/io.openliberty.connector-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/io.openliberty.connector-2.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jakarta.connector-2.0
+symbolicName=io.openliberty.connector-2.0
 visibility=protected
 singleton=true
 IBM-API-Package: jakarta.resource; type="spec", \
@@ -8,8 +8,7 @@ IBM-API-Package: jakarta.resource; type="spec", \
  jakarta.resource.spi.endpoint; type="spec", \
  jakarta.resource.spi.security; type="spec", \
  jakarta.resource.spi.work; type="spec"
--features=com.ibm.websphere.appserver.jakarta.connector.internal-2.0, \
+-features=io.openliberty.jakarta.connector-2.0, \
  com.ibm.websphere.appserver.eeCompatible-9.0
--bundles=io.openliberty.jakarta.connector.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.resource:jakarta.resource-api:2.0.0-RC1"
 kind=beta
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-3.0/io.openliberty.cdi-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-3.0/io.openliberty.cdi-3.0.feature
@@ -36,20 +36,20 @@ IBM-API-Package: jakarta.decorator;  type="spec", \
 IBM-SPI-Package: io.openliberty.cdi.spi;type="ibm-spi"
 IBM-ShortName: cdi-3.0
 Subsystem-Name: Jakarta Contexts and Dependency Injection 3.0
--features=com.ibm.websphere.appserver.jakarta.jsp-3.0, \
+-features=io.openliberty.jakarta.jsp-3.0, \
  com.ibm.websphere.appserver.containerServices-1.0, \
- com.ibm.websphere.appserver.jakarta.persistence-3.0, \
- com.ibm.websphere.appserver.jakartaeePlatform-9.0, \
- com.ibm.websphere.appserver.jakarta.ejb-4.0, \
- com.ibm.websphere.appserver.jakarta.annotation-2.0, \
+ io.openliberty.jakarta.persistence-3.0, \
+ io.openliberty.jakartaeePlatform-9.0, \
+ io.openliberty.jakarta.ejb-4.0, \
+ io.openliberty.jakarta.annotation-2.0, \
  com.ibm.websphere.appserver.eeCompatible-9.0, \
- com.ibm.websphere.appserver.jakarta.interceptor-2.0, \
+ io.openliberty.jakarta.interceptor-2.0, \
  io.openliberty.jakarta.cdi-3.0, \
  com.ibm.websphere.appserver.injection-2.0, \
  com.ibm.websphere.appserver.classloading-1.0, \
  com.ibm.websphere.appserver.appmanager-1.0, \
  com.ibm.websphere.appserver.transaction-2.0, \
- com.ibm.websphere.appserver.jakarta.servlet-5.0, \
+ io.openliberty.jakarta.servlet-5.0, \
  io.openliberty.jakarta.jaxws-3.0, \
  io.openliberty.jakarta.jaxb-3.0, \
  com.ibm.websphere.appserver.internal.slf4j-1.7.7, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-1.0/com.ibm.websphere.appserver.concurrent-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-1.0/com.ibm.websphere.appserver.concurrent-1.0.feature
@@ -11,7 +11,7 @@ Subsystem-Name: Concurrency Utilities for Java EE 1.0
  com.ibm.websphere.appserver.appLifecycle-1.0, \
  com.ibm.websphere.appserver.concurrencyPolicy-1.0, \
  com.ibm.websphere.appserver.contextService-1.0, \
- io.openliberty.jakarta.concurrency-2.0,\
+ io.openliberty.jakarta.concurrency-2.0; apiJar=false,\
  com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.0; ibm.tolerates:="1.1"
 -bundles=com.ibm.ws.javaee.platform.defaultresource, \
  com.ibm.websphere.javaee.concurrent.1.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.enterprise.concurrent:javax.enterprise.concurrent-api:1.0", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-1.0/com.ibm.websphere.appserver.concurrent-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-1.0/com.ibm.websphere.appserver.concurrent-1.0.feature
@@ -11,7 +11,7 @@ Subsystem-Name: Concurrency Utilities for Java EE 1.0
  com.ibm.websphere.appserver.appLifecycle-1.0, \
  com.ibm.websphere.appserver.concurrencyPolicy-1.0, \
  com.ibm.websphere.appserver.contextService-1.0, \
- com.ibm.websphere.appserver.jakarta.concurrency-2.0,\
+ io.openliberty.jakarta.concurrency-2.0,\
  com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.0; ibm.tolerates:="1.1"
 -bundles=com.ibm.ws.javaee.platform.defaultresource, \
  com.ibm.websphere.javaee.concurrent.1.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.enterprise.concurrent:javax.enterprise.concurrent-api:1.0", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-2.0/com.ibm.websphere.appserver.concurrent-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-2.0/com.ibm.websphere.appserver.concurrent-2.0.feature
@@ -18,7 +18,7 @@ Subsystem-Name: Jakarta EE Concurrency 2.0
  io.openliberty.jakarta.concurrency-2.0, \
  com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.0; ibm.tolerates:="1.1"
 -bundles=\
- com.ibm.websphere.javaee.concurrent.1.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.enterprise.concurrent:javax.enterprise.concurrent-api:1.0", \
+ com.ibm.websphere.javaee.concurrent.1.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.enterprise.concurrent:javax.enterprise.concurrent-api:1.0"; apiJar=false, \
  com.ibm.ws.concurrent, \
  com.ibm.ws.javaee.platform.defaultresource, \
  com.ibm.ws.resource

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-2.0/com.ibm.websphere.appserver.concurrent-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-2.0/com.ibm.websphere.appserver.concurrent-2.0.feature
@@ -9,13 +9,13 @@ IBM-API-Service: jakarta.enterprise.concurrent.ContextService; id="DefaultContex
  jakarta.enterprise.concurrent.ManagedScheduledExecutorService; id="DefaultManagedScheduledExecutorService"
 Subsystem-Name: Jakarta EE Concurrency 2.0
 -features=\
- com.ibm.websphere.appserver.jakartaeePlatform-9.0, \
+ io.openliberty.jakartaeePlatform-9.0, \
  com.ibm.websphere.appserver.appLifecycle-1.0, \
  com.ibm.websphere.appserver.concurrencyPolicy-1.0, \
  com.ibm.websphere.appserver.containerServices-1.0, \
  com.ibm.websphere.appserver.contextService-1.0, \
  com.ibm.websphere.appserver.eeCompatible-9.0, \
- com.ibm.websphere.appserver.jakarta.concurrency-2.0, \
+ io.openliberty.jakarta.concurrency-2.0, \
  com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.0; ibm.tolerates:="1.1"
 -bundles=\
  com.ibm.websphere.javaee.concurrent.1.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.enterprise.concurrent:javax.enterprise.concurrent-api:1.0", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/ejbLite-4.0/com.ibm.websphere.appserver.ejbLite-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/ejbLite-4.0/com.ibm.websphere.appserver.ejbLite-4.0.feature
@@ -7,11 +7,11 @@ IBM-App-ForceRestart: install, \
 IBM-ShortName: ejbLite-4.0
 IBM-API-Package: com.ibm.websphere.ejbcontainer.mbean; type="ibm-api"
 Subsystem-Category: JakartaEE9Application
--features=com.ibm.websphere.appserver.jakarta.ejb-4.0, \
+-features=io.openliberty.jakarta.ejb-4.0, \
  com.ibm.websphere.appserver.contextService-1.0, \
  com.ibm.websphere.appserver.transaction-2.0, \
  com.ibm.websphere.appserver.eeCompatible-9.0, \
- com.ibm.websphere.appserver.jakarta.interceptor-2.0
+ io.openliberty.jakarta.interceptor-2.0
 Subsystem-Name: Jakarta Enterprise Beans Lite 4.0
 kind=noship
 edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/el-4.0/com.ibm.websphere.appserver.el-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/el-4.0/com.ibm.websphere.appserver.el-4.0.feature
@@ -12,7 +12,7 @@ IBM-API-Package: jakarta.el; type="spec", \
 IBM-ShortName: el-4.0
 Subsystem-Version: 4.0.0
 Subsystem-Name: Jakarta Expression Language 4.0
--features=com.ibm.websphere.appserver.jakarta.el-4.0
+-features=io.openliberty.jakarta.el-4.0
 -bundles=com.ibm.ws.org.apache.jasper.el.3.0.jakarta
 kind=beta
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jca-2.0/com.ibm.websphere.appserver.jca-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jca-2.0/com.ibm.websphere.appserver.jca-2.0.feature
@@ -4,9 +4,9 @@ visibility=public
 singleton=true
 IBM-API-Package: com.ibm.ws.jca.service; type="internal"
 IBM-ShortName: jca-2.0
-Subsystem-Name: Java Connector Architecture 2.0
+Subsystem-Name: Jakarta EE Connector Architecture 2.0
 Subsystem-Category: JakartaEE9Application
--features=com.ibm.websphere.appserver.jakarta.connector-2.0, \
+-features=io.openliberty.connector-2.0, \
  com.ibm.websphere.appserver.transaction-2.0
 kind=noship
 edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jpaContainer-3.0/com.ibm.websphere.appserver.jpaContainer-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jpaContainer-3.0/com.ibm.websphere.appserver.jpaContainer-3.0.feature
@@ -15,8 +15,8 @@ IBM-App-ForceRestart: uninstall, \
 -features=com.ibm.websphere.appserver.jndi-1.0, \
  com.ibm.websphere.appserver.classloading-1.0, \
  com.ibm.websphere.appserver.optional.jaxb-2.2; ibm.tolerates:=2.3, \
- com.ibm.websphere.appserver.jakarta.persistence-3.0, \
- com.ibm.websphere.appserver.jakarta.annotation-2.0; apiJar=false, \
+ io.openliberty.jakarta.persistence-3.0, \
+ io.openliberty.jakarta.annotation-2.0; apiJar=false, \
  com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:="4.3", \
  com.ibm.websphere.appserver.transaction-2.0, \
  com.ibm.websphere.appserver.eeCompatible-9.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-3.0/com.ibm.websphere.appserver.jsp-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-3.0/com.ibm.websphere.appserver.jsp-3.0.feature
@@ -32,8 +32,7 @@ IBM-API-Package: jakarta.servlet.jsp;  type="spec", \
 IBM-ShortName: jsp-3.0
 IBM-SPI-Package: com.ibm.wsspi.jsp.taglib.config
 Subsystem-Name: Jakarta Server Pages 3.0
--features=com.ibm.websphere.appserver.jakarta.jsp-3.0, \
- com.ibm.websphere.appserver.jakarta.el-4.0, \
+-features=io.openliberty.jakarta.jsp-3.0, \
  com.ibm.websphere.appserver.servlet-5.0; \
  com.ibm.websphere.appserver.el-4.0
 -bundles=com.ibm.ws.org.eclipse.jdt.core.3.10.2.v20160712-0000, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/servlet-5.0/com.ibm.websphere.appserver.servlet-5.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/servlet-5.0/com.ibm.websphere.appserver.servlet-5.0.feature
@@ -41,9 +41,9 @@ Subsystem-Category: JakartaEE9Application
  com.ibm.websphere.appserver.appmanager-1.0, \
  com.ibm.websphere.appserver.javaeePlatform-8.0, \
  com.ibm.websphere.appserver.anno-2.0, \
- com.ibm.websphere.appserver.jakarta.annotation-2.0, \
+ io.openliberty.jakarta.annotation-2.0, \
  com.ibm.websphere.appserver.httptransport-1.0, \
- com.ibm.websphere.appserver.jakarta.servlet-5.0, \
+ io.openliberty.jakarta.servlet-5.0, \
  com.ibm.websphere.appserver.requestProbes-1.0, \
  com.ibm.websphere.appserver.eeCompatible-9.0, \
  com.ibm.websphere.appserver.servlet-servletSpi1.0, \

--- a/dev/com.ibm.ws.concurrent_fat_policy/build.gradle
+++ b/dev/com.ibm.ws.concurrent_fat_policy/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,4 +14,3 @@ dependencies {
   requiredLibs 'jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:2.0.0-RC1'
 }
 
-addRequiredLibraries.dependsOn addDerby

--- a/dev/io.openliberty.jakarta.concurrency.2.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.concurrency.2.0/bnd.bnd
@@ -20,7 +20,10 @@ Include-Resource: \
 
 instrument.disabled: true
 
-publish.wlp.jar.suffix: dev/api/spec
+#Because the implementation is shared between both 1.0 and 2.0, this API bundle is being shipped as GA already (with the 1.0 feature).
+#However, we don't want to expose it to users just yet because the 2.0 Jakarta API and our 2.0 implementation feature are not ready.
+#When the 2.0 feature moves to beta then this bundle should be moved from lib to dev/api/spec by uncommenting the line below.
+#publish.wlp.jar.suffix: dev/api/spec
 
 -buildpath: \
   jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api;version=2.0.0


### PR DESCRIPTION
#build

Note about the 2nd commit:
Because the implementation is shared between both concurrent 1.0 and 2.0, the 2.0 API bundle is already being shipped as GA with the 1.0 feature. This was a little premature because Jakarta have not released the API yet,

We can't remove the 2.0 API bundle without drastically reworking the implmentation. However, we don't want to expose it to users just yet either. No one should be using the API yet so moving it out of the dev folder and into lib is safe enough.

When the 2.0 feature moves to beta then the API bundle should be moved back from lib to dev/api/spec.