### PR TITLE
Issue 12911: Skip tests on specific OS/JDK

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSimpleTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSimpleTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -130,7 +131,7 @@ public class AcmeSimpleTest {
 	@Test
 	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
 	public void startup_server() throws Exception {
-
+		assumeTrue(!AcmeFatUtils.isWindowsWithOpenJDK1105(testName.getMethodName()));
 		Certificate[] startingCertificateChain = null, endingCertificateChain = null;
 
 		/*
@@ -267,7 +268,7 @@ public class AcmeSimpleTest {
 	@Test
 	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
 	public void update_domains() throws Exception {
-
+		assumeTrue(!AcmeFatUtils.isWindowsWithOpenJDK1105(testName.getMethodName()));
 		/*
 		 * Configure the acmeCA-2.0 feature.
 		 */
@@ -367,7 +368,7 @@ public class AcmeSimpleTest {
 	@Test
 	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
 	public void update_subjectdn() throws Exception {
-
+		assumeTrue(!AcmeFatUtils.isWindowsWithOpenJDK1105(testName.getMethodName()));
 		ServerConfiguration configuration = ORIGINAL_CONFIG.clone();
 
 		/*
@@ -491,7 +492,7 @@ public class AcmeSimpleTest {
 	@MinimumJavaLevel(javaLevel = 9)
 	/* Minimum Java Level to avoid a known/fixed IBM Java 8 bug with an empty keystore, IJ19292. When the builds move to 8SR6, we can run this test again */
 	public void keystore_exists_without_default_alias() throws Exception {
-
+		assumeTrue(!AcmeFatUtils.isWindowsWithOpenJDK1105(testName.getMethodName()));
 		ServerConfiguration configuration = ORIGINAL_CONFIG.clone();
 
 		/*
@@ -531,6 +532,7 @@ public class AcmeSimpleTest {
 	@Test
 	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
 	public void account_keypair_directory_does_not_exist() throws Exception {
+		assumeTrue(!AcmeFatUtils.isWindowsWithOpenJDK1105(testName.getMethodName()));
 		ServerConfiguration configuration = ORIGINAL_CONFIG.clone();
 
 		/*
@@ -578,6 +580,7 @@ public class AcmeSimpleTest {
 	@Test
 	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
 	public void domain_keypair_directory_does_not_exist() throws Exception {
+		assumeTrue(!AcmeFatUtils.isWindowsWithOpenJDK1105(testName.getMethodName()));
 		ServerConfiguration configuration = ORIGINAL_CONFIG.clone();
 
 		/*

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
@@ -841,7 +841,34 @@ public class AcmeFatUtils {
  		}
  		return false;
  	}
- 	
+
+	/**
+	 * Check if the test is running on Windows OS and a specific java
+	 * 
+	 * @param methodName
+	 * @return True if the test is running on the specific OS/JDK combo
+	 */
+	public static boolean isWindowsWithOpenJDK1105(String methodName) {
+		if (System.getProperty("os.name").toLowerCase().startsWith("win")
+				&& System.getProperty("java.vendor").toLowerCase().contains("openjdk")
+				&& System.getProperty("java.version").equals("11.0.5")) {
+			/*
+			 * On Windows with OpenJDK 11.0.5, we sometimes get an exception deleting the
+			 * Acme related files.
+			 * 
+			 * "The process cannot access the file because it is being used by another
+			 * process"
+			 * 
+			 * The exception is not seen on later OpenJDK versions.
+			 */
+			Log.info(AcmeFatUtils.class, methodName,
+					"Skipping this test due to a bug with the specific OS/JDK combo: " + System.getProperty("os.name")
+							+ " " + System.getProperty("java.vendor") + " " + System.getProperty("java.version"));
+			return true;
+		}
+		return false;
+	}
+
  	/**
  	 * Handle adding CWPKI2045W as an allowed warning message to all stopServer requests.
  	 * 


### PR DESCRIPTION
Fixes #12911 

Skipped AcmeSimpleTests on Windows/OpenJDK 11.0.5. Appears to work on later drivers (for sure 11.0.7) so don't want to be limited when the build systems upgrade.