### PR TITLE
EJB Remote Fats: Add heapdump testwatcher to tests on failure

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.remote.client_fat/fat/src/com/ibm/ws/ejbcontainer/remote/client/fat/tests/EjbLinkTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote.client_fat/fat/src/com/ibm/ws/ejbcontainer/remote/client/fat/tests/EjbLinkTest.java
@@ -22,7 +22,10 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -41,6 +44,22 @@ import componenttest.topology.utils.FATServletClient;
 
 @RunWith(FATRunner.class)
 public class EjbLinkTest extends FATServletClient {
+
+    @Rule
+    public TestWatcher watchman = new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+            try {
+                System.runFinalization();
+                System.gc();
+                server.serverDump("heap");
+            } catch (Exception e1) {
+                System.out.println("Failed to dump server");
+                e1.printStackTrace();
+            }
+        }
+    };
+
     private static Class<?> c = EjbLinkTest.class;
 
     private static LibertyClient client = LibertyClientFactory.getLibertyClient("com.ibm.ws.ejbcontainer.remote.client.fat.clientInjection");

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/AbstractTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/AbstractTest.java
@@ -29,7 +29,9 @@ public abstract class AbstractTest {
         @Override
         protected void failed(Throwable e, Description description) {
             try {
-                getServer().dumpServer("serverDump");
+                System.runFinalization();
+                System.gc();
+                getServer().serverDump("heap");
             } catch (Exception e1) {
                 System.out.println("Failed to dump server");
                 e1.printStackTrace();


### PR DESCRIPTION
I will also add this to the bindings_fat but in a different PR to be cleaner with timing / merge conflicts.