### PR TITLE
[14050] Allow RESTEasy bundle to be used as a client in a Java SE env

### DIFF
--- a/dev/io.openliberty.org.jboss.resteasy.common/.classpath
+++ b/dev/io.openliberty.org.jboss.resteasy.common/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="test"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/io.openliberty.org.jboss.resteasy.common/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.common/bnd.bnd
@@ -13,6 +13,8 @@ bVersion=1.0
 
 Bundle-SymbolicName: io.openliberty.org.jboss.resteasy.common
 
+src: src, resources
+
 app-resources= \
   META-INF/services/javax.ws.rs.client.ClientBuilder | \
   META-INF/services/javax.ws.rs.sse.SseEventSource\$Builder | \
@@ -193,5 +195,13 @@ Include-Resource:\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	javax.activation:activation;version=1.1,\
 	com.ibm.websphere.org.osgi.core;version=latest
+
+-testpath: \
+	../build.sharedResources/lib/junit/old/junit.jar;version=file,\
+	com.ibm.websphere.javaee.mail.1.6,\
+	com.ibm.ws.org.apache.commons.io,\
+	com.ibm.ws.org.apache.commons.logging.1.0.3,\
+	com.ibm.ws.org.apache.httpcomponents,\
+	com.ibm.ws.org.glassfish.json.1.1
 
 jakartaeeMe: true

--- a/dev/io.openliberty.org.jboss.resteasy.common/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigProviderResolver
+++ b/dev/io.openliberty.org.jboss.resteasy.common/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigProviderResolver
@@ -1,0 +1,2 @@
+# Intended only for Java SE environments - should NOT be exposed by the ResourceProvider in the bnd file
+io.openliberty.restfulWS.client.ConfigProviderResolverImpl

--- a/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/client/LibertyResteasyClientBuilderImpl.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/client/LibertyResteasyClientBuilderImpl.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
@@ -50,14 +51,20 @@ public class LibertyResteasyClientBuilderImpl extends ResteasyClientBuilderImpl 
     
     private BundleContext getBundleContext() {
         if (isSecurityManagerPresent) {
-            return AccessController.doPrivileged((PrivilegedAction<BundleContext>) () -> 
-                FrameworkUtil.getBundle(getClass()).getBundleContext());
+            return AccessController.doPrivileged((PrivilegedAction<BundleContext>) () -> {
+                Bundle b = FrameworkUtil.getBundle(getClass());
+                return b == null ? null : b.getBundleContext(); 
+            });
         }
-        return FrameworkUtil.getBundle(getClass()).getBundleContext();
+        Bundle b = FrameworkUtil.getBundle(getClass());
+        return b == null ? null : b.getBundleContext();
     }
 
     @SuppressWarnings("unchecked")
     private Optional<ServiceReference<ClientBuilderListener>[]> getServiceRefs(BundleContext ctx) {
+        if (ctx == null) {
+            return Optional.empty();
+        }
         try {
             if (isSecurityManagerPresent) {
                 return Optional.ofNullable(AccessController.doPrivileged(

--- a/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/restfulWS/client/ConfigProviderResolverImpl.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/restfulWS/client/ConfigProviderResolverImpl.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS.client;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Optional;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigBuilder;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+/**
+ * Only intended to be used in Java SE client environments.
+ */
+public class ConfigProviderResolverImpl extends ConfigProviderResolver {
+    
+    private final boolean java2SecurityEnabled = System.getSecurityManager() != null;
+
+    private final Config config = new Config() {
+
+        @Override
+        public Iterable<ConfigSource> getConfigSources() {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public <T> Optional<T> getOptionalValue(String propName, Class<T> type) {
+            return Optional.ofNullable(getValue(propName, type));
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public Iterable<String> getPropertyNames() {
+            if (java2SecurityEnabled) {
+                return AccessController.doPrivileged((PrivilegedAction<Iterable<String>>) () ->
+                    (Iterable<String>) System.getProperties().keySet().iterator());
+            }
+            return (Iterable<String>) System.getProperties().keySet().iterator();
+        }
+
+        @Override
+        public <T> T getValue(String propName, Class<T> propType) {
+            return propType.cast(System.getProperty(propName));
+        }};
+
+    @Override
+    public ConfigBuilder getBuilder() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public Config getConfig() {
+        return getConfig(getThisClassLoader());
+    }
+
+    @Override
+    public Config getConfig(ClassLoader loader) {
+        if (loader != getThisClassLoader()) {
+            return null;
+        }
+        return config;
+    }
+
+    @Override
+    public void registerConfig(Config arg0, ClassLoader arg1) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void releaseConfig(Config arg0) {
+        // TODO Auto-generated method stub
+
+    }
+
+    private ClassLoader getThisClassLoader() {
+        if (java2SecurityEnabled) {
+            return AccessController.doPrivileged((PrivilegedAction<ClassLoader>) () -> 
+                this.getClass().getClassLoader());
+        }
+        return this.getClass().getClassLoader();
+    }
+}

--- a/dev/io.openliberty.org.jboss.resteasy.common/test/io/openliberty/org/jboss/resteasy/common/client/LibertyResteasyClientBuilderImplTest.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/test/io/openliberty/org/jboss/resteasy/common/client/LibertyResteasyClientBuilderImplTest.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.org.jboss.resteasy.common.client;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.junit.Test;
+
+/**
+ * Unit test for LibertyResteasyClientBuilderImpl
+ */
+public class LibertyResteasyClientBuilderImplTest {
+
+    @Test
+    public void testCanBuildLibertyResteasyClientBuilderImpl() {
+        LibertyResteasyClientBuilderImpl builder = new LibertyResteasyClientBuilderImpl();
+        ResteasyClient client = builder.build();
+        assertNotNull(client);
+    }
+}


### PR DESCRIPTION
Fixes #14050 

Fixes the NPE (which occurs because there is no OSGi environment to provide Bundles/BundleContexts/etc.).
Adds a test case to verify that a client can be created in a Java SE environment.
Updates the bnd file to handle unit tests and add to the test path to include everything needed to build a client in a Java SE env.
Adds minimal MP Config implementation required in order to work with RESTEasy config.