### PR TITLE
Fix ManagedThreadFactory service

### DIFF
--- a/dev/com.ibm.ws.concurrent/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent/bnd.bnd
@@ -49,7 +49,7 @@ Service-Component:\
     threadGroupTracker=com.ibm.ws.concurrent.internal.ThreadGroupTracker;\
     properties:='\
       contextService.target=(id=unbound),\
-      creates.objectClass=|java.util.concurrent.ThreadFactory|jakarta.enterprise.concurrent.ManagedThreadFactory|javax.enterprise.concurrent.ManagedThreadFactory',\
+      creates.objectClass=|java.util.concurrent.ThreadFactory|javax.enterprise.concurrent.ManagedThreadFactory',\
   com.ibm.ws.concurrent.tracker;\
       provide:='\
         com.ibm.ws.container.service.metadata.ComponentMetaDataListener,\


### PR DESCRIPTION
- The bnd settings for the managedThreadFactory service still had
reference to the jakarta API.
