### PR TITLE
Unregister jndi global service listener

### DIFF
--- a/dev/com.ibm.ws.jndi/src/com/ibm/ws/jndi/internal/WSContextFactory.java
+++ b/dev/com.ibm.ws.jndi/src/com/ibm/ws/jndi/internal/WSContextFactory.java
@@ -73,6 +73,10 @@ public class WSContextFactory implements InitialContextFactory, ObjectFactory, A
         }
     }
 
+    protected void deactivate(ComponentContext cc) {
+        userContext.getBundle(Constants.SYSTEM_BUNDLE_LOCATION).getBundleContext().removeServiceListener(this);
+    }
+
     Object getService(final ServiceReference<?> ref) {
         return cache.computeIfAbsent(ref, (r) -> AccessController.doPrivileged((PrivilegedAction<Object>) () -> userContext.getService(r)));
     }


### PR DESCRIPTION
A global system listener was added to the jndi component. It needs to be removed when the jndi feature is removed

OpenLiberty Pull Requester,

