### PR TITLE
disabled multicasting for Mac OS in SessionCacheTwoServerTimeoutTest.java 

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTimeoutTest.java
@@ -56,8 +56,9 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
         serverB.useSecondaryHTTPPort();
 
         String hazelcastConfigFile = "hazelcast-localhost-only.xml";
+        String osName = System.getProperty("os.name").toLowerCase();
 
-        if (FATSuite.isMulticastDisabled()) {
+        if (FATSuite.isMulticastDisabled() || osName.contains("mac os") || osName.contains("macos")) {
             Log.info(SessionCacheTwoServerTimeoutTest.class, "setUp", "Disabling multicast in Hazelcast config.");
             hazelcastConfigFile = "hazelcast-localhost-only-multicastDisabled.xml";
         }


### PR DESCRIPTION
Disables multicasting for Mac OS in Hazelcast config due to a Hazelcast bug that occurs on Mac OS breaking builds. Fixes: https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=276637 

#build 