### PR TITLE
Make searching END line more specific to avoid intermittent FAT failures

### DIFF
--- a/dev/com.ibm.ws.request.probes_fat/fat/src/com/ibm/ws/request/probe/fat/RequestProbeTestDynamicFeatureChange.java
+++ b/dev/com.ibm.ws.request.probes_fat/fat/src/com/ibm/ws/request/probe/fat/RequestProbeTestDynamicFeatureChange.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
-import com.ibm.websphere.simplicity.Machine;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
@@ -62,7 +61,7 @@ public class RequestProbeTestDynamicFeatureChange {
     }
 
     private int fetchNoENDWarnings() throws Exception {
-        List<String> lines = server.findStringsInFileInLibertyServerRoot("END", MESSAGE_LOG);
+        List<String> lines = server.findStringsInFileInLibertyServerRoot("I END", MESSAGE_LOG);
         for (String line : lines) {
             CommonTasks.writeLogMsg(Level.INFO, "----> END warning : " + line);
         }
@@ -199,7 +198,8 @@ public class RequestProbeTestDynamicFeatureChange {
 
         long duration = 11000;
 
-        public RequestThread() {}
+        public RequestThread() {
+        }
 
         public RequestThread(long duration) {
             this.duration = duration;


### PR DESCRIPTION
The test fails intermittently because it expects no logs containing END in message log. Sometimes the build directory contains END which causes the FAT to fail intermittently.
e.g. `/home/jazz_build/_ut7mENDLEeqmIcsdsdUKbw-EBC.PROD.WASRTC-6I0-000-00-00/`
https://github.ibm.com/was-liberty/WS-CD-Open/issues/14988