### PR TITLE
Adding webcontainer trace to metrics authentication server test for debug

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics_fat/publish/servers/MetricsAuthenticationServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.metrics_fat/publish/servers/MetricsAuthenticationServer/bootstrap.properties
@@ -1,2 +1,2 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.rest.*=all:com.ibm.wsspi.rest.*=all:com.ibm.ws.microprofile.metrics*=all:com.ibm.ws.app.manager.*=all
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.rest.*=all:com.ibm.wsspi.rest.*=all:com.ibm.ws.microprofile.metrics*=all:com.ibm.ws.app.manager.*=all:com.ibm.ws.webcontainer.*=all:com.ibm.wsspi.webcontainer.*=all:HTTPChannel=all:GenericBNF=all


### PR DESCRIPTION
#build

Adding the recommended webcontainer trace: `com.ibm.ws.webcontainer.*=all:com.ibm.wsspi.webcontainer.*=all:HTTPChannel=all:GenericBNF=all` to the metrics authentication server for debugging purposes to see why the PrivateMicroProfileMetrics webmodule doesn't load.