### PR TITLE
PR for Issue 12197: Code drop for OAuth HTTP method limiting

### DIFF
--- a/dev/com.ibm.ws.security.oauth/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.oauth/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2019, 2020 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -260,6 +260,7 @@
         <!--  this is fixing a corner bug and has to be behind a property to protect existing users.  -->
         <AD id="ropcPreferUserSecurityName" name="%ropcPreferUserSecurityName" description="%ropcPreferUserSecurityName.desc" required="false" type="Boolean"  default="false"/>
         <AD id="trackOAuthClients" name="%trackOAuthClients" description="%trackOAuthClients.desc" required="false" type="Boolean" default="false" />
+        <AD id="oauthEndpoint" name="internal" description="internal use only" required="false" type="String" ibm:type="pid" ibm:reference="com.ibm.ws.security.oauth.endpoint" cardinality="20" />
     </OCD>
    <!--   
     <Designate factoryPid="com.ibm.ws.security.oauth20.provider.config">
@@ -268,6 +269,37 @@
     -->
     <Designate factoryPid="com.ibm.ws.security.oauth20.provider">
         <Object ocdref="com.ibm.ws.security.oauth20.provider.metatype" />
+    </Designate>
+
+     <OCD id="com.ibm.ws.security.oauth.endpoint.metatype" name="internal" description="internal use only" >
+         <AD id="name" name="internal" description="internal use only" required="true" type="String" ibm:unique="name" >
+             <Option label="authorize" value="authorize" />
+             <Option label="introspect" value="introspect" />
+             <Option label="revoke" value="revoke" />
+             <Option label="token" value="token" />
+             <Option label="coverageMap" value="coverageMap" />
+             <Option label="registration" value="registration" />
+             <Option label="logout" value="logout" />
+             <Option label="appPasswords" value="appPasswords" />
+             <Option label="appTokens" value="appTokens" />
+             <Option label="clientManagement" value="clientManagement" />
+             <Option label="personalTokenManagement" value="personalTokenManagement" />
+             <Option label="usersTokenManagement" value="usersTokenManagement" />
+             <Option label="clientMetatype" value="clientMetatype" />
+         </AD>
+         <AD id="supportedHttpMethods" name="internal" description="internal use only" required="false" type="String" default="all" cardinality="5" >
+             <Option label="all" value="all" />
+             <Option label="none" value="none" />
+             <Option label="get" value="GET" />
+             <Option label="head" value="HEAD" />
+             <Option label="post" value="POST" />
+             <Option label="delete" value="DELETE" />
+             <Option label="put" value="PUT" />
+         </AD>
+    </OCD>
+
+    <Designate factoryPid="com.ibm.ws.security.oauth.endpoint">
+        <Object ocdref="com.ibm.ws.security.oauth.endpoint.metatype" />
     </Designate>
 
     <OCD id="com.ibm.ws.security.oauth20.server.store.metatype"  

--- a/dev/com.ibm.ws.security.oauth/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.oauth/resources/OSGI-INF/metatype/metatype.xml
@@ -287,7 +287,7 @@
              <Option label="usersTokenManagement" value="usersTokenManagement" />
              <Option label="clientMetatype" value="clientMetatype" />
          </AD>
-         <AD id="supportedHttpMethods" name="internal" description="internal use only" required="false" type="String" default="all" cardinality="5" >
+         <AD id="supportedHttpMethods" name="internal" description="internal use only" required="false" type="String" default="all" cardinality="6" >
              <Option label="all" value="all" />
              <Option label="none" value="none" />
              <Option label="get" value="GET" />
@@ -295,6 +295,7 @@
              <Option label="post" value="POST" />
              <Option label="delete" value="DELETE" />
              <Option label="put" value="PUT" />
+             <Option label="trace" value="TRACE" />
          </AD>
     </OCD>
 

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/api/OAuth20Provider.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/api/OAuth20Provider.java
@@ -21,6 +21,8 @@ import com.ibm.oauth.core.api.oauth20.OAuth20Component;
 import com.ibm.oauth.core.internal.oauth20.config.OAuth20ConfigProvider;
 import com.ibm.ws.security.SecurityService;
 
+import io.openliberty.security.oauth20.internal.config.OAuthEndpointSettings;
+
 public interface OAuth20Provider extends OAuth20ConfigProvider, OAuthComponentInstance {
 
     public OAuth20Component getComponent();
@@ -162,5 +164,7 @@ public interface OAuth20Provider extends OAuth20ConfigProvider, OAuthComponentIn
     public boolean isROPCPreferUserSecurityName();
 
     public boolean isTrackOAuthClients();
+
+    public OAuthEndpointSettings getOAuthEndpointSettings();
 
 }

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/internal/LibertyOAuth20Provider.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/internal/LibertyOAuth20Provider.java
@@ -33,8 +33,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 
-import org.osgi.service.cm.Configuration;
 import org.osgi.framework.ServiceReference;
+import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.cm.ConfigurationEvent;
 import org.osgi.service.cm.ConfigurationListener;
@@ -107,6 +107,8 @@ import com.ibm.wsspi.library.Library;
 import com.ibm.wsspi.resource.ResourceConfig;
 import com.ibm.wsspi.resource.ResourceConfigFactory;
 import com.ibm.wsspi.resource.ResourceFactory;
+
+import io.openliberty.security.oauth20.internal.config.OAuthEndpointSettings;
 
 @Component(configurationPid = "com.ibm.ws.security.oauth20.provider", configurationPolicy = ConfigurationPolicy.REQUIRE, service = { OAuth20Provider.class, ConfigurationListener.class, ServerQuiesceListener.class }, immediate = false, property = { "service.vendor=IBM", "dataSourceFactory.target=(id=unbound)" })
 public class LibertyOAuth20Provider implements OAuth20Provider, ConfigurationListener, ServerQuiesceListener {
@@ -190,6 +192,7 @@ public class LibertyOAuth20Provider implements OAuth20Provider, ConfigurationLis
     protected static final String KEY_CACHE_ACCESSTOKEN = "accessTokenCacheEnabled";
     protected static final String KEY_REVOKE_ACCESSTOK_W_REFRESHTOK = "revokeAccessTokensWithRefreshTokens";
     public static final String KEY_TRACK_OAUTH_CLIENTS = "trackOAuthClients";
+    public static final String KEY_OAUTH_ENDPOINT = "oauthEndpoint";
 
     // TODO: Rational Jazz props. Determine if these can be move to OIDC config.
     protected static final String KEY_COVERAGE_MAP_SESSION_MAX_AGE = "coverageMapSessionMaxAge";
@@ -348,6 +351,7 @@ public class LibertyOAuth20Provider implements OAuth20Provider, ConfigurationLis
     private boolean revokeAccessTokensWithRefreshTokens = true;
     private boolean ropcPreferUserSecurityName = false;
     private boolean trackOAuthClients = false;
+    private OAuthEndpointSettings oauthEndpointSettings;
 
     // DS related methods
 
@@ -471,6 +475,7 @@ public class LibertyOAuth20Provider implements OAuth20Provider, ConfigurationLis
         clientSecretEncoding = getClientSecretEncodingFromConfig();
         ropcPreferUserSecurityName = (Boolean) properties.get(KEY_ROPC_PREFER_USERSECURITYNAME);
         trackOAuthClients = (Boolean) properties.get(KEY_TRACK_OAUTH_CLIENTS);
+        oauthEndpointSettings = populateOAuthEndpointSettings(properties, KEY_OAUTH_ENDPOINT);
 
         setUpInternalClient();
         // tolerate old jwtAccessToken attrib but if tokenFormat attrib is specified,
@@ -512,6 +517,33 @@ public class LibertyOAuth20Provider implements OAuth20Provider, ConfigurationLis
             configValue = OAuth20Constants.XOR;
         }
         return configValue;
+    }
+
+    private OAuthEndpointSettings populateOAuthEndpointSettings(Map<String, Object> configProps, String endpointSettingsElementName) {
+        OAuthEndpointSettings endpointSettings = null;
+        String[] endpointSettingsElementPids = configUtils.getStringArrayConfigAttribute(configProps, endpointSettingsElementName);
+        if (endpointSettingsElementPids != null && endpointSettingsElementPids.length > 0) {
+            endpointSettings = populateOAuthEndpointSettings(endpointSettingsElementPids);
+        }
+        return endpointSettings;
+    }
+
+    private OAuthEndpointSettings populateOAuthEndpointSettings(String[] endpointSettingsElementPids) {
+        OAuthEndpointSettings endpointSettings = new OAuthEndpointSettings();
+        for (String elementPid : endpointSettingsElementPids) {
+            Configuration config = getConfigurationFromConfigAdmin(elementPid);
+            endpointSettings.addOAuthEndpointSettings(config);
+        }
+        return endpointSettings;
+    }
+
+    Configuration getConfigurationFromConfigAdmin(String elementPid) {
+        Configuration config = null;
+        try {
+            config = configAdmin.getConfiguration(elementPid, "");
+        } catch (IOException e) {
+        }
+        return config;
     }
 
     void setUpInternalClient() {
@@ -2428,6 +2460,11 @@ public class LibertyOAuth20Provider implements OAuth20Provider, ConfigurationLis
     @Override
     public boolean isTrackOAuthClients() {
         return trackOAuthClients;
+    }
+
+    @Override
+    public OAuthEndpointSettings getOAuthEndpointSettings() {
+        return oauthEndpointSettings;
     }
 
 }

--- a/dev/com.ibm.ws.security.oauth/src/io/openliberty/security/oauth20/internal/config/OAuthEndpointSettings.java
+++ b/dev/com.ibm.ws.security.oauth/src/io/openliberty/security/oauth20/internal/config/OAuthEndpointSettings.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oauth20.internal.config;
+
+import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.osgi.service.cm.Configuration;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.security.oauth20.web.OAuth20Request.EndpointType;
+
+public class OAuthEndpointSettings {
+
+    private static final TraceComponent tc = Tr.register(OAuthEndpointSettings.class);
+
+    public static final String KEY_NAME = "name";
+    public static final String KEY_SUPPORTED_HTTP_METHODS = "supportedHttpMethods";
+
+    private final Map<EndpointType, SpecificOAuthEndpointSettings> allOAuthEndpointSettings = new HashMap<EndpointType, SpecificOAuthEndpointSettings>();
+
+    public Map<EndpointType, SpecificOAuthEndpointSettings> getAllOAuthEndpointSettings() {
+        return allOAuthEndpointSettings;
+    }
+
+    public SpecificOAuthEndpointSettings getSpecificOAuthEndpointSettings(EndpointType endpointType) {
+        return allOAuthEndpointSettings.get(endpointType);
+    }
+
+    @FFDCIgnore(RuntimeException.class)
+    public void addOAuthEndpointSettings(Configuration endpointSettingsConfig) {
+        if (endpointSettingsConfig == null) {
+            return;
+        }
+        Dictionary<String, Object> configProps = endpointSettingsConfig.getProperties();
+        if (configProps == null) {
+            return;
+        }
+        SpecificOAuthEndpointSettings endpointSettings = null;
+        try {
+            EndpointType endpoint = getEndpointTypeFromConfigName((String) configProps.get(KEY_NAME));
+            if (endpoint == null) {
+                return;
+            }
+            endpointSettings = new SpecificOAuthEndpointSettings(endpoint);
+            endpointSettings.setSupportedHttpMethods((String[]) configProps.get(KEY_SUPPORTED_HTTP_METHODS));
+        } catch (RuntimeException e) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Caught an exception reading endpoint settings from the config: {0}. Config properties were {1}", e, configProps);
+            }
+        }
+        updateAllEndpointSettings(endpointSettings);
+    }
+
+    @FFDCIgnore(IllegalArgumentException.class)
+    EndpointType getEndpointTypeFromConfigName(String endpointName) {
+        EndpointType endpointType = null;
+        try {
+            endpointType = EndpointType.valueOf(endpointName);
+        } catch (IllegalArgumentException e) {
+            // Didn't find easy match for endpoint name, so need to find the appropriate match
+            endpointType = getNonStandardEndpointTypeFromConfigName(endpointName);
+        }
+        if (endpointType == null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Failed to find matching endpoint type for intput [" + endpointName + "]");
+            }
+        }
+        return endpointType;
+    }
+
+    /**
+     * The values defined in metatype.xml for the endpoint names don't necessarily match 1:1 with the values defined by the
+     * EndpointType enum. This method finds those non-standard endpoint names.
+     */
+    EndpointType getNonStandardEndpointTypeFromConfigName(String endpointName) {
+        if ("coverageMap".equals(endpointName)) {
+            return EndpointType.coverage_map;
+        } else if ("appPasswords".equals(endpointName)) {
+            return EndpointType.app_password;
+        } else if ("appTokens".equals(endpointName)) {
+            return EndpointType.app_token;
+        }
+        return null;
+    }
+
+    void updateAllEndpointSettings(SpecificOAuthEndpointSettings newEndpointSettings) {
+        if (newEndpointSettings == null) {
+            return;
+        }
+        EndpointType newEndpointType = newEndpointSettings.getEndpointType();
+        if (allOAuthEndpointSettings.containsKey(newEndpointType)) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Endpoint settings already recorded for endpoint type {0}. Recorded settings are {1}. The following settings will be ignored: {2}", newEndpointType, allOAuthEndpointSettings.get(newEndpointType), newEndpointSettings);
+            }
+        } else {
+            allOAuthEndpointSettings.put(newEndpointType, newEndpointSettings);
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.security.oauth/src/io/openliberty/security/oauth20/internal/config/SpecificOAuthEndpointSettings.java
+++ b/dev/com.ibm.ws.security.oauth/src/io/openliberty/security/oauth20/internal/config/SpecificOAuthEndpointSettings.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oauth20.internal.config;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.security.oauth20.web.OAuth20Request.EndpointType;
+
+import io.openliberty.security.common.http.SupportedHttpMethodHandler.HttpMethod;
+
+@SuppressWarnings("restriction")
+public class SpecificOAuthEndpointSettings {
+
+    private static final TraceComponent tc = Tr.register(SpecificOAuthEndpointSettings.class);
+
+    private EndpointType endpoint = null;
+    private Set<HttpMethod> supportedHttpMethods = new HashSet<HttpMethod>();
+
+    public SpecificOAuthEndpointSettings(EndpointType endpointType) {
+        this.endpoint = endpointType;
+    }
+
+    public EndpointType getEndpointType() {
+        return endpoint;
+    }
+
+    public void setSupportedHttpMethods(String... supportedHttpMethods) {
+        this.supportedHttpMethods = new HashSet<HttpMethod>();
+        if (supportedHttpMethods != null) {
+            for (String method : supportedHttpMethods) {
+                if (method == null) {
+                    continue;
+                }
+                if (isSpecialHttpMethodCase(method)) {
+                    addSupportedMethodsForSpecialCase(method);
+                    break;
+                } else {
+                    addStandardHttpMethod(method);
+                }
+            }
+        }
+    }
+
+    boolean isSpecialHttpMethodCase(String method) {
+        return "all".equalsIgnoreCase(method) || "none".equalsIgnoreCase(method);
+    }
+
+    void addSupportedMethodsForSpecialCase(String method) {
+        if ("all".equalsIgnoreCase(method)) {
+            for (HttpMethod httpMethod : HttpMethod.values()) {
+                this.supportedHttpMethods.add(httpMethod);
+            }
+        } else if ("none".equalsIgnoreCase(method)) {
+            // Don't add any supported HTTP methods
+            this.supportedHttpMethods = new HashSet<HttpMethod>();
+        }
+    }
+
+    @FFDCIgnore(IllegalArgumentException.class)
+    void addStandardHttpMethod(String method) {
+        try {
+            HttpMethod convertedMethod = HttpMethod.valueOf(method.toUpperCase());
+            this.supportedHttpMethods.add(convertedMethod);
+        } catch (IllegalArgumentException e) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Caught exception trying to add supported HTTP method: " + e);
+            }
+        }
+    }
+
+    public Set<HttpMethod> getSupportedHttpMethods() {
+        return supportedHttpMethods;
+    }
+
+    @Override
+    public String toString() {
+        return "[EndpointType: " + endpoint + ", Supported HTTP methods: " + supportedHttpMethods + "]";
+    }
+
+}

--- a/dev/com.ibm.ws.security.oauth/src/io/openliberty/security/oauth20/internal/config/package-info.java
+++ b/dev/com.ibm.ws.security.oauth/src/io/openliberty/security/oauth20/internal/config/package-info.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ *
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+@TraceOptions(traceGroup = TraceConstants.TRACE_GROUP, messageBundle = TraceConstants.MESSAGE_BUNDLE)
+package io.openliberty.security.oauth20.internal.config;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;
+import com.ibm.ws.security.oauth20.TraceConstants;

--- a/dev/com.ibm.ws.security.oauth/test/io/openliberty/security/oauth20/internal/config/OAuthEndpointSettingsTest.java
+++ b/dev/com.ibm.ws.security.oauth/test/io/openliberty/security/oauth20/internal/config/OAuthEndpointSettingsTest.java
@@ -1,0 +1,307 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oauth20.internal.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.Set;
+
+import org.jmock.Expectations;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.osgi.service.cm.Configuration;
+
+import com.ibm.ws.security.oauth20.web.OAuth20Request.EndpointType;
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import io.openliberty.security.common.http.SupportedHttpMethodHandler.HttpMethod;
+import test.common.SharedOutputManager;
+
+public class OAuthEndpointSettingsTest extends CommonTestClass {
+
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("io.openliberty.security.oauth.*=all:com.ibm.ws.security.oauth.*=all");
+
+    private final Configuration config = mockery.mock(Configuration.class);
+
+    private OAuthEndpointSettings settings;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        System.out.println("Entering test: " + testName.getMethodName());
+        settings = new OAuthEndpointSettings();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.out.println("Exiting test: " + testName.getMethodName());
+        mockery.assertIsSatisfied();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    @Test
+    public void test_addOAuthEndpointSettings_nullConfig() {
+        settings.addOAuthEndpointSettings(null);
+
+        Map<EndpointType, SpecificOAuthEndpointSettings> allSettings = settings.getAllOAuthEndpointSettings();
+        assertTrue("Should not have recorded any endpoint settings, but did. Settings were: " + allSettings, allSettings.isEmpty());
+    }
+
+    @Test
+    public void test_addOAuthEndpointSettings_noProperties() {
+        mockery.checking(new Expectations() {
+            {
+                one(config).getProperties();
+                will(returnValue(null));
+            }
+        });
+        settings.addOAuthEndpointSettings(config);
+
+        Map<EndpointType, SpecificOAuthEndpointSettings> allSettings = settings.getAllOAuthEndpointSettings();
+        assertTrue("Should not have recorded any endpoint settings, but did. Settings were: " + allSettings, allSettings.isEmpty());
+    }
+
+    @Test
+    public void test_addOAuthEndpointSettings_emptyProperties() {
+        final Dictionary<String, Object> props = new Hashtable<String, Object>();
+        mockery.checking(new Expectations() {
+            {
+                one(config).getProperties();
+                will(returnValue(props));
+            }
+        });
+        settings.addOAuthEndpointSettings(config);
+
+        Map<EndpointType, SpecificOAuthEndpointSettings> allSettings = settings.getAllOAuthEndpointSettings();
+        assertTrue("Should not have recorded any endpoint settings, but did. Settings were: " + allSettings, allSettings.isEmpty());
+    }
+
+    @Test
+    public void test_addOAuthEndpointSettings_unknownEndpoint() {
+        final Dictionary<String, Object> props = new Hashtable<String, Object>();
+        props.put(OAuthEndpointSettings.KEY_NAME, "unknown");
+        mockery.checking(new Expectations() {
+            {
+                one(config).getProperties();
+                will(returnValue(props));
+            }
+        });
+        settings.addOAuthEndpointSettings(config);
+
+        Map<EndpointType, SpecificOAuthEndpointSettings> allSettings = settings.getAllOAuthEndpointSettings();
+        assertTrue("Should not have recorded any endpoint settings, but did. Settings were: " + allSettings, allSettings.isEmpty());
+    }
+
+    @Test
+    public void test_addOAuthEndpointSettings_knownEndpoint_noOtherSettings() {
+        EndpointType endpointUnderTest = EndpointType.coverage_map;
+
+        final Dictionary<String, Object> props = new Hashtable<String, Object>();
+        props.put(OAuthEndpointSettings.KEY_NAME, "coverageMap");
+        mockery.checking(new Expectations() {
+            {
+                one(config).getProperties();
+                will(returnValue(props));
+            }
+        });
+        settings.addOAuthEndpointSettings(config);
+
+        SpecificOAuthEndpointSettings testSettings = new SpecificOAuthEndpointSettings(endpointUnderTest);
+        assertSettingsPresentAndSupportedHttpMethodsAreCorrect(testSettings);
+    }
+
+    @Test
+    public void test_addOAuthEndpointSettings_knownEndpoint_supportedHttpMethodsString() {
+        EndpointType endpointUnderTest = EndpointType.token;
+        final Dictionary<String, Object> props = new Hashtable<String, Object>();
+
+        props.put(OAuthEndpointSettings.KEY_NAME, String.valueOf(endpointUnderTest));
+        props.put(OAuthEndpointSettings.KEY_SUPPORTED_HTTP_METHODS, "simple string");
+        mockery.checking(new Expectations() {
+            {
+                one(config).getProperties();
+                will(returnValue(props));
+            }
+        });
+        settings.addOAuthEndpointSettings(config);
+
+        SpecificOAuthEndpointSettings testSettings = new SpecificOAuthEndpointSettings(endpointUnderTest);
+        assertSettingsPresentAndSupportedHttpMethodsAreCorrect(testSettings);
+    }
+
+    @Test
+    public void test_addOAuthEndpointSettings_knownEndpoint_supportedHttpMethodsArray() {
+        EndpointType endpointUnderTest = EndpointType.introspect;
+        String[] intputSupportedHttpMethods = new String[] { "get", "GET", "post", "other" };
+
+        final Dictionary<String, Object> props = new Hashtable<String, Object>();
+        props.put(OAuthEndpointSettings.KEY_NAME, String.valueOf(endpointUnderTest));
+        props.put(OAuthEndpointSettings.KEY_SUPPORTED_HTTP_METHODS, intputSupportedHttpMethods);
+        mockery.checking(new Expectations() {
+            {
+                one(config).getProperties();
+                will(returnValue(props));
+            }
+        });
+        settings.addOAuthEndpointSettings(config);
+
+        SpecificOAuthEndpointSettings testSettings = new SpecificOAuthEndpointSettings(endpointUnderTest);
+        testSettings.setSupportedHttpMethods(intputSupportedHttpMethods);
+        assertSettingsPresentAndSupportedHttpMethodsAreCorrect(testSettings);
+    }
+
+    @Test
+    public void test_getEndpointTypeFromConfigName_emptyString() {
+        String endpointName = "";
+        EndpointType endpoint = settings.getEndpointTypeFromConfigName(endpointName);
+        assertEquals("Should not have found a matching endpoint type for input [" + endpointName + "].", null, endpoint);
+    }
+
+    @Test
+    public void test_getEndpointTypeFromConfigName_unknownValue() {
+        String endpointName = "some unknown value";
+        EndpointType endpoint = settings.getEndpointTypeFromConfigName(endpointName);
+        assertEquals("Should not have found a matching endpoint type for input [" + endpointName + "].", null, endpoint);
+    }
+
+    @Test
+    public void test_getEndpointTypeFromConfigName_authorize() {
+        String endpointName = "authorize";
+        EndpointType endpoint = settings.getEndpointTypeFromConfigName(endpointName);
+        assertEquals("Did not get correct matching endpoint type for input [" + endpointName + "].", EndpointType.authorize, endpoint);
+    }
+
+    @Test
+    public void test_getEndpointTypeFromConfigName_token() {
+        String endpointName = "token";
+        EndpointType endpoint = settings.getEndpointTypeFromConfigName(endpointName);
+        assertEquals("Did not get correct matching endpoint type for input [" + endpointName + "].", EndpointType.token, endpoint);
+    }
+
+    @Test
+    public void test_getEndpointTypeFromConfigName_appPasswords() {
+        String endpointName = "appPasswords";
+        EndpointType endpoint = settings.getEndpointTypeFromConfigName(endpointName);
+        assertEquals("Did not get correct matching endpoint type for input [" + endpointName + "].", EndpointType.app_password, endpoint);
+    }
+
+    @Test
+    public void test_getEndpointTypeFromConfigName_appTokens() {
+        String endpointName = "appTokens";
+        EndpointType endpoint = settings.getEndpointTypeFromConfigName(endpointName);
+        assertEquals("Did not get correct matching endpoint type for input [" + endpointName + "].", EndpointType.app_token, endpoint);
+    }
+
+    @Test
+    public void test_getEndpointTypeFromConfigName_coverageMap() {
+        String endpointName = "coverageMap";
+        EndpointType endpoint = settings.getEndpointTypeFromConfigName(endpointName);
+        assertEquals("Did not get correct matching endpoint type for input [" + endpointName + "].", EndpointType.coverage_map, endpoint);
+    }
+
+    @Test
+    public void test_updateAllEndpointSettings_nullSettings() {
+        settings.updateAllEndpointSettings(null);
+
+        Map<EndpointType, SpecificOAuthEndpointSettings> allSettings = settings.getAllOAuthEndpointSettings();
+        assertTrue("Should not have recorded any endpoint settings, but did. Settings were: " + allSettings, allSettings.isEmpty());
+    }
+
+    @Test
+    public void test_updateAllEndpointSettings_oneEndpoint_noSupportedMethods() {
+        EndpointType endpointUnderTest = EndpointType.revoke;
+        SpecificOAuthEndpointSettings newSettings = new SpecificOAuthEndpointSettings(endpointUnderTest);
+        settings.updateAllEndpointSettings(newSettings);
+
+        assertSettingsPresentAndSupportedHttpMethodsAreCorrect(newSettings);
+    }
+
+    @Test
+    public void test_updateAllEndpointSettings_addSameEndpointTwice() {
+        EndpointType endpointUnderTest = EndpointType.clientMetatype;
+        SpecificOAuthEndpointSettings newSettings = new SpecificOAuthEndpointSettings(endpointUnderTest);
+        settings.updateAllEndpointSettings(newSettings);
+
+        SpecificOAuthEndpointSettings recordedSettings = assertSettingsPresentForEndpoint(endpointUnderTest);
+        assertTrue("Should not have found any supported HTTP methods, but did: " + recordedSettings, recordedSettings.getSupportedHttpMethods().isEmpty());
+
+        SpecificOAuthEndpointSettings settingsForSameEndpoint = new SpecificOAuthEndpointSettings(endpointUnderTest);
+        settingsForSameEndpoint.setSupportedHttpMethods("get", "post");
+        settings.updateAllEndpointSettings(settingsForSameEndpoint);
+
+        // Verify that the second set of settings weren't accepted since we already have settings for this endpoint
+        assertSettingsPresentAndSupportedHttpMethodsAreCorrect(newSettings);
+    }
+
+    @Test
+    public void test_updateAllEndpointSettings_addMultipleEndpoints() {
+        SpecificOAuthEndpointSettings newSettings1 = new SpecificOAuthEndpointSettings(EndpointType.authorize);
+
+        SpecificOAuthEndpointSettings newSettings2 = new SpecificOAuthEndpointSettings(EndpointType.introspect);
+        String[] newSettings2SupportedHttpMethods = new String[] { "get", "post", "unknown" };
+        newSettings2.setSupportedHttpMethods(newSettings2SupportedHttpMethods);
+
+        SpecificOAuthEndpointSettings newSettings3 = new SpecificOAuthEndpointSettings(EndpointType.token);
+        String[] newSettings3SupportedHttpMethods = new String[] { "post" };
+        newSettings3.setSupportedHttpMethods(newSettings3SupportedHttpMethods);
+
+        settings.updateAllEndpointSettings(newSettings1);
+        settings.updateAllEndpointSettings(newSettings2);
+        settings.updateAllEndpointSettings(newSettings3);
+
+        assertSettingsPresentAndSupportedHttpMethodsAreCorrect(newSettings1);
+        assertSettingsPresentAndSupportedHttpMethodsAreCorrect(newSettings2);
+        assertSettingsPresentAndSupportedHttpMethodsAreCorrect(newSettings3);
+
+    }
+
+    @SuppressWarnings("restriction")
+    private void assertSettingsPresentAndSupportedHttpMethodsAreCorrect(SpecificOAuthEndpointSettings inputSettings) {
+        SpecificOAuthEndpointSettings recordedSettings = assertSettingsPresentForEndpoint(inputSettings.getEndpointType());
+        Set<HttpMethod> recordedSupportedHttpMethods = recordedSettings.getSupportedHttpMethods();
+        Set<HttpMethod> inputSupportedHttpMethods = inputSettings.getSupportedHttpMethods();
+        if (inputSupportedHttpMethods.isEmpty()) {
+            assertTrue("Should not have found any supported HTTP methods, but did: " + recordedSettings, recordedSupportedHttpMethods.isEmpty());
+        } else {
+            assertFalse("Should have found supported HTTP methods, but did not.", recordedSupportedHttpMethods.isEmpty());
+            for (HttpMethod method : inputSupportedHttpMethods) {
+                assertTrue("Supported HTTP methods for endpoint [" + inputSettings.getEndpointType() + "] is missing expected value [" + method + "]. Recorded methods were: " + recordedSupportedHttpMethods, recordedSupportedHttpMethods.contains(method));
+            }
+        }
+    }
+
+    private SpecificOAuthEndpointSettings assertSettingsPresentForEndpoint(EndpointType endpoint) {
+        Map<EndpointType, SpecificOAuthEndpointSettings> allSettings = settings.getAllOAuthEndpointSettings();
+        assertFalse("Should have recorded at least one set of endpoint settings, but did not.", allSettings.isEmpty());
+        SpecificOAuthEndpointSettings recordedSettings = settings.getSpecificOAuthEndpointSettings(endpoint);
+        assertNotNull("Should have found an entry for the [" + endpoint + "] endpoint, but did not. All settings were: " + allSettings, recordedSettings);
+        return recordedSettings;
+    }
+
+}

--- a/dev/com.ibm.ws.security.oauth/test/io/openliberty/security/oauth20/internal/config/SpecificOAuthEndpointSettingsTest.java
+++ b/dev/com.ibm.ws.security.oauth/test/io/openliberty/security/oauth20/internal/config/SpecificOAuthEndpointSettingsTest.java
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.oauth20.internal.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.ws.security.oauth20.web.OAuth20Request.EndpointType;
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import io.openliberty.security.common.http.SupportedHttpMethodHandler.HttpMethod;
+import test.common.SharedOutputManager;
+
+@SuppressWarnings("restriction")
+public class SpecificOAuthEndpointSettingsTest extends CommonTestClass {
+
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("io.openliberty.security.oauth.*=all:com.ibm.ws.security.oauth.*=all");
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        System.out.println("Entering test: " + testName.getMethodName());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.out.println("Exiting test: " + testName.getMethodName());
+        mockery.assertIsSatisfied();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    @Test
+    public void test_constructorAndGetters() {
+        EndpointType endpointType = EndpointType.authorize;
+        SpecificOAuthEndpointSettings settings = new SpecificOAuthEndpointSettings(endpointType);
+        assertEquals("Endpoint type did not match expected value.", endpointType, settings.getEndpointType());
+        // By default, there should be no supported HTTP methods
+        Set<HttpMethod> supportedMethods = settings.getSupportedHttpMethods();
+        assertNotNull("Set of supported methods should not have been null.", supportedMethods);
+        assertTrue("Should not have recorded any supported HTTP methods, but did. Supported methods were: " + supportedMethods, supportedMethods.isEmpty());
+    }
+
+    @Test
+    public void test_setSupportedHttpMethods_nullInput() {
+        SpecificOAuthEndpointSettings settings = new SpecificOAuthEndpointSettings(EndpointType.authorize);
+        settings.setSupportedHttpMethods((String[]) null);
+
+        Set<HttpMethod> supportedMethods = settings.getSupportedHttpMethods();
+        assertNotNull("Set of supported methods should not have been null.", supportedMethods);
+        assertTrue("Should not have recorded any supported HTTP methods, but did. Supported methods were: " + supportedMethods, supportedMethods.isEmpty());
+    }
+
+    @Test
+    public void test_setSupportedHttpMethods_emptyInput() {
+        SpecificOAuthEndpointSettings settings = new SpecificOAuthEndpointSettings(EndpointType.clientMetatype);
+        settings.setSupportedHttpMethods(new String[0]);
+
+        Set<HttpMethod> supportedMethods = settings.getSupportedHttpMethods();
+        assertTrue("Should not have recorded any supported HTTP methods, but did. Supported methods were: " + supportedMethods, supportedMethods.isEmpty());
+    }
+
+    @Test
+    public void test_setSupportedHttpMethods_simpleInput() {
+        SpecificOAuthEndpointSettings settings = new SpecificOAuthEndpointSettings(EndpointType.introspect);
+        String supportedMethod = "Get";
+        HttpMethod expectedMethod = HttpMethod.GET;
+        settings.setSupportedHttpMethods(supportedMethod);
+
+        Set<HttpMethod> supportedMethods = settings.getSupportedHttpMethods();
+        assertEquals("Set of supported HTTP methods did not expected number of inputs. Supported methods were: " + supportedMethods, 1, supportedMethods.size());
+        assertTrue("Supported HTTP methods for endpoint [" + settings.getEndpointType() + "] is missing expected value [" + expectedMethod + "]. Recorded methods were: " + supportedMethods, supportedMethods.contains(expectedMethod));
+    }
+
+    @Test
+    public void test_setSupportedHttpMethods_multipleInputs() {
+        SpecificOAuthEndpointSettings settings = new SpecificOAuthEndpointSettings(EndpointType.registration);
+        String supportedMethod = "POST";
+        HttpMethod expectedMethod = HttpMethod.POST;
+        settings.setSupportedHttpMethods(supportedMethod);
+
+        Set<HttpMethod> supportedMethods = settings.getSupportedHttpMethods();
+        assertEquals("Set of supported HTTP methods did not expected number of inputs. Supported methods were: " + supportedMethods, 1, supportedMethods.size());
+        assertTrue("Supported HTTP methods for endpoint [" + settings.getEndpointType() + "] is missing expected value [" + expectedMethod + "]. Recorded methods were: " + supportedMethods, supportedMethods.contains(expectedMethod));
+
+        supportedMethod = "unknown";
+        settings.setSupportedHttpMethods(supportedMethod);
+
+        supportedMethods = settings.getSupportedHttpMethods();
+        assertTrue("Should not have recorded any supported HTTP methods, but did. Supported methods were: " + supportedMethods, supportedMethods.isEmpty());
+
+        String[] inputSupportedMethods = new String[] { "one", "two", "three" };
+        settings.setSupportedHttpMethods(inputSupportedMethods);
+
+        supportedMethods = settings.getSupportedHttpMethods();
+        assertTrue("Should not have recorded any supported HTTP methods, but did. Supported methods were: " + supportedMethods, supportedMethods.isEmpty());
+    }
+
+}


### PR DESCRIPTION
Adds the metatype and code for limiting the HTTP methods supported by OAuth endpoints.

Related to #12197 