### PR TITLE
release connection after checking http status code

### DIFF
--- a/dev/fattest.simplicity/src/com/ibm/ws/fat/util/browser/HttpClientBrowser.java
+++ b/dev/fattest.simplicity/src/com/ibm/ws/fat/util/browser/HttpClientBrowser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -178,6 +178,8 @@ public class HttpClientBrowser extends WebBrowserCore {
             throw new WebBrowserException(e);
         } catch (IOException ioe) {
             throw new WebBrowserException(ioe);
+        } finally {
+            method.releaseConnection(); // be sure the connection is released back to the connection manager
         }
         return rv;
     }


### PR DESCRIPTION
https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=275920 affected a WS-CD bucket, but the bug is in OL but hidden so this PR ports the fix. 