### PR TITLE
Modify test to improve performance

### DIFF
--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/HungRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/HungRequestTiming.java
@@ -74,6 +74,11 @@ public class HungRequestTiming {
         if (server != null && !server.isStarted()) {
             server.startServer();
         }
+        
+        // Allow the configuration to change back to the original and ensure the update is finished before starting a test
+        server.setServerConfigurationFile("server_original.xml");
+        server.waitForStringInLog("CWWKG0017I", 90000);
+        server.setMarkToEndOfLog();
     }
 
     @After

--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/HungRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/HungRequestTiming.java
@@ -91,11 +91,11 @@ public class HungRequestTiming {
 
         assertNotNull("The server configuration was successfully updated message was not found!", srvConfigCompletedMsg);
 
-        CommonTasks.writeLogMsg(Level.INFO, "************ Thread 1 - Runs 3s  ************");
-        CommonTasks.writeLogMsg(Level.INFO, "************ Thread 2 - Runs 5s ************");
+        CommonTasks.writeLogMsg(Level.INFO, "************ Thread 1 - Runs 4s  ************");
+        CommonTasks.writeLogMsg(Level.INFO, "************ Thread 2 - Runs 6s ************");
 
-        HungRequestThread request1 = new HungRequestThread(3000);
-        HungRequestThread request2 = new HungRequestThread(5000);
+        HungRequestThread request1 = new HungRequestThread(4000);
+        HungRequestThread request2 = new HungRequestThread(6000);
 
         request1.start();
         request2.start();

--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/HungRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/HungRequestTiming.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -40,7 +40,6 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
-import com.ibm.websphere.simplicity.Machine;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
@@ -75,10 +74,6 @@ public class HungRequestTiming {
         if (server != null && !server.isStarted()) {
             server.startServer();
         }
-        // Need to ensure the configuration is finished updating before starting a test
-        server.setServerConfigurationFile("server_original.xml");
-        server.waitForStringInLog("CWWKG0017I", 90000);
-        server.setMarkToEndOfLog();
     }
 
     @After
@@ -90,17 +85,17 @@ public class HungRequestTiming {
 
     @Test
     public void testParallelMultipleRequests() throws Exception {
-        CommonTasks.writeLogMsg(Level.INFO, "Setting hung threshold as 6s");
-        server.setServerConfigurationFile("server_hungRequestThreshold6.xml");
+        CommonTasks.writeLogMsg(Level.INFO, "Setting hung threshold as 2s");
+        server.setServerConfigurationFile("server_hungRequestThreshold2.xml");
         String srvConfigCompletedMsg = server.waitForStringInLog("CWWKG0017I", 90000);
 
         assertNotNull("The server configuration was successfully updated message was not found!", srvConfigCompletedMsg);
 
-        CommonTasks.writeLogMsg(Level.INFO, "************ Thread 1 - Runs 10s  ************");
-        CommonTasks.writeLogMsg(Level.INFO, "************ Thread 2 - Runs 12s ************");
+        CommonTasks.writeLogMsg(Level.INFO, "************ Thread 1 - Runs 3s  ************");
+        CommonTasks.writeLogMsg(Level.INFO, "************ Thread 2 - Runs 4s ************");
 
-        HungRequestThread request1 = new HungRequestThread(10000);
-        HungRequestThread request2 = new HungRequestThread(12000);
+        HungRequestThread request1 = new HungRequestThread(3000);
+        HungRequestThread request2 = new HungRequestThread(4000);
 
         request1.start();
         request2.start();
@@ -125,7 +120,7 @@ public class HungRequestTiming {
 
         assertNotNull("The server configuration was successfully updated message was not found!", srvConfigCompletedMsg);
 
-        URL url = new URL("http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/TestWebApp/TestServlet?sleepTime=6500");
+        URL url = new URL("http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/TestWebApp/TestServlet?sleepTime=4500");
         CommonTasks.writeLogMsg(Level.INFO, "Calling TestWebApp Application with URL=" + url.toString());
         HttpURLConnection con = getHttpConnection(url);
         BufferedReader br = getConnectionStream(con);
@@ -235,12 +230,12 @@ public class HungRequestTiming {
 
     @Test
     public void testHungDynamicThresholdUpdate() throws Exception {
-        CommonTasks.writeLogMsg(Level.INFO, "Setting hung threshold as 6s");
-        server.setServerConfigurationFile("server_hungRequestThreshold6.xml");
+        CommonTasks.writeLogMsg(Level.INFO, "Setting hung threshold as 2s");
+        server.setServerConfigurationFile("server_hungRequestThreshold2.xml");
 
         server.waitForStringInLog("CWWKG0017I", 90000);
 
-        URL url = new URL("http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/TestWebApp/TestServlet?sleepTime=9000");
+        URL url = new URL("http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/TestWebApp/TestServlet?sleepTime=4000");
         CommonTasks.writeLogMsg(Level.INFO, "Calling TestWebApp Application with URL=" + url.toString());
         HttpURLConnection con = getHttpConnection(url);
         BufferedReader br = getConnectionStream(con);
@@ -256,11 +251,11 @@ public class HungRequestTiming {
         String line1 = lines.get(previous - 1);
         assertTrue("No Hung detection warning found!!!", (previous > 0));
         CommonTasks.writeLogMsg(Level.INFO, "----> Hung Request Warning 1 : " + line1);
-        assertTrue("Hung warning does not show that request was hung for 6s as expected..", isCorrectDuration(line1, 6000));
+        assertTrue("Hung warning does not show that request was hung for 2s as expected..", isCorrectDuration(line1, 2000));
 
-        CommonTasks.writeLogMsg(Level.INFO, "Setting hung threshold as 7s");
-        server.setServerConfigurationFile("server_hungRequestThreshold7.xml");
-        server.waitForStringInLog("CWWKG0017I", 90000);
+        CommonTasks.writeLogMsg(Level.INFO, "Setting hung threshold as 3s");
+        server.setServerConfigurationFile("server_hungRequestThreshold3.xml");
+        server.waitForStringInLogUsingMark("CWWKG0017I", 90000);
 
         CommonTasks.writeLogMsg(Level.INFO, "Calling TestWebApp Application with URL=" + url.toString());
         con = getHttpConnection(url);
@@ -269,7 +264,7 @@ public class HungRequestTiming {
 
         CommonTasks.writeLogMsg(Level.INFO, "Waiting for hung detection warning");
         CommonTasks.writeLogMsg(Level.INFO, "----> Hung Request Warning 1 : " + line1);
-        server.waitForStringInLog("TRAS0114W", 30000);
+        server.waitForStringInLogUsingMark("TRAS0114W", 30000);
 
         lines = server.findStringsInFileInLibertyServerRoot("TRAS0114W", MESSAGE_LOG);
         int current = lines.size();
@@ -279,7 +274,7 @@ public class HungRequestTiming {
         String line2 = lines.get(current - 1);
         CommonTasks.writeLogMsg(Level.INFO, "----> Hung RequestWarning 2 : " + line2);
 
-        assertTrue("Hung warning does not show that request was hung for 7s as expected..", isCorrectDuration(line2, 7000));
+        assertTrue("Hung warning does not show that request was hung for 3s as expected..", isCorrectDuration(line2, 3000));
 
         CommonTasks.writeLogMsg(Level.INFO, "***** Dynamic Update of HungRequestThreshold works as expected! *****");
     }
@@ -287,16 +282,14 @@ public class HungRequestTiming {
     @Test
     @Mode(TestMode.FULL)
     public void testHungRequestDynamicEnable() throws Exception {
-        server.setMarkToEndOfLog();
         CommonTasks.writeLogMsg(Level.INFO, "Starting server without Request Timing Feature..");
         server.setServerConfigurationFile("server_withOutReqTiming.xml");
-        server.waitForStringInLogUsingMark("CWWKF0007I", 90000); // feature update started message
-        server.waitForStringInLogUsingMark("CWWKF0013I", 90000); // feature removed message
-        server.waitForStringInLogUsingMark("CWWKF0008I", 90000); // feature update completed message
+        server.waitForStringInLog("CWWKF0007I", 90000); // feature update started message
+        String temp = server.waitForStringInLog("CWWKF0013I", 90000); // feature removed message
+        assertNotNull("Could not find message - Server removed Request Timing and Request Probe Features.", temp);
+        server.waitForStringInLog("CWWKF0008I", 90000); // feature update completed message
 
-        List<String> lines = server.findStringsInFileInLibertyServerRoot("CWWKF0013I", MESSAGE_LOG);
-        assertTrue("Could not find message - Server removed Request Timing and Request Probe Features.", lines.size() == 1);
-        CommonTasks.writeLogMsg(Level.INFO, " ------ > Request Timing feature removed : " + lines.get(0));
+        CommonTasks.writeLogMsg(Level.INFO, " ------> Request Timing feature removed : " + temp);
 
         server.setMarkToEndOfLog();
         CommonTasks.writeLogMsg(Level.INFO, "-----> Updating server configuration to ADD Request Timing feature..");
@@ -304,7 +297,7 @@ public class HungRequestTiming {
 
         server.waitForStringInLogUsingMark("CWWKF0012I", 30000);
 
-        lines = server.findStringsInFileInLibertyServerRoot("CWWKF0012I", MESSAGE_LOG);
+        List<String> lines = server.findStringsInFileInLibertyServerRoot("CWWKF0012I", MESSAGE_LOG);
         boolean featureFound = false;
         for (String line : lines) {
             CommonTasks.writeLogMsg(Level.INFO, " ------> Config Update Warning : " + line);
@@ -317,14 +310,15 @@ public class HungRequestTiming {
         CommonTasks.writeLogMsg(Level.INFO, "********* Added Request Timing Feature..! *********");
 
         server.setMarkToEndOfLog();
-        CommonTasks.writeLogMsg(Level.INFO, "Setting hung threshold as 6s");
-        server.setServerConfigurationFile("server_hungRequestThreshold6.xml");
+        CommonTasks.writeLogMsg(Level.INFO, "Setting hung threshold as 2s");
+        server.setServerConfigurationFile("server_hungRequestThreshold2.xml");
 
         server.waitForStringInLogUsingMark("CWWKG0017I", 50000);
         server.waitForStringInLogUsingMark("CWWKZ0018I", 10000);
         server.waitForStringInLogUsingMark("CWWKT0016I", 10000);
 
-        createRequest(9000);
+        createRequest(3000);
+        server.waitForStringInLogUsingMark("TRAS0114W", 90000);
         lines = server.findStringsInFileInLibertyServerRoot("TRAS0114W", MESSAGE_LOG);
         CommonTasks.writeLogMsg(Level.INFO, "---> No. of Hung warnings : " + lines.size());
         assertTrue("Hung detection warning found!!!", (lines.size() > 0));
@@ -335,14 +329,13 @@ public class HungRequestTiming {
     @Test
     @Mode(TestMode.FULL)
     public void testHungRequestDynamicDisable() throws Exception {
-        server.setMarkToEndOfLog();
-        CommonTasks.writeLogMsg(Level.INFO, "Setting hung threshold as 6s");
-        server.setServerConfigurationFile("server_hungRequestThreshold6.xml");
+        CommonTasks.writeLogMsg(Level.INFO, "Setting hung threshold as 2s");
+        server.setServerConfigurationFile("server_hungRequestThreshold2.xml");
         String srvConfigCompletedMsg = server.waitForStringInLog("CWWKG0017I|CWWKG0018I", 90000);
 
         assertNotNull("The server configuration was successfully updated message was not found!", srvConfigCompletedMsg);
 
-        createRequest(9000);
+        createRequest(3000);
 
         CommonTasks.writeLogMsg(Level.INFO, "Waiting for hung detection warning");
         server.waitForStringInLog("TRAS0114W", 30000);
@@ -357,28 +350,29 @@ public class HungRequestTiming {
 
         CommonTasks.writeLogMsg(Level.INFO, "***** Removing Threshold Configuration  *****");
         server.setServerConfigurationFile("server_original.xml");
-        server.waitForStringInLog("CWWKG0017I", 90000);
+        server.waitForStringInLogUsingMark("CWWKG0017I", 90000);
 
-        createRequest(9000);
+        createRequest(3000);
 
         lines = server.findStringsInFileInLibertyServerRoot("TRAS0114W", MESSAGE_LOG);
         CommonTasks.writeLogMsg(Level.INFO, "---> No of Hung detection warnings found : " + lines.size());
-        assertTrue("Hung detection warning found!!!", ((lines.size() - previous) == 0));
+        assertTrue("Hung detection warning found when none was expected!!!", ((lines.size() - previous) == 0));
 
         CommonTasks.writeLogMsg(Level.INFO, "***** Removing Request Timing Feature  *****");
         server.setServerConfigurationFile("server_withOutReqTiming.xml");
-        server.waitForStringInLog("CWWKF0013I", 30000);
+        server.waitForStringInLogUsingMark("CWWKF0013I", 30000);
 
         lines = server.findStringsInFileInLibertyServerRoot("CWWKF0013I", MESSAGE_LOG);
 
-        assertTrue("Request timing feature is not disabled..", (lines.size() > 0));
-        server.setMarkToEndOfLog();
-
-        if (lines.size() > 0) {
-            if (lines.get(0).contains("requestTiming")) {
+        boolean requestTimingFeatureRemoved = false;
+        for (int index = 0; index < lines.size(); index++) {
+            if (lines.get(index).contains("requestTiming")) {
                 CommonTasks.writeLogMsg(Level.INFO, "------> Request Timing feature disabled!" + "\n Message found  : " + lines.get(0));
+                requestTimingFeatureRemoved = true;
             }
         }
+
+        assertTrue("Request timing feature is not disabled..", requestTimingFeatureRemoved);
 
         CommonTasks.writeLogMsg(Level.INFO, "********* Removed Request Timing Feature..! *********");
     }
@@ -386,14 +380,18 @@ public class HungRequestTiming {
     @Test
     @Mode(TestMode.FULL)
     public void testSequentialHungMultipleRequests() throws Exception {
-        server.setMarkToEndOfLog();
-        CommonTasks.writeLogMsg(Level.INFO, "Setting hung threshold as 6s");
-        server.setServerConfigurationFile("server_hungRequestThreshold6.xml");
+        CommonTasks.writeLogMsg(Level.INFO, "Setting hung threshold as 2s");
+        server.setServerConfigurationFile("server_hungRequestThreshold2.xml");
 
-        server.waitForStringInLogUsingMark("CWWKG0017I|CWWKG0018I", 90000);
+        server.waitForStringInLog("CWWKG0017I|CWWKG0018I", 90000);
 
-        createRequest(9000);
+        createRequest(3000);
+        
+        // The next request will have 59secs to complete before the next Java core gets generated
+        // The Java cores get generated 1min apart from each other
+        long finishTimeOfFirstRequest = System.currentTimeMillis();
 
+        server.waitForStringInLog("TRAS0114W", 90000);
         List<String> lines = server.findStringsInFileInLibertyServerRoot("TRAS0114W", MESSAGE_LOG);
         int previous = lines.size();
         CommonTasks.writeLogMsg(Level.INFO, "---> No. of Hung warnings : " + previous);
@@ -402,13 +400,16 @@ public class HungRequestTiming {
             CommonTasks.writeLogMsg(Level.INFO, "---> Hung warning : " + line);
         }
 
-        //wait for request 1 to complete
+        // wait for request 1 to complete
         server.waitForStringInLog("TRAS0115W", 30000);
+
+        server.setMarkToEndOfLog();
 
         CommonTasks.writeLogMsg(Level.INFO, "****** Request 2 ******");
 
-        createRequest(9000);
+        createRequest(3000);
 
+        server.waitForStringInLogUsingMark("TRAS0114W", 90000);
         lines = server.findStringsInFileInLibertyServerRoot("TRAS0114W", MESSAGE_LOG);
         int current = lines.size();
         CommonTasks.writeLogMsg(Level.INFO, "---> No. of Hung warnings : " + current);
@@ -421,7 +422,12 @@ public class HungRequestTiming {
         lines = server.findStringsInFileInLibertyServerRoot("CWWKE0068I", MESSAGE_LOG);
         int cores = lines.size();
         CommonTasks.writeLogMsg(Level.INFO, "---> No. of java cores created : " + cores);
-        assertTrue("Expected 1 Java core.. But found : " + cores, (cores == 1));
+        if (System.currentTimeMillis() - finishTimeOfFirstRequest > 59000) {
+            fail("Test case testSequentialHungMultipleRequests is inconclusive as the second request was not able to complete within"
+                            + "one minute, thus allowing the possibility of another Java core to be generated");
+        }else {
+            assertTrue("Expected 1 Java core.. But found : " + cores, (cores == 1));
+        }
 
         CommonTasks.writeLogMsg(Level.INFO, "****** Hung Request Multiple Requests works as expected! ******");
     }
@@ -429,25 +435,25 @@ public class HungRequestTiming {
     @Test
     @Mode(TestMode.FULL)
     public void testHungRequestTiming() throws Exception {
-        server.setMarkToEndOfLog();
-        CommonTasks.writeLogMsg(Level.INFO, "Setting hung threshold as 6s");
-        server.setServerConfigurationFile("server_hungRequestThreshold6.xml");
+        CommonTasks.writeLogMsg(Level.INFO, "Setting hung threshold as 2s");
+        server.setServerConfigurationFile("server_hungRequestThreshold2.xml");
         String srvConfigCompletedMsg = server.waitForStringInLog("CWWKG0017I|CWWKG0018I", 90000);
 
         assertNotNull("The server configuration was successfully updated message was not found!", srvConfigCompletedMsg);
 
-        createRequest(290000);
+        createRequest(290000); // We must wait this long to see if more than 3 java cores are generated (we expect only 3)
 
         CommonTasks.writeLogMsg(Level.INFO, "Waiting for hung detection warning");
-        server.waitForStringInLogUsingMark("TRAS0114W", 90000);
+        server.waitForStringInLog("TRAS0114W", 90000);
 
         List<String> lines = server.findStringsInFileInLibertyServerRoot("TRAS0114W", MESSAGE_LOG);
         assertTrue("No Hung detection warning found!!!", (lines.size() > 0));
 
         CommonTasks.writeLogMsg(Level.INFO, "----> Hung Request Warning : \n" + lines.get(0));
         CommonTasks.writeLogMsg(Level.INFO, "Waiting for Java cores to be generated");
-        server.waitForStringInLogUsingMark("CWWKE0067I", 30000);
-        server.waitForStringInLogUsingMark("TRAS0115W", 30000);
+        // Waiting for just one of the Java core request message is enough since we already make the request sleep for about 4.83min
+        server.waitForStringInLog("CWWKE0067I", 30000);
+        server.waitForStringInLog("TRAS0115W", 30000);
 
         lines = server.findStringsInFileInLibertyServerRoot("TRAS0115W", MESSAGE_LOG);
         assertTrue("Hung completion message not found!!", (lines.size() > 0));
@@ -517,7 +523,6 @@ public class HungRequestTiming {
         }
         CommonTasks.writeLogMsg(Level.INFO, "----> Java cores are generated 1 min apart");
 
-        lines = server.findStringsInFileInLibertyServerRoot("TRAS0114W", MESSAGE_LOG);
         assertTrue("Expected 3 Hung detection warnings but found : " + javaCoreCount, (javaCoreCount == 3));
 
         CommonTasks.writeLogMsg(Level.INFO, "****** Hung Request Timing is works as expected ******");

--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/HungRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/HungRequestTiming.java
@@ -92,10 +92,10 @@ public class HungRequestTiming {
         assertNotNull("The server configuration was successfully updated message was not found!", srvConfigCompletedMsg);
 
         CommonTasks.writeLogMsg(Level.INFO, "************ Thread 1 - Runs 3s  ************");
-        CommonTasks.writeLogMsg(Level.INFO, "************ Thread 2 - Runs 4s ************");
+        CommonTasks.writeLogMsg(Level.INFO, "************ Thread 2 - Runs 5s ************");
 
         HungRequestThread request1 = new HungRequestThread(3000);
-        HungRequestThread request2 = new HungRequestThread(4000);
+        HungRequestThread request2 = new HungRequestThread(5000);
 
         request1.start();
         request2.start();
@@ -386,7 +386,7 @@ public class HungRequestTiming {
         server.waitForStringInLog("CWWKG0017I|CWWKG0018I", 90000);
 
         createRequest(3000);
-        
+
         // The next request will have 59secs to complete before the next Java core gets generated
         // The Java cores get generated 1min apart from each other
         long finishTimeOfFirstRequest = System.currentTimeMillis();
@@ -424,8 +424,8 @@ public class HungRequestTiming {
         CommonTasks.writeLogMsg(Level.INFO, "---> No. of java cores created : " + cores);
         if (System.currentTimeMillis() - finishTimeOfFirstRequest > 59000) {
             fail("Test case testSequentialHungMultipleRequests is inconclusive as the second request was not able to complete within"
-                            + "one minute, thus allowing the possibility of another Java core to be generated");
-        }else {
+                 + "one minute, thus allowing the possibility of another Java core to be generated");
+        } else {
             assertTrue("Expected 1 Java core.. But found : " + cores, (cores == 1));
         }
 

--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/SlowRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/SlowRequestTiming.java
@@ -565,44 +565,44 @@ public class SlowRequestTiming {
 
     /*
      * This is already tested in testDynamicDisableWithNoContextInfo
-     * 
+     *
      * @Test
-     * 
+     *
      * @Mode(TestMode.FULL)
      * public void testSlowReqDynamicPatternRemove() throws Exception {
      * //Step 1 - Update server configuration - ContextInfo = false , Threshold = 2s
      * CommonTasks.writeLogMsg(Level.INFO, "--------> Starting Server with Pattern disabled..");
      * server.setServerConfigurationFile("server_NOContextInfo.xml");
      * waitForConfigurationUpdate();
-     * 
+     *
      * //Step 2 - create request for 3seconds and look for slow request warnings do not have contextInfo
      * createRequest("?sleepTime=3000");
-     * 
+     *
      * List<String> lines = server.findStringsInFileInLibertyServerRoot("ms", MESSAGE_LOG);
-     * 
+     *
      * for (String line : lines) {
      * assertFalse("contextInfo found when it is disabled..", (line.contains("|")));
      * }
      * CommonTasks.writeLogMsg(Level.INFO, "******** As Expected : Pattern disabled ******* ");
-     * 
+     *
      * //Step 3 - Update server configuration - default of request timing feature.
      * server.setMarkToEndOfLog();
      * server.setServerConfigurationFile("server_original.xml");
      * waitForConfigurationUpdate();
-     * 
+     *
      * //Step 3 - create request for 11 seconds and look for slow request warnings have contextInfo
      * createRequest("?sleepTime=11000");
      * server.waitForStringInLogUsingMark("TRAS0112W", 30000);
-     * 
+     *
      * lines = server.findStringsInLogsUsingMark("ms", MESSAGE_LOG);
      * server.setMarkToEndOfLog();
-     * 
+     *
      * for (String line : lines) {
      * if (!line.contains("TRAS0112W") && !line.contains("TRAS0113I") && !line.contains("CWWKG0028A")) {
      * assertTrue("contextInfo NOT found when it is enabled by default ..", (line.contains("|")));
      * }
      * }
-     * 
+     *
      * CommonTasks.writeLogMsg(Level.INFO, "*********** As Expected : Pattern enabled ********* ");
      * }
      */
@@ -615,14 +615,13 @@ public class SlowRequestTiming {
         server.setServerConfigurationFile("server_sampleRate3.xml");
         waitForConfigurationUpdate();
 
-        //Step 2 - create 7 requests of 4s each - Every 3rd sample should generate a slow request warning.
+        //Step 2 - create 3 requests of 4s each - Every 3rd sample should generate a slow request warning.
         for (int count = 1; count < 4; count++) {
             createRequest("?sleepTime=4000");
         }
 
         //slow request warning:   Fetch ID and check if it ends with AC which confirms its 3rd request
         //TRAS0112W: Request AADJi05x9AW_AAAAAAAAAAC has been running on thread 00000023 for at least 3001.386ms
-
         server.waitForStringInLogUsingMark("TRAS0112W", 30000);
         List<String> lines = server.findStringsInFileInLibertyServerRoot("TRAS0112W", MESSAGE_LOG);
         List<String> IDs = new ArrayList<String>();
@@ -646,10 +645,7 @@ public class SlowRequestTiming {
     @Test
     @Mode(TestMode.FULL)
     public void testSlowReqSampleRateEven() throws Exception {
-
         //Step 1 - Update server configuration - sampleRate=2, Threshold = "3s"
-        server.setMarkToEndOfLog();
-
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> Updating server with configuration : sampleRate=2");
         server.setServerConfigurationFile("server_sampleRate2.xml");
         waitForConfigurationUpdate();

--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/SlowRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/SlowRequestTiming.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,7 +33,6 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
-import com.ibm.websphere.simplicity.Machine;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
@@ -60,7 +59,6 @@ public class SlowRequestTiming {
 
     @Before
     public void setupTestStart() throws Exception {
-        server.setServerConfigurationFile("server_original.xml");
         if (server != null && !server.isStarted()) {
             server.startServer();
         }
@@ -75,7 +73,7 @@ public class SlowRequestTiming {
 
     private void createRequest(String option) throws Exception {
         URL url = new URL("http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/jdbcTestPrj_3" + option);
-        CommonTasks.writeLogMsg(Level.INFO, "Calling jdbcTestPrj_3 Application with URL=\" + url.toString()");
+        CommonTasks.writeLogMsg(Level.INFO, "Calling jdbcTestPrj_3 Application with URL= " + url.toString());
         HttpURLConnection con = getHttpConnection(url);
         BufferedReader br = getConnectionStream(con);
         br.readLine();
@@ -88,14 +86,8 @@ public class SlowRequestTiming {
         server.setServerConfigurationFile("server_original.xml");
         server.waitForStringInLogUsingMark("CWWKG0017I", 30000);
 
-        // Warm up (This request should not be slow but it is fine if it is)
-        createRequest("?sleepTime=1");
-
-        // Set the mark to the end for messages.log so that any previous slow request does not interfere with the test
-        server.setMarkToEndOfLog();
-
-        // Access the application ... (This request will be slow)
-        createRequest("?sleepTime=30000");
+        // Access the application ... (This request will be slow ... sleep for 15secs)
+        createRequest("?sleepTime=15000");
 
         // Wait for the slow request warning message in message.log (default) with a timeout of 60 sec
         String slowRequestWarningLine = server.waitForStringInLogUsingMark("TRAS0112W", 60000);
@@ -165,14 +157,11 @@ public class SlowRequestTiming {
 
         server.waitForStringInLog("CWWKG0017I", 30000);
 
-        server.setMarkToEndOfLog();
-
         createRequest("?sleepTime=3000");
 
         server.waitForStringInLog("TRAS0112W");
 
         List<String> lines = server.findStringsInFileInLibertyServerRoot("ms", MESSAGE_LOG);
-        server.setMarkToEndOfLog();
 
         for (String rec : lines) {
             CommonTasks.writeLogMsg(Level.INFO, "------> Line :" + rec);
@@ -242,7 +231,7 @@ public class SlowRequestTiming {
         server.setServerConfigurationFile("server_slowRequestThreshold0.xml");
         server.waitForStringInLog("CWWKG0017I");
 
-        createRequest("");
+        createRequest("?sleepTime=11000");
 
         List<String> lines = server.findStringsInFileInLibertyServerRoot("TRAS0112W", MESSAGE_LOG);
 
@@ -386,11 +375,11 @@ public class SlowRequestTiming {
 
     @Test
     public void testSlowReqSampleRateZero() throws Exception {
-        CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> Updating server with configuration : sampleRate=-2");
+        CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> Updating server with configuration : sampleRate=0");
         server.setServerConfigurationFile("server_sampleRate0.xml");
         server.waitForStringInLog("CWWKG0017I", 30000);
 
-        createRequest("");
+        createRequest("?sleepTime=3000");
 
         server.waitForStringInLog("TRAS0112W", 15000);
         List<String> lines = server.findStringsInFileInLibertyServerRoot("TRAS0112W", MESSAGE_LOG);
@@ -398,14 +387,13 @@ public class SlowRequestTiming {
 
         assertTrue("Expected 1 (or more) slow request warning  but found : " + lines.size(), (lines.size() > 0));
 
-        CommonTasks.writeLogMsg(Level.INFO, "******* Slow request timing works for Negative Sample Rate*******");
+        CommonTasks.writeLogMsg(Level.INFO, "******* Slow request timing works for Zero Sample Rate*******");
     }
 
     @Test
     @Mode(TestMode.FULL)
     public void testDynamicEnableWithNoContextInfo() throws Exception {
         //Step 1 - Remove Request Timing feature
-        server.setMarkToEndOfLog();
         CommonTasks.writeLogMsg(Level.INFO, "-----> Updating server configuration to REMOVE Request Timing feature..");
         server.setServerConfigurationFile("server_withOutReqTiming.xml");
 
@@ -438,7 +426,6 @@ public class SlowRequestTiming {
 
         //Step 5 - Check if contextInfo is disabled as expected
         List<String> lines = server.findStringsInFileInLibertyServerRoot("ms", MESSAGE_LOG);
-        server.setMarkToEndOfLog();
 
         for (int i = 0; i < lines.size(); i++) {
             String line = lines.get(i);
@@ -456,14 +443,13 @@ public class SlowRequestTiming {
     @Mode(TestMode.FULL)
     public void testDynamicDisableWithNoContextInfo() throws Exception {
         //Step 1 -  Update server configuration - ContextInfo = false , Threshold = 2s
-        server.setMarkToEndOfLog();
         CommonTasks.writeLogMsg(Level.INFO, "---> Updating server with ContextInfo = false");
         server.setServerConfigurationFile("server_NOContextInfo.xml");
         waitForConfigurationUpdate();
 
         CommonTasks.writeLogMsg(Level.INFO, "-----> Started Server with contextInfo disabled");
 
-        //Step 2 -  create request for 3seconds and look for slow request warnings do not have contextInfo
+        //Step 2 -  create request for 3seconds and look for slow request warnings (they should have no contextInfo)
         createRequest("?sleepTime=3000");
 
         int slowCount = fetchNoOfslowRequestWarnings();
@@ -476,13 +462,13 @@ public class SlowRequestTiming {
 
         CommonTasks.writeLogMsg(Level.INFO, "---------> As expected : Pattern Not Found!  ...");
 
-        //Step 3 - Reset back to default Configuration of Request Timing feature.
+        //Step 3 - Reset back to a configuration with contextInfo enabled.
         server.setMarkToEndOfLog();
-        server.setServerConfigurationFile("server_original.xml");
+        server.setServerConfigurationFile("server_slowRequestThreshold1.xml");
         waitForConfigurationUpdate();
 
-        //Step 4 - Create request for 11 seconds and look for slow request warning, should contain contextInfo now.
-        createRequest("?sleepTime=11000");
+        //Step 4 - Create request for 3 seconds and look for slow request warning, should contain contextInfo now.
+        createRequest("?sleepTime=3000");
 
         server.waitForStringInLogUsingMark("TRAS0112W", 20000);
 
@@ -510,7 +496,6 @@ public class SlowRequestTiming {
     @Mode(TestMode.FULL)
     public void testSlowReqTimingThreshold() throws Exception {
         //Step 1 - Set slowRequestThreshold = 4 s
-        server.setMarkToEndOfLog();
         CommonTasks.writeLogMsg(Level.INFO, "Updating server with slowRequestThreshold : 4 seconds...");
         server.setServerConfigurationFile("server_slowRequestThreshold4.xml");
         waitForConfigurationUpdate();
@@ -540,7 +525,6 @@ public class SlowRequestTiming {
     @Mode(TestMode.FULL)
     public void testSlowReqDynamicPatternUpdate() throws Exception {
         //Step 1 - Update server configuration - ContextInfo = false , Threshold = 2s
-        server.setMarkToEndOfLog();
         CommonTasks.writeLogMsg(Level.INFO, "--------> Started Server with Pattern disabled..");
         server.setServerConfigurationFile("server_NOContextInfo.xml");
         waitForConfigurationUpdate();
@@ -579,52 +563,54 @@ public class SlowRequestTiming {
         CommonTasks.writeLogMsg(Level.INFO, "*********** As Expected : Pattern enabled ********* ");
     }
 
-    @Test
-    @Mode(TestMode.FULL)
-    public void testSlowReqDynamicPatternRemove() throws Exception {
-        //Step 1 - Update server configuration - ContextInfo = false , Threshold = 2s
-        server.setMarkToEndOfLog();
-        CommonTasks.writeLogMsg(Level.INFO, "--------> Starting Server with Pattern disabled..");
-        server.setServerConfigurationFile("server_NOContextInfo.xml");
-        waitForConfigurationUpdate();
-
-        //Step 2 -  create request for 3seconds and look for slow request warnings do not have contextInfo
-        createRequest("?sleepTime=3000");
-
-        List<String> lines = server.findStringsInFileInLibertyServerRoot("ms", MESSAGE_LOG);
-
-        for (String line : lines) {
-            assertFalse("contextInfo found when it is disabled..", (line.contains("|")));
-        }
-        CommonTasks.writeLogMsg(Level.INFO, "******** As Expected : Pattern disabled ******* ");
-
-        //Step 3 - Update server configuration - default of request timing feature.
-        server.setMarkToEndOfLog();
-        server.setServerConfigurationFile("server_original.xml");
-        waitForConfigurationUpdate();
-
-        //Step 3 -  create request for 11 seconds and look for slow request warnings have contextInfo
-        createRequest("?sleepTime=11000");
-        server.waitForStringInLogUsingMark("TRAS0112W", 30000);
-
-        lines = server.findStringsInLogsUsingMark("ms", MESSAGE_LOG);
-        server.setMarkToEndOfLog();
-
-        for (String line : lines) {
-            if (!line.contains("TRAS0112W") && !line.contains("TRAS0113I") && !line.contains("CWWKG0028A")) {
-                assertTrue("contextInfo NOT found when it is enabled by default ..", (line.contains("|")));
-            }
-        }
-
-        CommonTasks.writeLogMsg(Level.INFO, "*********** As Expected : Pattern enabled ********* ");
-    }
+    /*
+     * This is already tested in testDynamicDisableWithNoContextInfo
+     * 
+     * @Test
+     * 
+     * @Mode(TestMode.FULL)
+     * public void testSlowReqDynamicPatternRemove() throws Exception {
+     * //Step 1 - Update server configuration - ContextInfo = false , Threshold = 2s
+     * CommonTasks.writeLogMsg(Level.INFO, "--------> Starting Server with Pattern disabled..");
+     * server.setServerConfigurationFile("server_NOContextInfo.xml");
+     * waitForConfigurationUpdate();
+     * 
+     * //Step 2 - create request for 3seconds and look for slow request warnings do not have contextInfo
+     * createRequest("?sleepTime=3000");
+     * 
+     * List<String> lines = server.findStringsInFileInLibertyServerRoot("ms", MESSAGE_LOG);
+     * 
+     * for (String line : lines) {
+     * assertFalse("contextInfo found when it is disabled..", (line.contains("|")));
+     * }
+     * CommonTasks.writeLogMsg(Level.INFO, "******** As Expected : Pattern disabled ******* ");
+     * 
+     * //Step 3 - Update server configuration - default of request timing feature.
+     * server.setMarkToEndOfLog();
+     * server.setServerConfigurationFile("server_original.xml");
+     * waitForConfigurationUpdate();
+     * 
+     * //Step 3 - create request for 11 seconds and look for slow request warnings have contextInfo
+     * createRequest("?sleepTime=11000");
+     * server.waitForStringInLogUsingMark("TRAS0112W", 30000);
+     * 
+     * lines = server.findStringsInLogsUsingMark("ms", MESSAGE_LOG);
+     * server.setMarkToEndOfLog();
+     * 
+     * for (String line : lines) {
+     * if (!line.contains("TRAS0112W") && !line.contains("TRAS0113I") && !line.contains("CWWKG0028A")) {
+     * assertTrue("contextInfo NOT found when it is enabled by default ..", (line.contains("|")));
+     * }
+     * }
+     * 
+     * CommonTasks.writeLogMsg(Level.INFO, "*********** As Expected : Pattern enabled ********* ");
+     * }
+     */
 
     @Test
     @Mode(TestMode.FULL)
     public void testSlowReqSampleRateOdd() throws Exception {
         //Step 1 - Update server configuration - sampleRate=3, Threshold = "3s"
-        server.setMarkToEndOfLog();
-
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> Updating server with configuration : sampleRate=3");
         server.setServerConfigurationFile("server_sampleRate3.xml");
         waitForConfigurationUpdate();
@@ -664,17 +650,16 @@ public class SlowRequestTiming {
         //Step 1 - Update server configuration - sampleRate=2, Threshold = "3s"
         server.setMarkToEndOfLog();
 
-        CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> Updating server with configuration : sampleRate=3");
+        CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> Updating server with configuration : sampleRate=2");
         server.setServerConfigurationFile("server_sampleRate2.xml");
         waitForConfigurationUpdate();
 
-        //Step 2 - create 4 requests of 4s each - Every 2nd sample should generate a slow request warning.
-
+        //Step 2 - create 2 requests of 4s each - Every 2nd sample should generate a slow request warning.
         for (int count = 1; count < 3; count++) {
             createRequest("?sleepTime=4000");
         }
 
-        //slow request warning:   Fetch ID and check if it ends with AC which confirms its 3rd request
+        //slow request warning:   Fetch ID and check if it ends with AB which confirms its 2nd request
         //TRAS0112W: Request AADJi05x9AW_AAAAAAAAAAB has been running on thread 00000023 for at least 3001.386ms
 
         server.waitForStringInLogUsingMark("TRAS0112W", 30000);
@@ -702,7 +687,6 @@ public class SlowRequestTiming {
     @Mode(TestMode.FULL)
     public void testSlowReqSampleRateNegative() throws Exception {
         //Step 1 - Update server configuration - sampleRate=-2, Threshold = "3s"
-        server.setMarkToEndOfLog();
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> Updating server with configuration : sampleRate=-2");
         server.setServerConfigurationFile("server_sampleRateNeg2.xml");
         waitForConfigurationUpdate();
@@ -721,12 +705,11 @@ public class SlowRequestTiming {
     @Mode(TestMode.FULL)
     public void testSlowReqSampleRateDynamicUpdate() throws Exception {
         //Step 1 - Update server configuration - sampleRate=2, Threshold = "3s"
-        server.setMarkToEndOfLog();
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> Updating server with configuration : sampleRate=2");
         server.setServerConfigurationFile("server_sampleRate2.xml");
         waitForConfigurationUpdate();
 
-        //Step 2 - Create 2 requests of 4 seconds each and verify that it works like sampleRate 1.
+        //Step 2 - Create 2 requests of 4 seconds each.
         createRequest("?sleepTime=4000");
         createRequest("?sleepTime=4000");
         int slowCount = fetchNoOfslowRequestWarnings();
@@ -751,7 +734,6 @@ public class SlowRequestTiming {
     @Mode(TestMode.FULL)
     public void testSlowReqSampleRateDynamicEnable() throws Exception {
         //Step 1 - Update server configuration - Enable Request Timing
-        server.setMarkToEndOfLog();
         CommonTasks.writeLogMsg(Level.INFO, "**** Starting server with default Request Timing configuration");
         server.setServerConfigurationFile("server_original.xml");
 
@@ -780,7 +762,6 @@ public class SlowRequestTiming {
     @Mode(TestMode.FULL)
     public void testSlowReqSampleRateDynamicDisable() throws Exception {
         //Step 1 - Update server configuration - sampleRate=2, Threshold = "3s"
-        server.setMarkToEndOfLog();
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> Updating server with configuration : sampleRate=2");
         server.setServerConfigurationFile("server_sampleRate2.xml");
         waitForConfigurationUpdate();
@@ -811,7 +792,6 @@ public class SlowRequestTiming {
     @Mode(TestMode.FULL)
     public void testMaxSlowRequestTimingWarnings() throws Exception {
         //Step 1 - Update server configuration - Threshold = 3s
-        server.setMarkToEndOfLog();
         CommonTasks.writeLogMsg(Level.INFO, "$$$ Updated Server Configuration  : Slow Request Threshold = 3s");
         server.setServerConfigurationFile("server_slowRequestThreshold3.xml");
 

--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/TimingRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/TimingRequestTiming.java
@@ -205,9 +205,9 @@ public class TimingRequestTiming {
         // Should sleep and not hit hung request threshold since the context info specific settings
         // are longer than the global defaults.
         long startTime = System.nanoTime();
-        createRequests(1000, 1); /* Total sleep time: 25 sec + 1 sec + 5 sec = 31 sec */
+        createRequests(12000, 1);
         long elapsedSeconds = TimeUnit.SECONDS.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
-        assertTrue("Test did not run long enough (elapsedSeconds)", elapsedSeconds >= 30);
+        assertTrue("Test did not run long enough (elapsedSeconds)", elapsedSeconds >= 12);
 
         // Make sure we didn't get any hung request messages
         assertTrue("Test should not have found any slow request messages", fetchSlowRequestWarningsCount() == 0);
@@ -221,18 +221,18 @@ public class TimingRequestTiming {
 
         server.setMarkToEndOfLog();
 
-        // Should sleep and not hit hung request threshold since the context info specific settings
-        // are longer than the global defaults.
+        // Should sleep and hit hung request threshold since the context info specific settings
+        // are shorter than the global thresholds.
         startTime = System.nanoTime();
-        createRequests(1000, 1); /* Total sleep time: 25 sec + 1 sec + 5 sec = 31 sec */
+        createRequests(12000, 1);
         elapsedSeconds = TimeUnit.SECONDS.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
-        assertTrue("Test did not run long enough (elapsedSeconds)", elapsedSeconds >= 30);
+        assertTrue("Test did not run long enough (elapsedSeconds)", elapsedSeconds >= 12);
 
         // Make sure we had some hung request messages
         assertTrue("Test should have found slow request messages", fetchSlowRequestWarningsCount() > 0);
         assertTrue("Test should have found hung request messages", fetchHungRequestWarningsCount() > 0);
 
-        CommonTasks.writeLogMsg(Level.INFO, "***** Testcase pass *****");
+        CommonTasks.writeLogMsg(Level.INFO, "***** Testcase testContextInfoExactMatchOverrideDefault pass *****");
     }
 
     /**
@@ -247,11 +247,11 @@ public class TimingRequestTiming {
         server.setMarkToEndOfLog();
 
         // Should sleep and not hit hung request threshold since the context info specific settings
-        // are longer than the global defaults.
+        // are longer than the global thresholds.
         long startTime = System.nanoTime();
-        createRequests(1000, 1); /* Total sleep time: 25 sec + 1 sec + 5 sec = 31 sec */
+        createRequests(12000, 1);
         long elapsedSeconds = TimeUnit.SECONDS.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
-        assertTrue("Test did not run long enough (elapsedSeconds)", elapsedSeconds >= 30);
+        assertTrue("Test did not run long enough (elapsedSeconds)", elapsedSeconds >= 12);
 
         // Make sure we didn't get any hung request messages
         assertTrue("Test should not have found any slow request messages", fetchSlowRequestWarningsCount() == 0);
@@ -265,18 +265,18 @@ public class TimingRequestTiming {
 
         server.setMarkToEndOfLog();
 
-        // Should sleep and not hit hung request threshold since the context info specific settings
-        // are longer than the global defaults.
+        // Should sleep and hit hung request threshold since the context info specific settings
+        // are shorter than the global thresholds.
         startTime = System.nanoTime();
-        createRequests(1000, 1); /* Total sleep time: 25 sec + 1 sec + 5 sec = 31 sec */
+        createRequests(12000, 1);
         elapsedSeconds = TimeUnit.SECONDS.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
-        assertTrue("Test did not run long enough (elapsedSeconds)", elapsedSeconds >= 30);
+        assertTrue("Test did not run long enough (elapsedSeconds)", elapsedSeconds >= 12);
 
         // Make sure we had some hung request messages
         assertTrue("Test should have found slow request messages", fetchSlowRequestWarningsCount() > 0);
         assertTrue("Test should have found hung request messages", fetchHungRequestWarningsCount() > 0);
 
-        CommonTasks.writeLogMsg(Level.INFO, "***** Testcase pass *****");
+        CommonTasks.writeLogMsg(Level.INFO, "***** Testcase testContextInfoWildCardMatchOverrideDefault pass *****");
     }
 
     /*
@@ -291,7 +291,6 @@ public class TimingRequestTiming {
     @Test
     @Mode(TestMode.FULL)
     public void testTimingGlobalConfig() throws Exception {
-        server.setMarkToEndOfLog();
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration thresholds for  <global : slow : 3s , hung : 6s><timing - Slow : 10s , hung : 12s>");
         server.setServerConfigurationFile("server_timing_global.xml");
         waitForConfigurationUpdate();
@@ -306,7 +305,7 @@ public class TimingRequestTiming {
 
         assertTrue("Expected > 1 slow request warnings but found : " + slow, (slow > 1));
 
-        assertTrue("Expected 2 hung request warning but found : " + hung, (hung > 1));
+        assertTrue("Expected > 1 hung request warning but found : " + hung, (hung > 1));
 
         CommonTasks.writeLogMsg(Level.INFO, "***** timing works - global settings applies for rest of the root event types. *****");
     }
@@ -323,7 +322,6 @@ public class TimingRequestTiming {
     @Test
     @Mode(TestMode.FULL)
     public void testTimingLocalConfigOnly() throws Exception {
-        server.setMarkToEndOfLog();
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration thresholds for  <global : defaults ><timing - Slow : 3s , hung : 5s>");
         server.setServerConfigurationFile("server_timing_localOnly.xml");
         waitForConfigurationUpdate();
@@ -358,7 +356,6 @@ public class TimingRequestTiming {
     @Test
     @Mode(TestMode.FULL)
     public void testTimingGlobalConfigNotSpecified() throws Exception {
-        server.setMarkToEndOfLog();
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration thresholds for  <global : defaults ><timing - Slow : 3s , hung : 5s>");
         server.setServerConfigurationFile("server_timing_NoGlobal.xml");
         waitForConfigurationUpdate();
@@ -391,7 +388,6 @@ public class TimingRequestTiming {
     @Test
     @Mode(TestMode.FULL)
     public void testTimingLocalNegativeSlowThreshold() throws Exception {
-        server.setMarkToEndOfLog();
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration thresholds for  <global : slow : 9s , hung : 20s ><timing - Slow : -1 , hung : 3s>");
         server.setServerConfigurationFile("server_timing_local_NoSlowReq.xml");
         waitForConfigurationUpdate();
@@ -421,7 +417,6 @@ public class TimingRequestTiming {
     @Test
     @Mode(TestMode.FULL)
     public void testTimingLocalInheritsGlobalConfig() throws Exception {
-        server.setMarkToEndOfLog();
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration thresholds for  <global : slow : 2s , hung : 4s ><timing>");
         server.setServerConfigurationFile("server_timing_local_inherits.xml");
         waitForConfigurationUpdate();
@@ -451,7 +446,6 @@ public class TimingRequestTiming {
     @Test
     @Mode(TestMode.FULL)
     public void testTimingLocalGlobalNoConfig() throws Exception {
-        server.setMarkToEndOfLog();
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration thresholds for - <global -default> <timing - default>");
         server.setServerConfigurationFile("server_timing_local_global_noConfig.xml");
         waitForConfigurationUpdate();
@@ -481,7 +475,6 @@ public class TimingRequestTiming {
     @Test
     @Mode(TestMode.FULL)
     public void testTimingLocalDisableSlowHungRequest() throws Exception {
-        server.setMarkToEndOfLog();
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration thresholds for - <global : slow : 1s , hung : 2s ><timing - slow : 0 , hung : 0>");
         server.setServerConfigurationFile("server_timing_NoSlowHungReqs.xml");
         waitForConfigurationUpdate();
@@ -510,7 +503,6 @@ public class TimingRequestTiming {
     @Test
     @Mode(TestMode.FULL)
     public void testTimingGlobalConfigFollowsLocal() throws Exception {
-        server.setMarkToEndOfLog();
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration thresholds for - <global : slow : 3s , hung : 6s ><timing - slow : 2s , hung : 9m>");
         server.setServerConfigurationFile("server_timing_global_follows_local.xml");
         waitForConfigurationUpdate();
@@ -540,7 +532,6 @@ public class TimingRequestTiming {
     @Test
     @Mode(TestMode.FULL)
     public void testDynamicTimingUpdate() throws Exception {
-        server.setMarkToEndOfLog();
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> server configuration thresholds for - <global - slow : 9s , hung : 20s> <timing - Slow : 5s , hung : 7s>");
         server.setServerConfigurationFile("server_timing_local.xml");
         waitForConfigurationUpdate();
@@ -557,7 +548,6 @@ public class TimingRequestTiming {
         assertTrue("Expected 1 hung request warning but found : " + hung, (hung > 0));
         server.setMarkToEndOfLog();
 
-        server.setMarkToEndOfLog();
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> UPDATED server configuration thresholds for  <global : defaults ><timing - Slow : 3s , hung : 5s>");
         server.setServerConfigurationFile("server_timing_localOnly.xml");
         waitForConfigurationUpdate();
@@ -640,9 +630,9 @@ public class TimingRequestTiming {
         // Should sleep and not hit hung request threshold since the global defaults
         // are longer than all the context-info-specific settings.
         long startTime = System.nanoTime();
-        createRequests(1000, 1); /* Total sleep time: 25 sec + 1 sec + 5 sec = 31 sec */
+        createRequests(12000, 1);
         long elapsedSeconds = TimeUnit.SECONDS.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
-        assertTrue("Test did not run long enough (elapsedSeconds)", elapsedSeconds >= 30);
+        assertTrue("Test did not run long enough (elapsedSeconds)", elapsedSeconds >= 12);
 
         // Make sure we didn't get any hung request messages
         assertTrue("Test should not have found any slow request messages", fetchSlowRequestWarningsCount() == 0);
@@ -655,12 +645,12 @@ public class TimingRequestTiming {
 
         server.setMarkToEndOfLog();
 
-        // Should sleep and not hit hung request threshold since the context info specific settings
+        // Should sleep and hit the hung request threshold since the context info specific settings
         // are longer than the global defaults.
         startTime = System.nanoTime();
-        createRequests(1000, 1); /* Total sleep time: 25 sec + 1 sec + 5 sec = 31 sec */
+        createRequests(12000, 1);
         elapsedSeconds = TimeUnit.SECONDS.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
-        assertTrue("Test did not run long enough (elapsedSeconds)", elapsedSeconds >= 30);
+        assertTrue("Test did not run long enough (elapsedSeconds)", elapsedSeconds >= 12);
 
         // Make sure we had some hung request messages
         assertTrue("Test should have found slow request messages", fetchSlowRequestWarningsCount() > 0);
@@ -684,9 +674,9 @@ public class TimingRequestTiming {
         // Should sleep and not hit hung request threshold since the context info specific settings
         // are longer than the global defaults.
         long startTime = System.nanoTime();
-        createRequests(1000, 1); /* Total sleep time: 25 sec + 1 sec + 5 sec = 31 sec */
+        createRequests(12000, 1);
         long elapsedSeconds = TimeUnit.SECONDS.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
-        assertTrue("Test did not run long enough (elapsedSeconds)", elapsedSeconds >= 30);
+        assertTrue("Test did not run long enough (elapsedSeconds)", elapsedSeconds >= 12);
 
         // Make sure we didn't get any hung request messages
         assertTrue("Test should not have found any slow request messages", fetchSlowRequestWarningsCount() == 0);
@@ -703,15 +693,15 @@ public class TimingRequestTiming {
         // Should sleep and not hit hung request threshold since the context info specific settings
         // are longer than the global defaults.
         startTime = System.nanoTime();
-        createRequests(1000, 1); /* Total sleep time: 25 sec + 1 sec + 5 sec = 31 sec */
+        createRequests(12000, 1);
         elapsedSeconds = TimeUnit.SECONDS.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
-        assertTrue("Test did not run long enough (elapsedSeconds)", elapsedSeconds >= 30);
+        assertTrue("Test did not run long enough (elapsedSeconds)", elapsedSeconds >= 12);
 
         // Make sure we had some hung request messages
         assertTrue("Test should have found slow request messages", fetchSlowRequestWarningsCount() > 0);
         assertTrue("Test should have found hung request messages", fetchHungRequestWarningsCount() > 0);
 
-        CommonTasks.writeLogMsg(Level.INFO, "***** Testcase pass *****");
+        CommonTasks.writeLogMsg(Level.INFO, "***** Testcase testContextInfoExactMatchDisableDefault pass *****");
     }
 
     private void waitForConfigurationUpdate() throws Exception {

--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/TimingRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/TimingRequestTiming.java
@@ -89,7 +89,7 @@ public class TimingRequestTiming {
 
         server.setMarkToEndOfLog();
 
-        createRequests(8000, 1);
+        createRequests(9000, 1);
 
         server.waitForStringInLog("TRAS0112W", 10000); // adding timeout for wait as 10s
         server.waitForStringInLog("TRAS0114W", 10000);
@@ -120,7 +120,7 @@ public class TimingRequestTiming {
 
         server.setMarkToEndOfLog();
 
-        createRequests(5000, 1);
+        createRequests(6000, 1);
 
         server.waitForStringInLog("TRAS0112W", 10000);
         server.waitForStringInLog("TRAS0114W", 10000);
@@ -150,7 +150,7 @@ public class TimingRequestTiming {
         server.setServerConfigurationFile("server_original.xml");
         server.waitForStringInLogUsingMark("CWWKG0017I", 30000);
         CommonTasks.writeLogMsg(Level.INFO, "****  Started server without <timing> : default configurations for Request timing");
-        createRequests(11000, 1);
+        createRequests(12000, 1);
 
         server.waitForStringInLogUsingMark("TRAS0112W", 10000);
         int p_slow = fetchSlowRequestWarningsCount();
@@ -180,7 +180,7 @@ public class TimingRequestTiming {
         server.setServerConfigurationFile("server_original.xml");
         server.waitForStringInLogUsingMark("CWWKG0017I", 30000);
 
-        createRequests(11000, 1);
+        createRequests(12000, 1);
 
         int n_slow = fetchSlowRequestWarningsCount();
         int n_hung = fetchHungRequestWarningsCount();
@@ -295,7 +295,7 @@ public class TimingRequestTiming {
         server.setServerConfigurationFile("server_timing_global.xml");
         waitForConfigurationUpdate();
 
-        createRequests(13000, 1);
+        createRequests(20000, 1);
 
         server.waitForStringInLogUsingMark("TRAS0112W", 10000);
         server.waitForStringInLogUsingMark("TRAS0114W", 10000);
@@ -328,7 +328,7 @@ public class TimingRequestTiming {
 
         server.setMarkToEndOfLog();
 
-        createRequests(6000, 1);
+        createRequests(7000, 1);
 
         server.waitForStringInLogUsingMark("TRAS0112W", 10000);
         server.waitForStringInLogUsingMark("TRAS0114W", 10000);
@@ -394,7 +394,7 @@ public class TimingRequestTiming {
 
         server.setMarkToEndOfLog();
 
-        createRequests(4000, 1);
+        createRequests(5000, 1);
 
         server.waitForStringInLogUsingMark("TRAS0114W", 10000);
 
@@ -423,7 +423,7 @@ public class TimingRequestTiming {
 
         server.setMarkToEndOfLog();
 
-        createRequests(5000, 1);
+        createRequests(6000, 1);
 
         server.waitForStringInLogUsingMark("TRAS0112W", 10000);
         server.waitForStringInLogUsingMark("TRAS0114W", 10000);
@@ -536,7 +536,7 @@ public class TimingRequestTiming {
         server.setServerConfigurationFile("server_timing_local.xml");
         waitForConfigurationUpdate();
 
-        createRequests(8000, 1);
+        createRequests(9000, 1);
 
         server.waitForStringInLogUsingMark("TRAS0112W", 10000);
         server.waitForStringInLogUsingMark("TRAS0114W", 10000);
@@ -552,7 +552,7 @@ public class TimingRequestTiming {
         server.setServerConfigurationFile("server_timing_localOnly.xml");
         waitForConfigurationUpdate();
 
-        createRequests(6000, 1);
+        createRequests(7000, 1);
 
         server.waitForStringInLogUsingMark("TRAS0112W", 10000);
         server.waitForStringInLogUsingMark("TRAS0114W", 10000);

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_hungRequestThreshold2.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_hungRequestThreshold2.xml
@@ -1,0 +1,16 @@
+<server description="new server">
+
+  <!-- Enable features -->
+    <featureManager>
+        <feature>jsp-2.2</feature>
+      <feature>requestTiming-1.0</feature>
+    </featureManager>
+  
+	<httpEndpoint id="defaultHttpEndpoint" host="*" />
+
+	<include location="../fatTestPorts.xml"/>
+  	
+   <requestTiming slowRequestThreshold="0"/>
+   <requestTiming hungRequestThreshold = "2s" />
+  
+</server>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_hungRequestThreshold3.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_hungRequestThreshold3.xml
@@ -1,0 +1,16 @@
+<server description="new server">
+
+  <!-- Enable features -->
+    <featureManager>
+        <feature>jsp-2.2</feature>
+      <feature>requestTiming-1.0</feature>
+    </featureManager>
+  
+	<httpEndpoint id="defaultHttpEndpoint" host="*" />
+
+	<include location="../fatTestPorts.xml"/>
+  	
+   <requestTiming slowRequestThreshold="0"/>
+   <requestTiming hungRequestThreshold = "3s" />
+  
+</server>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRate0.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRate0.xml
@@ -27,5 +27,6 @@
  	<include location="../fatTestPorts.xml"/>
    
 	<requestTiming sampleRate = "0" />
+	<requestTiming slowRequestThreshold="2s" />
   
 </server>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold1.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_slowRequestThreshold1.xml
@@ -8,7 +8,7 @@
     </featureManager>
 
   
-	 <httpEndpoint id="defaultHttpEndpoint" host="*" />
+	<httpEndpoint id="defaultHttpEndpoint" host="*" />
                    
     <jdbcDriver id="DerbyEmbedded" libraryRef="DerbyLib"/>
     <library filesetRef="DerbyFileset" id="DerbyLib"/>
@@ -26,6 +26,6 @@
 
  	<include location="../fatTestPorts.xml"/>
   
-	  <requestTiming slowRequestThreshold="1s" />
+	<requestTiming slowRequestThreshold="1s" />
   
 </server>

--- a/dev/com.ibm.ws.request.timing_fat/test-applications/jdbcTestPrj_3/src/com/ibm/ws/request/timing/TestJDBC.java
+++ b/dev/com.ibm.ws.request.timing_fat/test-applications/jdbcTestPrj_3/src/com/ibm/ws/request/timing/TestJDBC.java
@@ -1,5 +1,6 @@
 package com.ibm.ws.request.timing;
 
+import static org.junit.Assert.assertEquals;
 
 import java.io.*;
 import java.sql.*;
@@ -56,14 +57,18 @@ public class TestJDBC extends HttpServlet
 
       System.out.println((new StringBuilder(" Session value is ")).append(s.getValue()).toString());
       
-      int returnValue = -9999999;
+      int returnValue = -1;
       for(int i = 11; i <= 15; i++) {
           returnValue = stmt.executeUpdate((new StringBuilder("insert into "+tableName+" values ('myHomeCity_ ")).append(i).append("', ").append(i).append(", 'myHomeCounty_").append(i).append("')").toString());
-          // We will need to ensure that the executeUpdate completes before continuing
-          while (returnValue == -9999999) {
-              continue;
+          try {
+              Thread.sleep(1500);  // Sleep to give time for update to fully complete
+              if (returnValue != 1) {
+                  System.out.println("Warning: The expected return value of stmt.executeUpdate is 1, but got: " + returnValue + ". This is fine and the test can still pass.");
+              }
+              returnValue = -1;
+          } catch (Exception e) {
+              e.printStackTrace();
           }
-          returnValue = -9999999;
       }  
       
       System.out.println("doGet completed Successfully");

--- a/dev/com.ibm.ws.request.timing_fat/test-applications/jdbcTestPrj_3/src/com/ibm/ws/request/timing/TestJDBC.java
+++ b/dev/com.ibm.ws.request.timing_fat/test-applications/jdbcTestPrj_3/src/com/ibm/ws/request/timing/TestJDBC.java
@@ -55,15 +55,37 @@ public class TestJDBC extends HttpServlet
 
 
       System.out.println((new StringBuilder(" Session value is ")).append(s.getValue()).toString());
-
-       
-      for(int i = 11; i <= 15; i++) {
-          stmt.executeUpdate((new StringBuilder("insert into "+tableName+" values ('myHomeCity_ ")).append(i).append("', ").append(i).append(", 'myHomeCounty_").append(i).append("')").toString());
-          try {
-              Thread.sleep(5000);
-          } catch (Exception e) {
-              e.printStackTrace();
+      
+      class executeUpdateThread extends Thread{
+          private int i;
+          private String tableName;
+          private Statement stmt;
+          
+          public executeUpdateThread(int i, String tableName, Statement stmt) {
+              this.i = i;
+              this.tableName = tableName;
+              this.stmt = stmt;
           }
+          
+          @Override
+          public void run() {
+              try {
+                  System.out.println("Starting thread action");
+                  stmt.executeUpdate((new StringBuilder("insert into "+tableName+" values ('myHomeCity_ ")).append(i).append("', ").append(i).append(", 'myHomeCounty_").append(i).append("')").toString());
+                  System.out.println("Ending thread action");
+              }catch (SQLException e){
+                  e.printStackTrace();
+              }
+          }  
+      }
+      
+      Thread th;
+      for(int i = 11; i <= 15; i++) {
+          th = new executeUpdateThread(i, tableName, stmt);
+          th.start();
+          System.out.println("Waiting for thread " + i);
+          th.join(5000);
+          System.out.println("Finished thread " + i);
       }
       
       System.out.println("doGet completed Successfully");
@@ -102,6 +124,7 @@ public class TestJDBC extends HttpServlet
             e.printStackTrace();
         }
         
+        /*
         try {
             System.out.println(" Some more delay... ");
             Thread.sleep(5000);
@@ -109,6 +132,7 @@ public class TestJDBC extends HttpServlet
         } catch (Exception e) {
             e.printStackTrace();
         }
+        */
         System.out.println("%%%%%%%%%%% Completed session set");
         return;
     }

--- a/dev/com.ibm.ws.request.timing_fat/test-applications/jdbcTestPrj_3/src/com/ibm/ws/request/timing/TestJDBC.java
+++ b/dev/com.ibm.ws.request.timing_fat/test-applications/jdbcTestPrj_3/src/com/ibm/ws/request/timing/TestJDBC.java
@@ -56,37 +56,15 @@ public class TestJDBC extends HttpServlet
 
       System.out.println((new StringBuilder(" Session value is ")).append(s.getValue()).toString());
       
-      class executeUpdateThread extends Thread{
-          private int i;
-          private String tableName;
-          private Statement stmt;
-          
-          public executeUpdateThread(int i, String tableName, Statement stmt) {
-              this.i = i;
-              this.tableName = tableName;
-              this.stmt = stmt;
-          }
-          
-          @Override
-          public void run() {
-              try {
-                  System.out.println("Starting thread action");
-                  stmt.executeUpdate((new StringBuilder("insert into "+tableName+" values ('myHomeCity_ ")).append(i).append("', ").append(i).append(", 'myHomeCounty_").append(i).append("')").toString());
-                  System.out.println("Ending thread action");
-              }catch (SQLException e){
-                  e.printStackTrace();
-              }
-          }  
-      }
-      
-      Thread th;
+      int returnValue = -9999999;
       for(int i = 11; i <= 15; i++) {
-          th = new executeUpdateThread(i, tableName, stmt);
-          th.start();
-          System.out.println("Waiting for thread " + i);
-          th.join(5000);
-          System.out.println("Finished thread " + i);
-      }
+          returnValue = stmt.executeUpdate((new StringBuilder("insert into "+tableName+" values ('myHomeCity_ ")).append(i).append("', ").append(i).append(", 'myHomeCounty_").append(i).append("')").toString());
+          // We will need to ensure that the executeUpdate completes before continuing
+          while (returnValue == -9999999) {
+              continue;
+          }
+          returnValue = -9999999;
+      }  
       
       System.out.println("doGet completed Successfully");
     } catch (Exception e) {
@@ -123,16 +101,7 @@ public class TestJDBC extends HttpServlet
         {
             e.printStackTrace();
         }
-        
-        /*
-        try {
-            System.out.println(" Some more delay... ");
-            Thread.sleep(5000);
-            System.out.println(" completed..");
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        */
+
         System.out.println("%%%%%%%%%%% Completed session set");
         return;
     }


### PR DESCRIPTION
DO NOT MERGE! Work still in progress.  Status ---> In for final review

The latest build is located here https://wasrtc.hursley.ibm.com:9443/jazz/resource/itemOid/com.ibm.team.build.BuildResult/_2aVDgMS2Eeq1S7zZzzGuaA
The build completed successfully without any failures or errors.

The following are the run times **before** the changes...
**Lite  --- Total approx.  26.5min**
HungRequestTiming 2m 26s
SlowRequestTiming 11m 52s
TimingRequestTiming 12m 07s
**Full  --- Total approx.  96.5min**
HungRequestTiming 16m 40s
SlowRequestTiming 46m 34s
TimingRequestTiming 33m 30s

The following are the run times **after** the changes...
**Lite  --- Total approx.  15min**
HungRequestTiming 1m 51s
SlowRequestTiming 6m 09s
TimingRequestTiming 6m 57s
**Full  --- Total approx.  59min**
HungRequestTiming 15m 07s
SlowRequestTiming 23m 50s
TimingRequestTiming 19m 42s

The following is a list of changes...
**List of changes in regards to increasing the performance and runtime of the tests**
1. Removed a lot of unnecessary server.setMarkToEndOfLog calls.
2. Removed unnecessary sleeps throughout the test cases and test applications.
3. Shorten the sleeps and hung/slow request thresholds where possible  (EX/ Instead of waiting 10 sec for a slow request we only have to wait 3+sec if we set the threshold to 3sec).
4. Removed many unnecessary server configuration changes/updates.
5. Improved the TestJDBC test applications to execute updates without having to wait for a hardcoded 5secs for each update and also removed unnecessary thread sleeps. This saves about 30secs per request. If a test case makes two requests then we save 1min of unnecessary waits.

**List of bug fixes and other fixes**
1. Corrected many log messages that contained wrong information
2. Corrected many comments in the code which contained wrong information
3. Fixed a rare synchronization bug in one of the test cases for HungRequestTiming where we can't find a message in the log since we did not give enough time for it to generate