### PR TITLE
Create auto cdi feature for jakarta websockets

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.cdi3.0-websocket2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.cdi3.0-websocket2.0.feature
@@ -1,0 +1,13 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.cdi3.0-websocket2.0.feature
+visibility=private
+IBM-App-ForceRestart: install, \
+ uninstall
+IBM-Provision-Capability: \
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.websocket-2.0)))", \
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.cdi-3.0)))"
+IBM-Install-Policy: when-satisfied
+-bundles=com.ibm.ws.wsoc.cdi.weld.jakarta
+kind=noship
+edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.ws.wsoc.cdi.weld/bnd.bnd
+++ b/dev/com.ibm.ws.wsoc.cdi.weld/bnd.bnd
@@ -16,6 +16,8 @@ Bundle-Name: WebSocketCDI1.2
 Bundle-SymbolicName: com.ibm.ws.wsoc.cdi.weld
 Bundle-Description: WebSocket v1.2 CDI Integration Bundle; version=${bVersion}
 
+jakartaeeMe:true
+
 Export-Package: \
   com.ibm.ws.wsoc.cdi.weld
 

--- a/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/Cdi12Test.java
+++ b/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/Cdi12Test.java
@@ -28,7 +28,6 @@ import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.browser.WebResponse;
 
 import componenttest.annotation.ExpectedFFDC;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -40,12 +39,7 @@ import io.openliberty.wsoc.util.WebServerControl;
 import io.openliberty.wsoc.util.WebServerSetup;
 import io.openliberty.wsoc.util.wsoc.WsocTest;
 
-/**
- * Skipped for EE9 until the jmsServer and jmsClient for JakartaEE9 are developed and delivered
- * to test CDI and Websocket integration
- */
 @RunWith(FATRunner.class)
-@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 public class Cdi12Test extends LoggingTest {
 
     @ClassRule
@@ -165,7 +159,7 @@ public class Cdi12Test extends LoggingTest {
         this.runAsSSCAndVerifyResponse("CdiTest", "testCdiInjectCDI12");
     }
 
-    @Mode(TestMode.FULL)
+    @Mode(TestMode.LITE)
     @Test
     public void testCdiProgrammaticEndpointCDI12() throws Exception {
         ct.testCdiProgrammaticEndpointCDI12();

--- a/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/Cdi20Test.java
+++ b/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/Cdi20Test.java
@@ -27,7 +27,6 @@ import com.ibm.ws.fat.util.LoggingTest;
 import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.fat.util.browser.WebResponse;
 
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -38,12 +37,7 @@ import io.openliberty.wsoc.util.WebServerControl;
 import io.openliberty.wsoc.util.WebServerSetup;
 import io.openliberty.wsoc.util.wsoc.WsocTest;
 
-/**
- * Skipped for EE9 until the jmsServer and jmsClient for JakartaEE9 are developed and delivered
- * to test CDI and Websocket integration
- */
 @RunWith(FATRunner.class)
-@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 public class Cdi20Test extends LoggingTest {
 
     @ClassRule
@@ -161,7 +155,7 @@ public class Cdi20Test extends LoggingTest {
         this.runAsSSCAndVerifyResponse("CdiTest", "testCdiInjectCDI12");
     }
 
-    @Mode(TestMode.FULL)
+    @Mode(TestMode.LITE)
     @Test
     public void testCdiProgrammaticEndpointCDI20() throws Exception {
         ct.testCdiProgrammaticEndpointCDI20();

--- a/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/all/CdiTest.java
+++ b/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/all/CdiTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,13 +14,13 @@ import java.util.logging.Logger;
 
 import org.junit.Assert;
 
-import io.openliberty.wsoc.util.wsoc.WsocTest;
-import io.openliberty.wsoc.util.wsoc.WsocTestContext;
-import io.openliberty.wsoc.util.wsoc.WsocTestRunner;
 import io.openliberty.wsoc.common.Constants;
 import io.openliberty.wsoc.endpoints.client.basic.AnnotatedClientEP;
 import io.openliberty.wsoc.endpoints.client.basic.ProgrammaticClientEP;
 import io.openliberty.wsoc.endpoints.client.context.SimpleClientEP;
+import io.openliberty.wsoc.util.wsoc.WsocTest;
+import io.openliberty.wsoc.util.wsoc.WsocTestContext;
+import io.openliberty.wsoc.util.wsoc.WsocTestRunner;
 
 /**
  *
@@ -172,6 +172,11 @@ public class CdiTest {
      */
     public void testCdiProgrammaticEndpointCDI12() throws Exception {
 
+        // Reset counter to 0 for the second FAT run since a new application is deployed
+        if (sequenceCounter12 == 2) {
+            sequenceCounter12 = 0;
+        }
+
         String s1 = "Message1FromClient";
         String e1 = "Dependent Scoped Counter: 2 ApplicationScopedCounter: 3";
 
@@ -193,6 +198,11 @@ public class CdiTest {
      * ServerEndpoint - @see ProgrammaticExtendEndpointCDI12
      */
     public void testCdiProgrammaticEndpointMultipleOnMessageCDI12() throws Exception {
+
+        // Reset counter to 0 for the second FAT run since a new application is deployed
+        if (sequenceCounter12 == 2) {
+            sequenceCounter12 = 0;
+        }
 
         String s1 = "Message1FromClient";
         String s2 = "Message2FromClient";
@@ -239,6 +249,11 @@ public class CdiTest {
      */
     public void testCdiProgrammaticEndpointCDI20() throws Exception {
 
+        // Reset counter to 0 for the second FAT run since a new application is deployed
+        if (sequenceCounter20 == 2) {
+            sequenceCounter20 = 0;
+        }
+
         String s1 = "Message1FromClient";
         String e1 = "Dependent Scoped Counter: 2 ApplicationScopedCounter: 3";
 
@@ -260,6 +275,11 @@ public class CdiTest {
      * ServerEndpoint - @see ProgrammaticExtendEndpointCDI20
      */
     public void testCdiProgrammaticEndpointMultipleOnMessageCDI20() throws Exception {
+
+        // Reset counter to 0 for the second FAT run since a new application is deployed
+        if (sequenceCounter20 == 2) {
+            sequenceCounter20 = 0;
+        }
 
         String s1 = "Message1FromClient";
         String s2 = "Message2FromClient";


### PR DESCRIPTION
fixes #12277 -- auto feature created 
fixes #12994 -- enabled skipped over skipped over tests 

if statements (as as one below) were added since those counters are static variables, and they need to be reset on the second run. 
```
        if (sequenceCounter12 == 2) {
            sequenceCounter12 = 0;
        }
```

the counter exists in the tests as the order of the unit tests is not guaranteed.  

testCdiProgrammaticEndpointCDI20 & testCdiProgrammaticEndpointCDI12 were changed to LITE so that both run in LITE & FULL modes. This ensures the check above works properly in both runs. ( Else the counter would differ in lite since only 1 test runs, and 2 in full) 