### PR TITLE
Consume FT 3.0-RC2 TCK

### DIFF
--- a/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
             <artifactId>microprofile-fault-tolerance-tck</artifactId>
-            <version>3.0-RC1</version>
+            <version>3.0-RC2</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.apis</groupId>

--- a/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/tckRunner/tck/tck-suite-lite.xml
+++ b/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/tckRunner/tck/tck-suite-lite.xml
@@ -115,24 +115,23 @@
             <class name="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackConfigTest"></class>
             <class name="org.eclipse.microprofile.fault.tolerance.tck.config.FallbackSkipOnConfigTest"></class>
             <class name="org.eclipse.microprofile.fault.tolerance.tck.interceptor.FaultToleranceInterceptorTest"></class>
-            <!-- Metrics tests disabled until TCK is updated to support MP Metrics 3.0 -->
-<!--             <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.AllMetricsTest"></class> -->
-<!--             <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.BulkheadMetricTest"> -->
-<!--                 <methods> -->
-<!--                     <include name="bulkheadMetricTest"/> -->
-<!--                     <include name="bulkheadMetricRejectionTest"/> -->
-<!--                 </methods> -->
-<!--             </class> -->
-<!--             <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.CircuitBreakerMetricTest"></class> -->
-<!--             <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.ClassLevelMetricTest"></class> -->
-<!--             <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.FallbackMetricTest"></class> -->
-<!--             <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.MetricsDisabledTest"></class> -->
-<!--             <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest"></class> -->
-<!--             <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.TimeoutMetricTest"> -->
-<!--                 <methods> -->
-<!--                     <include name="testTimeoutMetric"/> -->
-<!--                 </methods> -->
-<!--             </class> -->
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.AllMetricsTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.BulkheadMetricTest">
+                <methods>
+                    <include name="bulkheadMetricTest"/>
+                    <include name="bulkheadMetricRejectionTest"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.CircuitBreakerMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.ClassLevelMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.FallbackMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.MetricsDisabledTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest"></class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.TimeoutMetricTest">
+                <methods>
+                    <include name="testTimeoutMetric"/>
+                </methods>
+            </class>
             <class name="org.eclipse.microprofile.fault.tolerance.tck.visibility.retry.RetryVisibilityTest"></class>
         </classes>
     </test>

--- a/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -12,10 +12,7 @@
 
     <test name="microprofile-faulttolerance 3.0 TCK">
         <packages>
-            <package name="org.eclipse.microprofile.fault.tolerance.tck.*">
-                <!-- Metrics tests disabled until TCK is updated to support MP Metrics 3.0 -->
-                <exclude name="org.eclipse.microprofile.fault.tolerance.tck.metrics"></exclude>
-            </package>
+            <package name="org.eclipse.microprofile.fault.tolerance.tck.*"/>
         </packages>
     </test>
 </suite>


### PR DESCRIPTION
This TCK update bring compatibility with the MP Metrics 3.0 API and
allows us to re-enable the metrics tests from the TCK.

Note: I haven't consumed the RC2 API because it contains no changes and I don't want to conflict with #13265 