### PR TITLE
Move expose ports to constructor to avoid duplicate key exception

### DIFF
--- a/dev/fattest.databases/src/componenttest/topology/database/container/SQLServerContainer.java
+++ b/dev/fattest.databases/src/componenttest/topology/database/container/SQLServerContainer.java
@@ -49,6 +49,10 @@ public class SQLServerContainer<SELF extends SQLServerContainer<SELF>> extends J
         super(dockerImageName);
         withStartupTimeoutSeconds(DEFAULT_STARTUP_TIMEOUT_SECONDS);
         withConnectTimeoutSeconds(DEFAULT_CONNECT_TIMEOUT_SECONDS);
+        
+        addExposedPort(MS_SQL_SERVER_PORT);
+        addExposedPort(MSSQL_DTC_TCP_PORT);
+        addExposedPort(MSSQL_RPC_PORT);
     }
 
     @Override
@@ -63,10 +67,6 @@ public class SQLServerContainer<SELF extends SQLServerContainer<SELF>> extends J
             LicenseAcceptance.assertLicenseAccepted(this.getDockerImageName());
             acceptLicense();
         }
-
-        addExposedPort(MS_SQL_SERVER_PORT);
-        addExposedPort(MSSQL_DTC_TCP_PORT);
-        addExposedPort(MSSQL_RPC_PORT);
         
         addEnv("MSSQL_RPC_PORT", MSSQL_RPC_PORT.toString());
         addEnv("MSSQL_DTC_TCP_PORT", MSSQL_DTC_TCP_PORT.toString());


### PR DESCRIPTION
Issue originally resolved in Test Containers repo under PR https://github.com/testcontainers/testcontainers-java/pull/2473

But using a custom SQLServerContainer in Liberty to avoid having to provide an accept license file.  Applying fix to this custom SQLServerContainer.
