### PR TITLE
Adjust sslSessionTimeout value to seconds

### DIFF
--- a/dev/com.ibm.ws.channel.ssl/src/com/ibm/ws/channel/ssl/internal/SSLChannelData.java
+++ b/dev/com.ibm.ws.channel.ssl/src/com/ibm/ws/channel/ssl/internal/SSLChannelData.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import com.ibm.websphere.channelfw.ChannelData;
 import com.ibm.websphere.channelfw.FlowType;
@@ -116,7 +117,13 @@ public class SSLChannelData {
         this.decryptBuffersDirect = getBooleanProperty(DECRYPT_BUFFERS_DIRECT, DEFAULT_DECRYPT_BUFFERS_DIRECT, errors);
 
         this.sslSessionCacheSize = getIntProperty(SSLSESSION_CACHE_SIZE, true, DEFAULT_SSLSESSION_CACHE_SIZE, errors);
-        this.sslSessionTimeout = getIntProperty(SSLSESSION_TIMEOUT, true, DEFAULT_SSLSESSION_TIMEOUT, errors);
+        this.sslSessionTimeout = getIntProperty(SSLSESSION_TIMEOUT, true, DEFAULT_SSLSESSION_TIMEOUT * 1000, errors);
+        // The duration tag on the sslSession Metatype will change the value to milliseconds. As such, the value
+        // obtained from this will millis, convert to seconds.
+        this.sslSessionTimeout = (int) (TimeUnit.MILLISECONDS.toSeconds(sslSessionTimeout));
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "Property sslSessionTimout converted to seconds: " + sslSessionTimeout);
+        }
 
         // Throw an exception if errors were found in reading data.
         if (errors.length() != 0) {

--- a/dev/com.ibm.ws.channel.ssl/test/com/ibm/ws/channel/ssl/internal/SSLChannelDataTest.java
+++ b/dev/com.ibm.ws.channel.ssl/test/com/ibm/ws/channel/ssl/internal/SSLChannelDataTest.java
@@ -25,11 +25,11 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import test.common.SharedOutputManager;
-
 import com.ibm.websphere.channelfw.ChannelData;
 import com.ibm.websphere.channelfw.FlowType;
 import com.ibm.wsspi.channelfw.exception.ChannelException;
+
+import test.common.SharedOutputManager;
 
 /**
  * Test channel config object.
@@ -41,7 +41,7 @@ public class SSLChannelDataTest {
 
     /**
      * Capture stdout/stderr output to the manager.
-     * 
+     *
      * @throws Exception
      */
     @BeforeClass
@@ -52,7 +52,7 @@ public class SSLChannelDataTest {
 
     /**
      * Final teardown work when class is exiting.
-     * 
+     *
      * @throws Exception
      */
     @AfterClass
@@ -63,7 +63,7 @@ public class SSLChannelDataTest {
 
     /**
      * Individual teardown after each test.
-     * 
+     *
      * @throws Exception
      */
     @After
@@ -84,8 +84,7 @@ public class SSLChannelDataTest {
             configMap.put("SSLSessionCacheSize", "10");
             configMap.put("SSLSessionTimeout", "1000");
             configMap.put("testvalue", "false");
-            mocker.checking(new Expectations()
-            {
+            mocker.checking(new Expectations() {
                 {
                     allowing(fakeData).getName();
                     will(returnValue("testname"));
@@ -104,7 +103,7 @@ public class SSLChannelDataTest {
             assertTrue(config.getDecryptBuffersDirect());
             assertTrue(config.getEncryptBuffersDirect());
             assertTrue(10 == config.getSSLSessionCacheSize());
-            assertTrue(1000 == config.getSSLSessionTimeout());
+            assertTrue(1 == config.getSSLSessionTimeout());
             assertEquals(FlowType.INBOUND, config.getFlowType());
             assertTrue(config.getBooleanProperty("encryptBuffersDirect"));
             assertFalse(config.getBooleanProperty("testvalue"));
@@ -112,8 +111,7 @@ public class SSLChannelDataTest {
             // test invalid config now
             configMap.clear();
             configMap.put("encryptBuffersDirect", "blue");
-            mocker.checking(new Expectations()
-            {
+            mocker.checking(new Expectations() {
                 {
                     allowing(fakeData).getName();
                     will(returnValue("testname2"));


### PR DESCRIPTION
fixes #12032

This duration tag on the metatype for this property will convert values to milliseconds. Since the channel expects these values to be seconds, the value should be converted back. This change will do this conversion whenever a value other than the internal default is detected. 