### PR TITLE
Issue 13003: Change sleep to force renew, update method name

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSimpleTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSimpleTest.java
@@ -131,7 +131,7 @@ public class AcmeSimpleTest {
 	@Test
 	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
 	public void startup_server() throws Exception {
-		assumeTrue(!AcmeFatUtils.isWindowsWithOpenJDK1105(testName.getMethodName()));
+		assumeTrue(!AcmeFatUtils.isWindowsWithOpenJDK(testName.getMethodName()));
 		Certificate[] startingCertificateChain = null, endingCertificateChain = null;
 
 		/*
@@ -268,7 +268,7 @@ public class AcmeSimpleTest {
 	@Test
 	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
 	public void update_domains() throws Exception {
-		assumeTrue(!AcmeFatUtils.isWindowsWithOpenJDK1105(testName.getMethodName()));
+		assumeTrue(!AcmeFatUtils.isWindowsWithOpenJDK(testName.getMethodName()));
 		/*
 		 * Configure the acmeCA-2.0 feature.
 		 */
@@ -368,7 +368,7 @@ public class AcmeSimpleTest {
 	@Test
 	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
 	public void update_subjectdn() throws Exception {
-		assumeTrue(!AcmeFatUtils.isWindowsWithOpenJDK1105(testName.getMethodName()));
+		assumeTrue(!AcmeFatUtils.isWindowsWithOpenJDK(testName.getMethodName()));
 		ServerConfiguration configuration = ORIGINAL_CONFIG.clone();
 
 		/*
@@ -492,7 +492,7 @@ public class AcmeSimpleTest {
 	@MinimumJavaLevel(javaLevel = 9)
 	/* Minimum Java Level to avoid a known/fixed IBM Java 8 bug with an empty keystore, IJ19292. When the builds move to 8SR6, we can run this test again */
 	public void keystore_exists_without_default_alias() throws Exception {
-		assumeTrue(!AcmeFatUtils.isWindowsWithOpenJDK1105(testName.getMethodName()));
+		assumeTrue(!AcmeFatUtils.isWindowsWithOpenJDK(testName.getMethodName()));
 		ServerConfiguration configuration = ORIGINAL_CONFIG.clone();
 
 		/*
@@ -532,7 +532,7 @@ public class AcmeSimpleTest {
 	@Test
 	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
 	public void account_keypair_directory_does_not_exist() throws Exception {
-		assumeTrue(!AcmeFatUtils.isWindowsWithOpenJDK1105(testName.getMethodName()));
+		assumeTrue(!AcmeFatUtils.isWindowsWithOpenJDK(testName.getMethodName()));
 		ServerConfiguration configuration = ORIGINAL_CONFIG.clone();
 
 		/*
@@ -580,7 +580,7 @@ public class AcmeSimpleTest {
 	@Test
 	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
 	public void domain_keypair_directory_does_not_exist() throws Exception {
-		assumeTrue(!AcmeFatUtils.isWindowsWithOpenJDK1105(testName.getMethodName()));
+		assumeTrue(!AcmeFatUtils.isWindowsWithOpenJDK(testName.getMethodName()));
 		ServerConfiguration configuration = ORIGINAL_CONFIG.clone();
 
 		/*

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
@@ -848,12 +848,12 @@ public class AcmeFatUtils {
 	 * @param methodName
 	 * @return True if the test is running on the specific OS/JDK combo
 	 */
-	public static boolean isWindowsWithOpenJDK1105(String methodName) {
+	public static boolean isWindowsWithOpenJDK(String methodName) {
 		if (System.getProperty("os.name").toLowerCase().startsWith("win")
 				&& System.getProperty("java.vendor").toLowerCase().contains("openjdk")
 				&& System.getProperty("java.version").equals("11.0.5")) {
 			/*
-			 * On Windows with OpenJDK 11.0.5, we sometimes get an exception deleting the
+			 * On Windows with OpenJDK 11.0.5 (and others), we sometimes get an exception deleting the
 			 * Acme related files.
 			 * 
 			 * "The process cannot access the file because it is being used by another


### PR DESCRIPTION
Fixes #13003 

- Simplified the sleep to hit the renew window on restart
- Update the method name for isWindowsWithOpenJDK1105 to be more generic