### PR TITLE
Issue 13323: Fix messages and resolve ACME test issues

### DIFF
--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeClient.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeClient.java
@@ -650,7 +650,7 @@ public class AcmeClient {
 				account = accountBuilder.create(session);
 			} catch (AcmeException e) {
 				throw handleAcmeException(e,
-						Tr.formatMessage(tc, "CWPKI2018E", acmeConfig.getDirectoryURI(), e.getMessage()));
+						Tr.formatMessage(tc, "CWPKI2018E", acmeConfig.getDirectoryURI(), getRootCauseMessage(e)));
 			}
 		}
 

--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/web/AcmeCaRestHandler.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/web/AcmeCaRestHandler.java
@@ -371,7 +371,7 @@ public class AcmeCaRestHandler implements RESTHandler {
 				return;
 			}
 		} else {
-			commitJsonResponse(response, 405, Tr.formatMessage(tc, "REST_METHOD_NOT_SUPPORTED"));
+			commitJsonResponse(response, 405, Tr.formatMessage(tc, "REST_METHOD_NOT_SUPPORTED", method));
 			return;
 		}
 	}

--- a/dev/com.ibm.ws.security.acme/src/org/shredzone/acme4j/connector/HttpConnector.java
+++ b/dev/com.ibm.ws.security.acme/src/org/shredzone/acme4j/connector/HttpConnector.java
@@ -37,7 +37,6 @@ import com.ibm.websphere.ssl.SSLConfig;
 import com.ibm.websphere.ssl.SSLException;
 import com.ibm.ws.security.acme.internal.AcmeConfigService;
 import com.ibm.ws.security.acme.internal.AcmeProviderImpl;
-import com.ibm.ws.security.acme.internal.util.AcmeConstants;
 import com.ibm.ws.ssl.provider.AbstractJSSEProvider;
 
 /**
@@ -119,6 +118,10 @@ public class HttpConnector {
 		} else {
 			connectTimeout = AcmeProviderImpl.getAcmeConfig().getHTTPConnectTimeout();
 			readTimeout = AcmeProviderImpl.getAcmeConfig().getHTTPReadTimeout();
+		}
+		if (tc.isDebugEnabled()) {
+			Tr.debug(tc, "Setting http timeouts for ACME calls, connectTimeout: " + connectTimeout
+					+ " and readTimeout: " + readTimeout);
 		}
 		conn.setConnectTimeout(connectTimeout);
 		conn.setReadTimeout(readTimeout);

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeConfigVariationsTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeConfigVariationsTest.java
@@ -72,7 +72,7 @@ import componenttest.topology.impl.LibertyServer;
 @Mode(TestMode.FULL)
 public class AcmeConfigVariationsTest {
 
-	@Server("com.ibm.ws.security.acme.fat.simple")
+	@Server("com.ibm.ws.security.acme.fat.config_var")
 	public static LibertyServer server;
 
 	protected static ServerConfiguration ORIGINAL_CONFIG;
@@ -301,8 +301,6 @@ public class AcmeConfigVariationsTest {
 		acmeTransportConfig.setTrustStore("INVALID_TRUSTSTORE");
 		acmeTransportConfig.setTrustStorePassword("INVALID_PASSWORD");
 		acmeTransportConfig.setTrustStoreType("INVALID_TYPE");
-		acmeTransportConfig.setHttpConnectTimeout("1ms");
-		acmeTransportConfig.setHttpReadTimeout("1ms");
 
 		AcmeCA acmeCA = configuration.getAcmeCA();
 		acmeCA.setAccountKeyFile(unreadableFile.getAbsolutePath());
@@ -482,37 +480,15 @@ public class AcmeConfigVariationsTest {
 			assertNotNull("Expected CWPKI2016E in logs.",
 					server.waitForStringInLog("CWPKI2016E.*https://invalid.com/directory"));
 
+			
 			/***********************************************************************
 			 * 
-			 * Set the domain key file to default. The request will now timeout on http connect.
+			 * Set the domain key file to default. The certificate should now be configured.
 			 * 
 			 **********************************************************************/
-			Log.info(AcmeConfigVariationsTest.class, testName.getMethodName(), "Test 14 - http connect timeout");
+			Log.info(AcmeConfigVariationsTest.class, testName.getMethodName(),
+					"Test 14 - successful certificate generation");
 			acmeCA.setDirectoryURI(caContainer.getAcmeDirectoryURI(false));
-			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration);
-			assertNotNull("Expected CWPKI2016E in logs.",
-					server.waitForStringInLog("CWPKI2016E.*SocketTimeoutException"));
-			
-			/***********************************************************************
-			 * 
-			 * Set the http connect time to better length. The request will now timeout on http read.
-			 * 
-			 **********************************************************************/
-			Log.info(AcmeConfigVariationsTest.class, testName.getMethodName(), "Test 15 - http read timeout");
-			server.setMarkToEndOfLog(server.getDefaultLogFile());
-			acmeTransportConfig.setHttpConnectTimeout("45s");
-			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration);
-			assertNotNull("Expected CWPKI2016E in logs.",
-					server.waitForStringInLog("CWPKI2016E.*SocketTimeoutException"));
-			
-			/***********************************************************************
-			 * 
-			 * Set the http read time to better length. The certificate should now be
-			 * configured.
-			 * 
-			 **********************************************************************/
-			Log.info(AcmeConfigVariationsTest.class, testName.getMethodName(), "Test 16 - successful certificate generation");
-			acmeTransportConfig.setHttpReadTimeout("45s");
 			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration);
 			AcmeFatUtils.waitForAcmeToCreateCertificate(server);
 			AcmeFatUtils.waitForSslToCreateKeystore(server);
@@ -670,6 +646,76 @@ public class AcmeConfigVariationsTest {
 			assertFalse("Slow app not installed", server.findStringsInLogs("SlowApp is sleeping").isEmpty());
 		} finally {
 			stopServer();
+		}
+	}
+
+	@Test
+	@CheckForLeakedPasswords(AcmeFatUtils.CACERTS_TRUSTSTORE_PASSWORD)
+	@AllowedFFDC(value = { "java.io.IOException", "org.shredzone.acme4j.exception.AcmeNetworkException" })
+	public void httpReadConnectTimeouts() throws Exception {
+
+		ServerConfiguration configuration = ORIGINAL_CONFIG.clone();
+		AcmeFatUtils.configureAcmeCA(server, caContainer, configuration, false, true, DOMAINS_1);
+
+		try {
+			Log.info(this.getClass(), testName.getMethodName(), "TEST 1: Start");
+
+			/*
+			 * Start the server and wait for the certificate to be installed.
+			 */
+			server.startServer();
+			AcmeFatUtils.waitForAcmeToCreateCertificate(server);
+			AcmeFatUtils.waitForSslToCreateKeystore(server);
+			AcmeFatUtils.waitForSslEndpoint(server);
+
+			/*
+			 * Verify that the server is now using a certificate signed by the CA.
+			 */
+			AcmeFatUtils.assertAndGetServerCertificate(server, caContainer);
+
+			/***********************************************************************
+			 * 
+			 * Set a super low http connect and read timeout
+			 * 
+			 **********************************************************************/
+			Log.info(AcmeConfigVariationsTest.class, testName.getMethodName(), "Test 2 - http connect timeout");
+			configuration = server.getServerConfiguration().clone();
+			AcmeTransportConfig acmeTransportConfig = new AcmeTransportConfig();
+			acmeTransportConfig.setHttpConnectTimeout("1ms");
+			configuration.getAcmeCA().setAcmeTransportConfig(acmeTransportConfig);
+			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration);
+			AcmeFatUtils.renewCertificate(server);
+			assertNotNull("Expected CWPKI2016E in logs.",
+					server.waitForStringInLog("CWPKI2016E.*SocketTimeoutException"));
+
+			/***********************************************************************
+			 * 
+			 * Set the http connect time to better length. The request will now timeout on
+			 * http read.
+			 * 
+			 **********************************************************************/
+			Log.info(AcmeConfigVariationsTest.class, testName.getMethodName(), "Test 3 - http read timeout");
+			server.setMarkToEndOfLog(server.getDefaultLogFile());
+			acmeTransportConfig.setHttpConnectTimeout("45s");
+			acmeTransportConfig.setHttpReadTimeout("1ms");
+			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration);
+			AcmeFatUtils.renewCertificate(server);
+			assertNotNull("Expected CWPKI2016E in logs.",
+					server.waitForStringInLog("CWPKI2016E.*SocketTimeoutException"));
+
+			/***********************************************************************
+			 * 
+			 * Set the http read time to better length. The certificate should now be
+			 * configured.
+			 * 
+			 **********************************************************************/
+			Log.info(AcmeConfigVariationsTest.class, testName.getMethodName(),
+					"Test 4 - successful certificate generation");
+			acmeTransportConfig.setHttpReadTimeout("45s");
+			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration);
+
+		} finally {
+			stopServer("CWPKI2016E");
 		}
 	}
 }

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
@@ -11,6 +11,7 @@
 
 package com.ibm.ws.security.acme.utils;
 
+import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
@@ -36,16 +37,20 @@ import java.util.List;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSession;
+import javax.xml.bind.DatatypeConverter;
 
+import org.apache.http.Header;
 import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.conn.ManagedHttpClientConnection;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustAllStrategy;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.ConnectionShutdownException;
@@ -53,6 +58,7 @@ import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.HttpCoreContext;
 import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.util.EntityUtils;
 
 import com.ibm.websphere.simplicity.config.AcmeCA;
 import com.ibm.websphere.simplicity.config.AcmeCA.AcmeTransportConfig;
@@ -62,7 +68,9 @@ import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.crypto.certificateutil.DefaultSSLCertificateCreator;
 import com.ibm.ws.crypto.certificateutil.keytool.KeytoolSSLCertificateCreator;
 import com.ibm.ws.security.acme.docker.CAContainer;
-import com.ibm.ws.security.acme.docker.pebble.PebbleContainer;
+import com.ibm.ws.security.acme.fat.AcmeRevocationTest;
+import com.ibm.ws.security.acme.fat.AcmeValidityAndRenewTest;
+import com.ibm.ws.security.acme.internal.web.AcmeCaRestHandler;
 
 import componenttest.topology.impl.LibertyServer;
 
@@ -622,7 +630,7 @@ public class AcmeFatUtils {
 			 * Send the GET request and process the response.
 			 */
 			try (final CloseableHttpResponse response = httpclient.execute(httpGet, context)) {
-				AcmeFatUtils.logHttpResponse(PebbleContainer.class, methodName, httpGet, response);
+				AcmeFatUtils.logHttpResponse(AcmeFatUtils.class, methodName, httpGet, response);
 
 				StatusLine statusLine = response.getStatusLine();
 				if (statusLine.getStatusCode() != 200) {
@@ -849,11 +857,14 @@ public class AcmeFatUtils {
 	 * @return True if the test is running on the specific OS/JDK combo
 	 */
 	public static boolean isWindowsWithOpenJDK(String methodName) {
-		if (System.getProperty("os.name").toLowerCase().startsWith("win")
-				&& System.getProperty("java.vendor").toLowerCase().contains("openjdk")
-				&& (System.getProperty("java.version").equals("11.0.5")
-						|| System.getProperty("java.version").equals("14.0.1")
-						|| System.getProperty("java.version").equals("11"))) {
+		String os = System.getProperty("os.name").toLowerCase();
+		String javaVendor = System.getProperty("java.vendor").toLowerCase();
+		String javaVersion = System.getProperty("java.version");
+		Log.info(AcmeFatUtils.class, methodName,
+				"Checking os.name: " + os + " java.vendor: " + javaVendor + " java.version: " + javaVersion);
+		if (os.startsWith("win")
+				&& (javaVendor.contains("openjdk") || javaVendor.contains(("SUN_ORACLE").toLowerCase()))
+				&& (javaVersion.equals("11.0.5") || javaVersion.equals("14.0.1") || javaVersion.equals("11"))) {
 			/*
 			 * On Windows with OpenJDK 11.0.5 (and others), we sometimes get an exception deleting the
 			 * Acme related files.
@@ -889,4 +900,52 @@ public class AcmeFatUtils {
 		tempList.add(alwaysAdd);
 		server.stopServer(tempList.toArray(new String[tempList.size()]));
  	}
+
+	/**
+	 * Issue a POST request to the ACME REST API to renew the certificate
+	 * 
+	 * @return The JSON response.
+	 * @throws Exception
+	 *                       if the request failed.
+	 */
+	public static String renewCertificate(LibertyServer server) throws Exception {
+		final String methodName = "renewCertificate()";
+		Log.info(AcmeFatUtils.class, methodName, "RenewCertificate request");
+
+		try (CloseableHttpClient httpclient = AcmeFatUtils.getInsecureHttpsClient()) {
+
+			/*
+			 * Create a POST request to the Liberty server.
+			 */
+			HttpPost httpPost = new HttpPost("https://localhost:" + server.getHttpDefaultSecurePort() + "/ibm/api"
+					+ AcmeCaRestHandler.PATH_CERTIFICATE);
+			httpPost.setHeader("Authorization", "Basic " + DatatypeConverter
+					.printBase64Binary((AcmeFatUtils.ADMIN_USER + ":" + AcmeFatUtils.ADMIN_PASS).getBytes()));
+			httpPost.setHeader("Content-Type", "application/json");
+			httpPost.setEntity(new StringEntity("{\"operation\":\"renewCertificate\"}"));
+
+			/*
+			 * Send the POST request and process the response.
+			 */
+			try (final CloseableHttpResponse response = httpclient.execute(httpPost)) {
+				AcmeFatUtils.logHttpResponse(AcmeRevocationTest.class, methodName, httpPost, response);
+
+				StatusLine statusLine = response.getStatusLine();
+				assertEquals("Unexpected status code response.", 200, statusLine.getStatusCode());
+
+				/*
+				 * Check content type header.
+				 */
+				Header[] headers = response.getHeaders("content-type");
+				assertNotNull("Expected content type header.", headers);
+				assertEquals("Expected 1 content type header.", 1, headers.length);
+				assertEquals("Unexpected content type.", "application/json", headers[0].getValue());
+
+				String contentString = EntityUtils.toString(response.getEntity());
+				Log.info(AcmeValidityAndRenewTest.class, methodName, "HTTP post contents: \n" + contentString);
+
+				return contentString;
+			}
+		}
+	}
 }

--- a/dev/com.ibm.ws.security.acme_fat/publish/servers/com.ibm.ws.security.acme.fat.config_var/bootstrap.properties
+++ b/dev/com.ibm.ws.security.acme_fat/publish/servers/com.ibm.ws.security.acme.fat.config_var/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info=enabled:ACME=all:com.ibm.ws.ssl.*=all

--- a/dev/com.ibm.ws.security.acme_fat/publish/servers/com.ibm.ws.security.acme.fat.config_var/server.xml
+++ b/dev/com.ibm.ws.security.acme_fat/publish/servers/com.ibm.ws.security.acme.fat.config_var/server.xml
@@ -1,0 +1,30 @@
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+	<featureManager>
+		<feature>acmeCA-2.0</feature>
+		<feature>appSecurity-3.0</feature>
+	</featureManager>
+
+ 	<include location="../fatTestCommon.xml" />
+	
+	<keyStore id="defaultKeyStore" password="acmepassword"/>
+
+	<basicRegistry realm="basicRealm">
+		<user name="administrator" password="adminpass" />
+	</basicRegistry>
+
+	<administrator-role>
+		<user>administrator</user>
+	</administrator-role>
+
+</server>


### PR DESCRIPTION
Fixes #13323 

Based on several BB from the weekend, several small changes:

- Added another vendor to the isWindows check to match the failing Build config
- Fixed a Rest message (missing method)
- Added the causeby for another spot where we can get the generic `Network error` message from amce4j
- Moved the HTTP timeout tests to their own method
- Made the renew certificate request a helper method
- Added trace to the HTTPConnector class