### PR TITLE
Issue #13170: Allow MDB methods to be non-public final

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/ejbcontainer/jitdeploy/EJBWrapper.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/ejbcontainer/jitdeploy/EJBWrapper.java
@@ -444,7 +444,7 @@ public final class EJBWrapper {
                              nonPublicMethods.size());
 
             for (Method method : nonPublicMethods) {
-                if (!isAggregateWrapper) { // d677413
+                if (!isAggregateWrapper && isLocalBean) {
                     validateLocalBeanMethod(method, beanName); // must not be final
                 }
                 addNonPublicMethod(cw, method);


### PR DESCRIPTION
Message-driven beans using a "no methods" message listener interface
may have non-public methods that are final; per the EJB specification.

Stop calling the method validation rules for session no-interface view,
as the same limitations do not apply to message-driven beans.

fixes #13170 