### PR TITLE
Fix SimpleTag and JSPFragment transformations, Add Constant String Tr…

### DIFF
--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/BaseTagGenerator.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/BaseTagGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2007 IBM Corporation and others.
+ * Copyright (c) 1997, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -213,7 +213,9 @@ public abstract class BaseTagGenerator implements TagGenerator {
                 if (!(jspOptions.isAllowNullParentInTagFile())) {
                 	writer.print(tagHandlerVar);
                 	writer.print(".setParent(new javax.servlet.jsp.tagext.TagAdapter(");
-                	writer.print("(javax.servlet.jsp.tagext.SimpleTag) this ));");
+                	writer.print("(");
+                	writer.print("javax.servlet.jsp.tagext.SimpleTag");
+                	writer.print(") this ));");
                 } else {
                     writer.print(tagHandlerVar);
                     writer.print(".setParent(");
@@ -233,7 +235,9 @@ public abstract class BaseTagGenerator implements TagGenerator {
                     writer.print(tagHandlerVar);
                     writer.print(".setParent(");
                     writer.print("new javax.servlet.jsp.tagext.TagAdapter(");
-                    writer.print("(javax.servlet.jsp.tagext.SimpleTag) ");
+                    writer.print("(");
+                    writer.print("javax.servlet.jsp.tagext.SimpleTag");
+                    writer.print(") ");
                     writer.print(parentTagInstanceInfo.getTagHandlerVar());
                     writer.println("));");
                 }
@@ -253,7 +257,9 @@ public abstract class BaseTagGenerator implements TagGenerator {
             else if (isTagFile && !(jspOptions.isAllowNullParentInTagFile())) {
                 writer.print(tagHandlerVar);
                 writer.print(".setParent(new javax.servlet.jsp.tagext.TagAdapter(");
-                writer.print("(javax.servlet.jsp.tagext.SimpleTag) this ));");
+                writer.print("(");
+                writer.print("javax.servlet.jsp.tagext.SimpleTag");
+                writer.print(") this ));");
             }
             //PK62809 end
             else {

--- a/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/GenerateTagFileVisitor.java
+++ b/dev/com.ibm.ws.jsp/src/com/ibm/ws/jsp/translator/visitor/generator/GenerateTagFileVisitor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2004 IBM Corporation and others.
+ * Copyright (c) 1997, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -347,7 +347,8 @@ public class GenerateTagFileVisitor extends GenerateVisitor {
                 writer.print("public void ");
                 writer.print(GeneratorUtils.toSetterMethodName(attrInfos[i].getName()));
                 if (attrInfos[i].isFragment()) {
-                    writer.print("(javax.servlet.jsp.tagext.JspFragment ");
+                    writer.print("(");
+                    writer.print("javax.servlet.jsp.tagext.JspFragment ");
                 }
                 else {
                     writer.print("(");

--- a/dev/wlp-jakartaee-transform/rules/jakarta-direct.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-direct.properties
@@ -1,0 +1,32 @@
+# Direct String Replacement
+# (OL #12622)
+javax.servlet.jsp.tagext.JspFragment=jakarta.servlet.jsp.tagext.JspFragment
+javax.servlet.jsp.tagext.SimpleTag=jakarta.servlet.jsp.tagext.SimpleTag
+javax.servlet.forward.request_uri=jakarta.servlet.forward.request_uri
+javax.servlet.include.request_uri=jakarta.servlet.include.request_uri
+javax.servlet.async.request_uri=jakarta.servlet.async.request_uri
+javax.servlet.include.servlet_path=jakarta.servlet.include.servlet_path
+javax.servlet.include.path_info=jakarta.servlet.include.path_info
+javax.servlet.forward.seen=jakarta.servlet.forward.seen
+javax.servlet.context.tempdir=jakarta.servlet.context.tempdir
+
+# WebConatiner Constants (OL #12623)
+javax.servlet.request.ssl_session_id=jakarta.servlet.request.ssl_session_id
+javax.servlet.forward.servlet_path=jakarta.servlet.forward.servlet_path
+javax.servlet.forward.request_uri=jakarta.servlet.forward.request_uri
+javax.servlet.forward.context_path=jakarta.servlet.forward.context_path
+javax.servlet.forward.path_info =jakarta.servlet.forward.path_info
+javax.servlet.forward.query_string=jakarta.servlet.forward.query_strin
+javax.servlet.include.servlet_path=jakarta.servlet.include.servlet_path
+javax.servlet.include.request_uri=jakarta.servlet.include.request_uri
+javax.servlet.include.context_path=jakarta.servlet.include.context_path
+javax.servlet.include.path_info =jakarta.servlet.include.path_info
+javax.servlet.include.query_string =jakarta.servlet.include.query_string
+javax.servlet.async.servlet_path=jakarta.servlet.async.servlet_path
+javax.servlet.async.request_uri=jakarta.servlet.async.request_uri
+javax.servlet.async.context_path=jakarta.servlet.async.context_path
+javax.servlet.async.path_info =jakarta.servlet.async.path_info
+javax.servlet.async.query_string=jakarta.servlet.async.query_string
+javax.servlet.include.mapping=jakarta.servlet.include.mapping
+javax.servlet.forward.mapping=jakarta.servlet.forward.mapping
+javax.servlet.async.mapping=jakarta.servlet.async.mapping

--- a/dev/wlp-jakartaee-transform/rules/jakarta-renames.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-renames.properties
@@ -47,7 +47,6 @@ javax.servlet.jsp.jstl.sql=jakarta.servlet.jsp.jstl.sql
 javax.servlet.jsp.jstl.tlv=jakarta.servlet.jsp.jstl.tlv
 javax.servlet.jsp.jstl=jakarta.servlet.jsp.jstl
 javax.servlet.jsp.resources=jakarta.servlet.jsp.resources
-javax.servlet.jsp.tagext.JspFragment=jakarta.servlet.jsp.tagext.JspFragment
 javax.servlet.jsp.tagext=jakarta.servlet.jsp.tagext
 javax.servlet.jsp=jakarta.servlet.jsp
 javax.servlet.resources=jakarta.servlet.resources


### PR DESCRIPTION
fixes #12623 
fixes #12622 

There appears to be a [bug in the transformer](https://github.com/eclipse/transformer/issues/79), so instead, I updated the JSP strings to print everything on separate lines.
```

        if (attrInfos[j].isFragment()) {
          this.writer.print(“jakarta.servlet.jsp.tagext.JspFragment “);  <--------------- CHANGED
        } else {
          this.writer.print(GeneratorUtils.toJavaSourceType(attrInfos[j].getTypeName()));
          this.writer.print(“ “);
        } 
        this.writer.print(GeneratorUtils.toGetterMethod(attrInfos[j].getName()));
        this.writer.print(“ {“);
        this.writer.println();
        this.writer.print(“return this.”);
        this.writer.print(attrInfos[j].getName());
        this.writer.print(“;”);
        this.writer.println();
        this.writer.println(“}”);
        this.writer.println();
        this.writer.print(“public void “);
        this.writer.print(GeneratorUtils.toSetterMethodName(attrInfos[j].getName()));
        if (attrInfos[j].isFragment()) {
          this.writer.print(“(javax.servlet.jsp.tagext.JspFragment “); <----------------- NOT CHANGED 
        } else {
```

Additionally, I updated the Constants to use jakarta. 