### PR TITLE
[#12875] Ensure resources are invoked when no servlet is in web.xml

### DIFF
--- a/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/component/RESTfulServletContainerInitializer.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/component/RESTfulServletContainerInitializer.java
@@ -18,6 +18,10 @@ import javax.servlet.ServletContainerInitializer;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRegistration;
+import javax.servlet.annotation.HandlesTypes;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.ext.Provider;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -26,6 +30,7 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import org.jboss.resteasy.plugins.servlet.ResteasyServletInitializer;
 
 @Trivial
+@HandlesTypes({Application.class, Path.class, Provider.class})
 public class RESTfulServletContainerInitializer extends ResteasyServletInitializer implements ServletContainerInitializer {
     private final static TraceComponent tc = Tr.register(RESTfulServletContainerInitializer.class, "JAXRS");
 


### PR DESCRIPTION
Additional PR for Issue #12875 - this re-enables no-web.xml or no-rest-servlet-in-web.xml scenarios.