### PR TITLE
Get things building in eclipse again

### DIFF
--- a/dev/com.ibm.ws.grpc_fat/.classpath
+++ b/dev/com.ibm.ws.grpc_fat/.classpath
@@ -5,11 +5,11 @@
 	<classpathentry kind="src" path="test-applications/HelloWorldClient.war/src"/>
 	<classpathentry kind="src" path="test-applications/HelloWorldService.war/src"/>
 	<classpathentry kind="src" path="test-applications/FavoriteBeerService.war/src"/>
+	<classpathentry kind="src" path="test-applications/InvalidService.war/src"/>
 	<classpathentry kind="src" path="test-applications/StoreProducerApp.war/src"/>
 	<classpathentry kind="src" path="test-applications/StoreConsumerApp.war/src"/>
 	<classpathentry kind="src" path="test-applications/StoreApp.war/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="src" path="/com.ibm.ws.dynacache"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.transaction.core_fat/.classpath
+++ b/dev/com.ibm.ws.transaction.core_fat/.classpath
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
-	<classpathentry kind="src" path="test-bundles/xaflowcallback/src"/>
 	<classpathentry kind="src" path="test-applications/transaction/src"/>
 	<classpathentry kind="src" path="test-applications/transactionscoped/src"/>
 	<classpathentry exported="true" kind="con" path="aQute.bnd.classpath.container"/>

--- a/dev/com.ibm.ws.transaction.core_fat/bnd.bnd
+++ b/dev/com.ibm.ws.transaction.core_fat/bnd.bnd
@@ -14,8 +14,7 @@ bVersion=1.0
 src: \
 	fat/src,\
 	test-applications/transaction/src,\
-	test-applications/transactionscoped/src,\
-	test-bundles/xaflowcallback/src
+	test-applications/transactionscoped/src
 
 -sub: *.bnd
 

--- a/dev/com.ibm.ws.transaction.recovery_fat/.classpath
+++ b/dev/com.ibm.ws.transaction.recovery_fat/.classpath
@@ -3,7 +3,6 @@
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-bundles/xaflowcallback/src"/>
 	<classpathentry kind="src" path="test-applications/transaction/src"/>
-	<classpathentry kind="src" path="test-applications/transactionscoped/src"/>
 	<classpathentry exported="true" kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>


### PR DESCRIPTION
- Update grpc_fat to not use project references and just to rely on bnd and add new war src directory
- Update transaction fats to remove reference to source paths in .classpath and bnd.bnd that aren't there any longer.
