### PR TITLE
Issue #13309: Allow EJB Local to extend RMI Remote

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/ejbcontainer/jitdeploy/EJBWrapper.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/ejbcontainer/jitdeploy/EJBWrapper.java
@@ -206,7 +206,8 @@ public final class EJBWrapper {
         String internalParentName = getParentClassName(wrapperType, internalEJBClassName);
 
         // Remote Business interfaces may or may not extend java.rmi.Remote
-        boolean isRmiRemote = (Remote.class).isAssignableFrom(wrapperInterface);
+        // EJBDeploy allowed local interfaces to extend java.rmi.Remote, but did not treat differently
+        boolean isRmiRemote = (wrapperType == REMOTE || wrapperType == REMOTE_HOME || wrapperType == BUSINESS_REMOTE) ? (Remote.class).isAssignableFrom(wrapperInterface) : false;
 
         // For No-Interface View (LocalBean), switch the interface and parent
         // names, as the EJB itself must be the parent and it will implement

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionBean.jar/src/com/ibm/ws/ejbcontainer/exception/ejb/SLRemoteExLocalRemote.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionBean.jar/src/com/ibm/ws/ejbcontainer/exception/ejb/SLRemoteExLocalRemote.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.ejbcontainer.exception.ejb;
+
+import java.io.IOException;
+import java.rmi.Remote;
+import java.rmi.RemoteException;
+
+import javax.ejb.EJBLocalObject;
+
+/**
+ * Local interface for Enterprise Bean: SLRemoteExLocalRemoteBean
+ */
+public interface SLRemoteExLocalRemote extends EJBLocalObject, Remote {
+
+    void testMethodwithNoEx(String exceptionToThrow);
+
+    void testMethodwithException(String exceptionToThrow) throws Exception;
+
+    void testMethodwithExceptionAndRemote(String exceptionToThrow) throws Exception, RemoteException;
+
+    void testMethodwithExceptionAndRemoteSub(String exceptionToThrow) throws Exception, SLRemoteException;
+
+    void testMethodwithExceptionAndRemoteAndRemoteSub(String exceptionToThrow) throws Exception, RemoteException, SLRemoteException;
+
+    void testMethodwithIOException(String exceptionToThrow) throws IOException;
+
+    void testMethodwithIOExceptionAndRemote(String exceptionToThrow) throws IOException, RemoteException;
+
+    void testMethodwithIOExceptionAndRemoteSub(String exceptionToThrow) throws IOException, SLRemoteException;
+
+    void testMethodwithIOExceptionAndRemoteAndRemoteSub(String exceptionToThrow) throws IOException, RemoteException, SLRemoteException;
+
+    void testMethodwithRemoteEx(String exceptionToThrow) throws RemoteException;
+
+    void testMethodwithRemoteExAndSub(String exceptionToThrow) throws RemoteException, SLRemoteException;
+
+    void testMethodwithRemoteExSub(String exceptionToThrow) throws SLRemoteException;
+}

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionBean.jar/src/com/ibm/ws/ejbcontainer/exception/ejb/SLRemoteExLocalRemoteBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionBean.jar/src/com/ibm/ws/ejbcontainer/exception/ejb/SLRemoteExLocalRemoteBean.java
@@ -1,0 +1,235 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.ejbcontainer.exception.ejb;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.rmi.RemoteException;
+import java.sql.SQLException;
+import java.util.logging.Logger;
+
+import javax.ejb.EJBException;
+import javax.ejb.LocalHome;
+import javax.ejb.SessionBean;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+
+/**
+ * Enterprise Bean: SLRemoteExLocalRemoteBean
+ */
+@Stateless
+@LocalHome(SLRemoteExLocalRemoteHome.class)
+public class SLRemoteExLocalRemoteBean implements SessionBean {
+    private static final long serialVersionUID = -2207952128826591889L;
+    private static final String CLASS_NAME = SLRemoteExLocalRemoteBean.class.getName();
+    private static final Logger logger = Logger.getLogger(CLASS_NAME);
+
+    public void testMethodwithNoEx(String exceptionToThrow) {
+        logger.info(getClass().getSimpleName() + ".testMethodwithNoEx : " + exceptionToThrow);
+        if ("RuntimeException".equals(exceptionToThrow)) {
+            throw new RuntimeException(exceptionToThrow);
+        } else if ("IllegalStateException".equals(exceptionToThrow)) {
+            throw new IllegalStateException(exceptionToThrow);
+        }
+    }
+
+    public void testMethodwithException(String exceptionToThrow) throws Exception {
+        logger.info(getClass().getSimpleName() + ".testMethodwithException : " + exceptionToThrow);
+        if ("Exception".equals(exceptionToThrow)) {
+            throw new Exception(exceptionToThrow);
+        } else if ("IOException".equals(exceptionToThrow)) {
+            throw new IOException(exceptionToThrow);
+        } else if ("RemoteException".equals(exceptionToThrow)) {
+            throw new RemoteException(exceptionToThrow);
+        } else if ("RuntimeException".equals(exceptionToThrow)) {
+            throw new RuntimeException(exceptionToThrow);
+        } else if ("IllegalStateException".equals(exceptionToThrow)) {
+            throw new IllegalStateException(exceptionToThrow);
+        } else if ("SQLException".equals(exceptionToThrow)) {
+            throw new SQLException(exceptionToThrow);
+        } else if ("SLRemoteException".equals(exceptionToThrow)) {
+            throw new SLRemoteException(exceptionToThrow);
+        }
+    }
+
+    public void testMethodwithExceptionAndRemote(String exceptionToThrow) throws Exception, RemoteException {
+        logger.info(getClass().getSimpleName() + ".testMethodwithExceptionAndRemote : " + exceptionToThrow);
+        if ("Exception".equals(exceptionToThrow)) {
+            throw new Exception(exceptionToThrow);
+        } else if ("IOException".equals(exceptionToThrow)) {
+            throw new IOException(exceptionToThrow);
+        } else if ("RemoteException".equals(exceptionToThrow)) {
+            throw new RemoteException(exceptionToThrow);
+        } else if ("RuntimeException".equals(exceptionToThrow)) {
+            throw new RuntimeException(exceptionToThrow);
+        } else if ("IllegalStateException".equals(exceptionToThrow)) {
+            throw new IllegalStateException(exceptionToThrow);
+        } else if ("SLRemoteException".equals(exceptionToThrow)) {
+            throw new SLRemoteException(exceptionToThrow);
+        }
+    }
+
+    public void testMethodwithExceptionAndRemoteSub(String exceptionToThrow) throws Exception, SLRemoteException {
+        logger.info(getClass().getSimpleName() + ".testMethodwithExceptionAndRemoteSub : " + exceptionToThrow);
+        if ("Exception".equals(exceptionToThrow)) {
+            throw new Exception(exceptionToThrow);
+        } else if ("IOException".equals(exceptionToThrow)) {
+            throw new IOException(exceptionToThrow);
+        } else if ("RemoteException".equals(exceptionToThrow)) {
+            throw new RemoteException(exceptionToThrow);
+        } else if ("RuntimeException".equals(exceptionToThrow)) {
+            throw new RuntimeException(exceptionToThrow);
+        } else if ("IllegalStateException".equals(exceptionToThrow)) {
+            throw new IllegalStateException(exceptionToThrow);
+        } else if ("SLRemoteException".equals(exceptionToThrow)) {
+            throw new SLRemoteException(exceptionToThrow);
+        }
+    }
+
+    public void testMethodwithExceptionAndRemoteAndRemoteSub(String exceptionToThrow) throws Exception, RemoteException, SLRemoteException {
+        logger.info(getClass().getSimpleName() + ".testMethodwithExceptionAndRemoteAndRemoteSub : " + exceptionToThrow);
+        if ("Exception".equals(exceptionToThrow)) {
+            throw new Exception(exceptionToThrow);
+        } else if ("IOException".equals(exceptionToThrow)) {
+            throw new IOException(exceptionToThrow);
+        } else if ("RemoteException".equals(exceptionToThrow)) {
+            throw new RemoteException(exceptionToThrow);
+        } else if ("RuntimeException".equals(exceptionToThrow)) {
+            throw new RuntimeException(exceptionToThrow);
+        } else if ("IllegalStateException".equals(exceptionToThrow)) {
+            throw new IllegalStateException(exceptionToThrow);
+        } else if ("SLRemoteException".equals(exceptionToThrow)) {
+            throw new SLRemoteException(exceptionToThrow);
+        }
+    }
+
+    public void testMethodwithIOException(String exceptionToThrow) throws IOException {
+        logger.info(getClass().getSimpleName() + ".testMethodwithIOException : " + exceptionToThrow);
+        if ("IOException".equals(exceptionToThrow)) {
+            throw new IOException(exceptionToThrow);
+        } else if ("RemoteException".equals(exceptionToThrow)) {
+            throw new RemoteException(exceptionToThrow);
+        } else if ("RuntimeException".equals(exceptionToThrow)) {
+            throw new RuntimeException(exceptionToThrow);
+        } else if ("IllegalStateException".equals(exceptionToThrow)) {
+            throw new IllegalStateException(exceptionToThrow);
+        } else if ("FileNotFoundException".equals(exceptionToThrow)) {
+            throw new FileNotFoundException(exceptionToThrow);
+        } else if ("SLRemoteException".equals(exceptionToThrow)) {
+            throw new SLRemoteException(exceptionToThrow);
+        }
+    }
+
+    public void testMethodwithIOExceptionAndRemote(String exceptionToThrow) throws IOException, RemoteException {
+        logger.info(getClass().getSimpleName() + ".testMethodwithIOExceptionAndRemote : " + exceptionToThrow);
+        if ("IOException".equals(exceptionToThrow)) {
+            throw new IOException(exceptionToThrow);
+        } else if ("RemoteException".equals(exceptionToThrow)) {
+            throw new RemoteException(exceptionToThrow);
+        } else if ("RuntimeException".equals(exceptionToThrow)) {
+            throw new RuntimeException(exceptionToThrow);
+        } else if ("IllegalStateException".equals(exceptionToThrow)) {
+            throw new IllegalStateException(exceptionToThrow);
+        } else if ("FileNotFoundException".equals(exceptionToThrow)) {
+            throw new FileNotFoundException(exceptionToThrow);
+        } else if ("SLRemoteException".equals(exceptionToThrow)) {
+            throw new SLRemoteException(exceptionToThrow);
+        }
+    }
+
+    public void testMethodwithIOExceptionAndRemoteSub(String exceptionToThrow) throws IOException, SLRemoteException {
+        logger.info(getClass().getSimpleName() + ".testMethodwithIOExceptionAndRemoteSub : " + exceptionToThrow);
+        if ("IOException".equals(exceptionToThrow)) {
+            throw new IOException(exceptionToThrow);
+        } else if ("RemoteException".equals(exceptionToThrow)) {
+            throw new RemoteException(exceptionToThrow);
+        } else if ("RuntimeException".equals(exceptionToThrow)) {
+            throw new RuntimeException(exceptionToThrow);
+        } else if ("IllegalStateException".equals(exceptionToThrow)) {
+            throw new IllegalStateException(exceptionToThrow);
+        } else if ("FileNotFoundException".equals(exceptionToThrow)) {
+            throw new FileNotFoundException(exceptionToThrow);
+        } else if ("SLRemoteException".equals(exceptionToThrow)) {
+            throw new SLRemoteException(exceptionToThrow);
+        }
+    }
+
+    public void testMethodwithIOExceptionAndRemoteAndRemoteSub(String exceptionToThrow) throws IOException, RemoteException, SLRemoteException {
+        logger.info(getClass().getSimpleName() + ".testMethodwithIOExceptionAndRemoteAndRemoteSub : " + exceptionToThrow);
+        if ("IOException".equals(exceptionToThrow)) {
+            throw new IOException(exceptionToThrow);
+        } else if ("RemoteException".equals(exceptionToThrow)) {
+            throw new RemoteException(exceptionToThrow);
+        } else if ("RuntimeException".equals(exceptionToThrow)) {
+            throw new RuntimeException(exceptionToThrow);
+        } else if ("IllegalStateException".equals(exceptionToThrow)) {
+            throw new IllegalStateException(exceptionToThrow);
+        } else if ("FileNotFoundException".equals(exceptionToThrow)) {
+            throw new FileNotFoundException(exceptionToThrow);
+        } else if ("SLRemoteException".equals(exceptionToThrow)) {
+            throw new SLRemoteException(exceptionToThrow);
+        }
+    }
+
+    public void testMethodwithRemoteEx(String exceptionToThrow) throws RemoteException {
+        logger.info(getClass().getSimpleName() + ".testMethodwithRemoteEx : " + exceptionToThrow);
+        if ("RemoteException".equals(exceptionToThrow)) {
+            throw new RemoteException(exceptionToThrow);
+        } else if ("RuntimeException".equals(exceptionToThrow)) {
+            throw new RuntimeException(exceptionToThrow);
+        } else if ("IllegalStateException".equals(exceptionToThrow)) {
+            throw new IllegalStateException(exceptionToThrow);
+        } else if ("SLRemoteException".equals(exceptionToThrow)) {
+            throw new SLRemoteException(exceptionToThrow);
+        }
+    }
+
+    public void testMethodwithRemoteExAndSub(String exceptionToThrow) throws RemoteException, SLRemoteException {
+        logger.info(getClass().getSimpleName() + ".testMethodwithRemoteExAndSub : " + exceptionToThrow);
+        if ("RemoteException".equals(exceptionToThrow)) {
+            throw new RemoteException(exceptionToThrow);
+        } else if ("RuntimeException".equals(exceptionToThrow)) {
+            throw new RuntimeException(exceptionToThrow);
+        } else if ("IllegalStateException".equals(exceptionToThrow)) {
+            throw new IllegalStateException(exceptionToThrow);
+        } else if ("SLRemoteException".equals(exceptionToThrow)) {
+            throw new SLRemoteException(exceptionToThrow);
+        }
+    }
+
+    public void testMethodwithRemoteExSub(String exceptionToThrow) throws SLRemoteException {
+        logger.info(getClass().getSimpleName() + ".testMethodwithRemoteExSub : " + exceptionToThrow);
+        if ("RuntimeException".equals(exceptionToThrow)) {
+            throw new RuntimeException(exceptionToThrow);
+        } else if ("IllegalStateException".equals(exceptionToThrow)) {
+            throw new IllegalStateException(exceptionToThrow);
+        } else if ("SLRemoteException".equals(exceptionToThrow)) {
+            throw new SLRemoteException(exceptionToThrow);
+        }
+    }
+
+    @Override
+    public void ejbActivate() throws EJBException, RemoteException {
+    }
+
+    @Override
+    public void ejbPassivate() throws EJBException, RemoteException {
+    }
+
+    @Override
+    public void ejbRemove() throws EJBException, RemoteException {
+    }
+
+    @Override
+    public void setSessionContext(SessionContext arg0) throws EJBException, RemoteException {
+    }
+}

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionBean.jar/src/com/ibm/ws/ejbcontainer/exception/ejb/SLRemoteExLocalRemoteHome.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionBean.jar/src/com/ibm/ws/ejbcontainer/exception/ejb/SLRemoteExLocalRemoteHome.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.ejbcontainer.exception.ejb;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.CreateException;
+import javax.ejb.EJBLocalHome;
+
+/**
+ * Local Home interface for Enterprise Bean: SLRemoteExRemoteLocalBean
+ */
+public interface SLRemoteExLocalRemoteHome extends EJBLocalHome {
+
+    SLRemoteExLocalRemote create() throws CreateException, RemoteException;
+}

--- a/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionWeb.war/src/com/ibm/ws/ejbcontainer/exception/web/ExceptionServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.exception_fat/test-applications/ExceptionWeb.war/src/com/ibm/ws/ejbcontainer/exception/web/ExceptionServlet.java
@@ -33,6 +33,8 @@ import com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteEx;
 import com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteExHome;
 import com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteExLocal;
 import com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteExLocalHome;
+import com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteExLocalRemote;
+import com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteExLocalRemoteHome;
 import com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteException;
 
 import componenttest.annotation.ExpectedFFDC;
@@ -50,6 +52,11 @@ public class ExceptionServlet extends FATServlet {
 
     private SLRemoteExLocal lookupSLRemoteExBeanLocal() throws Exception {
         SLRemoteExLocalHome home = (SLRemoteExLocalHome) new InitialContext().lookup("java:app/ExceptionBean/SLRemoteExBean!com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteExLocalHome");
+        return home.create();
+    }
+
+    private SLRemoteExLocalRemote lookupSLRemoteExBeanLocalRemote() throws Exception {
+        SLRemoteExLocalRemoteHome home = (SLRemoteExLocalRemoteHome) new InitialContext().lookup("java:app/ExceptionBean/SLRemoteExLocalRemoteBean!com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteExLocalRemoteHome");
         return home.create();
     }
 
@@ -1292,6 +1299,655 @@ public class ExceptionServlet extends FATServlet {
     @ExpectedFFDC({ "java.lang.IllegalStateException", "java.lang.RuntimeException", "com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteException" })
     public void testLocalMethodwithRemoteExSub() throws Exception {
         SLRemoteExLocal remoteExLocal = lookupSLRemoteExBeanLocal();
+
+        // verify method with throws exception may be called without an exception
+        remoteExLocal.testMethodwithRemoteExSub("none");
+
+        try {
+            remoteExLocal.testMethodwithRemoteExSub("SLRemoteException");
+            fail("Expected SLRemoteException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not SLRemoteException : " + rootex.getClass().getName(), rootex.getClass() == SLRemoteException.class);
+            assertEquals("Wrong Exception message received", "SLRemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithRemoteExSub("RuntimeException");
+            fail("Expected RuntimeException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RuntimeException : " + rootex.getClass().getName(), rootex.getClass() == RuntimeException.class);
+            assertEquals("Wrong Exception message received", "RuntimeException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithRemoteExSub("IllegalStateException");
+            fail("Expected IllegalStateException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not IllegalStateException : " + rootex.getClass().getName(), rootex.getClass() == IllegalStateException.class);
+            assertEquals("Wrong Exception message received", "IllegalStateException", rootex.getMessage());
+        }
+    }
+
+    @Test
+    @ExpectedFFDC({ "java.lang.IllegalStateException", "java.lang.RuntimeException" })
+    public void testLocalRemoteMethodwithNoEx() throws Exception {
+        SLRemoteExLocalRemote remoteExLocal = lookupSLRemoteExBeanLocalRemote();
+
+        // verify method with throws exception may be called without an exception
+        remoteExLocal.testMethodwithNoEx("none");
+
+        try {
+            remoteExLocal.testMethodwithNoEx("RuntimeException");
+            fail("Expected RuntimeException was not thrown");
+        } catch (EJBException ex) { // (UnknownLocalException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RuntimeException : " + rootex.getClass().getName(), rootex.getClass() == RuntimeException.class);
+            assertEquals("Wrong Exception message received", "RuntimeException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithNoEx("IllegalStateException");
+            fail("Expected IllegalStateException was not thrown");
+        } catch (EJBException ex) { // (UnknownLocalException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not IllegalStateException : " + rootex.getClass().getName(), rootex.getClass() == IllegalStateException.class);
+            assertEquals("Wrong Exception message received", "IllegalStateException", rootex.getMessage());
+        }
+    }
+
+    @Test
+    @ExpectedFFDC({ "java.lang.IllegalStateException", "java.lang.RuntimeException", "java.rmi.RemoteException", "com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteException" })
+    public void testLocalRemoteMethodwithException() throws Exception {
+        SLRemoteExLocalRemote remoteExLocal = lookupSLRemoteExBeanLocalRemote();
+
+        // verify method with throws exception may be called without an exception
+        remoteExLocal.testMethodwithException("none");
+
+        try {
+            remoteExLocal.testMethodwithException("Exception");
+            fail("Expected Exception was not thrown");
+        } catch (Exception ex) {
+            assertTrue("Exception is not Exception : " + ex.getClass().getName(), ex.getClass() == Exception.class);
+            assertEquals("Wrong Exception message received", "Exception", ex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithException("IOException");
+            fail("Expected IOException was not thrown");
+        } catch (IOException ex) {
+            assertTrue("Exception is not IOException : " + ex.getClass().getName(), ex.getClass() == IOException.class);
+            assertEquals("Wrong Exception message received", "IOException", ex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithException("RemoteException");
+            fail("Expected RemoteException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            assertEquals("Wrong Exception message received", "RemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithException("SLRemoteException");
+            fail("Expected SLRemoteException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not SLRemoteException : " + rootex.getClass().getName(), rootex.getClass() == SLRemoteException.class);
+            assertEquals("Wrong Exception message received", "SLRemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithException("RuntimeException");
+            fail("Expected RuntimeException was not thrown");
+        } catch (EJBException ex) { // (UnknownLocalException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RuntimeException : " + rootex.getClass().getName(), rootex.getClass() == RuntimeException.class);
+            assertEquals("Wrong Exception message received", "RuntimeException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithException("IllegalStateException");
+            fail("Expected IllegalStateException was not thrown");
+        } catch (EJBException ex) { // (UnknownLocalException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not IllegalStateException : " + rootex.getClass().getName(), rootex.getClass() == IllegalStateException.class);
+            assertEquals("Wrong Exception message received", "IllegalStateException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithException("SQLException");
+            fail("Expected SQLException was not thrown");
+        } catch (SQLException ex) {
+            assertTrue("Exception is not SQLException : " + ex.getClass().getName(), ex.getClass() == SQLException.class);
+            assertEquals("Wrong Exception message received", "SQLException", ex.getMessage());
+        }
+    }
+
+    @Test
+    @ExpectedFFDC({ "java.lang.IllegalStateException", "java.lang.RuntimeException", "java.rmi.RemoteException", "com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteException" })
+    public void testLocalRemoteMethodwithExceptionAndRemote() throws Exception {
+        SLRemoteExLocalRemote remoteExLocal = lookupSLRemoteExBeanLocalRemote();
+
+        // verify method with throws exception may be called without an exception
+        remoteExLocal.testMethodwithExceptionAndRemote("none");
+
+        try {
+            remoteExLocal.testMethodwithExceptionAndRemote("Exception");
+            fail("Expected Exception was not thrown");
+        } catch (Exception ex) {
+            assertTrue("Exception is not Exception : " + ex.getClass().getName(), ex.getClass() == Exception.class);
+            assertEquals("Wrong Exception message received", "Exception", ex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithExceptionAndRemote("IOException");
+            fail("Expected IOException was not thrown");
+        } catch (IOException ex) {
+            assertTrue("Exception is not IOException : " + ex.getClass().getName(), ex.getClass() == IOException.class);
+            assertEquals("Wrong Exception message received", "IOException", ex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithExceptionAndRemote("RemoteException");
+            fail("Expected RemoteException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            assertEquals("Wrong Exception message received", "RemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithExceptionAndRemote("SLRemoteException");
+            fail("Expected SLRemoteException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not SLRemoteException : " + rootex.getClass().getName(), rootex.getClass() == SLRemoteException.class);
+            assertEquals("Wrong Exception message received", "SLRemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithExceptionAndRemote("RuntimeException");
+            fail("Expected RuntimeException was not thrown");
+        } catch (EJBException ex) { // (UnknownLocalException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RuntimeException : " + rootex.getClass().getName(), rootex.getClass() == RuntimeException.class);
+            assertEquals("Wrong Exception message received", "RuntimeException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithExceptionAndRemote("IllegalStateException");
+            fail("Expected IllegalStateException was not thrown");
+        } catch (EJBException ex) { // (UnknownLocalException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not IllegalStateException : " + rootex.getClass().getName(), rootex.getClass() == IllegalStateException.class);
+            assertEquals("Wrong Exception message received", "IllegalStateException", rootex.getMessage());
+        }
+    }
+
+    @Test
+    @ExpectedFFDC({ "java.lang.IllegalStateException", "java.lang.RuntimeException", "java.rmi.RemoteException", "com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteException" })
+    public void testLocalRemoteMethodwithExceptionAndRemoteSub() throws Exception {
+        SLRemoteExLocalRemote remoteExLocal = lookupSLRemoteExBeanLocalRemote();
+
+        // verify method with throws exception may be called without an exception
+        remoteExLocal.testMethodwithExceptionAndRemoteSub("none");
+
+        try {
+            remoteExLocal.testMethodwithExceptionAndRemoteSub("Exception");
+            fail("Expected Exception was not thrown");
+        } catch (Exception ex) {
+            assertTrue("Exception is not Exception : " + ex.getClass().getName(), ex.getClass() == Exception.class);
+            assertEquals("Wrong Exception message received", "Exception", ex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithExceptionAndRemoteSub("IOException");
+            fail("Expected IOException was not thrown");
+        } catch (IOException ex) {
+            assertTrue("Exception is not IOException : " + ex.getClass().getName(), ex.getClass() == IOException.class);
+            assertEquals("Wrong Exception message received", "IOException", ex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithExceptionAndRemoteSub("RemoteException");
+            fail("Expected RemoteException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            assertEquals("Wrong Exception message received", "RemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithExceptionAndRemoteSub("SLRemoteException");
+            fail("Expected SLRemoteException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not SLRemoteException : " + rootex.getClass().getName(), rootex.getClass() == SLRemoteException.class);
+            assertEquals("Wrong Exception message received", "SLRemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithExceptionAndRemoteSub("RuntimeException");
+            fail("Expected RuntimeException was not thrown");
+        } catch (EJBException ex) { // (UnknownLocalException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RuntimeException : " + rootex.getClass().getName(), rootex.getClass() == RuntimeException.class);
+            assertEquals("Wrong Exception message received", "RuntimeException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithExceptionAndRemoteSub("IllegalStateException");
+            fail("Expected IllegalStateException was not thrown");
+        } catch (EJBException ex) { // (UnknownLocalException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not IllegalStateException : " + rootex.getClass().getName(), rootex.getClass() == IllegalStateException.class);
+            assertEquals("Wrong Exception message received", "IllegalStateException", rootex.getMessage());
+        }
+    }
+
+    @Test
+    @ExpectedFFDC({ "java.lang.IllegalStateException", "java.lang.RuntimeException", "java.rmi.RemoteException", "com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteException" })
+    public void testLocalRemoteMethodwithExceptionAndRemoteAndRemoteSub() throws Exception {
+        SLRemoteExLocalRemote remoteExLocal = lookupSLRemoteExBeanLocalRemote();
+
+        // verify method with throws exception may be called without an exception
+        remoteExLocal.testMethodwithExceptionAndRemoteAndRemoteSub("none");
+
+        try {
+            remoteExLocal.testMethodwithExceptionAndRemoteAndRemoteSub("Exception");
+            fail("Expected Exception was not thrown");
+        } catch (Exception ex) {
+            assertTrue("Exception is not Exception : " + ex.getClass().getName(), ex.getClass() == Exception.class);
+            assertEquals("Wrong Exception message received", "Exception", ex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithExceptionAndRemoteAndRemoteSub("IOException");
+            fail("Expected IOException was not thrown");
+        } catch (IOException ex) {
+            assertTrue("Exception is not IOException : " + ex.getClass().getName(), ex.getClass() == IOException.class);
+            assertEquals("Wrong Exception message received", "IOException", ex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithExceptionAndRemoteAndRemoteSub("RemoteException");
+            fail("Expected RemoteException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            assertEquals("Wrong Exception message received", "RemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithExceptionAndRemoteAndRemoteSub("SLRemoteException");
+            fail("Expected SLRemoteException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not SLRemoteException : " + rootex.getClass().getName(), rootex.getClass() == SLRemoteException.class);
+            assertEquals("Wrong Exception message received", "SLRemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithExceptionAndRemoteAndRemoteSub("RuntimeException");
+            fail("Expected RuntimeException was not thrown");
+        } catch (EJBException ex) { // (UnknownLocalException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RuntimeException : " + rootex.getClass().getName(), rootex.getClass() == RuntimeException.class);
+            assertEquals("Wrong Exception message received", "RuntimeException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithExceptionAndRemoteAndRemoteSub("IllegalStateException");
+            fail("Expected IllegalStateException was not thrown");
+        } catch (EJBException ex) { // (UnknownLocalException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not IllegalStateException : " + rootex.getClass().getName(), rootex.getClass() == IllegalStateException.class);
+            assertEquals("Wrong Exception message received", "IllegalStateException", rootex.getMessage());
+        }
+    }
+
+    @Test
+    @ExpectedFFDC({ "java.lang.IllegalStateException", "java.lang.RuntimeException", "java.rmi.RemoteException", "com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteException" })
+    public void testLocalRemoteMethodwithIOException() throws Exception {
+        SLRemoteExLocalRemote remoteExLocal = lookupSLRemoteExBeanLocalRemote();
+
+        // verify method with throws exception may be called without an exception
+        remoteExLocal.testMethodwithIOException("none");
+
+        try {
+            remoteExLocal.testMethodwithIOException("IOException");
+            fail("Expected IOException was not thrown");
+        } catch (IOException ex) {
+            assertTrue("Exception is not IOException : " + ex.getClass().getName(), ex.getClass() == IOException.class);
+            assertEquals("Wrong Exception message received", "IOException", ex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithIOException("RemoteException");
+            fail("Expected RemoteException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            assertEquals("Wrong Exception message received", "RemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithIOException("SLRemoteException");
+            fail("Expected SLRemoteException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not SLRemoteException : " + rootex.getClass().getName(), rootex.getClass() == SLRemoteException.class);
+            assertEquals("Wrong Exception message received", "SLRemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithIOException("RuntimeException");
+            fail("Expected RuntimeException was not thrown");
+        } catch (EJBException ex) { // (UnknownLocalException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RuntimeException : " + rootex.getClass().getName(), rootex.getClass() == RuntimeException.class);
+            assertEquals("Wrong Exception message received", "RuntimeException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithIOException("IllegalStateException");
+            fail("Expected IllegalStateException was not thrown");
+        } catch (EJBException ex) { // (UnknownLocalException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not IllegalStateException : " + rootex.getClass().getName(), rootex.getClass() == IllegalStateException.class);
+            assertEquals("Wrong Exception message received", "IllegalStateException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithIOException("FileNotFoundException");
+            fail("Expected FileNotFoundException was not thrown");
+        } catch (FileNotFoundException ex) {
+            assertTrue("Exception is not FileNotFoundException : " + ex.getClass().getName(), ex.getClass() == FileNotFoundException.class);
+            assertEquals("Wrong Exception message received", "FileNotFoundException", ex.getMessage());
+        }
+    }
+
+    @Test
+    @ExpectedFFDC({ "java.lang.IllegalStateException", "java.lang.RuntimeException", "java.rmi.RemoteException", "com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteException" })
+    public void testLocalRemoteMethodwithIOExceptionAndRemote() throws Exception {
+        SLRemoteExLocalRemote remoteExLocal = lookupSLRemoteExBeanLocalRemote();
+
+        // verify method with throws exception may be called without an exception
+        remoteExLocal.testMethodwithIOExceptionAndRemote("none");
+
+        try {
+            remoteExLocal.testMethodwithIOExceptionAndRemote("IOException");
+            fail("Expected IOException was not thrown");
+        } catch (IOException ex) {
+            assertTrue("Exception is not IOException : " + ex.getClass().getName(), ex.getClass() == IOException.class);
+            assertEquals("Wrong Exception message received", "IOException", ex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithIOExceptionAndRemote("RemoteException");
+            fail("Expected RemoteException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            assertEquals("Wrong Exception message received", "RemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithIOExceptionAndRemote("SLRemoteException");
+            fail("Expected SLRemoteException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not SLRemoteException : " + rootex.getClass().getName(), rootex.getClass() == SLRemoteException.class);
+            assertEquals("Wrong Exception message received", "SLRemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithIOExceptionAndRemote("RuntimeException");
+            fail("Expected RuntimeException was not thrown");
+        } catch (EJBException ex) { // (UnknownLocalException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RuntimeException : " + rootex.getClass().getName(), rootex.getClass() == RuntimeException.class);
+            assertEquals("Wrong Exception message received", "RuntimeException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithIOExceptionAndRemote("IllegalStateException");
+            fail("Expected IllegalStateException was not thrown");
+        } catch (EJBException ex) { // (UnknownLocalException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not IllegalStateException : " + rootex.getClass().getName(), rootex.getClass() == IllegalStateException.class);
+            assertEquals("Wrong Exception message received", "IllegalStateException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithIOExceptionAndRemote("FileNotFoundException");
+            fail("Expected FileNotFoundException was not thrown");
+        } catch (FileNotFoundException ex) {
+            assertTrue("Exception is not FileNotFoundException : " + ex.getClass().getName(), ex.getClass() == FileNotFoundException.class);
+            assertEquals("Wrong Exception message received", "FileNotFoundException", ex.getMessage());
+        }
+    }
+
+    @Test
+    @ExpectedFFDC({ "java.lang.IllegalStateException", "java.lang.RuntimeException", "java.rmi.RemoteException", "com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteException" })
+    public void testLocalRemoteMethodwithIOExceptionAndRemoteSub() throws Exception {
+        SLRemoteExLocalRemote remoteExLocal = lookupSLRemoteExBeanLocalRemote();
+
+        // verify method with throws exception may be called without an exception
+        remoteExLocal.testMethodwithIOExceptionAndRemoteSub("none");
+
+        try {
+            remoteExLocal.testMethodwithIOExceptionAndRemoteSub("IOException");
+            fail("Expected IOException was not thrown");
+        } catch (IOException ex) {
+            assertTrue("Exception is not IOException : " + ex.getClass().getName(), ex.getClass() == IOException.class);
+            assertEquals("Wrong Exception message received", "IOException", ex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithIOExceptionAndRemoteSub("RemoteException");
+            fail("Expected RemoteException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            assertEquals("Wrong Exception message received", "RemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithIOExceptionAndRemoteSub("SLRemoteException");
+            fail("Expected SLRemoteException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not SLRemoteException : " + rootex.getClass().getName(), rootex.getClass() == SLRemoteException.class);
+            assertEquals("Wrong Exception message received", "SLRemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithIOExceptionAndRemoteSub("RuntimeException");
+            fail("Expected RuntimeException was not thrown");
+        } catch (EJBException ex) { // (UnknownLocalException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RuntimeException : " + rootex.getClass().getName(), rootex.getClass() == RuntimeException.class);
+            assertEquals("Wrong Exception message received", "RuntimeException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithIOExceptionAndRemoteSub("IllegalStateException");
+            fail("Expected IllegalStateException was not thrown");
+        } catch (EJBException ex) { // (UnknownLocalException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not IllegalStateException : " + rootex.getClass().getName(), rootex.getClass() == IllegalStateException.class);
+            assertEquals("Wrong Exception message received", "IllegalStateException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithIOExceptionAndRemoteSub("FileNotFoundException");
+            fail("Expected FileNotFoundException was not thrown");
+        } catch (FileNotFoundException ex) {
+            assertTrue("Exception is not FileNotFoundException : " + ex.getClass().getName(), ex.getClass() == FileNotFoundException.class);
+            assertEquals("Wrong Exception message received", "FileNotFoundException", ex.getMessage());
+        }
+    }
+
+    @Test
+    @ExpectedFFDC({ "java.lang.IllegalStateException", "java.lang.RuntimeException", "java.rmi.RemoteException", "com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteException" })
+    public void testLocalRemoteMethodwithIOExceptionAndRemoteAndRemoteSub() throws Exception {
+        SLRemoteExLocalRemote remoteExLocal = lookupSLRemoteExBeanLocalRemote();
+
+        // verify method with throws exception may be called without an exception
+        remoteExLocal.testMethodwithIOExceptionAndRemoteAndRemoteSub("none");
+
+        try {
+            remoteExLocal.testMethodwithIOExceptionAndRemoteAndRemoteSub("IOException");
+            fail("Expected IOException was not thrown");
+        } catch (IOException ex) {
+            assertTrue("Exception is not IOException : " + ex.getClass().getName(), ex.getClass() == IOException.class);
+            assertEquals("Wrong Exception message received", "IOException", ex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithIOExceptionAndRemoteAndRemoteSub("RemoteException");
+            fail("Expected RemoteException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            assertEquals("Wrong Exception message received", "RemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithIOExceptionAndRemoteAndRemoteSub("SLRemoteException");
+            fail("Expected SLRemoteException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not SLRemoteException : " + rootex.getClass().getName(), rootex.getClass() == SLRemoteException.class);
+            assertEquals("Wrong Exception message received", "SLRemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithIOExceptionAndRemoteAndRemoteSub("RuntimeException");
+            fail("Expected RuntimeException was not thrown");
+        } catch (EJBException ex) { // (UnknownLocalException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RuntimeException : " + rootex.getClass().getName(), rootex.getClass() == RuntimeException.class);
+            assertEquals("Wrong Exception message received", "RuntimeException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithIOExceptionAndRemoteAndRemoteSub("IllegalStateException");
+            fail("Expected IllegalStateException was not thrown");
+        } catch (EJBException ex) { // (UnknownLocalException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not IllegalStateException : " + rootex.getClass().getName(), rootex.getClass() == IllegalStateException.class);
+            assertEquals("Wrong Exception message received", "IllegalStateException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithIOExceptionAndRemoteAndRemoteSub("FileNotFoundException");
+            fail("Expected FileNotFoundException was not thrown");
+        } catch (FileNotFoundException ex) {
+            assertTrue("Exception is not FileNotFoundException : " + ex.getClass().getName(), ex.getClass() == FileNotFoundException.class);
+            assertEquals("Wrong Exception message received", "FileNotFoundException", ex.getMessage());
+        }
+    }
+
+    @Test
+    @ExpectedFFDC({ "java.lang.IllegalStateException", "java.lang.RuntimeException", "java.rmi.RemoteException", "com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteException" })
+    public void testLocalRemoteMethodwithRemoteEx() throws Exception {
+        SLRemoteExLocalRemote remoteExLocal = lookupSLRemoteExBeanLocalRemote();
+
+        // verify method with throws exception may be called without an exception
+        remoteExLocal.testMethodwithRemoteEx("none");
+
+        try {
+            remoteExLocal.testMethodwithRemoteEx("RemoteException");
+            fail("Expected RemoteException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            assertEquals("Wrong Exception message received", "RemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithRemoteEx("SLRemoteException");
+            fail("Expected SLRemoteException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not SLRemoteException : " + rootex.getClass().getName(), rootex.getClass() == SLRemoteException.class);
+            assertEquals("Wrong Exception message received", "SLRemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithRemoteEx("RuntimeException");
+            fail("Expected RuntimeException was not thrown");
+        } catch (EJBException ex) { // (UnknownLocalException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RuntimeException : " + rootex.getClass().getName(), rootex.getClass() == RuntimeException.class);
+            assertEquals("Wrong Exception message received", "RuntimeException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithRemoteEx("IllegalStateException");
+            fail("Expected IllegalStateException was not thrown");
+        } catch (EJBException ex) { // (UnknownLocalException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not IllegalStateException : " + rootex.getClass().getName(), rootex.getClass() == IllegalStateException.class);
+            assertEquals("Wrong Exception message received", "IllegalStateException", rootex.getMessage());
+        }
+    }
+
+    @Test
+    @ExpectedFFDC({ "java.lang.IllegalStateException", "java.lang.RuntimeException", "java.rmi.RemoteException", "com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteException" })
+    public void testLocalRemoteMethodwithRemoteExAndSub() throws Exception {
+        SLRemoteExLocalRemote remoteExLocal = lookupSLRemoteExBeanLocalRemote();
+
+        // verify method with throws exception may be called without an exception
+        remoteExLocal.testMethodwithRemoteExAndSub("none");
+
+        try {
+            remoteExLocal.testMethodwithRemoteExAndSub("RemoteException");
+            fail("Expected RemoteException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RemoteException : " + rootex.getClass().getName(), rootex.getClass() == RemoteException.class);
+            assertEquals("Wrong Exception message received", "RemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithRemoteExAndSub("SLRemoteException");
+            fail("Expected SLRemoteException was not thrown");
+        } catch (EJBException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not SLRemoteException : " + rootex.getClass().getName(), rootex.getClass() == SLRemoteException.class);
+            assertEquals("Wrong Exception message received", "SLRemoteException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithRemoteExAndSub("RuntimeException");
+            fail("Expected RuntimeException was not thrown");
+        } catch (EJBException ex) { // (UnknownLocalException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not RuntimeException : " + rootex.getClass().getName(), rootex.getClass() == RuntimeException.class);
+            assertEquals("Wrong Exception message received", "RuntimeException", rootex.getMessage());
+        }
+
+        try {
+            remoteExLocal.testMethodwithRemoteExAndSub("IllegalStateException");
+            fail("Expected IllegalStateException was not thrown");
+        } catch (EJBException ex) { // (UnknownLocalException ex) {
+            Throwable rootex = ex.getCause();
+            assertTrue("Exception is not IllegalStateException : " + rootex.getClass().getName(), rootex.getClass() == IllegalStateException.class);
+            assertEquals("Wrong Exception message received", "IllegalStateException", rootex.getMessage());
+        }
+    }
+
+    @Test
+    @ExpectedFFDC({ "java.lang.IllegalStateException", "java.lang.RuntimeException", "com.ibm.ws.ejbcontainer.exception.ejb.SLRemoteException" })
+    public void testLocalRemoteMethodwithRemoteExSub() throws Exception {
+        SLRemoteExLocalRemote remoteExLocal = lookupSLRemoteExBeanLocalRemote();
 
         // verify method with throws exception may be called without an exception
         remoteExLocal.testMethodwithRemoteExSub("none");


### PR DESCRIPTION
Allow an EJB Local interface to extend RMI Remote. RemoteException, if thrown
should be treated as an unchecked (local) exception.

Also add test to verify the correct exception handling behavior.

fixes #13309 