### PR TITLE
Minor fixes for wlp.lib.extract_fat project

### DIFF
--- a/dev/wlp.lib.extract_fat/fat/src/wlp/lib/extract/ExternalDependencyDownloadTest.java
+++ b/dev/wlp.lib.extract_fat/fat/src/wlp/lib/extract/ExternalDependencyDownloadTest.java
@@ -26,13 +26,16 @@ import java.util.zip.ZipOutputStream;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
+@RunWith(FATRunner.class)
 public class ExternalDependencyDownloadTest {
     private static LibertyServer hostingServer = LibertyServerFactory.getLibertyServer("dependencyHostServer");
     private static final String HOST_APP_NAME = "dependencyHost";

--- a/dev/wlp.lib.extract_fat/fat/src/wlp/lib/extract/PackageRunnableTest.java
+++ b/dev/wlp.lib.extract_fat/fat/src/wlp/lib/extract/PackageRunnableTest.java
@@ -36,10 +36,13 @@ import java.util.jar.JarFile;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
+@RunWith(FATRunner.class)
 public class PackageRunnableTest {
     private static String serverName = "runnableTestServer";
     private static LibertyServer server = LibertyServerFactory.getLibertyServer(serverName);
@@ -80,7 +83,8 @@ public class PackageRunnableTest {
     }
 
     @BeforeClass
-    public static void setupClass() throws Exception {}
+    public static void setupClass() throws Exception {
+    }
 
     @AfterClass
     public static void tearDownClass() throws Exception {
@@ -283,6 +287,7 @@ public class PackageRunnableTest {
 
         String extractLoc = null;
         boolean found = outputReader.foundWatchFor();
+        extractLoc = outputReader.extractLoc();
         while (!found && count <= 90) {
 
             synchronized (proc) {


### PR DESCRIPTION
- Use @RunWith(FATRunner.class) annotation.  This allows things like the
option to run a single test to work with options like
-Dfat.test.class.name
- Fix NPE on extractLoc when foundWatchFor returns fast.  This is
probably only realistic to happen when stepping through with a debugger.

