### PR TITLE
[13549] Resolve CDI warnings at startup

### DIFF
--- a/dev/io.openliberty.jaxrs.3.0_fat/fat/src/io/openliberty/jaxrs30/fat/AppAndResourceTest.java
+++ b/dev/io.openliberty.jaxrs.3.0_fat/fat/src/io/openliberty/jaxrs30/fat/AppAndResourceTest.java
@@ -31,7 +31,6 @@ import io.openliberty.jaxrs30.fat.appandresource.AppAndResourceTestServlet;
  * Tests whether a class can be both an <code>Application</code> subclass
  * <em>and<em> a resource class.
  */
-@AllowedFFDC
 @RunWith(FATRunner.class)
 public class AppAndResourceTest extends FATServletClient {
 
@@ -54,10 +53,6 @@ public class AppAndResourceTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        //TODO: investigate CDI scope errors and remove from stopServer method once resolved:
-        //E SRVE0271E: Uncaught init() exception created by servlet [io.openliberty.jaxrs30.fat.appandresource.AppAndResource] in application [appandresource]: org.jboss.weld.contexts.ContextNotActiveException: WELD-001303: No active contexts for scope type jakarta.enterprise.context.RequestScoped
-        //E SRVE0276E: Error while initializing Servlet [io.openliberty.jaxrs30.fat.appandresource.AppAndResource]: jakarta.servlet.ServletException: SRVE0207E: Uncaught initialization exception created by servlet
-        server.stopServer("SRVE0271E", "SRVE0276E");
+        server.stopServer();
     }
-
 }

--- a/dev/io.openliberty.jaxrs.3.0_fat/publish/servers/appandresource/bootstrap.properties
+++ b/dev/io.openliberty.jaxrs.3.0_fat/publish/servers/appandresource/bootstrap.properties
@@ -1,1 +1,3 @@
 bootstrap.include=../testports.properties
+#com.ibm.ws.logging.max.files=1
+#com.ibm.ws.logging.trace.specification=LogService=all:JAXRS=all

--- a/dev/io.openliberty.org.jboss.resteasy.common/resources/META-INF/beans.xml
+++ b/dev/io.openliberty.org.jboss.resteasy.common/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee 
+        http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="annotated">
+</beans>

--- a/dev/io.openliberty.org.jboss.resteasy.common/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/dev/io.openliberty.org.jboss.resteasy.common/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+io.openliberty.org.jboss.resteasy.common.component.LibertyResteasyCdiExtension

--- a/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/component/LibertyResteasyCdiExtension.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/component/LibertyResteasyCdiExtension.java
@@ -10,8 +10,25 @@
  *******************************************************************************/
 package io.openliberty.org.jboss.resteasy.common.component;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import javax.decorator.Decorator;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+import javax.enterprise.inject.spi.WithAnnotations;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.ext.Provider;
+
 import org.jboss.resteasy.cdi.ResteasyCdiExtension;
+import org.jboss.resteasy.cdi.i18n.LogMessages;
+import org.jboss.resteasy.cdi.i18n.Messages;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 
@@ -29,4 +46,110 @@ import com.ibm.ws.cdi.extension.WebSphereCDIExtension;
                 "javax.ws.rs.core.Application;" +
                 "javax.ws.rs.ext.Provider",
              "service.vendor=IBM" })
-public class LibertyResteasyCdiExtension extends ResteasyCdiExtension implements Extension, WebSphereCDIExtension {}
+
+public class LibertyResteasyCdiExtension extends ResteasyCdiExtension implements Extension, WebSphereCDIExtension {
+
+    private static final String JAVAX_EJB_STATELESS = "javax.ejb.Stateless";
+    private static final String JAVAX_EJB_SINGLETON = "javax.ejb.Singleton";
+
+
+    private boolean isSessionBean(AnnotatedType<?> annotatedType)
+    {
+       for (Annotation annotation : annotatedType.getAnnotations())
+       {
+          Class<?> annotationType = annotation.annotationType();
+          if (annotationType.getName().equals(JAVAX_EJB_STATELESS) || annotationType.getName().equals(JAVAX_EJB_SINGLETON))
+          {
+             LogMessages.LOGGER.debug(Messages.MESSAGES.beanIsSLSBOrSingleton(annotatedType.getJavaClass()));
+             return true; // Do not modify scopes of SLSBs and Singletons
+          }
+       }
+       return false;
+    }
+
+    /**
+     * Set a default scope for each CDI bean which is a JAX-RS Resource.
+     *
+     * @param <T> type
+     * @param event event
+     * @param beanManager bean manager
+     */
+    @Override
+    public <T> void observeResources(@WithAnnotations({Path.class}) @Observes ProcessAnnotatedType<T> event, BeanManager beanManager)
+    {
+       AnnotatedType<T> annotatedType = event.getAnnotatedType();
+       Class<?> javaClass = annotatedType.getJavaClass();
+       if(!javaClass.isInterface()
+           && !isSessionBean(annotatedType)
+           && !annotatedType.isAnnotationPresent(Decorator.class))
+       {
+          LogMessages.LOGGER.debug(Messages.MESSAGES.discoveredCDIBeanJaxRsResource(annotatedType.getJavaClass().getCanonicalName()));
+          if (Application.class.isAssignableFrom(javaClass)) {
+              event.setAnnotatedType(wrapAnnotatedType(annotatedType, applicationScopedLiteral));
+          } else {
+              event.setAnnotatedType(wrapAnnotatedType(annotatedType, requestScopedLiteral));
+          }
+          this.getResources().add(javaClass);
+       }
+    }
+
+    /**
+     * Set a default scope for each CDI bean which is a JAX-RS Provider.
+     *
+     * @param <T> type
+     * @param event event
+     * @param beanManager bean manager
+     */
+    @Override
+    public <T> void observeProviders(@WithAnnotations({Provider.class}) @Observes ProcessAnnotatedType<T> event, BeanManager beanManager)
+    {
+       AnnotatedType<T> annotatedType = event.getAnnotatedType();
+
+       if(!annotatedType.getJavaClass().isInterface()
+          && !isSessionBean(annotatedType)
+          && !isUnproxyableClass(annotatedType.getJavaClass()))
+       {
+          LogMessages.LOGGER.debug(Messages.MESSAGES.discoveredCDIBeanJaxRsProvider(annotatedType.getJavaClass().getCanonicalName()));
+          event.setAnnotatedType(wrapAnnotatedType(annotatedType, applicationScopedLiteral));
+          this.getProviders().add(annotatedType.getJavaClass());
+       }
+    }
+
+    /**
+     * Check for select case of unproxyable bean type.
+     * (see CDI 2.0 spec, section 3.11)
+     * @param clazz
+     * @return
+     */
+    private boolean isUnproxyableClass(Class<?> clazz) {
+       // Unproxyable bean type: classes which are declared final,
+       // or expose final methods,
+       // or have no non-private no-args constructor
+       return Modifier.isFinal(clazz.getModifiers()) ||
+             hasNonPrivateNonStaticFinalMethod(clazz) ||
+             hasNoNonPrivateNoArgsConstructor(clazz);
+    }
+
+    // Adapted from weld-core-impl:3.0.5.Final's Reflections.getNonPrivateNonStaticFinalMethod()
+    private boolean hasNonPrivateNonStaticFinalMethod(Class<?> type) {
+       for (Class<?> clazz = type; clazz != null && clazz != Object.class; clazz = clazz.getSuperclass()) {
+          for (Method method : clazz.getDeclaredMethods()) {
+             int modifiers = method.getModifiers();
+             if (Modifier.isFinal(modifiers) && !Modifier.isPrivate(modifiers) && !Modifier.isStatic(modifiers)) {
+                return true;
+             }
+          }
+       }
+       return false;
+    }
+
+    private boolean hasNoNonPrivateNoArgsConstructor(Class<?> clazz) {
+       Constructor<?> constructor;
+       try {
+          constructor = clazz.getConstructor();
+       } catch (NoSuchMethodException exception) {
+          return true;
+       }
+       return Modifier.isPrivate(constructor.getModifiers());
+    }
+}

--- a/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/component/ResteasyInjectionClassListCollaborator.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/component/ResteasyInjectionClassListCollaborator.java
@@ -80,8 +80,6 @@ public class ResteasyInjectionClassListCollaborator implements WebAppInjectionCl
         JAXRS_INTERFACE_NAMES.add("javax.ws.rs.container.DynamicFeature");
 
         JAXRS_INTERFACE_NAMES.add("org.apache.cxf.jaxrs.ext.ContextResolver");
-
-        JAXRS_INTERFACE_NAMES.add("javax.ws.rs.core.Application");
     }
 
     private static final Set<String> JAXRS_ABSTRACT_CLASS_NAMES;


### PR DESCRIPTION
Fixes #13549 

The updated beans.xml restricts CDI from scanning the RESTEasy bundle for annotations.

The CDI extension improves startup performance and handles cases where a class might be both an Application _and_ a resource, or a resource _and_ a provider.