### PR TITLE
Get Eclipse building again

### DIFF
--- a/dev/com.ibm.ws.security.audit_fat.common.tooling/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.security.audit_fat.common.tooling/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.security.authorization.jacc.testprovider/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.security.authorization.jacc.testprovider/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.security.jaspic.test/.classpath
+++ b/dev/com.ibm.ws.security.jaspic.test/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.security.jaspic.test/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.security.jaspic.test/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.security.jaspic_fat/.classpath
+++ b/dev/com.ibm.ws.security.jaspic_fat/.classpath
@@ -9,6 +9,6 @@
 	<classpathentry kind="src" path="test-applications/JASPIRegistrationTestServlet.war/src"/>
 	<classpathentry kind="src" path="test-applications/JASPIWrappingServlet.war/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.security.jaspic_fat/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.security.jaspic_fat/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/io.openliberty.microprofile.health.3.0.internal_fat/.classpath
+++ b/dev/io.openliberty.microprofile.health.3.0.internal_fat/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
-	<classpathentry kind="src" path="test-applications/DelayHealthCheckApp/src"/>
+	<classpathentry kind="src" path="test-applications/DelayedHealthCheckApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/io.openliberty.org.eclipse.microprofile.health.3.0/.classpath
+++ b/dev/io.openliberty.org.eclipse.microprofile.health.3.0/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>


### PR DESCRIPTION
- Update .classpath files to specify Java version to match the minimum required level
- Update .classpath files to remove non existent src directory and fix spelling of other source directory
- Add missing bndtools prefs files for new components