### PR TITLE
Don't use ThreadLocal for request data unless async

### DIFF
--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/async/AsyncAlreadyReadCallback.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/async/AsyncAlreadyReadCallback.java
@@ -45,7 +45,7 @@ public class AsyncAlreadyReadCallback implements InterChannelCallback {
     public AsyncAlreadyReadCallback(SRTInputStream31 in, ThreadContextManager tcm){
         this.in = in;
         this.threadContextManager = tcm;
-        _requestDataAsyncReadCallbackThread = SRTServletRequestThreadData.getInstance();
+        _requestDataAsyncReadCallbackThread = SRTServletRequestThreadData.getInstance(in.getRequest().getRequestData());
     }
 
     /* (non-Javadoc)

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/async/AsyncReadCallback.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/async/AsyncReadCallback.java
@@ -54,7 +54,7 @@ public class AsyncReadCallback implements InterChannelCallback {
     public AsyncReadCallback(SRTInputStream31 in, ThreadContextManager tcm){
         this.in = in;
         this.threadContextManager = tcm;
-        _requestDataAsyncReadCallbackThread = SRTServletRequestThreadData.getInstance();
+        _requestDataAsyncReadCallbackThread = SRTServletRequestThreadData.getInstance(in.getRequest().getRequestData());
     }
 
     /* (non-Javadoc)
@@ -86,7 +86,11 @@ public class AsyncReadCallback implements InterChannelCallback {
                 Tr.debug(tc, "Calling user's ReadListener onDataAvailable : " + this.in.getReadListener());
             }       
             
-            SRTServletRequestThreadData.getInstance().init(_requestDataAsyncReadCallbackThread);
+            //if (srt != null) {
+            //    SRTServletRequestThreadData.getInstance(srt.getRequestData()).init(_requestDataAsyncReadCallbackThread);
+            //} else {
+                SRTServletRequestThreadData.getInstance().init(_requestDataAsyncReadCallbackThread);
+            //}
             
             //Push the original thread's context onto the current thread, also save off the current thread's context
             boolean localPushedThreadContext = false;
@@ -181,7 +185,11 @@ public class AsyncReadCallback implements InterChannelCallback {
         onErrorDriven = true;
         Exception e = null;
         
-        SRTServletRequestThreadData.getInstance().init(_requestDataAsyncReadCallbackThread);
+        //if (srt != null) {
+        //    SRTServletRequestThreadData.getInstance(srt.getRequestData()).init(_requestDataAsyncReadCallbackThread);
+        //} else {
+            SRTServletRequestThreadData.getInstance().init(_requestDataAsyncReadCallbackThread);
+        //}
 
         synchronized( this.in.getCompleteLockObj()){
 

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/async/AsyncWriteCallback.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/async/AsyncWriteCallback.java
@@ -55,12 +55,12 @@ public class AsyncWriteCallback implements InterChannelCallback {
      * @param hout
      * @param originalCL
      */
-    public AsyncWriteCallback(WriteListener wl, WCOutputStream31 out, HttpOutputStreamEE7 hout, ThreadContextManager tcm){
+    public AsyncWriteCallback(WriteListener wl, WCOutputStream31 out, HttpOutputStreamEE7 hout, ThreadContextManager tcm, SRTServletRequestThreadData threadData) {
         this._wl = wl;
         this._out = out;
         this._hout = hout;
         this.tcm = tcm;
-        _requestDataAsyncWriteCallbackThread = SRTServletRequestThreadData.getInstance();
+        _requestDataAsyncWriteCallbackThread = threadData;
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()){  
             Tr.debug(tc, "AsyncWriteCallback created, " + this._wl +  ", hout --> "+this._hout +" ,current thread -->"+ Thread.currentThread().getName());  
         }  

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/async/listener/WriteListenerRunnable.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/async/listener/WriteListenerRunnable.java
@@ -40,12 +40,12 @@ public class WriteListenerRunnable implements Runnable{
     private AsyncWriteCallback _cb = null;
     private SRTServletRequestThreadData _requestDataWriteListenerThread;
 
-    public WriteListenerRunnable(WriteListener listener, HttpOutputStreamEE7 hout, AsyncWriteCallback callback, ThreadContextManager tcm ) {
+    public WriteListenerRunnable(WriteListener listener, HttpOutputStreamEE7 hout, AsyncWriteCallback callback, ThreadContextManager tcm, SRTServletRequestThreadData threadData ) {
         this._listener = listener;
         this._tcm = tcm;
         this._hout = hout;
         this._cb = callback;
-        _requestDataWriteListenerThread = SRTServletRequestThreadData.getInstance();
+        _requestDataWriteListenerThread = threadData;
     }
 
     /**

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/srt/SRTInputStream31.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/srt/SRTInputStream31.java
@@ -19,11 +19,11 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.http.channel.inputstream.HttpInputStreamConnectWeb;
 import com.ibm.ws.webcontainer.srt.SRTInputStream;
+import com.ibm.ws.webcontainer.srt.SRTServletRequest;
 import com.ibm.ws.webcontainer31.async.AsyncAlreadyReadCallback;
 import com.ibm.ws.webcontainer31.async.AsyncContext31Impl;
 import com.ibm.ws.webcontainer31.async.AsyncReadCallback;
 import com.ibm.ws.webcontainer31.async.ThreadContextManager;
-import com.ibm.ws.webcontainer31.async.listener.ReadListenerRunnable;
 import com.ibm.ws.webcontainer31.osgi.osgi.WebContainerConstants;
 import com.ibm.wsspi.channelfw.InterChannelCallback;
 import com.ibm.wsspi.http.channel.inbound.HttpInboundServiceContext;
@@ -491,5 +491,9 @@ public class SRTInputStream31 extends SRTInputStream
      */
     public InterChannelCallback getCallback() {
         return callback;
+    }
+    
+    public SRTServletRequest getRequest() {
+        return request;
     }
 }

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/srt/SRTServletRequest31.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/srt/SRTServletRequest31.java
@@ -121,7 +121,7 @@ public class SRTServletRequest31 extends SRTServletRequest implements HttpServle
 
             this._request = req;
             _srtRequestHelper = getRequestHelper();
-            SRTServletRequestThreadData.getInstance().init(null);
+            getRequestData().init(null);
             _in.init(_request.getInputStream());
             // begin 280584.1    SVT: StackOverflowError when installing app larger than 2GB    WAS.webcontainer    
             if( this.getContentLengthLong() > 0 ){            

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/async/AsyncContextImpl.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/async/AsyncContextImpl.java
@@ -329,7 +329,7 @@ public class AsyncContextImpl implements AsyncContext {
         }
         if (timeoutScheduledFuture!=null)
             throw new AsyncIllegalStateException(nls.getString("trying.to.schedule.timeout.without.cancelling.previous.timeout"));
-        AsyncTimeoutRunnable asyncTimeoutRunnable = new AsyncTimeoutRunnable (this);
+        AsyncTimeoutRunnable asyncTimeoutRunnable = new AsyncTimeoutRunnable(this, iExtendedRequest);
         timeoutScheduledFuture = ExecutorFieldHolder.field.schedule(asyncTimeoutRunnable, getTimeout(),TimeUnit.MILLISECONDS);
         if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINEST)) {
             logger.exiting(CLASS_NAME, "scheduleTimeout", this);
@@ -515,7 +515,7 @@ public class AsyncContextImpl implements AsyncContext {
 
             if (startWrappedRunnable){
 
-                WrapperRunnableImpl wrapperRunnable = new WrapperRunnableImpl(run,this);
+                WrapperRunnableImpl wrapperRunnable = new WrapperRunnableImpl(run, this, iExtendedRequest);
 
 
                 // Start:PM90834

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/async/AsyncTimeoutRunnable.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/async/AsyncTimeoutRunnable.java
@@ -13,11 +13,12 @@ package com.ibm.ws.webcontainer.async;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.ibm.ws.webcontainer.WebContainer;
 import com.ibm.ws.webcontainer.async.ListenerHelper.CheckDispatching;
 import com.ibm.ws.webcontainer.async.ListenerHelper.ExecuteNextRunnable;
+import com.ibm.ws.webcontainer.srt.SRTServletRequest;
 import com.ibm.ws.webcontainer.srt.SRTServletRequestThreadData;
 import com.ibm.wsspi.webcontainer.servlet.AsyncContext;
+import com.ibm.wsspi.webcontainer.servlet.IExtendedRequest;
 
 public class AsyncTimeoutRunnable implements Runnable {
 	private static Logger logger= Logger.getLogger("com.ibm.ws.webcontainer.async");
@@ -26,15 +27,15 @@ public class AsyncTimeoutRunnable implements Runnable {
 	private AsyncServletReentrantLock asyncServletReentrantLock;
         private SRTServletRequestThreadData requestDataOnTimedOutThread;
 	
-	public AsyncTimeoutRunnable	(AsyncContext asyncContext){
+	public AsyncTimeoutRunnable(AsyncContext asyncContext, IExtendedRequest req) {
 		if (logger.isLoggable(Level.FINEST)) {
-                    logger.logp(Level.FINEST,CLASS_NAME, "<init>","this->"+this+", asyncContext->"+asyncContext)    ;   
+                    logger.logp(Level.FINEST,CLASS_NAME, "<init>","this->"+this+", asyncContext->"+asyncContext);   
                 }
 		this.asyncContext = asyncContext;
                 this.asyncServletReentrantLock = asyncContext.getErrorHandlingLock();
-                
+                SRTServletRequestThreadData existing = req instanceof SRTServletRequest ? SRTServletRequestThreadData.getInstance(((SRTServletRequest) req).getRequestData()) : SRTServletRequestThreadData.getInstance();
                 requestDataOnTimedOutThread = new SRTServletRequestThreadData();
-                requestDataOnTimedOutThread.init(SRTServletRequestThreadData.getInstance());
+                requestDataOnTimedOutThread.init(existing);
 	}
 		
 	@Override

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/async/CompleteRunnable.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/async/CompleteRunnable.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.ibm.ws.webcontainer.WebContainer;
+import com.ibm.ws.webcontainer.srt.SRTServletRequest;
 import com.ibm.ws.webcontainer.srt.SRTServletRequestThreadData;
 import com.ibm.wsspi.webcontainer.WebContainerRequestState;
 import com.ibm.wsspi.webcontainer.logging.LoggerFactory;
@@ -35,7 +35,8 @@ public class CompleteRunnable implements Runnable {
         this.asyncContextImpl = asyncContextImpl;
        
         requestDataOnCompleteRequestThread = new SRTServletRequestThreadData();
-        requestDataOnCompleteRequestThread.init(SRTServletRequestThreadData.getInstance());
+        SRTServletRequestThreadData existing = extendedRequest != null && extendedRequest instanceof SRTServletRequest ? SRTServletRequestThreadData.getInstance(((SRTServletRequest) extendedRequest).getRequestData()) : SRTServletRequestThreadData.getInstance();
+        requestDataOnCompleteRequestThread.init(existing);
     }
 
     @Override

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/async/DispatchRunnable.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/async/DispatchRunnable.java
@@ -17,9 +17,9 @@ import javax.servlet.DispatcherType;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 
-import com.ibm.ws.webcontainer.WebContainer;
 import com.ibm.ws.webcontainer.async.ListenerHelper.CheckDispatching;
 import com.ibm.ws.webcontainer.async.ListenerHelper.ExecuteNextRunnable;
+import com.ibm.ws.webcontainer.srt.SRTServletRequest;
 import com.ibm.ws.webcontainer.srt.SRTServletRequestThreadData;
 import com.ibm.ws.webcontainer.webapp.WebAppRequestDispatcher;
 import com.ibm.wsspi.webcontainer.WebContainerRequestState;
@@ -51,7 +51,8 @@ public class DispatchRunnable extends ServiceWrapper implements Runnable {
         }
         
         requestDataOnDispatchRequestThread = new SRTServletRequestThreadData();
-        requestDataOnDispatchRequestThread.init(SRTServletRequestThreadData.getInstance());
+        SRTServletRequestThreadData existing = extRequest != null && extRequest instanceof SRTServletRequest ? SRTServletRequestThreadData.getInstance(((SRTServletRequest) extRequest).getRequestData()) : SRTServletRequestThreadData.getInstance();
+        requestDataOnDispatchRequestThread.init(existing);
     }
 
 

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/async/WrapperRunnableImpl.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/async/WrapperRunnableImpl.java
@@ -16,12 +16,12 @@ import java.util.logging.Logger;
 
 import com.ibm.ws.webcontainer.async.ListenerHelper.CheckDispatching;
 import com.ibm.ws.webcontainer.async.ListenerHelper.ExecuteNextRunnable;
+import com.ibm.ws.webcontainer.srt.SRTServletRequest;
 import com.ibm.ws.webcontainer.srt.SRTServletRequestThreadData;
 import com.ibm.wsspi.webcontainer.WebContainerRequestState;
 import com.ibm.wsspi.webcontainer.async.WrapperRunnable;
 import com.ibm.wsspi.webcontainer.logging.LoggerFactory;
-import com.ibm.ws.webcontainer.WebContainer;
-import com.ibm.ws.webcontainer.async.AsyncContextImpl;
+import com.ibm.wsspi.webcontainer.servlet.IExtendedRequest;
 
 public class WrapperRunnableImpl extends ServiceWrapper implements WrapperRunnable {
     protected static Logger logger = LoggerFactory.getInstance().getLogger("com.ibm.wsspi.webcontainer.async");
@@ -32,7 +32,7 @@ public class WrapperRunnableImpl extends ServiceWrapper implements WrapperRunnab
     private SRTServletRequestThreadData requestDataOnStartRequestThread;
 
     
-    public WrapperRunnableImpl(Runnable run, AsyncContextImpl asyncContext) {
+    public WrapperRunnableImpl(Runnable run, AsyncContextImpl asyncContext, IExtendedRequest extendedRequest) {
             super(asyncContext);
             this.runnable = run;
             this.asyncContext = asyncContext;
@@ -42,7 +42,8 @@ public class WrapperRunnableImpl extends ServiceWrapper implements WrapperRunnab
             }
             
             requestDataOnStartRequestThread = new  SRTServletRequestThreadData();
-            requestDataOnStartRequestThread.init(SRTServletRequestThreadData.getInstance());
+            SRTServletRequestThreadData existing = extendedRequest != null && extendedRequest instanceof SRTServletRequest ? SRTServletRequestThreadData.getInstance(((SRTServletRequest) extendedRequest).getRequestData()) : SRTServletRequestThreadData.getInstance();
+            requestDataOnStartRequestThread.init(existing);
     }
 
 

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTServletRequestThreadData.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTServletRequestThreadData.java
@@ -45,19 +45,33 @@ public class SRTServletRequestThreadData {
 
     private static WSThreadLocal<SRTServletRequestThreadData> instance = new WSThreadLocal<SRTServletRequestThreadData>();
 
+    public static SRTServletRequestThreadData getInstance (SRTServletRequestThreadData previousState) {
+        //System.out.println("***JTD: SRTData getInstance2 " + previousState);
+        if (previousState == null) {
+            return getInstance();
+        }
+        SRTServletRequestThreadData tempState = (SRTServletRequestThreadData) instance.get();
+         
+        if (tempState == null) {
+            instance.set(previousState);
+            return previousState;
+        }
+         
+        return tempState;
+    }
+
     public static SRTServletRequestThreadData getInstance () {
-
-        SRTServletRequestThreadData tempState = null;
-        tempState=(SRTServletRequestThreadData) instance.get();
+        //System.out.println("***JTD: SRTData getInstance1");
+        //Thread.dumpStack();
+        SRTServletRequestThreadData tempState = (SRTServletRequestThreadData) instance.get();
          
-         if (tempState == null) {
-                tempState = new SRTServletRequestThreadData();
-                instance.set(tempState);
-         }
+        if (tempState == null) {
+            tempState = new SRTServletRequestThreadData();
+            instance.set(tempState);
+        }
          
-         return tempState;
-   }
-
+        return tempState;
+    }
 
     public SRTServletRequestThreadData() {
         if (TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE))


### PR DESCRIPTION
Throughput profiles show SRTServletRequestThreadData using ThreadLocals during every request. Further examination shows the only reason we actually need thread-specific data is when doing async requests. Change the code to only do TLs during async requests to get 1-2% throughput increase.