### PR TITLE
Fix jdk curve issue

### DIFF
--- a/dev/com.ibm.ws.security.fat.common.jwt/src/com/ibm/ws/security/fat/common/jwt/JwtMessageConstants.java
+++ b/dev/com.ibm.ws.security.fat.common.jwt/src/com/ibm/ws/security/fat/common/jwt/JwtMessageConstants.java
@@ -56,4 +56,7 @@ public class JwtMessageConstants extends com.ibm.ws.security.fat.common.MessageC
     public static final String CWWKS6052E_JWT_TRUSTED_ISSUERS_NULL = "CWWKS6052E";
 
     public static final String CWWKS6054E_INVALID_AMR_CLAIM = "CWWKS6054E";
+
+    public static final String CWPKI0812E_CANT_FIND_KEY = "CWPKI0812E";
+
 }

--- a/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderAPIConfigTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderAPIConfigTests.java
@@ -73,7 +73,7 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
 
         // the server's default config contains an invalid value (on purpose),
         // tell the fat framework to ignore it!
-        builderServer.addIgnoredErrors(Arrays.asList(JwtMessageConstants.CWWKG0032W_CONFIG_INVALID_VALUE));
+        builderServer.addIgnoredErrors(Arrays.asList(JwtMessageConstants.CWWKG0032W_CONFIG_INVALID_VALUE, JwtMessageConstants.CWPKI0812E_CANT_FIND_KEY));
 
     }
 
@@ -376,7 +376,7 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
         validationUtils.validateResult(response, expectations);
 
     }
-    
+
     /**
      * Test Purpose:
      * <OL>
@@ -389,7 +389,7 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
      * <OL>
      * <LI>Should get a token built valid amr claim set to ["amrValue"]
      * </OL>
-     * 
+     *
      * @throws Exception
      */
     @Mode(TestMode.LITE)
@@ -410,7 +410,7 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
         validationUtils.validateResult(response, expectations);
 
     }
-	
+
     /**
      * Test Purpose:
      * <OL>
@@ -423,7 +423,7 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
      * <OL>
      * <LI>Should get a token built without amr claim set
      * </OL>
-     * 
+     *
      * @throws Exception
      */
     @Mode(TestMode.LITE)
@@ -435,12 +435,12 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
         JSONObject testSettings = new JSONObject();
         Expectations expectations = BuilderHelpers.createGoodBuilderExpectations(JWTBuilderConstants.JWT_BUILDER_PROTECTED_SETAPIS_ENDPOINT, expectationSettings, builderServer);
         expectations = BuilderHelpers.buildBuilderClaimsNotFound(expectations, JWTBuilderConstants.JWT_CLAIM, PayloadConstants.METHODS_REFERENCE);
-        
+
         Page response = actions.invokeProtectedJwtBuilder(_testName, builderServer, builderId, testSettings, "testuser", "testuserpwd");
         validationUtils.validateResult(response, expectations);
 
     }
-	
+
     /**
      * Test Purpose:
      * <OL>
@@ -452,10 +452,10 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
      * <OL>
      * <LI>Should get a token built without amr claim set
      * </OL>
-     * 
+     *
      * @throws Exception
      */
-	@Mode(TestMode.LITE)
+    @Mode(TestMode.LITE)
     @Test
     public void JwtBuilderAPIConfigTests_amrValue_empty() throws Exception {
 
@@ -464,7 +464,7 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
         JSONObject testSettings = new JSONObject();
         Expectations expectations = BuilderHelpers.createGoodBuilderExpectations(JWTBuilderConstants.JWT_BUILDER_PROTECTED_SETAPIS_ENDPOINT, expectationSettings, builderServer);
         expectations = BuilderHelpers.buildBuilderClaimsNotFound(expectations, JWTBuilderConstants.JWT_CLAIM, PayloadConstants.METHODS_REFERENCE);
-        
+
         Page response = actions.invokeProtectedJwtBuilder(_testName, builderServer, builderId, testSettings, "testuser", "testuserpwd");
         validationUtils.validateResult(response, expectations);
 

--- a/dev/com.ibm.ws.security.jwt_fat.builder/test-applications/jwtbuilderclient/src/com/ibm/ws/jaxrs/fat/jwtbuilderclient/JwtBuilderSetApisClient.java
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/test-applications/jwtbuilderclient/src/com/ibm/ws/jaxrs/fat/jwtbuilderclient/JwtBuilderSetApisClient.java
@@ -36,7 +36,6 @@ import javax.servlet.http.HttpServletResponse;
 import com.ibm.json.java.JSON;
 import com.ibm.json.java.JSONArray;
 import com.ibm.json.java.JSONObject;
-import com.ibm.websphere.security.WSSecurityException;
 import com.ibm.websphere.security.auth.WSSubject;
 import com.ibm.websphere.security.cred.WSCredential;
 import com.ibm.websphere.security.jwt.JwtBuilder;
@@ -102,7 +101,7 @@ public class JwtBuilderSetApisClient extends HttpServlet {
 
             String configId = request.getParameter(JWTBuilderConstants.JWT_BUILDER_PARAM_BUILDER_ID);
             appUtils.logIt(pw, JWTBuilderConstants.JWT_BUILDER_PARAM_BUILDER_ID + ": " + configId);
-			// Setting amr in the subject if it is in params
+            // Setting amr in the subject if it is in params
             setAMRInSubject(pw, request);
             // create a builder
             if (configId != null) {
@@ -295,7 +294,7 @@ public class JwtBuilderSetApisClient extends HttpServlet {
             }
             if (alg.startsWith("ES")) {
                 keyGenerator = KeyPairGenerator.getInstance("EC");
-                String spec = "secp256k1";
+                String spec = "secp256r1";
 
                 if (alg.contains("384")) {
                     spec = "secp384r1";
@@ -377,7 +376,7 @@ public class JwtBuilderSetApisClient extends HttpServlet {
             }
         }
     }
-    
+
     protected void setAMRInSubject(PrintWriter pw, HttpServletRequest request) throws Exception {
 
         String attrsString = request.getParameter("attrs");


### PR DESCRIPTION
Fix the setup within the "signWith" tests to use the correct curve for ES256.
Replace secp256k1 with secp256r1.
