### PR TITLE
Issue 13542: Skip response check when grabbing cert for Acme FATs

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
@@ -634,7 +634,10 @@ public class AcmeFatUtils {
 
 				StatusLine statusLine = response.getStatusLine();
 				if (statusLine.getStatusCode() != 200) {
-					fail(methodName + ": Expected response 200, but received response: " + statusLine);
+					/*
+					 * We can still get the certificate even if we get a non-200 response.
+					 */
+					Log.info(AcmeFatUtils.class, "assertAndGetServerCertificate", "Expected response 200, but received response: " + statusLine +". " + response);
 				}
 
 				/*


### PR DESCRIPTION
Fixes #13542