### PR TITLE
Issue #13195: Move EJBRemote 4 to beta

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/enterpriseBeansRemote-4.0/io.openliberty.enterpriseBeansRemote-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/enterpriseBeansRemote-4.0/io.openliberty.enterpriseBeansRemote-4.0.feature
@@ -11,5 +11,5 @@ Subsystem-Name: Jakarta Enterprise Beans Remote 4.0
  com.ibm.websphere.appserver.transaction-2.0
 -bundles=com.ibm.ws.ejbcontainer.remote.jakarta
 -files=clients/ejbRemotePortable.jakarta.jar
-kind=noship
-edition=full
+kind=beta
+edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaee-9.0/com.ibm.websphere.appserver.jakartaee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaee-9.0/com.ibm.websphere.appserver.jakartaee-9.0.feature
@@ -14,6 +14,7 @@ Subsystem-Name: Jakarta EE Platform 9.0
  com.ibm.websphere.appserver.transaction-2.0,\
  com.ibm.websphere.appserver.webProfile-9.0,\
  io.openliberty.enterpriseBeansHome-4.0,\
+ io.openliberty.enterpriseBeansRemote-4.0,\
  io.openliberty.jacc-2.0,\
  io.openliberty.jaxb-3.0
 kind=beta


### PR DESCRIPTION
enterpriseBeansRemote-4.0 is ready for beta

for #13195 