### PR TITLE
Issue #13306: el-3.0 should be eecompat7 and tolerate 60,8.0

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/el-3.0/com.ibm.websphere.appserver.el-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/el-3.0/com.ibm.websphere.appserver.el-3.0.feature
@@ -13,7 +13,7 @@ IBM-ShortName: el-3.0
 Subsystem-Version: 3.0.0
 Subsystem-Name: Expression Language 3.0
 -features=com.ibm.websphere.appserver.javax.el-3.0, \
- com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0,8.0"
+ com.ibm.websphere.appserver.eeCompatible-7.0; ibm.tolerates:="6.0,8.0"
 -bundles=com.ibm.ws.org.apache.jasper.el.3.0
 kind=ga
 edition=core


### PR DESCRIPTION
fixes #13306