### PR TITLE
Skip MP FT 1.1 TCK BulkheadMetricTest

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -71,9 +71,7 @@
                      !method.getName().startsWith("testFallbacktNoTimeout") &&
                      
                      // BulkheadMetricTest
-                     !method.getName().startsWith("bulkheadMetricAsyncTest") &&
-                     !method.getName().startsWith("bulkheadMetricHistogramTest") &&
-                     !method.getName().startsWith("bulkheadMetricRejectionTest") &&
+                     !method.getDeclaringClass().getSimpleName().equals("BulkheadMetricTest") &&
                      
                      // TimeoutMetricTest
                      !method.getDeclaringClass().getSimpleName().equals("TimeoutMetricTest") &&


### PR DESCRIPTION
All the timing issues in the tests in BulkheadMetricTest were fixed in the 2.0 TCK ([here](https://github.com/eclipse/microprofile-fault-tolerance/pull/511/files)).

We run these tests from the 2.0 TCK project against FT 1.1:
https://github.com/OpenLiberty/open-liberty/blob/8a720302eccc5fb824d43cb13b676bd922690d4d/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTck20Launcher.java#L54

Where mp20Features:
https://github.com/OpenLiberty/open-liberty/blob/8a720302eccc5fb824d43cb13b676bd922690d4d/dev/com.ibm.ws.microprofile.faulttolerance_repeat_tests/src/com/ibm/ws/microprofile/faulttolerance/fat/repeat/RepeatFaultTolerance.java#L29