### PR TITLE
update to connectors-2.0 RC2

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -819,7 +819,7 @@
     <dependency>
       <groupId>jakarta.resource</groupId>
       <artifactId>jakarta.resource-api</artifactId>
-      <version>2.0.0-RC1</version>
+      <version>2.0.0-RC2</version>
     </dependency>
     <dependency>
       <groupId>jakarta.security.auth.message</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -159,7 +159,7 @@ jakarta.json.bind:jakarta.json.bind-api:2.0.0-RC1
 jakarta.json:jakarta.json-api:2.0.0-RC2
 jakarta.jws:jakarta.jws-api:3.0.0-RC2
 jakarta.persistence:jakarta.persistence-api:3.0.0-RC1
-jakarta.resource:jakarta.resource-api:2.0.0-RC1
+jakarta.resource:jakarta.resource-api:2.0.0-RC2
 jakarta.security.auth.message:jakarta.security.auth.message-api:2.0.0-RC1
 jakarta.security.enterprise:jakarta.security.enterprise-api:2.0.0-RC2
 jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api:2.0.0-RC1


### PR DESCRIPTION
Update connectors-2.0 to latest release candidate.
fixes #13376 

Note that none of the feature bundle references need to change since the `jakarta.resource-api` jar manifest lists the version as `2.0.0` for both the RC1 and RC2 release. 

```
Bundle-SymbolicName: jakarta.resource-api
Implementation-Version: 2.0.0
```
