### PR TITLE
Correct servlet31 and40 fat server configuration issues

### DIFF
--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/FormLoginReadListenerTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/FormLoginReadListenerTest.java
@@ -20,8 +20,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
 import java.util.Set;
+import java.util.logging.Logger;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
@@ -29,7 +29,6 @@ import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.protocol.HTTP;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -44,10 +43,10 @@ import com.ibm.ws.fat.util.SharedServer;
 import com.ibm.ws.webcontainer.security.test.servlets.PostParamsClient;
 
 import componenttest.annotation.SkipForRepeat;
-import componenttest.topology.impl.LibertyServer;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
 
 //Temporarily skipped for EE9 jakarta until jakarta repeat bug is fixed and jakartaee 9 feature is developed
 @Mode(TestMode.FULL)
@@ -79,21 +78,23 @@ public class FormLoginReadListenerTest extends LoggingTest {
             Set<String> appInstalled = SHARED_SERVER.getLibertyServer().getInstalledAppNames(FORM_LOGIN_READ_LISTENER_APP_NAME);
             LOG.info("addAppToServer : " + FORM_LOGIN_READ_LISTENER_APP_NAME + " already installed : " + !appInstalled.isEmpty());
             if (appInstalled.isEmpty())
-              ShrinkHelper.exportAppToServer(SHARED_SERVER.getLibertyServer(), FormLoginReadListenerApp);
-          }
+                ShrinkHelper.exportAppToServer(SHARED_SERVER.getLibertyServer(), FormLoginReadListenerApp);
+        }
         //Replace config for the other server
         LibertyServer wlp = SHARED_SERVER.getLibertyServer();
         wlp.saveServerConfiguration();
         wlp.setServerConfigurationFile("FormLogin_ReadListener/server.xml");
-        
+
         SHARED_SERVER.startIfNotStarted();
-        SHARED_SERVER.getLibertyServer().waitForStringInLog("CWWKZ0001I.* " + FORM_LOGIN_READ_LISTENER_APP_NAME);
+        wlp.waitForStringInLog("CWWKZ0001I.* " + FORM_LOGIN_READ_LISTENER_APP_NAME);
     }
-    
+
     @AfterClass
     public static void testCleanup() throws Exception {
         // test cleanup
+        SHARED_SERVER.getLibertyServer().setMarkToEndOfLog();
         SHARED_SERVER.getLibertyServer().restoreServerConfiguration();
+        SHARED_SERVER.getLibertyServer().waitForConfigUpdateInLogUsingMark(null);
         if (SHARED_SERVER.getLibertyServer() != null && SHARED_SERVER.getLibertyServer().isStarted()) {
             SHARED_SERVER.getLibertyServer().stopServer("SRVE8015E:.*");
         }
@@ -177,7 +178,7 @@ public class FormLoginReadListenerTest extends LoggingTest {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.ws.fat.util.LoggingTest#getSharedServer()
      */
     @Override

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/publish/files/FormLogin_ReadListener/server.xml
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/publish/files/FormLogin_ReadListener/server.xml
@@ -8,32 +8,34 @@
     Contributors:
         IBM Corporation - initial API and implementation
  -->
-<server description="JASPIC 1.1 Security FAT">
+<server description="FormLogin_ReadListener">
 
-	<featureManager>
-		<feature>javaee-7.0</feature>
-	</featureManager>
+    <featureManager>
+        <feature>jaspic-1.1</feature>
+        <feature>servlet-3.1</feature>
+        <feature>jsp-2.3</feature>
+    </featureManager>
 
     <keyStore id="defaultKeyStore" password="{xor}EzY9Oi0rJg==" /> <!-- pwd: Liberty, expires 1/4/2099 -->
 
-	<basicRegistry id="basic1" realm="TestRealm">
-		<user name="user1" password="user1Login" />
-		<group name="group1">
-			<member name="user1" />
-		</group>
-	</basicRegistry>
+    <basicRegistry id="basic1" realm="TestRealm">
+        <user name="user1" password="user1Login" />
+        <group name="group1">
+            <member name="user1" />
+        </group>
+    </basicRegistry>
 
- 	<application type="war" id="FormLogin_ReadListener" name="FormLogin_ReadListener" location="FormLogin_ReadListener.war">
- 		<application-bnd>
-			<security-role name="servlet31Test_basic">
-				<user name="user1" />
-				<group name="group1" />
-			</security-role>	
-		</application-bnd>
-	</application>
-	
-	<webContainer servlet31.private.buffersizeforlargepostdata="4096" />
-	<webAppSecurity postParamCookieSize="65536" />
-	
-	<include location="../fatTestPorts.xml" />
+    <application type="war" id="FormLogin_ReadListener" name="FormLogin_ReadListener" location="FormLogin_ReadListener.war">
+        <application-bnd>
+            <security-role name="servlet31Test_basic">
+                <user name="user1" />
+                <group name="group1" />
+            </security-role>
+        </application-bnd>
+    </application>
+
+    <webContainer servlet31.private.buffersizeforlargepostdata="4096" />
+    <webAppSecurity postParamCookieSize="65536" />
+
+    <include location="../fatTestPorts.xml" />
 </server>

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCSameSiteCookieAttributeTests.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCSameSiteCookieAttributeTests.java
@@ -390,7 +390,6 @@ public class WCSameSiteCookieAttributeTests {
 
         ServerConfiguration configuration = sameSiteServer.getServerConfiguration();
         LOG.info("Server configuration that was saved: " + configuration);
-        LOG.info("Server configuration that was saved: " + sameSiteServer.getServerConfigurationFile().toString());
 
         HttpEndpoint httpEndpoint = configuration.getHttpEndpoints().getById("defaultHttpEndpoint");
         httpEndpoint.getSameSite().setLax("cookieOne");


### PR DESCRIPTION
fixes #13378

1) Update the FormLogin_ReadListener/server.xml  description, white space, also only specify the necessary features there is no need to pull in all of `javaee-7.0` for this test case. 
2) FormLoginReadListenerTest.java  need to wait for the configuration update to take place during the testCleanup.
3) WCSameSiteCookieAttributeTests.java  -> Remove the following code as it is not needed:
`LOG.info("Server configuration that was saved: " + sameSiteServer.getServerConfigurationFile().toString());`