### PR TITLE
new issue templates for creating release and beta blog posts

### DIFF
--- a/.github/ISSUE_TEMPLATE/blog_post_beta.md
+++ b/.github/ISSUE_TEMPLATE/blog_post_beta.md
@@ -1,0 +1,36 @@
+---
+name: Open Liberty BETA blog post
+about: Information to be included in the Open Liberty BETA blog post.
+title: BETA BLOG - title_of_your_update
+labels: beta
+assignees: lauracowen, jakub-pomykala
+
+---
+
+The information you provide here will be included in the Open Liberty beta blog post ([example](https://openliberty.io/blog/2020/08/05/jakarta-grpc-beta-20009.html)), which will be published on the OpenLiberty.io blog, and potentially elsewhere, to promote this beta of Open Liberty.
+
+Please provide the following information the week before the GA/beta date (to allow for review and publishing):
+
+1. Which Liberty feature does your update relate to?
+    
+   Human-readable name (eg WebSockets feature):
+   
+   Feature name (eg websockets-1.0): 
+
+2. Who is the target persona? Who do you expect to use the update? eg application developer, operations.
+
+3. Write a paragraph to summarises the update, including the following points:
+   
+   - A sentence or two that introduces the update to someone new to the general technology/concept.
+
+   - What was the problem before and how does your update make their life better? (Why should they care?)
+   
+   - Briefly explain how to make your update work. Include screenshots, diagrams, and/or code snippets, and provide a `server.xml` snippet.
+   
+   - Where can they find out more about this specific update (eg Open Liberty docs, Javadoc) and/or the wider technology?
+
+## What happens next?
+
+- Your paragraph will be included in the beta blog post. It might be edited for style and consistency.
+- You will be asked to review a draft before publication.
+- If you would _also_ like to write a standalone blog post about your update, raise an issue on the [Open Liberty blogs repo](https://github.com/OpenLiberty/blogs/issues/new/choose). State in the issue that the blog post relates to a specific release so that we can ensure it is published on an appropriate date (it won't be the same day as the beta blog post).

--- a/.github/ISSUE_TEMPLATE/blog_post_beta.md
+++ b/.github/ISSUE_TEMPLATE/blog_post_beta.md
@@ -2,7 +2,7 @@
 name: Open Liberty BETA blog post
 about: Information to be included in the Open Liberty BETA blog post.
 title: BETA BLOG - title_of_your_update
-labels: beta
+labels: ''
 assignees: lauracowen, jakub-pomykala
 
 ---
@@ -33,4 +33,4 @@ Please provide the following information the week before the GA/beta date (to al
 
 - Your paragraph will be included in the beta blog post. It might be edited for style and consistency.
 - You will be asked to review a draft before publication.
-- If you would _also_ like to write a standalone blog post about your update, raise an issue on the [Open Liberty blogs repo](https://github.com/OpenLiberty/blogs/issues/new/choose). State in the issue that the blog post relates to a specific release so that we can ensure it is published on an appropriate date (it won't be the same day as the beta blog post).
+- If you would _also_ like to write a standalone blog post about your update (highly recommended), raise an issue on the [Open Liberty blogs repo](https://github.com/OpenLiberty/blogs/issues/new/choose). State in the issue that the blog post relates to a specific release so that we can ensure it is published on an appropriate date (it won't be the same day as the beta blog post).

--- a/.github/ISSUE_TEMPLATE/blog_post_ga_release.md
+++ b/.github/ISSUE_TEMPLATE/blog_post_ga_release.md
@@ -1,0 +1,38 @@
+---
+name: Open Liberty GA release blog post
+about: Information to be included in the Open Liberty GA release blog post.
+title: GA BLOG - title_of_your_update
+labels: release
+assignees: lauracowen, jakub-pomykala
+
+---
+
+The information you provide here will be included in the Open Liberty GA release blog post ([example](https://openliberty.io/blog/2020/07/30/json-logging-open-liberty-20008.html)), which will be published on the OpenLiberty.io blog, and potentially elsewhere, to promote this release of Open Liberty.
+
+Please provide the following information the week before the GA date (to allow for review and publishing):
+
+1. Which Liberty feature does your update relate to?
+    
+   Human-readable name (eg WebSockets feature):
+   
+   Feature name (eg websockets-1.0): 
+
+2. Who is the target persona? Who do you expect to use the update? eg application developer, operations.
+
+3. Write a paragraph to summarises the update, including the following points:
+   
+   - A sentence or two that introduces the update to someone new to the general technology/concept.
+
+   - What was the problem before and how does your update make their life better? (Why should they care?)
+   
+   - Briefly explain how to make your update work. Include screenshots, diagrams, and/or code snippets, and provide a `server.xml` snippet.
+   
+   - Where can they find out more about this specific update (eg Open Liberty docs, Javadoc) and/or the wider technology?
+
+If you have previously provided this information for an Open Liberty beta blog post and nothing has changed since the beta, just provide a link to the published beta blog post and we'll take the information from there.
+
+## What happens next?
+
+- Your paragraph will be included in the GA release blog post. It might be edited for style and consistency.
+- You will be asked to review a draft before publication.
+- If you would _also_ like to write a standalone blog post about your update, raise an issue on the [Open Liberty blogs repo](https://github.com/OpenLiberty/blogs/issues/new/choose). State in the issue that the blog post relates to a specific release so that we can ensure it is published on an appropriate date (it won't be the same day as the GA blog post).

--- a/.github/ISSUE_TEMPLATE/blog_post_ga_release.md
+++ b/.github/ISSUE_TEMPLATE/blog_post_ga_release.md
@@ -2,7 +2,7 @@
 name: Open Liberty GA release blog post
 about: Information to be included in the Open Liberty GA release blog post.
 title: GA BLOG - title_of_your_update
-labels: release
+labels: ''
 assignees: lauracowen, jakub-pomykala
 
 ---
@@ -35,4 +35,4 @@ If you have previously provided this information for an Open Liberty beta blog p
 
 - Your paragraph will be included in the GA release blog post. It might be edited for style and consistency.
 - You will be asked to review a draft before publication.
-- If you would _also_ like to write a standalone blog post about your update, raise an issue on the [Open Liberty blogs repo](https://github.com/OpenLiberty/blogs/issues/new/choose). State in the issue that the blog post relates to a specific release so that we can ensure it is published on an appropriate date (it won't be the same day as the GA blog post).
+- If you would _also_ like to write a standalone blog post about your update (highly recommended), raise an issue on the [Open Liberty blogs repo](https://github.com/OpenLiberty/blogs/issues/new/choose). State in the issue that the blog post relates to a specific release so that we can ensure it is published on an appropriate date (it won't be the same day as the GA blog post).


### PR DESCRIPTION
Two new issue templates for use by developers to provide entries for the Open Liberty release blog post or beta blog post.

The aim is to replace the old internal wiki page that contained a questionnaire that developers had to copy across to an issue to fill in: https://apps.na.collabserv.com/wikis/home?lang=en-us#!/wiki/Wde4b45b770c2_47cd_9d6d_7061f359add9/page/Blog%20Questionnairs

Any feedback welcome.
