### PR TITLE
Fix await timing issue in EJB timer FAT

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/test-applications/NoDBNonPersistAutoTimerEJB.jar/src/com/ibm/ws/ejbcontainer/timer/nodb/npauto/ejb/NPAutoTimerBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/test-applications/NoDBNonPersistAutoTimerEJB.jar/src/com/ibm/ws/ejbcontainer/timer/nodb/npauto/ejb/NPAutoTimerBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,8 @@ import javax.ejb.Stateless;
 import javax.ejb.Timer;
 import javax.ejb.TimerService;
 
+import com.ibm.websphere.ejbcontainer.test.tools.FATHelper;
+
 /**
  * A simple stateless bean with non-persistent automatically created timers and methods
  * to verify the timers run as expected.
@@ -36,6 +38,7 @@ public class NPAutoTimerBean {
     private static final Logger logger = Logger.getLogger(NPAutoTimerBean.class.getName());
 
     private static final CountDownLatch autoTimerLatch = new CountDownLatch(1);
+    private static long POST_INVOKE_FUDGE_FACTOR = 400; //ms
 
     @Resource
     private TimerService ts;
@@ -57,6 +60,7 @@ public class NPAutoTimerBean {
         logger.info("> waitForAutomaticTimer");
         try {
             autoTimerLatch.await(30, TimeUnit.SECONDS);
+            FATHelper.sleep(POST_INVOKE_FUDGE_FACTOR);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/test-applications/NoDBPersistAutoTimerEJB.jar/src/com/ibm/ws/ejbcontainer/timer/nodb/pauto/ejb/PAutoTimerBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/test-applications/NoDBPersistAutoTimerEJB.jar/src/com/ibm/ws/ejbcontainer/timer/nodb/pauto/ejb/PAutoTimerBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,8 @@ import javax.ejb.Stateless;
 import javax.ejb.Timer;
 import javax.ejb.TimerService;
 
+import com.ibm.websphere.ejbcontainer.test.tools.FATHelper;
+
 /**
  * A simple stateless bean with persistent automatically created timers and methods
  * to verify the timers would run as expected if persistent timers supported.
@@ -33,6 +35,7 @@ public class PAutoTimerBean {
     private static final Logger logger = Logger.getLogger(PAutoTimerBean.class.getName());
 
     private static final CountDownLatch autoTimerLatch = new CountDownLatch(1);
+    private static long POST_INVOKE_FUDGE_FACTOR = 400; //ms
 
     @Resource
     private TimerService ts;
@@ -55,6 +58,7 @@ public class PAutoTimerBean {
         logger.info("> waitForAutomaticTimer");
         try {
             autoTimerLatch.await(30, TimeUnit.SECONDS);
+            FATHelper.sleep(POST_INVOKE_FUDGE_FACTOR);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Test creates 2 timers, then waits for one to run, which cancels itself.....
then checks for 1 remaining timer.  Problem is that the cancel hasn't
completed yet by the time the main thread checks for timers.

Added some time delay to allow for cancel to complete.
