### PR TITLE
Issue 12822: Add custom HTTP connect and read timeouts for acmeCA

### DIFF
--- a/dev/com.ibm.ws.security.acme/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.acme/resources/OSGI-INF/l10n/metatype.properties
@@ -88,7 +88,16 @@ certCheckerErrorSchedule=Certificate checker error schedule
 certCheckerErrorSchedule.desc=Performs the same function as the certCheckerSchedule attribute, but on an alternate schedule. For example, the certCheckerErrorSchedule attribute can be set to a shorter interval than the certCheckerSchedule attribute, to increase the frequency of checks after a failed request. The interval from the certCheckerSchedule attribute is resumed after the certificate is renewed. 
 
 disableMinRenewWindow=Disable minimum renew window
-disableMinRenewWindow.desc=Enables immediate certificate renew requests by disabling the specified minimum amount of time between renew requests. The minimum renew time is 15 seconds.
+disableMinRenewWindow.desc=Enables immediate certificate renew requests by disabling the specified minimum amount of time between renew requests. The default minimum renew time is 15 seconds.
 
 disableRenewOnNewHistory=Disable certificate refresh if the ACME history file does not yet exist
 disableRenewOnNewHistory.desc=Disables automatic certificate refresh when ACME creates the ACME history file.
+
+renewCertMin=Renew certificate minimum
+renewCertMin.desc=Controls the timing between certificate renew requests. A renew request is not allowed until the amount of time set by the renewCertMin elapses.
+
+httpConnectTimeout=HTTP Connect Timeout
+httpConnectTimeout.desc=The HTTP connect timeout for connecting to the Certificate Authority to create accounts or request certificates. The default timeout is 30 seconds. A timeout of zero is an infinite timeout.
+
+httpReadTimeout=HTTP Read Timeout
+httpReadTimeout.desc=The HTTP read timeout for reading from the Certificate Authority to create accounts or request certificates. The default timeout is 30 seconds. A timeout of zero is an infinite timeout.

--- a/dev/com.ibm.ws.security.acme/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.acme/resources/OSGI-INF/metatype/metatype.xml
@@ -70,6 +70,8 @@
    <AD id="trustStore"           name="%trustStore"         description="%trustStore.desc"         required="false" type="String" />
    <AD id="trustStorePassword"   name="%trustStorePassword" description="%trustStorePassword.desc" required="false" type="String" ibm:type="password" />
    <AD id="trustStoreType"       name="%trustStoreType"     description="%trustStoreType.desc"     required="false" type="String" />
+   <AD id="httpConnectTimeout"   name="internal" description="internal use only" type="String"  required="false" ibm:type="duration" default="30s" />
+   <AD id="httpReadTimeout"      name="internal" description="internal use only" type="String"  required="false" ibm:type="duration" default="30s" />
  </OCD>
 
  <Designate factoryPid="com.ibm.ws.security.acme.revocation">

--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeConfig.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeConfig.java
@@ -58,6 +58,8 @@ public class AcmeConfig {
 	private String trustStore = null;
 	private SerializableProtectedString trustStorePassword = null;
 	private String trustStoreType = null;
+	private int httpConnectTimeout = AcmeConstants.HTTP_CONNECT_TIMEOUT_DEFAULT;
+	private int httpReadTimeout = AcmeConstants.HTTP_READ_TIMEOUT_DEFAULT;
 
 	// Renew configuration options
 	private Long renewBeforeExpirationMs = AcmeConstants.RENEW_DEFAULT_MS;
@@ -166,6 +168,20 @@ public class AcmeConfig {
 			trustStorePassword = getSerializableProtectedStringValue(transportProps,
 					AcmeConstants.TRANSPORT_TRUST_STORE_PASSWORD);
 			trustStoreType = getStringValue(transportProps, AcmeConstants.TRANSPORT_TRUST_STORE_TYPE);
+
+			/*
+			 * We're passing these in the URLConnection where 0 is infinite timeout and the connect/read timeouts
+			 * are int parameters. If someone puts in longer than max int, we'll set to max int.
+			 * 
+			 * If we make these properties public, we may want to add messages if we adjusted the times (min/max).
+			 */
+			Long raw = getLongValue(transportProps, AcmeConstants.HTTP_CONNECT_TIMEOUT);
+			Long modToInt = Math.max(0, (raw == null) ? AcmeConstants.HTTP_CONNECT_TIMEOUT_DEFAULT : raw);
+			httpConnectTimeout = (int) Math.min(modToInt, Integer.MAX_VALUE);
+
+			raw = getLongValue(transportProps, AcmeConstants.HTTP_READ_TIMEOUT);
+			modToInt = Math.max(0, (raw == null) ? AcmeConstants.HTTP_READ_TIMEOUT_DEFAULT : raw);
+			httpReadTimeout = (int) Math.min(modToInt, Integer.MAX_VALUE);
 		}
 
 		setRenewBeforeExpirationMs(getLongValue(properties, AcmeConstants.RENEW_BEFORE_EXPIRATION), true);
@@ -786,5 +802,63 @@ public class AcmeConfig {
 		return renewCertMin;
 	}
 
+	/**
+	 * 
+	 * @return httpConnectTimeout
+	 */
+	@Trivial
+	public Integer getHTTPConnectTimeout() {
+		return httpConnectTimeout;
+	}
+
+	/**
+	 * 
+	 * @return httpReadTimeout
+	 */
+	@Trivial
+	public Integer getHTTPReadTimeout() {
+		return httpReadTimeout;
+	}
+	
+	@Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        sb.append(this.getClass().getName()).append(":{");
+        sb.append("directoryURI=").append(directoryURI).append("\n");
+        sb.append(", domains=").append(domains).append("\n");
+        sb.append(", validForMs=").append(validForMs).append("\n");
+        sb.append(", subjectDN=").append(subjectDN).append("\n");
+        sb.append(", challengePollTimeoutMs=").append(challengePollTimeoutMs).append("\n");
+        sb.append(", orderPollTimeoutMs=").append(orderPollTimeoutMs).append("\n");
+        sb.append(", accountKeyFile=").append(accountKeyFile).append("\n");
+        sb.append(", accountContacts=").append(accountContacts).append("\n");
+        sb.append(", domainKeyFile=").append(domainKeyFile).append("\n");
+        sb.append(", renewBeforeExpirationMs=").append(renewBeforeExpirationMs).append("\n");
+        sb.append(", autoRenewOnExpiration=").append(autoRenewOnExpiration).append("\n");
+        sb.append(", certCheckerScheduler=").append(certCheckerScheduler).append("\n");
+        sb.append(", certCheckerErrorScheduler=").append(certCheckerErrorScheduler).append("\n");
+        sb.append(", disableMinRenewWindow=").append(disableMinRenewWindow).append("\n");
+        sb.append(", disableRenewOnNewHistory=").append(disableRenewOnNewHistory).append("\n");
+        sb.append(", renewCertMin=").append(renewCertMin).append("\n");
+        sb.append(" }");
+
+        /* Transport configuration */
+        sb.append(", acmeTransportConfig{ protocol=").append(protocol).append("\n");
+        sb.append(", trustStore=").append(trustStore).append("\n");
+        sb.append(", trustStoreType=").append(trustStoreType).append("\n");
+        sb.append(", httpConnectTimeout=").append(httpConnectTimeout).append("\n");
+        sb.append(", httpReadTimeout=").append(httpReadTimeout).append("\n");
+        sb.append(" }");
+
+        /* Revocation configuration */
+        sb.append(", acmeRevocationChecker{ ocspResponderUrl=").append(ocspResponderUrl).append("\n");
+        sb.append(", revocationCheckerEnabled=").append(revocationCheckerEnabled).append("\n");
+        sb.append(", preferCRLs=").append(preferCRLs).append("\n");
+        sb.append(", disableFallback=").append(disableFallback).append("\n");
+        sb.append(" }");
+
+        sb.append("}");
+        return sb.toString();
+    }
 
 }

--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeProviderImpl.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeProviderImpl.java
@@ -331,7 +331,7 @@ public class AcmeProviderImpl implements AcmeProvider {
 	 * 
 	 */
 	@Trivial
-	protected AcmeConfig getAcmeConfig() {
+	public static AcmeConfig getAcmeConfig() {
 		return acmeConfig;
 	}
 

--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/util/AcmeConstants.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/util/AcmeConstants.java
@@ -65,6 +65,10 @@ public class AcmeConstants {
 	// Minimum allowed time to check for expiration
 	public static final String RENEW_CERT_MIN = "renewCertMin";
 
+	// HTTP timeouts connecting to the CA
+	public static final String HTTP_CONNECT_TIMEOUT = "httpConnectTimeout";
+	public static final String HTTP_READ_TIMEOUT = "httpReadTimeout";
+
 	/*
 	 * End constants that match the metatype fields
 	 */
@@ -90,10 +94,12 @@ public class AcmeConstants {
 	public static final long ORDER_POLL_DEFAULT = 120000l;
 	public static final long RENEW_CERT_MIN_DEFAULT = 15000L; 
 
-
 	public static final Long SCHEDULER_MS = TimeUnit.HOURS.toMillis(24L);
 	public static final Long SCHEDULER_ERROR_MS = TimeUnit.HOURS.toMillis(1L);
 	
 	public static final String ACME_HISTORY_FILE = "acmeca-history.txt";
+
+	public static final Integer HTTP_CONNECT_TIMEOUT_DEFAULT = 30000;
+	public static final Integer HTTP_READ_TIMEOUT_DEFAULT = 30000;
 
 }

--- a/dev/com.ibm.ws.security.acme/src/org/shredzone/acme4j/connector/HttpConnector.java
+++ b/dev/com.ibm.ws.security.acme/src/org/shredzone/acme4j/connector/HttpConnector.java
@@ -37,6 +37,7 @@ import com.ibm.websphere.ssl.SSLConfig;
 import com.ibm.websphere.ssl.SSLException;
 import com.ibm.ws.security.acme.internal.AcmeConfigService;
 import com.ibm.ws.security.acme.internal.AcmeProviderImpl;
+import com.ibm.ws.security.acme.internal.util.AcmeConstants;
 import com.ibm.ws.ssl.provider.AbstractJSSEProvider;
 
 /**
@@ -55,7 +56,6 @@ public class HttpConnector {
 
 	private static final TraceComponent tc = Tr.register(HttpConnector.class);
 
-	private static final int TIMEOUT = 10000;
 	private static final String USER_AGENT;
 
 	static {
@@ -111,8 +111,17 @@ public class HttpConnector {
 	 *            {@link URL} to connect to
 	 */
 	protected void configure(HttpURLConnection conn, URL url) throws IOException {
-		conn.setConnectTimeout(TIMEOUT);
-		conn.setReadTimeout(TIMEOUT);
+		int connectTimeout;
+		int readTimeout;
+		if (AcmeConfigService.getThreadLocalAcmeConfig() != null) {
+			connectTimeout = AcmeConfigService.getThreadLocalAcmeConfig().getHTTPConnectTimeout().intValue();
+			readTimeout = AcmeConfigService.getThreadLocalAcmeConfig().getHTTPReadTimeout().intValue();
+		} else {
+			connectTimeout = AcmeProviderImpl.getAcmeConfig().getHTTPConnectTimeout();
+			readTimeout = AcmeProviderImpl.getAcmeConfig().getHTTPReadTimeout();
+		}
+		conn.setConnectTimeout(connectTimeout);
+		conn.setReadTimeout(readTimeout);
 		conn.setUseCaches(false);
 		conn.setRequestProperty("User-Agent", USER_AGENT);
 

--- a/dev/com.ibm.ws.security.acme/test/com/ibm/ws/security/acme/internal/AcmeConfigTest.java
+++ b/dev/com.ibm.ws.security.acme/test/com/ibm/ws/security/acme/internal/AcmeConfigTest.java
@@ -382,6 +382,26 @@ public class AcmeConfigTest {
 		assertEquals(Boolean.FALSE, acmeConfig.isRevocationCheckerEnabled());
 		assertEquals(URI.create("http://localhost:4001"), acmeConfig.getOcspResponderUrl());
 		assertTrue(acmeConfig.isPreferCrls());
+		assertEquals(acmeConfig.getHTTPConnectTimeout(), AcmeConstants.HTTP_CONNECT_TIMEOUT_DEFAULT);
+		assertEquals(acmeConfig.getHTTPReadTimeout(), AcmeConstants.HTTP_READ_TIMEOUT_DEFAULT);
+
+		/*
+		 * Check custom config on httpConnect/httpRead
+		 */
+		properties.put(AcmeConstants.TRANSPORT_CONFIG + ".0." + AcmeConstants.HTTP_CONNECT_TIMEOUT, 17000L);
+		properties.put(AcmeConstants.TRANSPORT_CONFIG + ".0." + AcmeConstants.HTTP_READ_TIMEOUT, 60L);
+		acmeConfig = new AcmeConfig(properties);
+		assertEquals(17000, acmeConfig.getHTTPConnectTimeout().intValue());
+		assertEquals(60, acmeConfig.getHTTPReadTimeout().intValue());
+
+		/*
+		 * Check zero on httpConnect/httpRead
+		 */
+		properties.put(AcmeConstants.TRANSPORT_CONFIG + ".0." + AcmeConstants.HTTP_CONNECT_TIMEOUT, 0L);
+		properties.put(AcmeConstants.TRANSPORT_CONFIG + ".0." + AcmeConstants.HTTP_READ_TIMEOUT, 0L);
+		acmeConfig = new AcmeConfig(properties);
+		assertEquals(0, acmeConfig.getHTTPConnectTimeout().intValue());
+		assertEquals(0, acmeConfig.getHTTPReadTimeout().intValue());
 	}
 
 	@Test
@@ -427,6 +447,8 @@ public class AcmeConfigTest {
 		properties.put(AcmeConstants.RENEW_BEFORE_EXPIRATION, AcmeConstants.RENEW_CERT_MIN_DEFAULT - 10);
 		properties.put(AcmeConstants.CERT_CHECKER_SCHEDULE, AcmeConstants.RENEW_CERT_MIN_DEFAULT - 10);
 		properties.put(AcmeConstants.CERT_CHECKER_ERROR_SCHEDULE, AcmeConstants.RENEW_CERT_MIN_DEFAULT - 10);
+		properties.put(AcmeConstants.TRANSPORT_CONFIG + ".0." + AcmeConstants.HTTP_CONNECT_TIMEOUT, -2L);
+		properties.put(AcmeConstants.TRANSPORT_CONFIG + ".0." + AcmeConstants.HTTP_READ_TIMEOUT, -4L);
 
 		/*
 		 * Instantiate the ACME configuration.
@@ -443,6 +465,17 @@ public class AcmeConfigTest {
 		assertTrue("Auto-renewal should be enabled", acmeConfig.isAutoRenewOnExpiration());
 		assertEquals(acmeConfig.getRenewCertMin(), acmeConfig.getCertCheckerScheduler().longValue());
 		assertEquals(acmeConfig.getRenewCertMin(), acmeConfig.getCertCheckerErrorScheduler().longValue());
+		assertEquals(0, acmeConfig.getHTTPConnectTimeout().intValue());
+		assertEquals(0, acmeConfig.getHTTPReadTimeout().intValue());
+
+		/*
+		 * Check max values on httpConnect/httpRead
+		 */
+		properties.put(AcmeConstants.TRANSPORT_CONFIG + ".0." + AcmeConstants.HTTP_CONNECT_TIMEOUT, 2147483649L);
+		properties.put(AcmeConstants.TRANSPORT_CONFIG + ".0." + AcmeConstants.HTTP_READ_TIMEOUT, 2147483649L);
+		acmeConfig = new AcmeConfig(properties);
+		assertEquals(Integer.MAX_VALUE, acmeConfig.getHTTPConnectTimeout().intValue());
+		assertEquals(Integer.MAX_VALUE, acmeConfig.getHTTPReadTimeout().intValue());
 	}
 
 	private Map<String, Object> getBasicConfig() {

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSimpleTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSimpleTest.java
@@ -458,7 +458,7 @@ public class AcmeSimpleTest {
 			 **********************************************************************/
 			serial1 = serial2;
 			acmeCA.setSubjectDN("cn=domain1.com");
-			acmeCA.setChallengeRetries(5); // Force config update.
+			acmeCA.setChallengePoll("1m"); // Force config update.
 			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration);
 			AcmeFatUtils.waitForAcmeToNoOp(server);
 

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/AcmeCA.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/AcmeCA.java
@@ -29,9 +29,7 @@ public class AcmeCA extends ConfigElement {
 
     private AcmeTransportConfig acmeTransportConfig;
 
-    private Integer challengeRetries;
-
-    private String challengeRetryWait; // Duration
+    private String challengePollTimeout; // Duration
 
     private String subjectDN;
 
@@ -41,9 +39,7 @@ public class AcmeCA extends ConfigElement {
 
     private String domainKeyFile;
 
-    private Integer orderRetries;
-
-    private String orderRetryWait; // Duration
+    private String orderPollTimeout; // Duration
 
     private String validFor; // Duration
 
@@ -88,17 +84,10 @@ public class AcmeCA extends ConfigElement {
     }
 
     /**
-     * @return the challengeRetries
+     * @return the challengePollTimeout
      */
-    public Integer getChallengeRetries() {
-        return challengeRetries;
-    }
-
-    /**
-     * @return the challengeRetryWait
-     */
-    public String getChallengeRetryWait() {
-        return challengeRetryWait;
+    public String getChallengePoll() {
+        return challengePollTimeout;
     }
 
     /**
@@ -123,17 +112,10 @@ public class AcmeCA extends ConfigElement {
     }
 
     /**
-     * @return the orderRetries
+     * @return the orderPollTimeout
      */
-    public Integer getOrderRetries() {
-        return orderRetries;
-    }
-
-    /**
-     * @return the orderRetryWait
-     */
-    public String getOrderRetryWait() {
-        return orderRetryWait;
+    public String getOrderPoll() {
+        return orderPollTimeout;
     }
 
     /**
@@ -183,19 +165,11 @@ public class AcmeCA extends ConfigElement {
     }
 
     /**
-     * @param challengeRetries the challengeRetries to set
-     */
-    @XmlAttribute(name = "challengeRetries")
-    public void setChallengeRetries(Integer challengeRetries) {
-        this.challengeRetries = challengeRetries;
-    }
-
-    /**
      * @param challengeRetryWait the challengeRetryWait to set
      */
-    @XmlAttribute(name = "challengeRetryWait")
-    public void setChallengeRetryWait(String challengeRetryWait) {
-        this.challengeRetryWait = challengeRetryWait;
+    @XmlAttribute(name = "challengePollTimeout")
+    public void setChallengePoll(String challengePollTimeout) {
+        this.challengePollTimeout = challengePollTimeout;
     }
 
     /**
@@ -223,19 +197,11 @@ public class AcmeCA extends ConfigElement {
     }
 
     /**
-     * @param orderRetries the orderRetries to set
+     * @param orderPollTimeout the orderPollTimeout to set
      */
-    @XmlAttribute(name = "orderRetries")
-    public void setOrderRetries(Integer orderRetries) {
-        this.orderRetries = orderRetries;
-    }
-
-    /**
-     * @param orderRetryWait the orderRetryWait to set
-     */
-    @XmlAttribute(name = "orderRetryWait")
-    public void setOrderRetryWait(String orderRetryWait) {
-        this.orderRetryWait = orderRetryWait;
+    @XmlAttribute(name = "orderPollTimeout")
+    public void setOrderPoll(String orderPollTimeout) {
+        this.orderPollTimeout = orderPollTimeout;
     }
 
     /**
@@ -338,11 +304,8 @@ public class AcmeCA extends ConfigElement {
         if (certCheckerErrorSchedule != null) {
             sb.append("certCheckerErrorSchedule=\"").append(certCheckerErrorSchedule).append("\" ");;
         }
-        if (challengeRetries != null) {
-            sb.append("challengeRetries=\"").append(challengeRetries).append("\" ");;
-        }
-        if (challengeRetryWait != null) {
-            sb.append("challengeRetryWait=\"").append(challengeRetryWait).append("\" ");;
+        if (challengePollTimeout != null) {
+            sb.append("challengePollTimeout=\"").append(challengePollTimeout).append("\" ");;
         }
         if (directoryURI != null) {
             sb.append("directoryURI=\"").append(directoryURI).append("\" ");;
@@ -362,11 +325,8 @@ public class AcmeCA extends ConfigElement {
         if (domain != null) {
             sb.append("domain=\"").append(domain).append("\" ");;
         }
-        if (orderRetries != null) {
-            sb.append("orderRetries=\"").append(orderRetries).append("\" ");;
-        }
-        if (orderRetryWait != null) {
-            sb.append("orderRetryWait=\"").append(orderRetryWait).append("\" ");;
+        if (orderPollTimeout != null) {
+            sb.append("orderPollTimeout=\"").append(orderPollTimeout).append("\" ");;
         }
         if (renewBeforeExpiration != null) {
             sb.append("renewBeforeExpiration=\"").append(renewBeforeExpiration).append("\" ");;
@@ -396,6 +356,10 @@ public class AcmeCA extends ConfigElement {
 
         private String trustStoreType;
 
+        private String httpConnectTimeout; // duration
+
+        private String httpReadTimeout; // duration
+
         /**
          * @return the protocol
          */
@@ -422,6 +386,20 @@ public class AcmeCA extends ConfigElement {
          */
         public String getTrustStoreType() {
             return trustStoreType;
+        }
+
+        /**
+         * @return the httpConnectTimeout
+         */
+        public String getHttpConnectTimeout() {
+            return httpConnectTimeout;
+        }
+
+        /**
+         * @return the httpReadTimeout
+         */
+        public String getHttpReadTimeout() {
+            return httpReadTimeout;
         }
 
         /**
@@ -456,6 +434,22 @@ public class AcmeCA extends ConfigElement {
             this.trustStoreType = trustStoreType;
         }
 
+        /**
+         * @param httpConnectTimeout the httpConnectTimeout to set
+         */
+        @XmlAttribute(name = "httpConnectTimeout")
+        public void setHttpConnectTimeout(String httpConnectTimeout) {
+            this.httpConnectTimeout = httpConnectTimeout;
+        }
+
+        /**
+         * @param httpReadTimeout the httpReadTimeout to set
+         */
+        @XmlAttribute(name = "httpReadTimeout")
+        public void setHttpReadTimeout(String httpReadTimeout) {
+            this.httpReadTimeout = httpReadTimeout;
+        }
+
         @Override
         public String toString() {
             StringBuffer sb = new StringBuffer();
@@ -473,6 +467,12 @@ public class AcmeCA extends ConfigElement {
             }
             if (trustStoreType != null) {
                 sb.append("trustStoreType=\"").append(trustStoreType).append("\" ");;
+            }
+            if (httpConnectTimeout != null) {
+                sb.append("httpConnectTimeout=\"").append(httpConnectTimeout).append("\" ");;
+            }
+            if (httpReadTimeout != null) {
+                sb.append("httpReadTimeout=\"").append(httpReadTimeout).append("\" ");;
             }
 
             sb.append("}");


### PR DESCRIPTION
Fixes #12822 

- Added a httpConnectTimeout and an httpReadTimeout, but left them as internal properties for now
- Add the nlsprops for these properties and minRenew to save us from doing it in the future (if needed)
- Set default timeout to 30 seconds 
- Fixed the AcmeCA FAT test config for the order/challenge poll
- Added a toString for AcmeConfig
- Added a couple more trace points to log exceptions (FFDC is great, but customers don't always give us FFDC)
- Adjusted our exception parsing as I sometimes got an IOException with no message, but the exception class itself was helpful (SocketTimeoutException).
