### PR TITLE
Issue #11970: Add Injection-EJB FAT for Jakarta EE 9

### DIFF
--- a/dev/com.ibm.ws.injection_fat/bnd.bnd
+++ b/dev/com.ibm.ws.injection_fat/bnd.bnd
@@ -45,7 +45,12 @@ src: \
 fat.project: true
 
 tested.features: \
-	servlet-4.0, servlet-5.0, jpa-2.2, jdbc-4.2, ejbLite-3.2
+	ejbLite-3.2,\
+	ejbLite-4.0,\
+	jdbc-4.2,\
+	jpa-2.2,\
+	servlet-4.0,\
+	servlet-5.0
 	
 # Intentionally put javax.annotation (as opposed to websphere.javee.annotation) on the -buildpath
 # because otherwise bndtools will merge the artifacts together and it will only be on the classpath.

--- a/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/DSDTest.java
+++ b/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/DSDTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,6 +29,7 @@ import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -43,7 +44,7 @@ public class DSDTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.injection.fat.DSDServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.injection.fat.DSDServer"));
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.injection.fat.DSDServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.injection.fat.DSDServer")).andWith(new JakartaEE9Action().forServers("com.ibm.ws.injection.fat.DSDServer"));
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/EnvEntryTest.java
+++ b/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/EnvEntryTest.java
@@ -72,7 +72,7 @@ public class EnvEntryTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.injection.fat.EnvEntryServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.injection.fat.EnvEntryServer")).andWith(new JakartaEE9Action().forServers("com.ibm.ws.injection.fat.EnvEntryServer"));
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.injection.fat.EnvEntryServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.injection.fat.EnvEntryServer")).andWith(new JakartaEE9Action().forServers("com.ibm.ws.injection.fat.EnvEntryServer"));
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/RepeatableDSDTest.java
+++ b/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/RepeatableDSDTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,9 @@
  *******************************************************************************/
 package com.ibm.ws.injection.fat;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -18,6 +21,7 @@ import org.junit.runner.RunWith;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -37,7 +41,7 @@ public class RepeatableDSDTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification();
+    public static RepeatTests r = RepeatTests.withoutModification().andWith(new JakartaEE9Action().fullFATOnly().forServers("com.ibm.ws.injection.fat.RepeatableDSDServer"));
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -69,11 +73,27 @@ public class RepeatableDSDTest extends FATServletClient {
 //        ShrinkHelper.exportAppToServer(server, RepeatableDSDMixTest);
 //        ShrinkHelper.exportAppToServer(server, RepeatableDSDXMLTest);
 
+        // Since not using ShrinkWrap, manually transform the applications if required
+        if (JakartaEE9Action.isActive()) {
+            transformJakartaEE9App(server, "apps", "RepeatableDSDAnnTest.ear");
+            transformJakartaEE9App(server, "apps", "RepeatableDSDMixTest.ear");
+            transformJakartaEE9App(server, "apps", "RepeatableDSDXMLTest.ear");
+        }
+
         server.addInstalledAppForValidation("RepeatableDSDAnnTest");
         server.addInstalledAppForValidation("RepeatableDSDMixTest");
         server.addInstalledAppForValidation("RepeatableDSDXMLTest");
 
         server.startServer();
+    }
+
+    private static void transformJakartaEE9App(LibertyServer server, String path, String filename) throws Exception {
+        String localLocation = "publish/servers/" + server.getServerName() + "/" + path;
+
+        Path localAppPath = Paths.get(localLocation + "/" + filename);
+        JakartaEE9Action.transformApp(localAppPath);
+
+        server.copyFileToLibertyServerRoot(localLocation, path, filename);
     }
 
     @AfterClass
@@ -109,22 +129,22 @@ public class RepeatableDSDTest extends FATServletClient {
 
     @Test
     public void testRepeatableDSDAnnOnly() throws Exception {
-        runTest(APP_MIX_WEB, testName.getMethodName());
+        runTest(APP_MIX_WEB, getTestMethodSimpleName());
     }
 
     @Test
     public void testRepeatableDSDMerge() throws Exception {
-        runTest(APP_MIX_WEB, testName.getMethodName());
+        runTest(APP_MIX_WEB, getTestMethodSimpleName());
     }
 
     @Test
     public void testRepeatableDSDOverride() throws Exception {
-        runTest(APP_MIX_WEB, testName.getMethodName());
+        runTest(APP_MIX_WEB, getTestMethodSimpleName());
     }
 
     @Test
     public void testRepeatableDSDXMLOnly() throws Exception {
-        runTest(APP_MIX_WEB, testName.getMethodName());
+        runTest(APP_MIX_WEB, getTestMethodSimpleName());
     }
 
     @Test
@@ -144,12 +164,12 @@ public class RepeatableDSDTest extends FATServletClient {
 
     @Test
     public void testRepeatableDSDMetaDataCompleteAnnOnly() throws Exception {
-        runTest(APP_XML_WEB, testName.getMethodName());
+        runTest(APP_XML_WEB, getTestMethodSimpleName());
     }
 
     @Test
     public void testRepeatableDSDMetaDataCompleteValid() throws Exception {
-        runTest(APP_XML_WEB, testName.getMethodName());
+        runTest(APP_XML_WEB, getTestMethodSimpleName());
     }
 
     @Test

--- a/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/ResRefTest.java
+++ b/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/ResRefTest.java
@@ -56,7 +56,7 @@ public class ResRefTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.injection.fat.ResRefServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.injection.fat.ResRefServer")).andWith(new JakartaEE9Action().forServers("com.ibm.ws.injection.fat.ResRefServer"));
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.injection.fat.ResRefServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.injection.fat.ResRefServer")).andWith(new JakartaEE9Action().forServers("com.ibm.ws.injection.fat.ResRefServer"));
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/ServiceLookupTest.java
+++ b/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/ServiceLookupTest.java
@@ -35,7 +35,7 @@ public class ServiceLookupTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.injection.fat.ServiceLookupServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.injection.fat.ServiceLookupServer")).andWith(new JakartaEE9Action().forServers("com.ibm.ws.injection.fat.ServiceLookupServer"));
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.injection.fat.ServiceLookupServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.injection.fat.ServiceLookupServer")).andWith(new JakartaEE9Action().forServers("com.ibm.ws.injection.fat.ServiceLookupServer"));
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/TranTest.java
+++ b/dev/com.ibm.ws.injection_fat/fat/src/com/ibm/ws/injection/fat/TranTest.java
@@ -58,7 +58,7 @@ public class TranTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.injection.fat.TranServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.injection.fat.TranServer")).andWith(new JakartaEE9Action().forServers("com.ibm.ws.injection.fat.TranServer"));
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.injection.fat.TranServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.injection.fat.TranServer")).andWith(new JakartaEE9Action().forServers("com.ibm.ws.injection.fat.TranServer"));
 
     @BeforeClass
     public static void setUp() throws Exception {


### PR DESCRIPTION
Enabled the DataSourceDefinition tests to run with Jakarta EE 9

Also, changed some repeat actions to full mode only to reduce
time for Lite mode.

fixes #11970 