### PR TITLE
Fix timing error and onError behavior

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigurationMonitor.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigurationMonitor.java
@@ -52,6 +52,8 @@ class ConfigurationMonitor implements ManagedService {
 
     private ServiceRegistration<ManagedService> managedServiceRegistration;
 
+    private boolean isFirstUpdate = true;
+
     /** Configuration file monitor */
     private ConfigFileMonitor fileMonitor;
 
@@ -75,7 +77,7 @@ class ConfigurationMonitor implements ManagedService {
 
     @Override
     public void updated(Dictionary<String, ?> properties) throws ConfigurationException {
-        // The monitor interval can only be null when the element has not been metatype processed. 
+        // The monitor interval can only be null when the element has not been metatype processed.
         // update() should only run with the processed properties
         if ((properties == null) || (properties.get(MONITOR_INTERVAL) == null))
             return;
@@ -116,13 +118,14 @@ class ConfigurationMonitor implements ManagedService {
         }
 
         resetConfigurationMonitoring(monitorConfiguration, monitorInterval, fileMonitorType);
+        isFirstUpdate = false;
     }
 
     synchronized void resetConfigurationMonitoring(boolean monitorConfiguration, Long monitorInterval, String fileMonitorType) {
         if (fileMonitor == null) {
             if (monitorConfiguration) {
                 // check if configuration was changed when monitoring was disabled
-                boolean modified = serverXMLConfig.isModified();
+                boolean modified = isFirstUpdate ? false : serverXMLConfig.isModified();
                 Collection<String> filesToMonitor = serverXMLConfig.getFilesToMonitor();
                 Collection<String> directoriesToMonitor = serverXMLConfig.getDirectoriesToMonitor();
                 fileMonitor = new ConfigFileMonitor(bundleContext, filesToMonitor, directoriesToMonitor, monitorInterval, modified, fileMonitorType, configRefresher);

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ServerXMLConfiguration.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ServerXMLConfiguration.java
@@ -110,7 +110,7 @@ class ServerXMLConfiguration {
      */
 
     @FFDCIgnore(ConfigParserTolerableException.class)
-    public void loadInitialConfiguration(ConfigVariableRegistry variableRegistry) throws ConfigValidationException, ConfigParserTolerableException {
+    public void loadInitialConfiguration(ConfigVariableRegistry variableRegistry) throws ConfigValidationException, ConfigParserException {
         if (configRoot != null && configRoot.exists()) {
 
             try {
@@ -128,6 +128,8 @@ class ServerXMLConfiguration {
             } catch (ConfigParserException ex) {
                 Tr.error(tc, "error.config.update.init", ex.getMessage());
                 serverConfiguration = new ServerConfiguration();
+                if (ErrorHandler.INSTANCE.fail())
+                    throw ex;
             }
 
             serverConfiguration.setDefaultConfiguration(new BaseConfiguration());

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/SystemConfiguration.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/SystemConfiguration.java
@@ -21,6 +21,7 @@ import org.osgi.framework.ServiceReference;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.util.tracker.ServiceTracker;
 
+import com.ibm.websphere.config.ConfigParserException;
 import com.ibm.websphere.config.ConfigUpdateException;
 import com.ibm.websphere.config.ConfigValidationException;
 import com.ibm.websphere.config.WSConfigurationHelper;
@@ -127,7 +128,7 @@ class SystemConfiguration {
         bc.registerService(name, serviceInstance, properties);
     }
 
-    void start() throws ConfigUpdateException, ConfigValidationException, ConfigParserTolerableException {
+    void start() throws ConfigUpdateException, ConfigValidationException, ConfigParserException {
         if (serverXMLConfig.hasConfigRoot()) {
             configRefresher.start();
             serverXMLConfig.loadInitialConfiguration(variableRegistry);


### PR DESCRIPTION
1) Fix a timing error where we can start process config file changes before the runtime update manager is available
2) When onError is set to FAIL, make sure severe parser errors result in the server shutting down