### PR TITLE
Issue 12710: Reduce runtime on ldap_fat lite bucket

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATTestADNoId.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATTestADNoId.java
@@ -37,7 +37,7 @@ import componenttest.vulnerability.LeakedPasswordChecker;
  * configured in the server.xml without specifying an id.
  */
 @RunWith(FATRunner.class)
-@Mode(TestMode.LITE)
+@Mode(TestMode.FULL)
 public class FATTestADNoId {
     private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.security.registry.ldap.fat.ad.noId");
     private static final Class<?> c = FATTestADNoId.class;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATTestIDSNoFilters.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATTestIDSNoFilters.java
@@ -40,7 +40,7 @@ import componenttest.topology.utils.LDAPUtils;
 import componenttest.vulnerability.LeakedPasswordChecker;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.LITE)
+@Mode(TestMode.FULL)
 public class FATTestIDSNoFilters {
     private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.security.registry.ldap.fat.ids.nofilters");
     private static final Class<?> c = FATTestIDSNoFilters.class;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_SUNLDAPTest_URAttrMappingVar4.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_SUNLDAPTest_URAttrMappingVar4.java
@@ -35,7 +35,7 @@ import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.LDAPUtils;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.LITE)
+@Mode(TestMode.FULL)
 public class URAPIs_SUNLDAPTest_URAttrMappingVar4 {
     private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.security.wim.adapter.ldap.fat.sun.attrMappingVar4");
     private static final Class<?> c = URAPIs_SUNLDAPTest_URAttrMappingVar4.class;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_TDSLDAPTest_URAttrMappingVar1.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_TDSLDAPTest_URAttrMappingVar1.java
@@ -36,7 +36,7 @@ import componenttest.topology.utils.LDAPUtils;
 import componenttest.vulnerability.LeakedPasswordChecker;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.LITE)
+@Mode(TestMode.FULL)
 public class URAPIs_TDSLDAPTest_URAttrMappingVar1 {
     private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.security.wim.adapter.ldap.fat.tds.attrMappingVar1");
     private static final Class<?> c = URAPIs_TDSLDAPTest_URAttrMappingVar1.class;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_TDSLDAPTest_URAttrMappingVar2.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_TDSLDAPTest_URAttrMappingVar2.java
@@ -35,7 +35,7 @@ import componenttest.topology.utils.LDAPUtils;
 import componenttest.vulnerability.LeakedPasswordChecker;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.LITE)
+@Mode(TestMode.FULL)
 public class URAPIs_TDSLDAPTest_URAttrMappingVar2 {
     private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.security.wim.adapter.ldap.fat.tds.attrMappingVar2");
     private static final Class<?> c = URAPIs_TDSLDAPTest_URAttrMappingVar2.class;

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_TDSLDAPTest_URAttrMappingVar3.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_TDSLDAPTest_URAttrMappingVar3.java
@@ -36,7 +36,7 @@ import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.LDAPUtils;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.LITE)
+@Mode(TestMode.FULL)
 public class URAPIs_TDSLDAPTest_URAttrMappingVar3 {
     private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.security.wim.adapter.ldap.fat.tds.attrMappingVar3");
     private static final Class<?> c = URAPIs_TDSLDAPTest_URAttrMappingVar3.class;


### PR DESCRIPTION
Fixes #12710 

Bumped some tests that were variations from LITE to FULL to get our ldap_fat LITE bucket running around 5 minutes.

Pre-changes, the mean bucket duration is 9m17s

I think these changes will put us in the 4-5 minute range.