### PR TITLE
context serialization bucket with Jakarta

### DIFF
--- a/dev/com.ibm.ws.context_fat_serialization/bnd.bnd
+++ b/dev/com.ibm.ws.context_fat_serialization/bnd.bnd
@@ -18,6 +18,8 @@ src: \
 
 fat.project: true
 
+tested.features: appsecurity-4.0, cdi-3.0, concurrent-2.0, ejblite-4.0, el-4.0, jsp-3.0, servlet-5.0
+
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)
 -buildpath: \

--- a/dev/com.ibm.ws.context_fat_serialization/build.gradle
+++ b/dev/com.ibm.ws.context_fat_serialization/build.gradle
@@ -9,6 +9,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
+addRequiredLibraries.dependsOn addJakartaTransformer
+
 dependencies {
   requiredLibs 'commons-codec:commons-codec:1.4'
 }

--- a/dev/com.ibm.ws.context_fat_serialization/fat/src/test/context/serialization/ContextServiceSerializationTest.java
+++ b/dev/com.ibm.ws.context_fat_serialization/fat/src/test/context/serialization/ContextServiceSerializationTest.java
@@ -28,6 +28,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -36,11 +37,18 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
 @RunWith(FATRunner.class)
 public class ContextServiceSerializationTest extends FATServletClient {
+    @ClassRule
+    public static RepeatTests r = RepeatTests
+                    .withoutModification()
+                    .andWith(new JakartaEE9Action());
+
     @Server("com.ibm.ws.context.fat.serialization")
     //@TestServlet(servlet = ContextServiceSerializationTestServlet.class, path = "contextserbvt/ContextServiceSerializationTestServlet")
     public static LibertyServer server;

--- a/dev/wlp-jakartaee-transform/rules/jakarta-xml-master.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-xml-master.properties
@@ -23,3 +23,4 @@ com.ibm.ws.wsoc_1_0.ResourceProvider.xml=jakarta-websocketResources.properties
 com.ibm.ws.webcontainer.xml=jakarta-xml-servletContainerInitializer.properties
 permittedTaglibs.tld=jakarta-tld.properties
 scriptfree.tld=jakarta-tld.properties
+SerializationTestJSP.jsp=jakarta-renames.properties


### PR DESCRIPTION
Get the EE Concurrency context serialization test bucket running with Jakarta features. This will cover context that is serialized under Java EE and then deserialized on Jakarta.