### PR TITLE
Handle missing remotablepartition table for sqlserver

### DIFF
--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/JPAPersistenceManagerImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/JPAPersistenceManagerImpl.java
@@ -3116,7 +3116,8 @@ public class JPAPersistenceManagerImpl extends AbstractPersistenceManager implem
                 final String causeMsg = cause.getMessage();
                 final String causeClassName = cause.getClass().getCanonicalName();
                 logger.fine("Next chained RemotablePartition persistence exception: exc class = " + causeClassName + "; causeMsg = " + causeMsg);
-                if ((cause instanceof SQLSyntaxErrorException || causeClassName.contains("SqlSyntaxErrorException")) &&
+                if ((cause instanceof SQLSyntaxErrorException || causeClassName.contains("SqlSyntaxErrorException")
+			|| causeClassName.contains("SQLServerException")) &&
                     causeMsg != null &&
                     (causeMsg.contains("REMOTABLEPARTITION") || causeMsg.contains("ORA-00942"))) {
                     // The table isn't there.


### PR DESCRIPTION
Fixes issue #12813 

Update runtime check to check for exception used by SQLServer

Personal build: https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.build.viewResult&id=_j7wWsLlCEeqsDL_UN9umug

