### PR TITLE
Don't send HTTP/2 goaway on client terminated connection

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/H2InboundLink.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/H2InboundLink.java
@@ -1245,18 +1245,22 @@ public class H2InboundLink extends HttpInboundLink {
             }
 
             try {
-
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "H2ConnectionTimeout-run: sending GOAWAY Frame" + " :close: H2InboundLink hc: " + hcDebug);
-                }
-                if (e == null) {
-                    streamTable.get(0).sendGOAWAYFrame(new Http2Exception("the http2 connection has timed out"));
-                } else if (e instanceof Http2Exception) {
-                    streamTable.get(0).sendGOAWAYFrame((Http2Exception) e);
+                if (e instanceof IOException) {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "H2ConnectionTimeout-run: IOException encountered, close immediately" + " :close: H2InboundLink hc: " + hcDebug);
+                    }
                 } else {
-                    streamTable.get(0).sendGOAWAYFrame(new Http2Exception(e.getMessage()));
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "H2ConnectionTimeout-run: sending GOAWAY Frame" + " :close: H2InboundLink hc: " + hcDebug);
+                    }
+                    if (e == null) {
+                        streamTable.get(0).sendGOAWAYFrame(new Http2Exception("the http2 connection has timed out"));
+                    } else if (e instanceof Http2Exception) {
+                        streamTable.get(0).sendGOAWAYFrame((Http2Exception) e);
+                    } else {
+                        streamTable.get(0).sendGOAWAYFrame(new Http2Exception(e.getMessage()));
+                    }
                 }
-
             } catch (Exception x) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(tc, "H2ConnectionTimeout-run: exeception received while sending GOAWAY: " + " :close: H2InboundLink hc: " + hcDebug + " " + x);


### PR DESCRIPTION
for #12599