### PR TITLE
Retry requests if slow requests are not found in RequestTiming FAT

### DIFF
--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/SlowRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/SlowRequestTiming.java
@@ -533,6 +533,12 @@ public class SlowRequestTiming {
         createRequest("?sleepTime=3000");
 
         int slowCount = fetchNoOfslowRequestWarnings();
+        //Retry the request again
+        if (slowCount == 0) {
+            CommonTasks.writeLogMsg(Level.INFO, "$$$$ -----> Retry because no slow request warning found!");
+            createRequest("?sleepTime=3000");
+            slowCount = fetchNoOfslowRequestWarnings();
+        }
         assertTrue("No Slow request timing records found! : ", (slowCount > 0));
 
         List<String> lines = server.findStringsInFileInLibertyServerRoot("ms", MESSAGE_LOG);

--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/TimingRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/TimingRequestTiming.java
@@ -128,6 +128,14 @@ public class TimingRequestTiming {
         int slow = fetchSlowRequestWarningsCount();
         int hung = fetchHungRequestWarningsCount();
 
+        //Retry the request again
+        if (slow == 0) {
+            CommonTasks.writeLogMsg(Level.INFO, "$$$$ -----> Retry because no slow request warning found!");
+            createRequests(6000, 1);
+            server.waitForStringInLogUsingMark("TRAS0112W", 10000);
+            slow = fetchSlowRequestWarningsCount();
+        }
+
         assertTrue("Expected > 0 slow request warning but found : " + slow, (slow > 0));
 
         assertTrue("Expected > 0 hung request warning but found : " + hung, (hung > 0));

--- a/dev/com.ibm.ws.request.timing_fat/test-applications/jdbcTestPrj_3/src/com/ibm/ws/request/timing/TestJDBC.java
+++ b/dev/com.ibm.ws.request.timing_fat/test-applications/jdbcTestPrj_3/src/com/ibm/ws/request/timing/TestJDBC.java
@@ -1,119 +1,111 @@
 package com.ibm.ws.request.timing;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.*;
-import java.sql.*;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 
 import javax.annotation.Resource;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.*;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import javax.sql.DataSource;
 
 @WebServlet("/*")
-public class TestJDBC extends HttpServlet
-{
-  private static final long serialVersionUID = 1L;
+public class TestJDBC extends HttpServlet {
+    private static final long serialVersionUID = 1L;
 
-  @Resource(name="jdbc/exampleDS")
-  DataSource ds1;
+    @Resource(name = "jdbc/exampleDS")
+    DataSource ds1;
 
-  protected void doGet(HttpServletRequest request, HttpServletResponse response)
-    throws ServletException, IOException
-  {
-    Statement stmt = null;
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        Statement stmt = null;
 
-    Connection con = null;
-    int sleepTimeInMilliSecs = 12000;
-    String tableName = "cities";
-    
-    try {
-        
-        if (request.getParameter("sleepTime") != null) {
-                sleepTimeInMilliSecs = Integer.parseInt(request
-                                .getParameter("sleepTime"));
-        }
-        if (request.getParameter("table") != null) {
-            tableName = request.getParameter("table");
-        }
-      PrintWriter pw = response.getWriter();
-      System.out.println("Create DataSource connection");
-      con = this.ds1.getConnection();
+        Connection con = null;
+        int sleepTimeInMilliSecs = 12000;
+        String tableName = "cities";
 
-      stmt = con.createStatement();
-          
-      try {
-          stmt.executeUpdate("create table "+ tableName +" (name varchar(50) not null, population int, county varchar(30))");
-      } catch (Exception e) {
-         
-      }
-      
-      Stock myFavStock = new Stock("Stock1", new Double(100D));
-      HttpSession cSession = request.getSession(true);
-      cSession.setAttribute("FavStockC", myFavStock);
-      Stock s = (Stock)cSession.getAttribute("FavStockC");
+        try {
 
+            if (request.getParameter("sleepTime") != null) {
+                sleepTimeInMilliSecs = Integer.parseInt(request.getParameter("sleepTime"));
+            }
+            if (request.getParameter("table") != null) {
+                tableName = request.getParameter("table");
+            }
+            PrintWriter pw = response.getWriter();
+            System.out.println("Create DataSource connection");
+            con = this.ds1.getConnection();
 
-      System.out.println((new StringBuilder(" Session value is ")).append(s.getValue()).toString());
-      
-      int returnValue = -1;
-      for(int i = 11; i <= 15; i++) {
-          returnValue = stmt.executeUpdate((new StringBuilder("insert into "+tableName+" values ('myHomeCity_ ")).append(i).append("', ").append(i).append(", 'myHomeCounty_").append(i).append("')").toString());
-          try {
-              Thread.sleep(1500);  // Sleep to give time for update to fully complete
-              if (returnValue != 1) {
-                  System.out.println("Warning: The expected return value of stmt.executeUpdate is 1, but got: " + returnValue + ". This is fine and the test can still pass.");
-              }
-              returnValue = -1;
-          } catch (Exception e) {
-              e.printStackTrace();
-          }
-      }  
-      
-      System.out.println("doGet completed Successfully");
-    } catch (Exception e) {
-    // e.printStackTrace();
-    }
-    finally
-    {
-      try
-      {
-        if (stmt != null)
-          stmt.executeUpdate("drop table " + tableName);
-        else
-          System.out.println("stmt is null");
-      }
-      catch (SQLException e)
-      {
-        e.printStackTrace();
-      }
-      try {
-        if (con != null)
-          con.close();
-      } catch (SQLException e) {
-        e.printStackTrace();
-      }
-      
-	
-        try
-        {
-            System.out.println("Thread sleeping for:" + sleepTimeInMilliSecs);
-            Thread.sleep(sleepTimeInMilliSecs);
-            System.out.println("Thread woke up");
-        }
-        catch(InterruptedException e)
-        {
+            stmt = con.createStatement();
+
+            try {
+                stmt.executeUpdate("create table " + tableName + " (name varchar(50) not null, population int, county varchar(30))");
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+
+            Stock myFavStock = new Stock("Stock1", new Double(100D));
+            HttpSession cSession = request.getSession(true);
+            cSession.setAttribute("FavStockC", myFavStock);
+            Stock s = (Stock) cSession.getAttribute("FavStockC");
+
+            System.out.println((new StringBuilder(" Session value is ")).append(s.getValue()).toString());
+
+            int returnValue = -1;
+            for (int i = 11; i <= 15; i++) {
+                returnValue = stmt.executeUpdate((new StringBuilder("insert into " + tableName
+                                                                    + " values ('myHomeCity_ ")).append(i).append("', ").append(i).append(", 'myHomeCounty_").append(i).append("')").toString());
+                try {
+                    Thread.sleep(1500); // Sleep to give time for update to fully complete
+                    if (returnValue != 1) {
+                        System.out.println("Warning: The expected return value of stmt.executeUpdate is 1, but got: " + returnValue
+                                           + ". This is fine and the test can still pass.");
+                    }
+                    returnValue = -1;
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+
+            System.out.println("doGet completed Successfully");
+        } catch (Exception e) {
             e.printStackTrace();
+        } finally {
+            try {
+                if (stmt != null)
+                    stmt.executeUpdate("drop table " + tableName);
+                else
+                    System.out.println("stmt is null");
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+            try {
+                if (con != null)
+                    con.close();
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+
+            try {
+                System.out.println("Thread sleeping for:" + sleepTimeInMilliSecs);
+                Thread.sleep(sleepTimeInMilliSecs);
+                System.out.println("Thread woke up");
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+
+            System.out.println("%%%%%%%%%%% Completed session set");
+            return;
         }
-
-        System.out.println("%%%%%%%%%%% Completed session set");
-        return;
     }
-  }
 
-  protected void doPost(HttpServletRequest request, HttpServletResponse response)
-    throws ServletException, IOException
-  {
-  }
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    }
 }


### PR DESCRIPTION
Fixes #13564 and Fixes #13620
Exceptions are not printed sometimes in TestJDBC which causes FAT tests to fail. It looks for slow warning messages `TRAS0112W` which is not found sometimes as the exception is not printed.