### PR TITLE
Change logging.json_fat tests to check trace for server config update …

### DIFF
--- a/dev/com.ibm.ws.logging.json_fat/fat/src/com/ibm/ws/logging/json/fat/JsonConfigBootstrapTest.java
+++ b/dev/com.ibm.ws.logging.json_fat/fat/src/com/ibm/ws/logging/json/fat/JsonConfigBootstrapTest.java
@@ -22,6 +22,7 @@ import java.util.Properties;
 
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -496,10 +497,11 @@ public class JsonConfigBootstrapTest {
         TestUtils.runApp(server, "logServlet");
     }
 
-    private static String setServerConfig(String fileName) throws Exception {
-        server.setMarkToEndOfLog();
+    private static void setServerConfig(String fileName) throws Exception {
+        RemoteFile log = server.getDefaultTraceFile();
+        server.setMarkToEndOfLog(log);
         server.setServerConfigurationFile(fileName);
-        return server.waitForStringInLogUsingMark("CWWKG0017I.*|CWWKG0018I.*");
+        Assert.assertNotNull(server.waitForStringInLog("CWWKG0017I.*|CWWKG0018I.*", log));
     }
 
     @After

--- a/dev/com.ibm.ws.logging.json_fat/fat/src/com/ibm/ws/logging/json/fat/JsonConfigBootstrapTest.java
+++ b/dev/com.ibm.ws.logging.json_fat/fat/src/com/ibm/ws/logging/json/fat/JsonConfigBootstrapTest.java
@@ -206,6 +206,9 @@ public class JsonConfigBootstrapTest {
             consolesourceList = new ArrayList<String>(Arrays.asList("trace"));
             checkConsoleLogUpdate(true, consoleLogFile, "INFO", consolesourceList, "");
 
+            //set server.xml to a basic config so that when server stops, it can successfully check for CWWKE0036I in console log
+            setServerConfig(SERVER_XML_BASIC);
+
         } finally {
             // Restore the initial contents of bootstrap.properties
             FileOutputStream out = getFileOutputStreamForRemoteFile(bootstrapFile, false);
@@ -245,6 +248,9 @@ public class JsonConfigBootstrapTest {
 
             // Check in console.log file to see consoleLogLevel is set to WARNING
             checkConsoleLogUpdate(true, consoleLogFile, "ERROR", ALL_SOURCE_LIST, "");
+
+            //set server.xml to a basic config so that when server stops, it can successfully check for CWWKE0036I in console log
+            setServerConfig(SERVER_XML_BASIC);
 
         } finally {
             // Restore the initial contents of bootstrap.properties

--- a/dev/com.ibm.ws.logging.json_fat/fat/src/com/ibm/ws/logging/json/fat/JsonConfigTest.java
+++ b/dev/com.ibm.ws.logging.json_fat/fat/src/com/ibm/ws/logging/json/fat/JsonConfigTest.java
@@ -356,10 +356,12 @@ public class JsonConfigTest {
         TestUtils.runApp(server, "logServlet");
     }
 
-    private static String setServerConfig(String fileName) throws Exception {
-        server.setMarkToEndOfLog();
+    //check message.log for CWWKG0017I.*|CWWKG0018I. message, messageSource must have "message"
+    private static void setServerConfig(String fileName) throws Exception {
+        RemoteFile log = server.getDefaultTraceFile();
+        server.setMarkToEndOfLog(log);
         server.setServerConfigurationFile(fileName);
-        return server.waitForStringInLogUsingMark("CWWKG0017I.*|CWWKG0018I.*");
+        Assert.assertNotNull(server.waitForStringInLog("CWWKG0017I.*|CWWKG0018I.*", log));
     }
 
     @AfterClass


### PR DESCRIPTION
fixes: #12674

#build

The logging.json_fat suite was taking a long time because there were specific test cases that were timing out in `JSONConfigTest.java` and `JsonConfigBootstrapTest.java`.

The first type of time out is during the `setServerConfig()` function in both files. After updating the server.xml, the server checks for the `CWWKG0017I.*|CWWKG0018I.*` regex in the `messages.log` by default, but this message doesn't exist in some of the test cases because their server.xml configurations have `messageFormat="json"` while excluding the `message` log type from `messageSource`. The `setServerConfig()` function has been changed to use the `trace.log` to check for the regex, and an assert has been added to fail the test instead of allowing a timeout.

The second type of timeout occurs during server shut down when the server attempts to find the `CWWKE0036I` string in the console log. This message doesn't exist because of either: 1) the test case's server.xml configuration has `consoleFormat="json"` while excluding the `message` log type from `consoleSource`, or 2) the server.xml configuration has `consoleLogLevel="ERROR"`. Those specific tests have the server.xml reset to a basic server.xml configuration (that will generate the message in the console log) at the end of the test case, before the server shuts down.

This should cut down the LITE speed of the `logging.json_fat` suite from over 34 minutes to under 5 minutes.