### PR TITLE
move to in memory db

### DIFF
--- a/dev/com.ibm.ws.cdi.jee_fat/publish/servers/cdi12JaxNoInjectServer/server.xml
+++ b/dev/com.ibm.ws.cdi.jee_fat/publish/servers/cdi12JaxNoInjectServer/server.xml
@@ -28,7 +28,7 @@
     <dataSource id="batchDB" type="javax.sql.XADataSource">
         <jdbcDriver libraryRef="DerbyLib"/>
         <!-- The 'derby.url' databaseName is set in bootstrap.properties -->
-        <properties.derby.embedded createDatabase="create" databaseName="${derby.url}" user="user" password="pass" />
+        <properties.derby.embedded createDatabase="create" databaseName="memory:${derby.url}" user="user" password="pass" />
     </dataSource>
 
     <!--  In this sample we'll use the same database (as the runtime DB) but use a different DS to access it.
@@ -37,7 +37,7 @@
     -->
     <dataSource id="appDB" jndiName="jdbc/batch" type="javax.sql.XADataSource">
         <jdbcDriver libraryRef="DerbyLib"/>
-        <properties.derby.embedded createDatabase="create" databaseName="${derby.url}" user="user" password="pass"/>
+        <properties.derby.embedded createDatabase="create" databaseName="memory:${derby.url}" user="user" password="pass"/>
     </dataSource>
 
     <!-- 
@@ -49,7 +49,7 @@
            <dataSource id="appReadOnlyDB" jndiName="jdbc/ReadOnlyDS">
          -->
         <jdbcDriver libraryRef="DerbyLib"/>
-        <properties.derby.embedded createDatabase="create" databaseName="${derby.url}" user="user" password="pass"/>
+        <properties.derby.embedded createDatabase="create" databaseName="memory:${derby.url}" user="user" password="pass"/>
         <connectionManager enableSharingForDirectLookups="false"/>
     </dataSource>
 

--- a/dev/com.ibm.ws.cdi.third.party_fat/publish/servers/cdi20HibernateSearchServer/server.xml
+++ b/dev/com.ibm.ws.cdi.third.party_fat/publish/servers/cdi20HibernateSearchServer/server.xml
@@ -27,7 +27,7 @@
 
   <dataSource jndiName="jdbc/jpaDataSource" id="jpaDataSource">
       <jdbcDriver libraryRef="derbyJDBCLib" />
-      <properties.derby.embedded databaseName="TestDB" createDatabase="create"/>
+      <properties.derby.embedded databaseName="memory:TestDB" createDatabase="create"/>
   </dataSource> 
 
     <SSLDefault/>

--- a/dev/com.ibm.ws.cdi.third.party_fat/publish/servers/cdiEntityListenersServer/server.xml
+++ b/dev/com.ibm.ws.cdi.third.party_fat/publish/servers/cdiEntityListenersServer/server.xml
@@ -19,7 +19,7 @@
 
   <dataSource jndiName="jdbc/jpaDataSource" id="jpaDataSource">
       <jdbcDriver libraryRef="derbyJDBCLib" />
-      <properties.derby.embedded databaseName="TestDB" createDatabase="create"/>
+      <properties.derby.embedded databaseName="memory:TestDB" createDatabase="create"/>
   </dataSource> 
 
     <SSLDefault/>


### PR DESCRIPTION
This fixes https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=277237 by moving the derby db form the build engine's notoriously slow filesystems to memory. 