### PR TITLE
Add test for handling arrays as QueryParams parameters

### DIFF
--- a/dev/io.openliberty.jaxrs.3.0_fat/fat/src/io/openliberty/jaxrs30/fat/appandresource/AppAndResource.java
+++ b/dev/io.openliberty.jaxrs.3.0_fat/fat/src/io/openliberty/jaxrs30/fat/appandresource/AppAndResource.java
@@ -10,10 +10,13 @@
  *******************************************************************************/
 package io.openliberty.jaxrs30.fat.appandresource;
 
+import java.util.Arrays;
+
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Application;
 
 @ApplicationPath("/app")
@@ -25,5 +28,25 @@ public class AppAndResource extends Application {
     public String foo() {
         System.out.println("foo invoked!");
         return "foo";
+    }
+    
+    @GET
+    @Path("/queryArrays")
+    public long queryArrays(@QueryParam("stringArray") String[] stringArray) {
+        return Arrays.stream(stringArray).filter(this::startsWithAVowel).count();
+    }
+
+    private boolean startsWithAVowel(String s) {
+        if (s == null || s.length() < 1) {
+            return false;
+        }
+        switch(s.charAt(0)) {
+            case 'a':
+            case 'e':
+            case 'i':
+            case 'o':
+            case 'u': return true;
+        }
+        return false;
     }
 }

--- a/dev/io.openliberty.jaxrs.3.0_fat/fat/src/io/openliberty/jaxrs30/fat/appandresource/AppAndResourceTestServlet.java
+++ b/dev/io.openliberty.jaxrs.3.0_fat/fat/src/io/openliberty/jaxrs30/fat/appandresource/AppAndResourceTestServlet.java
@@ -34,6 +34,15 @@ public class AppAndResourceTestServlet extends FATServlet {
         assertEquals("foo", readEntity(conn.getInputStream()));
     }
 
+    @Test
+    public void testCanInvokeQueryParametersWithArrayType() throws Exception {
+        URI uri = URI.create("http://localhost:" + System.getProperty("bvt.prop.HTTP_default")
+            + "/appandresource/app/path/queryArrays?stringArray=ab&stringArray=cd&stringArray=ef&stringArray=gh");
+        HttpURLConnection conn = (HttpURLConnection) uri.toURL().openConnection();
+        assertEquals(200, conn.getResponseCode());
+        assertEquals("2", readEntity(conn.getInputStream()));
+    }
+
     private String readEntity(InputStream is) throws Exception {
         StringBuilder sb = new StringBuilder();
         byte[] b = new byte[256];
@@ -42,6 +51,6 @@ public class AppAndResourceTestServlet extends FATServlet {
             sb.append(new String(b, 0, i));
             i = is.read(b);
         }
-        return sb.toString();
+        return sb.toString().trim();
     }
 }

--- a/dev/io.openliberty.jaxrs.3.0_fat/publish/servers/appandresource/server.xml
+++ b/dev/io.openliberty.jaxrs.3.0_fat/publish/servers/appandresource/server.xml
@@ -12,5 +12,5 @@
     <include location="../fatTestPorts.xml"/>
     
     <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
-    <javaPermission className="java.net.URLPermission" name="http://localhost:8010/appandresource/app/path" actions="GET:"/>
+    <javaPermission className="java.net.URLPermission" name="http://localhost:8010/appandresource/app/-" actions="GET:"/>
 </server>


### PR DESCRIPTION
This came about from a conversation in the MP Metrics spec - which had outlined how arrays should be handled when used as query parameters.  The spec does not require arrays to be supported, but that is likely to change in JAX-RS 3.1. CXF already supports arrays as parameters, and this test ensures that RESTEasy does too.