### PR TITLE
13165-Declare eeCompatible-9.0 in public Jakarta EE9 features

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaMail-1.6/com.ibm.websphere.appserver.jakartaMail-1.6.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaMail-1.6/com.ibm.websphere.appserver.jakartaMail-1.6.feature
@@ -2,10 +2,11 @@
 symbolicName=com.ibm.websphere.appserver.jakartaMail-1.6
 visibility=public
 singleton=true
-IBM-ShortName: jakartaaMail-1.6
+IBM-ShortName: jakartaMail-1.6
 Subsystem-Version: 1.6
 Subsystem-Name: JakartaMail 1.6
 -features=\
-  io.openliberty.jakarta.activation-2.0
+  io.openliberty.jakarta.activation-2.0, \
+  com.ibm.websphere.appserver.eeCompatible-9.0
 kind=noship
 edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsonb-2.0/com.ibm.websphere.appserver.jsonb-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsonb-2.0/com.ibm.websphere.appserver.jsonb-2.0.feature
@@ -9,7 +9,8 @@ IBM-API-Package: jakarta.json.bind; type="spec", \
  jakarta.json.bind.config; type="spec", \
  jakarta.json.bind.serializer; type="spec", \
  jakarta.json.bind.spi; type="spec"
--features=com.ibm.websphere.appserver.jsonbInternal-2.0
+-features=com.ibm.websphere.appserver.jsonbInternal-2.0, \
+com.ibm.websphere.appserver.eeCompatible-9.0
 -bundles=com.ibm.ws.jsonb.service
 kind=beta
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsonbContainer-2.0/com.ibm.websphere.appserver.jsonbContainer-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsonbContainer-2.0/com.ibm.websphere.appserver.jsonbContainer-2.0.feature
@@ -9,7 +9,8 @@ IBM-API-Package: jakarta.json.bind; type="spec", \
  jakarta.json.bind.spi; type="spec"
 IBM-ShortName: jsonbContainer-2.0
 Subsystem-Name: JavaScript Object Notation Binding 2.0 via Bells
--features=com.ibm.websphere.appserver.jsonbImpl-2.0.0
+-features=com.ibm.websphere.appserver.jsonbImpl-2.0.0, \
+com.ibm.websphere.appserver.eeCompatible-9.0
 -bundles=com.ibm.ws.jsonb.service
 kind=noship
 edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsonp-2.0/com.ibm.websphere.appserver.jsonp-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsonp-2.0/com.ibm.websphere.appserver.jsonp-2.0.feature
@@ -7,7 +7,8 @@ IBM-API-Package: jakarta.json; type="spec", \
  jakarta.json.spi; type="spec"
 IBM-ShortName: jsonp-2.0
 Subsystem-Name: JavaScript Object Notation Processing 2.0
--features=com.ibm.websphere.appserver.jsonpInternal-2.0
+-features=com.ibm.websphere.appserver.jsonpInternal-2.0, \
+com.ibm.websphere.appserver.eeCompatible-9.0
 kind=beta
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsonpContainer-2.0/com.ibm.websphere.appserver.jsonpContainer-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsonpContainer-2.0/com.ibm.websphere.appserver.jsonpContainer-2.0.feature
@@ -6,6 +6,7 @@ IBM-API-Package: jakarta.json; type="spec", \
  jakarta.json.spi; type="spec"
 IBM-ShortName: jsonpContainer-2.0
 Subsystem-Name: JavaScript Object Notation Processing 2.0 via Bells
--features=com.ibm.websphere.appserver.jsonpImpl-2.0.0
+-features=com.ibm.websphere.appserver.jsonpImpl-2.0.0, \
+com.ibm.websphere.appserver.eeCompatible-9.0
 kind=noship
 edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-3.0/io.openliberty.jsp-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsp-3.0/io.openliberty.jsp-3.0.feature
@@ -33,8 +33,9 @@ IBM-ShortName: jsp-3.0
 IBM-SPI-Package: com.ibm.wsspi.jsp.taglib.config
 Subsystem-Name: Jakarta Server Pages 3.0
 -features=io.openliberty.jakarta.jsp-3.0, \
- com.ibm.websphere.appserver.servlet-5.0; \
- io.openliberty.el-4.0
+ com.ibm.websphere.appserver.servlet-5.0, \
+ io.openliberty.el-4.0, \
+ com.ibm.websphere.appserver.eeCompatible-9.0
 -bundles=com.ibm.ws.org.eclipse.jdt.core.3.10.2.v20160712-0000, \
  io.openliberty.jakarta.jstl.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.servlet:jstl:2.0", \
  com.ibm.ws.jsp.2.3.jakarta, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/managedBeans-2.0/io.openliberty.managedBeans-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/managedBeans-2.0/io.openliberty.managedBeans-2.0.feature
@@ -8,7 +8,8 @@ Subsystem-Name: Jakarta EE Managed Bean 2.0
 -features=com.ibm.websphere.appserver.transaction-2.0, \
  io.openliberty.jakarta.ejb-4.0; apiJar=false, \
  io.openliberty.managedBeansCore-2.0, \
- io.openliberty.jakarta.interceptor-2.0
+ io.openliberty.jakarta.interceptor-2.0, \
+ com.ibm.websphere.appserver.eeCompatible-9.0
 -bundles=com.ibm.ws.managedbeans
 -files=dev/api/ibm/schema/ibm-managed-bean-bnd_1_0.xsd, \
  dev/api/ibm/schema/ibm-managed-bean-bnd_1_1.xsd


### PR DESCRIPTION
Fixes #13165 

Ensure that public features for jakartaee9 technologies include an immediate dependency on private feature eeCompatible-9.0. 