### PR TITLE
test precedence for identity name

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat/test-applications/concurrentSpec/src/fat/concurrent/spec/app/EEConcurrencyTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat/test-applications/concurrentSpec/src/fat/concurrent/spec/app/EEConcurrencyTestServlet.java
@@ -11,6 +11,7 @@
 package fat.concurrent.spec.app;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.Closeable;
@@ -522,7 +523,8 @@ public class EEConcurrencyTestServlet extends FATServlet {
 
         ManagedTaskListener listener = new ManagedTaskListener() {
             @Override
-            public void taskAborted(Future<?> future, ManagedExecutorService executor, Object task, Throwable x) {}
+            public void taskAborted(Future<?> future, ManagedExecutorService executor, Object task, Throwable x) {
+            }
 
             @Override
             public void taskDone(Future<?> future, ManagedExecutorService executor, Object task, Throwable x) {
@@ -2935,6 +2937,29 @@ public class EEConcurrencyTestServlet extends FATServlet {
         long delay = future.getDelay(TimeUnit.MILLISECONDS);
         if (delay > 0)
             throw new Exception("Completed future should not have a delay: " + delay);
+    }
+
+    /**
+     * Tests the precedence for the ManagedTask.IDENTITY_NAME execution property when different values are
+     * specified for the Jakarta vs Java EE constant for the same task. The enabled spec must take precedence.
+     */
+    @Test
+    public void testIdentityNamePrecedence() throws Exception {
+        String disabledSpecIdentityNameConstant = ManagedTask.class.getPackage().getName().startsWith("jakarta") //
+                        ? ManagedTask.IDENTITY_NAME.replace("jakarta", "javax") //
+                        : ManagedTask.IDENTITY_NAME.replace("javax", "jakarta");
+
+        GetIdentityName getIdentityName = new GetIdentityName();
+        getIdentityName.execProps.put(disabledSpecIdentityNameConstant, "testIdentityNamePrecedence-DoNotUse");
+        getIdentityName.execProps.put(ManagedTask.IDENTITY_NAME, "testIdentityNamePrecedence-Expected");
+
+        ScheduledFuture<String> future = mschedxsvcClassloaderContext.schedule(getIdentityName, getIdentityName);
+
+        final long TIMEOUT_NS = TimeUnit.MILLISECONDS.toNanos(TIMEOUT);
+        for (long start = System.nanoTime(); !future.isDone() && System.nanoTime() - start < TIMEOUT_NS; Thread.sleep(POLL_INTERVAL));
+
+        assertTrue(future.isDone());
+        assertEquals("testIdentityNamePrecedence-Expected", future.get());
     }
 
     /**
@@ -7854,7 +7879,7 @@ public class EEConcurrencyTestServlet extends FATServlet {
      * Verify that Liberty executor/scheduled executors are always returned ahead of managed ones from EE concurrency.
      * Verify that default instances are always returned ahead of a configured instances.
      *
-     * @param request HTTP request
+     * @param request  HTTP request
      * @param response HTTP response
      * @throws Exception if an error occurs.
      */

--- a/dev/com.ibm.ws.concurrent_fat/test-applications/concurrentSpec/src/fat/concurrent/spec/app/GetIdentityName.java
+++ b/dev/com.ibm.ws.concurrent_fat/test-applications/concurrentSpec/src/fat/concurrent/spec/app/GetIdentityName.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package fat.concurrent.spec.app;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.concurrent.Callable;
+
+import javax.enterprise.concurrent.LastExecution;
+import javax.enterprise.concurrent.ManagedTask;
+import javax.enterprise.concurrent.ManagedTaskListener;
+import javax.enterprise.concurrent.Trigger;
+
+/**
+ * Combination task/trigger that returns the identity name that is supplied to the Trigger
+ * by the managed scheduled executor. This enables us to test if the value specified for the IDENTITY_NAME
+ * execution property is honored. The trigger schedules itself to run just long enough to record the
+ * identity name, which should be 2 executions because the LastExecution is NULL until after the first execution.
+ */
+public class GetIdentityName implements Callable<String>, ManagedTask, Trigger {
+    final Map<String, String> execProps = new TreeMap<String, String>();
+    private final Set<String> identityNames = new TreeSet<String>();
+
+    @Override
+    public String call() {
+        if (identityNames.size() == 1)
+            return identityNames.iterator().next();
+        else
+            return identityNames.toString();
+    }
+
+    @Override
+    public Map<String, String> getExecutionProperties() {
+        return execProps;
+    }
+
+    @Override
+    public ManagedTaskListener getManagedTaskListener() {
+        return null;
+    }
+
+    @Override
+    public Date getNextRunTime(LastExecution lastExecution, Date taskScheduledTime) {
+        if (lastExecution == null)
+            return taskScheduledTime;
+        else {
+            Date nextRunTime = identityNames.isEmpty() ? new Date() : null;
+            identityNames.add(lastExecution.getIdentityName());
+            return nextRunTime;
+        }
+    }
+
+    @Override
+    public boolean skipRun(LastExecution lastExecution, Date scheduledRunTime) {
+        if (lastExecution != null)
+            identityNames.add(lastExecution.getIdentityName());
+        return false;
+    }
+}


### PR DESCRIPTION
Add test case to cover that ManagedTask.IDENTITY_NAME from Jakarta or Java EE is given precedence based on whether the concurrent-2.0 (Jakarta Concurrency) or concurrent-1.0 (Java EE Concurrency) feature is enabled.