### PR TITLE
Update MP Health 3.0 to RC4

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1829,7 +1829,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.health</groupId>
       <artifactId>microprofile-health-api</artifactId>
-      <version>3.0-RC3</version>
+      <version>3.0-RC4</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.jwt</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -361,7 +361,7 @@ org.eclipse.microprofile.health:microprofile-health-api:1.0
 org.eclipse.microprofile.health:microprofile-health-api:2.0.1
 org.eclipse.microprofile.health:microprofile-health-api:2.1
 org.eclipse.microprofile.health:microprofile-health-api:2.2
-org.eclipse.microprofile.health:microprofile-health-api:3.0-RC3
+org.eclipse.microprofile.health:microprofile-health-api:3.0-RC4
 org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:1.0
 org.eclipse.microprofile.lra:microprofile-lra-api:1.0-M1
 org.eclipse.microprofile.metrics:microprofile-metrics-api:1.0

--- a/dev/io.openliberty.microprofile.health.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/health30/tck/Health30TCKLauncher.java
+++ b/dev/io.openliberty.microprofile.health.3.0.internal_fat_tck/fat/src/io/openliberty/microprofile/health30/tck/Health30TCKLauncher.java
@@ -21,7 +21,6 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.PortType;
 
 import componenttest.annotation.AllowedFFDC;
-import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -48,9 +47,6 @@ public class Health30TCKLauncher {
     }
 
     @Test
-    // TEMPORARILY Skip the MpHealth-3.0 TCK run for Java 14 for the MpHealth-3.0 RC3 release for beta
-    // Will re-enable once the fix is included in the next RC
-    @MaximumJavaLevel(javaLevel = 11)
     @AllowedFFDC // The tested deployment exceptions cause FFDC so we have to allow for this.
     public void launchHealth30Tck() throws Exception {
         String protocol = "http";

--- a/dev/io.openliberty.microprofile.health.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.health.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
     <name>MicroProfile Health 3.0 TCK Runner TCK Module</name>
 
     <properties>
-    	<microprofile.health.version>3.0-RC3</microprofile.health.version>
+    	<microprofile.health.version>3.0-RC4</microprofile.health.version>
         <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
@@ -118,11 +118,11 @@
             <version>2.9.8</version>
        </dependency>
        
-       <!--dependency>
+       <dependency>
     		<groupId>com.fasterxml.jackson.datatype</groupId>
     		<artifactId>jackson-datatype-jdk8</artifactId>
     		<version>2.9.8</version>
-		</dependency-->
+		</dependency>
     </dependencies>
 
     <build>

--- a/dev/io.openliberty.org.eclipse.microprofile/health.3.0.bnd
+++ b/dev/io.openliberty.org.eclipse.microprofile/health.3.0.bnd
@@ -21,6 +21,6 @@ Export-Package: org.eclipse.microprofile.health;version=3.0, \
                 org.eclipse.microprofile.health.spi;version=3.0
 
 Include-Resource: \
-  @${repo;org.eclipse.microprofile.health:microprofile-health-api;3.0.0.RC3;EXACT}
+  @${repo;org.eclipse.microprofile.health:microprofile-health-api;3.0.0.RC4;EXACT}
 
 WS-TraceGroup: HEALTH


### PR DESCRIPTION
Fixes #13450
- Updates the MP Health 3.0 API and TCK to RC4
- Re-enabled TCK to run on Java 14