### PR TITLE
Revisions to address FAT test failure.

### DIFF
--- a/dev/com.ibm.ws.javamail.1.6_fat/fat/src/com/ibm/ws/javamail/fat/IMAPTest.java
+++ b/dev/com.ibm.ws.javamail.1.6_fat/fat/src/com/ibm/ws/javamail/fat/IMAPTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -169,6 +169,7 @@ public class IMAPTest {
         // which is then used to create the actual GreenMail server.
         int imapPort = Integer.getInteger("imap_port"); // As per server.xml
         // Need to add -D to the start of the property name
+        System.out.println("Starting IMAP server on port "+imapPort);
         ServerSetup imapSetup = new ServerSetup(imapPort, "localhost", "imap");
         imapServer = new GreenMail(imapSetup);
         // Start the imapServer, the GreenMail server is now listening for connections
@@ -191,8 +192,7 @@ public class IMAPTest {
             message.setSubject("Sent from Liberty JavaMail");
             message.setText("Test mail sent by GreenMail");
         } catch (MessagingException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            e.printStackTrace(System.out);
         }
 
         // Now that the MimeMessage is created the user delivers it to imapServer

--- a/dev/com.ibm.ws.javamail.1.6_fat/fat/src/com/ibm/ws/javamail/fat/SMTPTest.java
+++ b/dev/com.ibm.ws.javamail.1.6_fat/fat/src/com/ibm/ws/javamail/fat/SMTPTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -139,6 +139,8 @@ public class SMTPTest {
         // Create a ServerSetup with a port and host name and protocol type passed to it
         // which is then used to create the actual GreenMail server
         int smtpPort = Integer.getInteger("smtp_port"); // As per server.xml
+
+        System.out.println("Starting SMTP server on port "+smtpPort);
         ServerSetup smtpSetup = new ServerSetup(smtpPort, "localhost", "smtp");
 
         smtpServer = new GreenMail(smtpSetup);

--- a/dev/com.ibm.ws.javamail.1.6_fat/publish/servers/com.ibm.ws.javamail.fat/server.xml
+++ b/dev/com.ibm.ws.javamail.1.6_fat/publish/servers/com.ibm.ws.javamail.fat/server.xml
@@ -1,19 +1,21 @@
 <server>
-    <featureManager>
-      <feature>componentTest-1.0</feature>
-      <feature>servlet-4.0</feature>
-      <feature>localConnector-1.0</feature>
-      <feature>javaMail-1.6</feature>
-      <feature>jndi-1.0</feature>
-      <feature>ejbLite-3.2</feature>
-    </featureManager>
+  <featureManager>
+    <feature>componentTest-1.0</feature>
+    <feature>servlet-4.0</feature>
+    <feature>localConnector-1.0</feature>
+    <feature>javaMail-1.6</feature>
+    <feature>jndi-1.0</feature>
+    <feature>ejbLite-3.2</feature>
+  </featureManager>
 
-    <include optional="true" location="../fatTestPorts.xml"/>
+  <include optional="true" location="../fatTestPorts.xml"/>
 
-    <variable name="onError" value="FAIL"/>
+  <variable name="onError" value="FAIL"/>
 
-    <application type="ear" id="fvtapp" name="fvtapp" location="fvtapp.ear"/>
-    
-    <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
+  <application type="ear" id="fvtapp" name="fvtapp" location="fvtapp.ear"/>
+
+  <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
+  <!-- Needed due to missing doPriv in javax.mail.Session.loadFile(), and we have no idea of the actual base paths -->
+  <javaPermission className="java.io.FilePermission" name="/-" actions="read"/>
 
 </server>

--- a/dev/com.ibm.ws.javamail.1.6_fat/publish/servers/mailSessionTestServer/server.xml
+++ b/dev/com.ibm.ws.javamail.1.6_fat/publish/servers/mailSessionTestServer/server.xml
@@ -1,62 +1,66 @@
 <server>
-    <featureManager>
-    	<feature>componentTest-1.0</feature>
-        <feature>servlet-4.0</feature>
-        <feature>jndi-1.0</feature>
-        <feature>javaMail-1.6</feature>
-    </featureManager>
+  <featureManager>
+    <feature>componentTest-1.0</feature>
+    <feature>servlet-4.0</feature>
+    <feature>jndi-1.0</feature>
+    <feature>javaMail-1.6</feature>
+  </featureManager>
 
-	<mailSession>
-		<mailSessionID>testPop3MailSession</mailSessionID>
-		<jndiName>TestingApp/POP3MailSessionServlet/testPOP3MailSession</jndiName>
-		<description>mailSession for testing Pop3 protocol</description>
-		<storeProtocol>pop3</storeProtocol>
-		<host>testserver.com</host>
-		<user>test</user>
-		<password>test</password>
-		<from>smtp@testserver.com</from>
-		<property name="mail.pop3.host" value="localhost" />
-		<property name="mail.pop3.port" value="${bvt.prop.pop3_port}" />
-	</mailSession>
-	
-	<mailSession>
-		<mailSessionID>testIMAPMailSession</mailSessionID>
-		<jndiName>TestingApp/IMAPMailSessionServlet/testIMAPMailSession</jndiName>
-		<description>mailSession for testing IMAP protocol</description>
-		<storeProtocol>imap</storeProtocol>
-		<host>localhost</host>
-		<user>imap@testserver.com</user>
-		<password>imapPa$$word4U2C</password>
-		<from>smtp@testserver.com</from>
-		<property name="mail.imap.host" value="localhost" />
-		<property name="mail.imap.port" value="${bvt.prop.imap_port}" />
-	</mailSession>
-	
-	<mailSession>
-		<mailSessionID>testSMTPMailSession</mailSessionID>
-		<jndiName>TestingApp/SMTPMailSessionServlet/testSMTPMailSession</jndiName>
-		<description>mailSession for testing SMTP protocol</description>
-		<transportProtocol>smtp</transportProtocol>
-		<host>localhost</host>
-		<user>smtp@testserver.com</user>
-		<password>smtpPa$$word4U2C</password>
-		<from>smtp@testserver.com</from>
-		<property name="mail.smtp.host" value="localhost" />
-		<property name="mail.smtp.port" value="${bvt.prop.smtp_port}" />
-	</mailSession>
-	
-	<jndiEntry jndiName="TestingApp/POP3InlineServlet/pop3_port" value="${bvt.prop.pop3_port}" />
-	<jndiEntry jndiName="TestingApp/IMAPInlineServlet/imap_port" value="${bvt.prop.imap_port}" />
-	<jndiEntry jndiName="TestingApp/SMTPInlineServlet/smtp_port" value="${bvt.prop.smtp_port}" />
-	
-    <include location="../fatTestPorts.xml"/>
-    
-    <application id="testingApp" name="TestingApp" type="war" location="TestingApp.war">
-  		<classloader apiTypeVisibility="+third-party"/>
-    </application>
-    
-    <!-- Needed due to missing doPriv in javax.mail.Session.getService() -->
-    <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
-    <!-- Needed due to missing doPriv in javax.mail.Service.connect() -->
-    <javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
+  <mailSession>
+    <mailSessionID>testPop3MailSession</mailSessionID>
+    <jndiName>TestingApp/POP3MailSessionServlet/testPOP3MailSession</jndiName>
+    <description>mailSession for testing Pop3 protocol</description>
+    <storeProtocol>pop3</storeProtocol>
+    <host>testserver.com</host>
+    <user>test</user>
+    <password>test</password>
+    <from>smtp@testserver.com</from>
+    <property name="mail.pop3.host" value="localhost" />
+    <property name="mail.pop3.port" value="${bvt.prop.pop3_port}" />
+  </mailSession>
+
+  <mailSession>
+    <mailSessionID>testIMAPMailSession</mailSessionID>
+    <jndiName>TestingApp/IMAPMailSessionServlet/testIMAPMailSession</jndiName>
+    <description>mailSession for testing IMAP protocol</description>
+    <storeProtocol>imap</storeProtocol>
+    <host>localhost</host>
+    <user>imap@testserver.com</user>
+    <password>imapPa$$word4U2C</password>
+    <from>smtp@testserver.com</from>
+    <property name="mail.imap.host" value="localhost" />
+    <property name="mail.imap.port" value="${bvt.prop.imap_port}" />
+  </mailSession>
+
+  <mailSession>
+    <mailSessionID>testSMTPMailSession</mailSessionID>
+    <jndiName>TestingApp/SMTPMailSessionServlet/testSMTPMailSession</jndiName>
+    <description>mailSession for testing SMTP protocol</description>
+    <transportProtocol>smtp</transportProtocol>
+    <host>localhost</host>
+    <user>smtp@testserver.com</user>
+    <password>smtpPa$$word4U2C</password>
+    <from>smtp@testserver.com</from>
+    <property name="mail.smtp.host" value="localhost" />
+    <property name="mail.smtp.port" value="${bvt.prop.smtp_port}" />
+  </mailSession>
+
+  <jndiEntry jndiName="TestingApp/pop3_port" value="${bvt.prop.pop3_port}" />
+  <jndiEntry jndiName="TestingApp/imap_port" value="${bvt.prop.imap_port}" />
+  <jndiEntry jndiName="TestingApp/smtp_port" value="${bvt.prop.smtp_port}" />
+
+  <include location="../fatTestPorts.xml"/>
+
+  <application id="testingApp" name="TestingApp" type="war" location="TestingApp.war">
+    <classloader apiTypeVisibility="+third-party"/>
+  </application>
+
+  <!-- Needed due to missing doPriv in javax.mail.Session.getService() -->
+  <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
+  <!-- Needed due to missing doPriv in javax.mail.Service.connect() -->
+  <javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
+  <!-- Needed due to missing doPriv in com.sun.mail.util.PropUtil.getBooleanSystemProperty() -->
+  <javaPermission className="java.util.PropertyPermission" name="*" actions="read,write"/>
+  <!-- Needed due to missing doPriv in javax.mail.Session.loadFile(), and we have no idea of the actual base paths -->
+  <javaPermission className="java.io.FilePermission" name="/-" actions="read"/>
 </server>

--- a/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/IMAP/IMAPInlineServlet.java
+++ b/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/IMAP/IMAPInlineServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -44,17 +44,15 @@ public class IMAPInlineServlet extends HttpServlet {
      */
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        // TODO Auto-generated method stub
-
         response.setContentType("text/html");
         PrintWriter out = response.getWriter();
 
         try {
-            jndiConstant = new InitialContext().lookup("TestingApp/IMAPInlineServlet/imap_port");
-
+            jndiConstant = new InitialContext().lookup("TestingApp/imap_port");
         } catch (NamingException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            System.out.println("Failed to lookup 'TestingApp/imap_port': "+e.getMessage());
+            e.printStackTrace(System.out);
+            throw new RuntimeException(e);
         }
 
         String imapPort = Integer.toString((Integer) jndiConstant);
@@ -71,7 +69,9 @@ public class IMAPInlineServlet extends HttpServlet {
             session = Session.getInstance(props, new Authenticator() {
                 @Override
                 protected PasswordAuthentication getPasswordAuthentication() {
-                    PasswordAuthentication passwordAuthentication = new PasswordAuthentication("imap@testserver.com", "imapPa$$word4U2C");
+                    PasswordAuthentication passwordAuthentication = new PasswordAuthentication("imap@testserver.com"
+                                                                                              ,"imapPa$$word4U2C"
+                                                                                              );
                     return passwordAuthentication;
                 }
             });
@@ -108,7 +108,7 @@ public class IMAPInlineServlet extends HttpServlet {
             store.close();
 
         } catch (Exception mex) {
-            mex.printStackTrace();
+            mex.printStackTrace(System.out);
         }
     }
 
@@ -117,8 +117,6 @@ public class IMAPInlineServlet extends HttpServlet {
      */
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        // TODO Auto-generated method stub
-
     }
 
 }

--- a/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/IMAP/IMAPJNDIServlet.java
+++ b/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/IMAP/IMAPJNDIServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -41,20 +41,38 @@ public class IMAPJNDIServlet extends HttpServlet {
      */
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        // TODO Auto-generated method stub		
         response.setContentType("text/html");
         PrintWriter out = response.getWriter();
+        Object jndiConstant;
+
+        try {
+            jndiConstant = new InitialContext().lookup("TestingApp/imap_port");
+        } catch (NamingException e) {
+            System.out.println("Failed to lookup 'TestingApp/imap_port': "+e.getMessage());
+            e.printStackTrace(System.out);
+            throw new RuntimeException(e);
+        }
+        String imapPort = Integer.toString((Integer) jndiConstant);
+
+        try {
+            jndiConstant = new InitialContext().lookup("TestingApp/smtp_port");
+        } catch (NamingException e) {
+            System.out.println("Failed to lookup 'TestingApp/smtp_port': "+e.getMessage());
+            e.printStackTrace(System.out);
+            throw new RuntimeException(e);
+        }
+        String smtpPort = Integer.toString((Integer) jndiConstant);
 
         Properties props = new Properties();
         props.setProperty("mail.store.protocol", "imap");
         props.setProperty("mail.imap.host", "localhost");
         props.setProperty("user", "imap@testserver.com");
         props.setProperty("password", "imapPa$$word4U2C");
-        props.setProperty("mail.imap.port", "6663");
+        props.setProperty("mail.imap.port", imapPort);
         props.setProperty("mail.transport.protocol", "smtp");
         props.setProperty("mail.transport.host", "smtp");
         props.setProperty("from", "imap@testserver.com");
-        props.setProperty("mail.smtp.port", "3025");
+        props.setProperty("mail.smtp.port", smtpPort);
 
         session = Session.getInstance(props, new Authenticator() {
             @Override
@@ -76,8 +94,8 @@ public class IMAPJNDIServlet extends HttpServlet {
             }
             ic.unbind(jndiName);
         } catch (NamingException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            e.printStackTrace(System.out);
+            throw new RuntimeException(e);
         }
 
     }
@@ -87,8 +105,6 @@ public class IMAPJNDIServlet extends HttpServlet {
      */
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        // TODO Auto-generated method stub
-
     }
 
 }

--- a/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/IMAP/IMAPMailSessionServlet.java
+++ b/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/IMAP/IMAPMailSessionServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,55 +33,47 @@ import javax.servlet.http.HttpServletResponse;
 
 @WebServlet("/IMAPMailSessionServlet")
 public class IMAPMailSessionServlet extends HttpServlet {
-	private static final long serialVersionUID = 1L;
-	
-	@Resource(name="TestingApp/IMAPMailSessionServlet/testIMAPMailSession")
-	Session session;
+    private static final long serialVersionUID = 1L;
 
-	/**
-	 * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response)
-	 */
-	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		// TODO Auto-generated method stub
+    @Resource(name="TestingApp/IMAPMailSessionServlet/testIMAPMailSession")
+    Session session;
 
-		
-		response.setContentType("text/html");
-		PrintWriter out = response.getWriter();
+    /**
+     * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response)
+     */
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        response.setContentType("text/html");
+        PrintWriter out = response.getWriter();
 
         try {
-    
-        	session.setDebug(true);
-        	Store store = session.getStore();
-        	store.connect();
+            session.setDebug(true);
+            Store store = session.getStore();
+            store.connect();
             Folder inbox = store.getFolder("INBOX");
             inbox.open(Folder.READ_WRITE);
             Message msg = inbox.getMessage(inbox.getMessageCount());  // get newest message
             out.println("Message headers are: ===========");  // includes content-type, might get charset. 
             out.println("<p></p>");
-            
+
             Enumeration en = msg.getAllHeaders();
             while(en.hasMoreElements()){
-            	Header h = (Header)en.nextElement();
+                Header h = (Header)en.nextElement();
                 out.println(h.getName() + " "+ h.getValue());
                 out.println("<p></p>");
             }
-            
+
             out.println(" end headers =================");
             out.println("<p></p>");
-            
+
         } catch (Exception mex) {
             mex.printStackTrace();
         }
- 
     }
-		
 
-	/**
-	 * @see HttpServlet#doPost(HttpServletRequest request, HttpServletResponse response)
-	 */
-	protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		// TODO Auto-generated method stub
-		
-	}
-	
+
+    /**
+     * @see HttpServlet#doPost(HttpServletRequest request, HttpServletResponse response)
+     */
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    }
 }

--- a/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/POP3/POP3InlineServlet.java
+++ b/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/POP3/POP3InlineServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -43,17 +43,16 @@ public class POP3InlineServlet extends HttpServlet {
      */
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        // TODO Auto-generated method stub
-
         response.setContentType("text/html");
         PrintWriter out = response.getWriter();
+        Object jndiConstant;
 
         try {
-            jndiConstant = new InitialContext().lookup("TestingApp/POP3InlineServlet/pop3_port");
-
+            jndiConstant = new InitialContext().lookup("TestingApp/pop3_port");
         } catch (NamingException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            System.out.println("Failed to lookup 'TestingApp/pop3_port': "+e.getMessage());
+            e.printStackTrace(System.out);
+            throw new RuntimeException(e);
         }
 
         String pop3Port = Integer.toString((Integer) jndiConstant);
@@ -106,7 +105,7 @@ public class POP3InlineServlet extends HttpServlet {
 
             store.close();
         } catch (Exception mex) {
-            mex.printStackTrace();
+            mex.printStackTrace(System.out);
         }
     }
 
@@ -115,8 +114,5 @@ public class POP3InlineServlet extends HttpServlet {
      */
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        // TODO Auto-generated method stub
-
     }
-
 }

--- a/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/POP3/POP3JNDIServlet.java
+++ b/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/POP3/POP3JNDIServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -39,15 +39,24 @@ public class POP3JNDIServlet extends HttpServlet {
      */
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        // TODO Auto-generated method stub
-
         response.setContentType("text/html");
         PrintWriter out = response.getWriter();
+        Object jndiConstant;
+
+        try {
+            jndiConstant = new InitialContext().lookup("TestingApp/pop3_port");
+        } catch (NamingException e) {
+            System.out.println("Failed to lookup 'TestingApp/pop3_port': "+e.getMessage());
+            e.printStackTrace(System.out);
+            throw new RuntimeException(e);
+        }
+
+        String pop3Port = Integer.toString((Integer) jndiConstant);
 
         Properties props = new Properties();
         props.put("mail.store.protocol", "pop3");
         props.put("mail.pop3.connectiontimeout", "10000");
-        props.put("mail.pop3.port", "3110");
+        props.put("mail.pop3.port", pop3Port);
         props.put("mail.pop3.host", "localhost");
         props.put("user", "test");
         props.put("mail.debug.auth", true);
@@ -74,8 +83,8 @@ public class POP3JNDIServlet extends HttpServlet {
             }
             ic.unbind(jndiName);
         } catch (NamingException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            e.printStackTrace(System.out);
+            throw new RuntimeException(e);
         }
     }
 
@@ -84,8 +93,6 @@ public class POP3JNDIServlet extends HttpServlet {
      */
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        // TODO Auto-generated method stub
-
     }
 
 }

--- a/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/POP3/POP3MailSessionServlet.java
+++ b/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/POP3/POP3MailSessionServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,8 +38,6 @@ public class POP3MailSessionServlet extends HttpServlet {
      */
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        // TODO Auto-generated method stub
-
         response.setContentType("text/html");
         PrintWriter out = response.getWriter();
 
@@ -64,7 +62,7 @@ public class POP3MailSessionServlet extends HttpServlet {
             out.println("<p></p>");
 
         } catch (Exception mex) {
-            mex.printStackTrace();
+            mex.printStackTrace(System.out);
         }
 
     }
@@ -74,8 +72,5 @@ public class POP3MailSessionServlet extends HttpServlet {
      */
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        // TODO Auto-generated method stub
-
     }
-
 }

--- a/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/POP3/POP3MailTest.java
+++ b/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/POP3/POP3MailTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,8 +33,9 @@ public class POP3MailTest {
             Context context = new InitialContext();
             session = (javax.mail.Session) context.lookup("POP3JNDISession");
         } catch (NamingException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            System.out.println("Failed to lookup 'POP3JNDISession': "+e.getMessage());
+            e.printStackTrace(System.out);
+            throw new RuntimeException(e);
         }
 
         try {
@@ -68,7 +69,7 @@ public class POP3MailTest {
             store.close();
 
         } catch (Exception mex) {
-            mex.printStackTrace();
+            mex.printStackTrace(System.out);
         }
     }
 }

--- a/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/SMTP/SMTPInlineServlet.java
+++ b/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/SMTP/SMTPInlineServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -45,23 +45,24 @@ public class SMTPInlineServlet extends HttpServlet {
      */
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        // TODO Auto-generated method stub
-
         response.setContentType("text/html");
         PrintWriter out = response.getWriter();
 
         String testSubjectString = "Sent from Liberty JavaMail";
         String testBodyString = "Test mail sent by GreenMail";
+        Object jndiConstant;
 
         try {
-            jndiConstant = new InitialContext().lookup("TestingApp/SMTPInlineServlet/smtp_port");
-
+            jndiConstant = new InitialContext().lookup("TestingApp/smtp_port");
         } catch (NamingException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            System.out.println("Failed to look-up 'TestingApp/smtp_port': "+e.getMessage());
+            e.printStackTrace(System.out);
+            throw new RuntimeException(e);
         }
 
+        System.out.println("jndiConstant="+jndiConstant);
         String smtpPort = Integer.toString((Integer) jndiConstant);
+        System.out.println("TestingApp/smtp_port="+smtpPort);
 
         Properties props = new Properties();
         props.setProperty("mail.smtp.host", "localhost");
@@ -73,7 +74,9 @@ public class SMTPInlineServlet extends HttpServlet {
         session = Session.getInstance(props, new Authenticator() {
             @Override
             protected PasswordAuthentication getPasswordAuthentication() {
-                PasswordAuthentication passwordAuthentication = new PasswordAuthentication("smtp@testserver.com", "smtpPa$$word4U2C");
+                PasswordAuthentication passwordAuthentication = new PasswordAuthentication("smtp@testserver.com"
+                                                                                          ,"smtpPa$$word4U2C"
+                                                                                          );
                 return passwordAuthentication;
             }
         });
@@ -94,6 +97,8 @@ public class SMTPInlineServlet extends HttpServlet {
             Transport.send(message);
 
         } catch (MessagingException e) {
+            System.out.println("Mail session properties: "+session.getProperties());
+            e.printStackTrace(System.out);
             throw new RuntimeException(e);
         }
     }
@@ -103,8 +108,6 @@ public class SMTPInlineServlet extends HttpServlet {
      */
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        // TODO Auto-generated method stub
-
     }
 
 }

--- a/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/SMTP/SMTPJNDIServlet.java
+++ b/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/SMTP/SMTPJNDIServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -39,17 +39,17 @@ public class SMTPJNDIServlet extends HttpServlet {
      */
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        // TODO Auto-generated method stub		
         response.setContentType("text/html");
         PrintWriter out = response.getWriter();
 
         Object jndiConstant = null;
         try {
             // this is the mail session JNDI name in the server.xml
-            jndiConstant = new InitialContext().lookup("TestingApp/SMTPInlineServlet/smtp_port");
+            jndiConstant = new InitialContext().lookup("TestingApp/smtp_port");
         } catch (NamingException e) {
-            e.printStackTrace();
-            return;
+            System.out.println("Failed to lookup 'TestingApp/smtp_port': "+e.getMessage());
+            e.printStackTrace(System.out);
+            throw new RuntimeException(e);
         }
         String smtpPort = Integer.toString((Integer) jndiConstant);
 
@@ -64,7 +64,9 @@ public class SMTPJNDIServlet extends HttpServlet {
         session = Session.getInstance(props, new Authenticator() {
             @Override
             protected PasswordAuthentication getPasswordAuthentication() {
-                PasswordAuthentication passwordAuthentication = new PasswordAuthentication("smtp@testserver.com", "smtpPa$$word4U2C");
+                PasswordAuthentication passwordAuthentication = new PasswordAuthentication("smtp@testserver.com"
+                                                                                          ,"smtpPa$$word4U2C"
+                                                                                          );
                 return passwordAuthentication;
             }
         });
@@ -81,8 +83,7 @@ public class SMTPJNDIServlet extends HttpServlet {
             }
             ic.unbind(jndiName);
         } catch (NamingException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            e.printStackTrace(System.out);
         }
 
     }
@@ -92,8 +93,6 @@ public class SMTPJNDIServlet extends HttpServlet {
      */
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        // TODO Auto-generated method stub
-
     }
 
 }

--- a/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/SMTP/SMTPMailSessionServlet.java
+++ b/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/SMTP/SMTPMailSessionServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,8 +38,6 @@ public class SMTPMailSessionServlet extends HttpServlet {
      */
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        // TODO Auto-generated method stub
-
         response.setContentType("text/html");
         PrintWriter out = response.getWriter();
 
@@ -71,8 +69,6 @@ public class SMTPMailSessionServlet extends HttpServlet {
      */
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        // TODO Auto-generated method stub
-
     }
 
 }

--- a/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/SMTP/SMTPMailTest.java
+++ b/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/SMTP/SMTPMailTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,8 +35,9 @@ public class SMTPMailTest {
             Context context = new InitialContext();
             session = (javax.mail.Session) context.lookup("SMTPJNDISession");
         } catch (NamingException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            System.out.println("Failed to lookup 'SMTPJNDISession': "+e.getMessage());
+            e.printStackTrace(System.out);
+            throw new RuntimeException(e);
         }
 
         MimeMessage message = new MimeMessage(session);
@@ -53,6 +54,8 @@ public class SMTPMailTest {
             Transport.send(message);
 
         } catch (MessagingException e) {
+            System.out.println("Mail session properties: "+session.getProperties());
+            e.printStackTrace(System.out);
             throw new RuntimeException(e);
         }
     }

--- a/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/web/IMAPMailTest.java
+++ b/dev/com.ibm.ws.javamail.1.6_fat/test-applications/TestingApp/src/TestingApp/web/IMAPMailTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,13 +28,13 @@ public class IMAPMailTest {
     Session session;
 
     public void readMail(HttpServletResponse response, PrintWriter out) throws FolderClosedException {
-
         try {
             Context context = new InitialContext();
             session = (javax.mail.Session) context.lookup("IMAPJNDISession");
         } catch (NamingException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            System.out.println("Failed to lookup 'IMAPJNDISession': "+e.getMessage());
+            e.printStackTrace(System.out);
+            throw new RuntimeException(e);
         }
 
         try {
@@ -68,7 +68,7 @@ public class IMAPMailTest {
             store.close();
 
         } catch (Exception mex) {
-            mex.printStackTrace();
+            mex.printStackTrace(System.out);
         }
     }
 }


### PR DESCRIPTION
Added javaPermission elements to resolve Java 2 security errors.

Revised lookup of ports to abort if there is a failure making it clearer
when it is the lookup that fails first.  Added explicit reporting of
looked-up values to aid diagnosis should similar problems occur again.

Changed exception stack reporting to go to System.out in an effort to
ensure failures are not missed in the testing framework logs. (Should be
unnecessary but test failure seems to be missing an exception stack in
order to explain what was seen.)

Removed all the automatically generated TODO comments.