### PR TITLE
Fix Max version and enable more client tests

### DIFF
--- a/dev/com.ibm.ws.clientcontainer.8.0_fat/fat/src/com/ibm/ws/clientcontainer/fat/AppClientTest.java
+++ b/dev/com.ibm.ws.clientcontainer.8.0_fat/fat/src/com/ibm/ws/clientcontainer/fat/AppClientTest.java
@@ -59,7 +59,6 @@ public class AppClientTest extends FATServletClient {
      * Check if the test application is printing out "Hello Application Client." to the console.
      */
     @Test
-    @SkipForRepeat({ "JAKARTAEECLIENT-9.0", SkipForRepeat.EE9_FEATURES })
     public void testHelloAppClient() throws Exception {
         ShrinkHelper.exportAppToClient(client, earHAC);
 
@@ -76,7 +75,6 @@ public class AppClientTest extends FATServletClient {
 
     // Test ${client.config.dir}
     @Test
-    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     public void testClientConfigDir() throws Exception {
         ShrinkHelper.exportAppToClient(client, earHAC);
         client.startClient();
@@ -131,7 +129,6 @@ public class AppClientTest extends FATServletClient {
 
     // Use <enterpriseApplication/>
     @Test
-    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     public void testHelloAppClientWithEnterpriseApplication() throws Exception {
         ShrinkHelper.exportAppToClient(client, earHAC);
 

--- a/dev/com.ibm.ws.clientcontainer.8.0_fat/fat/src/com/ibm/ws/clientcontainer/fat/FATSuite.java
+++ b/dev/com.ibm.ws.clientcontainer.8.0_fat/fat/src/com/ibm/ws/clientcontainer/fat/FATSuite.java
@@ -26,7 +26,4 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(new FeatureReplacementAction("javaeeClient-8.0", "jakartaeeClient-9.0")
-                                    .forceAddFeatures(true)
-                                    .withID("JAKARTAEECLIENT-9.0"))
                     .andWith(new JakartaEE9Action());}

--- a/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/client/ApplicationClientEntryAdapter.java
+++ b/dev/com.ibm.ws.javaee.ddmodel/src/com/ibm/ws/javaee/ddmodel/client/ApplicationClientEntryAdapter.java
@@ -23,7 +23,7 @@ import com.ibm.wsspi.artifact.ArtifactEntry;
 import com.ibm.wsspi.artifact.overlay.OverlayContainer;
 
 public final class ApplicationClientEntryAdapter implements EntryAdapter<ApplicationClient> {
-    private static final int DEFAULT_MAX_VERSION = ApplicationClient.VERSION_8;
+    private static final int DEFAULT_MAX_VERSION = ApplicationClient.VERSION_9;
 
     private ServiceReference<ApplicationClientDDParserVersion> versionRef;
     private volatile int version = DEFAULT_MAX_VERSION;


### PR DESCRIPTION
Removed the repeat action JAKARTAEECLIENT-9.0 because the Normal EE9 feature repeat is now doing the right swap...  

Enabled rest of app client tests - and fixed max version to 9