### PR TITLE
gRPC FAT improvements

### DIFF
--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldTest.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldTest.java
@@ -11,6 +11,7 @@
 
 package com.ibm.ws.fat.grpc;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.net.URL;
@@ -63,6 +64,7 @@ public class HelloWorldTest extends FATServletClient {
                                       "com.ibm.ws.fat.grpc.tls");
 
         helloWorldServer.startServer(HelloWorldTest.class.getSimpleName() + ".log");
+        assertNotNull("CWWKO0219I.*ssl not recieved", helloWorldServer.waitForStringInLog("CWWKO0219I.*ssl"));
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreServicesTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreServicesTests.java
@@ -12,6 +12,9 @@ package com.ibm.ws.fat.grpc;
 
 import static org.junit.Assert.assertNotNull;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -52,6 +55,10 @@ public class StoreServicesTests extends FATServletClient {
     @Server("ConsumerServer")
     @TestServlet(servlet = ConsumerEndpointFATServlet.class, contextRoot = "StoreConsumerApp")
     public static LibertyServer consumerServer;
+
+    private static String getSysProp(String key) {
+        return AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty(key));
+    }
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -100,8 +107,8 @@ public class StoreServicesTests extends FATServletClient {
         producerServer.startServer(StoreServicesTests.class.getSimpleName() + ".log");
 
         // set bvt.prop.member_1.http=8080 and bvt.prop.member_1.https=8081
-        consumerServer.setHttpDefaultPort(8080);
-        consumerServer.setHttpDefaultSecurePort(8081);
+        consumerServer.setHttpDefaultPort(Integer.parseInt(getSysProp("member_1.http")));
+        consumerServer.setHttpDefaultSecurePort(Integer.parseInt(getSysProp("member_1.https")));
         consumerServer.startServer(StoreServicesTests.class.getSimpleName() + ".log");
 
     }


### PR DESCRIPTION
`com.ibm.ws.fat.grpc.StoreServicesTests.testGetAppInfo()` fails on some platforms due to a hardcoded port - I'll get rid of that.  Additionally, there is a potential for the tests in HelloWorldTest to run before the SSL port comes up - that test class needs to wait for the ssl channel init message.

#10094