### PR TITLE
Metatype changes to add ES256 signature algorithm for JWT

### DIFF
--- a/dev/com.ibm.ws.org.jose4j/bnd.bnd
+++ b/dev/com.ibm.ws.org.jose4j/bnd.bnd
@@ -8,10 +8,10 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
--include= jar:${fileuri;${repo;org.bitbucket.b_c:jose4j;0.6.4;EXACT}}!/META-INF/MANIFEST.MF,bnd.overrides
+-include= jar:${fileuri;${repo;org.bitbucket.b_c:jose4j;0.6.5;EXACT}}!/META-INF/MANIFEST.MF,bnd.overrides
 
 -includeresource: \
-   @${repo;org.bitbucket.b_c:jose4j;0.6.4;EXACT}!/org/jose4j/*
+   @${repo;org.bitbucket.b_c:jose4j;0.6.5;EXACT}!/org/jose4j/*
 
 -buildpath: \
-    org.bitbucket.b_c:jose4j;version=0.6.4
+    org.bitbucket.b_c:jose4j;version=0.6.5

--- a/dev/com.ibm.ws.org.jose4j/bnd.overrides
+++ b/dev/com.ibm.ws.org.jose4j/bnd.overrides
@@ -2,7 +2,7 @@
 bVersion=1.0
 
 Bundle-Name: org.jose4j
-Bundle-Description: org.jose4j; version=0.6.4
+Bundle-Description: org.jose4j; version=0.6.5
 Bundle-SymbolicName: com.ibm.ws.org.jose4j
 
 WS-TraceGroup: \
@@ -12,7 +12,7 @@ Export-Package: \
     org.jose4j.base64url.internal.apache.commons.codec.binary;version="1.0.16", \
     org.jose4j.json.internal.json_simple;version="1.0.16", \
     org.jose4j.json.internal.json_simple.parser;version="1.0.16", \
-    org.jose4j.*;version="0.6.4"
+    org.jose4j.*;version="0.6.5"
 
 Import-Package: \
     !org.jose4j.*.internal.*,\

--- a/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JWKProvider.java
+++ b/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JWKProvider.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2016, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.common.jwk.impl;
 
@@ -50,7 +50,7 @@ public class JWKProvider {
 
     protected PublicKey publicKey = null;
     protected PrivateKey privateKey = null;
-    
+
     protected String publicKeyKid = null;
 
     protected JWKProvider() {
@@ -102,7 +102,7 @@ public class JWKProvider {
             Tr.debug(tc, "kid = " + this.publicKeyKid);
         }
     }
-    
+
     private String buildKidFromPublicKey(PublicKey cert) {
         JwkKidBuilder kidbuilder = new JwkKidBuilder();
         return kidbuilder.buildKeyId(cert);
@@ -113,7 +113,7 @@ public class JWKProvider {
         while (jwks.size() < JWKS_TO_GENERATE) {
             generateJWKs();
         }
-        jwk = jwks.get(JWKS_TO_GENERATE-1);
+        jwk = jwks.get(JWKS_TO_GENERATE - 1);
         return jwk;
     }
 
@@ -127,21 +127,52 @@ public class JWKProvider {
 
     protected JWK generateJWK(String alg, int size) {
         JWK jwk = null;
-        if (RS256.equals(alg)) {
+        if (isValidJwkAlgorithm(alg)) {
             if (publicKey != null && privateKey != null) {
                 jwk = Jose4jRsaJWK.getInstance(alg, use, publicKey, privateKey, publicKeyKid);
                 jwk.generateKey();
             } else {
-                jwk = generateRsaJWK(alg, size);
+                jwk = generateJwkForValidAlgorithm(alg, size);
             }
         }
         return jwk;
+    }
+
+    boolean isValidJwkAlgorithm(String alg) {
+        if (alg == null) {
+            return false;
+        }
+        return alg.matches("[RE]S[0-9]{3,}");
+    }
+
+    JWK generateJwkForValidAlgorithm(String alg, int size) {
+        JWK jwk = null;
+        if (isRsaAlgorithm(alg)) {
+            jwk = generateRsaJWK(alg, size);
+        } else if (isEcAlgorithm(alg)) {
+            jwk = generateEcJwk(alg, size);
+        }
+        return jwk;
+    }
+
+    boolean isRsaAlgorithm(String alg) {
+        return alg.matches("RS[0-9]{3,}");
+    }
+
+    boolean isEcAlgorithm(String alg) {
+        return alg.matches("ES[0-9]{3,}");
     }
 
     protected JWK generateRsaJWK(String alg, int size) {
         JWK jwk = Jose4jRsaJWK.getInstance(size, alg, null, RSA);
         jwk.generateKey();
 
+        return jwk;
+    }
+
+    protected JWK generateEcJwk(String alg, int size) {
+        JWK jwk = Jose4jEllipticCurveJWK.getInstance(size, alg, null, "EC");
+        jwk.generateKey();
         return jwk;
     }
 

--- a/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/Jose4jEllipticCurveJWK.java
+++ b/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/Jose4jEllipticCurveJWK.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 
 package com.ibm.ws.security.common.jwk.impl;
@@ -64,6 +64,7 @@ public class Jose4jEllipticCurveJWK extends EllipticCurveJsonWebKey implements J
         }
 
         keyGenerator.initialize(size);
+        //            keyGenerator.initialize(new ECGenParameterSpec("secp256r1"));
         KeyPair keypair = keyGenerator.generateKeyPair();
 
         ECPublicKey pubKey = (ECPublicKey) keypair.getPublic();

--- a/dev/com.ibm.ws.security.jwt/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.jwt/resources/OSGI-INF/l10n/metatype.properties
@@ -66,6 +66,7 @@ signatureAlgorithm.desc=Specifies the signature algorithm that will be used to s
 
 tokenSignAlgorithm.RS256=Use the RS256 signature algorithm to sign and verify tokens.
 tokenSignAlgorithm.HS256=Use the HS256 signature algorithm to sign and verify tokens.
+tokenSignAlgorithm.ES256=Use the ES256 signature algorithm to sign and verify tokens.
 
 sharedKey=Shared secret
 sharedKey.desc=Specifies the string that will be used to generate the shared keys. The value can be stored in clear text or in the more secure encoded form. Use the securityUtility tool with the encode option to encode the shared key.

--- a/dev/com.ibm.ws.security.jwt/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.jwt/resources/OSGI-INF/metatype/metatype.xml
@@ -19,16 +19,17 @@
          <AD id="id" name="%jwtBuilderId" description="%jwtBuilderId.desc" required="false" type="String" default="defaultJWT"/>
          <AD id="issuer" name="%issuerIdentifier" description="%issuerIdentifier.desc" required="false" type="String" />
          <AD id="jwkEnabled" name="%jwkEnabled" description="%jwkEnabled.desc" required="false" type="Boolean" default="false"/> 
-  		 <!-- deprecated --><AD id="expiry" name="%valid" description="%valid.desc" required="false" type="String" default="2h" ibm:type="duration(h)"/>
-  		 <AD id="expiresInSeconds" name="%expiresInSeconds" description= "%expiresInSeconds.desc" required="false" type="String" default="-1" ibm:type="duration(s)" />
-  		 <AD id="audiences" name="%audiences" description="%audiences.desc" required="false" type="String" cardinality="400" />
-  		 <AD id="claims" name="%claims" description="%claims.desc" required="false" type="String" cardinality="400" />
-  		 <AD id="scope" name="%scope" description="%scope.desc" required="false" type="String" />
-		 <AD id="signatureAlgorithm" required="false" type="String" name="%signatureAlgorithm" description="%signatureAlgorithm.desc" default="RS256">
-            	<Option label="%tokenSignAlgorithm.RS256" value="RS256" />
-            	<Option label="%tokenSignAlgorithm.HS256" value="HS256" />
+         <!-- deprecated --><AD id="expiry" name="%valid" description="%valid.desc" required="false" type="String" default="2h" ibm:type="duration(h)"/>
+         <AD id="expiresInSeconds" name="%expiresInSeconds" description= "%expiresInSeconds.desc" required="false" type="String" default="-1" ibm:type="duration(s)" />
+         <AD id="audiences" name="%audiences" description="%audiences.desc" required="false" type="String" cardinality="400" />
+         <AD id="claims" name="%claims" description="%claims.desc" required="false" type="String" cardinality="400" />
+         <AD id="scope" name="%scope" description="%scope.desc" required="false" type="String" />
+         <AD id="signatureAlgorithm" required="false" type="String" name="%signatureAlgorithm" description="%signatureAlgorithm.desc" default="RS256">
+             <Option label="%tokenSignAlgorithm.RS256" value="RS256" />
+             <Option label="%tokenSignAlgorithm.HS256" value="HS256" />
+             <Option label="internal" value="ES256" />
          </AD>
-        
+
          <AD id="sharedKey" name="%sharedKey" description="%sharedKey.desc" required="false" type="String" ibm:type="password" />
 		 <AD id="jti" name="%jti" description="%jti.desc" required="false" type="Boolean" default="false"/>
          <AD id="keyStoreRef" name="%keyStoreRef" description="%keyStoreRef.desc" required="false" type="String" ibmui:uiReference="com.ibm.ws.ssl.keystore" />
@@ -55,6 +56,7 @@
         <AD id="signatureAlgorithm" required="false" type="String" name="%signatureAlgorithm" description="%signatureAlgorithm.desc" default="RS256">
             <Option label="%tokenSignAlgorithm.RS256" value="RS256" />
             <Option label="%tokenSignAlgorithm.HS256" value="HS256" />
+            <Option label="internal" value="ES256" />
         </AD>
         <AD id="trustStoreRef" name="%trustStoreRef" description="%trustStoreRef.desc" required="false" type="String" ibmui:uiReference="com.ibm.ws.ssl.keystore" />
         <AD id="trustedAlias" name="%trustedAliasName" description="%trustedAliasName.desc" required="false" type="String" />

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/ConsumerUtil.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/ConsumerUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2016, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@ package com.ibm.ws.security.jwt.internal;
 import java.io.UnsupportedEncodingException;
 import java.security.InvalidKeyException;
 import java.security.Key;
+import java.security.PublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Date;
 import java.util.List;
@@ -40,7 +41,6 @@ import com.ibm.websphere.security.jwt.InvalidTokenException;
 import com.ibm.websphere.security.jwt.JwtToken;
 import com.ibm.websphere.security.jwt.KeyException;
 import com.ibm.websphere.security.jwt.KeyStoreServiceException;
-import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.common.jwk.impl.JwKRetriever;
 import com.ibm.ws.security.common.time.TimeUtils;
 import com.ibm.ws.security.jwt.config.JwtConsumerConfig;
@@ -51,641 +51,641 @@ import com.ibm.ws.ssl.KeyStoreService;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 
 public class ConsumerUtil {
-	private static final TraceComponent tc = Tr.register(ConsumerUtil.class);
-	private static final Class<?> thisClass = ConsumerUtil.class;
-
-	private AtomicServiceReference<KeyStoreService> keyStoreService = null;
-
-	private static TimeUtils timeUtils = new TimeUtils(TimeUtils.YearMonthDateHourMinSecZone);
-	private final JtiNonceCache jtiCache = new JtiNonceCache();
-	public final static String ISSUER = "mp.jwt.verify.issuer";
-	public final static String PUBLIC_KEY = "mp.jwt.verify.publickey";
-	public final static String KEY_LOCATION = "mp.jwt.verify.publickey.location";
-
-	public ConsumerUtil(AtomicServiceReference<KeyStoreService> kss) {
-		keyStoreService = kss;
-	}
-
-	public JwtToken parseJwt(String jwtString, JwtConsumerConfig config) throws Exception {
-		return parseJwt(jwtString, config, null);
-	}
-
-	public JwtToken parseJwt(String jwtString, JwtConsumerConfig config, Map properties) throws Exception {
-		JwtContext jwtContext = parseJwtAndGetJwtContext(jwtString, config, properties);
-		JwtTokenConsumerImpl jwtToken = new JwtTokenConsumerImpl(jwtContext);
-		checkForReusedJwt(jwtToken, config);
-		return jwtToken;
-	}
-
-	JwtContext parseJwtAndGetJwtContext(String jwtString, JwtConsumerConfig config, Map properties) throws Exception {
-		JwtContext jwtContext = parseJwtWithoutValidation(jwtString, config);
-		if (config.isValidationRequired()) {
-			jwtContext = getSigningKeyAndParseJwtWithValidation(jwtString, config, jwtContext, properties);
-		}
-		return jwtContext;
-	}
-
-	JwtContext getSigningKeyAndParseJwtWithValidation(String jwtString, JwtConsumerConfig config, JwtContext jwtContext,
-			Map properties) throws Exception {
-		Key signingKey = getSigningKey(config, jwtContext, properties);
-		return parseJwtWithValidation(jwtString, jwtContext, config, signingKey, properties);
-	}
-
-	/**
-	 * Throws an exception if JWTs are not allowed to be reused (as configured by
-	 * the provided config option) AND a token with a matching "jti" and "issuer"
-	 * claim already exists in the cache.
-	 */
-	void checkForReusedJwt(JwtTokenConsumerImpl jwt, JwtConsumerConfig config) throws InvalidTokenException {
-		// Only throw an error if tokens are not allowed to be reused
-		if (!config.getTokenReuse()) {
-			throwExceptionIfJwtReused(jwt);
-		}
-	}
-
-	void throwExceptionIfJwtReused(JwtTokenConsumerImpl jwt) throws InvalidTokenException {
-		if (jtiCache.contains(jwt)) {
-			if (tc.isDebugEnabled()) {
-				Tr.debug(tc, "JWT token can only be submitted once. The issuer is " + jwt.getClaims().getIssuer()
-						+ ", and JTI is " + jwt.getClaims().getJwtId());
-			}
-			String errorMsg = Tr.formatMessage(tc, "JWT_DUP_JTI_ERR",
-					new Object[] { jwt.getClaims().getIssuer(), jwt.getClaims().getJwtId() });
-			throw new InvalidTokenException(errorMsg);
-		}
-	}
-
-	/**
-	 * Get the appropriate signing key based on the signature algorithm specified in
-	 * the config.
-	 */
-	Key getSigningKey(JwtConsumerConfig config, JwtContext jwtContext, Map properties) throws KeyException {
-		Key signingKey = null;
-		if (config == null) {
-			if (tc.isDebugEnabled()) {
-				Tr.debug(tc, "JWT consumer config object is null");
-			}
-			return null;
-		}
-		signingKey = getSigningKeyBasedOnSignatureAlgorithm(config, jwtContext, properties);
-		if (signingKey == null) {
-			if (tc.isDebugEnabled()) {
-				Tr.debug(tc, "A signing key could not be found");
-			}
-		}
-		return signingKey;
-	}
-
-	Key getSigningKeyBasedOnSignatureAlgorithm(JwtConsumerConfig config, JwtContext jwtContext, Map properties)
-			throws KeyException {
-		Key signingKey = null;
-		String sigAlg = config.getSignatureAlgorithm();
-
-		if (Constants.SIGNATURE_ALG_HS256.equals(sigAlg)) {
-			signingKey = getSigningKeyForHS256(config);
-		} else if (Constants.SIGNATURE_ALG_RS256.equals(sigAlg)) {
-			signingKey = getSigningKeyForRS256(config, jwtContext, properties);
-		}
-		return signingKey;
-	}
-
-	Key getSigningKeyForHS256(JwtConsumerConfig config) throws KeyException {
-		Key signingKey = null;
-		try {
-			signingKey = getSharedSecretKey(config);
-		} catch (Exception e) {
-			String msg = Tr.formatMessage(tc, "JWT_ERROR_GETTING_SHARED_KEY", new Object[] { e.getLocalizedMessage() });
-			throw new KeyException(msg, e);
-		}
-		return signingKey;
-	}
-
-	/**
-	 * Creates a Key object from the shared key specified in the provided
-	 * configuration.
-	 */
-	Key getSharedSecretKey(JwtConsumerConfig config) throws KeyException {
-		if (config == null) {
-			if (tc.isDebugEnabled()) {
-				Tr.debug(tc, "JWT consumer config object is null");
-			}
-			return null;
-		}
-		String sharedKey = config.getSharedKey();
-		return createKeyFromSharedKey(sharedKey);
-	}
-
-	Key createKeyFromSharedKey(String sharedKey) throws KeyException {
-		if (sharedKey == null || sharedKey.isEmpty()) {
-			String msg = Tr.formatMessage(tc, "JWT_MISSING_SHARED_KEY");
-			throw new KeyException(msg);
-		}
-		try {
-			return new HmacKey(sharedKey.getBytes(Constants.UTF_8));
-		} catch (UnsupportedEncodingException e) {
-			// Should not happen - UTF-8 should be supported
-			if (tc.isDebugEnabled()) {
-				Tr.debug(tc, "Caught exception getting shared key bytes: " + e.getLocalizedMessage());
-			}
-		}
-		return null;
-	}
-
-	boolean isPublicKeyPropsPresent(Map props) {
-		if (props == null) {
-			return false;
-		}
-		return props.get(PUBLIC_KEY) != null || props.get(KEY_LOCATION) != null;
-	}
-
-	Key getSigningKeyForRS256(JwtConsumerConfig config, JwtContext jwtContext, Map properties) throws KeyException {
-		Key signingKey = null;
-		if (config.getJwkEnabled() || (config.getTrustedAlias() == null && isPublicKeyPropsPresent(properties))) { // need
-																													// change
-																													// to
-																													// consider
-																													// MP-Config
-			signingKey = getKeyForJwkEnabled(config, jwtContext, properties);
-		} else {
-			signingKey = getKeyForJwkDisabled(config);
-		}
-		return signingKey;
-	}
-
-	Key getKeyForJwkEnabled(JwtConsumerConfig config, JwtContext jwtContext, Map properties) throws KeyException {
-		Key signingKey = null;
-		try {
-			signingKey = getJwksKey(config, jwtContext, properties);
-		} catch (Exception e) {
-			String msg = Tr.formatMessage(tc, "JWT_ERROR_GETTING_JWK_KEY",
-					new Object[] { config.getJwkEndpointUrl(), e.getLocalizedMessage() });
-			throw new KeyException(msg, e);
-		}
-		return signingKey;
-	}
-
-	protected Key getJwksKey(JwtConsumerConfig config, JwtContext jwtContext, Map properties) throws Exception {
-		JsonWebStructure jwtHeader = getJwtHeader(jwtContext);
-		String kid = jwtHeader.getKeyIdHeaderValue();
-		JwKRetriever jwkRetriever = null;
-		if (properties != null) {
-			String publickey = (String) properties.get(PUBLIC_KEY);
-			String keyLocation = (String) properties.get(KEY_LOCATION);
-			if (publickey != null || keyLocation != null) {
-				jwkRetriever = new JwKRetriever(config.getId(), config.getSslRef(), config.getJwkEndpointUrl(),
-						config.getJwkSet(), JwtUtils.getSSLSupportService(), config.isHostNameVerificationEnabled(),
-						null, null, publickey, keyLocation);
-			}
-		}
-		if (jwkRetriever == null) {
-			jwkRetriever = new JwKRetriever(config.getId(), config.getSslRef(), config.getJwkEndpointUrl(),
-					config.getJwkSet(), JwtUtils.getSSLSupportService(), config.isHostNameVerificationEnabled(), null,
-					null);
-		}
-		Key signingKey = jwkRetriever.getPublicKeyFromJwk(kid, null,
-				config.getUseSystemPropertiesForHttpClientConnections()); // only kid or x5t will work but not both
-		return signingKey;
-	}
-
-	JsonWebStructure getJwtHeader(JwtContext jwtContext) throws Exception {
-		List<JsonWebStructure> jsonStructures = jwtContext.getJoseObjects();
-		if (jsonStructures == null || jsonStructures.isEmpty()) {
-			// TODO - NLS message
-		    throw new Exception("Invalid JsonWebStructure");
-		}
-		JsonWebStructure jwtHeader = jsonStructures.get(0);
-		debugJwtHeader(jwtHeader);
-		return jwtHeader;
-	}
-
-	void debugJwtHeader(JsonWebStructure jwtHeader) {
-		if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-			Tr.debug(tc, "JsonWebStructure class: " + jwtHeader.getClass().getName() + " data:" + jwtHeader);
-			if (jwtHeader instanceof JsonWebSignature) {
-				JsonWebSignature signature = (JsonWebSignature) jwtHeader;
-				Tr.debug(tc, "JsonWebSignature alg: " + signature.getAlgorithmHeaderValue() + " 3rd:'"
-						+ signature.getEncodedSignature() + "'");
-			}
-		}
-	}
-
-	Key getKeyForJwkDisabled(JwtConsumerConfig config) throws KeyException {
-		Key signingKey = null;
-		String trustedAlias = config.getTrustedAlias();
-		String trustStoreRef = config.getTrustStoreRef();
-		try {
-			signingKey = getPublicKey(trustedAlias, trustStoreRef, Constants.SIGNATURE_ALG_RS256);
-		} catch (Exception e) {
-			String msg = Tr.formatMessage(tc, "JWT_ERROR_GETTING_PUBLIC_KEY",
-					new Object[] { trustedAlias, trustStoreRef, e.getLocalizedMessage() });
-			throw new KeyException(msg, e);
-		}
-		return signingKey;
-	}
-
-	/**
-	 * Creates a Key object from the certificate stored in the trust store and alias
-	 * provided.
-	 */
-	Key getPublicKey(String trustedAlias, String trustStoreRef, String signatureAlgorithm)
-			throws KeyStoreServiceException, KeyException {
-		Key signingKey = getPublicKeyFromKeystore(trustedAlias, trustStoreRef, signatureAlgorithm);
-		if (tc.isDebugEnabled()) {
-			Tr.debug(tc, "Trusted alias: " + trustedAlias + ", Truststore: " + trustStoreRef);
-			Tr.debug(tc, "RSAPublicKey: " + (signingKey instanceof RSAPublicKey));
-		}
-		if (signingKey != null && !(signingKey instanceof RSAPublicKey)) {
-			signingKey = null;
-		}
-		return signingKey;
-	}
-
-	Key getPublicKeyFromKeystore(String trustedAlias, String trustStoreRef, String signatureAlgorithm)
-			throws KeyException {
-		try {
-			if (keyStoreService == null) {
-				String msg = Tr.formatMessage(tc, "JWT_TRUSTSTORE_SERVICE_NOT_AVAILABLE");
-				throw new KeyStoreServiceException(msg);
-			}
-			return JwtUtils.getPublicKey(trustedAlias, trustStoreRef, keyStoreService.getService());
-		} catch (Exception e) {
-			String msg = Tr.formatMessage(tc, "JWT_NULL_SIGNING_KEY_WITH_ERROR",
-					new Object[] { signatureAlgorithm, Constants.SIGNING_KEY_X509, e.getLocalizedMessage() });
-			throw new KeyException(msg, e);
-		}
-	}
-
-	protected JwtContext parseJwtWithoutValidation(String jwtString, JwtConsumerConfig config) throws Exception {
-		if (jwtString == null || jwtString.isEmpty()) {
-			String errorMsg = Tr.formatMessage(tc, "JWT_CONSUMER_NULL_OR_EMPTY_STRING",
-					new Object[] { config.getId(), jwtString });
-			throw new InvalidTokenException(errorMsg);
-		}
-		JwtConsumerBuilder builder = initializeJwtConsumerBuilderWithoutValidation(config);
-		JwtConsumer firstPassJwtConsumer = builder.build();
-		return firstPassJwtConsumer.process(jwtString);
-	}
-
-	protected JwtContext parseJwtWithValidation(String jwtString, JwtContext jwtContext, JwtConsumerConfig config,
-			Key key, Map properties) throws Exception {
-		JwtClaims jwtClaims = jwtContext.getJwtClaims();
-
-		if (tc.isDebugEnabled()) {
-			Tr.debug(tc, "Key from config: " + key);
-		}
-
-		validateClaims(jwtClaims, jwtContext, config, properties);
-		validateSignatureAlgorithmWithKey(config, key);
-
-		JwtConsumerBuilder consumerBuilder = initializeJwtConsumerBuilderWithValidation(config, jwtClaims, key);
-		JwtConsumer jwtConsumer = consumerBuilder.build();
-		return processJwtStringWithConsumer(jwtConsumer, jwtString);
-	}
-
-	JwtConsumerBuilder initializeJwtConsumerBuilderWithoutValidation(JwtConsumerConfig config) {
-		JwtConsumerBuilder builder = new JwtConsumerBuilder();
-		builder.setSkipAllValidators();
-		builder.setDisableRequireSignature();
-		builder.setSkipSignatureVerification();
-		builder.setAllowedClockSkewInSeconds((int) ((config.getClockSkew()) / 1000));
-		return builder;
-	}
-
-	JwtConsumerBuilder initializeJwtConsumerBuilderWithValidation(JwtConsumerConfig config, JwtClaims jwtClaims,
-			Key key) throws MalformedClaimException {
-		JwtConsumerBuilder builder = new JwtConsumerBuilder();
-		builder.setExpectedIssuer(jwtClaims.getIssuer());
-		builder.setSkipDefaultAudienceValidation();
-		builder.setRequireExpirationTime();
-		builder.setVerificationKey(key);
-		builder.setRelaxVerificationKeyValidation();
-		builder.setAllowedClockSkewInSeconds((int) (config.getClockSkew() / 1000));
-		return builder;
-	}
-
-	void validateClaims(JwtClaims jwtClaims, JwtContext jwtContext, JwtConsumerConfig config, Map properties)
-			throws MalformedClaimException, InvalidClaimException, InvalidTokenException {
-		String issuer = config.getIssuer();
-		if (issuer == null) {
-			issuer = (properties == null) ? null : (String) properties.get(ISSUER);
-		}
-
-		validateIssuer(config.getId(), issuer, jwtClaims.getIssuer());
-
-		if (!validateAudience(config.getAudiences(), jwtClaims.getAudience())) {
-			String msg = Tr.formatMessage(tc, "JWT_AUDIENCE_NOT_TRUSTED",
-					new Object[] { jwtClaims.getAudience(), config.getId(), config.getAudiences() });
-			throw new InvalidClaimException(msg);
-		}
-
-		// check azp
-
-		validateIatAndExp(jwtClaims, config.getClockSkew());
-
-		validateNbf(jwtClaims, config.getClockSkew());
-
-		validateAlgorithm(jwtContext, config.getSignatureAlgorithm());
-	}
-
-	/**
-	 * Throws an exception if the provided key is null but the config specifies a
-	 * signature algorithm other than "none".
-	 */
-	void validateSignatureAlgorithmWithKey(JwtConsumerConfig config, Key key) throws InvalidClaimException {
-		String signatureAlgorithm = config.getSignatureAlgorithm();
-		if (key == null && signatureAlgorithm != null && !signatureAlgorithm.equalsIgnoreCase("none")) {
-			String msg = Tr.formatMessage(tc, "JWT_MISSING_KEY", new Object[] { signatureAlgorithm });
-			throw new InvalidClaimException(msg);
-		}
-	}
-
-	/**
-	 * Verifies that tokenIssuer is one of the values specified in the
-	 * comma-separated issuers string.
-	 */
-	boolean validateIssuer(String consumerConfigId, String issuers, String tokenIssuer) throws InvalidClaimException {
-		boolean isIssuer = false;
-		if (issuers == null || issuers.isEmpty()) {
-			String msg = Tr.formatMessage(tc, "JWT_TRUSTED_ISSUERS_NULL",
-					new Object[] { tokenIssuer, consumerConfigId });
-			throw new InvalidClaimException(msg);
-		}
-
-		StringTokenizer st = new StringTokenizer(issuers, ",");
-		while (st.hasMoreTokens()) {
-			String iss = st.nextToken().trim();
-			if (tc.isDebugEnabled()) {
-				Tr.debug(tc, "Trusted issuer: " + iss);
-			}
-			if (Constants.ALL_ISSUERS.equals(iss) || (tokenIssuer != null && tokenIssuer.equals(iss))) {
-				isIssuer = true;
-				break;
-			}
-		}
-
-		if (!isIssuer) {
-			String msg = Tr.formatMessage(tc, "JWT_ISSUER_NOT_TRUSTED",
-					new Object[] { tokenIssuer, consumerConfigId, issuers });
-			throw new InvalidClaimException(msg);
-		}
-		return isIssuer;
-	}
-
-	/**
-	 * Verifies that at least one of the values specified in audiences is contained
-	 * in the allowedAudiences list.
-	 */
-	boolean validateAudience(List<String> allowedAudiences, List<String> audiences) {
-		boolean valid = false;
-
-		if (allowedAudiences != null && allowedAudiences.contains(Constants.ALL_AUDIENCES)) {
-			return true;
-		}
-		if (allowedAudiences != null && audiences != null) {
-			for (String audience : audiences) {
-				for (String allowedAud : allowedAudiences) {
-					if (allowedAud.equals(audience)) {
-						valid = true;
-						break;
-					}
-				}
-			}
-		} else if (allowedAudiences == null && (audiences == null || audiences.isEmpty())) {
-			valid = true;
-		}
-
-		return valid;
-	}
-
-	/**
-	 * Validates the the {@value Claims#ISSUED_AT} and {@value Claims#EXPIRATION}
-	 * claims are present and properly formed. Also verifies that the
-	 * {@value Claims#ISSUED_AT} time is after the {@value Claims#EXPIRATION} time.
-	 */
-	void validateIatAndExp(JwtClaims jwtClaims, long clockSkewInMilliseconds) throws InvalidClaimException {
-		if (jwtClaims == null) {
-			if (tc.isDebugEnabled()) {
-				Tr.debug(tc, "Missing JwtClaims object");
-			}
-			return;
-		}
-		NumericDate issueAtClaim = getIssuedAtClaim(jwtClaims);
-		NumericDate expirationClaim = getExpirationClaim(jwtClaims);
-
-		debugCurrentTimes(clockSkewInMilliseconds, issueAtClaim, expirationClaim);
-
-		validateIssuedAtClaim(issueAtClaim, expirationClaim, clockSkewInMilliseconds);
-		validateExpirationClaim(expirationClaim, clockSkewInMilliseconds);
-
-	}
-
-	void debugCurrentTimes(long clockSkewInMilliseconds, NumericDate issueAtClaim, NumericDate expirationClaim) {
-		if (tc.isDebugEnabled()) {
-			long now = (new Date()).getTime();
-			NumericDate currentTimeMinusSkew = NumericDate.fromMilliseconds(now - clockSkewInMilliseconds);
-			NumericDate currentTimePlusSkew = NumericDate.fromMilliseconds(now + clockSkewInMilliseconds);
-			Tr.debug(tc, "Checking iat [" + createDateString(issueAtClaim) + "] and exp ["
-					+ createDateString(expirationClaim) + "]");
-			Tr.debug(tc, "Comparing against current time (minus clock skew of " + (clockSkewInMilliseconds / 1000)
-					+ " seconds) [" + createDateString(currentTimeMinusSkew) + "]");
-			Tr.debug(tc, "Comparing against current time (plus clock skew of " + (clockSkewInMilliseconds / 1000)
-					+ " seconds) [" + createDateString(currentTimePlusSkew) + "]");
-		}
-	}
-
-	void validateIssuedAtClaim(NumericDate issueAtClaim, NumericDate expirationClaim, long clockSkewInMilliseconds)
-			throws InvalidClaimException {
-		long now = (new Date()).getTime();
-		NumericDate currentTimePlusSkew = NumericDate.fromMilliseconds(now + clockSkewInMilliseconds);
-
-		if (issueAtClaim != null && expirationClaim != null) {
-			if (issueAtClaim.isAfter(currentTimePlusSkew)) {
-				String msg = Tr.formatMessage(tc, "JWT_IAT_AFTER_CURRENT_TIME",
-						new Object[] { createDateString(issueAtClaim), createDateString(currentTimePlusSkew),
-								(clockSkewInMilliseconds / 1000) });
-				throw new InvalidClaimException(msg);
-			}
-			if (issueAtClaim.isOnOrAfter(expirationClaim)) {
-				String msg = Tr.formatMessage(tc, "JWT_IAT_AFTER_EXP",
-						new Object[] { createDateString(issueAtClaim), createDateString(expirationClaim) });
-				throw new InvalidClaimException(msg);
-			}
-		} else {
-			// TODO - what if one or the other is missing? is that an error
-			// condition?
-		}
-	}
-
-	
-	void validateExpirationClaim(NumericDate expirationClaim, long clockSkewInMilliseconds)
-			throws InvalidClaimException {
-		long now = (new Date()).getTime();
-		NumericDate currentTimeMinusSkew = NumericDate.fromMilliseconds(now - clockSkewInMilliseconds);
-
-		// Check that expiration claim is in the future, accounting for the
-		// clock skew
-		if (expirationClaim == null || (!expirationClaim.isAfter(currentTimeMinusSkew))) {
-			JwtUtils.setJwtSsoValidationPathExiredToken();
-			String msg = Tr.formatMessage(tc, "JWT_TOKEN_EXPIRED", new Object[] { createDateString(expirationClaim),
-					createDateString(currentTimeMinusSkew), (clockSkewInMilliseconds / 1000) });
-			throw new InvalidClaimException(msg);
-		}
-	}
-
-	/**
-	 * Validates the the {@value Claims#NOT_BEFORE} claim is present and properly
-	 * formed. Also
-	 */
-	void validateNbf(JwtClaims jwtClaims, long clockSkewInMilliseconds) throws InvalidClaimException {
-		if (jwtClaims == null) {
-			if (tc.isDebugEnabled()) {
-				Tr.debug(tc, "Missing JwtClaims object");
-			}
-			return;
-		}
-		NumericDate nbf = getNotBeforeClaim(jwtClaims);
-		validateNotBeforeClaim(nbf, clockSkewInMilliseconds);
-	}
-
-	void validateNotBeforeClaim(NumericDate nbfClaim, long clockSkewInMilliseconds) throws InvalidClaimException {
-		long now = (new Date()).getTime();
-		NumericDate currentTimePlusSkew = NumericDate.fromMilliseconds(now + clockSkewInMilliseconds);
-
-		// Check that nbf claim is in the past, accounting for the clock skew
-		if (nbfClaim != null && (nbfClaim.isOnOrAfter(currentTimePlusSkew))) {
-			String msg = Tr.formatMessage(tc, "JWT_TOKEN_BEFORE_NBF", new Object[] { createDateString(nbfClaim),
-					createDateString(currentTimePlusSkew), (clockSkewInMilliseconds / 1000) });
-			throw new InvalidClaimException(msg);
-		}
-	}
-
-	NumericDate getIssuedAtClaim(JwtClaims jwtClaims) throws InvalidClaimException {
-		NumericDate iatClaim = null;
-		try {
-			iatClaim = jwtClaims.getIssuedAt();
-		} catch (MalformedClaimException e) {
-			String msg = Tr.formatMessage(tc, "JWT_CONSUMER_MALFORMED_CLAIM",
-					new Object[] { Claims.ISSUED_AT, e.getLocalizedMessage() });
-			throw new InvalidClaimException(msg, e);
-		}
-		return iatClaim;
-	}
-
-	NumericDate getExpirationClaim(JwtClaims jwtClaims) throws InvalidClaimException {
-		NumericDate expClaim = null;
-		try {
-			expClaim = jwtClaims.getExpirationTime();
-		} catch (MalformedClaimException e) {
-			String msg = Tr.formatMessage(tc, "JWT_CONSUMER_MALFORMED_CLAIM",
-					new Object[] { Claims.EXPIRATION, e.getLocalizedMessage() });
-			throw new InvalidClaimException(msg, e);
-		}
-		return expClaim;
-	}
-
-	NumericDate getNotBeforeClaim(JwtClaims jwtClaims) throws InvalidClaimException {
-		NumericDate nbfClaim = null;
-		try {
-			nbfClaim = jwtClaims.getNotBefore();
-		} catch (MalformedClaimException e) {
-			String msg = Tr.formatMessage(tc, "JWT_CONSUMER_MALFORMED_CLAIM",
-					new Object[] { Claims.NOT_BEFORE, e.getLocalizedMessage() });
-			throw new InvalidClaimException(msg, e);
-		}
-		return nbfClaim;
-	}
-
-	void validateAlgorithm(JwtContext jwtContext, String requiredAlg) throws InvalidTokenException {
-		if (requiredAlg == null) {
-			if (tc.isDebugEnabled()) {
-				Tr.debug(tc, "No required signature algorithm was specified");
-			}
-			return;
-		}
-		String tokenAlg = getAlgorithmFromJwtHeader(jwtContext);
-		validateAlgorithm(requiredAlg, tokenAlg);
-	}
-
-	void validateAlgorithm(String requiredAlg, String tokenAlg) throws InvalidTokenException {
-		if (tokenAlg == null) {
-			if (tc.isDebugEnabled()) {
-				Tr.debug(tc, "Signature algorithm was not found in the JWT");
-			}
-			String msg = Tr.formatMessage(tc, "JWT_MISSING_ALG_HEADER", new Object[] { requiredAlg });
-			throw new InvalidTokenException(msg);
-		}
-		if (tc.isDebugEnabled()) {
-			Tr.debug(tc, "JWT is signed with algorithm: ", tokenAlg);
-			Tr.debug(tc, "JWT is required to be signed with algorithm: ", requiredAlg);
-		}
-		if (!requiredAlg.equals(tokenAlg)) {
-			String msg = Tr.formatMessage(tc, "JWT_ALGORITHM_MISMATCH", new Object[] { tokenAlg, requiredAlg });
-			throw new InvalidTokenException(msg);
-		}
-	}
-
-	JwtContext processJwtStringWithConsumer(JwtConsumer jwtConsumer, String jwtString)
-			throws InvalidTokenException, InvalidJwtException {
-		JwtContext validatedJwtContext = null;
-		try {
-			validatedJwtContext = jwtConsumer.process(jwtString);
-		} catch (InvalidJwtSignatureException e) {
-			String msg = Tr.formatMessage(tc, "JWT_INVALID_SIGNATURE", new Object[] { e.getLocalizedMessage() });
-			throw new InvalidTokenException(msg, e);
-		} catch (InvalidJwtException e) {
-			Throwable cause = getRootCause(e);
-			if (cause != null && cause instanceof InvalidKeyException) {
-				throw e;
-			} else {
-				// Don't have enough information to output a more useful error
-				// message
-				throw e;
-			}
-		}
-		return validatedJwtContext;
-	}
-
-	String getAlgorithmFromJwtHeader(JwtContext jwtContext) {
-		if (jwtContext == null) {
-			if (tc.isDebugEnabled()) {
-				Tr.debug(tc, "JwtContext is null");
-			}
-			return null;
-		}
-		JsonWebStructure jwtHeader = null;
-		try {
-			jwtHeader = getJwtHeader(jwtContext);
-		} catch (Exception e) {
-			// TODO - NLS message?
-			if (tc.isDebugEnabled()) {
-				Tr.debug(tc, "Failed to obtain JWT header");
-			}
-			return null;
-		}
-		String algHeader = jwtHeader.getAlgorithmHeaderValue();
-		if (tc.isDebugEnabled()) {
-			Tr.debug(tc, "JWT is signed with algorithm: ", algHeader);
-		}
-		return algHeader;
-	}
-
-	Throwable getRootCause(Exception e) {
-		Throwable rootCause = null;
-		Throwable tmpCause = e;
-		while (tmpCause != null) {
-			rootCause = tmpCause;
-			tmpCause = rootCause.getCause();
-		}
-		return rootCause;
-	}
-
-	String createDateString(NumericDate date) {
-		if (date == null) {
-			return null;
-		}
-		// NumericDate.getValue() returns a value in seconds, so convert to
-		// milliseconds
-		return timeUtils.createDateString(1000 * date.getValue());
-	}
+    private static final TraceComponent tc = Tr.register(ConsumerUtil.class);
+    private static final Class<?> thisClass = ConsumerUtil.class;
+
+    private AtomicServiceReference<KeyStoreService> keyStoreService = null;
+
+    private static TimeUtils timeUtils = new TimeUtils(TimeUtils.YearMonthDateHourMinSecZone);
+    private final JtiNonceCache jtiCache = new JtiNonceCache();
+    public final static String ISSUER = "mp.jwt.verify.issuer";
+    public final static String PUBLIC_KEY = "mp.jwt.verify.publickey";
+    public final static String KEY_LOCATION = "mp.jwt.verify.publickey.location";
+
+    public ConsumerUtil(AtomicServiceReference<KeyStoreService> kss) {
+        keyStoreService = kss;
+    }
+
+    public JwtToken parseJwt(String jwtString, JwtConsumerConfig config) throws Exception {
+        return parseJwt(jwtString, config, null);
+    }
+
+    public JwtToken parseJwt(String jwtString, JwtConsumerConfig config, Map properties) throws Exception {
+        JwtContext jwtContext = parseJwtAndGetJwtContext(jwtString, config, properties);
+        JwtTokenConsumerImpl jwtToken = new JwtTokenConsumerImpl(jwtContext);
+        checkForReusedJwt(jwtToken, config);
+        return jwtToken;
+    }
+
+    JwtContext parseJwtAndGetJwtContext(String jwtString, JwtConsumerConfig config, Map properties) throws Exception {
+        JwtContext jwtContext = parseJwtWithoutValidation(jwtString, config);
+        if (config.isValidationRequired()) {
+            jwtContext = getSigningKeyAndParseJwtWithValidation(jwtString, config, jwtContext, properties);
+        }
+        return jwtContext;
+    }
+
+    JwtContext getSigningKeyAndParseJwtWithValidation(String jwtString, JwtConsumerConfig config, JwtContext jwtContext,
+            Map properties) throws Exception {
+        Key signingKey = getSigningKey(config, jwtContext, properties);
+        return parseJwtWithValidation(jwtString, jwtContext, config, signingKey, properties);
+    }
+
+    /**
+     * Throws an exception if JWTs are not allowed to be reused (as configured by
+     * the provided config option) AND a token with a matching "jti" and "issuer"
+     * claim already exists in the cache.
+     */
+    void checkForReusedJwt(JwtTokenConsumerImpl jwt, JwtConsumerConfig config) throws InvalidTokenException {
+        // Only throw an error if tokens are not allowed to be reused
+        if (!config.getTokenReuse()) {
+            throwExceptionIfJwtReused(jwt);
+        }
+    }
+
+    void throwExceptionIfJwtReused(JwtTokenConsumerImpl jwt) throws InvalidTokenException {
+        if (jtiCache.contains(jwt)) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "JWT token can only be submitted once. The issuer is " + jwt.getClaims().getIssuer()
+                        + ", and JTI is " + jwt.getClaims().getJwtId());
+            }
+            String errorMsg = Tr.formatMessage(tc, "JWT_DUP_JTI_ERR",
+                    new Object[] { jwt.getClaims().getIssuer(), jwt.getClaims().getJwtId() });
+            throw new InvalidTokenException(errorMsg);
+        }
+    }
+
+    /**
+     * Get the appropriate signing key based on the signature algorithm specified in
+     * the config.
+     */
+    Key getSigningKey(JwtConsumerConfig config, JwtContext jwtContext, Map properties) throws KeyException {
+        Key signingKey = null;
+        if (config == null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "JWT consumer config object is null");
+            }
+            return null;
+        }
+        signingKey = getSigningKeyBasedOnSignatureAlgorithm(config, jwtContext, properties);
+        if (signingKey == null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "A signing key could not be found");
+            }
+        }
+        return signingKey;
+    }
+
+    Key getSigningKeyBasedOnSignatureAlgorithm(JwtConsumerConfig config, JwtContext jwtContext, Map properties)
+            throws KeyException {
+        Key signingKey = null;
+        String sigAlg = config.getSignatureAlgorithm();
+
+        if (Constants.SIGNATURE_ALG_HS256.equals(sigAlg)) {
+            signingKey = getSigningKeyForHS256(config);
+        } else if (Constants.SIGNATURE_ALG_RS256.equals(sigAlg)) {
+            signingKey = getSigningKeyForRS256(config, jwtContext, properties);
+        } else if (Constants.SIGNATURE_ALG_ES256.equals(sigAlg)) {
+            signingKey = getSigningKeyForES256(config, jwtContext, properties);
+        }
+        return signingKey;
+    }
+
+    Key getSigningKeyForHS256(JwtConsumerConfig config) throws KeyException {
+        Key signingKey = null;
+        try {
+            signingKey = getSharedSecretKey(config);
+        } catch (Exception e) {
+            String msg = Tr.formatMessage(tc, "JWT_ERROR_GETTING_SHARED_KEY", new Object[] { e.getLocalizedMessage() });
+            throw new KeyException(msg, e);
+        }
+        return signingKey;
+    }
+
+    /**
+     * Creates a Key object from the shared key specified in the provided
+     * configuration.
+     */
+    Key getSharedSecretKey(JwtConsumerConfig config) throws KeyException {
+        if (config == null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "JWT consumer config object is null");
+            }
+            return null;
+        }
+        String sharedKey = config.getSharedKey();
+        return createKeyFromSharedKey(sharedKey);
+    }
+
+    Key createKeyFromSharedKey(String sharedKey) throws KeyException {
+        if (sharedKey == null || sharedKey.isEmpty()) {
+            String msg = Tr.formatMessage(tc, "JWT_MISSING_SHARED_KEY");
+            throw new KeyException(msg);
+        }
+        try {
+            return new HmacKey(sharedKey.getBytes(Constants.UTF_8));
+        } catch (UnsupportedEncodingException e) {
+            // Should not happen - UTF-8 should be supported
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Caught exception getting shared key bytes: " + e.getLocalizedMessage());
+            }
+        }
+        return null;
+    }
+
+    boolean isPublicKeyPropsPresent(Map props) {
+        if (props == null) {
+            return false;
+        }
+        return props.get(PUBLIC_KEY) != null || props.get(KEY_LOCATION) != null;
+    }
+
+    Key getSigningKeyForRS256(JwtConsumerConfig config, JwtContext jwtContext, Map properties) throws KeyException {
+        return getKeyFromJwkOrTrustStore(config, jwtContext, properties);
+    }
+
+    Key getKeyFromJwkOrTrustStore(JwtConsumerConfig config, JwtContext jwtContext, Map properties) throws KeyException {
+        Key signingKey = null;
+        if (config.getJwkEnabled() || (config.getTrustedAlias() == null && isPublicKeyPropsPresent(properties))) { // need change to consider MP-Config
+            signingKey = getKeyForJwkEnabled(config, jwtContext, properties);
+        } else {
+            signingKey = getKeyForJwkDisabled(config);
+        }
+        return signingKey;
+    }
+
+    Key getKeyForJwkEnabled(JwtConsumerConfig config, JwtContext jwtContext, Map properties) throws KeyException {
+        Key signingKey = null;
+        try {
+            signingKey = getJwksKey(config, jwtContext, properties);
+        } catch (Exception e) {
+            String msg = Tr.formatMessage(tc, "JWT_ERROR_GETTING_JWK_KEY", new Object[] { config.getJwkEndpointUrl(), e.getLocalizedMessage() });
+            throw new KeyException(msg, e);
+        }
+        return signingKey;
+    }
+
+    protected Key getJwksKey(JwtConsumerConfig config, JwtContext jwtContext, Map properties) throws Exception {
+        JsonWebStructure jwtHeader = getJwtHeader(jwtContext);
+        String kid = jwtHeader.getKeyIdHeaderValue();
+        JwKRetriever jwkRetriever = null;
+        if (properties != null) {
+            String publickey = (String) properties.get(PUBLIC_KEY);
+            String keyLocation = (String) properties.get(KEY_LOCATION);
+            if (publickey != null || keyLocation != null) {
+                jwkRetriever = new JwKRetriever(config.getId(), config.getSslRef(), config.getJwkEndpointUrl(),
+                        config.getJwkSet(), JwtUtils.getSSLSupportService(), config.isHostNameVerificationEnabled(),
+                        null, null, publickey, keyLocation);
+            }
+        }
+        if (jwkRetriever == null) {
+            jwkRetriever = new JwKRetriever(config.getId(), config.getSslRef(), config.getJwkEndpointUrl(),
+                    config.getJwkSet(), JwtUtils.getSSLSupportService(), config.isHostNameVerificationEnabled(), null,
+                    null);
+        }
+        Key signingKey = jwkRetriever.getPublicKeyFromJwk(kid, null,
+                config.getUseSystemPropertiesForHttpClientConnections()); // only kid or x5t will work but not both
+        return signingKey;
+    }
+
+    JsonWebStructure getJwtHeader(JwtContext jwtContext) throws Exception {
+        List<JsonWebStructure> jsonStructures = jwtContext.getJoseObjects();
+        if (jsonStructures == null || jsonStructures.isEmpty()) {
+            // TODO - NLS message
+            throw new Exception("Invalid JsonWebStructure");
+        }
+        JsonWebStructure jwtHeader = jsonStructures.get(0);
+        debugJwtHeader(jwtHeader);
+        return jwtHeader;
+    }
+
+    void debugJwtHeader(JsonWebStructure jwtHeader) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "JsonWebStructure class: " + jwtHeader.getClass().getName() + " data:" + jwtHeader);
+            if (jwtHeader instanceof JsonWebSignature) {
+                JsonWebSignature signature = (JsonWebSignature) jwtHeader;
+                Tr.debug(tc, "JsonWebSignature alg: " + signature.getAlgorithmHeaderValue() + " 3rd:'"
+                        + signature.getEncodedSignature() + "'");
+            }
+        }
+    }
+
+    Key getKeyForJwkDisabled(JwtConsumerConfig config) throws KeyException {
+        Key signingKey = null;
+        String trustedAlias = config.getTrustedAlias();
+        String trustStoreRef = config.getTrustStoreRef();
+        try {
+            signingKey = getPublicKey(trustedAlias, trustStoreRef, config.getSignatureAlgorithm());
+        } catch (Exception e) {
+            String msg = Tr.formatMessage(tc, "JWT_ERROR_GETTING_PUBLIC_KEY", new Object[] { trustedAlias, trustStoreRef, e.getLocalizedMessage() });
+            throw new KeyException(msg, e);
+        }
+        return signingKey;
+    }
+
+    /**
+     * Creates a Key object from the certificate stored in the trust store and alias
+     * provided.
+     */
+    Key getPublicKey(String trustedAlias, String trustStoreRef, String signatureAlgorithm) throws KeyStoreServiceException, KeyException {
+        Key signingKey = getPublicKeyFromKeystore(trustedAlias, trustStoreRef, signatureAlgorithm);
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "Trusted alias: " + trustedAlias + ", Truststore: " + trustStoreRef);
+            Tr.debug(tc, "RSAPublicKey: " + (signingKey instanceof RSAPublicKey));
+        }
+        if (signingKey != null && !(signingKey instanceof PublicKey)) {
+            signingKey = null;
+        }
+        return signingKey;
+    }
+
+    Key getPublicKeyFromKeystore(String trustedAlias, String trustStoreRef, String signatureAlgorithm) throws KeyException {
+        try {
+            if (keyStoreService == null) {
+                String msg = Tr.formatMessage(tc, "JWT_TRUSTSTORE_SERVICE_NOT_AVAILABLE");
+                throw new KeyStoreServiceException(msg);
+            }
+            return JwtUtils.getPublicKey(trustedAlias, trustStoreRef, keyStoreService.getService());
+        } catch (Exception e) {
+            String msg = Tr.formatMessage(tc, "JWT_NULL_SIGNING_KEY_WITH_ERROR", new Object[] { signatureAlgorithm, Constants.SIGNING_KEY_X509, e.getLocalizedMessage() });
+            throw new KeyException(msg, e);
+        }
+    }
+
+    Key getSigningKeyForES256(JwtConsumerConfig config, JwtContext jwtContext, Map properties) throws KeyException {
+        return getKeyFromJwkOrTrustStore(config, jwtContext, properties);
+    }
+
+    protected JwtContext parseJwtWithoutValidation(String jwtString, JwtConsumerConfig config) throws Exception {
+        if (jwtString == null || jwtString.isEmpty()) {
+            String errorMsg = Tr.formatMessage(tc, "JWT_CONSUMER_NULL_OR_EMPTY_STRING",
+                    new Object[] { config.getId(), jwtString });
+            throw new InvalidTokenException(errorMsg);
+        }
+        JwtConsumerBuilder builder = initializeJwtConsumerBuilderWithoutValidation(config);
+        JwtConsumer firstPassJwtConsumer = builder.build();
+        return firstPassJwtConsumer.process(jwtString);
+    }
+
+    protected JwtContext parseJwtWithValidation(String jwtString, JwtContext jwtContext, JwtConsumerConfig config,
+            Key key, Map properties) throws Exception {
+        JwtClaims jwtClaims = jwtContext.getJwtClaims();
+
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "Key from config: " + key);
+        }
+
+        validateClaims(jwtClaims, jwtContext, config, properties);
+        validateSignatureAlgorithmWithKey(config, key);
+
+        JwtConsumerBuilder consumerBuilder = initializeJwtConsumerBuilderWithValidation(config, jwtClaims, key);
+        JwtConsumer jwtConsumer = consumerBuilder.build();
+        return processJwtStringWithConsumer(jwtConsumer, jwtString);
+    }
+
+    JwtConsumerBuilder initializeJwtConsumerBuilderWithoutValidation(JwtConsumerConfig config) {
+        JwtConsumerBuilder builder = new JwtConsumerBuilder();
+        builder.setSkipAllValidators();
+        builder.setDisableRequireSignature();
+        builder.setSkipSignatureVerification();
+        builder.setAllowedClockSkewInSeconds((int) ((config.getClockSkew()) / 1000));
+        return builder;
+    }
+
+    JwtConsumerBuilder initializeJwtConsumerBuilderWithValidation(JwtConsumerConfig config, JwtClaims jwtClaims,
+            Key key) throws MalformedClaimException {
+        JwtConsumerBuilder builder = new JwtConsumerBuilder();
+        builder.setExpectedIssuer(jwtClaims.getIssuer());
+        builder.setSkipDefaultAudienceValidation();
+        builder.setRequireExpirationTime();
+        builder.setVerificationKey(key);
+        builder.setRelaxVerificationKeyValidation();
+        builder.setAllowedClockSkewInSeconds((int) (config.getClockSkew() / 1000));
+        return builder;
+    }
+
+    void validateClaims(JwtClaims jwtClaims, JwtContext jwtContext, JwtConsumerConfig config, Map properties)
+            throws MalformedClaimException, InvalidClaimException, InvalidTokenException {
+        String issuer = config.getIssuer();
+        if (issuer == null) {
+            issuer = (properties == null) ? null : (String) properties.get(ISSUER);
+        }
+
+        validateIssuer(config.getId(), issuer, jwtClaims.getIssuer());
+
+        if (!validateAudience(config.getAudiences(), jwtClaims.getAudience())) {
+            String msg = Tr.formatMessage(tc, "JWT_AUDIENCE_NOT_TRUSTED",
+                    new Object[] { jwtClaims.getAudience(), config.getId(), config.getAudiences() });
+            throw new InvalidClaimException(msg);
+        }
+
+        // check azp
+
+        validateIatAndExp(jwtClaims, config.getClockSkew());
+
+        validateNbf(jwtClaims, config.getClockSkew());
+
+        validateAlgorithm(jwtContext, config.getSignatureAlgorithm());
+    }
+
+    /**
+     * Throws an exception if the provided key is null but the config specifies a
+     * signature algorithm other than "none".
+     */
+    void validateSignatureAlgorithmWithKey(JwtConsumerConfig config, Key key) throws InvalidClaimException {
+        String signatureAlgorithm = config.getSignatureAlgorithm();
+        if (key == null && signatureAlgorithm != null && !signatureAlgorithm.equalsIgnoreCase("none")) {
+            String msg = Tr.formatMessage(tc, "JWT_MISSING_KEY", new Object[] { signatureAlgorithm });
+            throw new InvalidClaimException(msg);
+        }
+    }
+
+    /**
+     * Verifies that tokenIssuer is one of the values specified in the
+     * comma-separated issuers string.
+     */
+    boolean validateIssuer(String consumerConfigId, String issuers, String tokenIssuer) throws InvalidClaimException {
+        boolean isIssuer = false;
+        if (issuers == null || issuers.isEmpty()) {
+            String msg = Tr.formatMessage(tc, "JWT_TRUSTED_ISSUERS_NULL",
+                    new Object[] { tokenIssuer, consumerConfigId });
+            throw new InvalidClaimException(msg);
+        }
+
+        StringTokenizer st = new StringTokenizer(issuers, ",");
+        while (st.hasMoreTokens()) {
+            String iss = st.nextToken().trim();
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Trusted issuer: " + iss);
+            }
+            if (Constants.ALL_ISSUERS.equals(iss) || (tokenIssuer != null && tokenIssuer.equals(iss))) {
+                isIssuer = true;
+                break;
+            }
+        }
+
+        if (!isIssuer) {
+            String msg = Tr.formatMessage(tc, "JWT_ISSUER_NOT_TRUSTED",
+                    new Object[] { tokenIssuer, consumerConfigId, issuers });
+            throw new InvalidClaimException(msg);
+        }
+        return isIssuer;
+    }
+
+    /**
+     * Verifies that at least one of the values specified in audiences is contained
+     * in the allowedAudiences list.
+     */
+    boolean validateAudience(List<String> allowedAudiences, List<String> audiences) {
+        boolean valid = false;
+
+        if (allowedAudiences != null && allowedAudiences.contains(Constants.ALL_AUDIENCES)) {
+            return true;
+        }
+        if (allowedAudiences != null && audiences != null) {
+            for (String audience : audiences) {
+                for (String allowedAud : allowedAudiences) {
+                    if (allowedAud.equals(audience)) {
+                        valid = true;
+                        break;
+                    }
+                }
+            }
+        } else if (allowedAudiences == null && (audiences == null || audiences.isEmpty())) {
+            valid = true;
+        }
+
+        return valid;
+    }
+
+    /**
+     * Validates the the {@value Claims#ISSUED_AT} and {@value Claims#EXPIRATION}
+     * claims are present and properly formed. Also verifies that the
+     * {@value Claims#ISSUED_AT} time is after the {@value Claims#EXPIRATION} time.
+     */
+    void validateIatAndExp(JwtClaims jwtClaims, long clockSkewInMilliseconds) throws InvalidClaimException {
+        if (jwtClaims == null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Missing JwtClaims object");
+            }
+            return;
+        }
+        NumericDate issueAtClaim = getIssuedAtClaim(jwtClaims);
+        NumericDate expirationClaim = getExpirationClaim(jwtClaims);
+
+        debugCurrentTimes(clockSkewInMilliseconds, issueAtClaim, expirationClaim);
+
+        validateIssuedAtClaim(issueAtClaim, expirationClaim, clockSkewInMilliseconds);
+        validateExpirationClaim(expirationClaim, clockSkewInMilliseconds);
+
+    }
+
+    void debugCurrentTimes(long clockSkewInMilliseconds, NumericDate issueAtClaim, NumericDate expirationClaim) {
+        if (tc.isDebugEnabled()) {
+            long now = (new Date()).getTime();
+            NumericDate currentTimeMinusSkew = NumericDate.fromMilliseconds(now - clockSkewInMilliseconds);
+            NumericDate currentTimePlusSkew = NumericDate.fromMilliseconds(now + clockSkewInMilliseconds);
+            Tr.debug(tc, "Checking iat [" + createDateString(issueAtClaim) + "] and exp ["
+                    + createDateString(expirationClaim) + "]");
+            Tr.debug(tc, "Comparing against current time (minus clock skew of " + (clockSkewInMilliseconds / 1000)
+                    + " seconds) [" + createDateString(currentTimeMinusSkew) + "]");
+            Tr.debug(tc, "Comparing against current time (plus clock skew of " + (clockSkewInMilliseconds / 1000)
+                    + " seconds) [" + createDateString(currentTimePlusSkew) + "]");
+        }
+    }
+
+    void validateIssuedAtClaim(NumericDate issueAtClaim, NumericDate expirationClaim, long clockSkewInMilliseconds)
+            throws InvalidClaimException {
+        long now = (new Date()).getTime();
+        NumericDate currentTimePlusSkew = NumericDate.fromMilliseconds(now + clockSkewInMilliseconds);
+
+        if (issueAtClaim != null && expirationClaim != null) {
+            if (issueAtClaim.isAfter(currentTimePlusSkew)) {
+                String msg = Tr.formatMessage(tc, "JWT_IAT_AFTER_CURRENT_TIME",
+                        new Object[] { createDateString(issueAtClaim), createDateString(currentTimePlusSkew),
+                                (clockSkewInMilliseconds / 1000) });
+                throw new InvalidClaimException(msg);
+            }
+            if (issueAtClaim.isOnOrAfter(expirationClaim)) {
+                String msg = Tr.formatMessage(tc, "JWT_IAT_AFTER_EXP",
+                        new Object[] { createDateString(issueAtClaim), createDateString(expirationClaim) });
+                throw new InvalidClaimException(msg);
+            }
+        } else {
+            // TODO - what if one or the other is missing? is that an error
+            // condition?
+        }
+    }
+
+    void validateExpirationClaim(NumericDate expirationClaim, long clockSkewInMilliseconds)
+            throws InvalidClaimException {
+        long now = (new Date()).getTime();
+        NumericDate currentTimeMinusSkew = NumericDate.fromMilliseconds(now - clockSkewInMilliseconds);
+
+        // Check that expiration claim is in the future, accounting for the
+        // clock skew
+        if (expirationClaim == null || (!expirationClaim.isAfter(currentTimeMinusSkew))) {
+            JwtUtils.setJwtSsoValidationPathExiredToken();
+            String msg = Tr.formatMessage(tc, "JWT_TOKEN_EXPIRED", new Object[] { createDateString(expirationClaim),
+                    createDateString(currentTimeMinusSkew), (clockSkewInMilliseconds / 1000) });
+            throw new InvalidClaimException(msg);
+        }
+    }
+
+    /**
+     * Validates the the {@value Claims#NOT_BEFORE} claim is present and properly
+     * formed. Also
+     */
+    void validateNbf(JwtClaims jwtClaims, long clockSkewInMilliseconds) throws InvalidClaimException {
+        if (jwtClaims == null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Missing JwtClaims object");
+            }
+            return;
+        }
+        NumericDate nbf = getNotBeforeClaim(jwtClaims);
+        validateNotBeforeClaim(nbf, clockSkewInMilliseconds);
+    }
+
+    void validateNotBeforeClaim(NumericDate nbfClaim, long clockSkewInMilliseconds) throws InvalidClaimException {
+        long now = (new Date()).getTime();
+        NumericDate currentTimePlusSkew = NumericDate.fromMilliseconds(now + clockSkewInMilliseconds);
+
+        // Check that nbf claim is in the past, accounting for the clock skew
+        if (nbfClaim != null && (nbfClaim.isOnOrAfter(currentTimePlusSkew))) {
+            String msg = Tr.formatMessage(tc, "JWT_TOKEN_BEFORE_NBF", new Object[] { createDateString(nbfClaim),
+                    createDateString(currentTimePlusSkew), (clockSkewInMilliseconds / 1000) });
+            throw new InvalidClaimException(msg);
+        }
+    }
+
+    NumericDate getIssuedAtClaim(JwtClaims jwtClaims) throws InvalidClaimException {
+        NumericDate iatClaim = null;
+        try {
+            iatClaim = jwtClaims.getIssuedAt();
+        } catch (MalformedClaimException e) {
+            String msg = Tr.formatMessage(tc, "JWT_CONSUMER_MALFORMED_CLAIM",
+                    new Object[] { Claims.ISSUED_AT, e.getLocalizedMessage() });
+            throw new InvalidClaimException(msg, e);
+        }
+        return iatClaim;
+    }
+
+    NumericDate getExpirationClaim(JwtClaims jwtClaims) throws InvalidClaimException {
+        NumericDate expClaim = null;
+        try {
+            expClaim = jwtClaims.getExpirationTime();
+        } catch (MalformedClaimException e) {
+            String msg = Tr.formatMessage(tc, "JWT_CONSUMER_MALFORMED_CLAIM",
+                    new Object[] { Claims.EXPIRATION, e.getLocalizedMessage() });
+            throw new InvalidClaimException(msg, e);
+        }
+        return expClaim;
+    }
+
+    NumericDate getNotBeforeClaim(JwtClaims jwtClaims) throws InvalidClaimException {
+        NumericDate nbfClaim = null;
+        try {
+            nbfClaim = jwtClaims.getNotBefore();
+        } catch (MalformedClaimException e) {
+            String msg = Tr.formatMessage(tc, "JWT_CONSUMER_MALFORMED_CLAIM",
+                    new Object[] { Claims.NOT_BEFORE, e.getLocalizedMessage() });
+            throw new InvalidClaimException(msg, e);
+        }
+        return nbfClaim;
+    }
+
+    void validateAlgorithm(JwtContext jwtContext, String requiredAlg) throws InvalidTokenException {
+        if (requiredAlg == null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "No required signature algorithm was specified");
+            }
+            return;
+        }
+        String tokenAlg = getAlgorithmFromJwtHeader(jwtContext);
+        validateAlgorithm(requiredAlg, tokenAlg);
+    }
+
+    void validateAlgorithm(String requiredAlg, String tokenAlg) throws InvalidTokenException {
+        if (tokenAlg == null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Signature algorithm was not found in the JWT");
+            }
+            String msg = Tr.formatMessage(tc, "JWT_MISSING_ALG_HEADER", new Object[] { requiredAlg });
+            throw new InvalidTokenException(msg);
+        }
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "JWT is signed with algorithm: ", tokenAlg);
+            Tr.debug(tc, "JWT is required to be signed with algorithm: ", requiredAlg);
+        }
+        if (!requiredAlg.equals(tokenAlg)) {
+            String msg = Tr.formatMessage(tc, "JWT_ALGORITHM_MISMATCH", new Object[] { tokenAlg, requiredAlg });
+            throw new InvalidTokenException(msg);
+        }
+    }
+
+    JwtContext processJwtStringWithConsumer(JwtConsumer jwtConsumer, String jwtString)
+            throws InvalidTokenException, InvalidJwtException {
+        JwtContext validatedJwtContext = null;
+        try {
+            validatedJwtContext = jwtConsumer.process(jwtString);
+        } catch (InvalidJwtSignatureException e) {
+            String msg = Tr.formatMessage(tc, "JWT_INVALID_SIGNATURE", new Object[] { e.getLocalizedMessage() });
+            throw new InvalidTokenException(msg, e);
+        } catch (InvalidJwtException e) {
+            Throwable cause = getRootCause(e);
+            if (cause != null && cause instanceof InvalidKeyException) {
+                throw e;
+            } else {
+                // Don't have enough information to output a more useful error
+                // message
+                throw e;
+            }
+        }
+        return validatedJwtContext;
+    }
+
+    String getAlgorithmFromJwtHeader(JwtContext jwtContext) {
+        if (jwtContext == null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "JwtContext is null");
+            }
+            return null;
+        }
+        JsonWebStructure jwtHeader = null;
+        try {
+            jwtHeader = getJwtHeader(jwtContext);
+        } catch (Exception e) {
+            // TODO - NLS message?
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Failed to obtain JWT header");
+            }
+            return null;
+        }
+        String algHeader = jwtHeader.getAlgorithmHeaderValue();
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "JWT is signed with algorithm: ", algHeader);
+        }
+        return algHeader;
+    }
+
+    Throwable getRootCause(Exception e) {
+        Throwable rootCause = null;
+        Throwable tmpCause = e;
+        while (tmpCause != null) {
+            rootCause = tmpCause;
+            tmpCause = rootCause.getCause();
+        }
+        return rootCause;
+    }
+
+    String createDateString(NumericDate date) {
+        if (date == null) {
+            return null;
+        }
+        // NumericDate.getValue() returns a value in seconds, so convert to
+        // milliseconds
+        return timeUtils.createDateString(1000 * date.getValue());
+    }
 
 }

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/JwtComponent.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/JwtComponent.java
@@ -162,7 +162,7 @@ public class JwtComponent implements JwtConfig {
         jwkSigningKeySize = ((Long) props.get(JwtUtils.CFG_KEY_JWK_SIGNING_KEY_SIZE)).intValue();
         elapsedNbfTime = ((Long) props.get(JwtUtils.CFG_KEY_ELAPSED_NBF)).longValue();
 
-        if ("RS256".equals(sigAlg)) {
+        if (isJwkCapableSigAlgorithm()) {
             initializeJwkProvider(this);
         }
 
@@ -172,6 +172,13 @@ public class JwtComponent implements JwtConfig {
         } else {
             valid = valid * 3600;
         }
+    }
+
+    private boolean isJwkCapableSigAlgorithm() {
+        if (sigAlg == null) {
+            return false;
+        }
+        return sigAlg.matches("[RE]S[0-9]{3,}");
     }
 
     private void initializeJwkProvider(JwtConfig jwtConfig) {

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/Constants.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/Constants.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2016, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.jwt.utils;
 
@@ -16,6 +16,7 @@ public class Constants {
 
     public static final String SIGNATURE_ALG_HS256 = "HS256";
     public static final String SIGNATURE_ALG_RS256 = "RS256";
+    public static final String SIGNATURE_ALG_ES256 = "ES256";
 
     public static final String SIGNING_KEY_X509 = "x509";
     public static final String SIGNING_KEY_JWK = "jwk";

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JwtData.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JwtData.java
@@ -181,7 +181,7 @@ public class JwtData {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "RSAPrivateKey: " + (_signingKey instanceof RSAPrivateKey));
         }
-        if (_signingKey != null && !(_signingKey instanceof PrivateKey)) {
+        if (!isPrivateKeyValidType()) {
             // error handling
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "clear _signingKey and _keyId");
@@ -189,6 +189,16 @@ public class JwtData {
             _signingKey = null; // we will catch this later in jwtSigner
             _keyId = null;
         }
+    }
+
+    boolean isPrivateKeyValidType() {
+        if (_signingKey == null) {
+            return true;
+        }
+        if (signatureAlgorithm.matches("RS[0-9]{3,}")) {
+            return (_signingKey instanceof RSAPrivateKey);
+        }
+        return (_signingKey instanceof PrivateKey);
     }
 
     private String buildKidFromPublicKey(PublicKey cert) {

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JwtData.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JwtData.java
@@ -6,12 +6,16 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.jwt.utils;
 
+import java.io.UnsupportedEncodingException;
 import java.security.Key;
+import java.security.KeyStoreException;
+import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.cert.CertificateException;
 import java.security.interfaces.RSAPrivateKey;
 
 import org.jose4j.keys.HmacKey;
@@ -19,6 +23,7 @@ import org.jose4j.keys.HmacKey;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.websphere.security.jwt.InvalidTokenException;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.common.jwk.impl.JWKProvider;
 import com.ibm.ws.security.common.jwk.impl.JwkKidBuilder;
@@ -32,198 +37,204 @@ import com.ibm.ws.webcontainer.security.jwk.JSONWebKey;
  */
 public class JwtData {
 
-	private static final TraceComponent tc = Tr.register(JwtData.class);
+    private static final TraceComponent tc = Tr.register(JwtData.class);
 
-	private static final String SIGNATURE_ALG_HS256 = "HS256";
-	private static final String SIGNATURE_ALG_RS256 = "RS256";
-	private static final String SIGNATURE_ALG_NONE = "none";
+    private static final String SIGNATURE_ALG_HS256 = "HS256";
+    private static final String SIGNATURE_ALG_RS256 = "RS256";
+    private static final String SIGNATURE_ALG_NONE = "none";
 
-	// public static final String TYPE_ID_TOKEN = "ID Token";
-	public static final String TYPE_JWT_TOKEN = "Json Web Token";
+    // public static final String TYPE_ID_TOKEN = "ID Token";
+    public static final String TYPE_JWT_TOKEN = "Json Web Token";
 
-	boolean bIdToken = false;
-	boolean bJwtToken = false;
+    boolean bIdToken = false;
+    boolean bJwtToken = false;
 
-	private Key _signingKey = null;
-	private String _keyId = null;
+    private Key _signingKey = null;
+    private String _keyId = null;
 
-	JwtConfig jwtConfig = null;
-	JwtDataConfig jwtDataConfig = null;
-	String tokenType = TYPE_JWT_TOKEN;
-	JWKProvider jwkProvider = null;
+    JwtConfig jwtConfig = null;
+    JwtDataConfig jwtDataConfig = null;
+    String tokenType = TYPE_JWT_TOKEN;
+    JWKProvider jwkProvider = null;
 
-	String signatureAlgorithm = null;
-	JwtTokenException noKeyException = null;
+    String signatureAlgorithm = null;
+    JwtTokenException noKeyException = null;
 
-	public JwtData(BuilderImpl jwtBuilder, JwtConfig jwtConfig, String tokenType) throws JwtTokenException {
-		this.jwtConfig = jwtConfig;
-		this.tokenType = tokenType;
-		signatureAlgorithm = jwtBuilder.getAlgorithm();
-		bJwtToken = TYPE_JWT_TOKEN.equals(tokenType);
-		String sharedKey = jwtBuilder.getSharedKey();
-		sharedKey = (JwtUtils.isNullEmpty(sharedKey) ? jwtConfig.getSharedKey() : sharedKey);
-		jwtDataConfig = new JwtDataConfig(jwtBuilder.getAlgorithm(), jwtConfig.getJSONWebKey(), sharedKey,
-				jwtBuilder.getKey(), jwtConfig.getKeyAlias(), jwtConfig.getKeyStoreRef(), tokenType,
-				jwtConfig.isJwkEnabled());
-		initSigningKey(jwtDataConfig);
-	}
+    public JwtData(BuilderImpl jwtBuilder, JwtConfig jwtConfig, String tokenType) throws JwtTokenException {
+        this.jwtConfig = jwtConfig;
+        this.tokenType = tokenType;
+        signatureAlgorithm = jwtBuilder.getAlgorithm();
+        bJwtToken = TYPE_JWT_TOKEN.equals(tokenType);
+        String sharedKey = jwtBuilder.getSharedKey();
+        sharedKey = (JwtUtils.isNullEmpty(sharedKey) ? jwtConfig.getSharedKey() : sharedKey);
+        jwtDataConfig = new JwtDataConfig(jwtBuilder.getAlgorithm(), jwtConfig.getJSONWebKey(), sharedKey,
+                jwtBuilder.getKey(), jwtConfig.getKeyAlias(), jwtConfig.getKeyStoreRef(), tokenType,
+                jwtConfig.isJwkEnabled());
+        initSigningKey(jwtDataConfig);
+    }
 
-	public JwtData(JwtDataConfig config) throws JwtTokenException {
-		tokenType = config.tokenType;
-		jwtDataConfig = config;
-		signatureAlgorithm = config.signatureAlgorithm;
-		bJwtToken = TYPE_JWT_TOKEN.equals(tokenType);
-		initSigningKey(jwtDataConfig);
-	}
+    public JwtData(JwtDataConfig config) throws JwtTokenException {
+        tokenType = config.tokenType;
+        jwtDataConfig = config;
+        signatureAlgorithm = config.signatureAlgorithm;
+        bJwtToken = TYPE_JWT_TOKEN.equals(tokenType);
+        initSigningKey(jwtDataConfig);
+    }
 
-	public JwtConfig getConfig() {
-		return jwtConfig;
-	}
+    public JwtConfig getConfig() {
+        return jwtConfig;
+    }
 
-	/*
-	 * Handle the signingKey here to get the same error messages
-	 */
-	@FFDCIgnore(Exception.class)
-	// protected void initSigningKey(BuilderImpl jwtBuilder, JwtConfig jwtConfig)
-	// throws JwtTokenException {
-	protected void initSigningKey(JwtDataConfig config) throws JwtTokenException {
-		String keyType = Constants.SIGNING_KEY_X509;
-		try {
-			if (config.isJwkEnabled && SIGNATURE_ALG_RS256.equals(config.signatureAlgorithm)) {
-				keyType = Constants.SIGNING_KEY_JWK;
-				if (tc.isDebugEnabled()) {
-					Tr.debug(tc, "JWK + RS256 Signing key type is " + keyType);
-				}
-				JSONWebKey jwk = config.jwk;
-				if (jwk == null) {
-					if (tc.isDebugEnabled()) {
-						Tr.debug(tc, "Did not succcessfully build a JWK");
-					}
-					_signingKey = null;
-					_keyId = null;
-				} else {
-					_signingKey = jwk.getPrivateKey();
-					_keyId = jwk.getKeyID();
-				}
-			} else {
-				if (SIGNATURE_ALG_HS256.equals(signatureAlgorithm)) {
-					keyType = Constants.SIGNING_KEY_SECRET;
-					if (tc.isDebugEnabled()) {
-						Tr.debug(tc, "hs256 Signing key type is " + keyType);
-					}
-					String sharedKey = config.sharedKey;
-					if (!(sharedKey == null || sharedKey.isEmpty())) {
-						_signingKey = new HmacKey(sharedKey.getBytes("UTF-8"));
-					} else {
-						_signingKey = null;
-					}
+    /*
+     * Handle the signingKey here to get the same error messages
+     */
+    @FFDCIgnore(Exception.class)
+    // protected void initSigningKey(BuilderImpl jwtBuilder, JwtConfig jwtConfig)
+    // throws JwtTokenException {
+    protected void initSigningKey(JwtDataConfig config) throws JwtTokenException {
+        String keyType = Constants.SIGNING_KEY_X509;
+        try {
+            if (isJwkSignatureAlgorithmType(config)) {
+                initSigningKeyUsingJwk(config);
+            } else {
+                if (isHSSignatureAlgorithm()) {
+                    initSigningKeyUsingHSAlgorithm(config);
+                } else if (isSignatureAlgorithmUsingKeyStore()) {
+                    initSigningKeyUsingKeyStore(config, keyType);
+                }
+            }
+        } catch (Exception e) {
+            Object[] objs = new Object[] { signatureAlgorithm, jwtDataConfig.isJwkEnabled, e.getLocalizedMessage() }; // let JWTTokenException handle the exception
+            JwtTokenException jte = JwtTokenException.newInstance(false, "JWT_NO_SIGNING_KEY_WITH_ERROR", objs);
+            jte.initCause(e);
+            throw jte;
+        }
+        if (_signingKey == null && !signatureAlgorithm.equals(SIGNATURE_ALG_NONE)) {
+            Object[] objs = new Object[] { signatureAlgorithm, jwtDataConfig.isJwkEnabled, "" }; // let JWTTokenException handle the exception
+            throw JwtTokenException.newInstance(true, "JWT_NO_SIGNING_KEY_WITH_ERROR", objs);
+        }
+    }
 
-				} else if (SIGNATURE_ALG_RS256.equals(signatureAlgorithm)) {
-					_signingKey = config.signingKey;
-					if (tc.isDebugEnabled()) {
-						Tr.debug(tc, "RS256 Signing key type is " + keyType);
-					}
-					if (_signingKey == null) {
-						String keyAlias = null;
-						String keyStoreRef = null;
-						keyAlias = config.keyAlias;
-						keyStoreRef = config.keyStoreRef;
-						_signingKey = JwtUtils.getPrivateKey(keyAlias, keyStoreRef);
-						_keyId = buildKidFromPublicKey(JwtUtils.getPublicKey(keyAlias, keyStoreRef));
-						if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-							Tr.debug(tc, "Key alias: " + keyAlias + ", Keystore: " + keyStoreRef + ", kid: " + _keyId);
-						}
-					}
+    boolean isJwkSignatureAlgorithmType(JwtDataConfig config) {
+        // RSxxx or ESxxx signature algorithms
+        return config.isJwkEnabled && config.signatureAlgorithm.matches("[RE]S[0-9]{3,}");
+    }
 
-					if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-						Tr.debug(tc, "RSAPrivateKey: " + (_signingKey instanceof RSAPrivateKey));
-					}
-					if (_signingKey != null && !(_signingKey instanceof RSAPrivateKey)) {
-						// error handling
-						// String errorMsg = Tr.formatMessage(tc, "SIGNING_KEY_NOT_RSA", new Object[] {
-						// signatureAlgorithm });
-						// Object[] objs = new Object[] { signatureAlgorithm, errorMsg };
-						// noKeyException = JWTTokenException.newInstance(false, "JWT_BAD_SIGNING_KEY",
-						// objs);
-						if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-							Tr.debug(tc, "clear _signingKey and _keyId");
-						}
-						_signingKey = null; // we will catch this later in jwtSigner
-						_keyId = null;
-					}
-				}
-			}
-		} catch (Exception e) {
-			// UnsupportedEncodingException e (won't happen)
-			// if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-			// Tr.debug(tc, "Exception obtaining the signing key: " + e);
-			// }
-			// error messages
-			// JWT_BAD_SIGNING_KEY=CWWKS1455E: A signing key was not available. The
-			// signature algorithm is [{0}]. {1}
+    boolean isHSSignatureAlgorithm() {
+        // HSxxx signature algorithms
+        return signatureAlgorithm.matches("HS[0-9]{3,}");
+    }
 
-			Object[] objs = new Object[] { signatureAlgorithm, jwtDataConfig.isJwkEnabled, e.getLocalizedMessage() }; // let
-																														// JWTTokenException
-																														// handle
-																														// the
-																														// exception
-			JwtTokenException jte = JwtTokenException.newInstance(false, "JWT_NO_SIGNING_KEY_WITH_ERROR", objs);
-			jte.initCause(e);
-			throw jte;
-		}
-		if (_signingKey == null && !signatureAlgorithm.equals(SIGNATURE_ALG_NONE)) {
-			Object[] objs = new Object[] { signatureAlgorithm, jwtDataConfig.isJwkEnabled, "" }; // let
-																									// JWTTokenException
-																									// handle the
-																									// exception
-			throw JwtTokenException.newInstance(true, "JWT_NO_SIGNING_KEY_WITH_ERROR", objs);
-		}
-	}
+    boolean isSignatureAlgorithmUsingKeyStore() {
+        // RSxxx or ESxxx signature algorithms
+        return signatureAlgorithm.matches("[RE]S[0-9]{3,}");
+    }
 
-	private String buildKidFromPublicKey(PublicKey cert) {
-		JwkKidBuilder kidbuilder = new JwkKidBuilder();
-		return kidbuilder.buildKeyId(cert);
-	}
+    void initSigningKeyUsingJwk(JwtDataConfig config) {
+        String keyType = Constants.SIGNING_KEY_JWK;
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "JWK + RS256 Signing key type is " + keyType);
+        }
+        JSONWebKey jwk = config.jwk;
+        if (jwk == null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Did not succcessfully build a JWK");
+            }
+            _signingKey = null;
+            _keyId = null;
+        } else {
+            _signingKey = jwk.getPrivateKey();
+            _keyId = jwk.getKeyID();
+        }
+    }
 
-	public String getSignatureAlgorithm() {
-		return signatureAlgorithm;
-	}
+    void initSigningKeyUsingHSAlgorithm(JwtDataConfig config) throws UnsupportedEncodingException {
+        String keyType = Constants.SIGNING_KEY_SECRET;
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "hs256 Signing key type is " + keyType);
+        }
+        String sharedKey = config.sharedKey;
+        if (!(sharedKey == null || sharedKey.isEmpty())) {
+            _signingKey = new HmacKey(sharedKey.getBytes("UTF-8"));
+        } else {
+            _signingKey = null;
+        }
+    }
 
-	@Sensitive
-	public JwtData(Key key, String id) {
-		_signingKey = key;
-		_keyId = id;
-	}
+    void initSigningKeyUsingKeyStore(JwtDataConfig config, String keyType) throws KeyStoreException, CertificateException, InvalidTokenException {
+        _signingKey = config.signingKey;
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "Signing key type is " + keyType);
+        }
+        if (_signingKey == null) {
+            String keyAlias = null;
+            String keyStoreRef = null;
+            keyAlias = config.keyAlias;
+            keyStoreRef = config.keyStoreRef;
+            _signingKey = JwtUtils.getPrivateKey(keyAlias, keyStoreRef);
+            _keyId = buildKidFromPublicKey(JwtUtils.getPublicKey(keyAlias, keyStoreRef));
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Key alias: " + keyAlias + ", Keystore: " + keyStoreRef + ", kid: " + _keyId);
+            }
+        }
 
-	@Sensitive
-	public Key getSigningKey() {
-		return _signingKey;
-	}
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "RSAPrivateKey: " + (_signingKey instanceof RSAPrivateKey));
+        }
+        if (_signingKey != null && !(_signingKey instanceof PrivateKey)) {
+            // error handling
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "clear _signingKey and _keyId");
+            }
+            _signingKey = null; // we will catch this later in jwtSigner
+            _keyId = null;
+        }
+    }
 
-	public String getKeyID() {
-		return _keyId;
-	}
+    private String buildKidFromPublicKey(PublicKey cert) {
+        JwkKidBuilder kidbuilder = new JwkKidBuilder();
+        return kidbuilder.buildKeyId(cert);
+    }
 
-	/**
-	 * @return
-	 */
-	public String getTokenType() {
-		return tokenType;
-	}
+    public String getSignatureAlgorithm() {
+        return signatureAlgorithm;
+    }
 
-	public JwtTokenException getNoKeyException() {
-		if (noKeyException != null) {
-			return noKeyException;
-		} else {
-			// this should not happen
-			return new JwtTokenException("No signing key found");
-		}
-	}
+    @Sensitive
+    public JwtData(Key key, String id) {
+        _signingKey = key;
+        _keyId = id;
+    }
 
-	/**
-	 * @return
-	 */
-	public boolean isJwt() {
-		return bJwtToken;
-	}
+    @Sensitive
+    public Key getSigningKey() {
+        return _signingKey;
+    }
+
+    public String getKeyID() {
+        return _keyId;
+    }
+
+    /**
+     * @return
+     */
+    public String getTokenType() {
+        return tokenType;
+    }
+
+    public JwtTokenException getNoKeyException() {
+        if (noKeyException != null) {
+            return noKeyException;
+        } else {
+            // this should not happen
+            return new JwtTokenException("No signing key found");
+        }
+    }
+
+    /**
+     * @return
+     */
+    public boolean isJwt() {
+        return bJwtToken;
+    }
 }

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/web/JwtEndpointServices.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/web/JwtEndpointServices.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2016, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.jwt.web;
 
@@ -39,275 +39,288 @@ import com.ibm.wsspi.kernel.service.utils.ConcurrentServiceReferenceMap;
 
 @Component(service = JwtEndpointServices.class, name = "com.ibm.ws.security.jwt.web.JwtEndpointServices", immediate = true, configurationPolicy = ConfigurationPolicy.IGNORE, property = "service.vendor=IBM")
 public class JwtEndpointServices {
-	private static TraceComponent tc = Tr.register(JwtEndpointServices.class, TraceConstants.TRACE_GROUP,
-			TraceConstants.MESSAGE_BUNDLE);
+    private static TraceComponent tc = Tr.register(JwtEndpointServices.class, TraceConstants.TRACE_GROUP,
+            TraceConstants.MESSAGE_BUNDLE);
 
-	/***********************************
-	 * Begin OSGi-related fields and methods
-	 ***********************************/
+    /***********************************
+     * Begin OSGi-related fields and methods
+     ***********************************/
 
-	public static final String KEY_ID = "id";
-	public static final String KEY_JWT_CONFIG = "jwtConfig";
+    public static final String KEY_ID = "id";
+    public static final String KEY_JWT_CONFIG = "jwtConfig";
 
-	private final ConcurrentServiceReferenceMap<String, JwtConfig> jwtConfigRef = new ConcurrentServiceReferenceMap<String, JwtConfig>(
-			KEY_JWT_CONFIG);
+    private final ConcurrentServiceReferenceMap<String, JwtConfig> jwtConfigRef = new ConcurrentServiceReferenceMap<String, JwtConfig>(
+            KEY_JWT_CONFIG);
 
-	@Reference(service = JwtConfig.class, name = KEY_JWT_CONFIG, policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MULTIPLE, policyOption = ReferencePolicyOption.GREEDY)
-	protected void setJwtConfig(ServiceReference<JwtConfig> ref) {
-		synchronized (jwtConfigRef) {
-			if (tc.isDebugEnabled()) {
-				Tr.debug(tc, "Setting reference for " + ref.getProperty(KEY_ID));
-			}
-			jwtConfigRef.putReference((String) ref.getProperty(KEY_ID), ref);
-		}
-	}
+    @Reference(service = JwtConfig.class, name = KEY_JWT_CONFIG, policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MULTIPLE, policyOption = ReferencePolicyOption.GREEDY)
+    protected void setJwtConfig(ServiceReference<JwtConfig> ref) {
+        synchronized (jwtConfigRef) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Setting reference for " + ref.getProperty(KEY_ID));
+            }
+            jwtConfigRef.putReference((String) ref.getProperty(KEY_ID), ref);
+        }
+    }
 
-	protected void unsetJwtConfig(ServiceReference<JwtConfig> ref) {
-		synchronized (jwtConfigRef) {
-			jwtConfigRef.removeReference((String) ref.getProperty(KEY_ID), ref);
-		}
-	}
+    protected void unsetJwtConfig(ServiceReference<JwtConfig> ref) {
+        synchronized (jwtConfigRef) {
+            jwtConfigRef.removeReference((String) ref.getProperty(KEY_ID), ref);
+        }
+    }
 
-	@Activate
-	protected void activate(ComponentContext cc) {
-		jwtConfigRef.activate(cc);
+    @Activate
+    protected void activate(ComponentContext cc) {
+        jwtConfigRef.activate(cc);
 
-		Tr.info(tc, "JWT_ENDPOINT_SERVICE_ACTIVATED");
-	}
+        Tr.info(tc, "JWT_ENDPOINT_SERVICE_ACTIVATED");
+    }
 
-	@Deactivate
-	protected void deactivate(ComponentContext cc) {
-		jwtConfigRef.deactivate(cc);
-	}
+    @Deactivate
+    protected void deactivate(ComponentContext cc) {
+        jwtConfigRef.deactivate(cc);
+    }
 
-	/***********************************
-	 * End OSGi-related fields and methods
-	 ***********************************/
+    /***********************************
+     * End OSGi-related fields and methods
+     ***********************************/
 
-	protected void handleEndpointRequest(HttpServletRequest request, HttpServletResponse response,
-			ServletContext servletContext) throws IOException {
-		JwtRequest jwtRequest = getJwtRequest(request, response);
-		if (jwtRequest == null) {
-			// Error redirect already taken care of
-			return;
-		}
+    protected void handleEndpointRequest(HttpServletRequest request, HttpServletResponse response,
+            ServletContext servletContext) throws IOException {
+        JwtRequest jwtRequest = getJwtRequest(request, response);
+        if (jwtRequest == null) {
+            // Error redirect already taken care of
+            return;
+        }
 
-		String jwtConfigId = jwtRequest.getJwtConfigId();
-		JwtConfig jwtConfig = getJwtConfig(response, jwtConfigId);
-		if (jwtConfig == null) {
-			// Error redirect already taken care of
-			return;
-		}
+        String jwtConfigId = jwtRequest.getJwtConfigId();
+        JwtConfig jwtConfig = getJwtConfig(response, jwtConfigId);
+        if (jwtConfig == null) {
+            // Error redirect already taken care of
+            return;
+        }
 
-		EndpointType endpointType = jwtRequest.getType();
-		handleJwtRequest(request, response, servletContext, jwtConfig, endpointType);
+        EndpointType endpointType = jwtRequest.getType();
+        handleJwtRequest(request, response, servletContext, jwtConfig, endpointType);
 
-	}
+    }
 
-	/**
-	 * Extracts the {@value WebConstants#JWT_REQUEST_ATTR} attribute from the
-	 * provided request. That particular attribute is supposed to be created and
-	 * set by the filter directing the request.
-	 *
-	 * @param request
-	 * @param response
-	 * @return
-	 * @throws IOException
-	 */
-	private JwtRequest getJwtRequest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-		JwtRequest jwtRequest = (JwtRequest) request.getAttribute(WebConstants.JWT_REQUEST_ATTR);
-		if (jwtRequest == null) {
-			String errorMsg = Tr.formatMessage(tc, "JWT_REQUEST_ATTRIBUTE_MISSING",
-					new Object[] { request.getRequestURI(), WebConstants.JWT_REQUEST_ATTR });
-			Tr.error(tc, errorMsg);
-			response.sendError(HttpServletResponse.SC_NOT_FOUND, errorMsg);
-		}
-		return jwtRequest;
-	}
+    /**
+     * Extracts the {@value WebConstants#JWT_REQUEST_ATTR} attribute from the
+     * provided request. That particular attribute is supposed to be created and
+     * set by the filter directing the request.
+     *
+     * @param request
+     * @param response
+     * @return
+     * @throws IOException
+     */
+    private JwtRequest getJwtRequest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        JwtRequest jwtRequest = (JwtRequest) request.getAttribute(WebConstants.JWT_REQUEST_ATTR);
+        if (jwtRequest == null) {
+            String errorMsg = Tr.formatMessage(tc, "JWT_REQUEST_ATTRIBUTE_MISSING",
+                    new Object[] { request.getRequestURI(), WebConstants.JWT_REQUEST_ATTR });
+            Tr.error(tc, errorMsg);
+            response.sendError(HttpServletResponse.SC_NOT_FOUND, errorMsg);
+        }
+        return jwtRequest;
+    }
 
-	private JwtConfig getJwtConfig(HttpServletResponse response, String jwtConfigId) throws IOException {
-		JwtConfig jwtConfig = jwtConfigRef.getService(jwtConfigId);
-		if (jwtConfig == null) {
-			String errorMsg = Tr.formatMessage(tc, "JWT_CONFIG_SERVICE_NOT_AVAILABLE", new Object[] { jwtConfigId });
-			Tr.error(tc, errorMsg);
-			response.sendError(HttpServletResponse.SC_NOT_FOUND, errorMsg);
-		}
-		return jwtConfig;
-	}
+    private JwtConfig getJwtConfig(HttpServletResponse response, String jwtConfigId) throws IOException {
+        JwtConfig jwtConfig = jwtConfigRef.getService(jwtConfigId);
+        if (jwtConfig == null) {
+            String errorMsg = Tr.formatMessage(tc, "JWT_CONFIG_SERVICE_NOT_AVAILABLE", new Object[] { jwtConfigId });
+            Tr.error(tc, errorMsg);
+            response.sendError(HttpServletResponse.SC_NOT_FOUND, errorMsg);
+        }
+        return jwtConfig;
+    }
 
-	/**
-	 * Handle the request for the respective endpoint to which the request was
-	 * directed.
-	 *
-	 * @param request
-	 * @param response
-	 * @param servletContext
-	 * @param jwtConfig
-	 * @param endpointType
-	 * @throws IOException
-	 */
-	protected void handleJwtRequest(HttpServletRequest request, HttpServletResponse response,
-			ServletContext servletContext, JwtConfig jwtConfig, EndpointType endpointType) throws IOException {
-		if (jwtConfig == null) {
-			if (tc.isDebugEnabled()) {
-				Tr.debug(tc, "No JwtConfig object provided");
-			}
-			return;
-		}
-		switch (endpointType) {
-		case jwk:
-			processJWKRequest(response, jwtConfig);
-			return;
-		case token:
-			try {
-				if (!isTransportSecure(request)) {
-					String url = request.getRequestURL().toString();
-					Tr.error(tc, "SECURITY.JWT.ERROR.WRONG.HTTP.SCHEME", new Object[] { url });
-					response.sendError(HttpServletResponse.SC_NOT_FOUND,
-							Tr.formatMessage(tc, "SECURITY.JWT.ERROR.WRONG.HTTP.SCHEME", new Object[] { url }));
-					return;
-				}
+    /**
+     * Handle the request for the respective endpoint to which the request was
+     * directed.
+     *
+     * @param request
+     * @param response
+     * @param servletContext
+     * @param jwtConfig
+     * @param endpointType
+     * @throws IOException
+     */
+    protected void handleJwtRequest(HttpServletRequest request, HttpServletResponse response,
+            ServletContext servletContext, JwtConfig jwtConfig, EndpointType endpointType) throws IOException {
+        if (jwtConfig == null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "No JwtConfig object provided");
+            }
+            return;
+        }
+        switch (endpointType) {
+        case jwk:
+            processJWKRequest(response, jwtConfig);
+            return;
+        case token:
+            try {
+                if (!isTransportSecure(request)) {
+                    String url = request.getRequestURL().toString();
+                    Tr.error(tc, "SECURITY.JWT.ERROR.WRONG.HTTP.SCHEME", new Object[] { url });
+                    response.sendError(HttpServletResponse.SC_NOT_FOUND,
+                            Tr.formatMessage(tc, "SECURITY.JWT.ERROR.WRONG.HTTP.SCHEME", new Object[] { url }));
+                    return;
+                }
 
-				boolean result = request.authenticate(response);
-				if (tc.isDebugEnabled()) {
-					Tr.debug(tc, "request.authenticate result: " + result);
-				}
-				// if false, then not authenticated,
-				// a 401 w. auth challenge will be sent back and
-				// the response will be committed.
-				// Requester can then try again with creds on a new request.
-				if (result == false) {
-					return;
-				}
-			} catch (ServletException e) {
-				// ffdc
-				return;
-			}
-			processTokenRequest(response, jwtConfig);
-			return;
-		default:
-			break;
-		}
-	}
+                boolean result = request.authenticate(response);
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "request.authenticate result: " + result);
+                }
+                // if false, then not authenticated,
+                // a 401 w. auth challenge will be sent back and
+                // the response will be committed.
+                // Requester can then try again with creds on a new request.
+                if (result == false) {
+                    return;
+                }
+            } catch (ServletException e) {
+                // ffdc
+                return;
+            }
+            processTokenRequest(response, jwtConfig);
+            return;
+        default:
+            break;
+        }
+    }
 
-	/**
-	 * determine if transport is secure. Either the protocol must be https or we
-	 * must see a forwarding header that indicates it was https upstream of a
-	 * proxy. Use of a configuration property to allow plain http was rejected
-	 * in review.
-	 *
-	 * @param req
-	 * @return
-	 */
-	private boolean isTransportSecure(HttpServletRequest req) {
-		String url = req.getRequestURL().toString();
-		if (req.getScheme().equals("https")) {
-			return true;
-		}
+    /**
+     * determine if transport is secure. Either the protocol must be https or we
+     * must see a forwarding header that indicates it was https upstream of a
+     * proxy. Use of a configuration property to allow plain http was rejected
+     * in review.
+     *
+     * @param req
+     * @return
+     */
+    private boolean isTransportSecure(HttpServletRequest req) {
+        req.getRequestURL().toString();
+        if (req.getScheme().equals("https")) {
+            return true;
+        }
 
-		String value = req.getHeader("X-Forwarded-Proto");
-		if (value != null && value.toLowerCase().equals("https")) {
-			return true;
-		}
-		return false;
-	}
+        String value = req.getHeader("X-Forwarded-Proto");
+        if (value != null && value.toLowerCase().equals("https")) {
+            return true;
+        }
+        return false;
+    }
 
-	/**
-	 * produces a JWT token based upon the jwt Configuration, and the security
-	 * credentials of the authenticated user that called this method. Returns
-	 * the token as JSON in the response.
-	 *
-	 * @param response
-	 * @param jwtConfig
-	 * @throws IOException
-	 */
-	private void processTokenRequest(HttpServletResponse response, JwtConfig jwtConfig) throws IOException {
+    /**
+     * produces a JWT token based upon the jwt Configuration, and the security
+     * credentials of the authenticated user that called this method. Returns
+     * the token as JSON in the response.
+     *
+     * @param response
+     * @param jwtConfig
+     * @throws IOException
+     */
+    private void processTokenRequest(HttpServletResponse response, JwtConfig jwtConfig) throws IOException {
 
-		String tokenString = new TokenBuilder().createTokenString(jwtConfig);
-		addNoCacheHeaders(response);
-		response.setStatus(200);
+        String tokenString = new TokenBuilder().createTokenString(jwtConfig);
+        addNoCacheHeaders(response);
+        response.setStatus(200);
 
-		if (tokenString == null) {
-			return;
-		}
-		try {
-			PrintWriter pw = response.getWriter();
-			response.setHeader(WebConstants.HTTP_HEADER_CONTENT_TYPE, WebConstants.HTTP_CONTENT_TYPE_JSON);
-			pw.write("{\"token\": \"" + tokenString + "\"}");
-			pw.flush();
-			pw.close();
-		} catch (IOException e) {
-			if (tc.isDebugEnabled()) {
-				Tr.debug(tc, "Caught an exception attempting to get the response writer: " + e.getLocalizedMessage());
-			}
-		}
-	}
+        if (tokenString == null) {
+            return;
+        }
+        try {
+            PrintWriter pw = response.getWriter();
+            response.setHeader(WebConstants.HTTP_HEADER_CONTENT_TYPE, WebConstants.HTTP_CONTENT_TYPE_JSON);
+            pw.write("{\"token\": \"" + tokenString + "\"}");
+            pw.flush();
+            pw.close();
+        } catch (IOException e) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Caught an exception attempting to get the response writer: " + e.getLocalizedMessage());
+            }
+        }
+    }
 
-	/**
-	 * Obtains the JWK string that is active in the specified config and prints
-	 * it in JSON format in the response. If a JWK is not found, the response
-	 * will be empty.
-	 *
-	 * @param response
-	 * @param jwtConfig
-	 * @throws IOException
-	 */
-	private void processJWKRequest(HttpServletResponse response, JwtConfig jwtConfig) throws IOException {
+    /**
+     * Obtains the JWK string that is active in the specified config and prints
+     * it in JSON format in the response. If a JWK is not found, the response
+     * will be empty.
+     *
+     * @param response
+     * @param jwtConfig
+     * @throws IOException
+     */
+    private void processJWKRequest(HttpServletResponse response, JwtConfig jwtConfig) throws IOException {
 
-		/*
-		 * if (!jwtConfig.isJwkEnabled()) { String errorMsg =
-		 * Tr.formatMessage(tc, "JWK_ENDPOINT_JWK_NOT_ENABLED", new Object[] {
-		 * jwtConfig.getId() }); Tr.error(tc, errorMsg);
-		 * response.sendError(HttpServletResponse.SC_BAD_REQUEST, errorMsg);
-		 * return; }
-		 */
+        /*
+         * if (!jwtConfig.isJwkEnabled()) { String errorMsg =
+         * Tr.formatMessage(tc, "JWK_ENDPOINT_JWK_NOT_ENABLED", new Object[] {
+         * jwtConfig.getId() }); Tr.error(tc, errorMsg);
+         * response.sendError(HttpServletResponse.SC_BAD_REQUEST, errorMsg);
+         * return; }
+         */
 
-		String signatureAlg = jwtConfig.getSignatureAlgorithm();
-		if (!Constants.SIGNATURE_ALG_RS256.equals(signatureAlg)) {
-			String errorMsg = Tr.formatMessage(tc, "JWK_ENDPOINT_WRONG_ALGORITHM",
-					new Object[] { jwtConfig.getId(), signatureAlg, Constants.SIGNATURE_ALG_RS256 });
-			Tr.error(tc, errorMsg);
-			response.sendError(HttpServletResponse.SC_BAD_REQUEST, errorMsg);
-			return;
-		}
+        String signatureAlg = jwtConfig.getSignatureAlgorithm();
+        if (!isPossibleJwkAlgorithm(signatureAlg)) {
+            String errorMsg = Tr.formatMessage(tc, "JWK_ENDPOINT_WRONG_ALGORITHM",
+                    new Object[] { jwtConfig.getId(), signatureAlg, getAcceptableJwkSignatureAlgorithms() });
+            Tr.error(tc, errorMsg);
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, errorMsg);
+            return;
+        }
 
-		String jwkString = jwtConfig.getJwkJsonString();
+        String jwkString = jwtConfig.getJwkJsonString();
 
-		addNoCacheHeaders(response);
-		response.setStatus(200);
+        addNoCacheHeaders(response);
+        response.setStatus(200);
 
-		if (jwkString == null) {
-			return;
-		}
-		try {
-			PrintWriter pw = response.getWriter();
-			response.setHeader(WebConstants.HTTP_HEADER_CONTENT_TYPE, WebConstants.HTTP_CONTENT_TYPE_JSON);
-			pw.write(jwkString);
-			pw.flush();
-			pw.close();
-		} catch (IOException e) {
-			if (tc.isDebugEnabled()) {
-				Tr.debug(tc, "Caught an exception attempting to get the response writer: " + e.getLocalizedMessage());
-			}
-		}
-	}
+        if (jwkString == null) {
+            return;
+        }
+        try {
+            PrintWriter pw = response.getWriter();
+            response.setHeader(WebConstants.HTTP_HEADER_CONTENT_TYPE, WebConstants.HTTP_CONTENT_TYPE_JSON);
+            pw.write(jwkString);
+            pw.flush();
+            pw.close();
+        } catch (IOException e) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Caught an exception attempting to get the response writer: " + e.getLocalizedMessage());
+            }
+        }
+    }
 
-	/**
-	 * Adds header values to avoid caching of the provided response.
-	 *
-	 * @param response
-	 */
-	protected void addNoCacheHeaders(HttpServletResponse response) {
-		String cacheControlValue = response.getHeader(WebConstants.HEADER_CACHE_CONTROL);
+    boolean isPossibleJwkAlgorithm(String signatureAlgorithm) {
+        if (signatureAlgorithm == null) {
+            return false;
+        }
+        return signatureAlgorithm.matches("[RE]S[0-9]{3,}");
+    }
 
-		if (cacheControlValue != null && !cacheControlValue.isEmpty()) {
-			cacheControlValue = cacheControlValue + ", " + WebConstants.CACHE_CONTROL_NO_STORE;
-		} else {
-			cacheControlValue = WebConstants.CACHE_CONTROL_NO_STORE;
-		}
+    String getAcceptableJwkSignatureAlgorithms() {
+        // TODO more will be added
+        return Constants.SIGNATURE_ALG_RS256 + ", " +
+                Constants.SIGNATURE_ALG_ES256;
+    }
 
-		response.setHeader(WebConstants.HEADER_CACHE_CONTROL, cacheControlValue);
-		response.setHeader(WebConstants.HEADER_PRAGMA, WebConstants.PRAGMA_NO_CACHE);
-	}
+    /**
+     * Adds header values to avoid caching of the provided response.
+     *
+     * @param response
+     */
+    protected void addNoCacheHeaders(HttpServletResponse response) {
+        String cacheControlValue = response.getHeader(WebConstants.HEADER_CACHE_CONTROL);
+
+        if (cacheControlValue != null && !cacheControlValue.isEmpty()) {
+            cacheControlValue = cacheControlValue + ", " + WebConstants.CACHE_CONTROL_NO_STORE;
+        } else {
+            cacheControlValue = WebConstants.CACHE_CONTROL_NO_STORE;
+        }
+
+        response.setHeader(WebConstants.HEADER_CACHE_CONTROL, cacheControlValue);
+        response.setHeader(WebConstants.HEADER_PRAGMA, WebConstants.PRAGMA_NO_CACHE);
+    }
 
 }

--- a/dev/com.ibm.ws.security.jwt/test/com/ibm/ws/security/jwt/internal/ConsumerUtilTest.java
+++ b/dev/com.ibm.ws.security.jwt/test/com/ibm/ws/security/jwt/internal/ConsumerUtilTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -286,7 +286,7 @@ public class ConsumerUtilTest {
             ConsumerUtil testConsumerUtil = new ConsumerUtil(null);
             mockery.checking(new Expectations() {
                 {
-                    one(jwtConfig).getSignatureAlgorithm();
+                    allowing(jwtConfig).getSignatureAlgorithm();
                     will(returnValue(RS256));
                     one(jwtConfig).getJwkEnabled(); // for jwksUri(jwkEndpointUrl
                     will(returnValue(false)); //
@@ -316,7 +316,7 @@ public class ConsumerUtilTest {
             mockery.checking(new Expectations() {
                 {
 
-                    one(jwtConfig).getSignatureAlgorithm();
+                    allowing(jwtConfig).getSignatureAlgorithm();
                     will(returnValue(RS256));
                     one(jwtConfig).getJwkEnabled(); // for jwksUri
                     will(returnValue(false)); //
@@ -494,7 +494,7 @@ public class ConsumerUtilTest {
                 }
             });
             Key result = consumerUtil.getPublicKey(trustedAlias, trustStoreRef, randomAlg);
-            assertNull("Resulting key was not null when it should have been. Result: " + result, result);
+            assertEquals("Returned PublicKey did not match the expected object.", publicKey, result);
 
         } catch (Throwable t) {
             outputMgr.failWithThrowable(testName.getMethodName(), t);

--- a/dev/com.ibm.ws.security.mp.jwt/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.mp.jwt/resources/OSGI-INF/metatype/metatype.xml
@@ -49,6 +49,7 @@
         <AD id="signatureAlgorithm" required="false" type="String" name="%signatureAlgorithm" description="%signatureAlgorithm.desc" default="RS256">
             <Option label="%tokenSignAlgorithm.RS256" value="RS256" />
             <Option label="%tokenSignAlgorithm.HS256" value="HS256" />
+            <Option label="internal" value="ES256" />
         </AD>
     </OCD>
 


### PR DESCRIPTION
Initial drop for partial support for the ES256 signature algorithm. This is aimed primarily at getting the JWT builder and consumer to function with the algorithm, although I suspect the implementation may still be incomplete.