### PR TITLE
Fix release builds and fix things building in eclipse

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -939,7 +939,7 @@
     <dependency>
       <groupId>javax.json</groupId>
       <artifactId>javax.json-api</artifactId>
-      <version>1.1.3</version>
+      <version>1.1.4</version>
     </dependency>
     <dependency>
       <groupId>javax.jws</groupId>
@@ -2119,7 +2119,7 @@
     <dependency>
       <groupId>org.glassfish</groupId>
       <artifactId>javax.json</artifactId>
-      <version>1.1.3</version>
+      <version>1.1.4</version>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/dev/com.ibm.ws.transaction.cloud_fat.7/.classpath
+++ b/dev/com.ibm.ws.transaction.cloud_fat.7/.classpath
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="fat/src" including="com/ibm/ws/transaction/test/CustompostgreSQLContainer.java"/>
-	<classpathentry kind="src" path="fat/src" including="com/ibm/ws/transaction/test/DualServerDynamicPostgreSQLTest.java"/>
-	<classpathentry kind="src" path="fat/src" including="com/ibm/ws/transaction/test/FATSuite.java"/>
-	<classpathentry kind="src" path="fat/src" including="com/ibm/ws/transaction/test/PostgreSQLTest.java"/>
+	<classpathentry kind="src" path="fat/src" including="com/ibm/ws/transaction/test/*.java"/>
 	<classpathentry kind="src" path="com.ibm.ws.transaction.cloud_fat.1-fatsrc" excluding="com/ibm/ws/transaction/test/FATSuite.java"/>
 	<classpathentry kind="src" path="com.ibm.ws.transaction.cloud_fat.1-cloudtx"/>
 	<classpathentry kind="src" path="com.ibm.ws.transaction.cloud_fat.1-transaction"/>

--- a/dev/com.ibm.ws.wsat.common/test/com/ibm/ws/wsat/tm/impl/CoordinatorFactoryServiceTest.java
+++ b/dev/com.ibm.ws.wsat.common/test/com/ibm/ws/wsat/tm/impl/CoordinatorFactoryServiceTest.java
@@ -21,6 +21,8 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 
+import org.apache.cxf.ws.addressing.AttributedURIType;
+import org.apache.cxf.ws.addressing.EndpointReferenceType;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,6 +46,7 @@ public class CoordinatorFactoryServiceTest {
 
     private WSATTransaction tran = null;
     private WSATCoordinator coordinator = null;
+    private EndpointReferenceType epr;
 
     @Before
     public void setup() throws Exception {
@@ -51,6 +54,12 @@ public class CoordinatorFactoryServiceTest {
         Utils.setTranService("syncRegistry", new MockProxy());
         tran = new WSATTransaction(Utils.tranId(), 10);
         coordinator = new WSATCoordinator(tran.getGlobalId(), null);
+        epr = new EndpointReferenceType();
+        AttributedURIType uri = new AttributedURIType();
+        uri.setValue("http://www.example.com/endpoint");
+        epr.setAddress(uri);
+
+        ProtocolImpl.getInstance().setParticipantEndpoint(epr);
     }
 
     @Test


### PR DESCRIPTION
- Update CoordinatorFactoryServiceTest to be able to run first or on its
own.  If it doesn't run in the same JVM as previous unit tests, it will
fail.
- Update dependabot pom for new changes
- Update .classpath for transaction.cloud_fat.7 to build in eclipse.
