### PR TITLE
Fix race condition committing kafka offsets

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/PartitionTracker.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/PartitionTracker.java
@@ -43,6 +43,10 @@ public class PartitionTracker {
         this.isClosed = new AtomicBoolean(false);
     }
 
+    public TopicPartition getTopicPartition() {
+        return topicPartition;
+    }
+
     /**
      * Records that the assigned partition has been revoked
      */


### PR DESCRIPTION
Fix #12780 

Fix a race condition where the partition could be revoked between us
checking if the partition had been revoked and us requesting a commit,
resulting in an unhelpful warning being emitted in the logs.

When we want to commit from an async thread, we were checking whether the partition was closed and then queuing an action to do the commit on the polling thread.

The fix moves the partition closed check inside the action (so it runs on the polling thread) and also ensures that any queued tasks will be given the chance to run before the partition is revoked.