### PR TITLE
Issue 13786: Skip CWWKG0027W in AcmeConfigVariationsTest

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeURIConfigVariationsTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeURIConfigVariationsTest.java
@@ -38,11 +38,12 @@ public class AcmeURIConfigVariationsTest extends AcmeConfigVariationsTest {
 
 	@Override
 	protected void stopServer(String... msgs) throws Exception {
-		if (JavaInfo.JAVA_VERSION > 8) {
+		String os = System.getProperty("os.name").toLowerCase();
+		if (JavaInfo.JAVA_VERSION > 8 && !os.startsWith("z/os")) {
 			AcmeFatUtils.stopServer(server, msgs);
 		} else {
 			/*
-			 * HttpConnector.config runs oddly slow on Java 8 and can trigger the update
+			 * HttpConnector.config runs oddly slow on Java 8 and z/OS and can trigger the update
 			 * timeout warning
 			 */
 			List<String> tempList = new ArrayList<String>(Arrays.asList(msgs));

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeURISimpleTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeURISimpleTest.java
@@ -38,11 +38,12 @@ public class AcmeURISimpleTest extends AcmeSimpleTest {
 
 	@Override
 	protected void stopServer(String... msgs) throws Exception {
-		if (JavaInfo.JAVA_VERSION > 8) {
+		String os = System.getProperty("os.name").toLowerCase();
+		if (JavaInfo.JAVA_VERSION > 8 && !os.startsWith("z/os")) {
 			AcmeFatUtils.stopServer(server, msgs);
 		} else {
 			/*
-			 * HttpConnector.config runs oddly slow on Java 8 and can trigger the update
+			 * HttpConnector.config runs oddly slow on Java 8 and z/OS and can trigger the update
 			 * timeout warning
 			 */
 			List<String> tempList = new ArrayList<String>(Arrays.asList(msgs));


### PR DESCRIPTION
Fixes #13786

Also skip `W CWWKG0027W: Timeout while updating server configuration.` on z/OS (previously skipping on Java8).