### PR TITLE
Change date formatting for access log fields

### DIFF
--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/data/AccessLogData.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/data/AccessLogData.java
@@ -146,7 +146,7 @@ public class AccessLogData extends GenericData {
     }
 
     // @formatter:off
-    public void setRequestStartTime(String s)  { setPair(0, s); }
+    public void setRequestStartTime(long l)    { setPair(0, l); }
     public void setUriPath(String s)           { setPair(1, s); }
     public void setRequestMethod(String s)     { setPair(2, s); }
     public void setQueryString(String s)       { setPair(3, s); }
@@ -165,7 +165,7 @@ public class AccessLogData extends GenericData {
     public void setBytesSent(long l)           { setPair(15, l); }
     public void setRequestElapsedTime(long l)  { setPair(17, l); }
     public void setRequestFirstLine(String s)  { setPair(20, s); }
-    public void setAccessLogDatetime(String s) { setPair(21, s); }
+    public void setAccessLogDatetime(long l)   { setPair(21, l); }
     public void setRemoteUser(String s)        { setPair(22, s); }
     public void setCookies(String name, String value) {
         kvplCookies.addKeyValuePair(name, value);
@@ -180,7 +180,7 @@ public class AccessLogData extends GenericData {
         setPair(19, kvplResponseHeaders);
     }
 
-    public String getRequestStartTime()          { return getStringValue(0); }
+    public long getRequestStartTime()            { return getLongValue(0); }
     public String getUriPath()                   { return getStringValue(1); }
     public String getRequestMethod()             { return getStringValue(2); }
     public String getQueryString()               { return getStringValue(3); }
@@ -201,7 +201,7 @@ public class AccessLogData extends GenericData {
     public KeyValuePairList getRequestHeaders()  { return getValues(18); }
     public KeyValuePairList getResponseHeaders() { return getValues(19); }
     public String getRequestFirstLine()          { return getStringValue(20); }
-    public String getAccessLogDatetime()         { return getStringValue(21); }
+    public long getAccessLogDatetime()           { return getLongValue(21); }
     public String getRemoteUser()                { return getStringValue(22); }
 
     public static String getRequestStartTimeKey(int format)   { return nameAliases[format].aliases[0]; }

--- a/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/CustomAccessLogFieldsTest.java
+++ b/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/CustomAccessLogFieldsTest.java
@@ -358,6 +358,9 @@ public class CustomAccessLogFieldsTest {
         unwantedFields.add("ibm_userDir");
         unwantedFields.add("ibm_datetime");
         unwantedFields.add("ibm_sequence");
+        // The following two fields are formatted differently in JSON compared to the http_access.log
+        unwantedFields.add("ibm_accessLogDatetime");
+        unwantedFields.add("ibm_requestStartTime");
         parsedLine.keySet().removeAll(unwantedFields);
 
         // unfortunately, our JSON log isn't ordered like the http access logs

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/values/AccessLogCurrentTime.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/values/AccessLogCurrentTime.java
@@ -19,7 +19,7 @@ import com.ibm.wsspi.http.channel.HttpResponseMessage;
 public class AccessLogCurrentTime extends AccessLogData {
 
     // We're assuming that the methods below that use this datetime will be called on the same thread
-    private static ThreadLocal<String> accessLogDatetime = new ThreadLocal<>();
+    private static ThreadLocal<Long> accessLogDatetime = new ThreadLocal<>();
 
     public AccessLogCurrentTime() {
         super("%{t}W");
@@ -41,10 +41,10 @@ public class AccessLogCurrentTime extends AccessLogData {
     public boolean set(StringBuilder accessLogEntry,
                        HttpResponseMessage response, HttpRequestMessage request, Object data) {
         if (data == null) {
-            String currentTime = HttpDispatcher.getDateFormatter().getNCSATime(new Date(System.currentTimeMillis()));
-            String currentTimeFormatted = "[" + currentTime + "]";
+            long currentTime = System.currentTimeMillis();
+            String currentTimeFormatted = "[" + HttpDispatcher.getDateFormatter().getNCSATime(new Date(currentTime)) + "]";
             accessLogEntry.append(currentTimeFormatted);
-            accessLogDatetime.set(currentTimeFormatted);
+            accessLogDatetime.set(currentTime);
 
         } else {
             // just print out what was there
@@ -54,7 +54,7 @@ public class AccessLogCurrentTime extends AccessLogData {
         return true;
     }
 
-    public static String getAccessLogCurrentTimeAsString(HttpResponseMessage response, HttpRequestMessage request, Object data) {
+    public static long getAccessLogCurrentTimeAsLong(HttpResponseMessage response, HttpRequestMessage request, Object data) {
         return accessLogDatetime.get();
     }
 }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/values/AccessLogStartTime.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/values/AccessLogStartTime.java
@@ -21,7 +21,7 @@ import com.ibm.wsspi.http.channel.HttpResponseMessage;
 public class AccessLogStartTime extends AccessLogData {
 
     // We're assuming that the methods below that use this start time will be called on the same thread
-    private static ThreadLocal<String> startTimeFormatted = new ThreadLocal<>();
+    private static ThreadLocal<Long> accessLogStartTime = new ThreadLocal<>();
 
     public AccessLogStartTime() {
         super("%t");
@@ -38,7 +38,7 @@ public class AccessLogStartTime extends AccessLogData {
             Date startDate = new Date(startTime);
             String formattedDate = "[" + HttpDispatcher.getDateFormatter().getNCSATime(startDate) + "]";
             accessLogEntry.append(formattedDate);
-            startTimeFormatted.set(formattedDate);
+            accessLogStartTime.set(startTime);
         } else {
             accessLogEntry.append("-");
         }
@@ -60,7 +60,7 @@ public class AccessLogStartTime extends AccessLogData {
         return startTime;
     }
 
-    public static String getStartTimeAsStringForJSON(HttpResponseMessage response, HttpRequestMessage request, Object data) {
-        return startTimeFormatted.get();
+    public static long getStartTimeAsLongForJSON(HttpResponseMessage response, HttpRequestMessage request, Object data) {
+        return accessLogStartTime.get();
     }
 }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/logging/source/AccessLogSource.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/logging/source/AccessLogSource.java
@@ -318,8 +318,8 @@ public class AccessLogSource implements Source {
                             fieldSetters.add((ald, alrd) -> ald.setResponseHeader((String) data, AccessLogResponseHeaderValue.getHeaderValue(alrd.getResponse(), alrd.getRequest(), data)));
                     } break;
                 case "%r": fieldSetters.add((ald, alrd) -> ald.setRequestFirstLine(AccessLogFirstLine.getFirstLineAsString(alrd.getResponse(), alrd.getRequest(), null))); break;
-                case "%t": fieldSetters.add((ald, alrd) -> ald.setRequestStartTime(AccessLogStartTime.getStartTimeAsStringForJSON(alrd.getResponse(), alrd.getRequest(), null))); break;
-                case "%{t}W": fieldSetters.add((ald, alrd) -> ald.setAccessLogDatetime(AccessLogCurrentTime.getAccessLogCurrentTimeAsString(alrd.getResponse(), alrd.getRequest(), null))); break;
+                case "%t": fieldSetters.add((ald, alrd) -> ald.setRequestStartTime(AccessLogStartTime.getStartTimeAsLongForJSON(alrd.getResponse(), alrd.getRequest(), null))); break;
+                case "%{t}W": fieldSetters.add((ald, alrd) -> ald.setAccessLogDatetime(AccessLogCurrentTime.getAccessLogCurrentTimeAsLong(alrd.getResponse(), alrd.getRequest(), null))); break;
                 case "%u": fieldSetters.add((ald, alrd) -> ald.setRemoteUser(AccessLogRemoteUser.getRemoteUser(alrd.getResponse(), alrd.getRequest(), null))); break;
                 //@formatter:on
             }
@@ -607,13 +607,15 @@ public class AccessLogSource implements Source {
 
     private static JsonFieldAdder addRequestStartTimeField(int format) {
         return (jsonBuilder, ald) -> {
-            return jsonBuilder.addField(AccessLogData.getRequestStartTimeKey(format), ald.getRequestStartTime(), false, true);
+            String startTime = CollectorJsonHelpers.dateFormatTL.get().format(ald.getRequestStartTime());
+            return jsonBuilder.addField(AccessLogData.getRequestStartTimeKey(format), startTime, false, true);
         };
     }
 
     private static JsonFieldAdder addAccessLogDatetimeField(int format) {
         return (jsonBuilder, ald) -> {
-            return jsonBuilder.addField(AccessLogData.getAccessLogDatetimeKey(format), ald.getAccessLogDatetime(), false, true);
+            String accessLogDatetime = CollectorJsonHelpers.dateFormatTL.get().format(ald.getAccessLogDatetime());
+            return jsonBuilder.addField(AccessLogData.getAccessLogDatetimeKey(format), accessLogDatetime, false, true);
         };
     }
 


### PR DESCRIPTION
Change date formatting from NCSA-format to match the format as the current `ibm_datetime` field.

ex. access log snippet with code change (cleaned up a little):
```
{"type":"liberty_accesslog",
"host":"192.168.1.15",
"ibm_userDir":"\/Users\/jennifer.zhen.chengibm.com\/libertyGit\/open-liberty\/dev\/build.image\/wlp\/usr\/",
"ibm_serverName":"defaultServer",
"ibm_elapsedTime":24012,
"ibm_accessLogDatetime":"2020-07-15T14:14:25.663-0400",
"ibm_cookie_my_cookie":"example_cookie",
"ibm_responseCode":200,
"ibm_requestStartTime":"2020-07-15T14:14:25.631-0400",
"ibm_datetime":"2020-07-15T14:14:25.671-0400",
"ibm_sequence":"1594836865632_0000000000001"}
```

The `accessLogDatetime` being a little bit later than `requestStartTime` is expected because the former indicates when the access log event is logged, while the latter represents the time the HTTP request was initially sent.

#build