### PR TITLE
EJB Synchronize Bindings List and add trace

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/BindToJavaGlobalTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/BindToJavaGlobalTest.java
@@ -19,7 +19,10 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -41,6 +44,20 @@ import componenttest.topology.utils.FATServletClient;
  */
 @RunWith(FATRunner.class)
 public class BindToJavaGlobalTest extends FATServletClient {
+
+    @Rule
+    public TestWatcher watchman = new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+            try {
+                server.dumpServer("serverDump");
+            } catch (Exception e1) {
+                System.out.println("Failed to dump server");
+                e1.printStackTrace();
+            }
+        }
+    };
+
     private static final Class<?> c = BindToJavaGlobalTest.class;
     private static HashSet<String> apps = new HashSet<String>();
     private static String servlet = "ConfigTestsWeb/BindToJavaGlobalServlet";

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/BindingNameTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/BindingNameTest.java
@@ -17,6 +17,9 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 
 import com.ibm.ejb3x.BindingName.web.BindingNameTestServlet;
@@ -35,6 +38,19 @@ import componenttest.topology.utils.FATServletClient;
  */
 @RunWith(FATRunner.class)
 public class BindingNameTest extends FATServletClient {
+
+    @Rule
+    public TestWatcher watchman = new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+            try {
+                server.dumpServer("serverDump");
+            } catch (Exception e1) {
+                System.out.println("Failed to dump server");
+                e1.printStackTrace();
+            }
+        }
+    };
 
     @Server("com.ibm.ws.ejbcontainer.bindings.fat.server")
     @TestServlet(servlet = BindingNameTestServlet.class, contextRoot = "BindingNameWeb")

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/BndErrorTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/BndErrorTest.java
@@ -18,7 +18,10 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -35,6 +38,19 @@ import componenttest.topology.utils.FATServletClient;
 
 @RunWith(FATRunner.class)
 public class BndErrorTest extends FATServletClient {
+
+    @Rule
+    public TestWatcher watchman = new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+            try {
+                server.dumpServer("serverDump");
+            } catch (Exception e1) {
+                System.out.println("Failed to dump server");
+                e1.printStackTrace();
+            }
+        }
+    };
 
     @Server("com.ibm.ws.ejbcontainer.bindings.fat.server.err")
     public static LibertyServer server;

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/ComponentIDTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/ComponentIDTest.java
@@ -17,6 +17,9 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 
 import com.ibm.ejb3x.ComponentIDBnd.web.ComponentIDBndTestServlet;
@@ -35,6 +38,19 @@ import componenttest.topology.utils.FATServletClient;
  */
 @RunWith(FATRunner.class)
 public class ComponentIDTest extends FATServletClient {
+
+    @Rule
+    public TestWatcher watchman = new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+            try {
+                server.dumpServer("serverDump");
+            } catch (Exception e1) {
+                System.out.println("Failed to dump server");
+                e1.printStackTrace();
+            }
+        }
+    };
 
     @Server("com.ibm.ws.ejbcontainer.bindings.fat.server")
     @TestServlet(servlet = ComponentIDBndTestServlet.class, contextRoot = "ComponentIDBndWeb")

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/CustomBindingsTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/CustomBindingsTest.java
@@ -17,6 +17,9 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -33,6 +36,19 @@ import componenttest.topology.utils.FATServletClient;
 
 @RunWith(FATRunner.class)
 public class CustomBindingsTest extends FATServletClient {
+
+    @Rule
+    public TestWatcher watchman = new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+            try {
+                server.dumpServer("serverDump");
+            } catch (Exception e1) {
+                System.out.println("Failed to dump server");
+                e1.printStackTrace();
+            }
+        }
+    };
 
     @Server("com.ibm.ws.ejbcontainer.bindings.fat.server")
     @TestServlets({ @TestServlet(servlet = BindingsServlet.class, contextRoot = "EJB3BndWeb") })

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/DefaultBindingsTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/DefaultBindingsTest.java
@@ -17,6 +17,9 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 
 import com.ibm.ejb2x.defbnd.web.EJB2XDefBndTestServlet;
@@ -36,6 +39,19 @@ import componenttest.topology.utils.FATServletClient;
 
 @RunWith(FATRunner.class)
 public class DefaultBindingsTest extends FATServletClient {
+
+    @Rule
+    public TestWatcher watchman = new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+            try {
+                server.dumpServer("serverDump");
+            } catch (Exception e1) {
+                System.out.println("Failed to dump server");
+                e1.printStackTrace();
+            }
+        }
+    };
 
     @Server("com.ibm.ws.ejbcontainer.bindings.fat.server")
     @TestServlets({ @TestServlet(servlet = DefaultJavaColonBindingsServlet.class, contextRoot = "EJB3DefBndWeb"),

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/DisableShortBndTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/DisableShortBndTest.java
@@ -19,7 +19,10 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -43,6 +46,20 @@ import componenttest.topology.utils.FATServletClient;
  */
 @RunWith(FATRunner.class)
 public class DisableShortBndTest extends FATServletClient {
+
+    @Rule
+    public TestWatcher watchman = new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+            try {
+                server.dumpServer("serverDump");
+            } catch (Exception e1) {
+                System.out.println("Failed to dump server");
+                e1.printStackTrace();
+            }
+        }
+    };
+
     private static final Class<?> c = DisableShortBndTest.class;
     private static HashSet<String> apps = new HashSet<String>();
     private static String servlet = "ConfigTestsWeb/DisableShortBndServlet";
@@ -117,14 +134,6 @@ public class DisableShortBndTest extends FATServletClient {
     }
 
     @Test
-    public void testNoShortBindingsDisabled() throws Exception {
-        updateConfigElement(null);
-
-        FATServletClient.runTest(server, servletOther, "testNoShortBindingsDisabled");
-        FATServletClient.runTest(server, servlet, "testNoShortBindingsDisabled");
-    }
-
-    @Test
     public void testAllShortBindingsDisabled() throws Exception {
         updateConfigElement("*");
 
@@ -154,5 +163,13 @@ public class DisableShortBndTest extends FATServletClient {
 
         FATServletClient.runTest(server, servletOther, "testBothAppShortBindingsDisabled");
         FATServletClient.runTest(server, servlet, "testBothAppShortBindingsDisabled");
+    }
+
+    @Test
+    public void testNoShortBindingsDisabled() throws Exception {
+        updateConfigElement(null);
+
+        FATServletClient.runTest(server, servletOther, "testNoShortBindingsDisabled");
+        FATServletClient.runTest(server, servlet, "testNoShortBindingsDisabled");
     }
 }

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/EJBinWARBindingsTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/EJBinWARBindingsTest.java
@@ -17,6 +17,9 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -34,6 +37,20 @@ import componenttest.topology.utils.FATServletClient;
 
 @RunWith(FATRunner.class)
 public class EJBinWARBindingsTest extends FATServletClient {
+
+    @Rule
+    public TestWatcher watchman = new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+            try {
+                server.dumpServer("serverDump");
+            } catch (Exception e1) {
+                System.out.println("Failed to dump server");
+                e1.printStackTrace();
+            }
+        }
+    };
+
     @Server("com.ibm.ws.ejbcontainer.bindings.fat.server")
     @TestServlets({ @TestServlet(servlet = BndTestServlet.class, contextRoot = "EJBinWARTest"),
                     @TestServlet(servlet = InterfaceAndNamespaceTestServlet.class, contextRoot = "EJBinWARTest") })

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/HomeBindingNameTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/HomeBindingNameTest.java
@@ -17,6 +17,9 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 
 import com.ibm.ejb3x.HomeBindingName.web.HomeBindingNameTestServlet;
@@ -35,6 +38,19 @@ import componenttest.topology.utils.FATServletClient;
  */
 @RunWith(FATRunner.class)
 public class HomeBindingNameTest extends FATServletClient {
+
+    @Rule
+    public TestWatcher watchman = new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+            try {
+                server.dumpServer("serverDump");
+            } catch (Exception e1) {
+                System.out.println("Failed to dump server");
+                e1.printStackTrace();
+            }
+        }
+    };
 
     @Server("com.ibm.ws.ejbcontainer.bindings.fat.server")
     @TestServlet(servlet = HomeBindingNameTestServlet.class, contextRoot = "HomeBindingNameWeb")

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/JNDINameTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/JNDINameTest.java
@@ -17,6 +17,9 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 
 import com.ibm.ejb2x.jndiName.web.JNDINameTestServlet;
@@ -35,6 +38,19 @@ import componenttest.topology.utils.FATServletClient;
  */
 @RunWith(FATRunner.class)
 public class JNDINameTest extends FATServletClient {
+
+    @Rule
+    public TestWatcher watchman = new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+            try {
+                server.dumpServer("serverDump");
+            } catch (Exception e1) {
+                System.out.println("Failed to dump server");
+                e1.printStackTrace();
+            }
+        }
+    };
 
     @Server("com.ibm.ws.ejbcontainer.bindings.fat.server")
     @TestServlet(servlet = JNDINameTestServlet.class, contextRoot = "JNDINameWeb")

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/NoInterfaceBindingsTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/NoInterfaceBindingsTest.java
@@ -17,6 +17,9 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -35,6 +38,20 @@ import componenttest.topology.utils.FATServletClient;
 
 @RunWith(FATRunner.class)
 public class NoInterfaceBindingsTest extends FATServletClient {
+
+    @Rule
+    public TestWatcher watchman = new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+            try {
+                server.dumpServer("serverDump");
+            } catch (Exception e1) {
+                System.out.println("Failed to dump server");
+                e1.printStackTrace();
+            }
+        }
+    };
+
     @Server("com.ibm.ws.ejbcontainer.bindings.noInterface.fat.server")
     @TestServlets({ @TestServlet(servlet = NoInterfaceBindingSingletonServlet.class, contextRoot = "NoInterfaceBndWeb"),
                     @TestServlet(servlet = NoInterfaceBindingStatefulServlet.class, contextRoot = "NoInterfaceBndWeb"),

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/SimpleBindingNameTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/fat/src/com/ibm/ws/ejbcontainer/bindings/fat/tests/SimpleBindingNameTest.java
@@ -17,6 +17,9 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 
 import com.ibm.ejb3x.SimpleBindingName.web.SimpleBindingNameTestServlet;
@@ -35,6 +38,19 @@ import componenttest.topology.utils.FATServletClient;
  */
 @RunWith(FATRunner.class)
 public class SimpleBindingNameTest extends FATServletClient {
+
+    @Rule
+    public TestWatcher watchman = new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+            try {
+                server.dumpServer("serverDump");
+            } catch (Exception e1) {
+                System.out.println("Failed to dump server");
+                e1.printStackTrace();
+            }
+        }
+    };
 
     @Server("com.ibm.ws.ejbcontainer.bindings.fat.server")
     @TestServlet(servlet = SimpleBindingNameTestServlet.class, contextRoot = "SimpleBindingNameWeb")

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/AbstractTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/AbstractTest.java
@@ -12,6 +12,8 @@ package com.ibm.ws.ejbcontainer.remote.fat.tests;
 
 import org.junit.Rule;
 import org.junit.rules.TestName;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 
 import componenttest.custom.junit.runner.RepeatTestFilter;
 import componenttest.topology.impl.LibertyServer;
@@ -21,6 +23,19 @@ import componenttest.topology.utils.FATServletClient;
  *
  */
 public abstract class AbstractTest {
+
+    @Rule
+    public TestWatcher watchman = new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+            try {
+                getServer().dumpServer("serverDump");
+            } catch (Exception e1) {
+                System.out.println("Failed to dump server");
+                e1.printStackTrace();
+            }
+        }
+    };
 
     public abstract LibertyServer getServer();
 

--- a/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/EJBRuntimeImpl.java
+++ b/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/EJBRuntimeImpl.java
@@ -462,6 +462,8 @@ public class EJBRuntimeImpl extends AbstractEJBRuntime implements ApplicationSta
             }
         } else if (ContainerProperties.DisableShortDefaultBindingsFromJVM != null) {
             ContainerProperties.DisableShortDefaultBindings = ContainerProperties.DisableShortDefaultBindingsFromJVM;
+        } else {
+            ContainerProperties.DisableShortDefaultBindings = null;
         }
 
         if (isTraceOn && tc.isEntryEnabled())
@@ -1567,7 +1569,10 @@ public class EJBRuntimeImpl extends AbstractEJBRuntime implements ApplicationSta
             try {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                     Tr.debug(tc, "Waiting 30 seconds for EJBRemoteRuntime");
-                remoteLatch.await(30, TimeUnit.SECONDS);
+                if (remoteLatch.await(30, TimeUnit.SECONDS) == false) {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                        Tr.debug(tc, "EJBRemoteRuntime did not come up within 30 seconds");
+                }
             } catch (InterruptedException e) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                     Tr.debug(tc, "Waiting for EJBRemoteRuntime failed: " + e);


### PR DESCRIPTION
1.
NamespaceBinderImpl change is for this:
```
Caused by: java.lang.ArrayIndexOutOfBoundsExceArrayIndexOutOfBoundsExceptionption
    at java.util.ArrayList.add(ArrayList.java:474)
    at com.ibm.ws.ejbcontainer.osgi.internal.NameSpaceBinderImpl.bindLegacyRemoteBinding(NameSpaceBinderImpl.java:284)
    at com.ibm.ws.ejbcontainer.osgi.internal.NameSpaceBinderImpl.bindDefaultEJBRemote(NameSpaceBinderImpl.java:242)
    at com.ibm.ws.ejbcontainer.osgi.internal.NameSpaceBinderImpl.bindBindings(NameSpaceBinderImpl.java:518)
    at com.ibm.ws.ejbcontainer.osgi.internal.NameSpaceBinderImpl.bindBindings(NameSpaceBinderImpl.java:49)
    at com.ibm.ws.ejbcontainer.runtime.AbstractEJBRuntime.bindInterface(AbstractEJBRuntime.java:997)
    at com.ibm.ws.ejbcontainer.runtime.AbstractEJBRuntime.bindInterfaces(AbstractEJBRuntime.java:935)
    at com.ibm.ws.ejbcontainer.runtime.AbstractEJBRuntime.bindInterfaces(AbstractEJBRuntime.java:862)
    at com.ibm.ws.ejbcontainer.osgi.internal.EJBRuntimeImpl.bindInterfaces(EJBRuntimeImpl.java:1202)
    at com.ibm.ws.ejbcontainer.runtime.AbstractEJBRuntime.startModule(AbstractEJBRuntime.java:524)
```



this line: `registrations.add(registration);`

2.
The extra trace and server dumps in tests is to try and debug the RemoteRuntime being null.

3.
`ContainerProperties.DisableShortDefaultBindings = null;` is for deleting that config element while the server is up