### PR TITLE
Clear application REST metrics properly

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.x.monitor/src/com/ibm/ws/jaxrs/monitor/JaxRsMonitorFilter.java
+++ b/dev/com.ibm.ws.jaxrs.2.x.monitor/src/com/ibm/ws/jaxrs/monitor/JaxRsMonitorFilter.java
@@ -89,7 +89,6 @@ public class JaxRsMonitorFilter implements ContainerRequestFilter, ContainerResp
      */
 	@Override
 	public void filter(ContainerRequestContext reqCtx, ContainerResponseContext respCtx) throws IOException {
-
 		long elapsedTime = 0;
 		// Calculate the response time for the resource method.
 		Long startTime = (Long) reqCtx.getProperty(START_TIME);
@@ -98,7 +97,7 @@ public class JaxRsMonitorFilter implements ContainerRequestFilter, ContainerResp
 		}
 
 		Class<?> resourceClass = resourceInfo.getResourceClass();
-
+		
 		if (resourceClass != null) {
 			Method resourceMethod = resourceInfo.getResourceMethod();
 
@@ -140,14 +139,15 @@ public class JaxRsMonitorFilter implements ContainerRequestFilter, ContainerResp
 			//Check for MP Metrics 30 header;
 			if (metricsHeader == null)
 				metricsHeader = respCtx.getHeaderString("io.openliberty.microprofile.metrics.internal.monitor.MetricsJaxRsEMCallbackImpl.Exception");
+
+			// Save key in appMetricInfos for cleanup on application stop.
+			addKeyToMetricInfo(appName, key);
 			
 			if (metricsHeader == null) {
 				// Need to start new minute here.. we need to pass in the stat object so we can
 				// actually update Mbean
 				maybeStartNewMinute(stats);
 
-				// Save key in appMetricInfos for cleanup on application stop.
-				addKeyToMetricInfo(appName, key);
 
 				// Increment the request count for the resource method.
 				stats.incrementCountBy(1);


### PR DESCRIPTION
The REST.Request metrics for REST endpoints that are created by an unmapped exception are not stored and cleared properly when the application is unloaded.

This causes an edge case where if the application is loaded again (and the server has not shut down) then the REST.request metric will not be created and registered or updated.

#build