### PR TITLE
update the resteasy.common bundle to handle the javaee apis removed from the jdk

### DIFF
--- a/dev/io.openliberty.org.jboss.resteasy.common/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.common/bnd.bnd
@@ -78,7 +78,14 @@ Export-Package: \
   org.jboss.resteasy.util.snapshot;version=4.5.2.Final, \
   org.jboss.resteasy.util;version=4.5.2.Final
 
+# Using version=! in order to not have a version attached to the import for packages that were removed
+# from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the
+# packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: \
+  javax.activation;version=!, \
+  javax.annotation;version=!, \
+  javax.annotation.security;version=!, \
+  javax.xml.bind.annotation;version=!, \
   *
 
 Include-Resource:\


### PR DESCRIPTION
I missed this piece when combing the resteasy bundles.
#12746