### PR TITLE
13411: update TestContFrameAfterDataFrame test

### DIFF
--- a/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/H2FATDriverServlet.java
+++ b/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/H2FATDriverServlet.java
@@ -2627,7 +2627,6 @@ public class H2FATDriverServlet extends FATServlet {
         Http2Client h2Client = getDefaultH2Client(request, response, blockUntilConnectionIsDone);
 
         h2Client.addExpectedFrame(DEFAULT_SERVER_SETTINGS_FRAME);
-        addFirstExpectedHeaders(h2Client);
 
         byte[] debugData = "CONTINUATION Frame Received when not in a Continuation State".getBytes();
         FrameGoAwayClient errorFrame = new FrameGoAwayClient(0, debugData, new int[] { STREAM_CLOSED, PROTOCOL_ERROR }, new int[] { 1, 3 });


### PR DESCRIPTION
Sequence of events at the server:

Received request with upgrade header
Sent 101 upgrade
Read magic preface
Finished the rest of the settings frames to complete upgrade
Started working on the response to 1
Interrupted with reading a data frame
Interrupted again with a continuation frame
Send GOAWAY, protocol error
Back to the initial response, try to send it, but connection is closed
Need to update the testcase to not expect the HEADERS frame from the initial response as it may never come.

