### PR TITLE
PR for Issue 12778: Fix JWK cache logic

### DIFF
--- a/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JwKRetriever.java
+++ b/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JwKRetriever.java
@@ -179,11 +179,11 @@ public class JwKRetriever {
         } else if (use != null) {
             key = jwkSet.getPublicKeyBySetIdAndUse(setId, use);
         }
+        if (key == null && keyText != null) {
+            key = jwkSet.getPublicKeyBySetIdAndKeyText(setId, keyText);
+        }
         if (key != null) {
             return key;
-        }
-        if (keyText != null) {
-            return jwkSet.getPublicKeyBySetIdAndKeyText(setId, keyText);
         }
         return jwkSet.getPublicKeyBySetId(setId);
     }


### PR DESCRIPTION
A change delivered in https://github.com/OpenLiberty/open-liberty/pull/9597 can cause the logic to return `null` earlier than expected when trying to find a cached JWK. This can happen if Liberty falls back to using the key text to look up the key in the cache and fails to find a match. The logic is being updated to go back to falling back to checking the cache that's keyed off the JWK location.

Resolves #12778