### PR TITLE
13054: H2 tests timing out

### DIFF
--- a/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/Http2Client.java
+++ b/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/Http2Client.java
@@ -452,6 +452,8 @@ public class Http2Client {
                         LOGGER.logp(Level.INFO, CLASS_NAME + "$FATFramesListener", "receivedLastFrame", "caught exception: " + e);
                     }
                 }
+                isTestDone.set(true);
+                blockUntilConnectionIsDone.countDown();
             }
         }
 


### PR DESCRIPTION
When the H2 test client receives the last expected frame from the server, it sends a goaway frame.
It should also mark the test as done and decrease the countdown latch so that the test ends successfully.