### PR TITLE
Issue 13400: Adjust message for other JDKs Acme config test

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeConfigVariationsTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeConfigVariationsTest.java
@@ -685,8 +685,7 @@ public class AcmeConfigVariationsTest {
 			configuration.getAcmeCA().setAcmeTransportConfig(acmeTransportConfig);
 			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration);
 			AcmeFatUtils.renewCertificate(server);
-			assertNotNull("Expected CWPKI2016E in logs.",
-					server.waitForStringInLog("CWPKI2016E.*SocketTimeoutException"));
+			assertNotNull("Expected CWPKI2016E in logs.", server.waitForStringInLog("CWPKI2016E"));
 
 			/***********************************************************************
 			 * 
@@ -700,8 +699,7 @@ public class AcmeConfigVariationsTest {
 			acmeTransportConfig.setHttpReadTimeout("1ms");
 			AcmeFatUtils.configureAcmeCA(server, caContainer, configuration);
 			AcmeFatUtils.renewCertificate(server);
-			assertNotNull("Expected CWPKI2016E in logs.",
-					server.waitForStringInLog("CWPKI2016E.*SocketTimeoutException"));
+			assertNotNull("Expected CWPKI2016E in logs.", server.waitForStringInLog("CWPKI2016E"));
 
 			/***********************************************************************
 			 * 


### PR DESCRIPTION
Fixes #13400 

If the test is running on OpenJDK, sometimes the messages don't include the SocketTimeoutException. For example,

```
com.ibm.ws.security.acme.internal.AcmeConfigService          E CWPKI2016E: The ACME service request for an existing account from the ACME certificate authority at the https://localhost:32785/dir URI failed. The error is 'sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target'.
com.ibm.ws.security.acme.internal.AcmeConfigService          E CWPKI2016E: The ACME service request for an existing account from the ACME certificate authority at the https://localhost:32785/dir URI failed. The error is 'java.net.SocketTimeoutException: Read timed out'.
```

I thought this just happened on OpenJDK, but it seems more widespread. I'm going to make this more generic.