### PR TITLE
11278-Move JSON features to io.openliberty

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonbImpl-2.0.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonbImpl-2.0.0.feature
@@ -1,11 +1,11 @@
 # This private impl feature corresponds to JSON-B 2.0 with the Yasson implementation
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jsonbImpl-2.0.0
+symbolicName=io.openliberty.jsonbImpl-2.0.0
 singleton=true
 visibility=private
--features=com.ibm.websphere.appserver.jsonp-2.0, \
-  com.ibm.websphere.appserver.classloading-1.0, \
+-features=io.openliberty.jsonp-2.0, \
   io.openliberty.jakarta.cdi-3.0,\
+  com.ibm.websphere.appserver.classloading-1.0, \
   com.ibm.websphere.appserver.eeCompatible-9.0
 -bundles=com.ibm.ws.org.eclipse.yasson.2.0.jakarta, \
   io.openliberty.jakarta.jsonb.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.json.bind:jakarta.json.bind-api:2.0.0"

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonbInternal-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonbInternal-2.0.feature
@@ -1,7 +1,7 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jsonbInternal-2.0
+symbolicName=io.openliberty.jsonbInternal-2.0
 visibility=private
--features=com.ibm.websphere.appserver.jsonbImpl-2.0.0;
+-features=io.openliberty.jsonbImpl-2.0.0;
 kind=beta
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonpImpl-2.0.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonpImpl-2.0.0.feature
@@ -1,6 +1,6 @@
 # This private impl feature corresponds to JSON-P 2.0 with the Glassfish implementation
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jsonpImpl-2.0.0
+symbolicName=io.openliberty.jsonpImpl-2.0.0
 singleton=true
 visibility=private
 -features=com.ibm.websphere.appserver.eeCompatible-9.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonpInternal-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonpInternal-2.0.feature
@@ -1,7 +1,7 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jsonpInternal-2.0
+symbolicName=io.openliberty.jsonpInternal-2.0
 visibility=private
--features=com.ibm.websphere.appserver.jsonpImpl-2.0.0
+-features=io.openliberty.jsonpImpl-2.0.0
 kind=beta
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaeeClient-9.0/io.openliberty.jakartaeeClient-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaeeClient-9.0/io.openliberty.jakartaeeClient-9.0.feature
@@ -6,12 +6,12 @@ IBM-ShortName: jakartaeeClient-9.0
 Subsystem-Name: Jakarta EE Application Client
 -features=\
   com.ibm.websphere.appclient.appClient-2.0, \
-  com.ibm.websphere.appserver.jsonp-2.0, \
-  com.ibm.websphere.appserver.jsonb-2.0, \
   com.ibm.websphere.appserver.jakartaMail-1.6, \
   com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:="4.3",\
   com.ibm.websphere.appserver.transaction-2.0, \
   io.openliberty.beanValidation-3.0, \
+  io.openliberty.jsonb-2.0, \
+  io.openliberty.jsonp-2.0, \
   io.openliberty.cdi-3.0, \
   io.openliberty.jakarta.ejb-4.0, \
   io.openliberty.jakarta.jndiClient-2.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsonb-2.0/io.openliberty.jsonb-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsonb-2.0/io.openliberty.jsonb-2.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jsonb-2.0
+symbolicName=io.openliberty.jsonb-2.0
 visibility=public
 IBM-ShortName: jsonb-2.0
 Subsystem-Name: JavaScript Object Notation Binding 2.0
@@ -9,8 +9,8 @@ IBM-API-Package: jakarta.json.bind; type="spec", \
  jakarta.json.bind.config; type="spec", \
  jakarta.json.bind.serializer; type="spec", \
  jakarta.json.bind.spi; type="spec"
--features=com.ibm.websphere.appserver.jsonbInternal-2.0, \
-com.ibm.websphere.appserver.eeCompatible-9.0
+-features=io.openliberty.jsonbInternal-2.0, \
+ com.ibm.websphere.appserver.eeCompatible-9.0
 -bundles=com.ibm.ws.jsonb.service
 kind=beta
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsonbContainer-2.0/io.openliberty.jsonbContainer-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsonbContainer-2.0/io.openliberty.jsonbContainer-2.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jsonbContainer-2.0
+symbolicName=io.openliberty.jsonbContainer-2.0
 visibility=public
 IBM-API-Package: jakarta.json.bind; type="spec", \
  jakarta.json.bind.adapter; type="spec", \
@@ -9,8 +9,8 @@ IBM-API-Package: jakarta.json.bind; type="spec", \
  jakarta.json.bind.spi; type="spec"
 IBM-ShortName: jsonbContainer-2.0
 Subsystem-Name: JavaScript Object Notation Binding 2.0 via Bells
--features=com.ibm.websphere.appserver.jsonbImpl-2.0.0, \
-com.ibm.websphere.appserver.eeCompatible-9.0
+-features=io.openliberty.jsonbImpl-2.0.0, \
+ com.ibm.websphere.appserver.eeCompatible-9.0
 -bundles=com.ibm.ws.jsonb.service
 kind=noship
 edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsonp-2.0/io.openliberty.jsonp-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsonp-2.0/io.openliberty.jsonp-2.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jsonp-2.0
+symbolicName=io.openliberty.jsonp-2.0
 visibility=public
 singleton=true
 IBM-API-Package: jakarta.json; type="spec", \
@@ -7,8 +7,8 @@ IBM-API-Package: jakarta.json; type="spec", \
  jakarta.json.spi; type="spec"
 IBM-ShortName: jsonp-2.0
 Subsystem-Name: JavaScript Object Notation Processing 2.0
--features=com.ibm.websphere.appserver.jsonpInternal-2.0, \
-com.ibm.websphere.appserver.eeCompatible-9.0
+-features=io.openliberty.jsonpInternal-2.0, \
+ com.ibm.websphere.appserver.eeCompatible-9.0
 kind=beta
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsonpContainer-2.0/io.openliberty.jsonpContainer-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsonpContainer-2.0/io.openliberty.jsonpContainer-2.0.feature
@@ -1,12 +1,12 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jsonpContainer-2.0
+symbolicName=io.openliberty.jsonpContainer-2.0
 visibility=public
 IBM-API-Package: jakarta.json; type="spec", \
  jakarta.json.stream; type="spec", \
  jakarta.json.spi; type="spec"
 IBM-ShortName: jsonpContainer-2.0
 Subsystem-Name: JavaScript Object Notation Processing 2.0 via Bells
--features=com.ibm.websphere.appserver.jsonpImpl-2.0.0, \
-com.ibm.websphere.appserver.eeCompatible-9.0
+-features=io.openliberty.jsonpImpl-2.0.0, \
+ com.ibm.websphere.appserver.eeCompatible-9.0
 kind=noship
 edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/webProfile-9.0/com.ibm.websphere.appserver.webProfile-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/webProfile-9.0/com.ibm.websphere.appserver.webProfile-9.0.feature
@@ -9,11 +9,11 @@ Subsystem-Name: Jakarta EE Web Profile 9.0
 -features=\
   com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:="4.3",\
   com.ibm.websphere.appserver.jndi-1.0,\
-  com.ibm.websphere.appserver.jsonb-2.0,\
-  com.ibm.websphere.appserver.jsonp-2.0,\
   com.ibm.websphere.appserver.servlet-5.0,\
   com.ibm.websphere.appserver.transaction-2.0,\
   io.openliberty.beanValidation-3.0,\
+  io.openliberty.jsonb-2.0,\
+  io.openliberty.jsonp-2.0,\
   io.openliberty.cdi-3.0,\
   io.openliberty.ejbLite-4.0,\
   io.openliberty.el-4.0,\


### PR DESCRIPTION
Ref: #11278 

Move JSON features to the io.openliberty per Jakarta EE9 feature naming conventions.