### PR TITLE
Dynamically import com.sun JAXB impl classes in JAX-RS 3.0 / RESTEasy prototype

### DIFF
--- a/dev/io.openliberty.org.jboss.resteasy.common/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.common/bnd.bnd
@@ -110,14 +110,21 @@ Import-Package: \
   javax.activation;version=!, \
   javax.annotation;version=!, \
   javax.annotation.security;version=!, \
+  javax.xml.bind;version=!, \
   javax.xml.bind.annotation;version=!, \
+  javax.xml.bind.annotation.adapters;version=!, \
+  javax.xml.bind.attachment;version=!, \
+  javax.xml.bind.helpers;version=!, \
+  javax.xml.bind.util;version=!, \
   !javax.json.bind, \
   !javax.json.bind.spi, \
+  !com.sun.xml.bind.marshaller, \
   *
 
 DynamicImport-Package: \
   javax.json.bind, \
-  javax.json.bind.spi
+  javax.json.bind.spi, \
+  com.sun.xml.bind.marshaller
 
 
 Private-Package: \


### PR DESCRIPTION
The `jaxrs-3.0` feature's io.openliberty.org.jboss.resteasy.common bundle fails to resolve when using Java 8.  This is because the RESTEasy implementation code directly depends on some com.sun JAXB implementation classes that are part of the JDK in Java 8 (and thus not exported as an OSGi package), but are not part of the JDK in Java 11 (where we provide the JAXB implementation via separate bundle that _does_ export the package).

This change uses dynamic imports to import the package if it is exported, but will use the JDK-supplied package if it is not exported.