### PR TITLE
Replace unused fields with 'XXXXXXX' and remove unused fields from FFDC logs

### DIFF
--- a/dev/com.ibm.ws.collector.manager/src/com/ibm/ws/logging/ffdc/source/FFDCSource.java
+++ b/dev/com.ibm.ws.collector.manager/src/com/ibm/ws/logging/ffdc/source/FFDCSource.java
@@ -120,14 +120,10 @@ public class FFDCSource implements Source {
 
                 long timeStampVal = in.getTimeStamp();
                 ffdcData.setDatetime(timeStampVal);
-                ffdcData.setDateOfFirstOccurence(in.getDateOfFirstOccurrence().getTime());
-                ffdcData.setCount(countVal);
                 ffdcData.setMessage(th.getMessage());
                 ffdcData.setClassName(in.getSourceId());
-                ffdcData.setLabel(in.getLabel());
                 ffdcData.setExceptionName(in.getExceptionName());
                 ffdcData.setProbeId(in.getProbeId());
-                ffdcData.setSourceId(in.getSourceId());
                 ffdcData.setThreadId(in.getThreadId());
                 ffdcData.setStacktrace(getStackTraceAsString(th));
                 ffdcData.setObjectDetails(getCallerDetails(in));

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/LogFieldConstants.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/LogFieldConstants.java
@@ -97,31 +97,33 @@ public class LogFieldConstants {
     public static final String REMOTEUSERID = "remoteUserID";
 
     //liberty_ffdc
-    public static final String DATEOFFIRSTOCCURENCE = "dateOfFirstOccurence";
-    public static final String COUNT = "count";
-    public static final String LABEL = "label";
+    //fields that contain 'XXXXXXX' are not expected to be used
+    public static final String DATEOFFIRSTOCCURENCE = "XXXXXXX_dateOfFirstOccurence";
+    public static final String COUNT = "XXXXXXX_count";
+    public static final String LABEL = "XXXXXXX_label";
     public static final String IBM_EXCEPTIONNAME = "ibm_exceptionName";
     public static final String EXCEPTIONNAME = "exceptionName";
     public static final String IBM_PROBEID = "ibm_probeID";
     public static final String PROBEID = "probeID";
-    public static final String SOURCEID = "sourceID";
+    public static final String SOURCEID = "XXXXXXX_sourceID";
     public static final String IBM_STACKTRACE = "ibm_stackTrace";
     public static final String STACKTRACE = "stackTrace";
     public static final String IBM_OBJECTDETAILS = "ibm_objectDetails";
     public static final String OBJECTDETAILS = "objectDetails";
 
     //liberty_gc
-    public static final String IBM_HEAP = "ibm_heap";
+    //fields that contain 'XXXXXXX' are not expected to be used
+    public static final String IBM_HEAP = "XXXXXXX_ibm_heap";
     public static final String HEAP = "heap";
-    public static final String IBM_USED_HEAP = "ibm_usedHeap";
+    public static final String IBM_USED_HEAP = "XXXXXXX_ibm_usedHeap";
     public static final String USED_HEAP = "usedHeap";
-    public static final String IBM_MAX_HEAP = "ibm_maxHeap";
+    public static final String IBM_MAX_HEAP = "XXXXXXX_ibm_maxHeap";
     public static final String MAX_HEAP = "maxHeap";
-    public static final String IBM_DURATION = "ibm_duration";
+    public static final String IBM_DURATION = "XXXXXXX_ibm_duration";
     public static final String DURATION = "duration";
-    public static final String IBM_GC_TYPE = "ibm_gcType";
+    public static final String IBM_GC_TYPE = "XXXXXXX_ibm_gcType";
     public static final String GC_TYPE = "gcType";
-    public static final String IBM_REASON = "ibm_reason";
+    public static final String IBM_REASON = "XXXXXXX_ibm_reason";
     public static final String REASON = "reason";
 
     //other

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/LogFieldConstants.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/collector/LogFieldConstants.java
@@ -98,14 +98,10 @@ public class LogFieldConstants {
 
     //liberty_ffdc
     //fields that contain 'XXXXXXX' are not expected to be used
-    public static final String DATEOFFIRSTOCCURENCE = "XXXXXXX_dateOfFirstOccurence";
-    public static final String COUNT = "XXXXXXX_count";
-    public static final String LABEL = "XXXXXXX_label";
     public static final String IBM_EXCEPTIONNAME = "ibm_exceptionName";
     public static final String EXCEPTIONNAME = "exceptionName";
     public static final String IBM_PROBEID = "ibm_probeID";
     public static final String PROBEID = "probeID";
-    public static final String SOURCEID = "XXXXXXX_sourceID";
     public static final String IBM_STACKTRACE = "ibm_stackTrace";
     public static final String STACKTRACE = "stackTrace";
     public static final String IBM_OBJECTDETAILS = "ibm_objectDetails";

--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/data/FFDCData.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/data/FFDCData.java
@@ -25,14 +25,10 @@ public class FFDCData extends GenericData {
 
     public static final String[] NAMES_LC = {
                                               LogFieldConstants.DATETIME,
-                                              LogFieldConstants.DATEOFFIRSTOCCURENCE,
-                                              LogFieldConstants.COUNT,
                                               LogFieldConstants.MESSAGE,
                                               LogFieldConstants.CLASSNAME,
-                                              LogFieldConstants.LABEL,
                                               LogFieldConstants.EXCEPTIONNAME,
                                               LogFieldConstants.PROBEID,
-                                              LogFieldConstants.SOURCEID,
                                               LogFieldConstants.THREADID,
                                               LogFieldConstants.STACKTRACE,
                                               LogFieldConstants.OBJECTDETAILS,
@@ -45,14 +41,10 @@ public class FFDCData extends GenericData {
 
     public static final String[] NAMES_JSON = {
                                                 LogFieldConstants.IBM_DATETIME,
-                                                LogFieldConstants.DATEOFFIRSTOCCURENCE,
-                                                LogFieldConstants.COUNT,
                                                 LogFieldConstants.MESSAGE,
                                                 LogFieldConstants.IBM_CLASSNAME,
-                                                LogFieldConstants.LABEL,
                                                 LogFieldConstants.IBM_EXCEPTIONNAME,
                                                 LogFieldConstants.IBM_PROBEID,
-                                                LogFieldConstants.SOURCEID,
                                                 LogFieldConstants.IBM_THREADID, //long
                                                 LogFieldConstants.IBM_STACKTRACE,
                                                 LogFieldConstants.IBM_OBJECTDETAILS,
@@ -90,49 +82,37 @@ public class FFDCData extends GenericData {
 
     //@formatter:off
     public void setDatetime(long l)             { setPair(0, l); }
-    public void setDateOfFirstOccurence(long l) { setPair(1, l); }
-    public void setCount(int i)                 { setPair(2, i); }
-    public void setMessage(String s)            { setPair(3, s); }
-    public void setClassName(String s)          { setPair(4, s); }
-    public void setLabel(String s)              { setPair(5, s); }
-    public void setExceptionName(String s)      { setPair(6, s); }
-    public void setProbeId(String s)            { setPair(7, s); }
-    public void setSourceId(String s)           { setPair(8, s); }
-    public void setThreadId(long l)             { setPair(9, l); }
-    public void setStacktrace(String s)         { setPair(10, s); }
-    public void setObjectDetails(String s)      { setPair(11, s); }
-    public void setSequence(String s)           { setPair(12, s); }
+    public void setMessage(String s)            { setPair(1, s); }
+    public void setClassName(String s)          { setPair(2, s); }
+    public void setExceptionName(String s)      { setPair(3, s); }
+    public void setProbeId(String s)            { setPair(4, s); }
+    public void setThreadId(long l)             { setPair(5, l); }
+    public void setStacktrace(String s)         { setPair(6, s); }
+    public void setObjectDetails(String s)      { setPair(7, s); }
+    public void setSequence(String s)           { setPair(8, s); }
 
     public long getDatetime()             { return getLongValue(0); }
-    public long getDateOfFirstOccurence() { return getLongValue(1); }
-    public int getCount()                 { return getIntValue(2); }
-    public String getMessage()            { return getStringValue(3); }
-    public String getClassName()          { return getStringValue(4); }
-    public String getLabel()              { return getStringValue(5); }
-    public String getExceptionName()      { return getStringValue(6); }
-    public String getProbeId()            { return getStringValue(7); }
-    public String getSourceId()           { return getStringValue(8); }
-    public long getThreadId()             { return getLongValue(9); }
-    public String getStacktrace()         { return getStringValue(10); }
-    public String getObjectDetails()      { return getStringValue(11); }
-    public String getSequence()           { return getStringValue(12); }
+    public String getMessage()            { return getStringValue(1); }
+    public String getClassName()          { return getStringValue(2); }
+    public String getExceptionName()      { return getStringValue(3); }
+    public String getProbeId()            { return getStringValue(4); }
+    public long getThreadId()             { return getLongValue(5); }
+    public String getStacktrace()         { return getStringValue(6); }
+    public String getObjectDetails()      { return getStringValue(7); }
+    public String getSequence()           { return getStringValue(8); }
 
     public static String getDatetimeKey(int format)             { return nameAliases[format].aliases[0]; }
-    public static String getDateOfFirstOccurenceKey(int format) { return nameAliases[format].aliases[1]; }
-    public static String getCountKey(int format)                { return nameAliases[format].aliases[2]; }
-    public static String getMessageKey(int format)              { return nameAliases[format].aliases[3]; }
-    public static String getClassNameKey(int format)            { return nameAliases[format].aliases[4]; }
-    public static String getLabelKey(int format)                { return nameAliases[format].aliases[5]; }
-    public static String getExceptionNameKey(int format)        { return nameAliases[format].aliases[6]; }
-    public static String getProbeIdKey(int format)              { return nameAliases[format].aliases[7]; }
-    public static String getSourceIdKey(int format)             { return nameAliases[format].aliases[8]; }
-    public static String getThreadIdKey(int format)             { return nameAliases[format].aliases[9]; }
-    public static String getStacktraceKey(int format)           { return nameAliases[format].aliases[10]; }
-    public static String getObjectDetailsKey(int format)        { return nameAliases[format].aliases[11]; }
-    public static String getSequenceKey(int format)             { return nameAliases[format].aliases[12]; }
-    public static String getHostKey(int format)                 { return nameAliases[format].aliases[13]; }
-    public static String getUserDirKey(int format)              { return nameAliases[format].aliases[14]; }
-    public static String getServerNameKey(int format)           { return nameAliases[format].aliases[15]; }
-    public static String getTypeKey(int format)                 { return nameAliases[format].aliases[16]; }
+    public static String getMessageKey(int format)              { return nameAliases[format].aliases[1]; }
+    public static String getClassNameKey(int format)            { return nameAliases[format].aliases[2]; }
+    public static String getExceptionNameKey(int format)        { return nameAliases[format].aliases[3]; }
+    public static String getProbeIdKey(int format)              { return nameAliases[format].aliases[4]; }
+    public static String getThreadIdKey(int format)             { return nameAliases[format].aliases[5]; }
+    public static String getStacktraceKey(int format)           { return nameAliases[format].aliases[6]; }
+    public static String getObjectDetailsKey(int format)        { return nameAliases[format].aliases[7]; }
+    public static String getSequenceKey(int format)             { return nameAliases[format].aliases[8]; }
+    public static String getHostKey(int format)                 { return nameAliases[format].aliases[9]; }
+    public static String getUserDirKey(int format)              { return nameAliases[format].aliases[10]; }
+    public static String getServerNameKey(int format)           { return nameAliases[format].aliases[11]; }
+    public static String getTypeKey(int format)                 { return nameAliases[format].aliases[12]; }
 
 }


### PR DESCRIPTION
fixes: #13635

This is a reiteration of this PR: https://github.com/OpenLiberty/open-liberty/pull/13657 which replaces unused fields with 'XXXXXXX' in JSON Logging. This PR has an additional commit to remove fields `DATEOFFIRSTOCCURENCE`, `COUNT`, `LABEL`, and `SOURCEID` from FFDC logs in both JSON Logging and logstashCollector since those four fields are never used.

#build