### PR TITLE
Issue 12924: Add FFDC in create/update cert

### DIFF
--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeProviderImpl.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeProviderImpl.java
@@ -821,6 +821,11 @@ public class AcmeProviderImpl implements AcmeProvider {
 			createKeyStore(filePath, null, password, keyStoreType, keyStoreProvider);
 
 			throw new CertificateException(ace.getMessage(), ace);
+		} catch (Exception e) {
+			/*
+			 * Process an FFDC before we flow back to WSKeystore
+			 */
+			throw e;
 		}
 	}
 
@@ -912,6 +917,11 @@ public class AcmeProviderImpl implements AcmeProvider {
 
 		} catch (AcmeCaException e) {
 			throw new CertificateException(e.getMessage(), e);
+		} catch (Exception e) {
+			/*
+			 * Process an FFDC before we flow back to WSKeystore
+			 */
+			throw e;
 		}
 	}
 


### PR DESCRIPTION
Fixes #12924 

FFDC general exceptions before we return to WSKeyStore.

While testing, confirmed that we keep the flow with WSKeystore and add an FFDC

```
[7/7/20, 15:02:39:232 CDT] 00000059 id=5f6e9f32 com.ibm.ws.security.acme.internal.AcmeHistory                < directoryURIChanged Exit  
                                                                                                               false
[7/7/20, 15:02:39:265 CDT] 0000005e id=00000000 com.ibm.ws.tcpchannel.internal.TCPPort                       I CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now listening for requests on host *  (IPv6) port 5002.
[7/7/20, 15:02:39:311 CDT] 00000059 id=00000000 com.ibm.ws.logging.internal.impl.IncidentImpl                I FFDC1015I: An FFDC Incident has been created: "java.lang.ArithmeticException: divide by zero com.ibm.ws.security.acme.internal.AcmeProviderImpl 922" at ffdc_20.07.07_15.02.39.0.log
[7/7/20, 15:02:39:318 CDT] 00000059 id=00000000 com.ibm.ws.ssl.config.WSKeyStore                             3 Exception initializing KeyStore; java.lang.ArithmeticException: divide by zero 
                                                                                                               java.lang.ArithmeticException: divide by zero
	at com.ibm.ws.security.acme.internal.AcmeProviderImpl.updateDefaultSSLCertificate(AcmeProviderImpl.java:899)
	at com.ibm.ws.crypto.certificate.creator.acme.AcmeSSLCertificateCreator.updateDefaultSSLCertificate(AcmeSSLCertificateCreator.java:53)
	at com.ibm.ws.ssl.config.WSKeyStore$1.run(WSKeyStore.java:863)
	at com.ibm.ws.ssl.config.WSKeyStore$1.run(WSKeyStore.java:803)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:703)
	at com.ibm.ws.ssl.config.WSKeyStore.obtainKeyStore(WSKeyStore.java:803)
	at com.ibm.ws.ssl.config.WSKeyStore.do_getKeyStore(WSKeyStore.java:763)
	at com.ibm.ws.ssl.config.WSKeyStore.getKeyStore(WSKeyStore.java:1038)
	at com.ibm.ws.ssl.config.WSKeyStore.getKeyStore(WSKeyStore.java:1012)
	at com.ibm.ws.ssl.config.WSKeyStore.initializeKeyStore(WSKeyStore.java:1157)
	at com.ibm.ws.ssl.config.WSKeyStore.<init>(WSKeyStore.java:321)
```