### PR TITLE
1598: Handle stack traces from System.out and System.err as single events

### DIFF
--- a/dev/com.ibm.ws.logging.osgi/bnd.bnd
+++ b/dev/com.ibm.ws.logging.osgi/bnd.bnd
@@ -36,7 +36,12 @@ Export-Package: \
 Service-Component= \
   com.ibm.ws.logging.internal.ffdcjanitor; \
     scheduler=java.util.concurrent.ScheduledExecutorService; \
-    implementation:=com.ibm.ws.logging.internal.osgi.FFDCJanitor
+    implementation:=com.ibm.ws.logging.internal.osgi.FFDCJanitor \
+  com.ibm.ws.logging.internal.osgi.stackjoiner.ThrowableProxyComponent; \
+    implementation:="com.ibm.ws.logging.internal.osgi.stackjoiner.ThrowableProxyComponent"; \
+    instrumentation=java.lang.instrument.Instrumentation; \
+    properties:="service.vendor=IBM"; \
+    version:=1.1, \
    
 IBM-Default-Config: OSGI-INF/wlp/defaultInstances.xml
 
@@ -46,10 +51,12 @@ instrument.disabled: true
 	org.eclipse.osgi;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.websphere.org.osgi.service.cm;version=latest,\
+	com.ibm.websphere.org.osgi.service.component,\
 	com.ibm.wsspi.org.osgi.service.event;version=latest,\
 	com.ibm.wsspi.org.osgi.service.log;version=latest,\
 	com.ibm.ws.logging;version=latest,\
 	com.ibm.ws.ras.instrument;version=latest, \
+	com.ibm.ws.org.objectweb.asm;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest
 
 -testpath: \

--- a/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/stackjoiner/ReflectionHelper.java
+++ b/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/stackjoiner/ReflectionHelper.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.logging.internal.osgi.stackjoiner;
+
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+/**
+ * Helper class that performs necessary doPriv during reflection.
+ * 
+ * This class is borrowed from com.ibm.ws.monitor/src/com/ibm/ws/monitor/internal/ReflectionHelper.java.
+ */
+class ReflectionHelper {
+
+    private final static boolean securityEnabled = System.getSecurityManager() != null;
+
+    private ReflectionHelper() {}
+
+    static Field getDeclaredField(final Class<?> clazz, final String fieldName) {
+        if (clazz != null) {
+            return securityEnabled ? doPrivGetDeclaredField(clazz, fieldName) : doGetDeclaredField(clazz, fieldName);
+        }
+        return null;
+    }
+
+    private static Field doGetDeclaredField(final Class<?> clazz, final String fieldName) {
+        Field field = null;
+        try {
+            field = clazz.getDeclaredField(fieldName);
+        } catch (NoSuchFieldException nsfe) {
+        }
+        return field;
+    }
+
+    private static Field doPrivGetDeclaredField(final Class<?> clazz, final String fieldName) {
+        return AccessController.doPrivileged(new PrivilegedAction<Field>() {
+            public Field run() {
+                return doGetDeclaredField(clazz, fieldName);
+            }
+        });
+    }
+
+    static Method getDeclaredMethod(final Class<?> clazz, final String methodName, final Class<?>... parameterTypes) {
+        if (clazz != null) {
+            return securityEnabled ?
+                            doPrivGetDeclaredMethod(clazz, methodName, parameterTypes) :
+                            doGetDeclaredMethod(clazz, methodName, parameterTypes);
+        }
+        return null;
+    }
+
+    private static Method doGetDeclaredMethod(final Class<?> clazz, final String methodName, final Class<?>... parameterTypes) {
+        Method method = null;
+        try {
+            method = clazz.getDeclaredMethod(methodName, parameterTypes);
+        } catch (NoSuchMethodException e) {
+        }
+        return method;
+    }
+
+    private static Method doPrivGetDeclaredMethod(final Class<?> clazz, final String methodName, final Class<?>... parameterTypes) {
+        return AccessController.doPrivileged(new PrivilegedAction<Method>() {
+            public Method run() {
+                return doGetDeclaredMethod(clazz, methodName, parameterTypes);
+            }
+        });
+    }
+
+    static void setAccessible(final AccessibleObject accessibleObject, final boolean visible) {
+        if (securityEnabled) {
+            doPrivSetAccessible(accessibleObject, visible);
+        } else {
+            doSetAccessible(accessibleObject, visible);
+        }
+    }
+
+    private static void doSetAccessible(final AccessibleObject accessibleObject, final boolean visible) {
+        accessibleObject.setAccessible(visible);
+    }
+
+    private static void doPrivSetAccessible(final AccessibleObject accessibleObject, final boolean visible) {
+        AccessController.doPrivileged(new PrivilegedAction<Object>() {
+            public Object run() {
+                doSetAccessible(accessibleObject, visible);
+                return null;
+            }
+        });
+    }
+}

--- a/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/stackjoiner/ThrowableInfo.java
+++ b/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/stackjoiner/ThrowableInfo.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.logging.internal.osgi.stackjoiner;
+
+import java.io.PrintStream;
+import java.lang.instrument.Instrumentation;
+import java.lang.reflect.Method;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.logging.internal.osgi.OsgiLogConstants;
+
+/**
+ * Retrieves the printStackTraceOverride method from BaseTraceService via reflection.
+ */
+public class ThrowableInfo {
+	
+	 private static final TraceComponent tc = Tr.register(ThrowableInfo.class);
+
+    final String BASE_TRACE_SERVICE_CLASS_NAME = "com.ibm.ws.logging.internal.impl.BaseTraceService";
+    final String BASE_TRACE_SERVICE_METHOD_NAME = "printStackTraceOverride";
+
+    private Method btsMethod;
+
+    public ThrowableInfo(Instrumentation inst) {
+    	Class<?> btsClass = retrieveClass(inst, BASE_TRACE_SERVICE_CLASS_NAME);
+        if (btsClass != null) {
+			Method method = ReflectionHelper.getDeclaredMethod(btsClass, BASE_TRACE_SERVICE_METHOD_NAME, Throwable.class, PrintStream.class);
+			setBtsMethod(method);
+        }
+    }
+    
+    public boolean isInitialized() {
+    	if (getBtsMethod() == null) {
+    		if (tc.isDebugEnabled())
+    			Tr.debug(tc, "Stack joiner could not be initialized. Failed to reflect method " + BASE_TRACE_SERVICE_METHOD_NAME + " in " + BASE_TRACE_SERVICE_CLASS_NAME + ".");
+        	return false;
+        }
+    	return true;
+    }
+    
+    private Class<?> retrieveClass(Instrumentation inst, String classGroup) {
+        if (inst != null) {
+            Class[] loadedClasses = inst.getAllLoadedClasses();
+            for (int i = 0; i < loadedClasses.length; i++) {
+                String name = loadedClasses[i].getName();
+                if (name.equals(classGroup)) {
+                    return loadedClasses[i];
+                }
+            }
+        }
+        return null;
+    }
+
+    private void setBtsMethod(Method method) {
+        btsMethod = method;
+    }
+
+    public Method getBtsMethod() {
+        return btsMethod;
+    }
+}

--- a/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/stackjoiner/ThrowableProxyActivator.java
+++ b/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/stackjoiner/ThrowableProxyActivator.java
@@ -1,0 +1,394 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.logging.internal.osgi.stackjoiner;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.lang.instrument.Instrumentation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.text.DateFormat;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+
+import com.ibm.ws.logging.internal.osgi.stackjoiner.bci.AddVersionFieldClassAdapter;
+import com.ibm.ws.logging.internal.osgi.stackjoiner.bci.ThrowableClassFileTransformer;
+import com.ibm.ws.logging.internal.osgi.stackjoiner.boot.templates.ThrowableProxy;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.commons.ClassRemapper;
+import org.objectweb.asm.commons.SimpleRemapper;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Bundle;
+import org.osgi.service.component.ComponentException;
+
+public class ThrowableProxyActivator {
+	
+	private ThrowableInfo throwableInfo;
+	private Instrumentation inst;
+	private BundleContext bundleContext;
+	
+	/**
+     * The target package for the boot loader delegated classes.
+     */
+    public final static String BOOT_DELEGATED_PACKAGE = "com.ibm.ws.boot.delegated.logging";
+    
+    /**
+     * The bundle entry path prefix to the template classes.
+     */
+    final static String TEMPLATE_CLASSES_PATH = ThrowableProxy.class.getPackage().getName().replaceAll("\\.", "/");
+    
+    /**
+     * The name of the {@link ThrowableProxy} class that needs to be
+     * made available on the bootstrap class loader.
+     */
+    public final static String THROWABLE_PROXY_CLASS_NAME = BOOT_DELEGATED_PACKAGE + "." + ThrowableProxy.class.getSimpleName();
+
+    /**
+     * The internal name of the {@link ThrowableProxy} class.
+     */
+    public final static String THROWABLE_PROXY_CLASS_INTERNAL_NAME = THROWABLE_PROXY_CLASS_NAME.replaceAll("\\.", "/");
+    
+    /**
+     * The name of the field in generated classes that will contain the
+     * generating bundle version.
+     */
+    final static String VERSION_FIELD_NAME = "BUNDLE_VERSION";
+
+    /**
+     * The proxy jar manifest header that indicates the version of the bundle
+     * that created the jar.
+     */
+    final static String LOGGING_VERSION_MANIFEST_HEADER = "Liberty-Logging-Osgi-Bundle-Version";
+    
+	
+    public ThrowableProxyActivator(Instrumentation inst, BundleContext bundleContext) {
+    	this.inst = inst;
+    	this.bundleContext = bundleContext;
+    }
+    
+    /**
+     * Activation callback from the Declarative Services runtime where the
+     * component is ready for activation.
+     *
+     * @param bundleContext the bundleContext
+     */
+    protected void activate() throws Exception {    
+        // Store a reference to the printStackTraceOverride method from BaseTraceService
+        throwableInfo = new ThrowableInfo(inst);
+        
+        if (throwableInfo.isInitialized()) {
+        	String runtimeVersion = getRuntimeClassVersion();
+            if (runtimeVersion != null && !runtimeVersion.equals(getCurrentVersion())) {
+                // TODO: Use a compatibility check instead
+                throw new IllegalStateException("Incompatible proxy code (version " + runtimeVersion + ")");
+            }
+
+            // Find or create the proxy jar if the runtime code isn't loaded
+            if (runtimeVersion == null) {
+    	        JarFile proxyJar = getBootProxyJarIfCurrent();
+    	        if (proxyJar == null) {
+    	            proxyJar = createBootProxyJar();
+    	        }
+    	        inst.appendToBootstrapClassLoaderSearch(proxyJar);
+            }
+            
+        	activateThrowableProxyMethodTarget();
+    
+			inst.addTransformer(new ThrowableClassFileTransformer(), true);
+			for (Class<?> clazz : inst.getAllLoadedClasses()) {
+			    if (clazz.getName().equals("java.lang.Throwable")) {
+			    	try {
+			            inst.retransformClasses(clazz);
+			        } catch (Throwable t) {
+			            t.printStackTrace();
+			        }
+			     }
+			}
+        }
+    	
+	}
+	
+	protected void deactivate() throws Exception {
+        try {
+        	if (throwableInfo.isInitialized())
+        		deactivateThrowableProxyTarget();
+        } catch (Exception e) {
+            throw new Exception(e);
+        }
+    }
+	
+	/**
+     * Determine if the boot delegated proxy is already available and, if so,
+     * what its version is.
+     *
+     * @return the runtime version of the emitter proxy or null if the class
+     *         is not currently available
+     */
+    @FFDCIgnore(Exception.class)
+    String getRuntimeClassVersion() {
+        String runtimeVersion = null;
+        try {
+            Class<?> clazz = Class.forName(THROWABLE_PROXY_CLASS_NAME);
+            Field version = ReflectionHelper.getDeclaredField(clazz, VERSION_FIELD_NAME);
+            runtimeVersion = (String) version.get(null);
+        } catch (Exception e) {
+        }
+        return runtimeVersion;
+    }
+    
+	/**
+     * Create a jar file that contains the proxy code that will live in the
+     * boot delegation package.
+     *
+     * @return the jar file containing the proxy code to append to the boot
+     *         class path
+     *
+     * @throws IOException if a file I/O error occurs
+     */
+    JarFile createBootProxyJar() throws IOException {
+        File dataFile = bundleContext.getDataFile("boot-proxy-throwable.jar");
+
+        // Create the file if it doesn't already exist
+        if (!dataFile.exists()) {
+            dataFile.createNewFile();
+        }
+
+        // Generate a manifest
+        Manifest manifest = createBootJarManifest();
+
+        // Create the file
+        FileOutputStream fileOutputStream = new FileOutputStream(dataFile, false);
+        JarOutputStream jarOutputStream = new JarOutputStream(fileOutputStream, manifest);
+
+        // Add the jar path entries to reduce class load times
+        createDirectoryEntries(jarOutputStream, BOOT_DELEGATED_PACKAGE);
+
+        // Map the template classes into the delegation package and add to the jar
+        Bundle bundle = bundleContext.getBundle();
+        Enumeration<?> entryPaths = bundle.getEntryPaths(TEMPLATE_CLASSES_PATH);
+        if (entryPaths != null) {
+            while (entryPaths.hasMoreElements()) {
+                URL sourceClassResource = bundle.getEntry((String) entryPaths.nextElement());
+                if (sourceClassResource != null)
+                    writeRemappedClass(sourceClassResource, jarOutputStream, BOOT_DELEGATED_PACKAGE);
+            }
+        }
+
+        jarOutputStream.close();
+        fileOutputStream.close();
+
+        return new JarFile(dataFile);
+    }
+    
+    /**
+     * Transform the proxy template class that's in this package into a class
+     * that's in a package on the framework boot delegation package list.
+     *
+     * @return the byte array containing the updated class
+     *
+     * @throws IOException if an IO exception raised while processing the class
+     */
+    private void writeRemappedClass(URL classUrl, JarOutputStream jarStream, String targetPackage) throws IOException {
+        InputStream inputStream = classUrl.openStream();
+        String sourceInternalName = getClassInternalName(classUrl);
+        String targetInternalName = getTargetInternalName(sourceInternalName, targetPackage);
+        SimpleRemapper remapper = new SimpleRemapper(sourceInternalName, targetInternalName);
+
+        ClassReader reader = new ClassReader(inputStream);
+        ClassWriter writer = new ClassWriter(reader, ClassWriter.COMPUTE_FRAMES);
+        ClassRemapper remappingVisitor = new ClassRemapper(writer, remapper);
+        ClassVisitor versionVisitor = new AddVersionFieldClassAdapter(remappingVisitor, VERSION_FIELD_NAME, getCurrentVersion());
+        reader.accept(versionVisitor, ClassReader.EXPAND_FRAMES);
+
+        JarEntry jarEntry = new JarEntry(targetInternalName + ".class");
+        jarStream.putNextEntry(jarEntry);
+        jarStream.write(writer.toByteArray());
+    }
+    
+    /**
+     * Create the jar directory entries corresponding to the specified package
+     * name.
+     *
+     * @param jarStream the target jar's output stream
+     * @param packageName the target package name
+     *
+     * @throws IOException if an IO exception raised while creating the entries
+     */
+    public void createDirectoryEntries(JarOutputStream jarStream, String packageName) throws IOException {
+        StringBuilder entryName = new StringBuilder(packageName.length());
+        for (String str : packageName.split("\\.")) {
+            entryName.append(str).append("/");
+            JarEntry jarEntry = new JarEntry(entryName.toString());
+            jarStream.putNextEntry(jarEntry);
+        }
+    }
+    
+    /**
+     * Get the internal class name of the class referenced by {@code classUrl}.
+     *
+     * @param classUrl the URL of the class to inspect
+     *
+     * @return the internal class name of the class referenced by {@code classUrl}
+     *
+     * @throws IOException if an IO error occurs during processing
+     */
+    String getClassInternalName(URL classUrl) throws IOException {
+        InputStream inputStream = classUrl.openStream();
+
+        ClassReader reader = new ClassReader(inputStream);
+        reader.accept(new ClassVisitor(Opcodes.ASM7) {}, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
+        inputStream.close();
+
+        return reader.getClassName();
+    }
+
+    /**
+     * Get the class internal name that should be used where moving the internal
+     * class across packages.
+     *
+     * @param sourceInternalName the internal name of the template class
+     * @param targetPackage the package to move the class to
+     *
+     * @return the target class name
+     */
+    String getTargetInternalName(String sourceInternalName, String targetPackage) {
+        StringBuilder targetInternalName = new StringBuilder();
+        targetInternalName.append(targetPackage.replaceAll("\\.", "/"));
+
+        int lastSlashIndex = sourceInternalName.lastIndexOf('/');
+        targetInternalName.append(sourceInternalName.substring(lastSlashIndex));
+
+        return targetInternalName.toString();
+    }
+    
+    /**
+     * Get the boot proxy jar from the current data area if the code
+     * matches the current bundle version.
+     *
+     * @return the proxy jar iff the proxy jar exits and matches this
+     *         bundle's version
+     */
+    JarFile getBootProxyJarIfCurrent() {
+        File dataFile = bundleContext.getDataFile("boot-proxy-throwable.jar");
+        if (!dataFile.exists()) {
+            return null;
+        }
+
+        JarFile jarFile = null;
+        try {
+            jarFile = new JarFile(dataFile);
+            Manifest manifest = jarFile.getManifest();
+            Attributes attrs = manifest.getMainAttributes();
+            String jarVersion = attrs.getValue(LOGGING_VERSION_MANIFEST_HEADER);
+            if (!getCurrentVersion().equals(jarVersion)) {
+                jarFile.close();
+                jarFile = null;
+            }
+        } catch (Exception e) {
+        }
+
+        return jarFile;
+    }
+    
+    /**
+     * Create the {@code Manifest} for the boot proxy jar.
+     *
+     * @return the boot proxy jar {@code Manifest}
+     */
+    Manifest createBootJarManifest() {
+        Manifest manifest = new Manifest();
+
+        Attributes manifestAttributes = manifest.getMainAttributes();
+        manifestAttributes.putValue(Attributes.Name.MANIFEST_VERSION.toString(), "1.0");
+        manifestAttributes.putValue("Created-By", "Liberty Logging Osgi Extender");
+        manifestAttributes.putValue("Created-Time", DateFormat.getInstance().format(new Date()));
+        manifestAttributes.putValue(LOGGING_VERSION_MANIFEST_HEADER, getCurrentVersion());
+
+        return manifest;
+    }
+    
+    /**
+     * Get the host bundle's version string.
+     *
+     * @return the host bundle's version string
+     */
+    String getCurrentVersion() {
+        return bundleContext.getBundle().getVersion().toString();
+    }
+	
+    /**
+     * Binds this ThrowableProxyActivator class' printStackTraceOverride method to ThrowableProxy.
+     *
+     * @throws Exception the method invocation exception
+     */
+    void activateThrowableProxyMethodTarget() throws Exception {
+        Method method = ReflectionHelper.getDeclaredMethod(getClass(), "printStackTraceOverride", Throwable.class, PrintStream.class);
+        ReflectionHelper.setAccessible(method, true);
+        findThrowableProxySetFireTargetMethod().invoke(null, this, method);
+    }
+    
+    /**
+     * Returns the Method object representing a setter for the ThrowableProxy instance variables.
+     *
+     * @return
+     * @throws Exception
+     */
+    Method findThrowableProxySetFireTargetMethod() throws Exception {
+        Class<?> proxyClass = Class.forName(THROWABLE_PROXY_CLASS_NAME);
+        Method method = ReflectionHelper.getDeclaredMethod(proxyClass, "setFireTarget", Object.class, Method.class);
+        ReflectionHelper.setAccessible(method, true);
+        return method;
+    }
+
+    /**
+     * Unbinds the Activator class' and its method from ThrowableProxy.
+     *
+     * @throws Exception
+     */
+    void deactivateThrowableProxyTarget() throws Exception {
+        findThrowableProxySetFireTargetMethod().invoke(null, null, null);
+    }
+
+    /**
+     * Invokes the static BaseTraceService.printStackTraceOverride() method from the com.ibm.ws.logging package.
+     * This method is bound to the ThrowableProxy, which will be visible by the bootstrap class loader
+     * 
+     * @param t the
+     * @param originalStream that is retrieved via ThrowableMethodAdpater 
+     * 
+     * @return true if printStackTraceOverride() method in BaseTraceService evaluated to true, false otherwise
+     */
+    public boolean printStackTraceOverride(Throwable t, PrintStream originalStream) {
+        Method method = throwableInfo.getBtsMethod();
+        Boolean b = Boolean.FALSE;
+        try {
+            b = (Boolean) method.invoke(null, t, originalStream);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return b;
+    }
+}

--- a/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/stackjoiner/ThrowableProxyComponent.java
+++ b/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/stackjoiner/ThrowableProxyComponent.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.logging.internal.osgi.stackjoiner;
+
+import java.lang.instrument.Instrumentation;
+import org.osgi.service.component.ComponentContext;
+
+public class ThrowableProxyComponent {
+	
+	private ComponentContext componentContext;
+	private Instrumentation instrumentation;
+	private ThrowableProxyActivator proxyActivator;
+	
+    /**
+     * Activation callback from the Declarative Services runtime where the
+     * component is ready for activation.
+     *
+     * @param bundleContext the bundleContext
+     */
+    synchronized void activate(ComponentContext componentContext) throws Exception {
+    	this.componentContext = componentContext;
+        this.proxyActivator = new ThrowableProxyActivator(this.instrumentation, componentContext.getBundleContext());
+        this.proxyActivator.activate();
+    }
+    
+    /**
+     * Deactivation callback from the Declarative Services runtime where the
+     * component is deactivated.
+     *
+     * @param bundleContext the bundleContext
+     */
+    synchronized void deactivate() throws Exception {
+        this.proxyActivator.deactivate();
+    }
+    
+    /**
+     * Inject reference to the {@link java.lang.instrument.Instrumentation} implementation.
+     *
+     * @param instrumentationAgent the JVM's {@code Instrumentation) reference
+     */
+    protected void setInstrumentation(Instrumentation instrumentation) {
+        this.instrumentation = instrumentation;
+    }
+    
+}

--- a/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/stackjoiner/bci/AddVersionFieldClassAdapter.java
+++ b/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/stackjoiner/bci/AddVersionFieldClassAdapter.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.logging.internal.osgi.stackjoiner.bci;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+/**
+ * Simple adapter that adds a field to hold a version string. This is used
+ * where mapping the template classes into the bootstrap package so we can
+ * detect stale versions.
+ * <p>
+ * This implementation will <em>not<em> overwrite an existing field.
+ * 
+ * This class is borrowed from com.ibm.ws.monitor/src/com/ibm/ws/monitor/internal/bci/remap/AddVersionFieldClassAdapter.java.
+ */
+public class AddVersionFieldClassAdapter extends ClassVisitor {
+
+    /**
+     * The name of the version field.
+     */
+    final String versionFieldName;
+
+    /**
+     * The {@link String} value of the version field.
+     */
+    final String versionFieldValue;
+
+    /**
+     * Inidication that the field existed before augmentation.
+     */
+    boolean fieldAlreadyExists = false;
+
+    /**
+     * Create a class visitor that will create a field to hold a version {@link String}.
+     * 
+     * @param delegate the chained {@link ClassVisitor}
+     * @param versionFieldName the name of the version field
+     * @param versionFieldValue the value to associate with the version field
+     */
+    public AddVersionFieldClassAdapter(ClassVisitor delegate, String versionFieldName, String versionFieldValue) {
+        super(Opcodes.ASM8, delegate);
+        this.versionFieldName = versionFieldName;
+        this.versionFieldValue = versionFieldValue;
+    }
+
+    /**
+     * Field visitor that observes existing fields before chaining to the
+     * delegate {@ClassVisitor}.
+     * <p> {@inheritDoc}
+     */
+    @Override
+    public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
+        fieldAlreadyExists |= name.equals(versionFieldName);
+
+        return super.visitField(access, name, desc, signature, value);
+    }
+
+    /**
+     * End of class visitor that creates a version field definition if an
+     * existing definition wasn't observed.
+     */
+    @Override
+    public void visitEnd() {
+        if (!fieldAlreadyExists) {
+            FieldVisitor fv = super.visitField(
+                                               Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL + Opcodes.ACC_STATIC,
+                                               versionFieldName,
+                                               Type.getDescriptor(String.class),
+                                               null,
+                                               versionFieldValue);
+            fv.visitEnd();
+        }
+
+        super.visitEnd();
+    }
+
+    /**
+     * Indication of whether or not a version field existed. Existing fields
+     * are not overriden by this adapter.
+     * 
+     * @return true if the version field named existed before adapter execution
+     */
+    public boolean doesFieldAlreadyExist() {
+        return fieldAlreadyExists;
+    }
+}

--- a/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/stackjoiner/bci/ThrowableClassAdapter.java
+++ b/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/stackjoiner/bci/ThrowableClassAdapter.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.logging.internal.osgi.stackjoiner.bci;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * Applies a transformation to the java.lang.Throwable class
+ *
+ */
+public class ThrowableClassAdapter extends ClassVisitor implements Opcodes {
+
+    public ThrowableClassAdapter(ClassVisitor cv) {
+        super(ASM8, cv);
+    }
+
+    @Override
+    public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+        MethodVisitor mv = cv.visitMethod(access, name, desc, signature, exceptions);
+        MethodVisitor tmv = new ThrowableMethodAdapter(mv, name, desc, signature);
+        return tmv != null ? tmv : mv;
+    };
+
+}

--- a/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/stackjoiner/bci/ThrowableClassFileTransformer.java
+++ b/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/stackjoiner/bci/ThrowableClassFileTransformer.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.logging.internal.osgi.stackjoiner.bci;
+
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.IllegalClassFormatException;
+import java.lang.instrument.Instrumentation;
+import java.security.ProtectionDomain;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+
+import com.ibm.ws.logging.internal.osgi.stackjoiner.bci.ThrowableClassAdapter;
+
+public class ThrowableClassFileTransformer implements ClassFileTransformer {
+
+    @Override
+    public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain,
+                            byte[] classfileBuffer) throws IllegalClassFormatException {
+        byte[] ba = null;
+        try {
+            ba = transformClassIfThrowable(classfileBuffer, className);
+        } catch (Exception e) {
+
+            throw e;
+        }
+        return ba;
+    }
+
+    private byte[] transformClassIfThrowable(byte[] cBuffer, String nameOfClass) {
+        ClassReader reader = new ClassReader(cBuffer);
+        ClassWriter writer = new ClassWriter(reader, ClassWriter.COMPUTE_FRAMES);
+        ClassVisitor visitor = writer;
+        if (nameOfClass.equals("java/lang/Throwable")) {
+            visitor = new ThrowableClassAdapter(visitor);
+        }
+        reader.accept(visitor, reader.SKIP_FRAMES);
+        return writer.toByteArray();
+    }
+
+}

--- a/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/stackjoiner/bci/ThrowableMethodAdapter.java
+++ b/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/stackjoiner/bci/ThrowableMethodAdapter.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.logging.internal.osgi.stackjoiner.bci;
+
+import java.io.PrintStream;
+
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+/**
+ * Injects all Throwable.printStackTrace(PrintStream) calls with a decision to override
+ * itself to squash stack traces into one line.
+ */
+class ThrowableMethodAdapter extends MethodVisitor implements Opcodes {
+
+    private final String name;
+    private final String desc;
+    private final String signature;
+
+    public ThrowableMethodAdapter(MethodVisitor mv, String name, String desc, String signature) {
+        super(ASM8, mv);
+        this.name = name;
+        this.desc = desc;
+        this.signature = signature;
+    }
+    
+    @Override
+    public void visitCode() {
+    	if (name.equals("printStackTrace") && desc.equals("(Ljava/io/PrintStream;)V")) {
+            mv.visitVarInsn(ALOAD, 0); // Loads 'this' (Throwable) onto the stack.
+            mv.visitVarInsn(ALOAD, 1); // Loads the first param (PrintStream) onto the stack.
+            // Call ThrowableProxy.fireMethod(Throwable, PrintStream) which invokes
+            // BaseTraceService.printStackTraceOverride(Throwable, PrintStream) via reflection.
+            // This method call consumes/pops the two objects off of the stack.
+            mv.visitMethodInsn(
+                               INVOKESTATIC,
+                               "com/ibm/ws/boot/delegated/logging/ThrowableProxy",
+                               "fireMethod",
+                               Type.getMethodDescriptor(
+                                                        Type.BOOLEAN_TYPE,
+                                                        new Type[] { Type.getType(Throwable.class), Type.getType(PrintStream.class) }),
+                               false);  // Pushes the Boolean value returned by BaseTraceService.printStackTraceOverride(...) onto the stack
+            Label l0 = new Label();     // Generate a reference to Label L0.
+            mv.visitJumpInsn(IFEQ, l0); // POP top of the stack, IF value on the stack is 0 (false), JUMP to Label L0.
+            mv.visitInsn(RETURN);       // ELSE trigger a RETURN.
+            mv.visitLabel(l0);          // Start of Label L0.
+        }
+    }
+} 

--- a/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/stackjoiner/boot/templates/ThrowableProxy.java
+++ b/dev/com.ibm.ws.logging.osgi/src/com/ibm/ws/logging/internal/osgi/stackjoiner/boot/templates/ThrowableProxy.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.logging.internal.osgi.stackjoiner.boot.templates;
+
+import java.io.PrintStream;
+import java.lang.reflect.Method;
+
+/**
+ * ThrowableProxy exposes an annotated BaseTraceService method to the Java Bootstrap ClassLoader
+ */
+public final class ThrowableProxy {
+
+    /**
+     * The method to be fired upon
+     */
+    private static Method fireMethod;
+
+    /**
+     * The class object in which the method is fired
+     */
+    private static Object fireTarget;
+
+    /**
+     * Sets the fire target
+     *
+     * @param target instance in which the method resides
+     * @param method to be fired
+     */
+    public final static void setFireTarget(Object target, Method method) {
+        fireTarget = target;
+        fireMethod = method;
+    }
+
+    /**
+     * Invokes the method that attempts a printStackTrace override
+     * 
+     * @return true if Throwable.printStackTrace(PrintStream) is overriden, false otherwise
+     */
+    public final static boolean fireMethod(Throwable t, PrintStream originalStream) {
+    	Boolean b = Boolean.FALSE;
+        try {
+            b = (Boolean) fireMethod.invoke(fireTarget, t, originalStream);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return b;
+    }
+
+}

--- a/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/FATSuite.java
+++ b/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/FATSuite.java
@@ -25,6 +25,7 @@ import org.junit.runners.Suite.SuiteClasses;
                 StackTraceFilteringForNoClassDefFoundErrorTest.class, StackTraceFilteringForBadlyWrittenThrowableTest.class,
                 StackTraceFilteringForIBMFeatureExceptionTest.class, StackTraceFilteringForUserFeatureExceptionTest.class,
                 StackTraceFilteringForSpecificationClassesExceptionTest.class,
+                StackTraceJoinerTest.class,
                 InvalidTraceSpecificationTest.class,
                 HealthCenterTest.class,
                 TestHideMessages.class,

--- a/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/StackTraceJoinerTest.java
+++ b/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/StackTraceJoinerTest.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.logging.fat;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.ProtocolException;
+import java.net.URL;
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.RemoteFile;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
+import componenttest.topology.utils.HttpUtils;
+
+/**
+ * This test class ensures that stack traces are written as single events
+ */
+@RunWith(FATRunner.class)
+public class StackTraceJoinerTest {
+
+    protected static LibertyServer server;
+    protected static RemoteFile messagesLog;
+    protected static RemoteFile consoleLog;
+
+    protected static final int CONN_TIMEOUT = 10;
+
+    protected static void hitWebPage(String contextRoot, String servletName, boolean failureAllowed) throws MalformedURLException, IOException, ProtocolException {
+        try {
+            URL url = new URL("http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/" + contextRoot + "/" + servletName);
+            int expectedResponseCode = failureAllowed ? HttpURLConnection.HTTP_INTERNAL_ERROR : HttpURLConnection.HTTP_OK;
+            HttpURLConnection con = HttpUtils.getHttpConnection(url, expectedResponseCode, CONN_TIMEOUT);
+            BufferedReader br = HttpUtils.getConnectionStream(con);
+            String line = br.readLine();
+            // Make sure the server gave us something back
+            assertNotNull(line);
+            con.disconnect();
+        } catch (IOException e) {
+            // A message about a 500 code may be fine
+            if (!failureAllowed) {
+                throw e;
+            }
+
+        }
+
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        server = LibertyServerFactory.getLibertyServer("com.ibm.ws.logging.stackjoiner", StackTraceJoinerTest.class);
+        ShrinkHelper.defaultDropinApp(server, "broken-servlet", "com.ibm.ws.logging.fat.broken.servlet");
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+    @Test
+    public void testPrintStackTracePrintStream() throws Exception {
+        consoleLog = server.getConsoleLogFile();
+        server.setMarkToEndOfLog(consoleLog);
+        hitWebPage("broken-servlet", "BrokenWithCustomPrintStreamServlet", false);
+        List<String> systemErrOutput = server.findStringsInLogsUsingMark("err.*", consoleLog);
+
+        assertTrue("Expected two single-lined stack traces to be found but found " + systemErrOutput.size() + " messages.", systemErrOutput.size() == 2);
+        assertTrue("Expected two single-lined stack traces to be identical but they were not.", systemErrOutput.get(0).equals(systemErrOutput.get(1)));
+    }
+
+    @Test
+    public void testSingleLinedStackTraceConsoleLog() throws Exception {
+        consoleLog = server.getConsoleLogFile();
+        server.setMarkToEndOfLog(consoleLog);
+        hitWebPage("broken-servlet", "ExceptionPrintingServlet", false);
+        List<String> systemErrOutput = server.findStringsInLogsUsingMark("err.*", consoleLog);
+        assertTrue("Expected stack trace as a single event but found " + systemErrOutput.size() + " messages.", systemErrOutput.size() == 1);
+    }
+
+    @Test
+    public void testSingleLinedStackTraceMessagesLog() throws Exception {
+        messagesLog = server.getDefaultLogFile();
+        server.setMarkToEndOfLog(messagesLog);
+        hitWebPage("broken-servlet", "ExceptionPrintingServlet", false);
+        List<String> systemErrOutput = server.findStringsInLogsUsingMark("SystemErr.*", messagesLog);
+        assertTrue("Expected stack trace as a single event but found " + systemErrOutput.size() + " messages.", systemErrOutput.size() == 1);
+    }
+
+    @Test
+    public void testPrintStackTraceOverrideReflection() throws Exception {
+        hitWebPage("broken-servlet", "ExceptionPrintingServlet", false);
+        List<String> traceOutput = server.findStringsInTrace("Stack joiner could not be initialized..*");
+        assertTrue("Stack joiner could not be initialized message was found in the trace.", traceOutput.size() == 0);
+    }
+
+    @Test
+    public void testPrintStackTraceMultipleThreads() {
+        // TODO: Test printStackTrace in multiple threads and ensure that messages are not leaking from one stack trace to another
+    }
+}

--- a/dev/com.ibm.ws.logging_fat/publish/servers/com.ibm.ws.logging.stackjoiner/bootstrap.properties
+++ b/dev/com.ibm.ws.logging_fat/publish/servers/com.ibm.ws.logging.stackjoiner/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=com.ibm.ws.logging.*=debug

--- a/dev/com.ibm.ws.logging_fat/publish/servers/com.ibm.ws.logging.stackjoiner/server.xml
+++ b/dev/com.ibm.ws.logging_fat/publish/servers/com.ibm.ws.logging.stackjoiner/server.xml
@@ -1,0 +1,22 @@
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Server for testing Liberty logging in a server">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+	   <feature>jsp-2.3</feature>
+    </featureManager>
+    
+    <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
+    
+    
+</server>

--- a/dev/com.ibm.ws.logging_fat/test-applications/broken-servlet/src/com/ibm/ws/logging/fat/broken/servlet/BrokenWithCustomPrintStreamServlet.java
+++ b/dev/com.ibm.ws.logging_fat/test-applications/broken-servlet/src/com/ibm/ws/logging/fat/broken/servlet/BrokenWithCustomPrintStreamServlet.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.logging.fat.broken.servlet;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Servlet which throws an exception.
+ */
+@WebServlet("/BrokenWithCustomPrintStreamServlet")
+public class BrokenWithCustomPrintStreamServlet extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @see HttpServlet#HttpServlet()
+     */
+    public BrokenWithCustomPrintStreamServlet() {
+        super();
+    }
+
+    /**
+     * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response)
+     */
+    @Override
+    protected void doGet(HttpServletRequest request,
+                         HttpServletResponse response) throws ServletException, IOException {
+        response.setContentType("text/plain");
+
+        response.getWriter().println("Howdy! This servlet is working just fine, except for all the bits that are deliberately broken.");
+
+        // In the absence of the jndi feature, this lookup shouldn't go well
+        try {
+            InitialContext ctx = new InitialContext();
+            ctx.lookup("something/That/Does/Not/Exist");
+        } catch (NamingException e) {
+            // Print two stack traces to System.err
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            PrintStream ps = new PrintStream(baos);
+            e.printStackTrace(ps);
+            System.err.println(baos.toString());
+            e.printStackTrace();
+        }
+
+        response.getWriter().println("There should be two exceptions in your logs.");
+
+    }
+
+}


### PR DESCRIPTION
Compresses each stack trace into 1 line by overriding calls to Throwable.printStackTrace() from System.out and System.err streams.