### PR TITLE
Fix for checkFFDC failures on Java 15

### DIFF
--- a/dev/com.ibm.ws.logging.json_fat/fat/src/com/ibm/ws/logging/json/fat/JSONEventsTest.java
+++ b/dev/com.ibm.ws.logging.json_fat/fat/src/com/ibm/ws/logging/json/fat/JSONEventsTest.java
@@ -101,7 +101,8 @@ public abstract class JSONEventsTest {
                                                                                       "ibm_sequence", "ibm_className", "ibm_exceptionName", "ibm_probeID",
                                                                                       "ibm_threadId", "ibm_stackTrace", "ibm_objectDetails"));
 
-        ArrayList<String> ffdcKeysOptionalList = new ArrayList<String>();
+        //JDK 15 has message as an additional field in ffdc events
+        ArrayList<String> ffdcKeysOptionalList = new ArrayList<String>(Arrays.asList("message"));
 
         getServer().addInstalledAppForValidation(APP_NAME);
         TestUtils.runApp(getServer(), "ffdc1");

--- a/dev/com.ibm.ws.logging.json_fat/fat/src/com/ibm/ws/logging/json/fat/JSONEventsTest.java
+++ b/dev/com.ibm.ws.logging.json_fat/fat/src/com/ibm/ws/logging/json/fat/JSONEventsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.logging.json_fat/fat/src/com/ibm/ws/logging/json/fat/JSONEventsTest.java
+++ b/dev/com.ibm.ws.logging.json_fat/fat/src/com/ibm/ws/logging/json/fat/JSONEventsTest.java
@@ -27,6 +27,8 @@ import com.ibm.websphere.simplicity.RemoteFile;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.MaximumJavaLevel;
+import componenttest.annotation.MinimumJavaLevel;
 import componenttest.topology.impl.LibertyServer;
 
 /**
@@ -94,6 +96,7 @@ public abstract class JSONEventsTest {
 
     @Test
     @ExpectedFFDC({ "java.lang.NullPointerException" })
+    @MaximumJavaLevel(javaLevel = 14)
     public void checkFfdc() throws Exception {
         final String method = "checkFfdc";
 
@@ -101,8 +104,37 @@ public abstract class JSONEventsTest {
                                                                                       "ibm_sequence", "ibm_className", "ibm_exceptionName", "ibm_probeID",
                                                                                       "ibm_threadId", "ibm_stackTrace", "ibm_objectDetails"));
 
+        ArrayList<String> ffdcKeysOptionalList = new ArrayList<String>();
+
+        getServer().addInstalledAppForValidation(APP_NAME);
+        TestUtils.runApp(getServer(), "ffdc1");
+
+        String line = getServer().waitForStringInLog("\\{.*\"type\":\"liberty_ffdc\".*\\}", getLogFile());
+        assertNotNull("Cannot find \"type\":\"liberty_ffdc\" from messages.log", line);
+
+        JsonReader reader = Json.createReader(new StringReader(line));
+        JsonObject jsonObj = reader.readObject();
+        reader.close();
+
+        if (!checkJsonMessage(jsonObj, ffdcKeysMandatoryList, ffdcKeysOptionalList)) {
+            Log.info(c, method, "Message line:" + line);
+            Assert.fail("Test failed with one or more errors");
+        }
+
+    }
+
+    @Test
+    @ExpectedFFDC({ "java.lang.NullPointerException" })
+    @MinimumJavaLevel(javaLevel = 15)
+    public void checkFfdcJava15() throws Exception {
+        final String method = "checkFfdc";
+
         //JDK 15 has message as an additional field in ffdc events
-        ArrayList<String> ffdcKeysOptionalList = new ArrayList<String>(Arrays.asList("message"));
+        ArrayList<String> ffdcKeysMandatoryList = new ArrayList<String>(Arrays.asList("ibm_datetime", "type", "host", "ibm_userDir", "ibm_serverName",
+                                                                                      "ibm_sequence", "ibm_className", "ibm_exceptionName", "ibm_probeID",
+                                                                                      "ibm_threadId", "ibm_stackTrace", "ibm_objectDetails", "message"));
+
+        ArrayList<String> ffdcKeysOptionalList = new ArrayList<String>();
 
         getServer().addInstalledAppForValidation(APP_NAME);
         TestUtils.runApp(getServer(), "ffdc1");


### PR DESCRIPTION
Fixes #13946 
Java 15 has additional field "message" in the ffdc log.