### PR TITLE
14086: Update testPriorityFrameAfterHeaderFrameNoEndHeaders

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/frames/FrameWindowUpdate.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/frames/FrameWindowUpdate.java
@@ -133,7 +133,7 @@ public class FrameWindowUpdate extends Frame {
     public boolean equals(Object object) {
         if (!(object instanceof FrameWindowUpdate)) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "equals: object is not a FrameSettings");
+                Tr.debug(tc, "equals: object is not a FrameWindowUpdate, it is a " + object.getClass());
             }
             return false;
         }

--- a/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/H2FATDriverServlet.java
+++ b/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/H2FATDriverServlet.java
@@ -2767,11 +2767,9 @@ public class H2FATDriverServlet extends FATServlet {
         FramePriority priorityFrame = new FramePriority(3, 0, 255, false, false);
         h2Client.sendFrame(priorityFrame);
 
-        List<H2HeaderField> firstContinuationHeadersToSend = new ArrayList<H2HeaderField>();
-        firstContinuationHeadersToSend.add(new H2HeaderField("harold", "padilla"));
-        FrameContinuationClient firstContinuationHeaders = new FrameContinuationClient(3, null, true, true, false);
-        firstContinuationHeaders.setHeaderFields(firstContinuationHeadersToSend);
-        h2Client.sendFrame(firstContinuationHeaders);
+        // The previous priority frame should cause the error, so no need to try to send anything else
+        // as it can cause a timing issue if the server has already detected the problem and
+        // closed the connection
 
         blockUntilConnectionIsDone.await();
         this.handleErrors(h2Client, testName);


### PR DESCRIPTION
This test was creating an error which caused the server to send a goaway frame.

After that, the test tried to send another unnecessary frame, which caused an intermittent problem where on occasion, the frame could not be sent because the connection was already closed.  The PR removes the extra send frame.

This is the error seen in the client log when the frame cannot be sent.
IOException while doing IO requested on local: 127.0.0.1/127.0.0.1:62462 remote: localhost/127.0.0.1:8030
[9/15/20, 8:06:02:144 BST] 0000004f id=00000000 com.ibm.ws.tcpchannel.internal.WorkQueueManager              1 Exception is: java.io.IOException: An established connection was aborted by the software in your host machine