### PR TITLE
Fix RequestTiming FAT Test failures

### DIFF
--- a/dev/com.ibm.ws.request.probes_fat/fat/src/com/ibm/ws/request/probe/fat/RequestProbeTestDynamicFeatureChange.java
+++ b/dev/com.ibm.ws.request.probes_fat/fat/src/com/ibm/ws/request/probe/fat/RequestProbeTestDynamicFeatureChange.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -53,6 +53,7 @@ public class RequestProbeTestDynamicFeatureChange {
     }
 
     private int fetchNoOfslowRequestWarnings() throws Exception {
+        server.waitForStringInLogUsingMark("TRAS0112W", 30000);
         List<String> lines = server.findStringsInFileInLibertyServerRoot("TRAS0112W", MESSAGE_LOG);
         for (String line : lines) {
             CommonTasks.writeLogMsg(Level.INFO, "----> slow request warning : " + line);
@@ -61,6 +62,7 @@ public class RequestProbeTestDynamicFeatureChange {
     }
 
     private int fetchNoENDWarnings() throws Exception {
+        server.waitForStringInLogUsingMark("I END", 30000);
         List<String> lines = server.findStringsInFileInLibertyServerRoot("I END", MESSAGE_LOG);
         for (String line : lines) {
             CommonTasks.writeLogMsg(Level.INFO, "----> END warning : " + line);
@@ -131,7 +133,16 @@ public class RequestProbeTestDynamicFeatureChange {
 
         createRequest(5000);
         int slow = fetchNoOfslowRequestWarnings();
+
+        // Retry the request again
+        if (slow == 0) {
+            CommonTasks.writeLogMsg(Level.INFO, "$$$$ -----> Retry because no slow request warning found!");
+            createRequest(5000);
+            slow = fetchNoOfslowRequestWarnings();
+        }
+
         int end_new = fetchNoENDWarnings() - end;
+
         CommonTasks.writeLogMsg(Level.INFO, "----> Slow Warnings : " + slow);
         CommonTasks.writeLogMsg(Level.INFO, "----> END Warnings : " + end_new);
 
@@ -198,8 +209,7 @@ public class RequestProbeTestDynamicFeatureChange {
 
         long duration = 11000;
 
-        public RequestThread() {
-        }
+        public RequestThread() {}
 
         public RequestThread(long duration) {
             this.duration = duration;

--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/TimingRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/TimingRequestTiming.java
@@ -334,6 +334,15 @@ public class TimingRequestTiming {
         server.waitForStringInLogUsingMark("TRAS0114W", 10000);
 
         int slow = fetchSlowRequestWarningsCount();
+
+        // Retry the request again
+        if (slow == 0) {
+            CommonTasks.writeLogMsg(Level.INFO, "$$$$ -----> Retry because no slow request warning found!");
+            createRequests(7000, 1);
+            server.waitForStringInLogUsingMark("TRAS0112W", 10000);
+            slow = fetchSlowRequestWarningsCount();
+        }
+
         int hung = fetchHungRequestWarningsCount();
 
         assertTrue("Expected > 0 slow request warning but found : " + slow, (slow > 0));
@@ -367,6 +376,15 @@ public class TimingRequestTiming {
         server.waitForStringInLogUsingMark("TRAS0112W", 10000);
 
         int slow = fetchSlowRequestWarningsCount();
+
+        // Retry the request again
+        if (slow == 0) {
+            CommonTasks.writeLogMsg(Level.INFO, "$$$$ -----> Retry because no slow request warning found!");
+            createRequests(11000, 1);
+            server.waitForStringInLogUsingMark("TRAS0112W", 10000);
+            slow = fetchSlowRequestWarningsCount();
+        }
+
         int hung = fetchHungRequestWarningsCount();
 
         assertTrue("Expected 1 slow request warning but found : " + slow, (slow > 0));


### PR DESCRIPTION
Fixes #13686 
Sometimes the requests need to be retried again, because the request is not slow enough in some SOE platforms. Hence, the requestTiming feature might not pick it up as being slow.