### PR TITLE
Use FATRunner with app manager tests

### DIFF
--- a/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/AppOrderTests.java
+++ b/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/AppOrderTests.java
@@ -20,11 +20,13 @@ import java.net.URL;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.fat.util.jmx.mbeans.ApplicationMBean;
 import com.ibm.ws.fat.util.jmx.mbeans.ApplicationMBean.ApplicationState;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
@@ -33,6 +35,7 @@ import componenttest.topology.utils.HttpUtils;
 /**
  * Tests that exercise the 'startAfter' attribute on applications
  */
+@RunWith(FATRunner.class)
 public class AppOrderTests extends AbstractAppManagerTest {
 
     private static final long LONG_TIMEOUT = 120000;

--- a/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/AutoExtractTest.java
+++ b/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/AutoExtractTest.java
@@ -23,17 +23,17 @@ import java.net.URL;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.HttpUtils;
 import test.utils.TestUtils;
 
-/**
- *
- */
+@RunWith(FATRunner.class)
 public class AutoExtractTest extends AbstractAppManagerTest {
 
     // Our tests delete binaries while they are still defined in server.xml, so we expect this warning.

--- a/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/DropinsTests.java
+++ b/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/DropinsTests.java
@@ -26,11 +26,13 @@ import java.net.URL;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.RemoteFile;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
@@ -38,9 +40,7 @@ import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.HttpUtils;
 import test.utils.TestUtils;
 
-/**
- *
- */
+@RunWith(FATRunner.class)
 public class DropinsTests extends AbstractAppManagerTest {
 
     private static LibertyServer server = LibertyServerFactory.getLibertyServer("dropinsTestServer");

--- a/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/FATTest.java
+++ b/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/FATTest.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.RemoteFile;
 import com.ibm.websphere.simplicity.config.Application;
@@ -40,6 +41,7 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.MinimumJavaLevel;
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyFileManager;
@@ -48,6 +50,7 @@ import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.HttpUtils;
 import test.utils.TestUtils;
 
+@RunWith(FATRunner.class)
 public class FATTest extends AbstractAppManagerTest {
 
     private static LibertyServer server = LibertyServerFactory.getLibertyServer("appManagerTestServer");


### PR DESCRIPTION
FULL tests are running in LITE mode because the test classes are not annotated with `@RunWith(FATRunner)`