### PR TITLE
Add support for the creation.retry.seconds option to the outgoing Kafka connector

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.adapter/src/com/ibm/ws/microprofile/reactive/messaging/kafka/adapter/KafkaAdapterFactory.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.adapter/src/com/ibm/ws/microprofile/reactive/messaging/kafka/adapter/KafkaAdapterFactory.java
@@ -21,6 +21,7 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 /**
  *
@@ -157,13 +158,16 @@ public abstract class KafkaAdapterFactory {
         return instance;
     }
 
+    @FFDCIgnore(InvocationTargetException.class)
     protected static final <T> T getInstance(Class<T> implClass, Class<?>[] parameterTypes, Object[] parameters) {
         Constructor<T> xtor = getConstructor(implClass, parameterTypes);
 
         T instance = null;
         try {
             instance = xtor.newInstance(parameters);
-        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException e) {
+            throw new KafkaAdapterException(e);
+        } catch (InvocationTargetException e) { // Separate catch block to ignore FFDCs
             throw new KafkaAdapterException(e);
         }
         return instance;

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/resources/com/ibm/ws/microprofile/reactive/messaging/kafka/resources/ReactiveMessaging.nlsprops
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/resources/com/ibm/ws/microprofile/reactive/messaging/kafka/resources/ReactiveMessaging.nlsprops
@@ -75,6 +75,11 @@ kafka.create.incoming.retry.CWMRX1009W=CWMRX1009W: A Kafka incoming connector fo
 kafka.create.incoming.retry.CWMRX1009W.explanation=An error occurred when the Kafka connector was set up for an incoming reactive messaging channel. This might be caused by a problem with the connector configuration, or by a problem resolving the Kafka broker hostname.
 kafka.create.incoming.retry.CWMRX1009W.useraction=Review the error message, the messages.log file on the server, and FFDC logs to identify whether the problem was transient and was resolved by retrying the connector setup.
 
+# {0} = channel name, {1} = error message
+kafka.create.outgoing.retry.CWMRX1010W=CWMRX1010W: A Kafka outgoing connector for the {0} channel cannot be created but this operation is being retried. The error is {1}
+kafka.create.outgoing.retry.CWMRX1010W.explanation=An error occurred when the Kafka connector was set up for an outgoing reactive messaging channel. This might be caused by a problem with the connector configuration, or by a problem resolving the Kafka broker hostname.
+kafka.create.outgoing.retry.CWMRX1010W.useraction=Review the error message, the messages.log file on the server, and FFDC logs to identify whether the problem was transient and was resolved by retrying the connector setup.
+
 
 #-----------------------------------------------------------------------------------------------------------------------------
 # Emergency Reactive Messaging error message

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaIncomingConnector.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaIncomingConnector.java
@@ -39,6 +39,7 @@ import org.osgi.framework.ServiceReference;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterException;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterFactory;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaConsumer;
@@ -138,6 +139,7 @@ public class KafkaIncomingConnector implements IncomingConnectorFactory {
         }
     }
 
+    @FFDCIgnore(KafkaAdapterException.class) // Here we're expecting and retrying a possible failure, so we don't want an FFDC
     private <K, V> KafkaConsumer<K, V> getKafkaConsumerWithRetry(Map<String, Object> consumerConfig, int retrySeconds, String channelName) throws InterruptedException {
         if (retrySeconds == 0) {
             return this.kafkaAdapterFactory.newKafkaConsumer(consumerConfig);

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaOutgoingConnector.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaOutgoingConnector.java
@@ -34,6 +34,7 @@ import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterException;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterFactory;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaProducer;
@@ -82,6 +83,7 @@ public class KafkaOutgoingConnector implements OutgoingConnectorFactory {
         }
     }
 
+    @FFDCIgnore(KafkaAdapterException.class) // Here we're expecting and retrying a possible failure, so we don't want an FFDC
     private <K, V> KafkaProducer<K, V> getKafkaProducerWithRetry(Map<String, Object> producerConfig, int retrySeconds, String channelName) throws InterruptedException {
         if (retrySeconds == 0) {
             return this.kafkaAdapterFactory.newKafkaProducer(producerConfig);

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaOutgoingConnector.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaOutgoingConnector.java
@@ -34,6 +34,7 @@ import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterException;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterFactory;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaProducer;
 
@@ -54,6 +55,8 @@ public class KafkaOutgoingConnector implements OutgoingConnectorFactory {
         String channelName = config.getValue(ConnectorFactory.CHANNEL_NAME_ATTRIBUTE, String.class);
 
         try {
+            int retrySeconds = config.getOptionalValue(KafkaConnectorConstants.CREATION_RETRY_SECONDS, Integer.class).orElse(0);
+
             // Configure our defaults
             Map<String, Object> producerConfig = new HashMap<>();
 
@@ -66,7 +69,7 @@ public class KafkaOutgoingConnector implements OutgoingConnectorFactory {
                                                .filter(k -> !KafkaConnectorConstants.NON_KAFKA_PROPS.contains(k))
                                                .collect(Collectors.toMap(Function.identity(), (k) -> config.getValue(k, String.class))));
 
-            KafkaProducer<String, Object> kafkaProducer = this.kafkaAdapterFactory.newKafkaProducer(producerConfig);
+            KafkaProducer<String, Object> kafkaProducer = getKafkaProducerWithRetry(producerConfig, retrySeconds, channelName);
 
             String configuredTopic = config.getOptionalValue(KafkaConnectorConstants.TOPIC, String.class).orElse(null);
 
@@ -76,6 +79,27 @@ public class KafkaOutgoingConnector implements OutgoingConnectorFactory {
             return ReactiveStreams.<Message<Object>> builder().to(kafkaOutput.getSubscriber());
         } catch (Exception e) {
             throw new KafkaConnectorException(Tr.formatMessage(tc, "kafka.create.outgoing.error.CWMRX1008E", channelName, e.getMessage()), e);
+        }
+    }
+
+    private <K, V> KafkaProducer<K, V> getKafkaProducerWithRetry(Map<String, Object> producerConfig, int retrySeconds, String channelName) throws InterruptedException {
+        if (retrySeconds == 0) {
+            return this.kafkaAdapterFactory.newKafkaProducer(producerConfig);
+        }
+
+        long retryNs = Duration.ofSeconds(retrySeconds).toNanos();
+        long startTime = System.nanoTime();
+
+        while (true) {
+            try {
+                return this.kafkaAdapterFactory.newKafkaProducer(producerConfig);
+            } catch (KafkaAdapterException e) {
+                if ((System.nanoTime() - startTime) > retryNs) {
+                    throw e;
+                }
+                Tr.warning(tc, "kafka.create.outgoing.retry.CWMRX1010W", channelName, e.getMessage());
+            }
+            Thread.sleep(1000);
         }
     }
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/badconfig/KafkaBadConfigIncomingBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/badconfig/KafkaBadConfigIncomingBean.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.invalid.badconfig;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+
+@ApplicationScoped
+public class KafkaBadConfigIncomingBean {
+
+    public static final String CHANNEL_NAME = "bad-config-input";
+
+    @Incoming(CHANNEL_NAME)
+    public void receive(String input) {
+        // Do nothing
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/badconfig/KafkaBadConfigOutgoingBean.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/badconfig/KafkaBadConfigOutgoingBean.java
@@ -12,16 +12,16 @@ package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.invalid.badconfig;
 
 import javax.enterprise.context.ApplicationScoped;
 
-import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
 
 @ApplicationScoped
-public class KafkaBadConfigBean {
+public class KafkaBadConfigOutgoingBean {
 
-    public static final String CHANNEL_NAME = "bad-config-input";
+    public static final String CHANNEL_NAME = "bad-config-output";
 
-    @Incoming(CHANNEL_NAME)
-    public void receive(String input) {
-        // Do nothing
+    @Outgoing(CHANNEL_NAME)
+    public String send() {
+        return "test";
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/badconfig/KafkaBadConfigTest.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/invalid/badconfig/KafkaBadConfigTest.java
@@ -37,6 +37,7 @@ import com.ibm.ws.microprofile.reactive.messaging.fat.suite.KafkaUtils;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.KafkaConnectorConstants;
 
 import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -48,6 +49,7 @@ import componenttest.topology.impl.LibertyServer;
  * hostname of the kafka broker does not resolve at startup.
  */
 @RunWith(FATRunner.class)
+@AllowedFFDC({ "org.jboss.weld.exceptions.DeploymentException", "com.ibm.ws.container.service.state.StateChangeException" }) // General exceptions when app deployment fails
 public class KafkaBadConfigTest {
 
     private static final String APP_NAME = "KafkaBadConfig";
@@ -72,7 +74,7 @@ public class KafkaBadConfigTest {
     }
 
     @Test
-    @AllowedFFDC
+    @ExpectedFFDC("com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterException")
     public void testBadConfig() throws Exception {
 
         // Invalid config because bootstrap.servers not set
@@ -108,7 +110,7 @@ public class KafkaBadConfigTest {
     }
 
     @Test
-    @AllowedFFDC
+    @ExpectedFFDC("com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterException")
     public void testBadConfigRetry() throws Exception {
         // Invalid config because bootstrap.servers not set, but creation retry enabled
         ConnectorProperties incomingProperties = simpleIncomingChannel("", KafkaBadConfigIncomingBean.CHANNEL_NAME, APP_GROUP_ID)
@@ -148,7 +150,7 @@ public class KafkaBadConfigTest {
     }
 
     @Test
-    @AllowedFFDC
+    @ExpectedFFDC("com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterException")
     public void testBadConfigOutgoing() throws Exception {
 
         // Invalid config because bootstrap.servers not set
@@ -184,7 +186,7 @@ public class KafkaBadConfigTest {
     }
 
     @Test
-    @AllowedFFDC
+    @ExpectedFFDC("com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterException")
     public void testBadConfigOutgoingRetry() throws Exception {
 
         // Invalid config because bootstrap.servers not set


### PR DESCRIPTION
Follow on work for  #10937

This parameter was handled by the incoming connector, but the same issue exists on the outgoing connector as well.