### PR TITLE
Export SmallRye GraphQL packages at the same version that we pull in

### DIFF
--- a/dev/com.ibm.ws.io.smallrye.graphql/bnd.bnd
+++ b/dev/com.ibm.ws.io.smallrye.graphql/bnd.bnd
@@ -42,7 +42,7 @@ DynamicImport-Package: \
 
 Export-Package: \
   com.ibm.ws.io.smallrye.graphql.component;thread-context=true,\
-  io.smallrye.graphql.*;version=1.0.2;thread-context=true,\
+  io.smallrye.graphql.*;version=${smallryeGraphQLVersion};thread-context=true,\
 
 Include-Resource: \
   META-INF=resources/META-INF


### PR DESCRIPTION
Updating package export version to match the same version of SmallRye that we pull in. The new version has not shipped yet, so this is not a release bug.