### PR TITLE
Issue 13416: Skip some Basic Reg tests based on JDK

### DIFF
--- a/dev/com.ibm.ws.security.registry.basic_fat/fat/src/com/ibm/ws/security/registry/basic/fat/FATTest.java
+++ b/dev/com.ibm.ws.security.registry.basic_fat/fat/src/com/ibm/ws/security/registry/basic/fat/FATTest.java
@@ -14,6 +14,7 @@ package com.ibm.ws.security.registry.basic.fat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assume.assumeTrue;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -225,6 +226,7 @@ public class FATTest {
      */
     @Test
     public void getUsersWithSingleParen() throws Exception {
+        assumeTrue(!isOpenJDK11());
         Log.info(c, "getUsersWithParenthesis", "Check getUsers with single paren patterns");
 
         setServerConfiguration(server, DEFAULT_CONFIG_FILE);
@@ -244,6 +246,7 @@ public class FATTest {
      */
     @Test
     public void getGroupsWithSingleParen() throws Exception {
+        assumeTrue(!isOpenJDK11());
         Log.info(c, "getGroupsWithSingleParen", "Check getGroups with single paren patterns");
 
         setServerConfiguration(server, DEFAULT_CONFIG_FILE);
@@ -291,5 +294,20 @@ public class FATTest {
 
         result = servlet.getGroups("*}*", 0);
         assertEquals("Expected 1 group with '}'.", 1, result.getList().size());
+    }
+
+    private boolean isOpenJDK11() {
+        String javaVendor = System.getProperty("java.vendor").toLowerCase();
+        String javaVersion = System.getProperty("java.version");
+        if (javaVendor.contains("openjdk") && javaVersion.equals("11.0.5")) {
+            /*
+             * Seeing test failure with only this level of java, runs fine on 11.0.8
+             */
+            Log.info(FATTest.class, "isOpenJDK11",
+                     "Skipping this test due to a bug with the specific JDK combo: " + System.getProperty("os.name")
+                                                   + " " + System.getProperty("java.vendor") + " " + System.getProperty("java.version"));
+            return true;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Fixes #13416 

Skipping on FATTest from BasicRegistry -- OpenJDK 11

These tests fail on 11.0.5 and pass on 11.0.8