### PR TITLE
Issue #13717: Repeat EJB Async FAT for Jakarta

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.async_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.async_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -35,7 +35,19 @@ src: \
 fat.project: true
 
 tested.features: \
-	appsecurity-3.0, cdi-2.0, el-3.0, ejbLite-3.2, ejbRemote-3.2, servlet-4.0
+	appsecurity-3.0,\
+	appsecurity-4.0,\
+	cdi-2.0,\
+	cdi-3.0,\
+	concurrent-2.0,\
+	el-3.0,\
+	el-4.0,\
+	ejbLite-3.2,\
+	ejbLite-4.0,\
+	ejbRemote-3.2,\
+	enterpriseBeansRemote-4.0,\
+	servlet-4.0,\
+	servlet-5.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
@@ -47,4 +59,5 @@ tested.features: \
 	com.ibm.websphere.security; version=latest, \
 	com.ibm.ws.security.jaas.common; version=latest, \
 	com.ibm.ws.ejbcontainer.fat_tools; version=latest, \
-	com.ibm.tx.jta;version=latest
+	com.ibm.tx.jta;version=latest, \
+	io.openliberty.ejbcontainer.jakarta.fat_tools; version=latest

--- a/dev/com.ibm.ws.ejbcontainer.async_fat/build.gradle
+++ b/dev/com.ibm.ws.ejbcontainer.async_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,10 +20,12 @@ repositories {
 
 configurations {
   ejbTools
+  enterpriseBeansTools
 }
 
 dependencies {
   ejbTools 'test:com.ibm.ws.ejbcontainer.fat_tools:1.+'
+  enterpriseBeansTools 'test:io.openliberty.ejbcontainer.jakarta.fat_tools:1.+'
 }
 
 task addEJBTools {
@@ -52,6 +54,34 @@ task addEJBTools {
   }
 }
 
+task addEnterpriseBeansTools {
+  dependsOn ':io.openliberty.ejbcontainer.jakarta.fat_tools:release'
+  doLast {
+    copy {
+      from configurations.enterpriseBeansTools
+      into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.ejbcontainer.async.fat.AsyncConfigServer/lib/global"
+      rename 'io.openliberty.ejbcontainer.jakarta.fat_tools-(.*).jar', 'io.openliberty.ejbcontainer.jakarta.fat_tools.jar'
+    }
+    copy {
+      from configurations.enterpriseBeansTools
+      into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.ejbcontainer.async.fat.AsyncCoreServer/lib/global"
+      rename 'io.openliberty.ejbcontainer.jakarta.fat_tools-(.*).jar', 'io.openliberty.ejbcontainer.jakarta.fat_tools.jar'
+    }
+    copy {
+      from configurations.enterpriseBeansTools
+      into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.ejbcontainer.async.fat.AsyncRemoteServer/lib/global"
+      rename 'io.openliberty.ejbcontainer.jakarta.fat_tools-(.*).jar', 'io.openliberty.ejbcontainer.jakarta.fat_tools.jar'
+    }
+    copy {
+      from configurations.enterpriseBeansTools
+      into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.ejbcontainer.async.fat.AsyncSecureServer/lib/global"
+      rename 'io.openliberty.ejbcontainer.jakarta.fat_tools-(.*).jar', 'io.openliberty.ejbcontainer.jakarta.fat_tools.jar'
+    }
+  }
+}
+
 addRequiredLibraries {
   dependsOn addEJBTools
+  dependsOn addEnterpriseBeansTools
+  dependsOn addJakartaTransformer
 }

--- a/dev/com.ibm.ws.ejbcontainer.remote.client_fat/fat/src/com/ibm/ws/ejbcontainer/remote/client/fat/tests/EjbLinkTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote.client_fat/fat/src/com/ibm/ws/ejbcontainer/remote/client/fat/tests/EjbLinkTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
@@ -80,8 +81,8 @@ public class EjbLinkTest extends FATServletClient {
         EjbLinkTest.addAsModule(EjbLinkClient);
         EjbLinkTest = (EnterpriseArchive) ShrinkHelper.addDirectory(EjbLinkTest, "test-applications/EjbLinkTest.ear/resources");
 
-        ShrinkHelper.exportDropinAppToServer(server, EjbLinkTest);
-        ShrinkHelper.exportToClient(client, "dropins", EjbLinkTest);
+        ShrinkHelper.exportDropinAppToServer(server, EjbLinkTest, DeployOptions.SERVER_ONLY);
+        ShrinkHelper.exportToClient(client, "dropins", EjbLinkTest, DeployOptions.SERVER_ONLY);
 
         // Start the server and wait for application to start
         server.startServer();
@@ -89,6 +90,7 @@ public class EjbLinkTest extends FATServletClient {
         // verify the appSecurity-2.0 feature is ready
         assertNotNull("Security service did not report it was ready", server.waitForStringInLogUsingMark("CWWKS0008I"));
         assertNotNull("LTPA configuration did not report it was ready", server.waitForStringInLogUsingMark("CWWKS4105I"));
+        server.setMarkToEndOfLog();
 
         //#################### InitTxRecoveryLogApp.ear (Automatically initializes transaction recovery logs)
         JavaArchive InitTxRecoveryLogEJBJar = ShrinkHelper.buildJavaArchive("InitTxRecoveryLogEJB.jar", "com.ibm.ws.ejbcontainer.init.recovery.ejb.");
@@ -98,7 +100,7 @@ public class EjbLinkTest extends FATServletClient {
 
         // Only after the server has started and appSecurity-2.0 feature is ready,
         // then allow the @Startup InitTxRecoveryLog bean to start.
-        ShrinkHelper.exportDropinAppToServer(server, InitTxRecoveryLogApp);
+        ShrinkHelper.exportDropinAppToServer(server, InitTxRecoveryLogApp, DeployOptions.SERVER_ONLY);
 
         client.addIgnoreErrors("CWWKC0105W");
         client.startClient();

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -5410,7 +5410,7 @@ public class LibertyServer implements LogMonitorClient {
 
     public void addInstalledAppForValidation(String app) {
         final String method = "addInstalledAppForValidation";
-        final String START_APP_MESSAGE_CODE = "CWWKZ0001I";
+        final String START_APP_MESSAGE_CODE = "CWWKZ0001I:.*" + app;
         Log.info(c, method, "Adding installed app: " + app + " for validation");
         installedApplications.add(app);
 
@@ -5421,7 +5421,7 @@ public class LibertyServer implements LogMonitorClient {
 
     public void removeInstalledAppForValidation(String app) {
         final String method = "removeInstalledAppForValidation";
-        final String REMOVE_APP_MESSAGE_CODE = "CWWKZ0009I";
+        final String REMOVE_APP_MESSAGE_CODE = "CWWKZ0009I:.*" + app;
         Log.info(c, method, "Removing installed app: " + app + " for validation");
         installedApplications.remove(app);
 


### PR DESCRIPTION
- Added the repeat action to all EJB container async FAT tests
- Fixed problem where addInstalledAppForValidation didn't wait for app to start
- Stop copying apps to publish directory to avoid starting too soon / restarting

for #13717 