### PR TITLE
[#13124] Log exception thrown during app start before shutting it down

### DIFF
--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/DynamicVirtualHost.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/DynamicVirtualHost.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2010 IBM Corporation and others.
+ * Copyright (c) 2004, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -470,12 +470,14 @@ public class DynamicVirtualHost extends com.ibm.ws.webcontainer.VirtualHost impl
             webApp.initialize();
             return !webApp.getDestroyed();
         } catch (Throwable th) {
-            stopWebApp(webApp);
+            try {
+                com.ibm.wsspi.webcontainer.util.FFDCWrapper.processException(th, CLASS_NAME, "startWebApp", new Object[] { this, webApp });
 
-            com.ibm.wsspi.webcontainer.util.FFDCWrapper.processException(th, CLASS_NAME, "startWebApp", new Object[] { this, webApp });
-
-            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                Tr.event(tc, "Error starting web app: " + webApp + "; " + th);
+                if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
+                    Tr.event(tc, "Error starting web app: " + webApp + "; " + th);
+                }
+            } finally {
+            	stopWebApp(webApp);
             }
         }
         return false;


### PR DESCRIPTION
Fixes #13124 - ensures that an exception caught during app start is logged before the app is stopped. This ensures that the original failure is not lost in the event that shutdown also throws an exception.