### PR TITLE
Replace unused fields with 'XXXXXXX'

### DIFF
--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/LogFieldConstants.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/LogFieldConstants.java
@@ -97,31 +97,33 @@ public class LogFieldConstants {
     public static final String REMOTEUSERID = "remoteUserID";
 
     //liberty_ffdc
-    public static final String DATEOFFIRSTOCCURENCE = "dateOfFirstOccurence";
-    public static final String COUNT = "count";
-    public static final String LABEL = "label";
+    //fields that contain 'XXXXXXX' are not expected to be used
+    public static final String DATEOFFIRSTOCCURENCE = "XXXXXXX_dateOfFirstOccurence";
+    public static final String COUNT = "XXXXXXX_count";
+    public static final String LABEL = "XXXXXXX_label";
     public static final String IBM_EXCEPTIONNAME = "ibm_exceptionName";
     public static final String EXCEPTIONNAME = "exceptionName";
     public static final String IBM_PROBEID = "ibm_probeID";
     public static final String PROBEID = "probeID";
-    public static final String SOURCEID = "sourceID";
+    public static final String SOURCEID = "XXXXXXX_sourceID";
     public static final String IBM_STACKTRACE = "ibm_stackTrace";
     public static final String STACKTRACE = "stackTrace";
     public static final String IBM_OBJECTDETAILS = "ibm_objectDetails";
     public static final String OBJECTDETAILS = "objectDetails";
 
     //liberty_gc
-    public static final String IBM_HEAP = "ibm_heap";
+    //fields that contain 'XXXXXXX' are not expected to be used
+    public static final String IBM_HEAP = "XXXXXXX_ibm_heap";
     public static final String HEAP = "heap";
-    public static final String IBM_USED_HEAP = "ibm_usedHeap";
+    public static final String IBM_USED_HEAP = "XXXXXXX_ibm_usedHeap";
     public static final String USED_HEAP = "usedHeap";
-    public static final String IBM_MAX_HEAP = "ibm_maxHeap";
+    public static final String IBM_MAX_HEAP = "XXXXXXX_ibm_maxHeap";
     public static final String MAX_HEAP = "maxHeap";
-    public static final String IBM_DURATION = "ibm_duration";
+    public static final String IBM_DURATION = "XXXXXXX_ibm_duration";
     public static final String DURATION = "duration";
-    public static final String IBM_GC_TYPE = "ibm_gcType";
+    public static final String IBM_GC_TYPE = "XXXXXXX_ibm_gcType";
     public static final String GC_TYPE = "gcType";
-    public static final String IBM_REASON = "ibm_reason";
+    public static final String IBM_REASON = "XXXXXXX_ibm_reason";
     public static final String REASON = "reason";
 
     //other


### PR DESCRIPTION
Fixes #13635 

For all the fields, the corresponding `get` methods are not being called anywhere - e.g. `getLabelKey` is not being called

The following fields have been replaced with 'XXXXXXX':
ffdc events
```
dateOfFirstOccurrence
count
label
sourceID
```

gc events
```
ibm_heap
ibm_used_heap
ibm_max_heap
ibm_duration
ibm_gc_type
ibm_reason
```
(the logstashCollector variants remain because gc events are only available in Logstash Collector)

#build