### PR TITLE
Add containsKey to reduce chances of hitting sync blocks

### DIFF
--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/WebContainer.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/WebContainer.java
@@ -1235,7 +1235,7 @@ public abstract class WebContainer extends BaseContainer {
         String cacheKeyStr = cacheKey.toString();
         // Servlet 4.0 : Use CacheServletWrapperFactory
         CacheServletWrapper wrapper =  cacheServletWrapperFactory.createCacheServletWrapper((IServletWrapper) s, req, cacheKeyStr, app);
-        if (_cacheMap.putIfAbsent(cacheKeyStr, wrapper) != null) {
+        if (_cacheMap.containsKey(cacheKeyStr) || _cacheMap.putIfAbsent(cacheKeyStr, wrapper) != null) {
             if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) //306998.15
             {
                 logger.logp(Level.FINE, CLASS_NAME, "addToCache", "Already cached cacheKey --> " + cacheKey);


### PR DESCRIPTION
Throughput profiles showing lock contention during WebContainer.addToCache. If we add a non-locking containsKey call before the putIfAbsent, we eliminate the contention on the ConcurrentMap.