### PR TITLE
Fixed MpHealth TCKs to include tested.features in bnd

### DIFF
--- a/dev/com.ibm.ws.microprofile.health.1.0_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.health.1.0_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ src: \
 
 fat.project: true
 
+tested.features=cdi-1.2,servlet-3.1,cdi-2.0,servlet-4.0
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ src: \
 
 fat.project: true
 
+tested.features=cdi-1.2,servlet-3.1,cdi-2.0,servlet-4.0
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/com.ibm.ws.microprofile.health.2.1_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.health.2.1_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ src: \
 
 fat.project: true
 
+tested.features=cdi-1.2,servlet-3.1,cdi-2.0,servlet-4.0
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/com.ibm.ws.microprofile.health.2.2_fat_tck/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.health.2.2_fat_tck/bnd.bnd
@@ -17,6 +17,7 @@ src: \
 
 fat.project: true
 
+tested.features=cdi-1.2,servlet-3.1,cdi-2.0,servlet-4.0
 
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}


### PR DESCRIPTION
fixes #13769
Added the `tested.features` proeprty to all the bnd.bnd files for the MP Health TCK projects to include all the implicit (features that are not explicitly specified in the server.xml) public features that are used in the TCK FATs.