### PR TITLE
Issue #12029: EE9 Managed Bean FAT with EJB and CDI

### DIFF
--- a/dev/com.ibm.ws.managedbeans_fat/bnd.bnd
+++ b/dev/com.ibm.ws.managedbeans_fat/bnd.bnd
@@ -29,6 +29,8 @@ fat.project: true
 # In this case, the following are added programmatically at runtime by the RepeatTests rule.
 tested.features:\
 	cdi-2.0,\
+	cdi-3.0,\
+	ejbLite-4.0,\
 	jdbc-4.2,\
 	jpa-2.2,\
 	jpaContainer-2.2,\

--- a/dev/com.ibm.ws.managedbeans_fat/fat/src/com/ibm/ws/managedbeans/fat/tests/ManagedBeansCdiTest.java
+++ b/dev/com.ibm.ws.managedbeans_fat/fat/src/com/ibm/ws/managedbeans/fat/tests/ManagedBeansCdiTest.java
@@ -27,6 +27,7 @@ import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -44,7 +45,8 @@ public class ManagedBeansCdiTest extends FATServletClient {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("ManagedBeansCdiServer"))
-                    .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly().forServers("ManagedBeansCdiServer"));
+                    .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly().forServers("ManagedBeansCdiServer"))
+                    .andWith(new JakartaEE9Action().fullFATOnly().forServers("ManagedBeansCdiServer"));
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.managedbeans_fat/fat/src/com/ibm/ws/managedbeans/fat/tests/ManagedBeansEjbTest.java
+++ b/dev/com.ibm.ws.managedbeans_fat/fat/src/com/ibm/ws/managedbeans/fat/tests/ManagedBeansEjbTest.java
@@ -28,6 +28,7 @@ import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -45,7 +46,8 @@ public class ManagedBeansEjbTest extends FATServletClient {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("ManagedBeansEjbServer"))
-                    .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly().forServers("ManagedBeansEjbServer"));
+                    .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly().forServers("ManagedBeansEjbServer"))
+                    .andWith(new JakartaEE9Action().fullFATOnly().forServers("ManagedBeansEjbServer"));
 
     @BeforeClass
     public static void setUp() throws Exception {


### PR DESCRIPTION
Enable the Managed Bean FAT that tests with EJB and CDI
to run with Jakarta EE 9 feature levels.

for #12879 