### PR TITLE
include jca features in repeat action

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EE7FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EE7FeatureReplacementAction.java
@@ -19,7 +19,7 @@ public class EE7FeatureReplacementAction extends FeatureReplacementAction {
 
     public static final String ID = "EE7_FEATURES";
 
-    static final String[] EE7_FEATURES_ARRAY = { "javaee-7.0", "webProfile-7.0", "javaeeClient-7.0", "servlet-3.1", "javaMail-1.5", "cdi-1.2", "jpa-2.1",
+    static final String[] EE7_FEATURES_ARRAY = { "javaee-7.0", "webProfile-7.0", "javaeeClient-7.0", "servlet-3.1", "javaMail-1.5", "cdi-1.2", "jca-1.7", "jpa-2.1",
                                                  "beanValidation-1.1", "jaxrs-2.0", "jaxrsClient-2.0", "jsf-2.2", "appSecurity-2.0", "jsonp-1.0",
                                                  "jsp-2.3", "el-3.0", "concurrent-1.0", "jaxb-2.2" };
     public static final Set<String> EE7_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE7_FEATURES_ARRAY)));

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EE8FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EE8FeatureReplacementAction.java
@@ -19,7 +19,7 @@ public class EE8FeatureReplacementAction extends FeatureReplacementAction {
 
     public static final String ID = "EE8_FEATURES";
 
-    static final String[] EE8_FEATURES_ARRAY = { "javaee-8.0", "webProfile-8.0", "javaeeClient-8.0", "servlet-4.0", "javaMail-1.6", "cdi-2.0", "jpa-2.2",
+    static final String[] EE8_FEATURES_ARRAY = { "javaee-8.0", "webProfile-8.0", "javaeeClient-8.0", "servlet-4.0", "javaMail-1.6", "cdi-2.0", "jca-1.7", "jpa-2.2",
                                                  "beanValidation-2.0", "jaxrs-2.1", "jaxrsClient-2.1", "jsf-2.3", "appSecurity-3.0", "jsonp-1.1", "jsonb-1.0", "jsonpContainer-1.1",
                                                  "jsonbContainer-1.0", "el-3.0", "jsp-2.3", "concurrent-1.0", "jaxb-2.2" };
     public static final Set<String> EE8_FEATURE_SET = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(EE8_FEATURES_ARRAY)));

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE9Action.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE9Action.java
@@ -63,6 +63,7 @@ public class JakartaEE9Action extends FeatureReplacementAction {
       "jaxb-3.0",
       "jaxrs-3.0",
       "jaxrsClient-3.0",
+      "jca-2.0",
       "jpa-3.0",
       "jsonp-2.0",
       "jsonb-2.0",


### PR DESCRIPTION
The Java EE/Jakarta EE repeat action for tests currently lacks JCA.  This pull adds it.