### PR TITLE
Get things building in eclipse again

### DIFF
--- a/dev/cnf/resources/bnd/repos.bnd
+++ b/dev/cnf/resources/bnd/repos.bnd
@@ -40,6 +40,7 @@ fetch.oss.repository: \
   aQute.bnd.repository.maven.provider.MavenBndRepository; \
     name              = RemotePublic; \
     releaseUrl        = https://repo.maven.apache.org/maven2/; \
+    snapshotUrl       = https://oss.sonatype.org/content/repositories/snapshots/; \
     index             = ${build}/oss_dependencies.maven
 
 fetch.oss.ibm.repository: \

--- a/dev/com.ibm.ws.kernel.filemonitor_fat/.classpath
+++ b/dev/com.ibm.ws.kernel.filemonitor_fat/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="test-bundles/com.ibm.ws.kernel.filemonitor.monitor.test.bundle/src"/>
+	<classpathentry kind="src" output="bin" path="fat/src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry exported="true" kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/com.ibm.ws.kernel.filemonitor_fat/.project
+++ b/dev/com.ibm.ws.kernel.filemonitor_fat/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.ibm.ws.kernel.filemonitor_fat</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/com.ibm.ws.kernel.filemonitor_fat/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.kernel.filemonitor_fat/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.kernel.filemonitor_fat/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.kernel.filemonitor_fat/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/wlp-jakartaee-transform/.settings/bndtools.core.prefs
+++ b/dev/wlp-jakartaee-transform/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1


### PR DESCRIPTION
- Add eclipse settings for com.ibm.ws.kernel.filemonitor_fat
- Add missing bndtools prefs for wlp-jakartaee-transform
- Update repos.bnd to include snapshotUrl that was added for gradle, but not for bnd which is what eclipse uses.
