### PR TITLE
MP Context Propagation 1.0 with Jakarta

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation-1.0/com.ibm.websphere.appserver.mpContextPropagation-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation-1.0/com.ibm.websphere.appserver.mpContextPropagation-1.0.feature
@@ -9,8 +9,8 @@ IBM-API-Package: \
   org.eclipse.microprofile.context; type="stable", \
   org.eclipse.microprofile.context.spi; type="stable"
 -features=\
-  com.ibm.websphere.appserver.concurrent-1.0, \
-  com.ibm.websphere.appserver.eeCompatible-8.0
+  com.ibm.websphere.appserver.concurrent-1.0; ibm.tolerates:=2.0, \
+  com.ibm.websphere.appserver.eeCompatible-8.0; ibm.tolerates:=9.0
 -bundles=\
   com.ibm.ws.require.java8, \
   com.ibm.ws.microprofile.contextpropagation.1.0

--- a/dev/com.ibm.ws.concurrent.mp_fat/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp_fat/bnd.bnd
@@ -23,6 +23,8 @@ src: \
 
 fat.project: true
 
+tested.features:cdi-3.0
+
 -buildpath: \
 	com.ibm.tx.core;version=latest,\
 	com.ibm.websphere.javaee.annotation.1.2;version=latest,\

--- a/dev/com.ibm.ws.concurrent.mp_fat/build.gradle
+++ b/dev/com.ibm.ws.concurrent.mp_fat/build.gradle
@@ -10,6 +10,7 @@
  *******************************************************************************/
 
 addRequiredLibraries.dependsOn addDerby
+addRequiredLibraries.dependsOn addJakartaTransformer
 
 dependencies {
   requiredLibs project(':com.ibm.ws.concurrent')

--- a/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2019 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,10 +17,10 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({
                 MPConcurrentTest.class,
-                MPConcurrentCDITest.class,
                 MPConcurrentConfigTest.class,
                 MPConcurrentJAXRSTest.class,
-                MPConcurrentTxTest.class
+                MPConcurrentTxTest.class,
+                MPConcurrentCDITest.class // moved last because @RepeatTests, when added to this class, interferes with test classes that run after it // TODO
 })
 public class FATSuite {
 }

--- a/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentCDITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.test.context.location.CityContextProvider;
 import org.test.context.location.StateContextProvider;
@@ -24,6 +25,8 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import concurrent.mp.fat.cdi.web.MPConcurrentCDITestServlet;
@@ -32,6 +35,11 @@ import concurrent.mp.fat.cdi.web.MPConcurrentCDITestServlet;
 public class MPConcurrentCDITest extends FATServletClient {
 
     private static final String CDI_APP = "MPConcurrentCDIApp";
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests
+                    .withoutModification();
+    // TODO                .andWith(new JakartaEE9Action());
 
     @Server("MPConcurrentCDITestServer")
     @TestServlet(servlet = MPConcurrentCDITestServlet.class, contextRoot = CDI_APP)

--- a/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentTxTestServer/server.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentTxTestServer/server.xml
@@ -15,7 +15,7 @@
         <feature>concurrent-2.0</feature>
         <feature>jdbc-4.2</feature>
         <feature>jndi-1.0</feature>
-        <feature>mpContextPropagation-1.1</feature>
+        <feature>mpContextPropagation-1.0</feature>
         <feature>servlet-5.0</feature>
     </featureManager>
     


### PR DESCRIPTION
Now that the eeCompatible features are consistently named across Jakarta/Java EE, update the mpContextPropagation-1.0 feature so that it can be used with Jakarta.