### PR TITLE
Revert "Issue 13645: Skip libh docker hosts for acme fat"

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/FATSuite.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package com.ibm.ws.security.acme.fat;
 
-import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -32,22 +31,13 @@ import componenttest.topology.utils.ExternalTestServiceDockerClientStrategy;
 	 })
 public class FATSuite {
 
-	@BeforeClass
-	public static void prepDockerCA() throws Exception {
-
-		/*
-		 * This static block should be the first static initialization in this class so
-		 * that the testcontainers config is cleared before we start our new
-		 * testcontainers.
-		 */
-
+	/*
+	 * This static block should be the first static initialization in this class
+	 * so that the testcontainers config is cleared before we start our new
+	 * testcontainers.
+	 */
+	static {
 		ExternalTestServiceDockerClientStrategy.clearTestcontainersConfig();
-
-		// Filter out any external docker servers in the 'libhpike' cluster
-		ExternalTestServiceDockerClientStrategy.serviceFilter = (svc) -> {
-			return !svc.getAddress().contains("libhpike-dockerengine");
-		};
-
 	}
 
 }


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#13646

Reverting due to suspected source of failures in acme_fat