### PR TITLE
Updated fat buckets with the new guidelines for OL fat buckets

### DIFF
--- a/dev/com.ibm.ws.el.3.0_fat/fat/src/com/ibm/ws/el/fat/FATSuite.java
+++ b/dev/com.ibm.ws.el.3.0_fat/fat/src/com/ibm/ws/el/fat/FATSuite.java
@@ -27,8 +27,8 @@ import com.ibm.ws.el.fat.tests.EL30ReservedWordsTest;
 import com.ibm.ws.el.fat.tests.EL30StaticFieldsAndMethodsTest;
 import com.ibm.ws.fat.util.FatLogHandler;
 
+import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 /**
  * EL 3.0 Tests
@@ -69,7 +69,7 @@ public class FATSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests
-                    .withoutModification()
-                    .andWith(new JakartaEE9Action());
+                    .with(new EmptyAction().fullFATOnly())
+                    .andWith(FeatureReplacementAction.EE9_FEATURES());
 
 }

--- a/dev/com.ibm.ws.jsp.2.3_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jsp.2.3_fat/bnd.bnd
@@ -27,6 +27,7 @@ tested.features:\
     el-4.0,\
     servlet-5.0,\
     jsp-3.0,\
+    cdi-3.0,\
 
 
 -buildpath: \

--- a/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/FATSuite.java
@@ -22,8 +22,8 @@ import com.ibm.ws.jsp23.fat.tests.JSPCdiTest;
 import com.ibm.ws.jsp23.fat.tests.JSPJava8Test;
 import com.ibm.ws.jsp23.fat.tests.JSPTests;
 
+import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
 /**
@@ -53,9 +53,11 @@ public class FATSuite {
      * using @SkipForRepeat("CDI-2.0").
      */
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification()
+    public static RepeatTests r = RepeatTests
+                    .with(new EmptyAction().fullFATOnly())
                     .andWith(new FeatureReplacementAction("cdi-1.2", "cdi-2.0")
                                     .withID("CDI-2.0")
-                                    .forceAddFeatures(false))
-                    .andWith(new JakartaEE9Action());
+                                    .forceAddFeatures(false)
+                                    .fullFATOnly())
+                    .andWith(FeatureReplacementAction.EE9_FEATURES());
 }

--- a/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSPCdiTest.java
+++ b/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSPCdiTest.java
@@ -31,7 +31,6 @@ import com.meterware.httpunit.WebRequest;
 import com.meterware.httpunit.WebResponse;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
@@ -39,7 +38,6 @@ import componenttest.topology.impl.LibertyServer;
  * Tests to execute on the jspCdiServer that use HttpUnit.
  */
 
-@SkipForRepeat("EE9_FEATURES")
 @RunWith(FATRunner.class)
 public class JSPCdiTest {
     private static final Logger LOG = Logger.getLogger(JSPCdiTest.class.getName());

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/FATSuite.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/FATSuite.java
@@ -42,8 +42,8 @@ import com.ibm.ws.webcontainer.servlet31.fat.tests.VHServerHttpUnit;
 import com.ibm.ws.webcontainer.servlet31.fat.tests.WCServerHttpUnit;
 import com.ibm.ws.webcontainer.servlet31.fat.tests.WCServerTest;
 
+import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
 /**
@@ -84,8 +84,7 @@ public class FATSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests
-                    .with(FeatureReplacementAction.EE7_FEATURES()
-                                    .fullFATOnly())
+                    .with(new EmptyAction().fullFATOnly())
                     .andWith(FeatureReplacementAction.EE8_FEATURES()
                                     .fullFATOnly())
                     .andWith(FeatureReplacementAction.EE9_FEATURES()); 

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/WCServerTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/WCServerTest.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package com.ibm.ws.webcontainer.servlet31.fat.tests;
 
-import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/FATSuite.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/FATSuite.java
@@ -33,7 +33,8 @@ import com.ibm.ws.fat.wc.tests.WCServletPathForDefaultMappingDefault;
 import com.ibm.ws.fat.wc.tests.WCServletPathForDefaultMappingFalse;
 import com.ibm.ws.fat.wc.tests.WCTrailersTest;
 
-import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 
 /**
@@ -81,7 +82,9 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
 
     @ClassRule
-    public static RepeatTests repeat = RepeatTests.withoutModification().andWith(new JakartaEE9Action());
+    public static RepeatTests repeat = RepeatTests
+                    .with(new EmptyAction().fullFATOnly())
+                    .andWith(FeatureReplacementAction.EE9_FEATURES());
 
     /**
      * @see {@link FatLogHandler#generateHelpFile()}


### PR DESCRIPTION
- Updated el-3.0, jsp-2.3, and servlet-4.0 bucket to follow guidelines
- Enabled cdi-3.0 test on jsp-2.3 bucket
fixes #12689
fixes #12690
fixes #12691
fixes #12937