### PR TITLE
Fix missing dependencies for the LRA coordinator

### DIFF
--- a/dev/io.openliberty.org.jboss.narayana.rts.lra-coordinator/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.narayana.rts.lra-coordinator/bnd.bnd
@@ -32,7 +32,8 @@ Bundle-SymbolicName: io.openliberty.org.jboss.narayana.rts.lra-coordinator; sing
 Private-Package: \
     com.arjuna*, \
     org.jboss.logging*, \
-    io.narayana.lra*
+    io.narayana.lra*, \
+    org.apache*
     
 
 # The excluded packages appear to be optional parts of narayana
@@ -56,6 +57,8 @@ instrument.disabled: true
   org.jboss.narayana.rts:lra-coordinator-jar;version=${narayanaVersion}.Final, \
   org.jboss.narayana.arjunacore:arjuna;version=${narayanaVersion}.Final, \
   org.jboss.narayana:common;version=${narayanaVersion}.Final, \
-  org.jboss.narayana.rts:lra-service-base;version=${narayanaVersion}.Final
+  org.jboss.narayana.rts:lra-service-base;version=${narayanaVersion}.Final, \
+  com.ibm.ws.org.apache.httpcomponents;version=latest, \
+  com.ibm.ws.org.apache.commons.logging.1.0.3;version=latest
   
 


### PR DESCRIPTION
There were some missing dependencies in the LRA coordinator feature. 