### PR TITLE
Resync all files for fixing SPI message ID

### DIFF
--- a/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi12/fat/tests/CDI12ExtensionSPIConstructorExceptionTest.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi12/fat/tests/CDI12ExtensionSPIConstructorExceptionTest.java
@@ -67,7 +67,7 @@ public class CDI12ExtensionSPIConstructorExceptionTest extends LoggingTest {
         final String METHOD_NAME = "cleanup";
         Log.info(CDI12ExtensionTest.class, METHOD_NAME, "Stopping the server.");
         if (server.isStarted()) {
-            server.stopServer("CWOWB10010E");//The error thrown when a SPI extension constructor fails. 
+            server.stopServer("CWOWB1010E");//The error thrown when a SPI extension constructor fails. 
         }
         Log.info(CDI12ExtensionTest.class, METHOD_NAME, "Removing cdi extension test user feature files.");
         server.uninstallUserBundle(INSTALL_USERBUNDLE);

--- a/dev/com.ibm.ws.cdi.internal/resources/com/ibm/ws/cdi/internal/resources/CDI.nlsprops
+++ b/dev/com.ibm.ws.cdi.internal/resources/com/ibm/ws/cdi/internal/resources/CDI.nlsprops
@@ -69,6 +69,6 @@ implicit.bean.scanning.disabled.CWOWB1009W=CWOWB1009W: Implicit bean archives ar
 implicit.bean.scanning.disabled.CWOWB1009W.explanation=Archives are not scanned for CDI beans unless they have a beans.xml file.
 implicit.bean.scanning.disabled.CWOWB1009W.useraction=Ensure that every archive that uses CDI has a beans.xml file or re-enable implicit beans scanning in your server.xml file.
 
-spi.extension.failed.to.construct.CWOWB10010E=CWOWB10010E: Failed to create CDI Extension via SPI.
-spi.extension.failed.to.construct.CWOWB10010E.explanation=CDI failed to invoke the constructor of the extension class {0} registered via the getExtensions() method of a CDIExtensionMetaData implementation because of the exception {1}.
-spi.extension.failed.to.construct.CWOWB10010E.useraction=Fix the error preventing your extension from instantiating.
+spi.extension.failed.to.construct.CWOWB1010E=CWOWB1010E: Failed to create CDI Extension with SPI.
+spi.extension.failed.to.construct.CWOWB1010E.explanation=CDI failed to invoke the constructor of the extension class {0} that is registered with the getExtensions() method of a CDIExtensionMetadata implementation because of the exception {1}.
+spi.extension.failed.to.construct.CWOWB1010E.useraction=Fix the error that is preventing your extension from instantiating.

--- a/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/CDIContainerImpl.java
+++ b/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/CDIContainerImpl.java
@@ -643,7 +643,7 @@ public class CDIContainerImpl implements CDIContainer, InjectionMetaDataListener
                 }
                 extensions.add(clazz.getDeclaredConstructor().newInstance());
             } catch (Exception e) {
-                Tr.error(tc, "spi.extension.failed.to.construct.CWOWB10010E", clazz.getCanonicalName(), e.toString());
+                Tr.error(tc, "spi.extension.failed.to.construct.CWOWB1010E", clazz.getCanonicalName(), e.toString());
             }
         }
 


### PR DESCRIPTION
This resyncs all the files involved in updating the CDI SPI message ID and delivers them in one place. 