### PR TITLE
Add support for session interfaces in javaee ddmodels

### DIFF
--- a/dev/com.ibm.ws.javaee.dd.ejb/src/com/ibm/ws/javaee/dd/ejbbnd/Interface.java
+++ b/dev/com.ibm.ws.javaee.dd.ejb/src/com/ibm/ws/javaee/dd/ejbbnd/Interface.java
@@ -13,13 +13,11 @@ package com.ibm.ws.javaee.dd.ejbbnd;
 import com.ibm.ws.javaee.ddmetadata.annotation.DDAttribute;
 import com.ibm.ws.javaee.ddmetadata.annotation.DDAttributeType;
 import com.ibm.ws.javaee.ddmetadata.annotation.DDIdAttribute;
-import com.ibm.ws.javaee.ddmetadata.annotation.LibertyNotInUse;
 
 /**
  * Represents &lt;interface>.
  */
 @DDIdAttribute
-@LibertyNotInUse
 public interface Interface {
 
     /**

--- a/dev/com.ibm.ws.javaee.dd.ejb/src/com/ibm/ws/javaee/dd/ejbbnd/Session.java
+++ b/dev/com.ibm.ws.javaee.dd.ejb/src/com/ibm/ws/javaee/dd/ejbbnd/Session.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corporation and others.
+ * Copyright (c) 2012, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,6 @@ import com.ibm.ws.javaee.ddmetadata.annotation.DDAttribute;
 import com.ibm.ws.javaee.ddmetadata.annotation.DDAttributeType;
 import com.ibm.ws.javaee.ddmetadata.annotation.DDElement;
 import com.ibm.ws.javaee.ddmetadata.annotation.DDXMIAttribute;
-import com.ibm.ws.javaee.ddmetadata.annotation.LibertyNotInUse;
 
 /**
  * Represents &lt;session>.
@@ -26,7 +25,6 @@ public interface Session extends EnterpriseBean {
     /**
      * @return &lt;Interface>, or empty list if unspecified
      */
-    @LibertyNotInUse
     @DDElement(name = "interface")
     List<Interface> getInterfaces();
 

--- a/dev/com.ibm.ws.javaee.ddmodel/bnd.bnd
+++ b/dev/com.ibm.ws.javaee.ddmodel/bnd.bnd
@@ -125,6 +125,7 @@ Include-Resource: OSGI-INF/metatype=resources.gen/OSGI-INF/metatype,OSGI-INF=res
     com.ibm.ws.javaee.ddmodel.ejbbnd.InterfaceComponentImpl,\
     com.ibm.ws.javaee.ddmodel.ejbbnd.JCAAdapterComponentImpl,\
     com.ibm.ws.javaee.ddmodel.ejbbnd.MessageDrivenComponentImpl,\
+    com.ibm.ws.javaee.ddmodel.ejbbbnd.InterfaceComponentImpl,\
     com.ibm.ws.javaee.ddmodel.managedbean.ManagedBeanBndComponentImpl,\
     com.ibm.ws.javaee.ddmodel.managedbean.ManagedBeanComponentImpl,\
     com.ibm.ws.javaee.ddmodel.commonbnd.RefBindingsGroupComponentImpl,\

--- a/dev/com.ibm.ws.javaee.ddmodel/resources.gen/OSGI-INF/metatype/InterfaceMetatype.xml
+++ b/dev/com.ibm.ws.javaee.ddmodel/resources.gen/OSGI-INF/metatype/InterfaceMetatype.xml
@@ -14,7 +14,7 @@
 xmlns:ibm="http://www.ibm.com/xmlns/appservers/osgi/metatype/v1.0.0"
 localization="OSGI-INF/l10n/metatype">
 
-<OCD id="com.ibm.ws.javaee.dd.ejbbnd.Interface" name="%interface.name" description="%interface.desc" >
+<OCD id="com.ibm.ws.javaee.dd.ejbbnd.Interface" name="%SessionMetatype.interface.name" description="%SessionMetatype.interface.desc" >
     <AD id="binding-name" description="%InterfaceMetatype.binding-name.desc" name="%InterfaceMetatype.binding-name.name" type="String" required="false" cardinality="0"/>
     <AD id="class" description="%InterfaceMetatype.class.desc" name="%InterfaceMetatype.class.name" type="String" required="false" cardinality="0"/>
    </OCD>

--- a/dev/com.ibm.ws.javaee.ddmodel/resources.gen/OSGI-INF/metatype/InterfaceMetatype.xml
+++ b/dev/com.ibm.ws.javaee.ddmodel/resources.gen/OSGI-INF/metatype/InterfaceMetatype.xml
@@ -1,0 +1,26 @@
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<!-- NOTE: This is a generated file. Do not edit it directly. -->
+
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.1.0"
+xmlns:ibm="http://www.ibm.com/xmlns/appservers/osgi/metatype/v1.0.0"
+localization="OSGI-INF/l10n/metatype">
+
+<OCD id="com.ibm.ws.javaee.dd.ejbbnd.Interface" name="%interface.name" description="%interface.desc" >
+    <AD id="binding-name" description="%InterfaceMetatype.binding-name.desc" name="%InterfaceMetatype.binding-name.name" type="String" required="false" cardinality="0"/>
+    <AD id="class" description="%InterfaceMetatype.class.desc" name="%InterfaceMetatype.class.name" type="String" required="false" cardinality="0"/>
+   </OCD>
+
+<Designate factoryPid="com.ibm.ws.javaee.dd.ejbbnd.Interface">
+     <Object ocdref="com.ibm.ws.javaee.dd.ejbbnd.Interface"/>
+</Designate>
+
+</metatype:MetaData>

--- a/dev/com.ibm.ws.javaee.ddmodel/resources.gen/OSGI-INF/metatype/SessionMetatype.xml
+++ b/dev/com.ibm.ws.javaee.ddmodel/resources.gen/OSGI-INF/metatype/SessionMetatype.xml
@@ -19,6 +19,9 @@ localization="OSGI-INF/l10n/metatype">
     <AD id="component-id" description="%SessionMetatype.component-id.desc" name="%SessionMetatype.component-id.name" type="String" required="false" cardinality="0"/>
     <AD id="remote-home-binding-name" description="%SessionMetatype.remote-home-binding-name.desc" name="%SessionMetatype.remote-home-binding-name.name" type="String" required="false" cardinality="0"/>
     <AD id="local-home-binding-name" description="%SessionMetatype.local-home-binding-name.desc" name="%SessionMetatype.local-home-binding-name.name" type="String" required="false" cardinality="0"/>
+    <AD id="interface" description="%SessionMetatype.interface.desc" name="%SessionMetatype.interface.name" type="String" required="false" cardinality="2147483647" ibm:type="pid" ibm:reference="com.ibm.ws.javaee.dd.ejbbnd.Interface"/>
+    <AD id="interface.target" default="${servicePidOrFilter(interface)}" description="internal" name="internal" type="String" required="true" cardinality="0"/>
+
 </OCD>
 
 <Designate factoryPid="com.ibm.ws.javaee.dd.ejbbnd.Session">

--- a/dev/com.ibm.ws.javaee.ddmodel/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.javaee.ddmodel/resources/OSGI-INF/l10n/metatype.properties
@@ -179,6 +179,11 @@ InterceptorMetatype.class.name=Class name
 interceptormetatype.desc=The name for the interceptor.
 InterceptorMetatype.class.desc=The class name for the interceptor.
 
+#Interface
+InterfaceMetatype.class.name=Class name
+InterfaceMetatype.class.desc=The class name for the interface.
+InterfaceMetatype.binding-name.name=Interface binding name
+InterfaceMetatype.binding-name.desc=Specifies a binding name for an interface.
 
 #JCA Adapter
 jcaadaptermetatype.name=JCA Adapter
@@ -350,6 +355,8 @@ SessionMetatype.local-home-binding-name.name=Local home binding name
 SessionMetatype.local-home-binding-name.desc=The local home binding name for a session bean.
 SessionMetatype.component-id.name=Component ID
 SessionMetatype.component-id.desc=The component ID for a session bean.
+SessionMetatype.interface.name=Interface
+SessionMetatype.interface.desc=Specifies a session interface.
  
 
 #SpecialSubject

--- a/dev/com.ibm.ws.javaee.ddmodel/src.gen/com/ibm/ws/javaee/ddmodel/ejbbnd/InterfaceComponentImpl.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src.gen/com/ibm/ws/javaee/ddmodel/ejbbnd/InterfaceComponentImpl.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2017,2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+// NOTE: This is a generated file. Do not edit it directly.
+package com.ibm.ws.javaee.ddmodel.ejbbnd;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+
+import com.ibm.ws.javaee.dd.ejbbnd.Interface;
+
+@Component(configurationPid = "com.ibm.ws.javaee.dd.ejbbnd.Interface",
+           configurationPolicy = ConfigurationPolicy.REQUIRE,
+           immediate = true,
+           property = "service.vendor = IBM")
+public class InterfaceComponentImpl extends InterfaceType implements com.ibm.ws.javaee.dd.ejbbnd.Interface {
+    private Map<String, Object> configAdminProperties;
+    private Interface delegate;
+
+    protected java.lang.String bindingName;
+    protected java.lang.String className;
+
+    @Activate
+    protected void activate(Map<String, Object> config) {
+        this.configAdminProperties = config;
+        bindingName = (java.lang.String) config.get("binding-name");
+        className = (java.lang.String) config.get("class");
+
+    }
+
+    public Map<String, Object> getConfigAdminProperties() {
+        return this.configAdminProperties;
+    }
+
+    public void setDelegate(Interface delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String getBindingName() {
+        if (delegate == null) {
+            return bindingName == null ? null : bindingName;
+        } else {
+            return bindingName == null ? delegate.getBindingName() : bindingName;
+        }
+    }
+
+    @Override
+    public String getClassName() {
+        if (delegate == null) {
+            return className == null ? null : className;
+        } else {
+            return className == null ? delegate.getClassName() : className;
+        }
+    }
+}

--- a/dev/com.ibm.ws.javaee.ddmodel/src.gen/com/ibm/ws/javaee/ddmodel/ejbbnd/SessionComponentImpl.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src.gen/com/ibm/ws/javaee/ddmodel/ejbbnd/SessionComponentImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,203 +11,219 @@
 // NOTE: This is a generated file. Do not edit it directly.
 package com.ibm.ws.javaee.ddmodel.ejbbnd;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
-import java.util.Map;
-import java.util.ArrayList;
-import java.util.List;
+
+import com.ibm.ws.javaee.dd.ejbbnd.Interface;
 
 @Component(configurationPid = "com.ibm.ws.javaee.dd.ejbbnd.Session",
-     configurationPolicy = ConfigurationPolicy.REQUIRE,
-     immediate=true,
-     property = "service.vendor = IBM")
+           configurationPolicy = ConfigurationPolicy.REQUIRE,
+           immediate = true,
+           property = "service.vendor = IBM")
 public class SessionComponentImpl extends com.ibm.ws.javaee.ddmodel.ejbbnd.EnterpriseBeanType implements com.ibm.ws.javaee.dd.ejbbnd.Session {
-private Map<String,Object> configAdminProperties;
-private com.ibm.ws.javaee.dd.ejbbnd.Session delegate;
-     protected java.lang.String simple_binding_name;
-     protected java.lang.String component_id;
-     protected java.lang.String remote_home_binding_name;
-     protected java.lang.String local_home_binding_name;
-     protected java.lang.String name;
+    private Map<String, Object> configAdminProperties;
+    private com.ibm.ws.javaee.dd.ejbbnd.Session delegate;
+    protected java.lang.String simple_binding_name;
+    protected java.lang.String component_id;
+    protected java.lang.String remote_home_binding_name;
+    protected java.lang.String local_home_binding_name;
+    protected java.lang.String name;
 
-     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, name = "ejb-ref", target = "(id=unbound)")
-     protected void setEjb_ref(com.ibm.ws.javaee.dd.commonbnd.EJBRef value) {
-          this.ejb_ref.add(value);
-     }
+    protected volatile List<com.ibm.ws.javaee.dd.commonbnd.EJBRef> ejb_ref = new ArrayList<com.ibm.ws.javaee.dd.commonbnd.EJBRef>();
 
-     protected void unsetEjb_ref(com.ibm.ws.javaee.dd.commonbnd.EJBRef value) {
-          this.ejb_ref.remove(value);
-     }
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, name = "ejb-ref", target = "(id=unbound)")
+    protected void setEjb_ref(com.ibm.ws.javaee.dd.commonbnd.EJBRef value) {
+        this.ejb_ref.add(value);
+    }
 
-     protected volatile List<com.ibm.ws.javaee.dd.commonbnd.EJBRef> ejb_ref = new ArrayList<com.ibm.ws.javaee.dd.commonbnd.EJBRef>();
+    protected void unsetEjb_ref(com.ibm.ws.javaee.dd.commonbnd.EJBRef value) {
+        this.ejb_ref.remove(value);
+    }
 
-     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, name = "resource-ref", target = "(id=unbound)")
-     protected void setResource_ref(com.ibm.ws.javaee.dd.commonbnd.ResourceRef value) {
-          this.resource_ref.add(value);
-     }
+    protected volatile List<Interface> interfaces = new ArrayList<Interface>();
 
-     protected void unsetResource_ref(com.ibm.ws.javaee.dd.commonbnd.ResourceRef value) {
-          this.resource_ref.remove(value);
-     }
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, name = "interface", target = "(id=unbound)")
+    protected void setInterface(Interface value) {
+        this.interfaces.add(value);
+    }
 
-     protected volatile List<com.ibm.ws.javaee.dd.commonbnd.ResourceRef> resource_ref = new ArrayList<com.ibm.ws.javaee.dd.commonbnd.ResourceRef>();
+    protected void unsetInterface(Interface value) {
+        this.interfaces.remove(value);
+    }
 
-     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, name = "resource-env-ref", target = "(id=unbound)")
-     protected void setResource_env_ref(com.ibm.ws.javaee.dd.commonbnd.ResourceEnvRef value) {
-          this.resource_env_ref.add(value);
-     }
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, name = "resource-ref", target = "(id=unbound)")
+    protected void setResource_ref(com.ibm.ws.javaee.dd.commonbnd.ResourceRef value) {
+        this.resource_ref.add(value);
+    }
 
-     protected void unsetResource_env_ref(com.ibm.ws.javaee.dd.commonbnd.ResourceEnvRef value) {
-          this.resource_env_ref.remove(value);
-     }
+    protected void unsetResource_ref(com.ibm.ws.javaee.dd.commonbnd.ResourceRef value) {
+        this.resource_ref.remove(value);
+    }
 
-     protected volatile List<com.ibm.ws.javaee.dd.commonbnd.ResourceEnvRef> resource_env_ref = new ArrayList<com.ibm.ws.javaee.dd.commonbnd.ResourceEnvRef>();
+    protected volatile List<com.ibm.ws.javaee.dd.commonbnd.ResourceRef> resource_ref = new ArrayList<com.ibm.ws.javaee.dd.commonbnd.ResourceRef>();
 
-     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, name = "message-destination-ref", target = "(id=unbound)")
-     protected void setMessage_destination_ref(com.ibm.ws.javaee.dd.commonbnd.MessageDestinationRef value) {
-          this.message_destination_ref.add(value);
-     }
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, name = "resource-env-ref", target = "(id=unbound)")
+    protected void setResource_env_ref(com.ibm.ws.javaee.dd.commonbnd.ResourceEnvRef value) {
+        this.resource_env_ref.add(value);
+    }
 
-     protected void unsetMessage_destination_ref(com.ibm.ws.javaee.dd.commonbnd.MessageDestinationRef value) {
-          this.message_destination_ref.remove(value);
-     }
+    protected void unsetResource_env_ref(com.ibm.ws.javaee.dd.commonbnd.ResourceEnvRef value) {
+        this.resource_env_ref.remove(value);
+    }
 
-     protected volatile List<com.ibm.ws.javaee.dd.commonbnd.MessageDestinationRef> message_destination_ref = new ArrayList<com.ibm.ws.javaee.dd.commonbnd.MessageDestinationRef>();
+    protected volatile List<com.ibm.ws.javaee.dd.commonbnd.ResourceEnvRef> resource_env_ref = new ArrayList<com.ibm.ws.javaee.dd.commonbnd.ResourceEnvRef>();
 
-     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, name = "data-source", target = "(id=unbound)")
-     protected void setData_source(com.ibm.ws.javaee.dd.commonbnd.DataSource value) {
-          this.data_source.add(value);
-     }
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, name = "message-destination-ref", target = "(id=unbound)")
+    protected void setMessage_destination_ref(com.ibm.ws.javaee.dd.commonbnd.MessageDestinationRef value) {
+        this.message_destination_ref.add(value);
+    }
 
-     protected void unsetData_source(com.ibm.ws.javaee.dd.commonbnd.DataSource value) {
-          this.data_source.remove(value);
-     }
+    protected void unsetMessage_destination_ref(com.ibm.ws.javaee.dd.commonbnd.MessageDestinationRef value) {
+        this.message_destination_ref.remove(value);
+    }
 
-     protected volatile List<com.ibm.ws.javaee.dd.commonbnd.DataSource> data_source = new ArrayList<com.ibm.ws.javaee.dd.commonbnd.DataSource>();
+    protected volatile List<com.ibm.ws.javaee.dd.commonbnd.MessageDestinationRef> message_destination_ref = new ArrayList<com.ibm.ws.javaee.dd.commonbnd.MessageDestinationRef>();
 
-     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, name = "env-entry", target = "(id=unbound)")
-     protected void setEnv_entry(com.ibm.ws.javaee.dd.commonbnd.EnvEntry value) {
-          this.env_entry.add(value);
-     }
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, name = "data-source", target = "(id=unbound)")
+    protected void setData_source(com.ibm.ws.javaee.dd.commonbnd.DataSource value) {
+        this.data_source.add(value);
+    }
 
-     protected void unsetEnv_entry(com.ibm.ws.javaee.dd.commonbnd.EnvEntry value) {
-          this.env_entry.remove(value);
-     }
+    protected void unsetData_source(com.ibm.ws.javaee.dd.commonbnd.DataSource value) {
+        this.data_source.remove(value);
+    }
 
-     protected volatile List<com.ibm.ws.javaee.dd.commonbnd.EnvEntry> env_entry = new ArrayList<com.ibm.ws.javaee.dd.commonbnd.EnvEntry>();
+    protected volatile List<com.ibm.ws.javaee.dd.commonbnd.DataSource> data_source = new ArrayList<com.ibm.ws.javaee.dd.commonbnd.DataSource>();
 
-     @Activate
-     protected void activate(Map<String, Object> config) {
-          this.configAdminProperties = config;
-          component_id = (java.lang.String) config.get("component-id");
-          name = (java.lang.String) config.get("name");
-          local_home_binding_name = (java.lang.String) config.get("local-home-binding-name");
-          remote_home_binding_name = (java.lang.String) config.get("remote-home-binding-name");
-          simple_binding_name = (java.lang.String) config.get("simple-binding-name");
-     }
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, name = "env-entry", target = "(id=unbound)")
+    protected void setEnv_entry(com.ibm.ws.javaee.dd.commonbnd.EnvEntry value) {
+        this.env_entry.add(value);
+    }
 
-     @Override
-     public java.util.List<com.ibm.ws.javaee.dd.ejbbnd.Interface> getInterfaces() {
-          // Not Used In Liberty -- returning default value or app configuration
-          java.util.List<com.ibm.ws.javaee.dd.ejbbnd.Interface> returnValue = delegate == null ? new ArrayList<com.ibm.ws.javaee.dd.ejbbnd.Interface>() : new ArrayList<com.ibm.ws.javaee.dd.ejbbnd.Interface>(delegate.getInterfaces());
-          return returnValue;
-     }
+    protected void unsetEnv_entry(com.ibm.ws.javaee.dd.commonbnd.EnvEntry value) {
+        this.env_entry.remove(value);
+    }
 
-     @Override
-     public java.lang.String getSimpleBindingName() {
-          if (delegate == null) {
-               return simple_binding_name == null ? null : simple_binding_name;
-          } else {
-               return simple_binding_name == null ? delegate.getSimpleBindingName() : simple_binding_name;
-          }
-     }
+    protected volatile List<com.ibm.ws.javaee.dd.commonbnd.EnvEntry> env_entry = new ArrayList<com.ibm.ws.javaee.dd.commonbnd.EnvEntry>();
 
-     @Override
-     public java.lang.String getComponentID() {
-          if (delegate == null) {
-               return component_id == null ? null : component_id;
-          } else {
-               return component_id == null ? delegate.getComponentID() : component_id;
-          }
-     }
+    @Activate
+    protected void activate(Map<String, Object> config) {
+        this.configAdminProperties = config;
+        component_id = (java.lang.String) config.get("component-id");
+        name = (java.lang.String) config.get("name");
+        local_home_binding_name = (java.lang.String) config.get("local-home-binding-name");
+        remote_home_binding_name = (java.lang.String) config.get("remote-home-binding-name");
+        simple_binding_name = (java.lang.String) config.get("simple-binding-name");
+    }
 
-     @Override
-     public java.lang.String getRemoteHomeBindingName() {
-          if (delegate == null) {
-               return remote_home_binding_name == null ? null : remote_home_binding_name;
-          } else {
-               return remote_home_binding_name == null ? delegate.getRemoteHomeBindingName() : remote_home_binding_name;
-          }
-     }
+    @Override
+    public java.util.List<com.ibm.ws.javaee.dd.ejbbnd.Interface> getInterfaces() {
+        java.util.List<com.ibm.ws.javaee.dd.ejbbnd.Interface> returnValue = delegate == null ? new ArrayList<com.ibm.ws.javaee.dd.ejbbnd.Interface>() : new ArrayList<com.ibm.ws.javaee.dd.ejbbnd.Interface>(delegate.getInterfaces());
+        returnValue.addAll(interfaces);
+        return returnValue;
 
-     @Override
-     public java.lang.String getLocalHomeBindingName() {
-          if (delegate == null) {
-               return local_home_binding_name == null ? null : local_home_binding_name;
-          } else {
-               return local_home_binding_name == null ? delegate.getLocalHomeBindingName() : local_home_binding_name;
-          }
-     }
+    }
 
-     @Override
-     public java.lang.String getName() {
-          if (delegate == null) {
-               return name == null ? null : name;
-          } else {
-               return name == null ? delegate.getName() : name;
-          }
-     }
+    @Override
+    public java.lang.String getSimpleBindingName() {
+        if (delegate == null) {
+            return simple_binding_name == null ? null : simple_binding_name;
+        } else {
+            return simple_binding_name == null ? delegate.getSimpleBindingName() : simple_binding_name;
+        }
+    }
 
-     @Override
-     public java.util.List<com.ibm.ws.javaee.dd.commonbnd.EJBRef> getEJBRefs() {
-          java.util.List<com.ibm.ws.javaee.dd.commonbnd.EJBRef> returnValue = delegate == null ? new ArrayList<com.ibm.ws.javaee.dd.commonbnd.EJBRef>() : new ArrayList<com.ibm.ws.javaee.dd.commonbnd.EJBRef>(delegate.getEJBRefs());
-          returnValue.addAll(ejb_ref);
-          return returnValue;
-     }
+    @Override
+    public java.lang.String getComponentID() {
+        if (delegate == null) {
+            return component_id == null ? null : component_id;
+        } else {
+            return component_id == null ? delegate.getComponentID() : component_id;
+        }
+    }
 
-     @Override
-     public java.util.List<com.ibm.ws.javaee.dd.commonbnd.ResourceRef> getResourceRefs() {
-          java.util.List<com.ibm.ws.javaee.dd.commonbnd.ResourceRef> returnValue = delegate == null ? new ArrayList<com.ibm.ws.javaee.dd.commonbnd.ResourceRef>() : new ArrayList<com.ibm.ws.javaee.dd.commonbnd.ResourceRef>(delegate.getResourceRefs());
-          returnValue.addAll(resource_ref);
-          return returnValue;
-     }
+    @Override
+    public java.lang.String getRemoteHomeBindingName() {
+        if (delegate == null) {
+            return remote_home_binding_name == null ? null : remote_home_binding_name;
+        } else {
+            return remote_home_binding_name == null ? delegate.getRemoteHomeBindingName() : remote_home_binding_name;
+        }
+    }
 
-     @Override
-     public java.util.List<com.ibm.ws.javaee.dd.commonbnd.ResourceEnvRef> getResourceEnvRefs() {
-          java.util.List<com.ibm.ws.javaee.dd.commonbnd.ResourceEnvRef> returnValue = delegate == null ? new ArrayList<com.ibm.ws.javaee.dd.commonbnd.ResourceEnvRef>() : new ArrayList<com.ibm.ws.javaee.dd.commonbnd.ResourceEnvRef>(delegate.getResourceEnvRefs());
-          returnValue.addAll(resource_env_ref);
-          return returnValue;
-     }
+    @Override
+    public java.lang.String getLocalHomeBindingName() {
+        if (delegate == null) {
+            return local_home_binding_name == null ? null : local_home_binding_name;
+        } else {
+            return local_home_binding_name == null ? delegate.getLocalHomeBindingName() : local_home_binding_name;
+        }
+    }
 
-     @Override
-     public java.util.List<com.ibm.ws.javaee.dd.commonbnd.MessageDestinationRef> getMessageDestinationRefs() {
-          java.util.List<com.ibm.ws.javaee.dd.commonbnd.MessageDestinationRef> returnValue = delegate == null ? new ArrayList<com.ibm.ws.javaee.dd.commonbnd.MessageDestinationRef>() : new ArrayList<com.ibm.ws.javaee.dd.commonbnd.MessageDestinationRef>(delegate.getMessageDestinationRefs());
-          returnValue.addAll(message_destination_ref);
-          return returnValue;
-     }
+    @Override
+    public java.lang.String getName() {
+        if (delegate == null) {
+            return name == null ? null : name;
+        } else {
+            return name == null ? delegate.getName() : name;
+        }
+    }
 
-     @Override
-     public java.util.List<com.ibm.ws.javaee.dd.commonbnd.DataSource> getDataSources() {
-          java.util.List<com.ibm.ws.javaee.dd.commonbnd.DataSource> returnValue = delegate == null ? new ArrayList<com.ibm.ws.javaee.dd.commonbnd.DataSource>() : new ArrayList<com.ibm.ws.javaee.dd.commonbnd.DataSource>(delegate.getDataSources());
-          returnValue.addAll(data_source);
-          return returnValue;
-     }
+    @Override
+    public java.util.List<com.ibm.ws.javaee.dd.commonbnd.EJBRef> getEJBRefs() {
+        java.util.List<com.ibm.ws.javaee.dd.commonbnd.EJBRef> returnValue = delegate == null ? new ArrayList<com.ibm.ws.javaee.dd.commonbnd.EJBRef>() : new ArrayList<com.ibm.ws.javaee.dd.commonbnd.EJBRef>(delegate.getEJBRefs());
+        returnValue.addAll(ejb_ref);
+        return returnValue;
+    }
 
-     @Override
-     public java.util.List<com.ibm.ws.javaee.dd.commonbnd.EnvEntry> getEnvEntries() {
-          java.util.List<com.ibm.ws.javaee.dd.commonbnd.EnvEntry> returnValue = delegate == null ? new ArrayList<com.ibm.ws.javaee.dd.commonbnd.EnvEntry>() : new ArrayList<com.ibm.ws.javaee.dd.commonbnd.EnvEntry>(delegate.getEnvEntries());
-          returnValue.addAll(env_entry);
-          return returnValue;
-     }
-     public Map<String,Object> getConfigAdminProperties() {
-          return this.configAdminProperties;
-     }
+    @Override
+    public java.util.List<com.ibm.ws.javaee.dd.commonbnd.ResourceRef> getResourceRefs() {
+        java.util.List<com.ibm.ws.javaee.dd.commonbnd.ResourceRef> returnValue = delegate == null ? new ArrayList<com.ibm.ws.javaee.dd.commonbnd.ResourceRef>() : new ArrayList<com.ibm.ws.javaee.dd.commonbnd.ResourceRef>(delegate.getResourceRefs());
+        returnValue.addAll(resource_ref);
+        return returnValue;
+    }
 
-     public void setDelegate(com.ibm.ws.javaee.dd.ejbbnd.Session delegate) {
-          this.delegate = delegate;
-     }
+    @Override
+    public java.util.List<com.ibm.ws.javaee.dd.commonbnd.ResourceEnvRef> getResourceEnvRefs() {
+        java.util.List<com.ibm.ws.javaee.dd.commonbnd.ResourceEnvRef> returnValue = delegate == null ? new ArrayList<com.ibm.ws.javaee.dd.commonbnd.ResourceEnvRef>() : new ArrayList<com.ibm.ws.javaee.dd.commonbnd.ResourceEnvRef>(delegate.getResourceEnvRefs());
+        returnValue.addAll(resource_env_ref);
+        return returnValue;
+    }
+
+    @Override
+    public java.util.List<com.ibm.ws.javaee.dd.commonbnd.MessageDestinationRef> getMessageDestinationRefs() {
+        java.util.List<com.ibm.ws.javaee.dd.commonbnd.MessageDestinationRef> returnValue = delegate == null ? new ArrayList<com.ibm.ws.javaee.dd.commonbnd.MessageDestinationRef>() : new ArrayList<com.ibm.ws.javaee.dd.commonbnd.MessageDestinationRef>(delegate.getMessageDestinationRefs());
+        returnValue.addAll(message_destination_ref);
+        return returnValue;
+    }
+
+    @Override
+    public java.util.List<com.ibm.ws.javaee.dd.commonbnd.DataSource> getDataSources() {
+        java.util.List<com.ibm.ws.javaee.dd.commonbnd.DataSource> returnValue = delegate == null ? new ArrayList<com.ibm.ws.javaee.dd.commonbnd.DataSource>() : new ArrayList<com.ibm.ws.javaee.dd.commonbnd.DataSource>(delegate.getDataSources());
+        returnValue.addAll(data_source);
+        return returnValue;
+    }
+
+    @Override
+    public java.util.List<com.ibm.ws.javaee.dd.commonbnd.EnvEntry> getEnvEntries() {
+        java.util.List<com.ibm.ws.javaee.dd.commonbnd.EnvEntry> returnValue = delegate == null ? new ArrayList<com.ibm.ws.javaee.dd.commonbnd.EnvEntry>() : new ArrayList<com.ibm.ws.javaee.dd.commonbnd.EnvEntry>(delegate.getEnvEntries());
+        returnValue.addAll(env_entry);
+        return returnValue;
+    }
+
+    public Map<String, Object> getConfigAdminProperties() {
+        return this.configAdminProperties;
+    }
+
+    public void setDelegate(com.ibm.ws.javaee.dd.ejbbnd.Session delegate) {
+        this.delegate = delegate;
+    }
 }


### PR DESCRIPTION
Removing LibertyNotInUse annotation and adding support for session.getInterfaces() in the javaee ddmodel overrides. 