### PR TITLE
Fix for injecting ManagedExecutorService using @Resource into CDI bean

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/publish/servers/concurrent_fat_cdi/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/publish/servers/concurrent_fat_cdi/server.xml
@@ -20,4 +20,6 @@
     
     <include location="../fatTestPorts.xml"/>
     
+    <managedExecutorService jndiName="concurrent/sampleExecutor"/>
+    
 </server>

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ConcurrentCDIServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ConcurrentCDIServlet.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package concurrent.cdi.web;
 
+import static org.junit.Assert.assertNotNull;
+
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -70,12 +72,21 @@ public class ConcurrentCDIServlet extends FATServlet {
     @Resource(lookup = "java:comp/TransactionSynchronizationRegistry")
     private TransactionSynchronizationRegistry tranSyncRegistry;
 
+    @Inject
+    private ManagedExecutorService injectedExec; // produced by ResourcesProducer.exec field
+
     /**
      * Initialize the transaction service (including recovery logs) so it doesn't slow down our tests and cause timeouts.
      */
     public void initTransactionService() throws Exception {
         tran.begin();
         tran.commit();
+    }
+
+    @Test
+    public void testInjectedManagedExecutorService() {
+        System.out.println("@AGG injected executor is: " + injectedExec);
+        assertNotNull(injectedExec);
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ResourcesProducer.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/test-applications/concurrentCDIApp/src/concurrent/cdi/web/ResourcesProducer.java
@@ -1,0 +1,21 @@
+package concurrent.cdi.web;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+import javax.enterprise.concurrent.ManagedExecutorService;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+@ApplicationScoped
+public class ResourcesProducer {
+
+    @PostConstruct
+    public void init() {
+        System.out.println("Initialized bean: " + this);
+    }
+
+    @Resource(lookup = "concurrent/sampleExecutor")
+    @Produces
+    private ManagedExecutorService exec;
+
+}


### PR DESCRIPTION
When an object is registered in JNDI as multiple types, trying to perform `@Resource` injection from inside a CDI-managed bean would cause validation to fail in some cases.

For example:
```java
@ApplicationScoped
public class ResourcesProducer {

    @Resource(lookup = "concurrent/sampleExecutor")
    @Produces
    private ManagedExecutorService exec;
}
```

This would result in a validation error from CDI such as:
```
javax.enterprise.inject.spi.DefinitionException: CWOWB1007E: The producer field, org.example.app.ResourcesProducer.exec, has type javax.enterprise.concurrent.ManagedExecutorService, which does not match the type of the injected object.
	at com.ibm.ws.cdi.impl.weld.injection.EEValidationUtils.throwDefinitionException(EEValidationUtils.java:77)
	at com.ibm.ws.cdi.impl.weld.injection.EEValidationUtils.throwDefinitionException(EEValidationUtils.java:81)
	at com.ibm.ws.cdi.impl.weld.injection.EEValidationUtils.validateJndiLookup(EEValidationUtils.java:234)
	at com.ibm.ws.cdi.impl.weld.injection.EEValidationUtils.validateJndiLookup(EEValidationUtils.java:168)
	at com.ibm.ws.cdi.impl.weld.injection.EEValidationUtils.validateResource(EEValidationUtils.java:343)
	at com.ibm.ws.cdi.impl.weld.injection.WebSphereInjectionServicesImpl.validateAnnotatedMember(WebSphereInjectionServicesImpl.java:383)
	at com.ibm.ws.cdi.impl.weld.injection.WebSphereInjectionServicesImpl.registerInjectionTarget(WebSphereInjectionServicesImpl.java:350)
	at org.jboss.weld.manager.InjectionTargetFactoryImpl.postProcess(InjectionTargetFactoryImpl.java:141)
	at org.jboss.weld.manager.InjectionTargetFactoryImpl.createInjectionTarget(InjectionTargetFactoryImpl.java:92)
	at org.jboss.weld.bean.ManagedBean.<init>(ManagedBean.java:100)
	at org.jboss.weld.bean.ManagedBean.of(ManagedBean.java:80)
	at org.jboss.weld.bootstrap.AbstractBeanDeployer.createManagedBean(AbstractBeanDeployer.java:274)
	at org.jboss.weld.bootstrap.BeanDeployer.createClassBean(BeanDeployer.java:226)
	at org.jboss.weld.bootstrap.ConcurrentBeanDeployer$2.doWork(ConcurrentBeanDeployer.java:74)
	at org.jboss.weld.bootstrap.ConcurrentBeanDeployer$2.doWork(ConcurrentBeanDeployer.java:71)
	at org.jboss.weld.executor.IterativeWorkerTaskFactory$1.call(IterativeWorkerTaskFactory.java:62)
	at org.jboss.weld.executor.IterativeWorkerTaskFactory$1.call(IterativeWorkerTaskFactory.java:55)
	at com.ibm.ws.threading.internal.PolicyTaskFutureImpl.run(PolicyTaskFutureImpl.java:718)
	at com.ibm.ws.threading.internal.PolicyExecutorImpl.runTask(PolicyExecutorImpl.java:1135)
	at com.ibm.ws.threading.internal.PolicyExecutorImpl$GlobalPoolTask.run(PolicyExecutorImpl.java:189)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

It appears we already had a special case for this on `javax.resource.cci.ConnectionFactory` where CDI would actually look up the object from JNDI and check its type, which turned out the be needed for the ExecutorService as well. The proposed solution generalizes that case so the JNDI lookup type check is always performed as a fallback before a validation exception is thrown.