### PR TITLE
Implicit Converter Cache

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.1/src/com/ibm/ws/microprofile/config/converters/PriorityConverter.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1/src/com/ibm/ws/microprofile/config/converters/PriorityConverter.java
@@ -31,8 +31,8 @@ public abstract class PriorityConverter {
      */
     @Trivial
     public PriorityConverter(Type type, int priority) {
-        this.type = type;
         this.priority = priority;
+        this.type = type;
     }
 
     /**
@@ -40,7 +40,7 @@ public abstract class PriorityConverter {
      */
     @Trivial
     public int getPriority() {
-        return priority;
+        return this.priority;
     }
 
     /**

--- a/dev/com.ibm.ws.microprofile.config.1.2/src/com/ibm/ws/microprofile/config12/converters/ConstructorFunction.java
+++ b/dev/com.ibm.ws.microprofile.config.1.2/src/com/ibm/ws/microprofile/config12/converters/ConstructorFunction.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.config12.converters;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.function.Function;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.microprofile.config.interfaces.ConversionException;
+
+public class ConstructorFunction<X> implements Function<String, X> {
+    private final Constructor<X> constructor;
+
+    public ConstructorFunction(Constructor<X> constructor) {
+        this.constructor = constructor;
+    }
+
+    /** {@inheritDoc} */
+    @SuppressWarnings("unchecked")
+    @Override
+    public X apply(String value) {
+        X converted = null;
+        if (value != null) { //if the value is null then we always return null
+            try {
+                converted = constructor.newInstance(value);
+            } catch (InvocationTargetException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof IllegalArgumentException) {
+                    throw (IllegalArgumentException) cause;
+                } else {
+                    throw new ConversionException(cause);
+                }
+            } catch (IllegalAccessException | InstantiationException e) {
+                throw new ConversionException(e);
+            }
+        }
+        return converted;
+    }
+
+    @FFDCIgnore(NoSuchMethodException.class)
+    @Trivial
+    public static <X> Function<String, X> getConstructorFunction(Class<X> reflectionClass) {
+        Function<String, X> implicitFunction = null;
+        try {
+            Constructor<X> ctor = reflectionClass.getConstructor(String.class);
+            implicitFunction = new ConstructorFunction<X>(ctor);
+        } catch (NoSuchMethodException e) {
+            //No FFDC
+        }
+
+        return implicitFunction;
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.config.1.2/src/com/ibm/ws/microprofile/config12/converters/ConstructorFunction.java
+++ b/dev/com.ibm.ws.microprofile.config.1.2/src/com/ibm/ws/microprofile/config12/converters/ConstructorFunction.java
@@ -26,8 +26,8 @@ public class ConstructorFunction<X> implements Function<String, X> {
     }
 
     /** {@inheritDoc} */
-    @SuppressWarnings("unchecked")
     @Override
+    @FFDCIgnore(InvocationTargetException.class)
     public X apply(String value) {
         X converted = null;
         if (value != null) { //if the value is null then we always return null

--- a/dev/com.ibm.ws.microprofile.config.1.2/src/com/ibm/ws/microprofile/config12/converters/ImplicitConverter.java
+++ b/dev/com.ibm.ws.microprofile.config.1.2/src/com/ibm/ws/microprofile/config12/converters/ImplicitConverter.java
@@ -35,33 +35,45 @@ public class ImplicitConverter extends BuiltInConverter {
         this.implicitFunction = getImplicitFunction(converterType);
     }
 
+    /**
+     * <p>If no explicit Converter and no built-in Converter could be found for a certain type,
+     * the {@code Config} provides an <em>Implicit Converter</em>, if</p>
+     * <ul>
+     * <li>The target type {@code T} has a public Constructor with a String parameter, or</li>
+     * <li>the target type {@code T} has a {@code public static T valueOf(String)} method, or</li>
+     * <li>the target type {@code T} has a {@code public static T parse(CharSequence)} method</li>
+     * </ul>
+     *
+     * @param converterType The class to convert using
+     */
     @Trivial
     protected <X> Function<String, X> getImplicitFunction(Class<X> converterType) {
         Function<String, X> implicitFunction = ConstructorFunction.getConstructorFunction(converterType);
 
+        if (implicitFunction != null && TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "Automatic converter for " + converterType + " using \"constructor\"");
+        }
+
         if (implicitFunction == null) {
             implicitFunction = MethodFunction.getValueOfFunction(converterType);
 
-            if (implicitFunction == null) {
-                implicitFunction = MethodFunction.getParseFunction(converterType);
-
-                if (implicitFunction == null) {
-                    throw new IllegalArgumentException(Tr.formatMessage(tc, "implicit.string.constructor.method.not.found.CWMCG0017E", converterType));
-                } else {
-                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                        Tr.debug(tc, "Automatic converter for " + converterType + " using \"parse\"");
-                    }
-                }
-            } else {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "Automatic converter for " + converterType + " using \"valueOf\"");
-                }
-            }
-        } else {
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "Automatic converter for " + converterType + " using \"constructor\"");
+            if (implicitFunction != null && TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Automatic converter for " + converterType + " using \"valueOf\"");
             }
         }
+
+        if (implicitFunction == null) {
+            implicitFunction = MethodFunction.getParseFunction(converterType);
+
+            if (implicitFunction != null && TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Automatic converter for " + converterType + " using \"parse\"");
+            }
+        }
+
+        if (implicitFunction == null) {
+            throw new IllegalArgumentException(Tr.formatMessage(tc, "implicit.string.constructor.method.not.found.CWMCG0017E", converterType));
+        }
+
         return implicitFunction;
     }
 

--- a/dev/com.ibm.ws.microprofile.config.1.2/src/com/ibm/ws/microprofile/config12/converters/ImplicitConverter.java
+++ b/dev/com.ibm.ws.microprofile.config.1.2/src/com/ibm/ws/microprofile/config12/converters/ImplicitConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,17 +10,12 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.config12.converters;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
+import java.util.function.Function;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
-import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.microprofile.config.converters.BuiltInConverter;
-import com.ibm.ws.microprofile.config.interfaces.ConversionException;
 
 /**
  *
@@ -28,112 +23,52 @@ import com.ibm.ws.microprofile.config.interfaces.ConversionException;
 public class ImplicitConverter extends BuiltInConverter {
 
     private static final TraceComponent tc = Tr.register(ImplicitConverter.class);
-    private Method valueOfMethod;
-    private final Constructor<?> ctor;
-    private Method parseMethod;
+    private final Function<String, ?> implicitFunction;
 
-    @Trivial
     /**
      *
      * @param converterType The class to convert using
      */
+    @Trivial
     public ImplicitConverter(Class<?> converterType) {
         super(converterType);
-        this.ctor = getConstructor(converterType);
-        if (this.ctor == null) {
-            this.valueOfMethod = getValueOfMethod(converterType);
-        }
-        if (this.ctor == null && this.valueOfMethod == null) {
-            this.parseMethod = getParse(converterType);
-        }
+        this.implicitFunction = getImplicitFunction(converterType);
+    }
 
-        if (this.ctor == null && this.valueOfMethod == null && this.parseMethod == null) {
-            throw new IllegalArgumentException(Tr.formatMessage(tc, "implicit.string.constructor.method.not.found.CWMCG0017E", converterType));
-        } else {
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                if (this.ctor != null) {
-                    Tr.debug(tc, "Automatic converter for {0} using {1}", converterType, this.ctor);
-                } else if (this.valueOfMethod != null) {
-                    Tr.debug(tc, "Automatic converter for {0} using {1}", converterType, this.valueOfMethod);
-                } else if (this.parseMethod != null) {
-                    Tr.debug(tc, "Automatic converter for {0} using {1}", converterType, this.parseMethod);
+    @Trivial
+    protected <X> Function<String, X> getImplicitFunction(Class<X> converterType) {
+        Function<String, X> implicitFunction = ConstructorFunction.getConstructorFunction(converterType);
+
+        if (implicitFunction == null) {
+            implicitFunction = MethodFunction.getValueOfFunction(converterType);
+
+            if (implicitFunction == null) {
+                implicitFunction = MethodFunction.getParseFunction(converterType);
+
+                if (implicitFunction == null) {
+                    throw new IllegalArgumentException(Tr.formatMessage(tc, "implicit.string.constructor.method.not.found.CWMCG0017E", converterType));
+                } else {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "Automatic converter for " + converterType + " using \"parse\"");
+                    }
+                }
+            } else {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Automatic converter for " + converterType + " using \"valueOf\"");
                 }
             }
-        }
-    }
-
-    @FFDCIgnore(NoSuchMethodException.class)
-    @Trivial
-    private static <M> Constructor<M> getConstructor(Class<M> reflectionClass) {
-        Constructor<M> ctor = null;
-        try {
-            ctor = reflectionClass.getConstructor(String.class);
-        } catch (NoSuchMethodException e) {
-            //No FFDC
-        }
-        return ctor;
-    }
-
-    @FFDCIgnore(NoSuchMethodException.class)
-    @Trivial
-    private static Method getValueOfMethod(Class<?> reflectionClass) {
-        Method method = null;
-        try {
-            method = reflectionClass.getMethod("valueOf", String.class);
-            if ((method.getModifiers() & Modifier.STATIC) == 0) {
-                method = null;
-            } else if (!reflectionClass.equals(method.getReturnType())) {
-                method = null;
+        } else {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Automatic converter for " + converterType + " using \"constructor\"");
             }
-        } catch (NoSuchMethodException e) {
-            //No FFDC
         }
-
-        return method;
-    }
-
-    @FFDCIgnore(NoSuchMethodException.class)
-    @Trivial
-    private static Method getParse(Class<?> reflectionClass) {
-        Method method = null;
-        try {
-            method = reflectionClass.getMethod("parse", CharSequence.class);
-            if ((method.getModifiers() & Modifier.STATIC) == 0) {
-                method = null;
-            } else if (!reflectionClass.equals(method.getReturnType())) {
-                method = null;
-            }
-        } catch (NoSuchMethodException e) {
-            //No FFDC
-        }
-        return method;
+        return implicitFunction;
     }
 
     /** {@inheritDoc} */
     @Override
     public Object convert(String value) {
-        Object converted = null;
-        if (value != null) { //if the value is null then we always return null
-            try {
-                if (this.ctor != null) {
-                    converted = this.ctor.newInstance(value);
-                } else if (this.valueOfMethod != null) {
-                    converted = this.valueOfMethod.invoke(null, value);
-                } else if (this.parseMethod != null) {
-                    converted = this.parseMethod.invoke(null, value);
-                }
-            } catch (InvocationTargetException e) {
-                Throwable cause = e.getCause();
-                if (cause instanceof IllegalArgumentException) {
-                    throw (IllegalArgumentException) cause;
-                } else {
-                    throw new ConversionException(cause);
-                }
-            } catch (IllegalAccessException | InstantiationException e) {
-                throw new ConversionException(e);
-            }
-        }
-        return converted;
+        return this.implicitFunction.apply(value);
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.ws.microprofile.config.1.2/src/com/ibm/ws/microprofile/config12/converters/MethodFunction.java
+++ b/dev/com.ibm.ws.microprofile.config.1.2/src/com/ibm/ws/microprofile/config12/converters/MethodFunction.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.config12.converters;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.function.Function;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.microprofile.config.interfaces.ConversionException;
+
+public class MethodFunction<X> implements Function<String, X> {
+    private final Method method;
+
+    protected MethodFunction(Method method) {
+        this.method = method;
+    }
+
+    /** {@inheritDoc} */
+    @SuppressWarnings("unchecked")
+    @Override
+    public X apply(String value) {
+        X converted = null;
+        if (value != null) { //if the value is null then we always return null
+            try {
+                converted = (X) method.invoke(null, value);
+            } catch (InvocationTargetException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof IllegalArgumentException) {
+                    throw (IllegalArgumentException) cause;
+                } else {
+                    throw new ConversionException(cause);
+                }
+            } catch (IllegalAccessException e) {
+                throw new ConversionException(e);
+            }
+        }
+        return converted;
+    }
+
+    @Trivial
+    public static <X> Function<String, X> getValueOfFunction(Class<X> reflectionClass) {
+        return getFunction(reflectionClass, "valueOf", String.class);
+    }
+
+    @Trivial
+    public static <X> Function<String, X> getParseFunction(Class<X> reflectionClass) {
+        return getFunction(reflectionClass, "parse", CharSequence.class);
+    }
+
+    @Trivial
+    public static <X> Function<String, X> getOfMethod(Class<X> reflectionClass) {
+        return getFunction(reflectionClass, "of", String.class);
+    }
+
+    @FFDCIgnore(NoSuchMethodException.class)
+    @Trivial
+    public static <X> Function<String, X> getFunction(Class<X> reflectionClass, String methodName, Class<?>... paramTypes) {
+        Function<String, X> implicitFunction = null;
+        try {
+            Method method = reflectionClass.getMethod(methodName, paramTypes);
+            if ((method.getModifiers() & Modifier.STATIC) == 0) {
+                method = null;
+            } else if (!reflectionClass.equals(method.getReturnType())) {
+                method = null;
+            }
+
+            if (method != null) {
+                implicitFunction = new MethodFunction<X>(method);
+            }
+        } catch (NoSuchMethodException e) {
+            //No FFDC
+        }
+        return implicitFunction;
+    }
+}

--- a/dev/com.ibm.ws.microprofile.config.1.2/src/com/ibm/ws/microprofile/config12/converters/MethodFunction.java
+++ b/dev/com.ibm.ws.microprofile.config.1.2/src/com/ibm/ws/microprofile/config12/converters/MethodFunction.java
@@ -29,6 +29,7 @@ public class MethodFunction<X> implements Function<String, X> {
     /** {@inheritDoc} */
     @SuppressWarnings("unchecked")
     @Override
+    @FFDCIgnore(InvocationTargetException.class)
     public X apply(String value) {
         X converted = null;
         if (value != null) { //if the value is null then we always return null

--- a/dev/com.ibm.ws.microprofile.config.1.2/src/com/ibm/ws/microprofile/config12/impl/Config12ConversionManager.java
+++ b/dev/com.ibm.ws.microprofile.config.1.2/src/com/ibm/ws/microprofile/config12/impl/Config12ConversionManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,10 +11,13 @@
 
 package com.ibm.ws.microprofile.config12.impl;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
-import com.ibm.ws.microprofile.config.converters.BuiltInConverter;
 import com.ibm.ws.microprofile.config.converters.PriorityConverterMap;
 import com.ibm.ws.microprofile.config.impl.ConversionManager;
 import com.ibm.ws.microprofile.config.impl.ConversionStatus;
@@ -25,6 +28,8 @@ import io.openliberty.microprofile.config.internal.common.ConfigException;
 public class Config12ConversionManager extends ConversionManager {
 
     private static final TraceComponent tc = Tr.register(Config12ConversionManager.class);
+
+    private final Map<Class<?>, ImplicitConverter> implicitConverterCache = Collections.synchronizedMap(new HashMap<>());
 
     /**
      * @param converters all the converters to use
@@ -43,12 +48,12 @@ public class Config12ConversionManager extends ConversionManager {
     @Override
     protected <T> ConversionStatus implicitConverters(String rawString, Class<T> type) {
         ConversionStatus status = new ConversionStatus();
-        BuiltInConverter automaticConverter = getConverter(type);
+        ImplicitConverter implicitConverter = getImplicitConverter(type);
 
         //will be null if a suitable string constructor method could not be found
-        if (automaticConverter != null) {
+        if (implicitConverter != null) {
             try {
-                Object converted = automaticConverter.convert(rawString);
+                Object converted = implicitConverter.convert(rawString);
                 status.setConverted(converted);
             } catch (IllegalArgumentException e) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -66,12 +71,21 @@ public class Config12ConversionManager extends ConversionManager {
         return status;
     }
 
-    @FFDCIgnore(IllegalArgumentException.class)
-    protected <T> BuiltInConverter getConverter(Class<T> type) {
-        ImplicitConverter automaticConverter = null;
+    protected <T> ImplicitConverter getImplicitConverter(Class<T> type) {
+        ImplicitConverter implicitConverter = implicitConverterCache.get(type);
 
+        if (implicitConverter == null) {
+            implicitConverter = newImplicitConverter(type);
+            implicitConverterCache.put(type, implicitConverter);
+        }
+        return implicitConverter;
+    }
+
+    @FFDCIgnore(IllegalArgumentException.class)
+    protected <T> ImplicitConverter newImplicitConverter(Class<T> type) {
+        ImplicitConverter implicitConverter = null;
         try {
-            automaticConverter = new ImplicitConverter(type);
+            implicitConverter = new ImplicitConverter(type);
         } catch (IllegalArgumentException e) {
             //no FFDC
             //this means that a suitable string constuctor method could not be found for the given class
@@ -85,8 +99,7 @@ public class Config12ConversionManager extends ConversionManager {
             }
             throw new ConfigException(t);
         }
-
-        return automaticConverter;
+        return implicitConverter;
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.config.1.2_fat/fat/src/com/ibm/ws/microprofile/config12/test/Config12ConverterTests.java
+++ b/dev/com.ibm.ws.microprofile.config.1.2_fat/fat/src/com/ibm/ws/microprofile/config12/test/Config12ConverterTests.java
@@ -67,7 +67,7 @@ public class Config12ConverterTests extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer("CWMCG0017E"); //stringConstructorMissingTest expects implicit.string.constructor.method.not.found.CWMCG0017E
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.config.1.3/src/com/ibm/ws/microprofile/config13/impl/Config13ConversionManager.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3/src/com/ibm/ws/microprofile/config13/impl/Config13ConversionManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,8 +14,8 @@ package com.ibm.ws.microprofile.config13.impl;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
-import com.ibm.ws.microprofile.config.converters.BuiltInConverter;
 import com.ibm.ws.microprofile.config.converters.PriorityConverterMap;
+import com.ibm.ws.microprofile.config12.converters.ImplicitConverter;
 import com.ibm.ws.microprofile.config12.impl.Config12ConversionManager;
 import com.ibm.ws.microprofile.config13.converters.Config13ImplicitConverter;
 
@@ -34,11 +34,10 @@ public class Config13ConversionManager extends Config12ConversionManager {
 
     @Override
     @FFDCIgnore(IllegalArgumentException.class)
-    protected <T> BuiltInConverter getConverter(Class<T> type) {
-        BuiltInConverter automaticConverter = null;
-
+    protected <T> ImplicitConverter newImplicitConverter(Class<T> type) {
+        ImplicitConverter implicitConverter = null;
         try {
-            automaticConverter = new Config13ImplicitConverter(type);
+            implicitConverter = new Config13ImplicitConverter(type);
         } catch (IllegalArgumentException e) {
             //no FFDC
             //this means that a suitable string constuctor method could not be found for the given class
@@ -52,8 +51,7 @@ public class Config13ConversionManager extends Config12ConversionManager {
             }
             throw new ConfigException(t);
         }
-
-        return automaticConverter;
+        return implicitConverter;
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/converters/Config14ImplicitConverter.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/converters/Config14ImplicitConverter.java
@@ -50,33 +50,33 @@ public class Config14ImplicitConverter extends Config13ImplicitConverter {
         Function<String, X> implicitFunction = null;
 
         implicitFunction = MethodFunction.getOfMethod(converterType);
+        if (implicitFunction != null && TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "Automatic converter for " + converterType + " using \"of\"");
+        }
+
         if (implicitFunction == null) {
             implicitFunction = MethodFunction.getValueOfFunction(converterType);
-            if (implicitFunction == null) {
-                implicitFunction = MethodFunction.getParseFunction(converterType);
-                if (implicitFunction == null) {
-                    implicitFunction = ConstructorFunction.getConstructorFunction(converterType);
-                    if (implicitFunction == null) {
-                        throw new IllegalArgumentException(Tr.formatMessage(tc, "implicit.string.constructor.method.not.found.CWMCG0017E", converterType));
-                    } else {
-                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                            Tr.debug(tc, "Automatic converter for " + converterType + " using \"constructor\"");
-                        }
-                    }
-                } else {
-                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                        Tr.debug(tc, "Automatic converter for " + converterType + " using \"parse\"");
-                    }
-                }
-            } else {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "Automatic converter for " + converterType + " using \"valueOf\"");
-                }
+            if (implicitFunction != null && TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Automatic converter for " + converterType + " using \"valueOf\"");
             }
-        } else {
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "Automatic converter for " + converterType + " using \"of\"");
+
+        }
+        if (implicitFunction == null) {
+            implicitFunction = MethodFunction.getParseFunction(converterType);
+            if (implicitFunction != null && TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Automatic converter for " + converterType + " using \"parse\"");
             }
+        }
+
+        if (implicitFunction == null) {
+            implicitFunction = ConstructorFunction.getConstructorFunction(converterType);
+            if (implicitFunction != null && TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Automatic converter for " + converterType + " using \"constructor\"");
+            }
+        }
+
+        if (implicitFunction == null) {
+            throw new IllegalArgumentException(Tr.formatMessage(tc, "implicit.string.constructor.method.not.found.CWMCG0017E", converterType));
         }
 
         return implicitFunction;

--- a/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/impl/Config14ConversionManager.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/impl/Config14ConversionManager.java
@@ -14,8 +14,8 @@ package com.ibm.ws.microprofile.config14.impl;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
-import com.ibm.ws.microprofile.config.converters.BuiltInConverter;
 import com.ibm.ws.microprofile.config.converters.PriorityConverterMap;
+import com.ibm.ws.microprofile.config12.converters.ImplicitConverter;
 import com.ibm.ws.microprofile.config13.impl.Config13ConversionManager;
 import com.ibm.ws.microprofile.config14.converters.Config14ImplicitConverter;
 
@@ -34,11 +34,10 @@ public class Config14ConversionManager extends Config13ConversionManager {
 
     @Override
     @FFDCIgnore(IllegalArgumentException.class)
-    protected <T> BuiltInConverter getConverter(Class<T> type) {
-        BuiltInConverter automaticConverter = null;
-
+    protected <T> ImplicitConverter newImplicitConverter(Class<T> type) {
+        ImplicitConverter implicitConverter = null;
         try {
-            automaticConverter = new Config14ImplicitConverter(type);
+            implicitConverter = new Config14ImplicitConverter(type);
         } catch (IllegalArgumentException e) {
             //no FFDC
             //this means that a suitable string constuctor method could not be found for the given class
@@ -52,8 +51,6 @@ public class Config14ConversionManager extends Config13ConversionManager {
             }
             throw new ConfigException(t);
         }
-
-        return automaticConverter;
+        return implicitConverter;
     }
-
 }


### PR DESCRIPTION
MP Config 1.2, 1.3 and 1.4 automatically create converters for types that have appropriate methods. This PR aims to cache them in a way which will not cause a memory leak.

#build 