### PR TITLE
Do not use trace injection workaround with Open J9 V8

### DIFF
--- a/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/main/LibertyJava8WorkaroundRuntimeTransformer.java
+++ b/dev/com.ibm.ws.ras.instrument/src/com/ibm/ws/ras/instrument/internal/main/LibertyJava8WorkaroundRuntimeTransformer.java
@@ -56,8 +56,7 @@ public class LibertyJava8WorkaroundRuntimeTransformer implements ClassFileTransf
     /**
      * Indication that the host is an IBM VM.
      */
-    private final static boolean isIBMVirtualMachine = System.getProperty("java.vm.name", "unknown").contains("IBM J9") ||
-                                                       System.getProperty("java.vm.name", "unknown").contains("OpenJ9");
+    private final static boolean isIBMVirtualMachine = System.getProperty("java.vm.name", "unknown").contains("IBM J9");
 
 	/**
 	 * Trace instrumentation force. Due to performance concerns with up-front instrumentation of all 1.8 bytecode classes,


### PR DESCRIPTION
- IBM Java 8 had issues with trace injection initially.  OpenJDK with
OpenJ9 did not have similar issue because they were fixed by the time
that it was released.  The code still blocks all OpenJ9 V8 releases from
doing trace injection.  This change resolves that.

Fixes #12708