### PR TITLE
Make minor fix to reading signature algorithm in MP JWT beta mode

### DIFF
--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/config/JwtConfigUtil.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/config/JwtConfigUtil.java
@@ -75,7 +75,7 @@ public class JwtConfigUtil {
             }
             signatureAlgorithm = defaultSignatureAlgorithm;
         }
-        if (signatureAlgorithm == null) {
+        if (signatureAlgorithm == null && !isBetaEnabled) {
             signatureAlgorithm = defaultSignatureAlgorithm;
         }
         return signatureAlgorithm;

--- a/dev/com.ibm.ws.security.jwt/test/com/ibm/ws/security/jwt/config/JwtConfigUtilTest.java
+++ b/dev/com.ibm.ws.security.jwt/test/com/ibm/ws/security/jwt/config/JwtConfigUtilTest.java
@@ -11,6 +11,7 @@
 package com.ibm.ws.security.jwt.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -114,7 +115,7 @@ public class JwtConfigUtilTest extends CommonTestClass {
         Map<String, Object> props = new HashMap<String, Object>();
 
         String result = JwtConfigUtil.getSignatureAlgorithm(testName.getMethodName(), props, SIG_ALG_ATTR_NAME);
-        assertEquals("Did not get the default signature algorithm as expected.", DEFAULT_SIG_ALG, result);
+        assertNull("Should have gotten null as the signature algorithm, but got " + result + ".", result);
 
         verifyNoLogMessage(outputMgr, MSG_BASE);
     }


### PR DESCRIPTION
#build
#spawn.fullfat.buckets=com.ibm.ws.security.jwt_fat.builder,com.ibm.ws.security.jwt_fat.consumer,com.ibm.ws.security.jwtsso_fat,com.ibm.ws.security.mp.jwt_fat_tck,com.ibm.ws.security.mp.jwt.1.1_fat

