### PR TITLE
Reduce Fault Tolerance TCK test length in LITE mode

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTck11Launcher.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FaultToleranceTck11Launcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.faulttolerance.tck;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.junit.AfterClass;
@@ -20,6 +21,8 @@ import org.junit.runner.RunWith;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.custom.junit.runner.TestModeFilter;
 import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.JavaInfo.Vendor;
 import componenttest.topology.impl.LibertyServer;
@@ -103,7 +106,12 @@ public class FaultToleranceTck11Launcher {
     @Test
     @AllowedFFDC // The tested exceptions cause FFDC so we have to allow for this.
     public void launchFaultToleranceTCK() throws Exception {
-        MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck", this.getClass() + ":launchFaultTolerance11TCK");
+        boolean isFullMode = TestModeFilter.shouldRun(TestMode.FULL);
+
+        String suiteFileName = isFullMode ? "tck-suite.xml" : "tck-suite-lite.xml";
+
+        MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck", this.getClass() + ":launchFaultToleranceTCK", suiteFileName,
+                              Collections.emptyMap(), Collections.emptySet());
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/publish/tckRunner/tck/tck-suite-lite.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/publish/tckRunner/tck/tck-suite-lite.xml
@@ -1,0 +1,85 @@
+<!-- Licensed under the Apache License, Version 2.0 (the "License"); you 
+    may not use this file except in compliance with the License. You may obtain 
+    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless 
+    required by applicable law or agreed to in writing, software distributed 
+    under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
+    OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
+    the specific language governing permissions and limitations under the License. -->
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="microprofile-faulttolerance-1.1-TCK" verbose="2"
+    configfailurepolicy="continue">
+
+    <test name="microprofile-faulttolerance 1.1 TCK">
+        <classes>
+        
+            <!-- Core functionality tests -->
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousTest" />
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsyncTimeoutTest">
+                <methods>
+                    <exclude name="testAsyncClassLevelTimeout"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.ConfigTest">
+                <methods>
+                    <exclude name="testConfigMaxDuration"/>
+                    <exclude name="testClassLevelConfigMaxDuration"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest">
+                <methods>
+                    <exclude name="testCircuitOpenWithMultiTimeouts"/>
+                    <exclude name="testCircuitOpenWithMultiTimeoutsAsync"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest" />
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest">
+                <methods>
+                    <exclude name="testFallbackTimeout"/>
+                    <exclude name="testFallbacktNoTimeout"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest" />
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryTest">
+                <methods>
+                    <exclude name="testRetryMaxDuration"/>
+                    <exclude name="testRetryMaxDurationSeconds"/>
+                    <exclude name="testRetryWithDelay"/>
+                    <exclude name="testRetryWithNoDelayAndJitter"/>
+                    <exclude name="testClassLevelRetryMaxDuration"/>
+                    <exclude name="testClassLevelRetryMaxDurationSeconds"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryTimeoutTest" />
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest">
+                <methods>
+                    <include name="testTimeout"></include>
+                    <include name="testNoTimeout"/>
+                    <include name="testSecondsTimeout"/>
+                    <include name="testSecondsNoTimeout"/>
+                    <include name="testTimeoutClassLevel"/>
+                    <include name="testNoTimeoutClassLevel"/>
+	            </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.TimeoutMethodConfigTest" />
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchTest">
+                <methods>
+                    <include name="testBulkheadClassSemaphore3"></include>
+                    <include name="testBulkheadMethodSemaphore10"></include>
+                </methods>
+            </class>
+            
+            <!-- New in 1.1: Disable annotations through config -->
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnMethodsTest"/>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassTest"/>
+            
+            <!-- New in 1.1: Metrics -->
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.AllMetricsTest"/>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.FallbackMetricTest"/>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.CircuitBreakerMetricTest"/>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.ClassLevelMetricTest"/>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.ClashingNameTest"/>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.MetricsDisabledTest"/>
+        </classes>
+    </test>
+</suite>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/tck-suite-lite.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/tck-suite-lite.xml
@@ -11,47 +11,214 @@
     configfailurepolicy="continue">
 
     <test name="microprofile-faulttolerance 2.0 TCK">
-        <method-selectors>
-            <method-selector>
-                <script language="beanshell">
-                     <!-- Some tests are sensitive to timing and can spuriously fail on slow build machines. -->
-                     <!-- We exclude all of these tests when running in lite mode -->
-                     <![CDATA[
-                     // All of these bulkhead tests are susceptable to timing issues or "not being parallel enough"
-                     // BulkheadAsynchTest
-                     !method.getName().startsWith("testBulkheadClassAsynchronous10") &&
-                     !method.getName().startsWith("testBulkheadMethodAsynchronous10") &&
-                     !method.getName().startsWith("testBulkheadClassAsynchronous3") &&
-                     !method.getName().startsWith("testBulkheadMethodAsynchronous3") &&
-                     !method.getName().startsWith("testBulkheadClassAsynchronousDefault") &&
-                     !method.getName().startsWith("testBulkheadMethodAsynchronousDefault") &&
-                     !method.getName().startsWith("testBulkheadClassAsynchronousQueueing10") &&
-                     !method.getName().startsWith("testBulkheadMethodAsynchronousQueueing10") &&
-                     
-                     // BulkheadAsynchRetryTest
-                     !method.getName().startsWith("testBulkheadClassAsynchronousPassiveRetry55") &&
-                     !method.getName().startsWith("testBulkheadMethodAsynchronousRetry55") &&
-                     !method.getName().startsWith("testBulkheadMethodAsynchronousRetry55Trip") &&
-                     !method.getName().startsWith("testBulkheadMethodAsynchronous55RetryOverload") &&
-                     !method.getName().startsWith("testBulkheadClassAsynchronous55RetryOverload") &&
-                     !method.getName().startsWith("testBulkheadPassiveRetryMethodAsynchronous55") &&
-                     !method.getName().startsWith("testBulkheadRetryClassAsynchronous55") &&
-                     !method.getName().startsWith("testBulkheadQueReplacesDueToClassRetryFailures") &&
-                     !method.getName().startsWith("testNoRetriesWithoutRetryOn") &&
-                     !method.getName().startsWith("testNoRetriesWithAbortOn") &&
-                     
-                     // BulkheadFutureTest
-                     !method.getDeclaringClass().getSimpleName().equals("BulkheadFutureTest")
-                     
-                     // Note: BulkheadSynchRetryTest and BulkheadSynchTest look vulnerable to the same issues but we haven't seen them fail
-                ]]>
-                </script>
-            </method-selector>
-        </method-selectors>
+        <classes>
+            <!-- Reduced test list for lite mode, retains coverage of core functionality -->
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsyncCancellationTest">
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsyncFallbackTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousCSTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsyncTimeoutTest">
+                <methods>
+                    <include name="testAsyncTimeout"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerBulkheadTest">
+                <methods>
+                    <include name="testCircuitBreakerAroundBulkheadSync"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest">
+                <methods>
+                    <exclude name="testRetriesSucceedWhenCircuitCloses"/>
+                    <exclude name="testRetriesSucceedWhenCircuitClosesAsync"/>
+                    <exclude name="testCircuitOpenWithMultiTimeouts"/>
+                    <exclude name="testCircuitOpenWithMultiTimeoutsAsync"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest">
+                <methods>
+                    <exclude name="testCircuitDefaultSuccessThreshold"/>
+                    <exclude name="testClassLevelCircuitOverrideNoDelay"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTimeoutTest">
+                <methods>
+                    <include name="testTimeout"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.ConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest">
+                <methods>
+                    <exclude name="testRetryParallelExceptionally"/>
+                    <exclude name="testRetryChainExceptionally"/>
+                    <exclude name="testRetryChainSuccess"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryTest">
+                <methods>
+                    <include name="testRetryMaxRetries"/>
+                    <include name="testRetryMaxDuration"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryTimeoutTest">
+                <methods>
+                    <include name="testRetryTimeout"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.TimeoutGlobalConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest">
+                <methods>
+                    <include name="testTimeout"/>
+                    <include name="testTimeoutClassLevel"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.TimeoutUninterruptableTest">
+                <methods>
+                    <include name="testTimeout"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.ZeroRetryJitterTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest">
+                <methods>
+                    <include name="testBulkheadRetryClassAsynchronous55"/>
+                    <include name="testBulkheadQueReplacesDueToClassRetryFailures"/>
+                    <include name="testRetriesReenterBulkhead"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest">
+                <methods>
+                    <include name="testBulkheadExceptionThrownWhenQueueFullAsync"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadFutureTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchRetryTest">
+                <methods>
+                    <include name="testBulkheadRetryClassSynchronous55"></include>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchTest">
+                <methods>
+                    <include name="testBulkheadMethodSemaphore10"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.interceptor.ftPriorityChange.FaultToleranceInterceptorPriorityChangeAnnotationConfTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.AllMetricsTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.BulkheadMetricTest">
+                <methods>
+                    <include name="bulkheadMetricTest"/>
+                    <include name="bulkheadMetricRejectionTest"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.CircuitBreakerMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.ClashingNameTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.ClassLevelMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.FallbackMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.MetricsDisabledTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest"></class>
+        </classes>
         
-        <packages>
-            <package name="org.eclipse.microprofile.fault.tolerance.tck.*">
-            </package>
-        </packages>
+        <!-- Full class list for 2.0 TCK:
+        <classes>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsyncCancellationTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsyncFallbackTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsyncTimeoutTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousCSTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerBulkheadTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerInitialSuccessTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerLateSuccessTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTimeoutTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.ConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryTimeoutTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.TimeoutGlobalConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.TimeoutMethodConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.TimeoutUninterruptableTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.ZeroRetryJitterTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadFutureTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchRetryTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.CircuitBreakerConfigGlobalTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.CircuitBreakerConfigOnMethodTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.config.ConfigPropertyGlobalVsClassTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.config.ConfigPropertyGlobalVsClassVsMethodTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.config.ConfigPropertyOnClassAndMethodTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassDisableOnMethod"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnMethodTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassEnableOnMethodTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnMethodsTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableGloballyTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnClassTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnMethodTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodAbstractTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodBasicTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodDefaultMethodTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericAbstractTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericArrayTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericComplexTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericDeepTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericWildcardTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodInPackageTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodInterfaceTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodOutOfPackageTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodPrivateTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodSubclassOverrideTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodSubclassTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodSuperclassPrivateTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodSuperclassTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodVarargsTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodWildcardNegativeTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodWildcardTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackMethodTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackMethodWithArgsTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackPolicies"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.interceptor.FaultToleranceInterceptorTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.interceptor.ftPriorityChange.FaultToleranceInterceptorPriorityChangeAnnotationConfTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling.FaultToleranceInterceptorEnableByXmlTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidAsynchronousClassTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidAsynchronousMethodTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidBulkheadAsynchQueueTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidBulkheadValueTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerDelayTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureRatioNegTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureRatioPosTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureReqVol0Test"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureReqVolNegTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureSuccess0Test"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureSuccessNegTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryDelayDurationTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryDelayTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryJitterTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryMaxRetriesTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidTimeoutValueTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.AllMetricsTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.BulkheadMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.CircuitBreakerMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.ClashingNameTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.ClassLevelMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.FallbackMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.MetricsDisabledTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.TimeoutMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest"></class>
+        </classes>
+        -->
     </test>
 </suite>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/publish/tckRunner/tck/tck-suite-lite.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/publish/tckRunner/tck/tck-suite-lite.xml
@@ -11,47 +11,234 @@
     configfailurepolicy="continue">
 
     <test name="microprofile-faulttolerance 2.1 TCK">
-        <method-selectors>
-            <method-selector>
-                <script language="beanshell">
-                     <!-- Some tests are sensitive to timing and can spuriously fail on slow build machines. -->
-                     <!-- We exclude all of these tests when running in lite mode -->
-                     <![CDATA[
-                     // All of these bulkhead tests are susceptable to timing issues or "not being parallel enough"
-                     // BulkheadAsynchTest
-                     !method.getName().startsWith("testBulkheadClassAsynchronous10") &&
-                     !method.getName().startsWith("testBulkheadMethodAsynchronous10") &&
-                     !method.getName().startsWith("testBulkheadClassAsynchronous3") &&
-                     !method.getName().startsWith("testBulkheadMethodAsynchronous3") &&
-                     !method.getName().startsWith("testBulkheadClassAsynchronousDefault") &&
-                     !method.getName().startsWith("testBulkheadMethodAsynchronousDefault") &&
-                     !method.getName().startsWith("testBulkheadClassAsynchronousQueueing10") &&
-                     !method.getName().startsWith("testBulkheadMethodAsynchronousQueueing10") &&
-                     
-                     // BulkheadAsynchRetryTest
-                     !method.getName().startsWith("testBulkheadClassAsynchronousPassiveRetry55") &&
-                     !method.getName().startsWith("testBulkheadMethodAsynchronousRetry55") &&
-                     !method.getName().startsWith("testBulkheadMethodAsynchronousRetry55Trip") &&
-                     !method.getName().startsWith("testBulkheadMethodAsynchronous55RetryOverload") &&
-                     !method.getName().startsWith("testBulkheadClassAsynchronous55RetryOverload") &&
-                     !method.getName().startsWith("testBulkheadPassiveRetryMethodAsynchronous55") &&
-                     !method.getName().startsWith("testBulkheadRetryClassAsynchronous55") &&
-                     !method.getName().startsWith("testBulkheadQueReplacesDueToClassRetryFailures") &&
-                     !method.getName().startsWith("testNoRetriesWithoutRetryOn") &&
-                     !method.getName().startsWith("testNoRetriesWithAbortOn") &&
-                     
-                     // BulkheadFutureTest
-                     !method.getDeclaringClass().getSimpleName().equals("BulkheadFutureTest")
-                     
-                     // Note: BulkheadSynchRetryTest and BulkheadSynchTest look vulnerable to the same issues but we haven't seen them fail
-                ]]>
-                </script>
-            </method-selector>
-        </method-selectors>
+        <classes>
+            <!-- Reduced test list for lite mode, retains coverate of core and new functionality -->
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsyncCancellationTest">
+                <methods>
+                    <include name="testCancel"/>
+                    <include name="testCancelledDoesNotRetry"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsyncFallbackTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsyncTimeoutTest">
+                <methods>
+                    <include name="testAsyncTimeout"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousCSTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerBulkheadTest">
+                <methods>
+                    <include name="testCircuitBreakerAroundBulkheadSync"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest"></class> <!-- new functionality -->
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest">
+                <methods>
+                    <exclude name="testRetriesSucceedWhenCircuitCloses"/>
+                    <exclude name="testRetriesSucceedWhenCircuitClosesAsync"/>
+                    <exclude name="testCircuitOpenWithMultiTimeouts"/>
+                    <exclude name="testCircuitOpenWithMultiTimeoutsAsync"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest">
+                <methods>
+                    <exclude name="testCircuitDefaultSuccessThreshold"/>
+                    <exclude name="testClassLevelCircuitOverrideNoDelay"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest">
+                <methods>
+                    <exclude name="testRetryParallelExceptionally"/>
+                    <exclude name="testRetryChainExceptionally"/>
+                    <exclude name="testRetryChainSuccess"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest"></class> <!-- new functionality -->
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryTest">
+                <methods>
+                    <include name="testRetryMaxRetries"/>
+                    <include name="testRetryMaxDuration"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryTimeoutTest">
+                <methods>
+                    <include name="testRetryTimeout"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest">
+                <methods>
+                    <include name="testTimeout"/>
+                    <include name="testTimeoutClassLevel"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.TimeoutUninterruptableTest">
+                <methods>
+                    <include name="testTimeout"/>
+                    <include name="testTimeoutAsync"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.ZeroRetryJitterTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest">
+                <methods>
+                    <include name="testBulkheadRetryClassAsynchronous55"/>
+                    <include name="testBulkheadQueReplacesDueToClassRetryFailures"/>
+                    <include name="testRetriesReenterBulkhead"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest">
+                <methods>
+                    <include name="testBulkheadExceptionThrownWhenQueueFullAsync"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadFutureTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchRetryTest">
+                <methods>
+                    <include name="testBulkheadRetryClassSynchronous55"></include>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchTest">
+                <methods>
+                    <include name="testBulkheadMethodSemaphore10"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.CircuitBreakerConfigGlobalTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.CircuitBreakerConfigOnMethodTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.config.CircuitBreakerConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.config.CircuitBreakerSkipOnConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackApplyOnConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackSkipOnConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.interceptor.FaultToleranceInterceptorTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.AllMetricsTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.BulkheadMetricTest">
+                <methods>
+                    <include name="bulkheadMetricTest"/>
+                    <include name="bulkheadMetricRejectionTest"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.CircuitBreakerMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.ClassLevelMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.FallbackMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.MetricsDisabledTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.TimeoutMetricTest">
+                <methods>
+                    <include name="testTimeoutMetric"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest"></class>
+        </classes>
         
-        <packages>
-            <package name="org.eclipse.microprofile.fault.tolerance.tck.*">
-            </package>
-        </packages>
+        <!-- Full class list for FT 2.1 TCK
+        <classes>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsyncCancellationTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsyncFallbackTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsyncTimeoutTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousCSTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerBulkheadTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerInitialSuccessTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerLateSuccessTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTimeoutTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.ConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryTimeoutTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.TimeoutGlobalConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.TimeoutMethodConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.TimeoutUninterruptableTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.ZeroRetryJitterTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadFutureTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchRetryTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.CircuitBreakerConfigGlobalTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.CircuitBreakerConfigOnMethodTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.config.CircuitBreakerConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.config.CircuitBreakerSkipOnConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.config.ConfigPropertyGlobalVsClassTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.config.ConfigPropertyGlobalVsClassVsMethodTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.config.ConfigPropertyOnClassAndMethodTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackApplyOnConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackSkipOnConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassDisableOnMethod"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnClassTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyEnableOnMethodTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationGloballyTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassEnableOnMethodTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnClassTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableAnnotationOnMethodsTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableGloballyTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnClassTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableFTEnableOnMethodTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodAbstractTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodBasicTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodDefaultMethodTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericAbstractTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericArrayTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericComplexTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericDeepTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodGenericWildcardTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodInPackageTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodInterfaceTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodOutOfPackageTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodPrivateTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodSubclassOverrideTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodSubclassTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodSuperclassPrivateTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodSuperclassTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodVarargsTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodWildcardNegativeTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodWildcardTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackMethodTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackMethodWithArgsTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackPolicies"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.interceptor.FaultToleranceInterceptorTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.interceptor.ftPriorityChange.FaultToleranceInterceptorPriorityChangeAnnotationConfTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling.FaultToleranceInterceptorEnableByXmlTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidAsynchronousClassTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidAsynchronousMethodTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidBulkheadAsynchQueueTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidBulkheadValueTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerDelayTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureRatioNegTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureRatioPosTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureReqVol0Test"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureReqVolNegTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureSuccess0Test"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureSuccessNegTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryDelayDurationTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryDelayTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryJitterTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryMaxRetriesTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidTimeoutValueTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.AllMetricsTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.BulkheadMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.CircuitBreakerMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.ClashingNameTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.ClassLevelMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.FallbackMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.MetricsDisabledTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.TimeoutMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest"></class>
+        </classes>
+        -->
     </test>
 </suite>

--- a/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/fat/src/com/ibm/ws/microprofile/faulttolerance/tck/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,20 +10,11 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.faulttolerance.tck;
 
-import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
-
 @RunWith(Suite.class)
 @SuiteClasses({ FaultToleranceTckLauncher.class })
 public class FATSuite {
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE8_FEATURES());
-
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/publish/tckRunner/tck/tck-suite-lite.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/publish/tckRunner/tck/tck-suite-lite.xml
@@ -1,0 +1,57 @@
+<!-- Licensed under the Apache License, Version 2.0 (the "License"); you 
+    may not use this file except in compliance with the License. You may obtain 
+    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless 
+    required by applicable law or agreed to in writing, software distributed 
+    under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
+    OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
+    the specific language governing permissions and limitations under the License. -->
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="microprofile-faulttolerance-TCK" verbose="2"
+    configfailurepolicy="continue">
+
+    <test name="microprofile-faulttolerance 1.0 TCK">
+        <method-selectors>
+            <method-selector>
+                <script language="beanshell">
+                     <!-- Some tests are sensitive to timing and can spuriously fail on slow build machines. -->
+                     <!-- We exclude all of these tests, but most of them were fixed in the 2.0 TCK and we run them from the 2.0 TCK project -->
+                     <![CDATA[
+                     // RetryTest
+                     !method.getName().startsWith("testRetryMaxDuration") &&
+                     !method.getName().startsWith("testRetryMaxDurationSeconds") &&
+                     !method.getName().startsWith("testRetryWithDelay") &&
+                     !method.getName().startsWith("testRetryWithNoDelayAndJitter") &&
+                     !method.getName().startsWith("testClassLevelRetryMaxDuration") &&
+                     !method.getName().startsWith("testClassLevelRetryMaxDurationSeconds") &&
+                     
+                     // CircuitBreakerRetryTest
+                     !method.getName().startsWith("testCircuitOpenWithMultiTimeouts") &&
+                     !method.getName().startsWith("testCircuitOpenWithMultiTimeoutsAsync") &&
+                     
+                     // ConfigTest
+                     !method.getName().startsWith("testConfigMaxDuration") &&
+                     !method.getName().startsWith("testClassLevelConfigMaxDuration") &&
+                     
+                     // FallbackTest
+                     !method.getName().startsWith("testFallbackTimeout") &&
+                     !method.getName().startsWith("testFallbacktNoTimeout") &&
+                     
+                     // RetryTimeoutTest
+                     !method.getDeclaringClass().getSimpleName().equals("RetryTimeoutTest")
+                     
+                     // Note: TimeoutTest is inherently timing sensitive, but we haven't seen it fail
+                ]]>
+                </script>
+            </method-selector>
+        </method-selectors>
+        <packages>
+            <!-- This package contains tests for all core functionality except Bulkhead -->
+            <package name="org.eclipse.microprofile.fault.tolerance.tck"></package>
+        </packages>
+        <classes>
+            <!-- Include basic Sync Bulkhead tests. All the async tests are not reliable in the 1.0 TCK -->
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchTest"></class>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
For #12683 

When the Fault Tolerance TCK tests run in LITE mode, run only a subset of tests which cover the core functionality.

It's essential to keep running the TCK tests in LITE mode because they cover some areas which are not covered at all by our FAT tests (since we've opted to contribute tests to the TCK in preference to writing them specifically for open liberty where that is appropriate).

Update - run times from personal builds:
1.0 - 5m51s
1.1 - 8m18s
2.0 - 8m08s
2.1 - 8m45s