### PR TITLE
Wait for string to appear in trace log before searching in LogServiceTest

### DIFF
--- a/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/LogServiceTest.java
+++ b/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/LogServiceTest.java
@@ -402,19 +402,30 @@ public class LogServiceTest {
         checkForTraceMessage("Event:org.osgi.framework.ServiceEvent", expectedBundles.length * 2);
     }
 
+    /** Checks if the logs appear in trace **/
     private void assertFrameworkEvents(boolean expected) throws Exception {
         flushLog("finalFrameworkEventsMsg");
 
         int num = expected ? 1 : 0;
-        checkForTraceMessage("FrameworkEvent PACKAGES REFRESHED", num);
-        checkForTraceMessage("LoggerName:Events.Framework", num);
-        checkForTraceMessage("Event:org.osgi.framework.FrameworkEvent", num);
+        checkForTrace("FrameworkEvent PACKAGES REFRESHED", num);
+        checkForTrace("LoggerName:Events.Framework", num);
+        checkForTrace("Event:org.osgi.framework.FrameworkEvent", num);
 
     }
 
     private void checkForTraceMessage(String msg, int expectedNum) throws Exception {
         // make sure it is not in console log
         assertTrue("Found unexpected message in console log: " + msg, server.findStringsInLogsUsingMark(msg, server.getConsoleLogFile()).isEmpty());
+        List<String> found = server.findStringsInLogsAndTraceUsingMark(msg);
+        assertEquals("Did not find the expected number of messages: " + msg, expectedNum, found.size());
+    }
+
+    private void checkForTrace(String msg, int expectedNum) throws Exception {
+        // make sure it is not in console log
+        assertTrue("Found unexpected message in console log: " + msg, server.findStringsInLogsUsingMark(msg, server.getConsoleLogFile()).isEmpty());
+        if (expectedNum > 0) {
+            server.waitForStringInTraceUsingMark(msg); //wait for string in trace log
+        }
         List<String> found = server.findStringsInLogsAndTraceUsingMark(msg);
         assertEquals("Did not find the expected number of messages: " + msg, expectedNum, found.size());
     }

--- a/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/LogServiceTest.java
+++ b/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/LogServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
Fixes #14023 
In the tests, the message is found in trace.log even though the test said it did not.
Wait for string to appear before searching the message in trace.log.