### PR TITLE
Remove duplicate tests and move some tests to FULL mode

### DIFF
--- a/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/AppManagerConstants.java
+++ b/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/AppManagerConstants.java
@@ -30,5 +30,6 @@ public interface AppManagerConstants {
     public static final String AUTO_INSTALL_PROP = ".installedByDropins";
     public static final String USE_JANDEX = "useJandex";
     public static final String XML_SUFFIX = ".xml";
-    public static final Object START_AFTER = "startAfter";
+    public static final String START_AFTER = "startAfter";
+    public static final String START_AFTER_REF = "startAfterRef";
 }

--- a/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/ApplicationConfig.java
+++ b/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/ApplicationConfig.java
@@ -202,6 +202,9 @@ public final class ApplicationConfig {
         String[] resultPids = null;
         if (_config != null) {
             resultPids = (String[]) _config.get(AppManagerConstants.START_AFTER);
+            if (resultPids == null) {
+                resultPids = (String[]) _config.get(AppManagerConstants.START_AFTER_REF);
+            }
         }
 
         if (resultPids == null)

--- a/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/AppOrderTests.java
+++ b/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/AppOrderTests.java
@@ -27,6 +27,8 @@ import com.ibm.ws.fat.util.jmx.mbeans.ApplicationMBean;
 import com.ibm.ws.fat.util.jmx.mbeans.ApplicationMBean.ApplicationState;
 
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
@@ -81,6 +83,7 @@ public class AppOrderTests extends AbstractAppManagerTest {
     }
 
     @Test
+    @Mode(TestMode.FULL)
     public void testAppOrderCycle() throws Exception {
         final String method = testName.getMethodName();
 
@@ -166,6 +169,7 @@ public class AppOrderTests extends AbstractAppManagerTest {
     }
 
     @Test
+    @Mode(TestMode.FULL)
     public void testComplexAppOrder() throws Exception {
         final String method = testName.getMethodName();
 
@@ -192,6 +196,7 @@ public class AppOrderTests extends AbstractAppManagerTest {
     }
 
     @Test
+    @Mode(TestMode.FULL)
     public void testIndividualAppUpdate() throws Exception {
         final String method = testName.getMethodName();
 

--- a/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/FATTest.java
+++ b/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/FATTest.java
@@ -81,100 +81,6 @@ public class FATTest extends AbstractAppManagerTest {
      *
      * It then removes the applications at the end of the test.
      */
-    @Test
-    public void testStartStopFromXml() throws Exception {
-        final String method = testName.getMethodName();
-        try {
-            //load a new server xml
-            server.setServerConfigurationFile("/appsConfigured/server.xml");
-            //copy file to correct location
-            server.copyFileToLibertyServerRoot(PUBLISH_FILES, "apps",
-                                               SNOOP_WAR);
-            //copy invalid file to the second location we should check - it should not pick this file up!
-            server.copyFileToLibertyInstallRoot("usr/shared/apps",
-                                                "invalidSnoopWar/snoop.war");
-            server.startServer(method + ".log");
-            // Wait for the application to be installed before proceeding
-            assertNotNull("The snoop application never came up", server.waitForStringInLog("CWWKZ0001I.* snoop"));
-
-            URL url = new URL("http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/snoop");
-            Log.info(c, method, "Calling Snoop Application with URL=" + url.toString());
-            //check application is installed
-            HttpURLConnection con = HttpUtils.getHttpConnection(url, HttpURLConnection.HTTP_OK, CONN_TIMEOUT);
-            BufferedReader br = HttpUtils.getConnectionStream(con);
-            String line = br.readLine();
-            assertTrue("The response did not contain the \'Snoop Servlet\'",
-                       line.contains("Snoop Servlet"));
-            con.disconnect();
-
-            //application is working, so now remove it from the install location (we should get an error message)
-            boolean deleted = deleteFile(server.getMachine(),
-                                         server.getInstallRoot() + "/usr/shared/apps/snoop.war");
-
-            //application is working, so now remove it from the install location (we should get an error message)
-            deleted &= deleteFile(server.getMachine(), server.getServerRoot() + "/apps/snoop.war");
-
-            if (!deleted) {
-                // If we can't delete files the test is worthless. This tends to happen on Windows randomly.
-                Log.info(c, method, "WARNING: Exiting from test early because files could not be deleted.");
-                return;
-            }
-
-            assertNotNull("The snoop application was not stopped when removed",
-                          server.waitForStringInLog("CWWKZ0059E.* snoop"));
-
-            assertNotNull("The snoop application was not removed from the web container when stopped",
-                          server.waitForStringInLog("CWWKT0017I.*snoop.*"));
-
-            try {
-                //check that the application won't load in the web container once stopped
-                Log.info(c, method, "Calling Snoop Application with URL=" + url.toString() + ", expecting no response.");
-                con = HttpUtils.getHttpConnection(url, HttpURLConnection.HTTP_NOT_FOUND, CONN_TIMEOUT);
-                br = HttpUtils.getConnectionStream(con);
-                line = br.readLine();
-                assertFalse("The response did contain the \'Snoop Servlet\' when it shouldn't",
-                            line.contains("Snoop Servlet"));
-                con.disconnect();
-
-            } catch (java.io.FileNotFoundException ex) {
-                //expected if the web container has unloaded the page already (it could be blank or not there)
-            }
-
-            //re-add the application to make sure it resumes working
-            server.setMarkToEndOfLog();
-            server.copyFileToLibertyServerRoot(PUBLISH_FILES, "tmp",
-                                               SNOOP_WAR);
-
-            //unzip the application into a temp location so that we can easily modify the application in a minute
-            TestUtils.unzip(new File(server.getServerRoot() + "/tmp/snoop.war"),
-                            new File(server.getServerRoot() + "/tmp/unzip/snoop.war"));
-
-            // Copy the expanded snoop.war to "apps"
-            server.renameLibertyServerRootFile("tmp/unzip/snoop.war", "apps/snoop.war");
-
-            //make sure the started message has been output twice by the server (once earlier, once now).
-            assertNotNull("The snoop application never resumed running after being stopped",
-                          server.waitForStringInLog("CWWKZ0003I.* snoop"));
-
-            //add a file to the extracted snoop application
-            server.setMarkToEndOfLog();
-            server.copyFileToLibertyServerRoot("/apps/snoop.war/",
-                                               "updatedApplications/blankFile.txt");
-
-            //make sure it loads into the web front end correctly again
-            con = HttpUtils.getHttpConnection(url, HttpURLConnection.HTTP_OK, CONN_TIMEOUT);
-            br = HttpUtils.getConnectionStream(con);
-            line = br.readLine();
-            assertTrue("The response did not contain the \'Snoop Servlet\'",
-                       line.contains("Snoop Servlet"));
-            con.disconnect();
-        } finally {
-            pathsToCleanup.add(server.getServerRoot() + "/apps");
-            pathsToCleanup.add(server.getServerRoot() + "/tmp");
-            pathsToCleanup.add(server.getInstallRoot() + "/usr/shared/apps/snoop.war");
-            server.stopServer("CWWKZ0059E", "CWWKZ0014W");
-        }
-    }
 
     @Test
     @Mode(TestMode.FULL)
@@ -277,6 +183,7 @@ public class FATTest extends AbstractAppManagerTest {
     }
 
     @Test
+    @Mode(TestMode.FULL)
     public void testSymbolicLinkInLooseApp() throws Exception {
         File link = new File("/bin/ln");
         if (link.exists() && link.canExecute()) {
@@ -360,6 +267,7 @@ public class FATTest extends AbstractAppManagerTest {
      * It then removes the applications at the end of the test.
      */
     @Test
+    @Mode(TestMode.FULL)
     public void testYouCannotDeployTwoAppsWithTheSameName() throws Exception {
         final String method = testName.getMethodName();
         try {
@@ -482,39 +390,6 @@ public class FATTest extends AbstractAppManagerTest {
      * application (one which does not exist) correctly.
      */
     @Test
-    public void testConfigureMissingApplication() throws Exception {
-        final String method = testName.getMethodName();
-
-        //load a new server xml
-        server.setServerConfigurationFile("/appsConfigured/server.xml");
-
-        server.startServer(method + ".log", true);
-        // Wait for the application to be installed before proceeding
-        assertNotNull("Snoop application start failure message not found", server.waitForStringInLog("CWWKZ0014W.* snoop"));
-
-        URL url = new URL("http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/snoop");
-        Log.info(c, method, "Calling Snoop Application with URL=" + url.toString());
-        try {
-            //check application is not installed
-            HttpURLConnection con = HttpUtils.getHttpConnection(url, HttpURLConnection.HTTP_NOT_FOUND, CONN_TIMEOUT);
-            BufferedReader br = HttpUtils.getConnectionStream(con);
-            String line = br.readLine();
-            fail("was expecting exception, but got nothing! In fact we got text output as: " + line);
-            con.disconnect();
-        } catch (FileNotFoundException e) {
-            //expected.
-        } catch (Exception e) {
-            fail("unexpected exception thrown. Expecting FileNotFoundException, got: " + e.getMessage());
-        }
-
-        server.stopServer("CWWKZ0014W");
-    }
-
-    /**
-     * This tests to see that the application manager handles being given an invalid
-     * application (one which does not exist) correctly.
-     */
-    @Test
     @Mode(TestMode.FULL)
     public void testConfigureMissingApplicationFull() throws Exception {
         final String method = testName.getMethodName();
@@ -545,6 +420,7 @@ public class FATTest extends AbstractAppManagerTest {
     }
 
     @Test
+    @Mode(TestMode.FULL)
     public void testConfigureInvalidApplication() throws Exception {
         final String method = testName.getMethodName();
 
@@ -567,7 +443,7 @@ public class FATTest extends AbstractAppManagerTest {
     }
 
     /**
-     * This is a test for defect 48922 to make sure that when application monitor is enabled on a directory and the directory changes in the server.xml then the application is
+     * This is a test to make sure that when application monitor is enabled on a directory and the directory changes in the server.xml then the application is
      * removed
      */
     @Test
@@ -715,20 +591,11 @@ public class FATTest extends AbstractAppManagerTest {
     }
 
     @Test
+    @Mode(TestMode.FULL)
     public void testDataSourceStillUsableByAppDuringServerShutdown() throws Exception {
         final String method = testName.getMethodName();
 
         try {
-
-            //ensure that derby.jar is available in the server_home/derby directory
-//            File derbyDir = new File(server.getServerRoot(), DERBY_DIR);
-//            if (!derbyDir.exists())
-//                assertTrue("Unable to create derby directory", derbyDir.mkdir());
-//            File derbyJar = new File(derbyDir, "derby.jar");
-//            if (!derbyJar.exists()) {
-//                server.copyFileToLibertyServerRoot(DERBY_DIR, "dataSourceApp/derby.jar");
-//            }
-//            assertTrue("derby.jar not available for JDBC driver: " + derbyJar.getAbsolutePath(), derbyJar.exists());
 
             //make sure we are using the correct server configuration before starting the server
             server.setServerConfigurationFile("/dataSourceApp/server.xml");


### PR DESCRIPTION
The app manager FAT is taking too long to run. We have some duplicate tests that can be removed, and some error scenarios can be moved to FULL mode. 