### PR TITLE
EJB Fat: stop application before server stop for BB

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.async_fat/fat/src/com/ibm/ws/ejbcontainer/async/fat/tests/AsyncConfigTests.java
+++ b/dev/com.ibm.ws.ejbcontainer.async_fat/fat/src/com/ibm/ws/ejbcontainer/async/fat/tests/AsyncConfigTests.java
@@ -92,6 +92,7 @@ public class AsyncConfigTests extends AbstractTest {
 
     @AfterClass
     public static void afterClass() throws Exception {
+        server.removeAndStopDropinsApplications("InitTxRecoveryLogApp.ear");
         server.stopServer();
     }
 


### PR DESCRIPTION
the last test does a config update, tests something and then the server shuts down. Sometimes the config update causes our apps to restart and then they are trying to come up while the server shuts down and we can hit a timing problem:

```
E CWWKZ0004E: An exception occurred while starting the application InitTxRecoveryLogApp. The exception message was: com.ibm.ws.container.service.state.StateChangeException: java.util.concurrent.RejectedExecutionException: CWWKE1202E: A task cannot be submitted because the executor managedExecutorService[DefaultManagedExecutorService] (concurrencyPolicy[defaultConcurrencyPolicy]) has been shut down.
```

Made the test stop the app before shutting down the server.