### PR TITLE
Fix usage of ConnectionManagerMBean attributes

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/PoolManagerMBeanImpl.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/PoolManagerMBeanImpl.java
@@ -199,14 +199,24 @@ public class PoolManagerMBeanImpl extends StandardMBean implements ConnectionMan
     }
 
     @Override
-    public Object getAttribute(String attribute) throws AttributeNotFoundException, MBeanException, ReflectionException {
-        String returnValue = null;
+    public Object getAttribute(String attribute) throws AttributeNotFoundException {
         if (attribute.equals("size")) {
-            returnValue = _pm.getTotalConnectionCount().toString();
+            // We need to keep the case for 'size' (lowercase s) because it was originally written this way
+            // and changing it to the proper return type of long would be a breaking change.
+            // Instead, we take advantage of the fact that when the MBean is used through JMX proxy the 'attribute'
+            // param comes in as 'Size' (uppercase S) so we can give the proper return type of long
+            return Long.valueOf(getSize()).toString();
+        } else if (attribute.equals("Size")) {
+            return getSize();
+        } else if (attribute.equalsIgnoreCase("maxSize")) {
+            return getMaxSize();
+        } else if (attribute.equalsIgnoreCase("available")) {
+            return getAvailable();
+        } else if (attribute.equalsIgnoreCase("jndiName")) {
+            return getJndiName();
         } else {
             throw new AttributeNotFoundException(attribute);
         }
-        return returnValue;
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.ws.jdbc_fat_v41/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_v41/bnd.bnd
@@ -25,4 +25,5 @@ tested.features: servlet-5.0
     com.ibm.websphere.javaee.jsonp.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
+	com.ibm.ws.jca.cm;version=latest,\
 	org.apache.derby:derby;version=10.11.1.1

--- a/dev/com.ibm.ws.jdbc_fat_v41/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_v41/build.gradle
@@ -14,7 +14,8 @@ configurations {
 }
 
 dependencies {
-  requiredLibs 'org.glassfish:javax.json:1.0.4'
+  requiredLibs 'org.glassfish:javax.json:1.0.4',
+               project(':com.ibm.ws.jca.cm')
   derby40 'org.apache.derby:derby:10.7.1.1'
 }
 

--- a/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/JDBC41UpgradeTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/JDBC41UpgradeTest.java
@@ -21,10 +21,13 @@ import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
 @RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
 @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 public class JDBC41UpgradeTest extends FATServletClient {
     private static final String servlet_basic = "BasicTestServlet";


### PR DESCRIPTION
If the ConnectionManagerMBean is used via proxy, currently most of the operations do not work, such as:
- getSize
- getMaxSize
- getAvailable
- getJndiName

#build 