### PR TITLE
Disable metrics TCK tests for java versions 11.0.0 - 11.0.3

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/metrics11/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/metrics11/tck/launcher/MetricsTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/metrics11/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/metrics11/tck/launcher/MetricsTCKLauncher.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.metrics11.tck.launcher;
 
+import static org.junit.Assume.assumeTrue;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -21,6 +23,7 @@ import org.junit.runner.RunWith;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.MvnUtils;
 
@@ -48,6 +51,11 @@ public class MetricsTCKLauncher {
     @Test
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchTck() throws Exception {
+        //disable tests for Java versions 11.0.0 - 11.0.3 since there's a bug in TLS 1.3 implementation
+        JavaInfo javaInfo = JavaInfo.forServer(server);
+        assumeTrue(!(javaInfo.majorVersion() == 11 && javaInfo.minorVersion() == 0
+                     && javaInfo.microVersion() <= 3));
+
         String protocol = "https";
         String host = server.getHostname();
         String port = Integer.toString(server.getHttpDefaultSecurePort());

--- a/dev/com.ibm.ws.microprofile.metrics.2.0_fat_tck/fat/src/com/ibm/ws/microprofile/metrics20/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0_fat_tck/fat/src/com/ibm/ws/microprofile/metrics20/tck/launcher/MetricsTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.metrics.2.0_fat_tck/fat/src/com/ibm/ws/microprofile/metrics20/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0_fat_tck/fat/src/com/ibm/ws/microprofile/metrics20/tck/launcher/MetricsTCKLauncher.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.metrics20.tck.launcher;
 
+import static org.junit.Assume.assumeTrue;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -21,6 +23,7 @@ import org.junit.runner.RunWith;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.MvnUtils;
 
@@ -48,6 +51,10 @@ public class MetricsTCKLauncher {
     @Test
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchTck() throws Exception {
+        //disable tests for Java versions 11.0.0 - 11.0.3 since there's a bug in TLS 1.3 implementation
+        JavaInfo javaInfo = JavaInfo.forServer(server);
+        assumeTrue(!(javaInfo.majorVersion() == 11 && javaInfo.minorVersion() == 0
+                     && javaInfo.microVersion() <= 3));
         String protocol = "https";
         String host = server.getHostname();
         String port = Integer.toString(server.getHttpDefaultSecurePort());

--- a/dev/com.ibm.ws.microprofile.metrics.2.2_fat_tck/fat/src/com/ibm/ws/microprofile/metrics22/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.2_fat_tck/fat/src/com/ibm/ws/microprofile/metrics22/tck/launcher/MetricsTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.microprofile.metrics.2.2_fat_tck/fat/src/com/ibm/ws/microprofile/metrics22/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.2_fat_tck/fat/src/com/ibm/ws/microprofile/metrics22/tck/launcher/MetricsTCKLauncher.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.metrics22.tck.launcher;
 
+import static org.junit.Assume.assumeTrue;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -21,6 +23,7 @@ import org.junit.runner.RunWith;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.MvnUtils;
 
@@ -48,6 +51,10 @@ public class MetricsTCKLauncher {
     @Test
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchTck() throws Exception {
+        //disable tests for Java versions 11.0.0 - 11.0.3 since there's a bug in TLS 1.3 implementation
+        JavaInfo javaInfo = JavaInfo.forServer(server);
+        assumeTrue(!(javaInfo.majorVersion() == 11 && javaInfo.minorVersion() == 0
+                     && javaInfo.microVersion() <= 3));
         String protocol = "https";
         String host = server.getHostname();
         String port = Integer.toString(server.getHttpDefaultSecurePort());

--- a/dev/com.ibm.ws.microprofile.metrics.2.3_fat_tck/fat/src/com/ibm/ws/microprofile/metrics23/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.3_fat_tck/fat/src/com/ibm/ws/microprofile/metrics23/tck/launcher/MetricsTCKLauncher.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.metrics23.tck.launcher;
 
+import static org.junit.Assume.assumeTrue;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -21,6 +23,7 @@ import org.junit.runner.RunWith;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.MvnUtils;
 
@@ -48,6 +51,10 @@ public class MetricsTCKLauncher {
     @Test
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchTck() throws Exception {
+        //disable tests for Java versions 11.0.0 - 11.0.3 since there's a bug in TLS 1.3 implementation
+        JavaInfo javaInfo = JavaInfo.forServer(server);
+        assumeTrue(!(javaInfo.majorVersion() == 11 && javaInfo.minorVersion() == 0
+                     && javaInfo.microVersion() <= 3));
         String protocol = "https";
         String host = server.getHostname();
         String port = Integer.toString(server.getHttpDefaultSecurePort());


### PR DESCRIPTION
Fixes #12522 
The test fails on Java  versions 11.0.0 - 11.0.3 since there is a bug in the TLS 1.3 implementation for those releases. The tests are disabled for any SOE builds running with those java versions