### PR TITLE
Issue 12576: Boulder with prune and improved cleanup

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/docker/boulder/BoulderContainer.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/docker/boulder/BoulderContainer.java
@@ -17,11 +17,13 @@ import java.time.Duration;
 import java.util.Map.Entry;
 
 import org.testcontainers.Testcontainers;
+import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 
 import com.github.dockerjava.api.model.ContainerNetwork;
 import com.github.dockerjava.api.model.ContainerNetwork.Ipam;
+import com.github.dockerjava.api.model.PruneType;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.acme.docker.CAContainer;
 
@@ -153,7 +155,6 @@ public class BoulderContainer extends CAContainer {
 		 * can pass the IP address of the DNS server to the Boulder server.
 		 */
 
-
 		/*
 		 * The excessive restarts and sleeps on bmysql are to avoid hitting
 		 * com.github.dockerjava.api.exception.DockerException:
@@ -161,86 +162,138 @@ public class BoulderContainer extends CAContainer {
 		 * build system is running fat tests in parallel. Usually, once we get the
 		 * database container running, we don't need restarts on the rest of the
 		 * containers.
+		 * 
+		 * If the test starts failing with "pool" errors, the docker container might
+		 * have a stale mariadb and/or boulder container running on it. Since the IP
+		 * addresses are hardcoded in the Boulder imaging we are using, we can't start
+		 * another container without conflicting with the stale container.
+		 * 
+		 * To clean:
+		 * 
+		 * You will need to have a docker client installed.
+		 * 
+		 * Check the output.txt for this, If you need to connect to any currently
+		 * running docker containers manually, export the following environment
+		 * variables in your terminal, and set the three variables in a terminal (swap
+		 * export to set for windows).
+		 * 
+		 * Now when you run docker commands, you will be connected to the remote
+		 * machine.
+		 * 
+		 * Run this to view the running containers:
+		 * 
+		 * > docker container ls
+		 * 
+		 * In the output, look for images with these names that are old (like > 1 hour)
+		 * mariaDB boulder letsencrypt
+		 * 
+		 * Copy the CONTAINER ID (first column) and then run
+		 * 
+		 * > docker container stop CONTAINER_ID
 		 */
-		initSQL();
-		for (int i = 0; i < (NUM_RESTART_ATTEMPTS_ON_EXCEPTION * 2); i++) {
-			try {
-				bmysql.start();
-
-				if (bmysql.isRunning()) {
-					break;
-				}
-				Log.info(BoulderContainer.class, "start",
-						"Failed to start bmysql, marked as not running, sleep and try again");
-			} catch (Throwable t) {
-				Log.error(BoulderContainer.class, "start", t, "Failed to start bmysql, sleep and try again.");
-			}
-
-			// clean up and reinitialize
-			bmysql.stop();
-			try {
-				bluenet.close();
-			} catch (Throwable bn) {
-				// may throw an NPE, but we don't care
-			}
-			bluenet = null;
-
-			try {
-				Thread.sleep(180000);
-			} catch (InterruptedException e) {
-			}
+		boolean everythingStarted = false;
+		try {
 			initSQL();
-		}
-		if (!bmysql.isRunning()) {
-			/*
-			 * One more try
-			 */
-			bmysql.start();
-		}
-
-		initSM();
-		for (int i = 1; i < NUM_RESTART_ATTEMPTS_ON_EXCEPTION + 1; i++) {
-			try {
-				bhsm.start();
-				break;
-			} catch (Throwable t) {
-				Log.error(BoulderContainer.class, "start", t, "Failed to start bhsm, try again.");
-			}
-			bhsm.stop();
-			initSM();
-			try {
-				Thread.sleep(120000 * i);
-			} catch (InterruptedException e) {
-			}
-		}
-		if (!bhsm.isRunning()) {
-			/*
-			 * One more try
-			 */
-			bhsm.start();
-		}
-
-		super.withStartupAttempts(WITH_STARTUP_ATTEMPTS);
-		for (int i = 1; i < NUM_RESTART_ATTEMPTS_ON_EXCEPTION + 1; i++) {
-			try {
-				super.start();
-				break;
-			} catch (Throwable t) {
-				Log.error(BoulderContainer.class, "start", t, "Failed to start boulder, try again.");
-				super.stop();
+			for (int i = 0; i < (NUM_RESTART_ATTEMPTS_ON_EXCEPTION * 2); i++) {
 				try {
+					bmysql.start();
+					break;
+				} catch (Throwable t) {
+					Log.error(BoulderContainer.class, "start", t, "Failed to start bmysql, sleep and try again.");
+
 					/*
-					 * On Windows, sometimes we get a java.lang.NoClassDefFoundError:
-					 * com/sun/jna/platform/win32/Kernel32 and a shorter sleep before a retry
-					 * normally works around it
+					 * clean up and reinitialize If we don't recreate bluenet from scratch, we'll
+					 * get a NPE on NetworkMode exception on restart
 					 */
-					Thread.sleep(t instanceof NoClassDefFoundError ? 10000 : (120000 * i));
-				} catch (InterruptedException e) {
+					bmysql.stop();
+					try {
+						bluenet.close();
+					} catch (Throwable bn) {
+						// may throw an NPE, but we don't care
+					}
+					bluenet = null;
+
+					try {
+						/*
+						 * On Windows, sometimes we get a java.lang.NoClassDefFoundError:
+						 * com/sun/jna/platform/win32/Kernel32 and a shorter sleep before a retry
+						 * normally works around it
+						 */
+						Thread.sleep(t instanceof NoClassDefFoundError ? 1000 : (120000));
+					} catch (InterruptedException e) {
+					}
+					initSQL();
 				}
 			}
-		}
-		if (!super.isRunning()) {
-			super.start();
+			if (!bmysql.isRunning()) {
+				/*
+				 * One more try
+				 */
+				bmysql.start();
+			}
+
+			initSM();
+			for (int i = 0; i < NUM_RESTART_ATTEMPTS_ON_EXCEPTION; i++) {
+				try {
+					bhsm.start();
+					break;
+				} catch (Throwable t) {
+					Log.error(BoulderContainer.class, "start", t, "Failed to start bhsm, try again.");
+
+					bhsm.stop();
+					initSM();
+					try {
+						Thread.sleep(t instanceof NoClassDefFoundError ? 1000 : (120000));
+					} catch (InterruptedException e) {
+					}
+				}
+			}
+			if (!bhsm.isRunning()) {
+				/*
+				 * One more try
+				 */
+				bhsm.start();
+			}
+
+			super.withStartupAttempts(WITH_STARTUP_ATTEMPTS);
+			for (int i = 0; i < NUM_RESTART_ATTEMPTS_ON_EXCEPTION; i++) {
+				try {
+					super.start();
+					break;
+				} catch (Throwable t) {
+					if (t instanceof ContainerLaunchException) {
+						Log.error(BoulderContainer.class, "start", t,
+								"Possibly failed to start boulder, to far along in the init process to restart.");
+						break;
+					}
+
+					Log.error(BoulderContainer.class, "start", t, "Failed to start boulder, try again.");
+					super.stop();
+
+					try {
+						/*
+						 * On Windows, sometimes we get a java.lang.NoClassDefFoundError:
+						 * com/sun/jna/platform/win32/Kernel32 and a shorter sleep before a retry
+						 * normally works around it
+						 */
+						Thread.sleep(t instanceof NoClassDefFoundError ? 1000 : (120000 * i));
+					} catch (InterruptedException e) {
+					}
+				}
+			}
+			if (!super.isRunning()) {
+				super.start();
+			}
+
+			everythingStarted = true;
+		} finally {
+			if (!everythingStarted) {
+				/*
+				 * Have to call stop here as we haven't finished initializing the caller for the
+				 * FAT test to call stop on teardown
+				 */
+				stop();
+			}
 		}
 
 	}
@@ -249,18 +302,58 @@ public class BoulderContainer extends CAContainer {
 	public void stop() {
 		Log.info(BoulderContainer.class, "stop", "Stopping Boulder services");
 		/*
-		 * Stop all the containers, the challenge server, and the networks.
+		 * Stop all the containers, the challenge server, and the networks. Do our best
+		 * to stop and clean everything, otherwise if we leave artifacts on the docker
+		 * containers, we can be prevented from started on them in the future with
+		 * "Pool overlaps with other one on this address space" exception
 		 */
-		if (bmysql != null) {
-			bmysql.stop();
+
+		try {
+			if (bmysql != null) {
+				bmysql.stop();
+				bmysql.close();
+			}
+		} catch (Exception e) {
+
 		}
-		if (bhsm != null) {
-			bhsm.stop();
+
+		try {
+
+			if (bhsm != null) {
+				bhsm.stop();
+				bhsm.close();
+
+			}
+		} catch (Exception e) {
+
+		}
+
+		try {
+			super.getDockerClient().disconnectFromNetworkCmd().withNetworkId(bluenet.getId());
+			super.getDockerClient().disconnectFromNetworkCmd().withNetworkId(rednet.getId());
+		} catch (Exception e) {
+
+		}
+
+		try {
+			if (bluenet != null) {
+				bluenet.close();
+			}
+		} catch (Exception e) {
+
+		}
+		try {
+			if (rednet != null) {
+				rednet.close();
+			}
+		} catch (Exception e) {
+
 		}
 
 		super.stop();
-		bluenet.close();
-		rednet.close();
+
+		super.getDockerClient().pruneCmd(PruneType.NETWORKS);
+
 		Log.info(BoulderContainer.class, "stop", "Stopped Boulder services");
 	}
 
@@ -310,6 +403,8 @@ public class BoulderContainer extends CAContainer {
 	}
 
 	private void initSQL() {
+		super.getDockerClient().pruneCmd(PruneType.NETWORKS);
+
 		if (bluenet == null) {
 			bluenet = Network.builder().createNetworkCmdModifier(cmd -> {
 				cmd.withDriver("bridge");
@@ -324,7 +419,7 @@ public class BoulderContainer extends CAContainer {
 				.withLogConsumer(o -> System.out.print("[SQL] " + o.getUtf8String()));
 		/*
 		 * If we get the "Pool overlaps with other one on this address space" then
-		 * retrying without rebuilding the supplied network results in no NetworkMode
+		 * retrying without rebuilding the supplied network results in a no NetworkMode
 		 * exception
 		 */
 		bmysql.withStartupAttempts(1);
@@ -337,6 +432,5 @@ public class BoulderContainer extends CAContainer {
 		.withCommand("/usr/local/bin/pkcs11-daemon /usr/lib/softhsm/libsofthsm2.so")
 		.withLogConsumer(o -> System.out.print("[HSM] " + o.getUtf8String()));
 		bhsm.withStartupAttempts(WITH_STARTUP_ATTEMPTS);
-		
 	}
 }

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeRevocationTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeRevocationTest.java
@@ -75,8 +75,7 @@ public class AcmeRevocationTest {
 	@Server("com.ibm.ws.security.acme.fat.revocation")
 	public static LibertyServer server;
 
-	@ClassRule
-	public static CAContainer boulder = new BoulderContainer();
+	public static CAContainer boulder = null;
 
 	private static ServerConfiguration originalServerConfig;
 
@@ -106,6 +105,7 @@ public class AcmeRevocationTest {
 
 	@BeforeClass
 	public static void beforeClass() throws Exception {
+		boulder = new BoulderContainer();
 		originalServerConfig = server.getServerConfiguration();
 		AcmeFatUtils.checkPortOpen(boulder.getHttpPort(), 60000);
 	}


### PR DESCRIPTION
Fixes #12376

Added pruning
Extra stop clean up
Adjusted the restarts
Had to move Boulder creation as we were initializing it twice otherwise.

Then I also manually cleaned up a bunch of our docker containers where we had stale images still running.

I was able to run back to back on the same server once the docker container was "clean"
