### PR TITLE
web-related throughput performance fixes

### DIFF
--- a/dev/com.ibm.ws.channel.ssl/src/com/ibm/ws/channel/ssl/internal/SSLConnectionLink.java
+++ b/dev/com.ibm.ws.channel.ssl/src/com/ibm/ws/channel/ssl/internal/SSLConnectionLink.java
@@ -134,12 +134,12 @@ public class SSLConnectionLink extends OutboundProtocolLink implements Connectio
 
         // Check to see if http/2 is enabled for this connection and save the result
         if (CHFWBundle.getServletConfiguredHttpVersionSetting() != null) {
-            if (SSLChannelConstants.OPTIONAL_DEFAULT_OFF_20.equalsIgnoreCase(CHFWBundle.getServletConfiguredHttpVersionSetting())) {
+            if (CHFWBundle.isHttp2DisabledByDefault()) {
                 if (getChannel().getUseH2ProtocolAttribute() != null && getChannel().getUseH2ProtocolAttribute()) {
                     http2Enabled = true;
                     this.sslChannel.checkandInitALPN();
                 }
-            } else if (SSLChannelConstants.OPTIONAL_DEFAULT_ON_20.equalsIgnoreCase(CHFWBundle.getServletConfiguredHttpVersionSetting())) {
+            } else if (CHFWBundle.isHttp2EnabledByDefault()) {
                 if (getChannel().getUseH2ProtocolAttribute() == null || getChannel().getUseH2ProtocolAttribute()) {
                     http2Enabled = true;
                     this.sslChannel.checkandInitALPN();
@@ -383,11 +383,11 @@ public class SSLConnectionLink extends OutboundProtocolLink implements Connectio
         /**
          * Constructor.
          *
-         * @param _connLink SSLConnectionLink associated with this callback.
-         * @param _netBuffer Buffer from the network / device side.
+         * @param _connLink           SSLConnectionLink associated with this callback.
+         * @param _netBuffer          Buffer from the network / device side.
          * @param _decryptedNetBuffer Buffer containing results of decrypting netbuffer
          * @param _encryptedAppBuffer Encrypted buffer to be sent out through network / device side.
-         * @param _flowType inbound or outbound
+         * @param _flowType           inbound or outbound
          */
         public MyHandshakeCompletedCallback(
                                             SSLConnectionLink _connLink,
@@ -784,7 +784,7 @@ public class SSLConnectionLink extends OutboundProtocolLink implements Connectio
      * outbound socket has been established. Establish the SSL connection before reporting
      * to the next channel. Note, this method is called in both sync and async flows.
      *
-     * @param inVC virtual connection associated with this request
+     * @param inVC  virtual connection associated with this request
      * @param async flag for asynchronous (true) or synchronous (false)
      * @throws IOException
      */
@@ -870,11 +870,11 @@ public class SSLConnectionLink extends OutboundProtocolLink implements Connectio
      * This method is called to handle the results of an SSL handshake. This may be called
      * by a callback or in the same thread as the connect request.
      *
-     * @param netBuffer buffer for data flowing in fron the net
+     * @param netBuffer          buffer for data flowing in fron the net
      * @param decryptedNetBuffer buffer for decrypted data from the net
      * @param encryptedAppBuffer buffer for encrypted data flowing from the app
-     * @param hsStatus output from the last call to the SSL engine
-     * @param async whether this is for an async (true) or sync (false) request
+     * @param hsStatus           output from the last call to the SSL engine
+     * @param async              whether this is for an async (true) or sync (false) request
      * @throws IOException
      */
     protected void readyOutboundPostHandshake(

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpConfigConstants.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpConfigConstants.java
@@ -385,10 +385,6 @@ public class HttpConfigConstants {
     /** The channel will never be enabled for HTTP/2.0. */
     public static final String NEVER_20 = "2.0_Never";
 
-    /** The channel will disable HTTP/2.0 by default. */
-    public static final String OPTIONAL_DEFAULT_OFF_20 = "2.0_Optional_Off";
-    /** The channel will be enabled for HTTP/2.0 by default". */
-    public static final String OPTIONAL_DEFAULT_ON_20 = "2.0_Optional_On";
     /** HTTP/1.1 Version protocol */
     public static final String PROTOCOL_VERSION_11 = "http/1.1";
     /** HTTP/2 Version protocol */
@@ -445,6 +441,7 @@ public class HttpConfigConstants {
         LAX("Lax"),
         NONE("None"),
         STRICT("Strict");
+
         SameSite(String name) {
             this.name = name;
         }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/inbound/HttpInboundServiceContextImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/inbound/HttpInboundServiceContextImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2019 IBM Corporation and others.
+ * Copyright (c) 2004, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -85,7 +85,7 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
     private String forwardedRemoteAddress = null;
     private String forwardedProto = null;
     private String forwardedHost = null;
-    private int h2ContentLength = -1;
+
     /**
      * Constructor for an HTTP inbound service context object.
      *
@@ -462,7 +462,7 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
 
         // if applicable set the HTTP/2 specific content length
         if (myLink instanceof H2HttpInboundLinkWrap) {
-            int len = ((H2HttpInboundLinkWrap)myLink).getH2ContentLength();
+            int len = ((H2HttpInboundLinkWrap) myLink).getH2ContentLength();
             if (len != -1) {
                 req.setContentLength(len);
             }
@@ -553,7 +553,7 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
     /**
      * Send the headers for the outgoing response synchronously.
      *
-     * @throws IOException -- if a socket exception occurs
+     * @throws IOException          -- if a socket exception occurs
      * @throws MessageSentException -- if a finishMessage API was already used
      */
     @Override
@@ -664,9 +664,9 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
      *
      * @param body
      * @throws IOException
-     *             -- if a socket exception occurs
+     *                                  -- if a socket exception occurs
      * @throws MessageSentException
-     *             -- if a finishMessage API was already used
+     *                                  -- if a finishMessage API was already used
      */
     @Override
     public void sendResponseBody(WsByteBuffer[] body) throws IOException, MessageSentException {
@@ -725,7 +725,7 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
      * @param bForce
      * @return VirtualConnection
      * @throws MessageSentException
-     *             -- if a finishMessage API was already used
+     *                                  -- if a finishMessage API was already used
      */
     @Override
     public VirtualConnection sendResponseBody(WsByteBuffer[] body, InterChannelCallback callback, boolean bForce) throws MessageSentException {
@@ -770,9 +770,9 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
      *
      * @param body
      * @throws IOException
-     *             -- if a socket error occurs
+     *                                  -- if a socket error occurs
      * @throws MessageSentException
-     *             -- if a finishMessage API was already used
+     *                                  -- if a finishMessage API was already used
      */
     @Override
     public void sendRawResponseBody(WsByteBuffer[] body) throws IOException, MessageSentException {
@@ -803,7 +803,7 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
      * @param bForce
      * @return VirtualConnection
      * @throws MessageSentException
-     *             -- if a finishMessage API was already used
+     *                                  -- if a finishMessage API was already used
      */
     @Override
     public VirtualConnection sendRawResponseBody(WsByteBuffer[] body, InterChannelCallback callback, boolean bForce) throws MessageSentException {
@@ -887,11 +887,11 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
      * the zero-length chunk is automatically appended.
      *
      * @param body
-     *            (last set of buffers to send, null if no body data)
+     *                 (last set of buffers to send, null if no body data)
      * @throws IOException
-     *             -- if a socket exception occurs
+     *                                  -- if a socket exception occurs
      * @throws MessageSentException
-     *             -- if a finishMessage API was already used
+     *                                  -- if a finishMessage API was already used
      */
     @Override
     public void finishResponseMessage(WsByteBuffer[] body) throws IOException, MessageSentException {
@@ -965,12 +965,12 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
      * be null and the callback always used.
      *
      * @param body
-     *            (last set of body data, null if no body information)
+     *                     (last set of body data, null if no body information)
      * @param callback
      * @param bForce
      * @return VirtualConnection
      * @throws MessageSentException
-     *             -- if a finishMessage API was already used
+     *                                  -- if a finishMessage API was already used
      */
     @Override
     public VirtualConnection finishResponseMessage(WsByteBuffer[] body, InterChannelCallback callback, boolean bForce) throws MessageSentException {
@@ -1045,11 +1045,11 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
      * been sent yet, then they will be prepended to the input data.
      *
      * @param body
-     *            -- null if there is no body data
+     *                 -- null if there is no body data
      * @throws IOException
-     *             -- if a socket exception occurs
+     *                                  -- if a socket exception occurs
      * @throws MessageSentException
-     *             -- if a finishMessage API was already used
+     *                                  -- if a finishMessage API was already used
      */
     @Override
     public void finishRawResponseMessage(WsByteBuffer[] body) throws IOException, MessageSentException {
@@ -1078,12 +1078,12 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
      * such that the callback is always used.
      *
      * @param body
-     *            -- null if there is no more body data
+     *                   -- null if there is no more body data
      * @param cb
      * @param bForce
      * @return VirtualConnection
      * @throws MessageSentException
-     *             -- if a finishMessage API was already used
+     *                                  -- if a finishMessage API was already used
      */
     @Override
     public VirtualConnection finishRawResponseMessage(WsByteBuffer[] body, InterChannelCallback cb, boolean bForce) throws MessageSentException {
@@ -1268,7 +1268,7 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
      * now that we're ready to read the next inbound request.
      *
      * @param callClose
-     *            (should this method call the close API itself)
+     *                      (should this method call the close API itself)
      */
     public void purgeBodyBuffers(boolean callClose) {
 
@@ -1298,11 +1298,11 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
      *
      * @return WsByteBuffer[]
      * @throws IOException
-     *             -- if a socket exceptions happens
+     *                                      -- if a socket exceptions happens
      * @throws IllegalHttpBodyException
-     *             -- if a malformed request body is
-     *             present such that the server should send an HTTP 400 Bad Request
-     *             back to the client.
+     *                                      -- if a malformed request body is
+     *                                      present such that the server should send an HTTP 400 Bad Request
+     *                                      back to the client.
      */
 
     @Override
@@ -1325,7 +1325,7 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
         // check for an HTTP/2 specific content length
         int h2ContentLength = -1;
         if (myLink instanceof H2HttpInboundLinkWrap) {
-            h2ContentLength = ((H2HttpInboundLinkWrap)myLink).getH2ContentLength();
+            h2ContentLength = ((H2HttpInboundLinkWrap) myLink).getH2ContentLength();
         }
 
         // check to see if a body is allowed before reading for one
@@ -1379,7 +1379,7 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
      * @return VirtualConnection (null if an async read is in progress,
      *         non-null if data is ready)
      * @throws BodyCompleteException
-     *             -- if the entire body has already been read
+     *                                   -- if the entire body has already been read
      */
     @Override
     public VirtualConnection getRequestBodyBuffers(InterChannelCallback callback, boolean bForce) throws BodyCompleteException {
@@ -1469,11 +1469,11 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
      *
      * @return WsByteBuffer
      * @throws IOException
-     *             -- if a socket exceptions happens
+     *                                      -- if a socket exceptions happens
      * @throws IllegalHttpBodyException
-     *             -- if a malformed request body is
-     *             present such that the server should send an HTTP 400 Bad Request
-     *             back to the client.
+     *                                      -- if a malformed request body is
+     *                                      present such that the server should send an HTTP 400 Bad Request
+     *                                      back to the client.
      */
     @Override
     public WsByteBuffer getRequestBodyBuffer() throws IOException, IllegalHttpBodyException {
@@ -1544,7 +1544,7 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
      * @return VirtualConnection (null if an async read is in progress,
      *         non-null if data is ready)
      * @throws BodyCompleteException
-     *             -- if the entire body has already been read
+     *                                   -- if the entire body has already been read
      */
     @Override
     public VirtualConnection getRequestBodyBuffer(InterChannelCallback callback, boolean bForce) throws BodyCompleteException {
@@ -1635,11 +1635,11 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
      *
      * @return WsByteBuffer
      * @throws IOException
-     *             -- if a socket exceptions happens
+     *                                      -- if a socket exceptions happens
      * @throws IllegalHttpBodyException
-     *             -- if a malformed request body is
-     *             present such that the server should send an HTTP 400 Bad Request
-     *             back to the client.
+     *                                      -- if a malformed request body is
+     *                                      present such that the server should send an HTTP 400 Bad Request
+     *                                      back to the client.
      */
     @Override
     public WsByteBuffer getRawRequestBodyBuffer() throws IOException, IllegalHttpBodyException {
@@ -1666,11 +1666,11 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
      *
      * @return WsByteBuffer[]
      * @throws IOException
-     *             -- if a socket exceptions happens
+     *                                      -- if a socket exceptions happens
      * @throws IllegalHttpBodyException
-     *             -- if a malformed request body is
-     *             present such that the server should send an HTTP 400 Bad Request
-     *             back to the client.
+     *                                      -- if a malformed request body is
+     *                                      present such that the server should send an HTTP 400 Bad Request
+     *                                      back to the client.
      */
     @Override
     public WsByteBuffer[] getRawRequestBodyBuffers() throws IOException, IllegalHttpBodyException {
@@ -1703,7 +1703,7 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
      * @param bForce
      * @return VirtualConnection
      * @throws BodyCompleteException
-     *             -- if the entire body has already been read
+     *                                   -- if the entire body has already been read
      */
     @Override
     public VirtualConnection getRawRequestBodyBuffer(InterChannelCallback cb, boolean bForce) throws BodyCompleteException {
@@ -1736,7 +1736,7 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
      * @param bForce
      * @return VirtualConnection
      * @throws BodyCompleteException
-     *             -- if the entire body has already been read
+     *                                   -- if the entire body has already been read
      */
     @Override
     public VirtualConnection getRawRequestBodyBuffers(InterChannelCallback cb, boolean bForce) throws BodyCompleteException {
@@ -2086,7 +2086,7 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
 
     /**
      * Check if HTTP/2 is enabled for this context
-     * 
+     *
      * @return true if HTTP/2 is enabled for this link
      */
     public boolean isHttp2Enabled() {
@@ -2094,13 +2094,13 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
         boolean isHTTP2Enabled = false;
 
         //If servlet-3.1 is enabled, HTTP/2 is optional and by default off.
-        if (HttpConfigConstants.OPTIONAL_DEFAULT_OFF_20.equalsIgnoreCase(CHFWBundle.getServletConfiguredHttpVersionSetting())) {
+        if (CHFWBundle.isHttp2DisabledByDefault()) {
             //If so, check if the httpEndpoint was configured for HTTP/2
             isHTTP2Enabled = (getHttpConfig().getUseH2ProtocolAttribute() != null && getHttpConfig().getUseH2ProtocolAttribute());
         }
 
         //If servlet-4.0 is enabled, HTTP/2 is optional and by default on.
-        else if (HttpConfigConstants.OPTIONAL_DEFAULT_ON_20.equalsIgnoreCase(CHFWBundle.getServletConfiguredHttpVersionSetting())) {
+        else if (CHFWBundle.isHttp2EnabledByDefault()) {
             //If not configured as an attribute, getUseH2ProtocolAttribute will be null, which returns true
             //to use HTTP/2.
             isHTTP2Enabled = (getHttpConfig().getUseH2ProtocolAttribute() == null || getHttpConfig().getUseH2ProtocolAttribute());

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2019 IBM Corporation and others.
+ * Copyright (c) 2009, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1193,7 +1193,6 @@ public class HttpDispatcherLink extends InboundApplicationLink implements HttpIn
             else {
                 HttpInboundLink link = isc.getLink();
                 if (link != null) {
-
                     return link.isHTTP2UpgradeRequest(headers);
                 }
             }
@@ -1208,13 +1207,13 @@ public class HttpDispatcherLink extends InboundApplicationLink implements HttpIn
      * @return false if some error occurred while servicing the upgrade request
      */
     @Override
-    public boolean handleHTTP2UpgradeRequest(Map<String, String> headers) {
+    public boolean handleHTTP2UpgradeRequest(Map<String, String> http2Settings) {
         HttpInboundLink link = isc.getLink();
         HttpInboundChannel channel = link.getChannel();
         VirtualConnection vc = link.getVirtualConnection();
         H2InboundLink h2Link = new H2InboundLink(channel, vc, getTCPConnectionContext());
 
-        boolean upgraded = h2Link.handleHTTP2UpgradeRequest(headers, link);
+        boolean upgraded = h2Link.handleHTTP2UpgradeRequest(http2Settings, link);
         if (upgraded) {
             h2Link.startAsyncRead(true);
         } else {

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/upgrade/H2HandlerImpl.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/upgrade/H2HandlerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2017 IBM Corporation and others.
+ * Copyright (c) 1997, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@
 package com.ibm.ws.webcontainer31.upgrade;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,7 +34,10 @@ import com.ibm.wsspi.http.ee8.Http2InboundConnection;
 public class H2HandlerImpl implements H2Handler {
 
     private static final TraceComponent tc = Tr.register(H2HandlerImpl.class,null);
-
+    private static final String CONSTANT_upgrade = "upgrade";
+    private static final String CONSTANT_connection = "connection";
+    private static final String HTTP2_SETTINGS = "HTTP2-Settings";
+    
     /**
      * Determines if a given request is an http2 upgrade request
      */
@@ -41,22 +45,23 @@ public class H2HandlerImpl implements H2Handler {
     public boolean isH2Request(HttpInboundConnection hic, ServletRequest request) throws ServletException {
         
         //first check if H2 is enabled for this channel/port
-        if (!((Http2InboundConnection)hic).isHTTP2UpgradeRequest(null, true) ){
+        if (!((Http2InboundConnection) hic).isHTTP2UpgradeRequest(null, true)) {
             return false;
         }
-        
-        Map<String, String> headers = new HashMap<String, String>();
+        // Retrieve the needed header values for this request
+        Map<String, String> h2Headers = null;
         HttpServletRequest hsrt = (HttpServletRequest) request;
         Enumeration<String> headerNames = hsrt.getHeaderNames();
-        
-        // create a map of the headers to pass to the transport code
         while (headerNames.hasMoreElements()) {
-            String key = (String) headerNames.nextElement();
-            String value = hsrt.getHeader(key);
-            headers.put(key, value);
+            String headerName = headerNames.nextElement();
+            if (CONSTANT_connection.equalsIgnoreCase(headerName) || CONSTANT_upgrade.equalsIgnoreCase(headerName)) {
+                if (h2Headers == null) {
+                    h2Headers = new HashMap<String, String>();
+                }
+                h2Headers.put(headerName, hsrt.getHeader(headerName));
+            }
         }
-        //check if this request is asking to do H2
-        return ((Http2InboundConnection)hic).isHTTP2UpgradeRequest(headers, false);
+        return ((Http2InboundConnection)hic).isHTTP2UpgradeRequest(h2Headers == null ? Collections.emptyMap() : h2Headers, false);
     }
 
     /**
@@ -86,17 +91,10 @@ public class H2HandlerImpl implements H2Handler {
             h2uh.init(new H2UpgradeHandler());
         }
         
-        // create a map of the headers to pass to the transport code
-        Map<String, String> headers = new HashMap<String, String>();
-        HttpServletRequest hsrt = (HttpServletRequest) request;
-        Enumeration<String> headerNames = hsrt.getHeaderNames();
+        String http2Settings = request.getHeader(HTTP2_SETTINGS);
         
-        while (headerNames.hasMoreElements()) {
-            String key = (String) headerNames.nextElement();
-            String value = hsrt.getHeader(key);
-            headers.put(key, value);
-        }
-        boolean upgraded = h2ic.handleHTTP2UpgradeRequest(headers);
+        Map<String, String> http2Headers = (http2Settings == null ? Collections.emptyMap() : Collections.singletonMap(HTTP2_SETTINGS, http2Settings));
+        boolean upgraded = h2ic.handleHTTP2UpgradeRequest(http2Headers);
         if (!upgraded) {
             if (tc.isDebugEnabled()) {
                 Tr.debug(tc, "returning: http2 connection initialization failed");


### PR DESCRIPTION
Throughput profiles for the pingperf app show several small improvements that can be made to the web container code to boost throughput by 1-2%. These areas include: making h2 determination more efficient and caching of scheme and isSSL in request.