### PR TITLE
managed executor copy stage and getThreadContext

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -66,7 +66,7 @@ com.ibm.ws.org.codehaus.jackson:jackson-xc:1.6.2
 com.ibm.ws.org.codehaus.jackson:jackson-xc:1.9.13
 com.ibm.ws.org.eclipse.equinox:console:1.1.200.v20150929-1405
 com.ibm.ws.org.eclipse.jdt.core.compiler:ecj:4.4.2
-com.ibm.ws.org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:0.20190322.204445.1
+com.ibm.ws.org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.1.20200728.204607-6
 com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.antlr:2.6.8.WAS-cf583f2
 com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.asm:2.6.8.WAS-cf583f2
 com.ibm.ws.org.eclipse.persistence:org.eclipse.persistence.core:2.6.8.WAS-cf583f2

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.1.feature
@@ -1,7 +1,7 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.1
 singleton=true
--bundles=com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.0.2"
+-bundles=com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.1; location:="dev/api/stable/,lib/"; mavenCoordinates="com.ibm.ws.org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.1.20200728.204607-6"
 kind=noship
 edition=full
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation-1.1/com.ibm.websphere.appserver.mpContextPropagation-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation-1.1/com.ibm.websphere.appserver.mpContextPropagation-1.1.feature
@@ -9,7 +9,8 @@ IBM-API-Package: \
   org.eclipse.microprofile.context; type="stable", \
   org.eclipse.microprofile.context.spi; type="stable"
 -features=\
-  com.ibm.websphere.appserver.concurrent-2.0; ibm.tolerates:=1.0
+  com.ibm.websphere.appserver.concurrent-2.0; ibm.tolerates:=1.0, \
+  com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.1
 -bundles=\
   com.ibm.ws.microprofile.contextpropagation.1.0
 kind=noship

--- a/dev/com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.1/.classpath
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.1/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.1/.project
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.1/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.1</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.1/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.1/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.1/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.1/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,12 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.1/bnd.bnd
+++ b/dev/com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.1/bnd.bnd
@@ -1,0 +1,36 @@
+#*******************************************************************************
+# Copyright (c) 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+# IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+
+Bundle-SymbolicName: com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.1; singleton:=true
+
+Import-Package: \
+  javax.inject;resolution:=optional,\
+  javax.enterprise.util;resolution:=optional,\
+  *
+
+Export-Package: \
+  org.eclipse.microprofile.context;version=1.1, \
+  org.eclipse.microprofile.context.spi;version=1.1
+
+Include-Resource: \
+   @${repo;com.ibm.ws.org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api;1.1.20200728.204607-6;EXACT}
+
+WS-TraceGroup: concurrent
+
+-buildpath: \
+  com.ibm.ws.org.osgi.annotation.versioning;version=latest
+
+instrument.disabled: true
+
+publish.wlp.jar.suffix: dev/api/stable

--- a/dev/com.ibm.ws.concurrent.mp_fat/.classpath
+++ b/dev/com.ibm.ws.concurrent.mp_fat/.classpath
@@ -6,6 +6,7 @@
 	<classpathentry kind="src" path="test-applications/MPConcurrentConfigApp/src"/>
 	<classpathentry kind="src" path="test-applications/MPConcurrentJAXRSApp/src"/>
 	<classpathentry kind="src" path="test-applications/MPConcurrentTxApp/src"/>
+	<classpathentry kind="src" path="test-applications/MPContextProp1_1_App/src"/>
 	<classpathentry kind="src" path="test-applications/customcontext/src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>

--- a/dev/com.ibm.ws.concurrent.mp_fat/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp_fat/bnd.bnd
@@ -19,6 +19,7 @@ src: \
 	test-applications/MPConcurrentConfigApp/src,\
 	test-applications/MPConcurrentJAXRSApp/src,\
 	test-applications/MPConcurrentTxApp/src,\
+	test-applications/MPContextProp1_1_App/src,\
 	test-applications/customcontext/src
 
 fat.project: true
@@ -34,7 +35,7 @@ tested.features:cdi-3.0
 	com.ibm.websphere.javaee.jsonp.1.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.4.0;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.2;version=latest,\
-	com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.0;version=latest,\
+	com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.1;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.config.1.3;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\

--- a/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/FATSuite.java
@@ -20,6 +20,7 @@ import org.junit.runners.Suite.SuiteClasses;
                 MPConcurrentConfigTest.class,
                 MPConcurrentJAXRSTest.class,
                 MPConcurrentTxTest.class,
+                MPContextProp1_1_Test.class,
                 MPConcurrentCDITest.class // moved last because @RepeatTests, when added to this class, interferes with test classes that run after it // TODO
 })
 public class FATSuite {

--- a/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPContextProp1_1_Test.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPContextProp1_1_Test.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp.fat;
+
+import org.eclipse.microprofile.context.spi.ThreadContextProvider;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.test.context.location.CityContextProvider;
+import org.test.context.location.StateContextProvider;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import concurrent.mp.fat.v11.web.MPContextProp1_1_TestServlet;
+
+@RunWith(FATRunner.class)
+public class MPContextProp1_1_Test extends FATServletClient {
+
+    private static final String APP_NAME = "MPContextProp1_1_App";
+
+    @Server("MPContextProp1_1_Server")
+    @TestServlet(servlet = MPContextProp1_1_TestServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultApp(server, APP_NAME, "concurrent.mp.fat.v11.web");
+
+        JavaArchive customContextProviders = ShrinkWrap.create(JavaArchive.class, "customContextProviders.jar")
+                        .addPackage("org.test.context.location")
+                        .addAsServiceProvider(ThreadContextProvider.class, CityContextProvider.class, StateContextProvider.class);
+        ShrinkHelper.exportToServer(server, "lib", customContextProviders);
+
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+}

--- a/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPContextProp1_1_Server/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPContextProp1_1_Server/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:concurrent=all

--- a/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPContextProp1_1_Server/server.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPContextProp1_1_Server/server.xml
@@ -1,0 +1,36 @@
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+    <featureManager>
+        <feature>componenttest-2.0</feature>
+        <feature>jdbc-4.2</feature>
+        <feature>jndi-1.0</feature>
+        <feature>mpContextPropagation-1.1</feature>
+        <feature>servlet-5.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+    
+    <application location="MPContextProp1_1_App.war">
+        <classloader commonLibraryRef="customContextProviderLib"/>
+    </application>
+
+    <library id="customContextProviderLib">
+        <file name="${server.config.dir}/lib/customContextProviders.jar"/>
+    </library>
+
+    <!-- Needed for application to use a ForkJoinPool, access the thread context class loader, and shut down an unmanaged ExecutorService that the test application creates -->
+    <javaPermission codebase="${server.config.dir}/apps/MPContextProp1_1_App.war" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codebase="${server.config.dir}/apps/MPContextProp1_1_App.war" className="java.lang.RuntimePermission" name="modifyThread"/>
+    <javaPermission codebase="${server.config.dir}/apps/MPContextProp1_1_App.war" className="java.lang.RuntimePermission" name="setContextClassLoader"/>
+    <javaPermission codebase="${server.config.dir}/apps/MPContextProp1_1_App.war" className="java.util.PropertyPermission" name="java.util.concurrent.ForkJoinPool.*" actions="read"/>
+</server>

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPContextProp1_1_App/src/concurrent/mp/fat/v11/web/MPContextProp1_1_TestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPContextProp1_1_App/src/concurrent/mp/fat/v11/web/MPContextProp1_1_TestServlet.java
@@ -1,0 +1,534 @@
+/*******************************************************************************
+ * Copyright (c) 2019,2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package concurrent.mp.fat.v11.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import jakarta.annotation.Resource;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.eclipse.microprofile.context.ThreadContext;
+import org.junit.Test;
+import org.test.context.location.CurrentLocation;
+import org.test.context.location.TestContextTypes;
+
+import componenttest.annotation.AllowedFFDC;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/MPContextProp1_1_TestServlet")
+public class MPContextProp1_1_TestServlet extends HttpServlet {
+    private static final String SUCCESS = "SUCCESS";
+    private static final String TEST_METHOD = "testMethod";
+
+    /**
+     * 2 minutes. Maximum number of nanoseconds to wait for a task to complete.
+     */
+    private static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(2);
+
+    @Resource(name = "java:module/env/defaultExecutorRef")
+    private ManagedExecutor defaultManagedExecutor;
+
+    /**
+     * Executor that can be used when tests don't want to tie up threads from the Liberty global thread pool to perform test logic
+     */
+    private ExecutorService testThreads;
+
+    @Override
+    public void destroy() {
+        AccessController.doPrivileged((PrivilegedAction<List<Runnable>>) () -> testThreads.shutdownNow());
+    }
+
+    /**
+     * The following is copied because this test cannot extend the Jakarta version of FATServlet when other tests
+     * in the project already extend the Java EE version of FATServlet, given that both have the same name and package.
+     */
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String method = request.getParameter(TEST_METHOD);
+
+        System.out.println(">>> BEGIN: " + method);
+        System.out.println("Request URL: " + request.getRequestURL() + '?' + request.getQueryString());
+        PrintWriter writer = response.getWriter();
+        if (method != null && method.length() > 0) {
+            try {
+                // Use reflection to try invoking various test method signatures:
+                // 1)  method(HttpServletRequest request, HttpServletResponse response)
+                // 2)  method()
+                // 3)  use custom method invocation by calling invokeTest(method, request, response)
+                try {
+                    Method mthd = getClass().getMethod(method, HttpServletRequest.class, HttpServletResponse.class);
+                    mthd.invoke(this, request, response);
+                } catch (NoSuchMethodException nsme) {
+                    Method mthd = getClass().getMethod(method, (Class<?>[]) null);
+                    mthd.invoke(this);
+                } finally {
+                    CurrentLocation.clear(); // clean up custom thread context after test
+                }
+
+                writer.println(SUCCESS);
+            } catch (Throwable t) {
+                if (t instanceof InvocationTargetException) {
+                    t = t.getCause();
+                }
+
+                System.out.println("ERROR: " + t);
+                StringWriter sw = new StringWriter();
+                t.printStackTrace(new PrintWriter(sw));
+                System.err.print(sw);
+
+                writer.println("ERROR: Caught exception attempting to call test method " + method + " on servlet " + getClass().getName());
+                t.printStackTrace(writer);
+            }
+        } else {
+            System.out.println("ERROR: expected testMethod parameter");
+            writer.println("ERROR: expected testMethod parameter");
+        }
+
+        writer.flush();
+        writer.close();
+
+        System.out.println("<<< END:   " + method);
+    }
+
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        testThreads = Executors.newFixedThreadPool(10);
+    }
+
+    /**
+     * Verify that ManagedExecutor.copy(CompletableFuture) returns a CompletableFuture that
+     * automatically completes when the original CompletableFuture completes, but applies
+     * to dependent stages the context and concurrency constraints of the ManagedExecutor.
+     */
+    @Test
+    public void testCopyFuture() throws Exception {
+        ManagedExecutor executor = ManagedExecutor.builder()
+                        .propagated(TestContextTypes.STATE)
+                        .cleared(ThreadContext.ALL_REMAINING)
+                        .build();
+
+        CurrentLocation.setLocation("Minneapolis", "Minnesota");
+
+        CompletableFuture<String> unmanagedFuture = new CompletableFuture<String>();
+        CompletableFuture<String> copy = executor.copy(unmanagedFuture);
+        CompletableFuture<String> dependentStage = copy.thenApplyAsync(s -> {
+            try {
+                fail("Should not be able to look up " + InitialContext.doLookup("java:module/env/defaultExecutorRef"));
+            } catch (NamingException x) {
+                // expected because application context should be cleared
+            }
+
+            String city = CurrentLocation.getCity();
+            return s + ("".equals(city) ? CurrentLocation.getState() : (city + ", " + CurrentLocation.getState()));
+        });
+
+        CurrentLocation.setLocation("Des Moines", "Iowa");
+
+        assertFalse(copy.isDone());
+
+        unmanagedFuture.complete("Arriving in ");
+        assertEquals("Arriving in Minnesota", dependentStage.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        assertTrue(copy.isDone());
+
+        // Complete the copy stage before the original
+        unmanagedFuture = new CompletableFuture<String>();
+        copy = executor.copy(unmanagedFuture);
+        dependentStage = copy.thenApplyAsync(s -> s + CurrentLocation.getState());
+
+        CurrentLocation.setLocation("Madison", "Wisconsin");
+
+        assertFalse(copy.isDone());
+        copy.complete("You are now in ");
+        assertEquals("You are now in Iowa", dependentStage.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        assertTrue(copy.isDone());
+        // Because the copy was completed separately, the original can complete after this point with a different value.
+        assertTrue(unmanagedFuture.complete("ABCDE"));
+        assertEquals("ABCDE", unmanagedFuture.getNow("F"));
+        assertEquals("You are now in ", copy.getNow("G"));
+
+        executor.shutdown();
+    }
+
+    /**
+     * Verify that ManagedExecutor.copy(CompletionStage) returns a CompletionStage that
+     * automatically completes when the original CompletionStage completes, but applies
+     * to dependent stages the context and concurrency constraints of the ManagedExecutor.
+     */
+    @Test
+    public void testCopyStage() throws Exception {
+        ManagedExecutor executor = ManagedExecutor.builder()
+                        .maxAsync(1)
+                        .maxQueued(1)
+                        .propagated(TestContextTypes.CITY)
+                        .build();
+
+        CountDownLatch originalStageBlocker = new CountDownLatch(1);
+        CountDownLatch dependentStageBlocker = new CountDownLatch(1);
+
+        CompletionStage<CountDownLatch> unmanagedFuture = CompletableFuture.supplyAsync(() -> {
+            try {
+                assertTrue(originalStageBlocker.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+                return dependentStageBlocker;
+            } catch (InterruptedException x) {
+                throw new CompletionException(x);
+            }
+        }, testThreads);
+        CompletionStage<CountDownLatch> copy = executor.copy(unmanagedFuture);
+
+        CurrentLocation.setLocation("Stewartville", "Minnesota");
+
+        CompletionStage<String> dependentStage1 = copy.thenApplyAsync(latch -> {
+            try {
+                return latch.await(TIMEOUT_NS, TimeUnit.NANOSECONDS) ? CurrentLocation.getCity() : "Dependent stage 1 timed out";
+            } catch (InterruptedException x) {
+                throw new CompletionException(x);
+            }
+        });
+
+        CompletionStage<String> dependentStage2 = copy.thenApplyAsync(latch -> {
+            try {
+                return latch.await(TIMEOUT_NS, TimeUnit.NANOSECONDS) ? CurrentLocation.getCity() : "Dependent stage 2 timed out";
+            } catch (InterruptedException x) {
+                throw new CompletionException(x);
+            }
+        });
+
+        CompletionStage<String> dependentStage3 = copy.thenApplyAsync(latch -> {
+            try {
+                return latch.await(TIMEOUT_NS, TimeUnit.NANOSECONDS) ? CurrentLocation.getCity() : "Dependent stage 3 timed out";
+            } catch (InterruptedException x) {
+                throw new CompletionException(x);
+            }
+        });
+
+        // Allow the original stage to complete
+        CurrentLocation.setLocation("Byron", "Minnesota");
+        originalStageBlocker.countDown();
+
+        // At least one of the dependent stages will be unable to queue for execution due to maxQueued=1, maxAsync=1
+        LinkedBlockingQueue<Throwable> abortedStageExceptions = new LinkedBlockingQueue<Throwable>(3);
+        LinkedBlockingQueue<String> successfulStageResults = new LinkedBlockingQueue<String>(3);
+
+        BiConsumer<String, Throwable> collectResult = (result, x) -> {
+            if (x == null)
+                successfulStageResults.add(result);
+            else
+                abortedStageExceptions.add(x);
+        };
+        dependentStage1.whenComplete(collectResult);
+        dependentStage2.whenComplete(collectResult);
+        dependentStage3.whenComplete(collectResult);
+
+        // At least one dependent stage must be rejected
+        Throwable x = abortedStageExceptions.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+        assertNotNull("1 or 2 dependent stages should be aborted due to the maxAsync/maxQueued limitations of the managed executor", x);
+        assertTrue(x.toString(), x instanceof RejectedExecutionException);
+        assertTrue(x.toString(), x.getMessage().contains("CWWKE1201E"));
+
+        // At least one dependent stage must complete successfully
+        dependentStageBlocker.countDown();
+        assertEquals("Stewartville", successfulStageResults.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        // The remaining stage can either be rejected or complete successfully based on timing
+        for (long start = System.nanoTime(); System.nanoTime() - start < TIMEOUT_NS; Thread.sleep(200)) {
+            String result = successfulStageResults.poll();
+            if (result != null) {
+                assertEquals("Stewartville", result);
+                break;
+            }
+            x = abortedStageExceptions.poll();
+            if (x != null) {
+                assertTrue(x.toString(), x instanceof RejectedExecutionException);
+                assertTrue(x.toString(), x.getMessage().contains("CWWKE1201E"));
+                break;
+            }
+        }
+
+        executor.shutdown();
+    }
+
+    /**
+     * Verify that ManagedExecutor.getThreadContext returns a usable ThreadContext instance,
+     * which propagates and clears the same types of thread context as the ManagedExecutor.
+     * Also verifies that a completion stage that is created by withContextCapture runs on the
+     * ManagedExecutor from which the ThreadContext was obtained.
+     */
+    @Test
+    public void testGetThreadContext() throws Exception {
+        ManagedExecutor executor = ManagedExecutor.builder()
+                        .maxAsync(1)
+                        .maxQueued(1)
+                        .propagated(ThreadContext.APPLICATION, TestContextTypes.STATE)
+                        .cleared(ThreadContext.ALL_REMAINING)
+                        .build();
+
+        ThreadContext threadContext = executor.getThreadContext();
+
+        CurrentLocation.setLocation("Rochester", "Minnesota");
+
+        Callable<String> contextualAction = threadContext.contextualCallable(() -> {
+            // application context must propagate for this to work
+            assertNotNull(InitialContext.doLookup("java:module/env/defaultExecutorRef"));
+
+            String city = CurrentLocation.getCity();
+            if ("".equals(city))
+                city = "Unknown location";
+            return city + " in " + CurrentLocation.getState();
+        });
+
+        CurrentLocation.setLocation("La Crosse", "Wisconsin");
+
+        // Run on JDK's fork join pool, but with previously captured context
+        Future<String> future = testThreads.submit(contextualAction);
+        assertEquals("Unknown location in Minnesota", future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        // Run on current thread
+        assertEquals("Unknown location in Minnesota", contextualAction.call());
+
+        // Verify context of current thread is restored
+        assertEquals("La Crosse in Wisconsin", CurrentLocation.getCity() + " in " + CurrentLocation.getState());
+        assertNotNull(InitialContext.doLookup("java:module/env/defaultExecutorRef"));
+
+        // Use up the maxAsync of 1
+        CountDownLatch blocker = new CountDownLatch(1);
+        CountDownLatch isBlocking = new CountDownLatch(1);
+        CompletableFuture<Boolean> blockingFuture = executor.supplyAsync(() -> {
+            try {
+                isBlocking.countDown();
+                return blocker.await(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+            } catch (InterruptedException x) {
+                throw new CompletionException(x);
+            }
+        });
+        assertTrue(isBlocking.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        CompletableFuture<String> unmanagedFuture = CompletableFuture.supplyAsync(() -> {
+            try {
+                TimeUnit.MILLISECONDS.sleep(200);
+                return "Location is ";
+            } catch (InterruptedException x) {
+                throw new CompletionException(x);
+            }
+        }, testThreads);
+
+        CompletableFuture<String> copy = threadContext.withContextCapture(unmanagedFuture);
+
+        CurrentLocation.setLocation("Decorah", "Iowa");
+
+        Function<String, String> getLocation = s -> s + CurrentLocation.getCity() + CurrentLocation.getState();
+        CompletableFuture<String> dependentStage1 = copy.thenApplyAsync(getLocation);
+        CompletableFuture<String> dependentStage2 = copy.thenApplyAsync(getLocation);
+
+        CurrentLocation.setLocation("Rockford", "Illinois");
+
+        // Only one of the stages can be queued. The other must be rejected.
+        Throwable abortedTaskException = null;
+        for (long start = System.nanoTime(); System.nanoTime() - start < TIMEOUT_NS && abortedTaskException == null; TimeUnit.MILLISECONDS.sleep(200)) {
+            try {
+                assertEquals("1 not done yet", dependentStage1.getNow("1 not done yet"));
+                assertEquals("2 not done yet", dependentStage2.getNow("2 not done yet"));
+            } catch (CancellationException x) {
+                abortedTaskException = x;
+            } catch (CompletionException x) {
+                Throwable cause = x.getCause();
+                if (cause instanceof RejectedExecutionException)
+                    abortedTaskException = cause;
+                else
+                    throw x;
+            }
+        }
+        assertNotNull("Neither stage was rejected, despite queue capacity configured to 1: " + dependentStage1 + ", " + dependentStage2, abortedTaskException);
+
+        blocker.countDown();
+ 
+        if (dependentStage1.isCompletedExceptionally())
+            assertEquals("Location is Iowa", dependentStage2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        if (dependentStage2.isCompletedExceptionally())
+            assertEquals("Location is Iowa", dependentStage1.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        executor.shutdown();
+    }
+
+    /**
+     * Verify that a completion stage that is created by withContextCapture runs on the DefaultManagedExecutorService
+     * when the ThreadContext was not obtained from a ManagedExecutor.
+     */
+    @Test
+    public void testStageWithContextCaptureThatRunsOnDefaultManagedExecutor() throws Exception {
+        ThreadContext threadContext = ThreadContext.builder()
+                        .propagated(ThreadContext.APPLICATION, TestContextTypes.CITY)
+                        .cleared(ThreadContext.ALL_REMAINING)
+                        .build();
+
+        CompletionStage<String> unmanagedStage = CompletableFuture.supplyAsync(() -> "City of ", testThreads);
+        CompletionStage<String> copy = threadContext.withContextCapture(unmanagedStage);
+
+        CountDownLatch blocker = new CountDownLatch(1);
+        LinkedBlockingQueue<ManagedExecutor> lookupResults = new LinkedBlockingQueue<ManagedExecutor>();
+        Function<String, String> getCity = s -> {
+            try {
+                // verify availability of application context
+                lookupResults.add(InitialContext.doLookup("java:module/env/defaultExecutorRef"));
+
+                blocker.await(TIMEOUT_NS * 3, TimeUnit.NANOSECONDS);
+            } catch (InterruptedException x) {
+                throw new CompletionException(x);
+            } catch (NamingException x) {
+                throw new CompletionException(x);
+            }
+
+            // verify availability of custom context
+            s += CurrentLocation.getCity();
+            // verify clearing of other custom context
+            String state = CurrentLocation.getState();
+            if (!"".equals(state))
+                s += " in " + state;
+            return s;
+        };
+
+        CurrentLocation.setLocation("Chatfield", "Minnesota");
+        CompletionStage<String> dependentStage1 = copy.thenApplyAsync(getCity);
+        CurrentLocation.setLocation("Fountain", "Minnesota");
+        CompletionStage<String> dependentStage2 = copy.thenApplyAsync(getCity);
+        CurrentLocation.setLocation("Preston", "Minnesota");
+        CompletionStage<String> dependentStage3 = copy.thenApplyAsync(getCity);
+        CurrentLocation.setLocation("Lanesboro", "Minnesota");
+        CompletionStage<String> dependentStage4 = copy.thenApplyAsync(getCity);
+        CurrentLocation.setLocation("Harmony", "Minnesota");
+
+        // wait for all 4 dependent stages to be running
+        assertNotNull(lookupResults.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertNotNull(lookupResults.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertNotNull(lookupResults.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertNotNull(lookupResults.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        // allow all stages to complete
+        blocker.countDown();
+
+        assertEquals("City of Chatfield", dependentStage1.toCompletableFuture().get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertEquals("City of Fountain", dependentStage2.toCompletableFuture().get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertEquals("City of Preston", dependentStage3.toCompletableFuture().get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertEquals("City of Lanesboro", dependentStage4.toCompletableFuture().get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        // Context of current thread does not change
+        assertEquals("Harmony", CurrentLocation.getCity());
+        assertEquals("Minnesota", CurrentLocation.getState());
+    }
+
+    /**
+     * Verify that a completion stage that is created by withContextCapture runs on the ManagedExecutor from which
+     * the ThreadContext was obtained.
+     */
+    @Test
+    public void testStageWithContextCaptureThatRunsOnItsManagedExecutor() throws Exception {
+        ManagedExecutor executor = ManagedExecutor.builder()
+                        .maxAsync(2)
+                        .propagated(ThreadContext.APPLICATION, TestContextTypes.CITY)
+                        .cleared(ThreadContext.ALL_REMAINING)
+                        .build();
+
+        ThreadContext threadContext = executor.getThreadContext();
+
+        CompletionStage<String> unmanagedStage = CompletableFuture.supplyAsync(() -> "City of ", testThreads);
+        CompletionStage<String> copy = threadContext.withContextCapture(unmanagedStage);
+
+        CountDownLatch blocker = new CountDownLatch(1);
+        LinkedBlockingQueue<ManagedExecutor> lookupResults = new LinkedBlockingQueue<ManagedExecutor>();
+        Function<String, String> getCity = s -> {
+            try {
+                // verify availability of application context
+                lookupResults.add(InitialContext.doLookup("java:module/env/defaultExecutorRef"));
+
+                blocker.await(TIMEOUT_NS * 3, TimeUnit.NANOSECONDS);
+            } catch (InterruptedException x) {
+                throw new CompletionException(x);
+            } catch (NamingException x) {
+                throw new CompletionException(x);
+            }
+
+            // verify availability of custom context
+            s += CurrentLocation.getCity();
+            // verify clearing of other custom context
+            String state = CurrentLocation.getState();
+            if (!"".equals(state))
+                s += " in " + state;
+            return s;
+        };
+
+        CurrentLocation.setLocation("Oronoco", "Minnesota");
+        CompletionStage<String> dependentStage1 = copy.thenApplyAsync(getCity);
+        CurrentLocation.setLocation("Pine Island", "Minnesota");
+        CompletionStage<String> dependentStage2 = copy.thenApplyAsync(getCity);
+        CurrentLocation.setLocation("Zumbrota", "Minnesota");
+        CompletionStage<String> dependentStage3 = copy.thenApplyAsync(getCity);
+        CurrentLocation.setLocation("Mazeppa", "Minnesota");
+        CompletionStage<String> dependentStage4 = copy.thenApplyAsync(getCity);
+        CurrentLocation.setLocation("Cannon Falls", "Minnesota");
+
+        // wait for 2 dependent stages to be running
+        assertNotNull(lookupResults.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertNotNull(lookupResults.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        // running of additional dependent stages must be blocked due to maxAsync
+        assertNull(lookupResults.poll(2, TimeUnit.SECONDS));
+
+        // allow all stages to complete
+        blocker.countDown();
+        assertNotNull(lookupResults.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertNotNull(lookupResults.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        assertEquals("City of Oronoco", dependentStage1.toCompletableFuture().get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertEquals("City of Pine Island", dependentStage2.toCompletableFuture().get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertEquals("City of Zumbrota", dependentStage3.toCompletableFuture().get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        assertEquals("City of Mazeppa", dependentStage4.toCompletableFuture().get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+    }
+}

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextServiceImpl.java
@@ -831,7 +831,10 @@ public class ContextServiceImpl implements ContextService, //
     public <T> CompletableFuture<T> withContextCapture(CompletableFuture<T> stage) {
         CompletableFuture<T> newCompletableFuture;
 
-        UnusableExecutor executor = new UnusableExecutor(this);
+        Executor executor = MPContextPropagationVersion.atLeast(MPContextPropagationVersion.V1_1) //
+                        ? new ContextualDefaultExecutor(this) //
+                        : new UnusableExecutor(this);
+
         if (ManagedCompletableFuture.JAVA8)
             newCompletableFuture = new ManagedCompletableFuture<T>(new CompletableFuture<T>(), executor, null);
         else
@@ -853,7 +856,10 @@ public class ContextServiceImpl implements ContextService, //
     public <T> CompletionStage<T> withContextCapture(CompletionStage<T> stage) {
         ManagedCompletionStage<T> newStage;
 
-        UnusableExecutor executor = new UnusableExecutor(this);
+        Executor executor = MPContextPropagationVersion.atLeast(MPContextPropagationVersion.V1_1) //
+                        ? new ContextualDefaultExecutor(this) //
+                        : new UnusableExecutor(this);
+
         if (ManagedCompletableFuture.JAVA8)
             newStage = new ManagedCompletionStage<T>(new CompletableFuture<T>(), executor, null);
         else

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextualDefaultExecutor.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextualDefaultExecutor.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.internal;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Collection;
+import java.util.concurrent.Executor;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.concurrent.WSManagedExecutorService;
+import com.ibm.ws.threading.PolicyExecutor;
+import com.ibm.wsspi.threadcontext.WSContextService;
+
+/**
+ * Executor that provides thread context capture/propagation according to the specified MP ThreadContext,
+ * but runs tasks on the DefaultManagedExecutorService, using its PolicyExecutor.
+ * WSManagedExecutorService is implemented to store a context service instance
+ * as a convenience to the managed completable future implementation.
+ * This class is used for the withContextCapture methods.
+ */
+class ContextualDefaultExecutor implements Executor, WSManagedExecutorService {
+    private final WSContextService contextService;
+    private final WSManagedExecutorService defaultManagedExecutor;
+
+    ContextualDefaultExecutor(WSContextService contextService) {
+        this.contextService = contextService;
+        this.defaultManagedExecutor = (WSManagedExecutorService) AccessController.doPrivileged(new PrivilegedAction<ManagedExecutor>() {
+            @Override
+            public ManagedExecutor run() {
+                BundleContext bundleContext = FrameworkUtil.getBundle(WSManagedExecutorService.class).getBundleContext();
+                Collection<ServiceReference<ManagedExecutor>> refs;
+                try {
+                    refs = bundleContext.getServiceReferences(ManagedExecutor.class, "(id=DefaultManagedExecutorService)");
+                } catch (InvalidSyntaxException x) {
+                    throw new RuntimeException(x);
+                }
+                if (refs.isEmpty())
+                    return null;
+                else
+                    return bundleContext.getService(refs.iterator().next());
+            }
+        });
+        if (defaultManagedExecutor == null)
+            throw new IllegalStateException("DefaultManagedExecutorService");
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        defaultManagedExecutor.getNormalPolicyExecutor().execute(command);
+    }
+
+    @Override
+    @Trivial
+    public WSContextService getContextService() {
+        return contextService;
+    }
+
+    @Override
+    @Trivial
+    public PolicyExecutor getNormalPolicyExecutor() {
+        return defaultManagedExecutor.getNormalPolicyExecutor();
+    }
+
+    @Override
+    @Trivial
+    public int hashCode() {
+        return contextService.hashCode(); // for easy correlation in trace with the context service that created it
+    }
+}

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/MPContextPropagationVersion.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/MPContextPropagationVersion.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.internal;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+
+/**
+ * Tracks the enabled version of MicroProfile Context Propagation and provides for
+ * comparisons with a target level.
+ */
+@Trivial
+enum MPContextPropagationVersion {
+    V1_0,
+    V1_1;
+
+    private static final MPContextPropagationVersion VERSION = mpContextPropagationVersion();
+
+    static boolean atLeast(MPContextPropagationVersion target) {
+        return VERSION.ordinal() >= target.ordinal();
+    }
+
+    static MPContextPropagationVersion get() {
+        return VERSION;
+    }
+
+    /**
+     * Returns the version of MicroProfile Context Propagation.
+     *
+     * @return the version of MicroProfile Context Propagation.
+     */
+    @FFDCIgnore(NoSuchMethodException.class)
+    private static MPContextPropagationVersion mpContextPropagationVersion() {
+        try {
+            ManagedExecutor.class.getMethod("getThreadContext");
+            return V1_1;
+        } catch (NoSuchMethodException x) {
+            return V1_0;
+        }
+    }
+}

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
@@ -203,7 +203,7 @@ public class ManagedExecutorServiceImpl implements ExecutorService,
     /**
      * Constructor for ManagedExecutorBuilder (from MicroProfile Context Propagation).
      */
-    public ManagedExecutorServiceImpl(String name, int hash, PolicyExecutor policyExecutor, WSContextService mpThreadContext,
+    public ManagedExecutorServiceImpl(String name, int hash, PolicyExecutor policyExecutor, ThreadContextImpl mpThreadContext,
                                       AtomicServiceReference<com.ibm.wsspi.threadcontext.ThreadContextProvider> tranContextProviderRef) {
         this.name.set(name);
         this.hash = hash;
@@ -212,6 +212,7 @@ public class ManagedExecutorServiceImpl implements ExecutorService,
         this.mpContextService = mpThreadContext;
         this.tranContextProviderRef = tranContextProviderRef;
         allowLifeCycleMethods = true;
+        mpThreadContext.managedExecutor = this;
     }
 
     /**
@@ -302,6 +303,41 @@ public class ManagedExecutorServiceImpl implements ExecutorService,
     @Override
     public <U> CompletionStage<U> completedStage(U value) {
         return ManagedCompletableFuture.completedStage(value, this);
+    }
+
+    /**
+     * This method was added to MicroProfile Context Propagation after v1.0.
+     *
+     * @return copy of the completion stage, where dependent stages of the copy uses this managed executor by default.
+     */
+    @Trivial
+    public final <T> CompletableFuture<T> copy(CompletableFuture<T> stage) {
+        return (CompletableFuture<T>) copy((CompletionStage<T>) stage);
+    }
+
+    /**
+     * This method was added to MicroProfile Context Propagation after v1.0.
+     *
+     * @return copy of the completion stage, where dependent stages of the copy uses this managed executor by default.
+     */
+    public <T> CompletionStage<T> copy(CompletionStage<T> stage) {
+        if (mpContextService == null || !MPContextPropagationVersion.atLeast(MPContextPropagationVersion.V1_1))
+            throw new UnsupportedOperationException();
+
+        final CompletableFuture<T> copy = ManagedCompletableFuture.JAVA8 //
+                        ? new ManagedCompletableFuture<T>(new CompletableFuture<T>(), this, null) //
+                        : new ManagedCompletableFuture<T>(this, null);
+
+        stage.whenComplete((result, failure) -> {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                Tr.debug(stage, tc, "whenComplete", result, failure);
+            if (failure == null)
+                copy.complete(result);
+            else
+                copy.completeExceptionally(failure);
+        });
+
+        return copy;
     }
 
     /**
@@ -449,6 +485,18 @@ public class ManagedExecutorServiceImpl implements ExecutorService,
         return policyExecutorIdentifier.startsWith("managed") //
                         ? policyExecutorIdentifier //
                         : new StringBuilder(name.get()).append(" (").append(policyExecutorIdentifier).append(')').toString();
+    }
+
+    /**
+     * This method was added to MicroProfile Context Propagation after v1.0.
+     *
+     * @return the backing instance of MicroProfile ThreadContext.
+     */
+    public org.eclipse.microprofile.context.ThreadContext getThreadContext() {
+        if (mpContextService == null || !MPContextPropagationVersion.atLeast(MPContextPropagationVersion.V1_1))
+            throw new UnsupportedOperationException();
+        else
+            return (org.eclipse.microprofile.context.ThreadContext) mpContextService;
     }
 
     @Override


### PR DESCRIPTION
Give Liberty a non-ship implementation of a couple of new MP Context Propagation 1.1 methods and add a few tests so that we can ensure these spec additions will be compatible with our implementation.