### PR TITLE
Get things building in eclipse again

### DIFF
--- a/dev/com.ibm.websphere.org.eclipse.microprofile.metrics.3.0/bnd.bnd
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.metrics.3.0/bnd.bnd
@@ -11,9 +11,6 @@
 -include ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-javac.source: 1.8
-javac.target: 1.8
-
 Bundle-SymbolicName: com.ibm.websphere.org.eclipse.microprofile.metrics.3.0; singleton:=true
 
 Import-Package: \
@@ -26,8 +23,6 @@ Export-Package: \
 
 #Include-Resource: \
 #  @${repo;org.eclipse.microprofile.metrics:microprofile-metrics-api;3.0;EXACT}
-
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version>=1.8))"
 
 WS-TraceGroup: METRICS
 

--- a/dev/com.ibm.ws.app.manager.wab.installer_fat/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.app.manager.wab.installer_fat/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.microprofile.metrics.3.0.monitor/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.metrics.3.0.monitor/bnd.bnd
@@ -11,9 +11,6 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
-javac.source: 1.8
-javac.target: 1.8
-
 Bundle-Name: com.ibm.ws.microprofile.metrics.3.0.monitor
 Bundle-SymbolicName: com.ibm.ws.microprofile.metrics.3.0.monitor
 Bundle-Description: MicroProfile Metrics Monitor Bridge Auto Feature, version ${bVersion}
@@ -33,8 +30,6 @@ Private-Package: \
 #    META-INF=resources/META-INF
 
 WS-TraceGroup: METRICS
-
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 -dsannotations: com.ibm.ws.microprofile.metrics.monitor.MonitorMetricsHandler
 

--- a/dev/com.ibm.ws.microprofile.metrics.3.0/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.metrics.3.0/bnd.bnd
@@ -49,8 +49,6 @@ Export-Package: \
 	com.ibm.ws.microprofile.metrics30.impl.SharedMetricRegistries30,\
 	com.ibm.ws.microprofile.metrics30.ApplicationListener30
 
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
-
 WS-TraceGroup: METRICS
 
 -buildpath: \

--- a/dev/com.ibm.ws.org.apache.cxf.ws.security.2.6.2/.classpath
+++ b/dev/com.ibm.ws.org.apache.cxf.ws.security.2.6.2/.classpath
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/io.openliberty.grpc.1.0.internal.client/bnd.bnd
+++ b/dev/io.openliberty.grpc.1.0.internal.client/bnd.bnd
@@ -40,8 +40,6 @@ Export-Package: \
   io.openliberty.grpc.internal.client.* ,\
   io.grpc.netty.shaded.io.*
 
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
-
 -dsannotations: io.openliberty.grpc.internal.client.config.GrpcClientConfigImpl
 
 # include the service providers and metatype

--- a/dev/io.openliberty.grpc.1.0.internal.common/bnd.bnd
+++ b/dev/io.openliberty.grpc.1.0.internal.common/bnd.bnd
@@ -36,8 +36,6 @@ Export-Package: \
 	org.checkerframework.checker.nullness.qual,\
 	org.checkerframework.checker.nullness.compatqual
 
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
-  
 Include-Resource: \
   @${repo;io.grpc:grpc-core;1.27.0;EXACT}!/META-INF/**, \
 

--- a/dev/io.openliberty.grpc.1.0.internal/bnd.bnd
+++ b/dev/io.openliberty.grpc.1.0.internal/bnd.bnd
@@ -34,8 +34,6 @@ Export-Package: \
 	io.openliberty.grpc.internal.config,\
 	io.openliberty.grpc.internal.servlet
 
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
-
 Include-Resource: \
   OSGI-INF=resources/OSGI-INF, \
   OSGI-INF/metatype/metatype.xml=resources/OSGI-INF/metatype/metatype.xml

--- a/dev/io.openliberty.microprofile.config.2.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.config.2.0.internal/bnd.bnd
@@ -12,14 +12,9 @@
 
 bVersion=1.0
 
-javac.source: 1.8
-javac.target: 1.8
-
 Bundle-SymbolicName: io.openliberty.microprofile.config.2.0.internal; singleton:=true
 
 WS-TraceGroup: APPCONFIG
-
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 src: src
 


### PR DESCRIPTION
- Update missing src directory that the bnd files depends on existing to
create a bin directory for output
- Update bnd files to remove Java 8 settings since that is the default
and it is not needed to be in the bnd files.
- Add missing bndtools.prefs file for new component.