### PR TITLE
Issue 13135: Updates for test failures acme_fat

### DIFF
--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeClient.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeClient.java
@@ -233,7 +233,7 @@ public class AcmeClient {
 					sleep(e.getRetryAfter().toEpochMilli() - current, pollUntil);
 				} catch (AcmeException e) {
 					throw handleAcmeException(e,
-							Tr.formatMessage(tc, "CWPKI2010E", acmeConfig.getDirectoryURI(), e.getMessage()));
+							Tr.formatMessage(tc, "CWPKI2010E", acmeConfig.getDirectoryURI(), getRootCauseMessage(e)));
 				}
 			}
 

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeConfigVariationsTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeConfigVariationsTest.java
@@ -515,7 +515,7 @@ public class AcmeConfigVariationsTest {
 		} finally {
 			stopServer("CWWKG0095E", "CWWKE0701E", "CWPKI2016E", "CWPKI2020E", "CWPKI2021E", "CWPKI2022E",
 					"CWPKI2023E", "CWPKI2008E", "CWPKI2037E", "CWPKI2039E", "CWPKI2040E", "CWPKI2041E", "CWPKI2042E",
-					"CWPKI0823E", "CWPKI0828E", "CWPKI2070W", "CWPKI2071W");
+					"CWPKI0823E", "CWPKI0828E", "CWPKI2070W", "CWPKI2071W", "CWPKI0804E");
 			/*
 			 * Running on Sun produces some additional errors on the invalid directory URI,
 			 * added them to the stop list

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
@@ -852,7 +852,8 @@ public class AcmeFatUtils {
 		if (System.getProperty("os.name").toLowerCase().startsWith("win")
 				&& System.getProperty("java.vendor").toLowerCase().contains("openjdk")
 				&& (System.getProperty("java.version").equals("11.0.5")
-						|| System.getProperty("java.version").equals("14.0.1"))) {
+						|| System.getProperty("java.version").equals("14.0.1")
+						|| System.getProperty("java.version").equals("11"))) {
 			/*
 			 * On Windows with OpenJDK 11.0.5 (and others), we sometimes get an exception deleting the
 			 * Acme related files.


### PR DESCRIPTION
Fixes #13135 

- Add JDK level for skipping on file removal
- Get the root exception on `Network error`
- Add another possible error message during `updateconfig_bad_to_good` test
