### PR TITLE
Add new <kerberos> config element

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/db2/JDBCKerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/db2/JDBCKerberosTest.java
@@ -78,7 +78,8 @@ public class JDBCKerberosTest extends FATServletClient {
         server.addEnvVar("KRB5_USER", KRB5_USER);
         server.addEnvVar("KRB5_CONF", krbConfPath.toAbsolutePath().toString());
         List<String> jvmOpts = new ArrayList<>();
-        jvmOpts.add("-Dsun.security.krb5.debug=true");
+        jvmOpts.add("-Dsun.security.krb5.debug=true"); // Hotspot/OpenJ9
+        jvmOpts.add("-Dcom.ibm.security.krb5.krb5Debug=true"); // IBM JDK
         server.setJvmOptions(jvmOpts);
 
         server.startServer();

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/db2/JDBCKerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/db2/JDBCKerberosTest.java
@@ -76,8 +76,8 @@ public class JDBCKerberosTest extends FATServletClient {
         server.addEnvVar("DB2_USER", db2.getUsername());
         server.addEnvVar("DB2_PASS", db2.getPassword());
         server.addEnvVar("KRB5_USER", KRB5_USER);
+        server.addEnvVar("KRB5_CONF", krbConfPath.toAbsolutePath().toString());
         List<String> jvmOpts = new ArrayList<>();
-        jvmOpts.add("-Djava.security.krb5.conf=" + krbConfPath.toAbsolutePath());
         jvmOpts.add("-Dsun.security.krb5.debug=true");
         server.setJvmOptions(jvmOpts);
 

--- a/dev/com.ibm.ws.jdbc_fat_krb5/publish/servers/com.ibm.ws.jdbc.fat.krb5/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/publish/servers/com.ibm.ws.jdbc.fat.krb5/server.xml
@@ -14,26 +14,25 @@
     <fileset dir="${server.config.dir}/db2"/>
   </library>
   
+  <kerberos keytab="${server.config.dir}security/krb5.keytab" configFile="${KRB5_CONF}"/>
+  
   <dataSource jndiName="jdbc/krb/basic">
     <jdbcDriver libraryRef="DB2JCCLib"/>
     <properties.db2.jcc databaseName="${DB2_DBNAME}" serverName="${DB2_HOSTNAME}" portNumber="${DB2_PORT}"/>
-    <containerAuthData krb5Principal="${KRB5_USER}" 
-                       krb5Keytab="${server.config.dir}security/krb5.keytab"/>
+    <containerAuthData krb5Principal="${KRB5_USER}"/>
   </dataSource>
   
   <dataSource jndiName="jdbc/krb/xa" type="javax.sql.XADataSource">
     <jdbcDriver libraryRef="DB2JCCLib" />
     <properties.db2.jcc databaseName="${DB2_DBNAME}" serverName="${DB2_HOSTNAME}" portNumber="${DB2_PORT}"/>
-    <containerAuthData krb5Principal="${KRB5_USER}" 
-                       krb5Keytab="${server.config.dir}security/krb5.keytab"/>
+    <containerAuthData krb5Principal="${KRB5_USER}"/>
   </dataSource>
   
   <!-- Mis-configured datasource: bogus name for krb5Principal -->
   <dataSource jndiName="jdbc/krb/invalidPrincipal">
     <jdbcDriver libraryRef="DB2JCCLib"/>
     <properties.db2.jcc databaseName="${DB2_DBNAME}" serverName="${DB2_HOSTNAME}" portNumber="${DB2_PORT}"/>
-    <containerAuthData krb5Principal="bogus" 
-                       krb5Keytab="${server.config.dir}security/krb5.keytab"/>
+    <containerAuthData krb5Principal="bogus"/>
   </dataSource>
   
   <!-- Mis-configured datasource: backend DB requires Kerb but only basic user/pass configured -->

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/SecureAction.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/SecureAction.java
@@ -57,7 +57,8 @@ public class SecureAction {
     static final ClassLoader bootClassLoader = AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
         @Override
         public ClassLoader run() {
-            return new ClassLoader(Object.class.getClassLoader()) { /* boot class loader */};
+            return new ClassLoader(Object.class.getClassLoader()) {
+                /* boot class loader */};
         }
     });
 
@@ -85,6 +86,23 @@ public class SecureAction {
                 return new SecureAction();
             }
         };
+    }
+
+    /**
+     * See {@link System#setProperty(String, String)}
+     */
+    public void setProperty(String property, String value) {
+        if (System.getSecurityManager() == null) {
+            System.setProperty(property, value);
+        } else {
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+                @Override
+                public Void run() {
+                    System.setProperty(property, value);
+                    return null;
+                }
+            }, controlContext);
+        }
     }
 
     /**
@@ -163,7 +181,7 @@ public class SecureAction {
      * Creates a FileInputStream from a File. Same as calling
      * new FileOutputStream(File,boolean).
      *
-     * @param file the File to create a FileOutputStream from.
+     * @param file   the File to create a FileOutputStream from.
      * @param append indicates if the OutputStream should append content.
      * @return The FileOutputStream.
      * @throws FileNotFoundException if the File does not exist.
@@ -391,10 +409,10 @@ public class SecureAction {
      * {@link URL#URL(java.lang.String, java.lang.String, int, java.lang.String, java.net.URLStreamHandler)}
      *
      * @param protocol the protocol
-     * @param host the host
-     * @param port the port
-     * @param file the file
-     * @param handler the URLStreamHandler
+     * @param host     the host
+     * @param port     the port
+     * @param file     the file
+     * @param handler  the URLStreamHandler
      * @return a URL
      * @throws MalformedURLException
      */
@@ -419,8 +437,8 @@ public class SecureAction {
      * Creates a new Thread from a Runnable. Same as calling
      * new Thread(target,name).setContextClassLoader(contextLoader).
      *
-     * @param target the Runnable to create the Thread from.
-     * @param name The name of the Thread.
+     * @param target        the Runnable to create the Thread from.
+     * @param name          The name of the Thread.
      * @param contextLoader the context class loader for the thread
      * @return The new Thread
      */
@@ -447,7 +465,7 @@ public class SecureAction {
      * context.getService(reference)
      *
      * @param reference the ServiceReference
-     * @param context the BundleContext
+     * @param context   the BundleContext
      * @return a service object
      */
     public <S> S getService(final ServiceReference<S> reference, final BundleContext context) {

--- a/dev/com.ibm.ws.security.auth.data.common/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.auth.data.common/resources/OSGI-INF/l10n/metatype.properties
@@ -35,5 +35,5 @@ maxSize.desc=Maximum number of entries supported by the authentication data subj
 
 #======= KERBEROS SETTINGS =========
 # Do not translate: Kerberos, principal
-krb5Principal=Kerberos service principal name
-krb5Principal.desc=The name of the principal to be used. The principal can be a simple username or a service name.
+krb5Principal=Kerberos principal name
+krb5Principal.desc=The name of the Kerberos principal name or Kerberos service name to be used.

--- a/dev/com.ibm.ws.security.auth.data.common/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.auth.data.common/resources/OSGI-INF/l10n/metatype.properties
@@ -37,9 +37,3 @@ maxSize.desc=Maximum number of entries supported by the authentication data subj
 # Do not translate: Kerberos, principal
 krb5Principal=Kerberos service principal name
 krb5Principal.desc=The name of the principal to be used. The principal can be a simple username or a service name.
-
-# Do not translate: Kerberos, keytab, principal, {user.home}/krb5.keytab
-krb5Keytab=Kerberos keytab file
-krb5Keytab.desc=The path of the keytab file that is used to obtain the principal's secret key. If unspecified, the keytab from \
-the Kerberos configuration file is used. If it is not specified in the Kerberos configuration file, then it looks for the file \
-at {user.home}/krb5.keytab.

--- a/dev/com.ibm.ws.security.auth.data.common/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.auth.data.common/resources/OSGI-INF/metatype/metatype.xml
@@ -23,8 +23,6 @@
         <!-- Kerberos settings -->
         <AD id="krb5Principal" name="%krb5Principal" description="%krb5Principal.desc"
             required="false" type="String" ibm:beta="true"/>
-        <AD id="krb5Keytab" name="%krb5Keytab" description="%krb5Keytab.desc"
-            required="false" type="String" ibm:type="location(file)" ibm:beta="true"/>
     </OCD>
 
     <Designate factoryPid="com.ibm.ws.security.jca.internal.authdata.config">

--- a/dev/com.ibm.ws.security.auth.data.common/src/com/ibm/websphere/security/auth/data/AuthData.java
+++ b/dev/com.ibm.ws.security.auth.data.common/src/com/ibm/websphere/security/auth/data/AuthData.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package com.ibm.websphere.security.auth.data;
 
-import java.nio.file.Path;
-
 /**
  * The AuthData interface is used to obtain the user and password from the configured auth data.
  */
@@ -32,7 +30,5 @@ public interface AuthData {
     public char[] getPassword();
 
     public String getKrb5Principal();
-
-    public Path getKrb5Keytab();
 
 }

--- a/dev/com.ibm.ws.security.auth.data.common/src/com/ibm/websphere/security/auth/data/AuthDataProvider.java
+++ b/dev/com.ibm.ws.security.auth.data.common/src/com/ibm/websphere/security/auth/data/AuthDataProvider.java
@@ -45,7 +45,6 @@ public class AuthDataProvider {
     protected static final String CFG_KEY_USER = "user";
     protected static final String CFG_KEY_PASSWORD = "password";
     protected static final String CFG_KEY_KRB5_PRINCIPAL = "krb5Principal";
-    protected static final String CFG_KEY_KRB5_KEYTAB = "krb5Keytab";
 
     private static final TraceComponent tc = Tr.register(AuthDataProvider.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
 

--- a/dev/com.ibm.ws.security.auth.data.common/src/com/ibm/ws/security/auth/data/internal/AuthDataImpl.java
+++ b/dev/com.ibm.ws.security.auth.data.common/src/com/ibm/ws/security/auth/data/internal/AuthDataImpl.java
@@ -75,12 +75,6 @@ public class AuthDataImpl implements AuthData {
 
     /** {@inheritDoc} */
     @Override
-    public Path getKrb5Keytab() {
-        return keytab;
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public String getKrb5Principal() {
         return principal;
     }

--- a/dev/com.ibm.ws.security.auth.data.common/test/com/ibm/websphere/security/auth/data/AuthDataProviderTest.java
+++ b/dev/com.ibm.ws.security.auth.data.common/test/com/ibm/websphere/security/auth/data/AuthDataProviderTest.java
@@ -74,8 +74,6 @@ public class AuthDataProviderTest {
                 will(returnValue(name));
                 allowing(authData).getPassword();
                 will(returnValue(password.toCharArray()));
-                allowing(authData).getKrb5Keytab();
-                will(returnValue(null));
                 allowing(authData).getKrb5Principal();
                 will(returnValue(null));
             }

--- a/dev/com.ibm.ws.security.auth.data/test/com/ibm/websphere/security/auth/data/WSPrincipalMappingLoginModuleTest.java
+++ b/dev/com.ibm.ws.security.auth.data/test/com/ibm/websphere/security/auth/data/WSPrincipalMappingLoginModuleTest.java
@@ -184,8 +184,6 @@ public class WSPrincipalMappingLoginModuleTest {
                 will(returnValue(user));
                 allowing(authData).getPassword();
                 will(returnValue(password));
-                allowing(authData).getKrb5Keytab();
-                will(returnValue(null));
                 allowing(authData).getKrb5Principal();
                 will(returnValue(null));
             }

--- a/dev/com.ibm.ws.security.jca/bnd.bnd
+++ b/dev/com.ibm.ws.security.jca/bnd.bnd
@@ -71,6 +71,7 @@ Service-Component: \
     provide:='com.ibm.ws.security.jca.AuthDataService'; \
     configuration-policy:=ignore; \
     authDataProvider=com.ibm.websphere.security.auth.data.AuthDataProvider; \
+    krb5Service=com.ibm.ws.security.kerberos.auth.KerberosService; \
     securityService=com.ibm.ws.security.SecurityService; \
     subjectManagerService=com.ibm.ws.security.intfc.SubjectManagerService; \
     optional:='securityService,subjectManagerService'; \

--- a/dev/com.ibm.ws.security.kerberos.auth/bnd.bnd
+++ b/dev/com.ibm.ws.security.kerberos.auth/bnd.bnd
@@ -23,6 +23,9 @@ WS-TraceGroup: \
 Export-Package: \
   com.ibm.ws.security.kerberos.auth;provide:=true
   
+Private-Package: \
+  com.ibm.ws.security.kerberos.auth.internal.*
+  
 Import-Package: \
   com.sun.security.auth.module;resolution:=optional, \
   com.sun.security.auth.callback;resolution:=optional , \
@@ -34,6 +37,8 @@ Import-Package: \
   
 Include-Resource: \
   OSGI-INF=resources/OSGI-INF
+  
+instrument.classesExcludes: com/ibm/ws/security/kerberos/auth/internal/resources/KerberosMessages*.class
 
 -buildpath: \
 	com.ibm.ws.internal.prereq.java:java.rtSunKrb5;version=1.8.0,\

--- a/dev/com.ibm.ws.security.kerberos.auth/bnd.bnd
+++ b/dev/com.ibm.ws.security.kerberos.auth/bnd.bnd
@@ -13,11 +13,15 @@ bVersion=1.0
 
 Bundle-SymbolicName: com.ibm.ws.security.kerberos.auth; singleton:=true
 
+-dsannotations=com.ibm.ws.security.kerberos.auth.KerberosService
+
+IBM-Default-Config: OSGI-INF/wlp/defaultInstances.xml
+
 WS-TraceGroup: \
   Kerberos
 
 Export-Package: \
-  com.ibm.ws.security.kerberos.auth
+  com.ibm.ws.security.kerberos.auth;provide:=true
   
 Import-Package: \
   com.sun.security.auth.module;resolution:=optional, \
@@ -27,6 +31,9 @@ Import-Package: \
   com.ibm.security.auth.callback;resolution:=optional , \
   com.ibm.security.jgss;resolution:=optional, \
   *
+  
+Include-Resource: \
+  OSGI-INF=resources/OSGI-INF
 
 -buildpath: \
 	com.ibm.ws.internal.prereq.java:java.rtSunKrb5;version=1.8.0,\

--- a/dev/com.ibm.ws.security.kerberos.auth/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.kerberos.auth/resources/OSGI-INF/l10n/metatype.properties
@@ -18,12 +18,12 @@
 kerberos=Kerberos
 kerberos.desc=System-wide settings for Kerberos authentication
 
-kerberos.keytab=Kerberos keytab file
-kerberos.keytab.desc=The path of the keytab file that is used to obtain the principal's secret key. If unspecified, the keytab from \
-the Kerberos configuration file is used. If it is not specified in the Kerberos configuration file, then it looks for the file \
-at {user.home}/krb5.keytab.
+keytab=Kerberos keytab file
+keytab.desc=The path of the keytab file that is used to obtain the principal's secret key. If unspecified, the keytab from \
+the Kerberos configuration file is used. If a keytab file is not specified in the Kerberos configuration file, then the location \
+{user.home}/krb5.keytab is checked.
 
-kerberos.configFile=Kerberos conf file
-kerberos.configFile.desc=The location of an MIT style krb5.conf configuration file. The location is passed to the JDK implementation of \
-the Kerberos APIs using the java.security.krb5.conf system property. If unspecified, the krb5.conf file is searched for according to the \
+configFile=Kerberos conf file
+configFile.desc=The location of an MIT style krb5.conf configuration file. The location is passed to the JDK implementation of \
+the Kerberos APIs by using the java.security.krb5.conf system property. If unspecified, the krb5.conf file is searched for according to the \
 JDK implementation of the Kerberos APIs.

--- a/dev/com.ibm.ws.security.kerberos.auth/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.kerberos.auth/resources/OSGI-INF/l10n/metatype.properties
@@ -1,0 +1,29 @@
+###############################################################################
+# Copyright (c) 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#
+#CMVCPATHNAME com.ibm.ws.security.kerberos.auth/resources/OSGI-INF/l10n/metatype.properties
+#ISMESSAGEFILE FALSE
+#NLS_ENCODING=UNICODE
+#NLS_MESSAGEFORMAT_NONE
+#
+
+kerberos=Kerberos
+kerberos.desc=System-wide settings for Kerberos authentication
+
+kerberos.keytab=Kerberos keytab file
+kerberos.keytab.desc=The path of the keytab file that is used to obtain the principal's secret key. If unspecified, the keytab from \
+the Kerberos configuration file is used. If it is not specified in the Kerberos configuration file, then it looks for the file \
+at {user.home}/krb5.keytab.
+
+kerberos.configFile=Kerberos conf file
+kerberos.configFile.desc=The location of an MIT style krb5.conf configuration file. The location is passed to the JDK implementation of \
+the Kerberos APIs using the java.security.krb5.conf system property. If unspecified, the krb5.conf file is searched for according to the \
+JDK implementation of the Kerberos APIs.

--- a/dev/com.ibm.ws.security.kerberos.auth/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.kerberos.auth/resources/OSGI-INF/metatype/metatype.xml
@@ -16,8 +16,8 @@
     <OCD id="com.ibm.ws.security.kerberos.auth.KerberosService" name="%kerberos" description="%kerberos.desc" 
     	  ibm:alias="kerberos" ibm:beta="true">
     	  
-    	<AD id="keytab"     name="%kerberos.keytab"     description="%kerberos.keytab.desc"     type="String" ibm:type="location(file)" required="false"/>
-    	<AD id="configFile" name="%kerberos.configFile" description="%kerberos.configFile.desc" type="String" ibm:type="location(file)" required="false"/>
+    	<AD id="keytab"     name="%keytab"     description="%keytab.desc"     type="String" ibm:type="location(file)" required="false"/>
+    	<AD id="configFile" name="%configFile" description="%configFile.desc" type="String" ibm:type="location(file)" required="false"/>
         	
     </OCD>
     

--- a/dev/com.ibm.ws.security.kerberos.auth/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.kerberos.auth/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+-->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.1.0" 
+                   xmlns:ibm="http://www.ibm.com/xmlns/appservers/osgi/metatype/v1.0.0" 
+                   localization="OSGI-INF/l10n/metatype">
+    
+    <OCD id="com.ibm.ws.security.kerberos.auth.KerberosService" name="%kerberos" description="%kerberos.desc" 
+    	  ibm:alias="kerberos" ibm:beta="true">
+    	  
+    	<AD id="keytab"     name="%kerberos.keytab"     description="%kerberos.keytab.desc"     type="String" ibm:type="location(file)" required="false"/>
+    	<AD id="configFile" name="%kerberos.configFile" description="%kerberos.configFile.desc" type="String" ibm:type="location(file)" required="false"/>
+        	
+    </OCD>
+    
+    <Designate pid="com.ibm.ws.security.kerberos.auth.KerberosService">
+        <Object ocdref="com.ibm.ws.security.kerberos.auth.KerberosService"/>
+    </Designate>
+
+</metatype:MetaData>
+

--- a/dev/com.ibm.ws.security.kerberos.auth/resources/OSGI-INF/wlp/defaultInstances.xml
+++ b/dev/com.ibm.ws.security.kerberos.auth/resources/OSGI-INF/wlp/defaultInstances.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2020 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.kerberos.auth/resources/OSGI-INF/wlp/defaultInstances.xml
+++ b/dev/com.ibm.ws.security.kerberos.auth/resources/OSGI-INF/wlp/defaultInstances.xml
@@ -1,0 +1,13 @@
+<!--
+    Copyright (c) 2019 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+-->
+<server>
+	<kerberos/>
+</server>

--- a/dev/com.ibm.ws.security.kerberos.auth/resources/com/ibm/ws/security/kerberos/auth/internal/resources/KerberosMessages.nlsprops
+++ b/dev/com.ibm.ws.security.kerberos.auth/resources/com/ibm/ws/security/kerberos/auth/internal/resources/KerberosMessages.nlsprops
@@ -1,0 +1,27 @@
+###############################################################################
+# Copyright (c) 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+#CMVCPATHNAME com.ibm.ws.security.kerberos.auth/resources/com/ibm/ws/security/kerberos/auth/internal/resources/KerberosMessages.nlsprops
+#COMPONENTPREFIX CWWKS
+#COMPONENTNAMEFOR WebSphere Application Server Security Kerberos Service
+#ISMESSAGEFILE TRUE
+#NLS_MESSAGEFORMAT_VAR
+#NLS_ENCODING=UNICODE
+# -------------------------------------------------------------------------------------------------
+
+# For any new messages reserve a code from the nlsprops file in the com.ibm.ws.security.kerberos.java8 bundle
+
+KRB5_FILE_NOT_FOUND_CWWKS4345E=CWWKS4345E: The [{0}] attribute from the {1} element is configured to a file that does not exist at: {2}
+KRB5_FILE_NOT_FOUND_CWWKS4345E.explanation=The configuration refers to a file that does not exist, or could not be read.
+KRB5_FILE_NOT_FOUND_CWWKS4345E.useraction=Ensure that the configuration points to a file that exists and is readable by the application process.
+
+KRB5_FILE_FOUND_CWWKS4346I=CWWKS4346I: The Kerberos component is configured to use a {0} file located at {1}
+KRB5_FILE_FOUND_CWWKS4346I.explanation=The configured file was successfully located.
+KRB5_FILE_FOUND_CWWKS4346I.useraction=No action is required.

--- a/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/KerberosService.java
+++ b/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/KerberosService.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.kerberos.auth;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.AccessController;
+
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.kernel.service.util.SecureAction;
+
+@Component(configurationPolicy = ConfigurationPolicy.REQUIRE,
+           service = KerberosService.class,
+           configurationPid = "com.ibm.ws.security.kerberos.auth.KerberosService",
+           immediate = true,
+           property = "service.vendor=IBM")
+public class KerberosService {
+
+    private static final TraceComponent tc = Tr.register(KerberosService.class);
+
+    private static final String KRB5_CONFIG_PROPERTY = "java.security.krb5.conf";
+
+    static SecureAction priv = AccessController.doPrivileged(SecureAction.get());
+
+    private Path keytab;
+
+    @Activate
+    protected void activate(ComponentContext ctx) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
+            Tr.entry(tc, "activate", ctx.getProperties());
+        }
+
+        String rawKeytab = (String) ctx.getProperties().get("keytab");
+        String rawConfigFile = (String) ctx.getProperties().get("configFile");
+
+        if (rawKeytab != null) {
+            keytab = Paths.get(rawKeytab);
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Keytab was configured to: " + keytab);
+            }
+        }
+        if (rawConfigFile != null) {
+            Path configFile = Paths.get(rawConfigFile);
+            String originalConfigFile = priv.getProperty(KRB5_CONFIG_PROPERTY);
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Setting system property " + KRB5_CONFIG_PROPERTY + "=" + configFile.toAbsolutePath().toString() +
+                             "  Previous value was: " + originalConfigFile);
+            }
+            priv.setProperty(KRB5_CONFIG_PROPERTY, configFile.toAbsolutePath().toString());
+        }
+    }
+
+    /**
+     * @return The path of the keytab file, or null if unspecified
+     */
+    public Path getKeytab() {
+        return keytab;
+    }
+
+}

--- a/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/KerberosService.java
+++ b/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/KerberosService.java
@@ -50,8 +50,12 @@ public class KerberosService {
 
         if (rawKeytab != null) {
             keytab = Paths.get(rawKeytab);
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "Keytab was configured to: " + keytab);
+            if (keytab.toFile().exists()) {
+                if (tc.isInfoEnabled()) {
+                    Tr.info(tc, "KRB5_FILE_FOUND_CWWKS4346I", "keytab", keytab.toAbsolutePath());
+                }
+            } else {
+                Tr.error(tc, "KRB5_FILE_NOT_FOUND_CWWKS4345E", "keytab", "<kerberos>", keytab.toAbsolutePath());
             }
         }
         if (rawConfigFile != null) {
@@ -62,6 +66,14 @@ public class KerberosService {
                              "  Previous value was: " + originalConfigFile);
             }
             priv.setProperty(KRB5_CONFIG_PROPERTY, configFile.toAbsolutePath().toString());
+
+            if (configFile.toFile().exists()) {
+                if (tc.isInfoEnabled()) {
+                    Tr.info(tc, "KRB5_FILE_FOUND_CWWKS4346I", "configFile", configFile.toAbsolutePath());
+                }
+            } else {
+                Tr.error(tc, "KRB5_FILE_NOT_FOUND_CWWKS4345E", "configFile", "<kerberos>", configFile.toAbsolutePath());
+            }
         }
     }
 

--- a/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/KerberosService.java
+++ b/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/KerberosService.java
@@ -37,6 +37,7 @@ public class KerberosService {
     static SecureAction priv = AccessController.doPrivileged(SecureAction.get());
 
     private Path keytab;
+    private Path configFile;
 
     @Activate
     protected void activate(ComponentContext ctx) {
@@ -54,7 +55,7 @@ public class KerberosService {
             }
         }
         if (rawConfigFile != null) {
-            Path configFile = Paths.get(rawConfigFile);
+            configFile = Paths.get(rawConfigFile);
             String originalConfigFile = priv.getProperty(KRB5_CONFIG_PROPERTY);
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "Setting system property " + KRB5_CONFIG_PROPERTY + "=" + configFile.toAbsolutePath().toString() +
@@ -62,6 +63,10 @@ public class KerberosService {
             }
             priv.setProperty(KRB5_CONFIG_PROPERTY, configFile.toAbsolutePath().toString());
         }
+    }
+
+    public Path getConfigFile() {
+        return configFile;
     }
 
     /**

--- a/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/TraceConstants.java
+++ b/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/TraceConstants.java
@@ -12,4 +12,5 @@ package com.ibm.ws.security.kerberos.auth;
 
 interface TraceConstants {
     public final static String TRACE_GROUP = "Kerberos";
+    public final static String MESSAGE_BUNDLE = "com.ibm.ws.security.kerberos.auth.internal.resources.KerberosMessages";
 }

--- a/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/package-info.java
+++ b/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,7 @@
  * @version 1.0
  */
 @org.osgi.annotation.versioning.Version("1.0")
-@TraceOptions(traceGroup = TraceConstants.TRACE_GROUP)
+@TraceOptions(traceGroup = TraceConstants.TRACE_GROUP, messageBundle = TraceConstants.MESSAGE_BUNDLE)
 package com.ibm.ws.security.kerberos.auth;
 
 import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/com.ibm.ws.security.kerberos.java8/resources/com/ibm/ws/security/kerberos/internal/resources/KerberosMessages.nlsprops
+++ b/dev/com.ibm.ws.security.kerberos.java8/resources/com/ibm/ws/security/kerberos/internal/resources/KerberosMessages.nlsprops
@@ -37,7 +37,9 @@ KRB_S4U2PROXY_IS_NOT_SUPPORT=CWWKS4344E: The Kerberos constrained delegation fea
 KRB_S4U2PROXY_IS_NOT_SUPPORT.explanation=The Kerberos constrained delegation feature cannot be enabled due to the Java runtime vendor and version.
 KRB_S4U2PROXY_IS_NOT_SUPPORT.useraction=Use the Java vendor and version that is supported by the Kerberos constrained delegation feature.
 
+# CWWKS4345E is used by the com.ibm.ws.security.kerberos.auth bundle
 
+# CWWKS4346I is used by the com.ibm.ws.security.kerberos.auth bundle
 
 
 

--- a/dev/com.ibm.ws.security.spnego/bnd.bnd
+++ b/dev/com.ibm.ws.security.spnego/bnd.bnd
@@ -61,6 +61,7 @@ com.ibm.ws.security.spnego.internal.SpnegoHelperProxy
 	com.ibm.ws.security.authentication.builtin;version=latest,\
 	com.ibm.ws.security.credentials;version=latest,\
 	com.ibm.ws.security.jaas.common;version=latest,\
+	com.ibm.ws.security.kerberos.auth;version=latest,\
 	com.ibm.ws.security.token.s4u2;version=latest,\
 	com.ibm.ws.security.token;version=latest,\
 	com.ibm.ws.security;version=latest,\

--- a/dev/com.ibm.ws.security.spnego/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.spnego/resources/OSGI-INF/l10n/metatype.properties
@@ -29,10 +29,10 @@ canonicalHostName=Use canonical host name
 canonicalHostName.desc= Controls whether you want to use the canonical host name.
 
 krb5Config=The Kerberos configuration file with full path
-krb5Config.desc=Specifies the fully qualified Kerberos configuration path and name. Standard variable substitutions, such as ${server.config.dir}, can be used when specifying the directory path.
+krb5Config.desc=Deprecated: use configFile attribute on the <kerberos> element instead. Specifies the fully qualified Kerberos configuration path and name. Standard variable substitutions, such as ${server.config.dir}, can be used when specifying the directory path.
 
 krb5Keytab=The Kerberos keytab file name and include path
-krb5Keytab.desc=Specifies the fully qualified Kerberos keytab  path and name. Standard variable substitutions, such as ${server.config.dir}, can be used when specifying the directory path. The Kerberos keytab file contains a list of keys that are analogous to user passwords. It is important for hosts to protect their Kerberos keytab files by storing them on the local disk.
+krb5Keytab.desc=Deprecated: use keytab attribute on the <kerberos> element instead. Specifies the fully qualified Kerberos keytab  path and name. Standard variable substitutions, such as ${server.config.dir}, can be used when specifying the directory path. The Kerberos keytab file contains a list of keys that are analogous to user passwords. It is important for hosts to protect their Kerberos keytab files by storing them on the local disk.
 
 kerberosRealmName= The Kerberos realm name
 kerberosRealmName.desc= Specifies the name of your Kerberos realm. In most cases, your realm is your domain name in uppercase letters. For example, a machine with the domain name of test.austin.ibm.com might have a Kerberos realm name of AUSTIN.IBM.COM. If you use the MS KDC, the realm name is in uppercase letters of the MS domain controller name.

--- a/dev/com.ibm.ws.security.spnego/resources/com/ibm/ws/security/spnego/internal/resources/SpnegoMessages.nlsprops
+++ b/dev/com.ibm.ws.security.spnego/resources/com/ibm/ws/security/spnego/internal/resources/SpnegoMessages.nlsprops
@@ -114,6 +114,6 @@ SPNEGO_DELEGATE_SPN_LOGIN_TO_KDC_FAILURE=CWWKS4322E: Delegate SPN {0} can not au
 SPNEGO_DELEGATE_SPN_LOGIN_TO_KDC_FAILURE.explanation=Can not authenticate to the Key Distribution Center (KDC).
 SPNEGO_DELEGATE_SPN_LOGIN_TO_KDC_FAILURE.useraction=Verify the service principal name format, and make sure it exists on the Windows domain and that the Kerberos keytab file contains the service principal name.
 
-SPNEGO_CONFLICTING_SETTINGS_CWWKS4323E=CWWKS4323E: The attribute {0} from the {1} element conflicts with the attribute {2} from the {3} element. Only specify a value on either the {1} or the {3} element. It is suggested to only specify the value on the {1} element.
-SPNEGO_CONFLICTING_SETTINGS_CWWKS4323E.explanation=In order to honor each attribute, a system property needs to be set, which is a system-wide setting. Different values for a system-wide setting cannot be honored.
-SPNEGO_CONFLICTING_SETTINGS_CWWKS4323E.useraction=Specify the attribute in only one of the config elements.
+SPNEGO_CONFLICTING_SETTINGS_CWWKS4323E=The [{0}] attribute from the {1} element conflicts with the [{2}] attribute from the {3} element. Specify a value only on either the {1} or the {3} element, not on both elements. It is suggested to specify the value only on the {1} element.
+SPNEGO_CONFLICTING_SETTINGS_CWWKS4323E.explanation=To recognize each attribute, a system property needs to be set, which is a system-wide setting. Different values for a system-wide setting cannot be recognized.
+SPNEGO_CONFLICTING_SETTINGS_CWWKS4323E.useraction=Specify the attribute in only one of the configuration elements.

--- a/dev/com.ibm.ws.security.spnego/resources/com/ibm/ws/security/spnego/internal/resources/SpnegoMessages.nlsprops
+++ b/dev/com.ibm.ws.security.spnego/resources/com/ibm/ws/security/spnego/internal/resources/SpnegoMessages.nlsprops
@@ -113,3 +113,7 @@ SPNEGO_CAN_NOT_GET_DELEGATE_SERVICE_SPN.useraction=Verify the service principal 
 SPNEGO_DELEGATE_SPN_LOGIN_TO_KDC_FAILURE=CWWKS4322E: Delegate SPN {0} can not authenticate to the Key Distribution Center (KDC) using the Kerberos configuration file {1} and keytab file {2}. Login exception was received: {3}
 SPNEGO_DELEGATE_SPN_LOGIN_TO_KDC_FAILURE.explanation=Can not authenticate to the Key Distribution Center (KDC).
 SPNEGO_DELEGATE_SPN_LOGIN_TO_KDC_FAILURE.useraction=Verify the service principal name format, and make sure it exists on the Windows domain and that the Kerberos keytab file contains the service principal name.
+
+SPNEGO_CONFLICTING_SETTINGS_CWWKS4323E=CWWKS4323E: The attribute {0} from the {1} element conflicts with the attribute {2} from the {3} element. Only specify a value on either the {1} or the {3} element. It is suggested to only specify the value on the {1} element.
+SPNEGO_CONFLICTING_SETTINGS_CWWKS4323E.explanation=In order to honor each attribute, a system property needs to be set, which is a system-wide setting. Different values for a system-wide setting cannot be honored.
+SPNEGO_CONFLICTING_SETTINGS_CWWKS4323E.useraction=Specify the attribute in only one of the config elements.

--- a/dev/com.ibm.ws.security.spnego/src/com/ibm/ws/security/spnego/SpnegoService.java
+++ b/dev/com.ibm.ws.security.spnego/src/com/ibm/ws/security/spnego/SpnegoService.java
@@ -48,13 +48,15 @@ import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
                         "com.ibm.ws.security.webAuthenticator.type=SPNEGO" })
 public class SpnegoService implements WebAuthenticator {
     public static final TraceComponent tc = Tr.register(SpnegoService.class);
-    static final String CONFIGURATION_ADMIN = "configurationAdmin";
-    public final static String KEY_FILTER = "authenticationFilter";
-    private final String KEY_LOCATION_ADMIN = "locationAdmin";
 
-    private final AtomicServiceReference<WsLocationAdmin> locationAdminRef = new AtomicServiceReference<WsLocationAdmin>(KEY_LOCATION_ADMIN);
-    protected final AtomicServiceReference<AuthenticationFilter> authFilterServiceRef = new AtomicServiceReference<AuthenticationFilter>(KEY_FILTER);
-    protected final AtomicServiceReference<KerberosService> kerberosServiceRef = new AtomicServiceReference<>("kerberosService");
+    static final String CONFIGURATION_ADMIN = "configurationAdmin";
+    public static final String KEY_FILTER = "authenticationFilter";
+    private static final String KEY_LOCATION_ADMIN = "locationAdmin";
+    private static final String KERB_SERVICE = "kerberosService";
+
+    private final AtomicServiceReference<WsLocationAdmin> locationAdminRef = new AtomicServiceReference<>(KEY_LOCATION_ADMIN);
+    protected final AtomicServiceReference<AuthenticationFilter> authFilterServiceRef = new AtomicServiceReference<>(KEY_FILTER);
+    protected final AtomicServiceReference<KerberosService> kerberosServiceRef = new AtomicServiceReference<>(KERB_SERVICE);
 
     private final AuthenticationResult CONTINUE = new AuthenticationResult(AuthResult.CONTINUE, "SPNEGO service said continue...");
     private SpnegoAuthenticator spnegoAuthenticator = null;
@@ -93,7 +95,7 @@ public class SpnegoService implements WebAuthenticator {
         locationAdminRef.unsetReference(ref);
     }
 
-    @Reference(service = KerberosService.class)
+    @Reference(name = KERB_SERVICE, service = KerberosService.class)
     protected void setKerberosService(ServiceReference<KerberosService> ref) {
         kerberosServiceRef.setReference(ref);
     }

--- a/dev/com.ibm.ws.security.spnego/src/com/ibm/ws/security/spnego/internal/SpnegoConfigImpl.java
+++ b/dev/com.ibm.ws.security.spnego/src/com/ibm/ws/security/spnego/internal/SpnegoConfigImpl.java
@@ -167,20 +167,28 @@ public class SpnegoConfigImpl implements SpnegoConfig {
      * @param props
      */
     protected String processKrb5Keytab(Map<String, Object> props) {
-        String keytab = (String) props.get(KEY_KRB5_KEYTAB);
-        Path kerbKeytab = kerbSvc.getKeytab(); // from the <kerberos> element
+        String spnegoKeytab = (String) props.get(KEY_KRB5_KEYTAB);
+        Path kerberosKeytab = kerbSvc.getKeytab(); // from the <kerberos> element
 
-        if (keytab == null && kerbKeytab != null) {
-            keytab = kerbKeytab.toAbsolutePath().toString();
-        }
-
-        if (keytab != null) {
-            WsResource kt = locationAdmin.resolveResource(keytab);
-            if (kt == null || !kt.exists()) {
-                Tr.error(tc, "SPNEGO_KRB5_KEYTAB_FILE_NOT_FOUND", keytab);
+        if (kerberosKeytab != null) {
+            if (spnegoKeytab == null) {
+                spnegoKeytab = kerberosKeytab.toAbsolutePath().toString();
+            } else if (!kerberosKeytab.toAbsolutePath().toString().equals(spnegoKeytab)) {
+                // Error: Conflicting values specified on <spnego> and <kerberos> element
+                Tr.error(tc, "SPNEGO_CONFLICTING_SETTINGS_CWWKS4323E", "keytab", "<kerberos>", KEY_KRB5_KEYTAB, "<spnego>");
                 return null;
             } else {
-                return keytab;
+                // both values are set but are equal, tolerate it
+            }
+        }
+
+        if (spnegoKeytab != null) {
+            WsResource kt = locationAdmin.resolveResource(spnegoKeytab);
+            if (kt == null || !kt.exists()) {
+                Tr.error(tc, "SPNEGO_KRB5_KEYTAB_FILE_NOT_FOUND", spnegoKeytab);
+                return null;
+            } else {
+                return spnegoKeytab;
             }
         } else {
             return krb5DefaultFile.getDefaultKrb5KeytabFile();
@@ -191,13 +199,13 @@ public class SpnegoConfigImpl implements SpnegoConfig {
      * @param props
      */
     protected String processKrb5Config(Map<String, Object> props) {
-        String krbCf = (String) props.get(KEY_KRB5_CONFIG);
-        Path kerbConfigFile = kerbSvc.getConfigFile(); // from the <kerberos> element
+        String spnegoConfigFile = (String) props.get(KEY_KRB5_CONFIG);
+        Path kerberosConfigFile = kerbSvc.getConfigFile(); // from the <kerberos> element
 
-        if (kerbConfigFile != null) {
-            if (krbCf == null) {
-                krbCf = kerbConfigFile.toAbsolutePath().toString();
-            } else if (!kerbConfigFile.toAbsolutePath().toString().equals(krbCf)) {
+        if (kerberosConfigFile != null) {
+            if (spnegoConfigFile == null) {
+                spnegoConfigFile = kerberosConfigFile.toAbsolutePath().toString();
+            } else if (!kerberosConfigFile.toAbsolutePath().toString().equals(spnegoConfigFile)) {
                 // Error: Conflicting values specified on <spnego> and <kerberos> element
                 Tr.error(tc, "SPNEGO_CONFLICTING_SETTINGS_CWWKS4323E", "configFile", "<kerberos>", KEY_KRB5_CONFIG, "<spnego>");
                 return null;
@@ -206,13 +214,13 @@ public class SpnegoConfigImpl implements SpnegoConfig {
             }
         }
 
-        if (krbCf != null) {
-            WsResource kcf = locationAdmin.resolveResource(krbCf);
+        if (spnegoConfigFile != null) {
+            WsResource kcf = locationAdmin.resolveResource(spnegoConfigFile);
             if (kcf == null || !kcf.exists()) {
-                Tr.error(tc, "SPNEGO_KRB5_CONFIG_FILE_NOT_FOUND", krbCf);
+                Tr.error(tc, "SPNEGO_KRB5_CONFIG_FILE_NOT_FOUND", spnegoConfigFile);
                 return null;
             } else {
-                return krbCf;
+                return spnegoConfigFile;
             }
         } else {
             return krb5DefaultFile.getDefaultKrb5ConfigFile();


### PR DESCRIPTION
Implements the resolution of design issue https://github.com/openliberty/open-liberty/issues/12835

Part of #12670 and #12838 

- Adds new `<kerberos>` element with 2 properties: `keytab` and `configFile` (both optional)
- If `<authData krb5Principal="...">` is set, then keytab is retrieved from `<kerberos keytab="..."/>` (if set)
- Adds interop with existing `<spnego>` element which has its own `krb5Config` and `krb5Keytab` properties. If `krb5Config` and `configFile` are both specified, raise an error.