### PR TITLE
Move logstash-5.5.0 to DHE

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -21,6 +21,7 @@ com.ibm.ws.javax.j2ee:servlet.resources:3.1
 com.ibm.ws.javax.j2ee:servlet:3.1
 com.ibm.ws.javax.j2ee:standardtld:1.2
 com.ibm.ws.lars:larsServer-memoryBackend:war:1.0.1
+com.ibm.ws.logstash:logstash:5.5.0
 com.ibm.ws:nekohtml:1.9.18
 com.ibm.ws.org.eclipse.equinox:console:1.1.200.v20150929-1405
 com.ibm.ws.org.eclipse.jdt.core.compiler:ecj:4.4.2
@@ -77,7 +78,6 @@ com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.core:2.6.8.WAS-cf583f
 com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:2.6.8.WAS-cf583f2
 com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen:2.6.8.WAS-cf583f2
 com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.jpa:2.6.8.WAS-cf583f2
-com.ibm.ws.logstash:logstash:5.5.0
 com.ibm.ws.org.objenesis:objenesis:1.0
 com.googlecode.jsontoken:jsontoken:1.1.0-ibm-s20140416-2113
 net.sf.jtidy:jtidy:9.3.8

--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -77,6 +77,7 @@ com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.core:2.6.8.WAS-cf583f
 com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:2.6.8.WAS-cf583f2
 com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen:2.6.8.WAS-cf583f2
 com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.jpa:2.6.8.WAS-cf583f2
+com.ibm.ws.logstash:logstash:5.5.0
 com.ibm.ws.org.objenesis:objenesis:1.0
 com.googlecode.jsontoken:jsontoken:1.1.0-ibm-s20140416-2113
 net.sf.jtidy:jtidy:9.3.8

--- a/dev/com.ibm.ws.logstash.collector_fat/.gitignore
+++ b/dev/com.ibm.ws.logstash.collector_fat/.gitignore
@@ -1,3 +1,4 @@
 dropins
 /autoFVT*
 publish/files/logstash-5.5.0
+lib/*

--- a/dev/com.ibm.ws.logstash.collector_fat/build.gradle
+++ b/dev/com.ibm.ws.logstash.collector_fat/build.gradle
@@ -8,13 +8,27 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+configurations {
+     libs
+}
+dependencies {
+     libs 'com.ibm.ws.logstash:logstash:5.5.0'
+  
+}
+task copyJar {
+     copy {
+          from configurations.libs
+          into "$projectDir/lib/"
+     }
+}
 task unzip(type: Copy) {
-    from zipTree(file("$projectDir/lib/logstash-5.5.0.zip"))
-    into file("$projectDir/publish/files/")
+     dependsOn copyJar
+     from zipTree(file("$projectDir/lib/logstash-5.5.0.jar"))
+     into file("$projectDir/publish/files/")
 }
 
 build.dependsOn unzip
 
 dependencies {
-	requiredLibs 'org.json:json:20080701'
+     requiredLibs 'org.json:json:20080701'
 }


### PR DESCRIPTION
Fixes #12923 
Regarding #12942
Logstash-5.5.0.jar file is added to Public DHE repo http://public.dhe.ibm.com/ibmdl/export/pub/software/olrepo/com/ibm/ws/logstash/logstash/5.5.0/ (external users can download as well) and artifactory. Gradle downloads the file and unzips it into the project's /publish directory to use when the FAT is run.
Tested both scenarios when file is pulled from DHE and file is pulled from artifactory.