### PR TITLE
Move gRPC features to beta

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.grpc-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.grpc-1.0.feature
@@ -19,6 +19,6 @@ Subsystem-Name: gRPC internal 1.0
   com.ibm.websphere.appserver.containerServices-1.0,\
   com.ibm.websphere.appserver.httptransport-1.0, \
   com.ibm.websphere.appserver.javax.annotation-1.3; ibm.tolerates:=1.2
-kind=noship
+kind=beta
 edition=full
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/grpc-1.0/io.openliberty.grpc-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/grpc-1.0/io.openliberty.grpc-1.0.feature
@@ -16,6 +16,6 @@ Subsystem-Name: gRPC 1.0
 -features=\
   io.openliberty.internal.grpc-1.0, \
   com.ibm.websphere.appserver.servlet-4.0
-kind=noship
+kind=beta
 edition=full
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/grpcClient-1.0/io.openliberty.grpcClient-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/grpcClient-1.0/io.openliberty.grpcClient-1.0.feature
@@ -26,6 +26,6 @@ Subsystem-Name: gRPC Client 1.0
   io.openliberty.grpc.1.0.internal.common, \
   io.openliberty.grpc.1.0.internal.client, \
   com.ibm.ws.org.apache.commons.logging.1.0.3
-kind=noship
+kind=beta
 edition=full
 WLP-Activation-Type: parallel


### PR DESCRIPTION
Mark the `grpc-1.0` and `grpcClient-1.0` features as beta

for #10088 and #10089