### PR TITLE
13447: Clean up H2 connection

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/outbound/HttpOutputStreamImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/outbound/HttpOutputStreamImpl.java
@@ -234,7 +234,8 @@ public class HttpOutputStreamImpl extends HttpOutputStreamConnectWeb {
                 Tr.debug(tc, "validate response is cleaned up hc: " + this.hashCode() + " details: " + this);
             }
 
-            throw new IOException("H2 Response already destroyed on error condition");
+            // Return to clean up the rest of the request/response
+            return;
 
         }
 


### PR DESCRIPTION
This problem is a http/2 timing issue where different threads are handling requests on a connection.  An error on one thread causes the connection to be cleaned up, and then a second thread wakes up only to find all it's resources are gone.

A previous attempt at fixing this threw an ioException when this condition occurred. This causes an FFDC in the server log.
Instead of throwing an exception, a log message is issued, and the code should just return so the connection, request, and response are cleaned up.