### PR TITLE
11772-Move jta-2.0 to io.openliberty and update FATs

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.transaction-2.0.feature
@@ -16,7 +16,7 @@ IBM-API-Service: com.ibm.wsspi.uow.UOWManager, \
  jakarta.transaction.UserTransaction
 -features=io.openliberty.jakarta.connector-2.0, \
  io.openliberty.jakarta.cdi-3.0; apiJar=false, \
- com.ibm.websphere.appserver.jta-2.0, \
+ io.openliberty.jta-2.0, \
  com.ibm.websphere.appserver.injection-2.0, \
  io.openliberty.jakarta.servlet-5.0; apiJar=false, \
  com.ibm.websphere.appserver.artifact-1.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/io.openliberty.jta-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/io.openliberty.jta-2.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jta-2.0
+symbolicName=io.openliberty.jta-2.0
 visibility=protected
 singleton=true
 IBM-API-Package: jakarta.transaction;  type="spec", \

--- a/dev/com.ibm.ws.tx.jta_fat/publish/features/txjtafat-2.0.mf
+++ b/dev/com.ibm.ws.tx.jta_fat/publish/features/txjtafat-2.0.mf
@@ -2,8 +2,8 @@ Subsystem-ManifestVersion: 1
 IBM-Test-Feature: true
 Subsystem-SymbolicName: txjtafat-2.0; visibility:=public
 Subsystem-Version: 1.0.0
-Subsystem-Content: com.ibm.websphere.appserver.jta-2.0; type="osgi.subsystem.feature"
+Subsystem-Content: io.openliberty.jta-2.0; type="osgi.subsystem.feature"
 Subsystem-Type: osgi.subsystem.feature
 IBM-Feature-Version: 2
-IBM-API-Package: javax.transaction; type=spec,
+IBM-API-Package: jakarta.transaction; type=spec,
  javax.transaction.xa; type=spec


### PR DESCRIPTION
Ref: #11772 

Move protected feature jta-2.0 to io.openliberty feature namespace according to current naming conventions.