### PR TITLE
Add clear error message for IBM JDK 8 with Oracle JDBC using kerberos

### DIFF
--- a/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
+++ b/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
@@ -648,5 +648,9 @@ KERBEROS_NOT_SUPPORTED_WARNING.useraction= Disable Kerberos, or use a DB2 backen
 
 # 9544-9548 deleted
 
+KERBEROS_ORACLE_IBMJDK_NOT_SUPPORTED=DSRA9549E: Using the IBM Java 8 SDK with an Oracle database is not supported. The Oracle JDBC driver only supports Kerberos authentication using the default security APIs available in OpenJDK, OpenJ9, or other similar SDKs.
+KERBEROS_ORACLE_IBMJDK_NOT_SUPPORTED.explanation=Using the IBM Java 8 SDK with an Oracle database is not supported. The Oracle JDBC driver only supports Kerberos authentication using the default security APIs available in OpenJDK, OpenJ9, or other similar SDKs.
+KERBEROS_ORACLE_IBMJDK_NOT_SUPPORTED.useraction=Disable Kerberos authentication for the Oracle data source, or switch to a different Java SDK besides the IBM Java 8 SDK.
+
 # 9600-9603 deleted 
 # 9900 deleted

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DatabaseHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DatabaseHelper.java
@@ -33,6 +33,7 @@ import java.sql.PreparedStatement;
 import javax.naming.Context; 
 import javax.sql.CommonDataSource;
 import javax.sql.ConnectionPoolDataSource;
+import javax.sql.DataSource;
 import javax.sql.PooledConnection;
 import javax.sql.XADataSource;
 import javax.transaction.xa.XAException;
@@ -911,6 +912,10 @@ public class DatabaseHelper {
     public boolean isInDatabaseUnitOfWork(Connection conn) throws SQLException {
         Tr.info(tc, "UNSUPPORTED_METHOD", "isInDatabaseUnitOfWork");
         throw new SQLException("method not supported for this backend database");
+    }
+    
+    public Connection getConnectionFromDatasource(DataSource ds, KerbUsage useKerb, Object gssCredential) throws SQLException {
+        return ds.getConnection();
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
@@ -43,10 +43,8 @@ import java.util.logging.XMLFormatter;
 
 import javax.resource.ResourceException;
 import javax.sql.CommonDataSource;
-import javax.sql.PooledConnection;
+import javax.sql.DataSource;
 import javax.transaction.xa.XAException;
-
-import org.ietf.jgss.GSSCredential;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -779,7 +777,7 @@ public class OracleHelper extends DatabaseHelper {
     
     private void setKerberosDatasourceProperties(CommonDataSource ds) throws ResourceException {
         try {
-            if (getConnectionProperties == null) {
+            if (setConnectionProperties == null) {
                 getConnectionProperties = lookup.findVirtual(ds.getClass(), "getConnectionProperties", MethodType.methodType(Properties.class));
                 setConnectionProperties = lookup.findVirtual(ds.getClass(), "setConnectionProperties", MethodType.methodType(void.class, Properties.class));
             }
@@ -802,6 +800,21 @@ public class OracleHelper extends DatabaseHelper {
             throw new ResourceException(e);
         }
     }
+    
+    @Override
+    public Connection getConnectionFromDatasource(DataSource ds, KerbUsage useKerb, Object gssCredential) throws SQLException {
+        
+        if (useKerb != KerbUsage.NONE) {
+            try {
+                checkIBMJava8();
+                setKerberosDatasourceProperties(ds);
+            } catch (ResourceException ex) {
+                throw AdapterUtil.toSQLException(ex);
+            }
+        }
+        
+        return super.getConnectionFromDatasource(ds, useKerb, gssCredential);
+    }
 
     @Override
     public ConnectionResults getPooledConnection(final CommonDataSource ds, String userName, String password, final boolean is2Phase, 
@@ -812,22 +825,24 @@ public class OracleHelper extends DatabaseHelper {
             Tr.entry(this, tc, "getPooledConnection", AdapterUtil.toString(ds), userName, "******", is2Phase ? "two-phase" : "one-phase",
                      cri, useKerberos, gssCredential);
         
-        if (useKerberos != KerbUsage.NONE && JavaInfo.majorVersion() == 8 && JavaInfo.vendor() == Vendor.IBM) {
+        if (useKerberos != KerbUsage.NONE) {
+            checkIBMJava8();
+            setKerberosDatasourceProperties(ds);
+        }
+        ConnectionResults results = super.getPooledConnection(ds, userName, password, is2Phase, cri, useKerberos, gssCredential);
+
+        if (isTraceOn && tc.isEntryEnabled()) 
+            Tr.exit(this, tc, "getPooledConnection", results);
+        return results;
+    }
+    
+    private static void checkIBMJava8() throws ResourceException {
+        if (JavaInfo.majorVersion() == 8 && JavaInfo.vendor() == Vendor.IBM) {
             // The Oracle JDBC driver does not support kerberos authentication on IBM JDK 8 because
             // it has dependencies to the internal Sun security APIs which don't exist in IBM JDK 8
             Tr.error(tc, "KERBEROS_ORACLE_IBMJDK_NOT_SUPPORTED");
             throw new ResourceException(AdapterUtil.getNLSMessage("KERBEROS_ORACLE_IBMJDK_NOT_SUPPORTED"));
         }
-
-        ConnectionResults results;
-        if (useKerberos != KerbUsage.NONE) {
-            setKerberosDatasourceProperties(ds);
-        }
-        results = super.getPooledConnection(ds, userName, password, is2Phase, cri, useKerberos, gssCredential);
-
-        if (isTraceOn && tc.isEntryEnabled()) 
-            Tr.exit(this, tc, "getPooledConnection", results);
-        return results;
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc_fat_krb5/publish/servers/com.ibm.ws.jdbc.fat.krb5.oracle/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/publish/servers/com.ibm.ws.jdbc.fat.krb5.oracle/server.xml
@@ -27,6 +27,12 @@
     <properties.oracle URL="${oracle.url}"/>
     <containerAuthData krb5Principal="${KRB5_USER}"/>
   </dataSource>
+
+  <dataSource jndiName="jdbc/krb/DataSource" type="javax.sql.DataSource">
+    <jdbcDriver libraryRef="OracleLib" />
+    <properties.oracle URL="${oracle.url}"/>
+    <containerAuthData krb5Principal="${KRB5_USER}"/>
+  </dataSource>
   
   <!-- Mis-configured datasource: bogus name for krb5Principal -->
   <dataSource jndiName="jdbc/krb/invalidPrincipal">

--- a/dev/com.ibm.ws.jdbc_fat_krb5/publish/servers/com.ibm.ws.jdbc.fat.krb5/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/publish/servers/com.ibm.ws.jdbc.fat.krb5/server.xml
@@ -27,6 +27,11 @@
     <properties.db2.jcc databaseName="${DB2_DBNAME}" serverName="${DB2_HOSTNAME}" portNumber="${DB2_PORT}"/>
   </dataSource>
   
+  <dataSource jndiName="jdbc/krb/DataSource" type="javax.sql.DataSource" containerAuthDataRef="krb5Auth">
+    <jdbcDriver libraryRef="DB2JCCLib" javax.sql.DataSource="com.ibm.db2.jcc.DB2SimpleDataSource"/>
+    <properties.db2.jcc databaseName="${DB2_DBNAME}" serverName="${DB2_HOSTNAME}" portNumber="${DB2_PORT}"/>
+  </dataSource>
+  
   <dataSource jndiName="jdbc/krb/basicPassword">
     <jdbcDriver libraryRef="DB2JCCLib"/>
     <properties.db2.jcc databaseName="${DB2_DBNAME}" serverName="${DB2_HOSTNAME}" portNumber="${DB2_PORT}"/>


### PR DESCRIPTION
When Kerberos authentication is used in the Oracle JDBC driver, it goes down a code path that tries to load some JDK internal Kerberos APIs which do not exist on IBM JDK 8, which has its own set of security APIs.

To make this situation more clear to users, detect this combination and emit a clear error message indicating that the combination of IBM JDK 8 and Oracle JDBC w/ Kerberos is not supported.

Also, add support+tests for getting a Kerberos connection with the javax.sql.DataSource interface (previously only ConnectionPoolDataSource and XADataSource worked)