### PR TITLE
Add variable to configure coordinator context root

### DIFF
--- a/dev/io.openliberty.microprofile.lra.coordinator.1.0.internal/resources/OSGI-INF/wlp/defaultInstances.xml
+++ b/dev/io.openliberty.microprofile.lra.coordinator.1.0.internal/resources/OSGI-INF/wlp/defaultInstances.xml
@@ -9,5 +9,6 @@
         IBM Corporation - initial implementation
  -->
 <server>
-    <application context-root="/lrac" type="war" id="lra-c" location="${wlp.install.dir}/lib/mpLRACoordinator_5.10.6.jar"/>
+    <variable name="lraCoordinatorContextRoot" defaultValue="/lrac" />
+    <application context-root="${lraCoordinatorContextRoot}" type="war" id="lra-c" location="${wlp.install.dir}/lib/mpLRACoordinator_5.10.6.jar"/>
 </server>


### PR DESCRIPTION
This can be overriden by the user, as per normal liberty config variables