### PR TITLE
Issue 12640: Skip 2019I msg on dryRun fetchCert

### DIFF
--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeClient.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeClient.java
@@ -294,7 +294,7 @@ public class AcmeClient {
 		/*
 		 * Get the Account. If there is no account yet, create a new one.
 		 */
-		Account acct = findOrRegisterAccount(session, accountKeyPair);
+		Account acct = findOrRegisterAccount(session, accountKeyPair, dryRun);
 
 		/*
 		 * Create a key pair for the domains.
@@ -592,7 +592,7 @@ public class AcmeClient {
 	 *             if there was an issue finding or registering an account.
 	 */
 	@FFDCIgnore(AcmeException.class)
-	private Account findOrRegisterAccount(Session session, KeyPair accountKey) throws AcmeCaException {
+	private Account findOrRegisterAccount(Session session, KeyPair accountKey, boolean dryRun) throws AcmeCaException {
 
 		/*
 		 * Find an existing account.
@@ -654,7 +654,9 @@ public class AcmeClient {
 			}
 		}
 
-		Tr.audit(tc, "CWPKI2019I", acmeConfig.getDirectoryURI(), account.getLocation());
+		if (!dryRun) {
+			Tr.audit(tc, "CWPKI2019I", acmeConfig.getDirectoryURI(), account.getLocation());
+		}
 		return account;
 	}
 

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/FATSuite.java
@@ -27,10 +27,7 @@ import componenttest.topology.utils.ExternalTestServiceDockerClientStrategy;
 	AcmeConfigVariationsTest.class,
 	AcmeURIConfigVariationsTest.class,
 	AcmeRevocationTest.class
-	/*
-	 * Until we resolve Boulder issues, keep the AcmeRevocationTest last, otherwise when it fails, the
-	 * whole suite stops running.
-	 */
+
 	 })
 public class FATSuite {
 


### PR DESCRIPTION
Fixes #12640 