### PR TITLE
Mark acmeCA-2.0 feature as GA

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.certificateCreator-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.certificateCreator-2.0.feature
@@ -6,5 +6,5 @@ Subsystem-Version: 2.0.0
 IBM-App-ForceRestart: install, \
  uninstall
 -bundles=com.ibm.ws.crypto.certificate.creator.acme
-kind=noship
-edition=full
+kind=ga
+edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/acmeCA-2.0/com.ibm.websphere.appserver.acmeCA-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/acmeCA-2.0/com.ibm.websphere.appserver.acmeCA-2.0.feature
@@ -14,5 +14,5 @@ Subsystem-Name: Automatic Certificate Management Environment (ACME) Support 2.0
   com.ibm.websphere.appserver.restHandler-1.0
 -bundles=\
   com.ibm.ws.security.acme
-kind=noship
-edition=full
+kind=ga
+edition=base


### PR DESCRIPTION
Fixes #13435 

Enable `acmeCA-2.0` and `certificateCreator-2.0`

Received approval to set edition to `base`