### PR TITLE
Correct springboot feature subsystem names

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/springBoot-1.5/com.ibm.websphere.appserver.springBoot-1.5.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/springBoot-1.5/com.ibm.websphere.appserver.springBoot-1.5.feature
@@ -4,7 +4,7 @@ visibility=public
 singleton=true
 IBM-ShortName: springBoot-1.5
 IBM-Process-Types: server
-Subsystem-Name: Spring Boot Support version 1.5
+Subsystem-Name: Spring Boot Support 1.5
 -features=com.ibm.websphere.appserver.springBootHandler-1.0
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/springBoot-2.0/com.ibm.websphere.appserver.springBoot-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/springBoot-2.0/com.ibm.websphere.appserver.springBoot-2.0.feature
@@ -4,7 +4,7 @@ visibility=public
 singleton=true
 IBM-ShortName: springBoot-2.0
 IBM-Process-Types: server
-Subsystem-Name: Spring Boot Support version 2.0
+Subsystem-Name: Spring Boot Support 2.0
 -features=com.ibm.websphere.appserver.springBootHandler-1.0
 kind=ga
 edition=core


### PR DESCRIPTION
The springboot feature Subsystem-Names are not standard. While
they are not referenced elsewhere in the code, they are used by
tooling to generate supporting documentation and result in incorrect
output.

