### PR TITLE
Remove ibm:beta metatype for spnego, tai and jwtsso

### DIFF
--- a/dev/com.ibm.ws.security.authentication.tai/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.authentication.tai/resources/OSGI-INF/metatype/metatype.xml
@@ -26,7 +26,7 @@
             required="false" type="String" cardinality="2147483647" />
         <AD id="continueAfterUnprotectedURI" name="%continueAfterUnprotectedURI" description="%continueAfterUnprotectedURI.desc"
             required="true" type="Boolean" default="false" />  
-        <AD id="disableLtpaCookie" ibm:beta="true" name ="%disableLtpaCookie" description="%disableLtpaCookie.desc"
+        <AD id="disableLtpaCookie" name="%disableLtpaCookie" description="%disableLtpaCookie.desc"
             required="false" type="Boolean" default="false"/>          
     </OCD>
 

--- a/dev/com.ibm.ws.security.jwtsso/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.jwtsso/resources/OSGI-INF/metatype/metatype.xml
@@ -44,7 +44,7 @@
          <AD id="useLtpaIfJwtAbsent"  name="%fallbackToLtpa" description="%fallbackToLtpa.desc"
              required="false"  type="Boolean" default="false" />
            
-         <AD id="disableJwtCookie" ibm:beta="true" name ="%disableJwtCookie" description="%disableJwtCookie.desc"
+         <AD id="disableJwtCookie"  name="%disableJwtCookie" description="%disableJwtCookie.desc"
             required="false" type="Boolean" default="false"/>    
          <!-- 
              <AD id="groupBaseDnOmitted" name="%groupBaseDnOmitted" description="%groupBaseDnOmitted"

--- a/dev/com.ibm.ws.security.spnego/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.spnego/resources/OSGI-INF/metatype/metatype.xml
@@ -59,7 +59,7 @@
         <AD id="invokeAfterSSO" name="internal"  description="internal use only" 
             required="false" type="Boolean" default="true" />
             
-        <AD id="disableLtpaCookie" ibm:beta="true" name ="%disableLtpaCookie" description="%disableLtpaCookie.desc"
+        <AD id="disableLtpaCookie" name="%disableLtpaCookie" description="%disableLtpaCookie.desc"
             required="false" type="Boolean" default="false"/>    
 
     </OCD>


### PR DESCRIPTION
Remove ibm:beta metatype for spnego, tai and jwtsso to get it ready for GA