### PR TITLE
Beta MicroProfile 4.0

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -96,6 +96,7 @@ org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0
 org.apache.santuario:xmlsec:1.5.2-ibm
 org.apache.ws.security:wss4j:1.6.7-ibm-s20130913-2015
 org.eclipse.microprofile.config:microprofile-config-api:2.0-ibm20200908
+org.eclipse.microprofile.config:microprofile-config-tck:2.0-ibm20200908
 org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.0-20191203
 org.eclipse.microprofile.graphql:microprofile-graphql-tck:1.0.0-20191203
 org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.7-69f2c2b

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.config-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.config-2.0.feature
@@ -1,8 +1,8 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.org.eclipse.microprofile.config-2.0
 singleton=true
--features=com.ibm.websphere.appserver.javax.cdi-1.2; ibm.tolerates:=2.0
+-features=com.ibm.websphere.appserver.javax.cdi-2.0
 -bundles=io.openliberty.org.eclipse.microprofile.config.2.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.config:microprofile-config-api:2.0"
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-4.0/io.openliberty.microProfile-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-4.0/io.openliberty.microProfile-4.0.feature
@@ -14,13 +14,12 @@ Subsystem-Name: MicroProfile 4.0
   com.ibm.websphere.appserver.jaxrsClient-2.1, \
   com.ibm.websphere.appserver.jsonb-1.0, \
   com.ibm.websphere.appserver.jsonp-1.1, \
-  com.ibm.websphere.appserver.mpConfig-1.4, \
+  io.openliberty.mpConfig-2.0, \
   io.openliberty.mpFaultTolerance-3.0, \
   io.openliberty.mpHealth-3.0, \
   io.openliberty.mpJwt-1.2, \
   io.openliberty.mpMetrics-3.0, \
-  com.ibm.websphere.appserver.mpOpenAPI-1.1, \
-  io.openliberty.mpOpenTracing-2.0, \
-  com.ibm.websphere.appserver.mpRestClient-1.4
-kind=noship
-edition=full
+  io.openliberty.mpOpenAPI-2.0, \
+  io.openliberty.mpOpenTracing-2.0
+kind=beta
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpConfig-2.0/io.openliberty.mpConfig-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpConfig-2.0/io.openliberty.mpConfig-2.0.feature
@@ -22,6 +22,6 @@ Subsystem-Name: MicroProfile Config 2.0
  com.ibm.ws.org.apache.commons.lang3, \
  com.ibm.ws.cdi.interfaces, \
  com.ibm.ws.org.jboss.logging
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpFaultTolerance-3.0/io.openliberty.mpFaultTolerance-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpFaultTolerance-3.0/io.openliberty.mpFaultTolerance-3.0.feature
@@ -11,7 +11,7 @@ Subsystem-Name: MicroProfile Fault Tolerance 3.0
 -features=io.openliberty.org.eclipse.microprofile.faulttolerance-3.0, \
  com.ibm.websphere.appserver.cdi-2.0, \
  com.ibm.websphere.appserver.concurrent-1.0, \
- com.ibm.websphere.appserver.mpConfig-1.4; ibm.tolerates:="1.1, 1.2, 1.3"
+ io.openliberty.mpConfig-2.0
 -bundles=com.ibm.ws.microprofile.faulttolerance; apiJar=false; location:="lib/", \
  com.ibm.ws.microprofile.faulttolerance.2.0; apiJar=false; location:="lib/", \
  com.ibm.ws.microprofile.faulttolerance.spi; apiJar=false; location:="lib/", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpHealth-3.0/io.openliberty.mpHealth-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpHealth-3.0/io.openliberty.mpHealth-3.0.feature
@@ -16,7 +16,7 @@ Subsystem-Name: MicroProfile Health 3.0
  com.ibm.websphere.appserver.jndi-1.0, \
  com.ibm.websphere.appserver.json-1.0, \
  com.ibm.websphere.appserver.servlet-4.0,\
- com.ibm.websphere.appserver.mpConfig-1.4; ibm.tolerates:=1.3,\
+ io.openliberty.mpConfig-2.0,\
  com.ibm.wsspi.appserver.webBundle-1.0 
 -bundles=com.ibm.websphere.jsonsupport, \
  com.ibm.ws.classloader.context, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpJwt-1.2/io.openliberty.mpJwt-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpJwt-1.2/io.openliberty.mpJwt-1.2.feature
@@ -14,7 +14,7 @@ Subsystem-Name: MicroProfile JSON Web Token 1.2
   com.ibm.websphere.appserver.jwt-1.0, \
   com.ibm.websphere.appserver.jsonp-1.1, \
   com.ibm.websphere.appserver.httpcommons-1.0, \
-  com.ibm.websphere.appserver.mpConfig-1.4
+  io.openliberty.mpConfig-2.0
 -bundles=com.ibm.ws.security.mp.jwt,\
   io.openliberty.org.eclipse.microprofile.jwt.1.2; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:1.2-RC1",\
   com.ibm.ws.security.mp.jwt.cdi,\

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-3.0/io.openliberty.mpMetrics-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-3.0/io.openliberty.mpMetrics-3.0.feature
@@ -7,12 +7,12 @@ IBM-API-Package: org.eclipse.microprofile.metrics.annotation;  type="stable", \
 IBM-ShortName: mpMetrics-3.0
 Subsystem-Name: MicroProfile Metrics 3.0
 -features=io.openliberty.org.eclipse.microprofile.metrics-3.0, \
- com.ibm.websphere.appserver.cdi-2.0; ibm.tolerates:=1.2,\
- com.ibm.websphere.appserver.javax.annotation-1.3; ibm.tolerates:=1.2, \
+ com.ibm.websphere.appserver.cdi-2.0,\
+ com.ibm.websphere.appserver.javax.annotation-1.3, \
  com.ibm.websphere.appserver.restHandler-1.0, \
  com.ibm.websphere.appserver.monitor-1.0, \
- com.ibm.websphere.appserver.servlet-4.0; ibm.tolerates:=3.1,\
- com.ibm.websphere.appserver.mpConfig-1.4
+ com.ibm.websphere.appserver.servlet-4.0,\
+ io.openliberty.mpConfig-2.0
 -bundles=com.ibm.ws.microprofile.metrics.common, \
  io.openliberty.microprofile.metrics.internal.3.0, \
  io.openliberty.microprofile.metrics.internal.cdi.3.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-2.0/io.openliberty.mpOpenAPI-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-2.0/io.openliberty.mpOpenAPI-2.0.feature
@@ -37,7 +37,7 @@ IBM-SPI-Package: \
     org.eclipse.microprofile.openapi.spi; type="stable"
 -features=\
     io.openliberty.org.eclipse.microprofile.openapi-2.0, \
-    com.ibm.websphere.appserver.mpConfig-1.3; ibm.tolerates:="1.4", \
+    io.openliberty.mpConfig-2.0, \
     com.ibm.websphere.appserver.servlet-4.0, \
     com.ibm.wsspi.appserver.webBundle-1.0, \
     com.ibm.websphere.appserver.jaxrs-2.1

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenTracing-2.0/io.openliberty.mpOpenTracing-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenTracing-2.0/io.openliberty.mpOpenTracing-2.0.feature
@@ -11,7 +11,7 @@ IBM-API-Package: \
 -features=\
     io.openliberty.opentracing-2.0, \
     io.openliberty.org.eclipse.microprofile.opentracing-2.0, \
-    com.ibm.websphere.appserver.mpConfig-1.4
+    io.openliberty.mpConfig-2.0
 -bundles=\
     io.openliberty.microprofile.opentracing.2.0.internal
 kind=beta

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-2.0/io.openliberty.opentracing-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-2.0/io.openliberty.opentracing-2.0.feature
@@ -12,7 +12,7 @@ IBM-API-Package: io.opentracing;  type="third-party",\
                  io.openliberty.opentracing.spi.tracer; type="ibm-spi"
 -features=com.ibm.websphere.appserver.jaxrs-2.1, \
           com.ibm.websphere.appserver.cdi-2.0, \
-          com.ibm.websphere.appserver.mpConfig-1.4
+          io.openliberty.mpConfig-2.0
 -bundles=com.ibm.ws.jaxrs.defaultexceptionmapper, \
          io.openliberty.opentracing.2.0.internal, \
          io.openliberty.opentracing.2.0.internal.cdi, \

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0.cdi/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0.cdi/bnd.bnd
@@ -17,7 +17,7 @@ Bundle-SymbolicName: com.ibm.ws.microprofile.faulttolerance.2.0.cdi
 Bundle-Description: MicroProfile Fault Tolerance CDI 2.0 Integration, version ${bVersion}
 
 Import-Package: \
-	org.eclipse.microprofile.config.*;version="[1.0,2)",\
+	org.eclipse.microprofile.config.*;version="[1.0,3)",\
 	*
 
 Export-Package: 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.1.cdi/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.1.cdi/bnd.bnd
@@ -16,10 +16,6 @@ Bundle-Name: com.ibm.ws.microprofile.faulttolerance.2.1.cdi
 Bundle-SymbolicName: com.ibm.ws.microprofile.faulttolerance.2.1.cdi
 Bundle-Description: MicroProfile Fault Tolerance 2.1 CDI Integration, version ${bVersion}
 
-Import-Package: \
-	org.eclipse.microprofile.config.*;version="[1.0,2)",\
-	*
-
 Export-Package: com.ibm.ws.microprofile.faulttolerance21.cdi.config.impl
 
 Include-Resource: 
@@ -40,7 +36,6 @@ testsrc=test/src
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.cdi.interfaces;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.faulttolerance.2.1;version=latest,\
-	com.ibm.websphere.org.eclipse.microprofile.config.1.1;version=latest,\
 	com.ibm.websphere.javaee.interceptor.1.2;version=latest,\
 	com.ibm.websphere.javaee.annotation.1.2;version=latest,\
 	com.ibm.ws.microprofile.faulttolerance.spi;version=latest,\
@@ -53,6 +48,7 @@ testsrc=test/src
 	com.ibm.ws.microprofile.config.1.3;version=latest,\
 	com.ibm.ws.microprofile.config.1.2;version=latest,\
 	com.ibm.ws.microprofile.config.1.1;version=latest,\
+	com.ibm.websphere.org.eclipse.microprofile.config.1.1;version=latest,\
 	io.openliberty.microprofile.config.internal.common;version=latest, \
 	io.openliberty.microprofile.config.internal.serverxml;version=latest, \
 	com.ibm.ws.container.service;version=latest, \

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi/bnd.bnd
@@ -18,7 +18,7 @@ Bundle-Description: MicroProfile Fault Tolerance CDI Integration, version ${bVer
 
 Import-Package: \
 	javax.enterprise.*;version="[1.1,3)",\
-	org.eclipse.microprofile.config.*;version="[1.0,2)",\
+	org.eclipse.microprofile.config.*;version="[1.0,3)",\
 	*
 
 Export-Package: \

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/CDIFallbackTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/fat/src/com/ibm/websphere/microprofile/faulttolerance/metrics/fat/tests/CDIFallbackTest.java
@@ -13,60 +13,52 @@ package com.ibm.websphere.microprofile.faulttolerance.metrics.fat.tests;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.ibm.ws.fat.util.LoggingTest;
-import com.ibm.ws.fat.util.SharedServer;
-import com.ibm.ws.fat.util.browser.WebBrowser;
+import com.ibm.websphere.microprofile.faulttolerance.metrics.app.FallbackServlet;
 import com.ibm.ws.microprofile.faulttolerance.fat.repeat.RepeatFaultTolerance;
 
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
 
 @Mode(TestMode.LITE)
 @RunWith(FATRunner.class)
-public class CDIFallbackTest extends LoggingTest {
+public class CDIFallbackTest extends FATServletClient {
+
+    private static final String SERVER_NAME = "CDIFaultToleranceMetrics";
+
+    @Server(value = SERVER_NAME)
+    @TestServlet(servlet = FallbackServlet.class, contextRoot = "CDIFaultToleranceMetrics")
+    public static LibertyServer server;
 
     @ClassRule
-    public static SharedServer SHARED_SERVER = new SharedServer("CDIFaultToleranceMetrics");
-
-    @ClassRule
-    public static RepeatTests rep = RepeatFaultTolerance.repeatAll(SHARED_SERVER.getServerName())
-                    .andWith(RepeatFaultTolerance.ft11metrics20Features(SHARED_SERVER.getServerName()));
-
-    @Test
-    public void testFallback() throws Exception {
-        WebBrowser browser = createWebBrowserForTestCase();
-        getSharedServer().verifyResponse(browser, "/CDIFaultToleranceMetrics/fallback?testMethod=testFallback", "SUCCESS");
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    protected SharedServer getSharedServer() {
-        return SHARED_SERVER;
-    }
+    public static RepeatTests rep = RepeatFaultTolerance.repeatAll(SERVER_NAME)
+                    .andWith(RepeatFaultTolerance.ft11metrics20Features(SERVER_NAME));
 
     @BeforeClass
     public static void setUp() throws Exception {
-        if (!SHARED_SERVER.getLibertyServer().isStarted()) {
-            SHARED_SERVER.getLibertyServer().startServer();
+        if (!server.isStarted()) {
+            server.startServer();
         }
 
     }
 
     @AfterClass
     public static void tearDown() throws Exception {
-        if (SHARED_SERVER != null && SHARED_SERVER.getLibertyServer().isStarted()) {
+        if (server != null && server.isStarted()) {
             /*
              * Ignore following exception as those are expected:
              * CWWKC1101E: The task com.ibm.ws.microprofile.faulttolerance.cdi.FutureTimeoutMonitor@3f76c259, which was submitted to executor service
              * managedScheduledExecutorService[DefaultManagedScheduledExecutorService], failed with the following error:
              * org.eclipse.microprofile.faulttolerance.exceptions.FTTimeoutException: java.util.concurrent.TimeoutException
              */
-            SHARED_SERVER.getLibertyServer().stopServer("CWWKC1101E");
+            server.stopServer("CWWKC1101E");
         }
     }
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/test-applications/CDIFaultToleranceMetrics.war/src/com/ibm/websphere/microprofile/faulttolerance/metrics/app/FallbackServlet.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/test-applications/CDIFaultToleranceMetrics.war/src/com/ibm/websphere/microprofile/faulttolerance/metrics/app/FallbackServlet.java
@@ -14,13 +14,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
-
 import javax.inject.Inject;
-import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Test;
 
 import com.ibm.websphere.microprofile.faulttolerance.metrics.app.beans.FallbackBean;
 import com.ibm.websphere.microprofile.faulttolerance.metrics.utils.ConnectException;
@@ -38,8 +35,8 @@ public class FallbackServlet extends FATServlet {
     @Inject
     FallbackBean bean;
 
-    public void testFallback(HttpServletRequest request,
-                             HttpServletResponse response) throws ServletException, IOException, ConnectException, NoSuchMethodException, SecurityException {
+    @Test
+    public void testFallback() throws ConnectException {
         //should be retried twice and then fallback and we get a result
         Connection connection = bean.connectA();
         String data = connection.getData();

--- a/dev/com.ibm.ws.security.mp.jwt.1.1.config/bnd.bnd
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1.config/bnd.bnd
@@ -34,7 +34,7 @@ Export-Package: \
 Import-Package: \
    !com.ibm.ws.security.mp.jwt.v11.config.impl, \
    com.ibm.ws.security.mp.jwt, \
-   org.eclipse.microprofile.config;version="[1.0,2)", \
+   org.eclipse.microprofile.config;version="[1.0,3)", \
    org.jose4j.*;version="[0.5,1)", \
    *
 

--- a/dev/io.openliberty.microprofile.faulttolerance.3.0.internal.metrics/bnd.bnd
+++ b/dev/io.openliberty.microprofile.faulttolerance.3.0.internal.metrics/bnd.bnd
@@ -33,7 +33,7 @@ WS-TraceGroup: FAULTTOLERANCE
         com.ibm.ws.microprofile.faulttolerance;version=latest, \
         com.ibm.ws.microprofile.faulttolerance.spi;version=latest, \
         io.openliberty.org.eclipse.microprofile.metrics.3.0;version=latest, \
-        com.ibm.websphere.org.eclipse.microprofile.config.1.3;version=latest,\
+        io.openliberty.org.eclipse.microprofile.config.2.0;version=latest,\
         com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
         com.ibm.ws.microprofile.metrics;version=latest
 

--- a/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/servers/FaultTolerance30TCKServer/server.xml
+++ b/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/servers/FaultTolerance30TCKServer/server.xml
@@ -14,7 +14,7 @@
         <feature>mpFaultTolerance-3.0</feature>
         <feature>cdi-2.0</feature>
         <feature>servlet-4.0</feature>
-        <feature>mpConfig-1.4</feature>
+        <feature>mpConfig-2.0</feature>
         <feature>mpMetrics-3.0</feature>
         <feature>localConnector-1.0</feature>
         <feature>arquillian-support-1.0</feature>

--- a/dev/io.openliberty.microprofile.health.3.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.health.3.0.internal/bnd.bnd
@@ -59,12 +59,12 @@ src: src,resources
 testsrc: test/src
 
 -buildpath: \
-        com.ibm.websphere.javaee.annotation.1.2;version=latest,\
+        com.ibm.websphere.javaee.annotation.1.3;version=latest,\
         com.ibm.websphere.javaee.servlet.4.0; version=latest,\
         com.ibm.websphere.javaee.cdi.2.0;version=latest,\
         com.ibm.websphere.jsonsupport;version=latest,\
         io.openliberty.org.eclipse.microprofile.health.3.0;version=latest,\
-        com.ibm.websphere.org.eclipse.microprofile.config.1.4;version=latest,\
+        io.openliberty.org.eclipse.microprofile.config.2.0;version=latest,\
         com.ibm.websphere.org.osgi.core;version=latest,\
         com.ibm.websphere.org.osgi.service.component;version=latest,\
         com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\

--- a/dev/io.openliberty.microprofile.health.3.0.internal_fat/fat/src/io/openliberty/microprofile/health30/fat/DefaultOverallReadinessStatusUpAppStartupTest.java
+++ b/dev/io.openliberty.microprofile.health.3.0.internal_fat/fat/src/io/openliberty/microprofile/health30/fat/DefaultOverallReadinessStatusUpAppStartupTest.java
@@ -67,7 +67,7 @@ public class DefaultOverallReadinessStatusUpAppStartupTest {
         ShrinkHelper.exportAppToServer(server, app, DeployOptions.DISABLE_VALIDATION);
 
         if (!server.isStarted())
-            server.startServer();
+            server.startServer(false, false);
 
         server.waitForStringInLog("CWWKT0016I: Web application available.*DelayedHealthCheckApp*");
     }

--- a/dev/io.openliberty.microprofile.metrics.internal.3.0/bnd.bnd
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0/bnd.bnd
@@ -59,7 +59,7 @@ WS-TraceGroup: METRICS
 	com.ibm.ws.classloading;version=latest,\
 	com.ibm.websphere.org.osgi.service.component;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
-	com.ibm.websphere.org.eclipse.microprofile.config.1.4;version=latest,\
+	io.openliberty.org.eclipse.microprofile.config.2.0;version=latest,\
 	io.openliberty.org.eclipse.microprofile.metrics.3.0;version=latest,\
 	com.ibm.websphere.appserver.spi.kernel.service;version=latest,\
 	com.ibm.websphere.appserver.api.json;version=latest,\

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/files/server_monitor30.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/files/server_monitor30.xml
@@ -1,7 +1,7 @@
 <server>
     <featureManager>
         <feature>jaxws-2.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>servlet-4.0</feature>
         <feature>jdbc-4.0</feature>
         <feature>mpMetrics-3.0</feature>
     </featureManager>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/files/server_monitorFilter1.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/files/server_monitorFilter1.xml
@@ -1,7 +1,7 @@
 <server>
     <featureManager>
         <feature>jaxws-2.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>servlet-4.0</feature>
         <feature>jdbc-4.0</feature>
         <feature>mpMetrics-3.0</feature>
         <feature>monitor-1.0</feature>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/files/server_monitorFilter2.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/files/server_monitorFilter2.xml
@@ -1,7 +1,7 @@
 <server>
     <featureManager>
         <feature>jaxws-2.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>servlet-4.0</feature>
         <feature>jdbc-4.0</feature>
         <feature>mpMetrics-3.0</feature>
         <feature>monitor-1.0</feature>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/files/server_monitorFilter3.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/files/server_monitorFilter3.xml
@@ -1,7 +1,7 @@
 <server>
     <featureManager>
         <feature>jaxws-2.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>servlet-4.0</feature>
         <feature>jdbc-4.0</feature>
         <feature>mpMetrics-3.0</feature>
         <feature>monitor-1.0</feature>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/files/server_monitorFilter4.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/files/server_monitorFilter4.xml
@@ -1,7 +1,7 @@
 <server>
     <featureManager>
         <feature>jaxws-2.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>servlet-4.0</feature>
         <feature>jdbc-4.0</feature>
         <feature>mpMetrics-3.0</feature>
         <feature>monitor-1.0</feature>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/files/server_monitorOnly.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/files/server_monitorOnly.xml
@@ -1,7 +1,7 @@
 <server>
     <featureManager>
         <feature>jaxws-2.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>servlet-4.0</feature>
         <feature>jdbc-4.0</feature>
         <feature>monitor-1.0</feature>
     </featureManager>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/files/server_mpMetric30.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/files/server_mpMetric30.xml
@@ -1,7 +1,7 @@
 <server>
     <featureManager>
         <feature>jaxws-2.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>servlet-4.0</feature>
         <feature>jdbc-4.0</feature>
         <feature>mpMetrics-3.0</feature>
     </featureManager>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/files/server_noJDBC.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/files/server_noJDBC.xml
@@ -1,7 +1,7 @@
 <server>
     <featureManager>
         <feature>jaxws-2.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>servlet-4.0</feature>
         <feature>mpMetrics-3.0</feature>
         <feature>monitor-1.0</feature>
     </featureManager>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/files/server_noJDBCMonitor.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/files/server_noJDBCMonitor.xml
@@ -1,7 +1,7 @@
 <server>
     <featureManager>
         <feature>jaxws-2.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>servlet-4.0</feature>
         <feature>mpMetrics-3.0</feature>
     </featureManager>
 

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/files/server_noJaxWs.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/files/server_noJaxWs.xml
@@ -1,6 +1,6 @@
 <server>
     <featureManager>
-        <feature>servlet-3.1</feature>
+        <feature>servlet-4.0</feature>
         <feature>jdbc-4.0</feature>
         <feature>mpMetrics-3.0</feature>
         <feature>monitor-1.0</feature>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF10/server.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF10/server.xml
@@ -1,7 +1,7 @@
 <server>
     <featureManager>
         <feature>jaxws-2.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>servlet-4.0</feature>
         <feature>jdbc-4.0</feature>
         <feature>mpMetrics-3.0</feature>
         <feature>monitor-1.0</feature>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF11/server.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF11/server.xml
@@ -1,6 +1,6 @@
 <server>
     <featureManager>
-        <feature>servlet-3.1</feature>
+        <feature>servlet-4.0</feature>
         <feature>jdbc-4.0</feature>
         <feature>mpMetrics-3.0</feature>
         <feature>monitor-1.0</feature>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF2/server.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF2/server.xml
@@ -1,7 +1,7 @@
 <server>
     <featureManager>
         <feature>jaxws-2.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>servlet-4.0</feature>
         <feature>jdbc-4.0</feature>
         <feature>mpMetrics-3.0</feature>
     </featureManager>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF3/server.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF3/server.xml
@@ -1,7 +1,7 @@
 <server>
     <featureManager>
         <feature>jaxws-2.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>servlet-4.0</feature>
         <feature>jdbc-4.0</feature>
         <feature>mpMetrics-3.0</feature>
         <feature>monitor-1.0</feature>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF4/server.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF4/server.xml
@@ -1,7 +1,7 @@
 <server>
     <featureManager>
         <feature>jaxws-2.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>servlet-4.0</feature>
         <feature>jdbc-4.0</feature>
         <feature>mpMetrics-3.0</feature>
         <feature>monitor-1.0</feature>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF5/server.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF5/server.xml
@@ -1,7 +1,7 @@
 <server>
     <featureManager>
         <feature>jaxws-2.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>servlet-4.0</feature>
         <feature>jdbc-4.0</feature>
         <feature>mpMetrics-3.0</feature>
         <feature>monitor-1.0</feature>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF6/server.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF6/server.xml
@@ -1,7 +1,7 @@
 <server>
     <featureManager>
         <feature>jaxws-2.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>servlet-4.0</feature>
         <feature>jdbc-4.0</feature>
         <feature>mpMetrics-3.0</feature>
         <feature>monitor-1.0</feature>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF8/server.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF8/server.xml
@@ -1,7 +1,7 @@
 <server>
     <featureManager>
         <feature>jaxws-2.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>servlet-4.0</feature>
         <feature>jdbc-4.0</feature>
         <feature>mpMetrics-3.0</feature>
         <feature>monitor-1.0</feature>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF9/server.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/publish/servers/TestEDF9/server.xml
@@ -1,7 +1,7 @@
 <server>
     <featureManager>
         <feature>jaxws-2.2</feature>
-        <feature>servlet-3.1</feature>
+        <feature>servlet-4.0</feature>
         <feature>jdbc-4.0</feature>
         <feature>mpMetrics-3.0</feature>
         <feature>monitor-1.0</feature>

--- a/dev/io.openliberty.microprofile.metrics.internal.cdi.3.0/bnd.bnd
+++ b/dev/io.openliberty.microprofile.metrics.internal.cdi.3.0/bnd.bnd
@@ -52,7 +52,7 @@ WS-TraceGroup: METRICS
 	com.ibm.ws.cdi.interfaces;version=latest,\
 	com.ibm.ws.container.service;version=latest,\
 	com.ibm.ws.container.service.compat;version=latest,\
-	com.ibm.websphere.org.eclipse.microprofile.config.1.4;version=latest,\
+	io.openliberty.org.eclipse.microprofile.config.2.0;version=latest,\
 	com.ibm.ws.classloading;version=latest,\
 	com.ibm.ws.kernel.service;version=latest,\
 	io.openliberty.microprofile.metrics.internal.3.0;version=latest,\
@@ -61,7 +61,7 @@ WS-TraceGroup: METRICS
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
     com.ibm.websphere.javaee.interceptor.1.2;version=latest,\
-    com.ibm.websphere.javaee.annotation.1.2;version=latest,\
+    com.ibm.websphere.javaee.annotation.1.3;version=latest,\
     com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
     com.ibm.ws.microprofile.metrics.cdi.common,\
     com.ibm.ws.microprofile.metrics.common;version=latest

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/bnd.bnd
@@ -52,10 +52,10 @@ WS-TraceGroup: MPOPENAPI
     io.openliberty.io.smallrye.openapi.jaxrs;version=latest,\
     com.ibm.websphere.appserver.spi.httptransport;version=latest,\
     com.ibm.websphere.javaee.jaxrs.2.1;version=latest,\
-    com.ibm.websphere.javaee.servlet.3.1;version=latest,\
+    com.ibm.websphere.javaee.servlet.4.0;version=latest,\
     com.ibm.websphere.javaee.validation.2.0;version=latest,\
     io.openliberty.org.eclipse.microprofile.openapi.2.0;version=latest,\
-    com.ibm.websphere.org.eclipse.microprofile.config.1.3;version=latest,\
+    io.openliberty.org.eclipse.microprofile.config.2.0;version=latest,\
     com.ibm.websphere.org.osgi.core;version=latest,\
     com.ibm.websphere.org.osgi.service.component;version=latest,\
     com.ibm.ws.adaptable.module;version=latest,\

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/bnd.bnd
@@ -20,7 +20,7 @@ IBM-Web-Extension-Processing-Disabled: true
 Web-ContextPath: /openapi
 
 Import-Package: \
-    org.eclipse.microprofile.config.*;version="[1.0,2)",\
+    org.eclipse.microprofile.config.*;version="[1.0,3)",\
     javax.xml.bind.annotation;version=!,\
     *
 

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/bnd.bnd
@@ -25,9 +25,9 @@ tested.features=mpOpenAPI-2.0
 -buildpath: \
     com.ibm.ws.microprofile.openapi;version=latest, \
     com.ibm.websphere.javaee.jaxrs.2.1;version=latest, \
-    com.ibm.websphere.javaee.servlet.3.1;version=latest, \
+    com.ibm.websphere.javaee.servlet.4.0;version=latest, \
     io.openliberty.org.eclipse.microprofile.openapi.2.0;version=latest,\
-    com.ibm.websphere.org.eclipse.microprofile.config.1.2.1;version=latest, \
+    io.openliberty.org.eclipse.microprofile.config.2.0;version=latest,\
     com.ibm.ws.common.encoder;version=latest, \
     com.fasterxml.jackson.core.jackson-core;version=2.11.2, \
     com.fasterxml.jackson.core.jackson-annotations;version=2.11.2, \

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal.jaeger_fat/build.gradle
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal.jaeger_fat/build.gradle
@@ -25,7 +25,7 @@ dependencies {
   jaegerClient 'io.jaegertracing:jaeger-tracerresolver:1.2.0'
   jaegerClient 'org.apache.thrift:libthrift:0.13.0'
   jaegerClient 'org.slf4j:slf4j-simple:1.7.30'
-  jaegerClient 'org.slf4j:slf4j-api:1.7.28'
+  jaegerClient 'org.slf4j:slf4j-api:1.7.30'
 }
 
 autoFVT {

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal.jaeger_fat/publish/servers/jaegerServer1/server.xml
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal.jaeger_fat/publish/servers/jaegerServer1/server.xml
@@ -16,7 +16,7 @@
         <file name="${server.config.dir}/jaegerLib/jaeger-client-1.2.0.jar" />
         <file name="${server.config.dir}/jaegerLib/jaeger-core-1.2.0.jar" />
         <file name="${server.config.dir}/jaegerLib/jaeger-thrift-1.2.0.jar" />
-        <file name="${server.config.dir}/jaegerLib/slf4j-api-1.7.28.jar" />
+        <file name="${server.config.dir}/jaegerLib/slf4j-api-1.7.30.jar" />
         <file name="${server.config.dir}/jaegerLib/slf4j-simple-1.7.30.jar" />
         <file name="${server.config.dir}/jaegerLib/libthrift-0.13.0.jar" />
         <file name="${server.config.dir}/jaegerLib/gson-2.8.6.jar" />
@@ -25,6 +25,6 @@
     </library>
 
     <javaPermission
-        codebase="${server.config.dir}/jaegerLib/slf4j-api-1.7.28.jar"
+        codebase="${server.config.dir}/jaegerLib/slf4j-api-1.7.30.jar"
         className="java.security.AllPermission" />
 </server>

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal.jaeger_fat/publish/servers/jaegerServer2/server.xml
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal.jaeger_fat/publish/servers/jaegerServer2/server.xml
@@ -11,6 +11,6 @@
     </application>
 
     <javaPermission
-        codebase="${server.config.dir}/lib/slf4j-api-1.7.28.jar"
+        codebase="${server.config.dir}/lib/slf4j-api-1.7.30.jar"
         className="java.security.AllPermission" />
 </server>

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal.jaeger_fat/publish/servers/jaegerServer3/server.xml
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal.jaeger_fat/publish/servers/jaegerServer3/server.xml
@@ -11,7 +11,7 @@
     </application>
 
     <javaPermission
-        codebase="${server.config.dir}/jaegerLib/slf4j-api-1.7.28.jar"
+        codebase="${server.config.dir}/jaegerLib/slf4j-api-1.7.30.jar"
         className="java.security.AllPermission" />
 
     <javaPermission

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal.jaeger_fat/publish/servers/jaegerServerInventory/server.xml
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal.jaeger_fat/publish/servers/jaegerServerInventory/server.xml
@@ -26,7 +26,7 @@
         <file
             name="${server.config.dir}/jaegerLib/jaeger-thrift-1.2.0.jar" />
         <file
-            name="${server.config.dir}/jaegerLib/slf4j-api-1.7.28.jar" />
+            name="${server.config.dir}/jaegerLib/slf4j-api-1.7.30.jar" />
         <file
             name="${server.config.dir}/jaegerLib/slf4j-simple-1.7.30.jar" />
         <file
@@ -39,7 +39,7 @@
     </library>
 
     <javaPermission
-        codebase="${server.config.dir}/jaegerLib/slf4j-api-1.7.28.jar"
+        codebase="${server.config.dir}/jaegerLib/slf4j-api-1.7.30.jar"
         className="java.security.AllPermission" />
 
     <javaPermission

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal.jaeger_fat/publish/servers/jaegerServerSystem/server.xml
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal.jaeger_fat/publish/servers/jaegerServerSystem/server.xml
@@ -25,7 +25,7 @@
         <file
             name="${server.config.dir}/jaegerLib/jaeger-thrift-1.2.0.jar" />
         <file
-            name="${server.config.dir}/jaegerLib/slf4j-api-1.7.28.jar" />
+            name="${server.config.dir}/jaegerLib/slf4j-api-1.7.30.jar" />
         <file
             name="${server.config.dir}/jaegerLib/slf4j-simple-1.7.30.jar" />
         <file
@@ -38,7 +38,7 @@
     </library>
 
     <javaPermission
-        codebase="${server.config.dir}/jaegerLib/slf4j-api-1.7.28.jar"
+        codebase="${server.config.dir}/jaegerLib/slf4j-api-1.7.30.jar"
         className="java.security.AllPermission" />
 
     <javaPermission

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/FATSuite.java
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/FATSuite.java
@@ -28,9 +28,9 @@ import componenttest.topology.impl.LibertyServerFactory;
 @RunWith(Suite.class)
 @SuiteClasses({
     OpentracingTCKLauncher.class,
-// Temporary comment this out until MicroProfile-4.0 is available
+// Temporary comment this out until MicroProfile-4.0 is available ... including MP Rest Client 2.0
 //    OpentracingTCKLauncherMicroProfile.class,
-    OpentracingRestClientTCKLauncher.class
+    // OpentracingRestClientTCKLauncher.class //Disabled until MP Rest Client 2.0 is available
 })
 public class FATSuite {
     private static final String FEATURE_NAME = "io.openliberty.opentracing.mock-2.0.mf";

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -15,7 +15,7 @@
     <name>MicroProfile Opentracing TCK Runner TCK Module</name>
 
     <properties>
-        <microprofile.opentracing.version>2.0-RC1</microprofile.opentracing.version>
+        <microprofile.opentracing.version>2.0-RC2</microprofile.opentracing.version>
         <arquillian.version>1.1.14.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->

--- a/dev/io.openliberty.security.mp.jwt.1.2.config/bnd.bnd
+++ b/dev/io.openliberty.security.mp.jwt.1.2.config/bnd.bnd
@@ -31,7 +31,6 @@ Export-Package: \
 Import-Package: \
    !io.openliberty.security.mp.jwt.v12.config.impl, \
    com.ibm.ws.security.mp.jwt, \
-   org.eclipse.microprofile.config;version="[1.0,2)", \
    org.jose4j.*;version="[0.5,1)", \
    *
 
@@ -56,7 +55,7 @@ Private-Package: \
     com.ibm.ws.logging;version=latest, \
     com.ibm.ws.kernel.service;version=latest, \
     com.ibm.ws.resource;version=latest, \
-    com.ibm.websphere.org.eclipse.microprofile.config.1.3;version=latest, \
+    io.openliberty.org.eclipse.microprofile.config.2.0;version=latest, \
     com.ibm.ws.security.mp.jwt;version=latest, \
     com.ibm.ws.security.mp.jwt.1.1.config;version=latest
 


### PR DESCRIPTION
This PR
- ensures that all MP 4.0 have the correct dependencies
- sets the convenience feature to beta
- ensures that OL is using a common version of SLF4J (this is tech debt but was convenient to do it now)

#build

