### PR TITLE
InitialPollingTest.testRestartWithFourTasks should tolerate slower tasks

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/test-applications/initialpollingtest/src/web/PersistentExecutorsTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_initial_polling/test-applications/initialpollingtest/src/web/PersistentExecutorsTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -46,7 +46,7 @@ public class PersistentExecutorsTestServlet extends HttpServlet {
     /**
      * Maximum number of nanoseconds to wait for a task to finish.
      */
-    private static final long TIMEOUT_NS = TimeUnit.SECONDS.toNanos(30);
+    private static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(2);
 
     @Resource
     private UserTransaction tran;


### PR DESCRIPTION
fixes #13903