### PR TITLE
Issue 13706: Fix CWPKI2028E and NPE in acmeCA

### DIFF
--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeClient.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/AcmeClient.java
@@ -1117,7 +1117,8 @@ public class AcmeClient {
 				cause = e;
 			}
 
-			throw new AcmeCaException(Tr.formatMessage(tc, "CWPKI2028E", acmeConfig.getDirectoryURI()), cause);
+			throw new AcmeCaException(
+					Tr.formatMessage(tc, "CWPKI2028E", acmeConfig.getDirectoryURI(), cause.getMessage()), cause);
 		}
 	}
 

--- a/dev/com.ibm.ws.security.acme/src/org/shredzone/acme4j/connector/HttpConnector.java
+++ b/dev/com.ibm.ws.security.acme/src/org/shredzone/acme4j/connector/HttpConnector.java
@@ -61,12 +61,19 @@ public class HttpConnector {
 		StringBuilder agent = new StringBuilder("acme4j");
 
 		try (InputStream in = HttpConnector.class.getResourceAsStream("/org/shredzone/acme4j/version.properties")) {
-			Properties prop = new Properties();
-			prop.load(in);
-			agent.append('/').append(prop.getProperty("version"));
+			if (in == null) {
+				if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+					Tr.debug(tc,
+							"Could not read /org/shredzone/acme4j/version.properties, ignore and skip library version.");
+				}
+			} else {
+				Properties prop = new Properties();
+				prop.load(in);
+				agent.append('/').append(prop.getProperty("version"));
+			}
 		} catch (Exception ex) {
 			if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-				Tr.debug(tc, "Could not read library version", ex);
+				Tr.debug(tc, "Could not read library version, ignore and skip adding it.", ex);
 			}
 		}
 


### PR DESCRIPTION
Fixes #13706 

Added missing error message to CWPKI2028E 

NPE: After reviewing the original code for HttpConnector from acme4j, we can skip checking the library version if we can't load it. Logging it and continuing it.

```
Exception = java.lang.NullPointerException
Source = org.shredzone.acme4j.connector.HttpConnector
probeid = 63
Stack Dump = java.lang.NullPointerException: inStream parameter is null
	at java.base/java.util.Objects.requireNonNull(Objects.java:246)
	at java.base/java.util.Properties.load(Properties.java:403)
	at org.shredzone.acme4j.connector.HttpConnector.<clinit>(HttpConnector.java:65)
	at org.shredzone.acme4j.provider.AbstractAcmeProvider.createHttpConnector(AbstractAcmeProvider.java:114)
	at org.shredzone.acme4j.provider.AbstractAcmeProvider.connect(AbstractAcmeProvider.java:52)
	at org.shredzone.acme4j.Session.connect(Session.java:182)
	at org.shredzone.acme4j.AccountBuilder.createLogin(AccountBuilder.java:196)
	at org.shredzone.acme4j.AccountBuilder.create(AccountBuilder.java:175)
	at com.ibm.ws.security.acme.internal.AcmeClient.getExistingAccount(AcmeClient.java:564)
```