### PR TITLE
Writing Events and Files for new way of publishing results

### DIFF
--- a/dev/.gitignore
+++ b/dev/.gitignore
@@ -9,3 +9,4 @@
 *chkpii.checksums.properties
 generated.properties
 /build.pii.package/
+/published_outputs/

--- a/dev/cnf/build.gradle
+++ b/dev/cnf/build.gradle
@@ -144,6 +144,14 @@ task updatePluginClasses(type: Copy) {
     }
 }
 
+
+task cleanPublishedOutputs(type: Delete) {
+	doLast {
+		println rootProject.file(rootProject.ext.get('published.outputs'))
+		rootProject.delete rootProject.file(rootProject.ext.get('published.outputs'))
+	}
+}
+
 task cleanRepos(type: Delete) {
     doLast {
         project.delete('release')
@@ -156,6 +164,7 @@ task cleanRepos(type: Delete) {
 
 task initialize {
     dependsOn cleanRepos
+	dependsOn cleanPublishedOutputs
     dependsOn copyMavenLibs
     dependsOn updatePluginClasses
     doLast {
@@ -165,6 +174,7 @@ task initialize {
 
 clean {
     dependsOn cleanRepos
+	dependsOn cleanPublishedOutputs
 }
 
 classes {

--- a/dev/cnf/resources/bnd/anttaskdefs.bnd
+++ b/dev/cnf/resources/bnd/anttaskdefs.bnd
@@ -77,3 +77,6 @@ repo.mavenRepoTasks.path: ${path;\
     ${repo;org.apache.aries:org.apache.aries.util;1.1.3},\
     ${workspace}/cnf/mavenlibs/plexus-utils-3.0.24.jar}
 #    ${repo;org.codehaus.plexus:plexus-utils;3.0.24}}
+
+repo.junitReportTask.path: ${path;\
+    ${repo;org.apache.ant:ant-junit;1.9.6}}

--- a/dev/wlp-gradle/bndSettings.gradle
+++ b/dev/wlp-gradle/bndSettings.gradle
@@ -52,6 +52,7 @@ buildscript {
         classpath bnd_plugin
         classpath 'gradle.plugin.net.ossindex:ossindex-gradle-plugin:0.4.11'
         classpath 'com.gradle:build-scan-plugin:2.1'
+            
     }
 
     // Add bnd gradle plugin to buildscript classpath of rootProject

--- a/dev/wlp-gradle/java.gradle
+++ b/dev/wlp-gradle/java.gradle
@@ -15,14 +15,77 @@
  */
 subprojects {
   apply plugin: 'java'
+  
+  task publishJunitReport() {
+    ext {
+      outputFilesDir = rootProject.file(rootProject.ext.get('published.outputs.files'))
+      outputEventsDir = rootProject.file(rootProject.ext.get('published.outputs.events')+"/rawJUnitResults")
+      reportDir = project.file("${project.buildDir}/libs/merged-test-reports/test/")
+    }
+    doLast {
+      if(new File(reportDir,"TESTS-TestSuites.xml").exists()){
+        mkdir outputFilesDir
+        mkdir outputEventsDir;
 
-  test {
+        ant.checksum(file: new File(reportDir,"TESTS-TestSuites.xml"), algorithm: "SHA-256", property: "junitSHA256")
+        copy {
+          from reportDir
+          include "TESTS-TestSuites.xml"
+          into new File(outputFilesDir,"junits/unit_"+project.name+"/"+ant.junitSHA256+"/")
+        }
+
+        def prop = new Properties()
+        def propFile = File.createTempFile("unit_"+project.name,".properties",outputEventsDir) 
+        prop.put("event","rawJUnitResult")
+        prop.put("bucketName","unit_"+project.name)
+        prop.put("bucketType","Unit")
+        prop.put("bucketRunMode","n/a")
+        prop.put("resultType","normal")
+        prop.put("junit","junits/unit_"+project.name+"/"+ant.junitSHA256+"/TESTS-TestSuites.xml")
+        def propWriter = new FileWriter(propFile)
+        try {
+          prop.store(propWriter, null)
+        } finally {
+          propWriter.close()
+        }
+      }
+    }
+    
+  }
+
+  task junitReport() {
+    finalizedBy publishJunitReport
+    ext {
+        resultsDir = file("$project.buildDir/libs/test-reports/test/")
+        targetDir = file("$project.buildDir/libs/merged-test-reports/test/")
+    }
+    doLast {
+        if(resultsDir.exists()){
+          mkdir targetDir
+          ant.taskdef(name: 'junitreport', 
+                      classname: 'org.apache.tools.ant.taskdefs.optional.junit.XMLResultAggregator', 
+                      classpath: bnd('repo.junitReportTask.path'))
+
+          ant.junitreport(todir: targetDir) {
+              fileset(dir: resultsDir, includes: 'TEST-*.xml')
+              report(todir: targetDir, format: 'frames')
+          }
+        }
+    }
+  }
+
+  test { 
+    // Once testing is complete copy 
+    finalizedBy junitReport
+  
     ignoreFailures = true
+	
     //  A number of tests make heavy use of java.util.Random, which can drain the entropy pool of /dev/random on Linux when
     // running on OpenJDK-based distributions. This results in large delays as tests wait for the entropy pool to be repopulated.
     // The fix is thus to ensure we use the pseudorandom entropy pool (/dev/urandom) (which is also valid for Windows/zOS).
     jvmArgs '-Djava.security.egd=file:///dev/urandom'
   }
+
   
   tasks.withType(JavaCompile) {
     doFirst {
@@ -55,7 +118,7 @@ subprojects {
       }
     }
   }
-
+  
 }
 
 /**
@@ -84,3 +147,5 @@ task testResults {
   dependsOn subprojects.test
   dependsOn testReport
 }
+
+

--- a/dev/wlp-gradle/propertiesSettings.gradle
+++ b/dev/wlp-gradle/propertiesSettings.gradle
@@ -134,6 +134,15 @@ def setProperties = { props ->
     props.setProperty('version.qualifier', qualifier)
     props.setProperty('buildLabel', timestamp)
 
+    /**
+	 * Properties used for making test outputs available in a commmon location.
+	 */
+
+	props.setProperty('published.outputs'       , 'published_outputs')
+	props.setProperty('published.outputs.files' , 'published_outputs/files')
+	props.setProperty('published.outputs.events', 'published_outputs/events')
+	
+
     // The qualifier below is needed for service builds only, do not delete it.
     gradle.rootProject { rootProject ->
         rootProject.ext.qualifier = gradle.userProps.getProperty("version.qualifier")


### PR DESCRIPTION
Adding support into the gradle build to product events and files for when we run tests. This allows us develop a new way of collecting the results rather than having the RTC launcher guessing at information