### PR TITLE
Issue 12596: Update error message, add swapping CA test

### DIFF
--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeClient.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeClient.java
@@ -1072,7 +1072,7 @@ public class AcmeClient {
 				cause = e;
 			}
 
-			throw new AcmeCaException(Tr.formatMessage(tc, "CWPKI2028E", acmeConfig.getDirectoryURI()), cause);
+			throw new AcmeCaException(Tr.formatMessage(tc, "CWPKI2028E", acmeConfig.getDirectoryURI(), cause), cause);
 		}
 	}
 
@@ -1088,16 +1088,31 @@ public class AcmeClient {
 	@Trivial
 	private static String getRootCauseMessage(Throwable t) {
 		Throwable cause;
-		String rootMessage = t.getMessage();
+		String rootMessage = addExceptionClass(t);
 
 		for (cause = t; cause != null; cause = cause.getCause()) {
 			String msg = cause.getMessage();
 			if (msg != null && !msg.trim().isEmpty()) {
-				rootMessage = msg;
+				rootMessage = addExceptionClass(cause);
 			}
 		}
 
 		return rootMessage;
+	}
+
+	/**
+	 * Add on the Exception class name as sometimes the message does not make sense
+	 * without the name of the Exception included. For example,
+	 * java.net.UnknownHostException: <exampleUnknownHost . net>
+	 * 
+	 * @param t
+	 * @return
+	 */
+	private static String addExceptionClass(Throwable t) {
+		if (t != null) {
+			return t.getClass().getName() + ": " + t.getMessage();
+		}
+		return "";
 	}
 
 	/**

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
@@ -779,8 +779,8 @@ public class AcmeFatUtils {
 	 * @param startingCertificateChain
 	 * @throws Exception
 	 */
-	public static final void waitForNewCert(LibertyServer server, CAContainer acmeContainer, Certificate[] startingCertificateChain) throws Exception {
-		waitForNewCert(server, acmeContainer, startingCertificateChain, SCHEDULE_TIME);
+	public static final Certificate[]  waitForNewCert(LibertyServer server, CAContainer acmeContainer, Certificate[] startingCertificateChain) throws Exception {
+		return waitForNewCert(server, acmeContainer, startingCertificateChain, SCHEDULE_TIME);
 	}
 
 	/**
@@ -791,7 +791,7 @@ public class AcmeFatUtils {
 	 * @param timeout
 	 * @throws Exception
 	 */
-	public static final void waitForNewCert(LibertyServer server, CAContainer acmeContainer, Certificate[] startingCertificateChain, long timeout) throws Exception {
+	public static final Certificate[]  waitForNewCert(LibertyServer server, CAContainer acmeContainer, Certificate[] startingCertificateChain, long timeout) throws Exception {
 		Certificate[] endingCertificateChain;
 		long startTime = System.currentTimeMillis();
 		while (System.currentTimeMillis() < startTime + timeout) {
@@ -812,6 +812,8 @@ public class AcmeFatUtils {
 		String serial2 = ((X509Certificate) endingCertificateChain[0]).getSerialNumber().toString(16);
 
 		assertThat("Expected a new certificate.", serial1, not(equalTo(serial2)));	
+		
+		return endingCertificateChain;
 	}
 	
 	/**


### PR DESCRIPTION
Fixes #12596 

- Fixed a parameter on a message (wasn't filling in second msg parameter)
- Added the exception class name when getting the root cause Exception
Example: `CWPKI2016E: The ACME service request for an existing account from the ACME certificate authority at the https://invalid.com/directory URI failed. The error is 'javax.net.ssl.SSLHandshakeException: received handshake warning: unrecognized_name'.`
- Added a test that swaps back and forth between Pebble and Boulder