### PR TITLE
Consume Fault Tolerance 3.0-RC1

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1982,6 +1982,11 @@
       <version>2.1</version>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
+      <artifactId>microprofile-fault-tolerance-api</artifactId>
+      <version>3.0-RC1</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.microprofile.graphql</groupId>
       <artifactId>microprofile-graphql-api</artifactId>
       <version>1.0.2</version>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -392,6 +392,7 @@ org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:1.0
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:1.1
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:2.0.1
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:2.1
+org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:3.0-RC1
 org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.2
 org.eclipse.microprofile.health:microprofile-health-api:2.0.1
 org.eclipse.microprofile.health:microprofile-health-api:2.1

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/publish/tckRunner/tck/tck-suite-lite.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/publish/tckRunner/tck/tck-suite-lite.xml
@@ -12,7 +12,7 @@
 
     <test name="microprofile-faulttolerance 2.1 TCK">
         <classes>
-            <!-- Reduced test list for lite mode, retains coverate of core and new functionality -->
+            <!-- Reduced test list for lite mode, retains coverage of core and new functionality -->
             <class name="org.eclipse.microprofile.fault.tolerance.tck.AsyncCancellationTest">
                 <methods>
                     <include name="testCancel"/>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/bnd.bnd
@@ -22,6 +22,7 @@ tested.features: mpFaultTolerance-1.0,\
                  mpFaultTolerance-1.1,\
                  mpFaultTolerance-2.0,\
                  mpFaultTolerance-2.1,\
+                 mpFaultTolerance-3.0,\
                  mpConfig-1.1,\
                  mpConfig-1.2,\
                  mpConfig-1.3,\

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/FaultToleranceMainTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/FaultToleranceMainTest.java
@@ -44,6 +44,7 @@ import com.ibm.ws.microprofile.faulttolerance_fat.cdi.SyncBulkheadServlet;
 import com.ibm.ws.microprofile.faulttolerance_fat.cdi.TimeoutServlet;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
@@ -83,7 +84,7 @@ public class FaultToleranceMainTest extends FATServletClient {
     @Rule
     public AnnotationFilter filter = AnnotationFilter
                     .requireAnnotations(BasicTest.class)
-                    .forAllRepeatsExcept(RepeatFaultTolerance.MP33_FEATURES_ID)
+                    .forAllRepeatsExcept(RepeatFaultTolerance.MP40_FEATURES_ID)
                     .inModes(TestMode.LITE);
 
     @BeforeClass
@@ -169,6 +170,7 @@ public class FaultToleranceMainTest extends FATServletClient {
         }
     }
 
+    @SkipForRepeat(RepeatFaultTolerance.MP40_FEATURES_ID) // FT 3.0 does not close executors until the application shuts down
     @Test
     public void testExecutorsClose() throws Exception {
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/bnd.bnd
@@ -22,6 +22,7 @@ fat.project: true
 tested.features: mpfaulttolerance-1.0,\
                  mpFaultTolerance-1.1,\
                  mpfaulttolerance-2.0,\
+                 mpfaulttolerance-3.0,\
                  mpConfig-1.3,\
                  cdi-2.0,\
                  appsecurity-3.0,\

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/MetricRemovalTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/MetricRemovalTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests;
 
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertNotNull;
@@ -53,6 +55,7 @@ public class MetricRemovalTest {
                     .andWith(RepeatFaultTolerance.ft11metrics20Features(SERVER_NAME));
 
     private final static String TEST_METRIC = "ft.com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests.removal.RemovalBean.doWorkWithRetry.invocations.total";
+    private final static String TEST_METRIC2 = "ft.retry.retries.total";
 
     @Test
     public void metricRemovalTest() throws Exception {
@@ -76,7 +79,7 @@ public class MetricRemovalTest {
                 HttpUtils.findStringInUrl(server, "removalTest/removaltest", "OK");
 
                 // Check that metrics exist
-                assertThat(getMetricsPage(), containsString(TEST_METRIC));
+                assertThat(getMetricsPage(), anyOf(containsString(TEST_METRIC), containsString(TEST_METRIC2)));
 
             } finally {
                 // Remove the test app
@@ -84,7 +87,7 @@ public class MetricRemovalTest {
             }
 
             // Check that metrics do not exist
-            assertThat(getMetricsPage(), not(containsString(TEST_METRIC)));
+            assertThat(getMetricsPage(), both(not(containsString(TEST_METRIC))).and(not(containsString(TEST_METRIC2))));
         } finally {
             server.stopServer();
         }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/circuitbreaker/CircuitBreakerMetricTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/circuitbreaker/CircuitBreakerMetricTest.java
@@ -39,8 +39,10 @@ public class CircuitBreakerMetricTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatFaultTolerance.repeatDefault(SERVER_NAME)
-                    .andWith(RepeatFaultTolerance.ft11metrics20Features(SERVER_NAME));
+    // Note: this test only runs against FT 1.1 and 2.0 as later versions of the TCK include this test.
+    public static RepeatTests r = RepeatTests.with(RepeatFaultTolerance.mp32Features(SERVER_NAME))
+                    .andWith(RepeatFaultTolerance.ft11metrics20Features(SERVER_NAME).fullFATOnly())
+                    .andWith(RepeatFaultTolerance.mp20Features(SERVER_NAME).fullFATOnly());
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/removal/MetricListServlet.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/removal/MetricListServlet.java
@@ -20,6 +20,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricRegistry.Type;
+import org.eclipse.microprofile.metrics.annotation.RegistryType;
 
 /**
  * Lists the metrics currently registered in the application registry
@@ -32,9 +34,16 @@ public class MetricListServlet extends HttpServlet {
     @Inject
     MetricRegistry reg;
 
+    @Inject
+    @RegistryType(type = Type.BASE)
+    MetricRegistry baseReg;
+
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         for (String metricName : reg.getNames()) {
+            resp.getWriter().println(metricName);
+        }
+        for (String metricName : baseReg.getNames()) {
             resp.getWriter().println(metricName);
         }
     }

--- a/dev/com.ibm.ws.microprofile.faulttolerance_repeat_tests/src/com/ibm/ws/microprofile/faulttolerance/fat/repeat/RepeatFaultTolerance.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_repeat_tests/src/com/ibm/ws/microprofile/faulttolerance/fat/repeat/RepeatFaultTolerance.java
@@ -50,6 +50,11 @@ public class RepeatFaultTolerance {
     static final Set<String> MP33_FEATURE_SET = new HashSet<>(Arrays.asList(MP33_FEATURES_ARRAY));
     public static final String MP33_FEATURES_ID = "MICROPROFILE33";
 
+    // TODO: update this once all features are ready and integrated correctly
+    static final String[] MP40_FEATURES_ARRAY = { "mpConfig-1.4" /* 2.0 */, "mpFaultTolerance-3.0", "servlet-4.0", "cdi-2.0", "appSecurity-3.0", "mpMetrics-2.3" /* 3.0 */ };
+    static final Set<String> MP40_FEATURE_SET = new HashSet<>(Arrays.asList(MP40_FEATURES_ARRAY));
+    public static final String MP40_FEATURES_ID = "MICROPROFILE40";
+
     static final Set<String> ALL_FEATURE_SET = new HashSet<>();
     static {
         ALL_FEATURE_SET.addAll(MP13_FEATURE_SET);
@@ -59,6 +64,7 @@ public class RepeatFaultTolerance {
         ALL_FEATURE_SET.addAll(FT11_METRICS20_FEATURE_SET);
         ALL_FEATURE_SET.addAll(MP32_FEATURE_SET);
         ALL_FEATURE_SET.addAll(MP33_FEATURE_SET);
+        ALL_FEATURE_SET.addAll(MP40_FEATURE_SET);
     }
 
     public static FeatureReplacementAction mp20Features(String server) {
@@ -110,10 +116,17 @@ public class RepeatFaultTolerance {
                         .forServers(server);
     }
 
+    public static FeatureReplacementAction mp40Features(String server) {
+        return new FeatureReplacementAction(ALL_FEATURE_SET, MP40_FEATURE_SET)
+                        .withID(MP40_FEATURES_ID)
+                        .forceAddFeatures(false)
+                        .forServers(server);
+    }
+
     /**
-     * Return a rule to repeat tests for FT 1.1 and 2.1
+     * Return a rule to repeat tests for FT 1.1 and 3.0
      * <p>
-     * This is the default because FT 1.* and 2.* have a mostly separate implementation so we want to ensure both are tested
+     * This is the default because FT 1.* and 2.*+ have a mostly separate implementation so we want to ensure both are tested
      * mp20Features includes FT 1.1, and as it is an older version it will only run in full mode.
      *
      * @param server the server name
@@ -121,11 +134,11 @@ public class RepeatFaultTolerance {
      */
     public static RepeatTests repeatDefault(String server) {
         return RepeatTests.with(mp20Features(server).fullFATOnly())
-                        .andWith(mp33Features(server));
+                        .andWith(mp40Features(server));
     }
 
     /**
-     * Return a rule to repeat tests for FT 1.0, 1.1, 2.0, and 2.1
+     * Return a rule to repeat tests for FT 1.0, 1.1, 2.0, 2.1 and 3.0
      * <p>
      * We run a few tests using this rule so that we have some coverage of all implementations
      *
@@ -138,14 +151,16 @@ public class RepeatFaultTolerance {
                         .andWith(ft20metrics11Features(server))
                         .andWith(mp30Features(server))
                         .andWith(mp32Features(server))
-                        .andWith(mp33Features(server));
+                        .andWith(mp33Features(server))
+                        .andWith(mp40Features(server));
     }
 
     public static RepeatTests repeat20AndAbove(String server) {
         return RepeatTests.with(ft20metrics11Features(server).fullFATOnly())
                         .andWith(mp30Features(server).fullFATOnly())
                         .andWith(mp32Features(server).fullFATOnly())
-                        .andWith(mp33Features(server));
+                        .andWith(mp33Features(server).fullFATOnly())
+                        .andWith(mp40Features(server));
     }
 
 }

--- a/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/faulttolerance/tck/FATSuite.java
+++ b/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/faulttolerance/tck/FATSuite.java
@@ -14,10 +14,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import componenttest.custom.junit.runner.AlwaysPassesTest;
-
 @RunWith(Suite.class)
-@SuiteClasses({ FaultToleranceTck30Launcher.class, AlwaysPassesTest.class })
+@SuiteClasses({ FaultToleranceTck30Launcher.class })
 
 public class FATSuite {
 

--- a/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/faulttolerance/tck/FaultToleranceTck30Launcher.java
+++ b/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/faulttolerance/tck/FaultToleranceTck30Launcher.java
@@ -11,6 +11,7 @@
 package io.openliberty.microprofile.faulttolerance.tck;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.AfterClass;
@@ -21,7 +22,6 @@ import org.junit.runner.RunWith;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.custom.junit.runner.TestModeFilter;
 import componenttest.topology.impl.JavaInfo;
@@ -37,10 +37,11 @@ import componenttest.topology.utils.MvnUtils;
  * location.
  */
 @RunWith(FATRunner.class)
-@Mode(TestMode.EXPERIMENTAL)
 public class FaultToleranceTck30Launcher {
 
     private static final String SERVER_NAME = "FaultTolerance30TCKServer";
+
+    private static final boolean FAT_TEST_LOCALRUN = Boolean.getBoolean("fat.test.localrun");
 
     @Server(SERVER_NAME)
     public static LibertyServer server;
@@ -114,8 +115,14 @@ public class FaultToleranceTck30Launcher {
 
         String suiteFileName = isFullMode ? "tck-suite.xml" : "tck-suite-lite.xml";
 
+        Map<String, String> additionalProps = new HashMap<>();
+        if (FAT_TEST_LOCALRUN) {
+            // Reduce timeout multiplier when running locally
+            additionalProps.put("timeoutMultiplier", "1.0");
+        }
+
         MvnUtils.runTCKMvnCmd(server, "com.ibm.ws.microprofile.faulttolerance.3.0_fat_tck", this.getClass() + ":launchFaultToleranceTCK", suiteFileName,
-                              Collections.emptyMap(), Collections.emptySet());
+                              additionalProps, Collections.emptySet());
     }
 
 }

--- a/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -23,6 +23,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        
+        <!-- Overridden to 1.0 when running locally -->
+        <timeoutMultiplier>6.0</timeoutMultiplier>
 
         <!--  the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>
@@ -54,12 +57,12 @@
         <dependency>
             <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
             <artifactId>microprofile-fault-tolerance-tck</artifactId>
-            <version>3.0-SNAPSHOT</version>
+            <version>3.0-RC1</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.apis</groupId>
             <artifactId>microprofile-fault-tolerance-api</artifactId>
-            <version>3.0-SNAPSHOT</version>
+            <version>3.0-RC1</version>
             <scope>system</scope>
             <systemPath>${io.openliberty.org.eclipse.microprofile.faulttolerance.3.0}</systemPath>
         </dependency>
@@ -76,7 +79,7 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-	    <version>2.0</version>
+            <version>2.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -139,7 +142,7 @@
                         <tck_server>${tck_server}</tck_server>
                         <tck_port>${tck_port}</tck_port>
                         <sun.rmi.transport.tcp.responseTimeout>${sun.rmi.transport.tcp.responseTimeout}</sun.rmi.transport.tcp.responseTimeout>
-                        <org.eclipse.microprofile.fault.tolerance.tck.timeout.multiplier>6.0</org.eclipse.microprofile.fault.tolerance.tck.timeout.multiplier>
+                        <org.eclipse.microprofile.fault.tolerance.tck.timeout.multiplier>${timeoutMultiplier}</org.eclipse.microprofile.fault.tolerance.tck.timeout.multiplier>
                     </systemPropertyVariables>
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>

--- a/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/tckRunner/tck/tck-suite-lite.xml
+++ b/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/tckRunner/tck/tck-suite-lite.xml
@@ -11,47 +11,128 @@
     configfailurepolicy="continue">
 
     <test name="microprofile-faulttolerance 3.0 TCK">
-        <method-selectors>
-            <method-selector>
-                <script language="beanshell">
-                     <!-- Some tests are sensitive to timing and can spuriously fail on slow build machines. -->
-                     <!-- We exclude all of these tests when running in lite mode -->
-                     <![CDATA[
-                     // All of these bulkhead tests are susceptable to timing issues or "not being parallel enough"
-                     // BulkheadAsynchTest
-                     !method.getName().startsWith("testBulkheadClassAsynchronous10") &&
-                     !method.getName().startsWith("testBulkheadMethodAsynchronous10") &&
-                     !method.getName().startsWith("testBulkheadClassAsynchronous3") &&
-                     !method.getName().startsWith("testBulkheadMethodAsynchronous3") &&
-                     !method.getName().startsWith("testBulkheadClassAsynchronousDefault") &&
-                     !method.getName().startsWith("testBulkheadMethodAsynchronousDefault") &&
-                     !method.getName().startsWith("testBulkheadClassAsynchronousQueueing10") &&
-                     !method.getName().startsWith("testBulkheadMethodAsynchronousQueueing10") &&
-                     
-                     // BulkheadAsynchRetryTest
-                     !method.getName().startsWith("testBulkheadClassAsynchronousPassiveRetry55") &&
-                     !method.getName().startsWith("testBulkheadMethodAsynchronousRetry55") &&
-                     !method.getName().startsWith("testBulkheadMethodAsynchronousRetry55Trip") &&
-                     !method.getName().startsWith("testBulkheadMethodAsynchronous55RetryOverload") &&
-                     !method.getName().startsWith("testBulkheadClassAsynchronous55RetryOverload") &&
-                     !method.getName().startsWith("testBulkheadPassiveRetryMethodAsynchronous55") &&
-                     !method.getName().startsWith("testBulkheadRetryClassAsynchronous55") &&
-                     !method.getName().startsWith("testBulkheadQueReplacesDueToClassRetryFailures") &&
-                     !method.getName().startsWith("testNoRetriesWithoutRetryOn") &&
-                     !method.getName().startsWith("testNoRetriesWithAbortOn") &&
-                     
-                     // BulkheadFutureTest
-                     !method.getDeclaringClass().getSimpleName().equals("BulkheadFutureTest")
-                     
-                     // Note: BulkheadSynchRetryTest and BulkheadSynchTest look vulnerable to the same issues but we haven't seen them fail
-                ]]>
-                </script>
-            </method-selector>
-        </method-selectors>
-        
-        <packages>
-            <package name="org.eclipse.microprofile.fault.tolerance.tck.*">
-            </package>
-        </packages>
+        <classes>
+            <!-- Reduced test list for lite mode, retains coverage of core and new functionality -->
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsyncCancellationTest">
+                <methods>
+                    <include name="testCancel"/>
+                    <include name="testCancelledDoesNotRetry"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsyncFallbackTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsyncTimeoutTest">
+                <methods>
+                    <include name="testAsyncTimeout"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousCSTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.AsynchronousTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerBulkheadTest">
+                <methods>
+                    <include name="testCircuitBreakerAroundBulkheadSync"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerExceptionHierarchyTest"></class> <!-- new functionality -->
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest">
+                <methods>
+                    <exclude name="testRetriesSucceedWhenCircuitCloses"/>
+                    <exclude name="testRetriesSucceedWhenCircuitClosesAsync"/>
+                    <exclude name="testCircuitOpenWithMultiTimeouts"/>
+                    <exclude name="testCircuitOpenWithMultiTimeoutsAsync"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest">
+                <methods>
+                    <exclude name="testCircuitDefaultSuccessThreshold"/>
+                    <exclude name="testClassLevelCircuitOverrideNoDelay"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.FallbackExceptionHierarchyTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest">
+                <methods>
+                    <exclude name="testRetryParallelExceptionally"/>
+                    <exclude name="testRetryChainExceptionally"/>
+                    <exclude name="testRetryChainSuccess"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryExceptionHierarchyTest"></class> <!-- new functionality -->
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryTest">
+                <methods>
+                    <include name="testRetryMaxRetries"/>
+                    <include name="testRetryMaxDuration"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryTimeoutTest">
+                <methods>
+                    <include name="testRetryTimeout"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.TimeoutTest">
+                <methods>
+                    <include name="testTimeout"/>
+                    <include name="testTimeoutClassLevel"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.TimeoutUninterruptableTest">
+                <methods>
+                    <include name="testTimeout"/>
+                    <include name="testTimeoutAsync"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.ZeroRetryJitterTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest">
+                <methods>
+                    <include name="testBulkheadRetryClassAsynchronous55"/>
+                    <include name="testBulkheadQueReplacesDueToClassRetryFailures"/>
+                    <include name="testRetriesReenterBulkhead"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest">
+                <methods>
+                    <include name="testBulkheadExceptionThrownWhenQueueFullAsync"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadFutureTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadPressureTest"/>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchRetryTest">
+                <methods>
+                    <include name="testBulkheadRetryClassSynchronous55"></include>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchTest">
+                <methods>
+                    <include name="testBulkheadMethodSemaphore10"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.lifecycle.BulkheadLifecycleTest"/>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.CircuitBreakerConfigGlobalTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.CircuitBreakerConfigOnMethodTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.lifecycle.CircuitBreakerLifecycleTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.config.CircuitBreakerConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.config.CircuitBreakerSkipOnConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackApplyOnConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackSkipOnConfigTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.interceptor.FaultToleranceInterceptorTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.AllMetricsTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.BulkheadMetricTest">
+                <methods>
+                    <include name="bulkheadMetricTest"/>
+                    <include name="bulkheadMetricRejectionTest"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.CircuitBreakerMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.ClassLevelMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.FallbackMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.MetricsDisabledTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.TimeoutMetricTest">
+                <methods>
+                    <include name="testTimeoutMetric"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest"></class>
+        </classes>
     </test>
 </suite>

--- a/dev/io.openliberty.org.eclipse.microprofile.faulttolerance.3.0/bnd.bnd
+++ b/dev/io.openliberty.org.eclipse.microprofile.faulttolerance.3.0/bnd.bnd
@@ -18,9 +18,8 @@ Export-Package: \
   org.eclipse.microprofile.faulttolerance;version=1.2, \
   org.eclipse.microprofile.faulttolerance.exceptions;version=1.0
 
-## TODO: we're currently just pulling in the 2.1 API because there are no meaningful changes yet
 Include-Resource: \
-  @${repo;org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api;2.1;EXACT}
+  @${repo;org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api;3.0.0.RC1;EXACT}
 
 
 WS-TraceGroup: FAULTTOLERANCE


### PR DESCRIPTION
Consume the FT 3.0 artifacts and enable tests in the build.