### PR TITLE
Issue #12934: Enable EJB CMD auto feature for EJB 4.0

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.ejbComponentMetadataDecorator-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.ejbComponentMetadataDecorator-1.0.feature
@@ -1,7 +1,7 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.ejbComponentMetadataDecorator-1.0
 visibility=private
-IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.ejbCore-1.0))", \
+IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.ejbCore-1.0)(osgi.identity=io.openliberty.ejbCore-2.0)))", \
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.jeeMetadataContext-1.0))"
 IBM-Install-Policy: when-satisfied
 -bundles=com.ibm.ws.javaee.metadata.context.ejb


### PR DESCRIPTION
Enable the ejbComponentMetadataDecorator-1.0 feature for
EJB 4.0 features; required for propagation with concurrency feature.

for #12934 