### PR TITLE
Issue 12807: AcmeHistory updates and debug

### DIFF
--- a/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/util/AcmeConstants.java
+++ b/dev/com.ibm.ws.security.acme/src/com/ibm/ws/security/acme/internal/util/AcmeConstants.java
@@ -100,6 +100,7 @@ public class AcmeConstants {
 	public static final Long SCHEDULER_MS = TimeUnit.HOURS.toMillis(24L);
 	public static final Long SCHEDULER_ERROR_MS = TimeUnit.HOURS.toMillis(1L);
 	
+	public static final String ACME_HISTORY_DIR = "acmeca/";
 	public static final String ACME_HISTORY_FILE = "acmeca-history.txt";
 
 	public static final Integer HTTP_CONNECT_TIMEOUT_DEFAULT = 30000;

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
@@ -467,8 +467,24 @@ public class AcmeFatUtils {
 	 *            The server to check.
 	 */
 	public static final void waitForSslToCreateKeystore(LibertyServer server) {
-		assertNotNull("ACME did not create a new certificate.",
-				server.waitForStringInLog("CWPKI0803A: SSL certificate created"));
+		/*
+		 * Temporary extra debug for RTC bug 277292
+		 */
+		if (server.waitForStringInLog("CWPKI0803A: SSL certificate created") == null) {
+			Log.info(AcmeFatUtils.class, "waitForSslToCreateKeystore",
+					"SSL Cert not created -- requesting javacore to see if RTC bug 277292 was recreated.");
+			try {
+				server.javadumpThreads();
+			} catch (Exception e) {
+				Log.error(AcmeFatUtils.class, "waitForSslToCreateKeystore", e,
+						"Tried to request a java thread dump, but it failed.");
+			}
+			junit.framework.Assert.fail(
+					"ACME did not create a new certificate. Issued javacore. Check if RTC bug 277292 was recreated.");
+		}
+
+		// assertNotNull("ACME did not create a new certificate.",
+		// server.waitForStringInLog("CWPKI0803A: SSL certificate created"));
 	}
 
 	/**


### PR DESCRIPTION
Fixes #13807

Adding debug for a build break that we encountered that looked like the `acmeFile = wslocation.getServerWorkareaResource("acmeca/" + acmeFileName).asFile();` call might be blocked. I walked the path for that call and no blocking calls jumped out at me. I was unable to recreate after running server starts/stops several times on my local box.

I added debug to the AcmeFatUtils that will take a javacore if we hit the same failure spot as the build break.

While reviewing AcmeHistory, I also added some debug and moved some closes to try/finally blocks.