### PR TITLE
13488: Reorder the unknown frame type test

### DIFF
--- a/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/GenericFrameTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/GenericFrameTests.java
@@ -180,15 +180,15 @@ public class GenericFrameTests extends H2FATDriverServlet {
 
         setupDefaultPreface(h2Client);
 
-        // send over a PING frame and expect a response
-        pingFrame = new FramePing(0, pingData, false);
-        h2Client.sendFrame(pingFrame);
-
         // malformed frame: set frame type byte to unknown
         //_________________________||____________________ - frame type byte
         String dataString = "0000060f0000000003414243313233";
         byte[] b = parseHexBinary(dataString);
         h2Client.sendBytesAfterPreface(b);
+
+        // send over a PING frame and expect a response
+        pingFrame = new FramePing(0, pingData, false);
+        h2Client.sendFrame(pingFrame);
 
         waitForTestCompletion(blockUntilConnectionIsDone);
         handleErrors(h2Client, testName);


### PR DESCRIPTION
The purpose of this test is to send a frame which has an unknown type to the server, where the server should ignore it.

Currently the client side log shows the following:

1) Connection and upgrade happens normally
2) 200 response received
3) Ping frame sent
4) Ping frame received
5) Client determines that the ping was the last expected frame and sends a goaway which causes the connection to close
6) The test continues and the bad frame is sent
7) Client gets IOException, connection aborted by host

This fix is to reorder the testcase to send the frame with the bad type before the ping.
Then when the ping response is received, it is actually the last expected frame, the client can then close things up.

