### PR TITLE
Resolve incorrect async isFinished

### DIFF
--- a/dev/com.ibm.ws.grpc_fat/test-applications/StoreProducerApp.war/src/com/ibm/testapp/g3store/restProducer/client/ProducerEndpointFATServlet.java
+++ b/dev/com.ibm.ws.grpc_fat/test-applications/StoreProducerApp.war/src/com/ibm/testapp/g3store/restProducer/client/ProducerEndpointFATServlet.java
@@ -166,7 +166,7 @@ public class ProducerEndpointFATServlet extends FATServlet {
      * @param resp
      * @throws Exception
      */
-//    @Test
+    @Test
     public void testCreateDeleteMultiApp(HttpServletRequest req, HttpServletResponse resp) throws Exception {
 
         String m = "testCreateMulitDeleteAllApp";

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/H2StreamProcessor.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/H2StreamProcessor.java
@@ -1074,14 +1074,12 @@ public class H2StreamProcessor {
         }
 
         if (direction == Constants.Direction.READ_IN) {
-            if (currentFrame.flagEndStreamSet()) {
-                endStream = true;
-                updateStreamState(StreamState.HALF_CLOSED_REMOTE);
-            }
             if (frameType == FrameTypes.DATA) {
                 if (GrpcServletServices.grpcInUse == false) {
                     getBodyFromFrame();
                     if (currentFrame.flagEndStreamSet()) {
+                        endStream = true;
+                        updateStreamState(StreamState.HALF_CLOSED_REMOTE);
                         processCompleteData(true);
                         setReadyForRead();
                     }
@@ -1094,6 +1092,10 @@ public class H2StreamProcessor {
                         }
                         passCount++;
                         getBodyFromFrame();
+                        if (currentFrame.flagEndStreamSet()) {
+                            endStream = true;
+                            updateStreamState(StreamState.HALF_CLOSED_REMOTE);
+                        }
                         processCompleteData(true);
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                             Tr.debug(tc, "processOpen: first DATA frame read. calling setReadyForRead() getEndStream returns: " + this.getEndStream());
@@ -1121,6 +1123,11 @@ public class H2StreamProcessor {
                         }
 
                         getBodyFromFrame();
+                        if (currentFrame.flagEndStreamSet()) {
+                            endStream = true;
+                            updateStreamState(StreamState.HALF_CLOSED_REMOTE);
+                        }
+
                         WsByteBuffer buf = processCompleteData(false);
 
                         if (buf != null) {
@@ -1151,6 +1158,8 @@ public class H2StreamProcessor {
                     processCompleteHeaders(false);
                     setHeadersComplete();
                     if (currentFrame.flagEndStreamSet()) {
+                        endStream = true;
+                        updateStreamState(StreamState.HALF_CLOSED_REMOTE);
                         setReadyForRead();
                     }
                 } else {

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/ee7/HttpInputStreamEE7.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/ee7/HttpInputStreamEE7.java
@@ -125,9 +125,6 @@ public class HttpInputStreamEE7 extends HttpInputStreamImpl {
                         }
                         return false;
                     } else if (eos == 2) {
-                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                            Tr.debug(tc, "isFinished(): GRPC detected, stream ended, return true");
-                        }
                         // check that all the buffers have been drained
                         if (isc != null && isc.isIncomingMessageFullyRead()) {
                             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {


### PR DESCRIPTION
In a specific async case, the input stream will return true from isFinished() prematurely.  This PR will fix that case.  For #13091