### PR TITLE
Fix build break when running JAXRS executor tests on Java 8

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -108,9 +108,9 @@ org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen:2.7.7-69f2c2b
 org.eclipse.persistence:org.eclipse.persistence.jpa:2.7.7-69f2c2b
 org.eclipse.persistence:org.eclipse.persistence.jpa:3.0.0-M1
 org.mock-server:mockserver-core:3.10.7-IBM20191022
+org.mock-server:mockserver-core:3.10.7-IBM20191022
 org.openid4java:openid4java:0.9.7-ibm-s20130624-1827
 org.opensaml:opensaml:2.6.6
 org.opensaml:openws:1.5.6
 org.owasp.esapi:esapi:2.1.0
-org.mock-server:mockserver-core:3.10.7-IBM20191022
 org.xmlunit:xmlunit-core:2.0.0.ibm

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_executor/publish/servers/com.ibm.ws.jaxrs.2.1.fat.executor/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_executor/publish/servers/com.ibm.ws.jaxrs.2.1.fat.executor/server.xml
@@ -21,4 +21,5 @@
     </managedScheduledExecutorService>
 
     <variable name="onError" value="FAIL"/>
+    <javaPermission className="java.util.PropertyPermission" name="java.specification.version" actions="read"/>
 </server>

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_executor/test-applications/jaxrsapp/src/web/jaxrstest/JAXRSExecutorTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_executor/test-applications/jaxrsapp/src/web/jaxrstest/JAXRSExecutorTestServlet.java
@@ -149,7 +149,12 @@ public class JAXRSExecutorTestServlet extends FATServlet {
         assertEquals("test456", results[0]);
 
         String executionThreadName = (String) results[1];
-        assertTrue(resultString, executionThreadName.startsWith("Default Executor-thread-"));
+        // On JDK 8, it will use the ForkJoin pool now
+        if (System.getProperty("java.specification.version").startsWith("1.")) {
+            assertTrue(resultString, executionThreadName.startsWith("ForkJoin"));
+        } else {
+            assertTrue(resultString, executionThreadName.startsWith("Default Executor-thread-"));
+        }
         assertTrue(resultString, results[2] instanceof NamingException);
     }
 


### PR DESCRIPTION
- Change assertion for thread name to be conditional on whether it is
running with Java 8 or higher.  The assertion is changed due to the
changes done with PR #13675
- Update oss_ibm.maven for being in alphabetical order after building.