### PR TITLE
Remove Java8 requirement in OpenTracing 2.0 features

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenTracing-2.0/io.openliberty.mpOpenTracing-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenTracing-2.0/io.openliberty.mpOpenTracing-2.0.feature
@@ -13,7 +13,6 @@ IBM-API-Package: \
     io.openliberty.org.eclipse.microprofile.opentracing-2.0, \
     com.ibm.websphere.appserver.mpConfig-1.4
 -bundles=\
-    com.ibm.ws.require.java8, \
     io.openliberty.microprofile.opentracing.2.0.internal
 kind=noship
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-2.0/io.openliberty.opentracing-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-2.0/io.openliberty.opentracing-2.0.feature
@@ -13,8 +13,7 @@ IBM-API-Package: io.opentracing;  type="third-party",\
 -features=com.ibm.websphere.appserver.jaxrs-2.1, \
           com.ibm.websphere.appserver.cdi-2.0, \
           com.ibm.websphere.appserver.mpConfig-1.4
--bundles=com.ibm.ws.require.java8, \
-         com.ibm.ws.jaxrs.defaultexceptionmapper, \
+-bundles=com.ibm.ws.jaxrs.defaultexceptionmapper, \
          io.openliberty.opentracing.2.0.internal, \
          io.openliberty.opentracing.2.0.internal.cdi, \
          io.openliberty.io.opentracing.opentracing-util.0.33.0, \


### PR DESCRIPTION
#13267 removed `com.ibm.ws.require.java8` but the OpenTracing 2.0 features got a clean build before #13267 was merged.  This is to remove `com.ibm.ws.require.java8` in the OpenTracing 2.0 features.