### PR TITLE
Remove Javadoc in ConnectionWaitTimeoutException

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/websphere/ce/cm/ConnectionWaitTimeoutException.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/websphere/ce/cm/ConnectionWaitTimeoutException.java
@@ -12,120 +12,86 @@ package com.ibm.websphere.ce.cm;
 
 import java.sql.SQLTransientConnectionException;
 
-/**
- * Used as a chained exception when unable to allocate a connection before the connection timeout is reached.
- * Would like to get rid of this and combine with top level exception, but could any application code be relying
- * on the chained exception?
- */
+// Note:  This class is not used to generate any Javadoc for ConnectionWaitTimeoutException, 
+// so it has all been changed to non-Javadoc formatted comments.
+// To change the Javadoc for ConnectionWaitTimeoutException, please change the other copy.
+// If code changes or comment changes are made here, please update the other copy as well.
+
+
+// Used as a chained exception when unable to allocate a connection before the connection timeout is reached.
 public class ConnectionWaitTimeoutException extends SQLTransientConnectionException {
     private static final long serialVersionUID = 5958695928250441720L;
 
-    /**
-     * Constructs a <code>ConnectionWaitTimeoutException</code> object.
-     * The <code>reason</code>, <code>SQLState</code> are initialized
-     * to <code>null</code> and the vendor code is initialized to 0.
-     * <p>
-     */
+    // Constructs a ConnectionWaitTimeoutException object.
+    // The reason and SQLState are initialized to null and the vendor code is initialized to 0.
     public ConnectionWaitTimeoutException() {
         super();
     }
 
-    /**
-     * Constructs a <code>ConnectionWaitTimeoutException</code> object
-     * with a given <code>reason</code>. The <code>SQLState</code>
-     * is initialized to <code>null</code> and the vendor code is initialized
-     * to 0.
-     * <p>
-     * @param reason a description of the exception
-     */
+    // Constructs a ConnectionWaitTimeoutException object with a given reason. 
+    // The SQLState is initialized to null and the vendor code is initialized to 0.
+    //
+    // parameter reason is a description of the exception.
     public ConnectionWaitTimeoutException(String reason) {
         super(reason);
     }
 
-    /**
-     * Constructs a <code>ConnectionWaitTimeoutException</code> object
-     * with a given <code>reason</code> and <code>SQLState</code>.
-     * 
-     * The vendor code is initialized to 0.
-     * <p>
-     * @param reason a description of the exception
-     * @param SQLState an XOPEN or SQL:2003 code identifying the exception
-     */
+    // Constructs a ConnectionWaitTimeoutException object with a given reason and SQLState.
+    // The vendor code is initialized to 0.
+    //
+    // parameter reason is a description of the exception.
+    // parameter SQLState is an XOPEN or SQL:2003 code identifying the exception.
     public ConnectionWaitTimeoutException(String reason, String SQLState) {
         super(reason,SQLState);
     }
 
-    /**
-     * Constructs a <code>ConnectionWaitTimeoutException</code> object
-     * with a given <code>reason</code>, <code>SQLState</code>  and
-     * <code>vendorCode</code>.
-     * <p>
-     * @param reason a description of the exception
-     * @param SQLState an XOPEN or SQL:2003 code identifying the exception
-     * @param vendorCode a database vendor specific exception code
-     */
+    // Constructs a ConnectionWaitTimeoutException object with a given reason, SQLState and vendorCode.
+    //
+    // parameter reason is a description of the exception.
+    // parameter SQLState is an XOPEN or SQL:2003 code identifying the exception.
+    // parameter vendorCode is a database vendor specific exception code.
     public ConnectionWaitTimeoutException(String reason, String SQLState, int vendorCode) {
         super(reason,SQLState,vendorCode);
     }
 
-    /**
-     * Constructs a <code>ConnectionWaitTimeoutException</code> object
-     * with a given  <code>cause</code>.
-     * The <code>SQLState</code> is initialized
-     * to <code>null</code> and the vendor code is initialized to 0.
-     * The <code>reason</code>  is initialized to <code>null</code> if
-     * <code>cause==null</code> or to <code>cause.toString()</code> if
-     * <code>cause!=null</code>.
-     * <p>
-     * @param cause the underlying reason for this <code>SQLException</code> (which is saved for later retrieval by the <code>getCause()</code> method); may be null indicating
-     *     the cause is non-existent or unknown.
-     */
+    // Constructs a ConnectionWaitTimeoutException object with a given cause.
+    // The SQLState is initialized to null and the vendor code is initialized to 0.
+    // The reason is initialized to null if cause==null or to cause.toString() if cause!=null.
+    //
+    // parameter cause is the underlying reason for this SQLException (which is saved for later retrieval by the getCause() method);
+    //           may be null indicating the cause is non-existent or unknown.
     public ConnectionWaitTimeoutException(Throwable cause) {
         super(cause);
     }
 
-    /**
-     * Constructs a <code>ConnectionWaitTimeoutException</code> object
-     * with a given
-     * <code>reason</code> and  <code>cause</code>.
-     * The <code>SQLState</code> is  initialized to <code>null</code>
-     * and the vendor code is initialized to 0.
-     * <p>
-     * @param reason a description of the exception.
-     * @param cause the underlying reason for this <code>SQLException</code>(which is saved for later retrieval by the <code>getCause()</code> method); may be null indicating
-     *     the cause is non-existent or unknown.
-     */
+    // Constructs a ConnectionWaitTimeoutException object with a given reason and cause.
+    // The SQLState is initialized to null and the vendor code is initialized to 0.
+    //
+    // parameter reason is a description of the exception.
+    // parameter cause is the underlying reason for this SQLException (which is saved for later retrieval by the getCause() method); 
+    //           may be null indicating the cause is non-existent or unknown.
     public ConnectionWaitTimeoutException(String reason, Throwable cause) {
         super(reason,cause);
     }
 
-    /**
-     * Constructs a <code>ConnectionWaitTimeoutException</code> object
-     * with a given
-     * <code>reason</code>, <code>SQLState</code> and  <code>cause</code>.
-     * The vendor code is initialized to 0.
-     * <p>
-     * @param reason a description of the exception.
-     * @param SQLState an XOPEN or SQL:2003 code identifying the exception
-     * @param cause the underlying reason for this <code>SQLException</code> (which is saved for later retrieval by the <code>getCause()</code> method); may be null indicating
-     *     the cause is non-existent or unknown.
-     */
+    // Constructs a ConnectionWaitTimeoutException object with a given reason, SQLState and cause.
+    // The vendor code is initialized to 0.
+    //
+    // parameter reason is a description of the exception.
+    // parameter SQLState is an XOPEN or SQL:2003 code identifying the exception.
+    // parameter cause is the underlying reason for this SQLException (which is saved for later retrieval by the getCause() method); 
+    //           may be null indicating the cause is non-existent or unknown.
     public ConnectionWaitTimeoutException(String reason, String SQLState, Throwable cause) {
         super(reason,SQLState,cause);
     }
 
-    /**
-     *  Constructs a <code>ConnectionWaitTimeoutException</code> object
-     * with a given
-     * <code>reason</code>, <code>SQLState</code>, <code>vendorCode</code>
-     * and  <code>cause</code>.
-     * <p>
-     * @param reason a description of the exception
-     * @param SQLState an XOPEN or SQL:2003 code identifying the exception
-     * @param vendorCode a database vendor-specific exception code
-     * @param cause the underlying reason for this <code>SQLException</code> (which is saved for later retrieval by the <code>getCause()</code> method); may be null indicating
-     *     the cause is non-existent or unknown.
-     */
+    // Constructs a ConnectionWaitTimeoutException object with a given reason, SQLState, vendorCode and cause.
+    //
+    // parameter reason is a description of the exception.
+    // parameter SQLState is an XOPEN or SQL:2003 code identifying the exception.
+    // parameter vendorCode is a database vendor-specific exception code.
+    // parameter cause is the underlying reason for this SQLException (which is saved for later retrieval by the getCause() method); 
+    //           may be null indicating the cause is non-existent or unknown.
     public ConnectionWaitTimeoutException(String reason, String SQLState, int vendorCode, Throwable cause) {
         super(reason,SQLState,vendorCode,cause);
     }


### PR DESCRIPTION
Updated Javadoc and class comments to match/distinguish the duplicate class in CL.

Primarily cleaned up the spacing, layout and grammatical formatting that would appear in the Javadoc.

Related to CL CWTE epic:
#20885