### PR TITLE
Change default coordinator location to match

### DIFF
--- a/dev/io.openliberty.microprofile.lra.1.0.internal/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/io.openliberty.microprofile.lra.1.0.internal/resources/OSGI-INF/metatype/metatype.xml
@@ -23,7 +23,7 @@
         <AD id="port"
             name="%lra.coordinator.port.name"
             description="%lra.coordinator.port.desc"
-            required="false" type="Integer" default="8080" />
+            required="false" type="Integer" default="9080" />
 
         <AD id="host"
             name="%lra.coordinator.host.name"
@@ -33,7 +33,7 @@
         <AD id="path"
             name="%lra.coordinator.path.name"
             description="%lra.coordinator.path.desc"
-            required="false" type="String" default="lra-coordinator" />
+            required="false" type="String" default="lrac/lra-coordinator" />
             
     </OCD>
 


### PR DESCRIPTION
For an Open Liberty coordinator with default config

This should mean that a coordinator and participant with default config should talk to each other