### PR TITLE
Allow z/OS specific msgs for missing key tests

### DIFF
--- a/dev/com.ibm.ws.security.fat.common.jwt/src/com/ibm/ws/security/fat/common/jwt/JwtMessageConstants.java
+++ b/dev/com.ibm.ws.security.fat.common.jwt/src/com/ibm/ws/security/fat/common/jwt/JwtMessageConstants.java
@@ -56,4 +56,7 @@ public class JwtMessageConstants extends com.ibm.ws.security.fat.common.MessageC
     public static final String CWWKS6052E_JWT_TRUSTED_ISSUERS_NULL = "CWWKS6052E";
 
     public static final String CWWKS6054E_INVALID_AMR_CLAIM = "CWWKS6054E";
+
+    public static final String CWPKI0812E_CANT_FIND_KEY = "CWPKI0812E";
+
 }

--- a/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderAPIConfigTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderAPIConfigTests.java
@@ -73,7 +73,7 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
 
         // the server's default config contains an invalid value (on purpose),
         // tell the fat framework to ignore it!
-        builderServer.addIgnoredErrors(Arrays.asList(JwtMessageConstants.CWWKG0032W_CONFIG_INVALID_VALUE));
+        builderServer.addIgnoredErrors(Arrays.asList(JwtMessageConstants.CWWKG0032W_CONFIG_INVALID_VALUE, JwtMessageConstants.CWPKI0812E_CANT_FIND_KEY));
 
     }
 
@@ -376,7 +376,7 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
         validationUtils.validateResult(response, expectations);
 
     }
-    
+
     /**
      * Test Purpose:
      * <OL>
@@ -389,7 +389,7 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
      * <OL>
      * <LI>Should get a token built valid amr claim set to ["amrValue"]
      * </OL>
-     * 
+     *
      * @throws Exception
      */
     @Mode(TestMode.LITE)
@@ -410,7 +410,7 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
         validationUtils.validateResult(response, expectations);
 
     }
-	
+
     /**
      * Test Purpose:
      * <OL>
@@ -423,7 +423,7 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
      * <OL>
      * <LI>Should get a token built without amr claim set
      * </OL>
-     * 
+     *
      * @throws Exception
      */
     @Mode(TestMode.LITE)
@@ -435,12 +435,12 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
         JSONObject testSettings = new JSONObject();
         Expectations expectations = BuilderHelpers.createGoodBuilderExpectations(JWTBuilderConstants.JWT_BUILDER_PROTECTED_SETAPIS_ENDPOINT, expectationSettings, builderServer);
         expectations = BuilderHelpers.buildBuilderClaimsNotFound(expectations, JWTBuilderConstants.JWT_CLAIM, PayloadConstants.METHODS_REFERENCE);
-        
+
         Page response = actions.invokeProtectedJwtBuilder(_testName, builderServer, builderId, testSettings, "testuser", "testuserpwd");
         validationUtils.validateResult(response, expectations);
 
     }
-	
+
     /**
      * Test Purpose:
      * <OL>
@@ -452,10 +452,10 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
      * <OL>
      * <LI>Should get a token built without amr claim set
      * </OL>
-     * 
+     *
      * @throws Exception
      */
-	@Mode(TestMode.LITE)
+    @Mode(TestMode.LITE)
     @Test
     public void JwtBuilderAPIConfigTests_amrValue_empty() throws Exception {
 
@@ -464,7 +464,7 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
         JSONObject testSettings = new JSONObject();
         Expectations expectations = BuilderHelpers.createGoodBuilderExpectations(JWTBuilderConstants.JWT_BUILDER_PROTECTED_SETAPIS_ENDPOINT, expectationSettings, builderServer);
         expectations = BuilderHelpers.buildBuilderClaimsNotFound(expectations, JWTBuilderConstants.JWT_CLAIM, PayloadConstants.METHODS_REFERENCE);
-        
+
         Page response = actions.invokeProtectedJwtBuilder(_testName, builderServer, builderId, testSettings, "testuser", "testuserpwd");
         validationUtils.validateResult(response, expectations);
 


### PR DESCRIPTION
Allow z/OS specific error message for tests that are validating behavior with missing keys.