### PR TITLE
Enable initial EE9 feature testing on jaxrs20 tests

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/bnd.bnd
@@ -63,6 +63,7 @@ fat.project: true
 tested.features: \
   jaxrs-2.1,\
   cdi-2.0,\
+  restfulWS-3.0,\
   appsecurity-3.0
 
 -buildpath: \

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/build.gradle
@@ -138,3 +138,5 @@ addRequiredLibraries {
   dependsOn createWadlTempDir
   dependsOn addDerby
 }
+
+addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/FATSuite.java
@@ -65,6 +65,7 @@ import com.ibm.ws.jaxrs20.fat.webcontainer.JAXRSWebContainerTest;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
@@ -123,5 +124,6 @@ import componenttest.rules.repeater.RepeatTests;
 public class FATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE8_FEATURES().withID("JAXRS-2.1"));
+                    .andWith(FeatureReplacementAction.EE8_FEATURES().withID("JAXRS-2.1"))
+                    .andWith(new JakartaEE9Action());
 }

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/SimpleJsonTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/SimpleJsonTest.java
@@ -21,11 +21,13 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs.fat.simpleJson.JaxrsJsonClientTestServlet;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class SimpleJsonTest {
 
     private static final String CONTEXT_ROOT = "simpleJson";

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/annotationscan/AnnotationScanTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/annotationscan/AnnotationScanTest.java
@@ -38,12 +38,14 @@ import com.ibm.ws.jaxrs.fat.duplicateuris.MyRegularResource;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.JavaInfo.Vendor;
 import componenttest.topology.impl.LibertyServer;
 
 @AllowedFFDC("java.lang.ClassNotFoundException")
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 @RunWith(FATRunner.class)
 public class AnnotationScanTest {
 

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/beanparam/BeanParamTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/beanparam/BeanParamTest.java
@@ -18,11 +18,13 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs.fat.beanparam.ClientTestServlet;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 @RunWith(FATRunner.class)
 public class BeanParamTest extends FATServletClient {
 

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/beanvalidation/JAXRSClientServerValidationTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/beanvalidation/JAXRSClientServerValidationTest.java
@@ -21,12 +21,14 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs20.fat.AbstractTest;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class JAXRSClientServerValidationTest extends AbstractTest {
 
     private static final String bvwar = "beanvalidation";

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/beanvalidation/JAXRSPerRequestValidationTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/beanvalidation/JAXRSPerRequestValidationTest.java
@@ -21,10 +21,12 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs20.fat.AbstractTest;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class JAXRSPerRequestValidationTest extends AbstractTest {
 
     private static final String bvwar = "beanvalidation";

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/bookcontinuationstore/JAXRSContinuationsTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/bookcontinuationstore/JAXRSContinuationsTest.java
@@ -40,12 +40,14 @@ import com.ibm.ws.jaxrs20.fat.TestUtils;
 import com.ibm.ws.jaxrs20.fat.bookstore.IOUtils;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class JAXRSContinuationsTest {
 
     @Server("com.ibm.ws.jaxrs.fat.bookcontinuationstore")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/bookstore/JAXRS20ClientServerBookTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/bookstore/JAXRS20ClientServerBookTest.java
@@ -24,10 +24,12 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs20.fat.AbstractTest;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class JAXRS20ClientServerBookTest extends AbstractTest {
 
     @Server("com.ibm.ws.jaxrs.fat.bookstore")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/callback/JAXRS20CallBackTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/callback/JAXRS20CallBackTest.java
@@ -28,6 +28,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -35,6 +36,7 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class JAXRS20CallBackTest {
 
     @Server("com.ibm.ws.jaxrs.fat.callback")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/checkFeature/CheckFeature12Test.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/checkFeature/CheckFeature12Test.java
@@ -21,6 +21,7 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -31,6 +32,7 @@ import componenttest.topology.impl.LibertyServer;
  * the server had to be restarted if the cdi-1.0 feature was added after the server had started.
  */
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class CheckFeature12Test {
 
     @Server("com.ibm.ws.jaxrs.fat.checkFeature")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/class_as_provider_resource/SameClassAsProviderAndResourceTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/class_as_provider_resource/SameClassAsProviderAndResourceTest.java
@@ -30,10 +30,12 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class SameClassAsProviderAndResourceTest {
 
     @Server("com.ibm.ws.jaxrs.fat.providerAndResource")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/client/ClientTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/client/ClientTest.java
@@ -28,12 +28,14 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs20.fat.AbstractTest;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class ClientTest extends AbstractTest {
 
     @Server("com.ibm.ws.jaxrs.fat.client")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/context/ContextTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/context/ContextTest.java
@@ -26,10 +26,12 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class ContextTest {
 
     @Server("com.ibm.ws.jaxrs.fat.context")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/contextresolver/DepartmentTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/contextresolver/DepartmentTest.java
@@ -48,10 +48,12 @@ import com.ibm.ws.jaxrs.fat.contextresolver.DepartmentListWrapper;
 import com.ibm.ws.jaxrs.fat.contextresolver.User;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class DepartmentTest {
 
     @Server("com.ibm.ws.jaxrs.fat.contextresolver")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/exceptionmappers/ExceptionMappersTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/exceptionmappers/ExceptionMappersTest.java
@@ -38,10 +38,12 @@ import com.ibm.ws.jaxrs.fat.exceptionmappers.mapped.CommentError;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class ExceptionMappersTest {
 
     @Server("com.ibm.ws.jaxrs.fat.providers")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/exceptionmappingWithOT/ExceptionMappingWithOTTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/exceptionmappingWithOT/ExceptionMappingWithOTTest.java
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
@@ -38,6 +39,7 @@ import componenttest.topology.impl.LibertyServer;
  * the MP OT mapper.
  */
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class ExceptionMappingWithOTTest {
 
     @Server("com.ibm.ws.jaxrs.fat.exceptionMappingWithOT")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/extraproviders/ExtraProvidersTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/extraproviders/ExtraProvidersTest.java
@@ -23,10 +23,12 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs20.fat.AbstractTest;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class ExtraProvidersTest extends AbstractTest {
 
     // Use the same server as JAXRSWebContainerTest

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/getClasses_getSingletons/SameClassInGetClassesAndGetSingletonsTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/getClasses_getSingletons/SameClassInGetClassesAndGetSingletonsTest.java
@@ -30,10 +30,12 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class SameClassInGetClassesAndGetSingletonsTest {
 
     @Server("com.ibm.ws.jaxrs.fat.getCgetS")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/helloworld/HelloWorldTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/helloworld/HelloWorldTest.java
@@ -28,10 +28,12 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class HelloWorldTest {
 
     @Server("com.ibm.ws.jaxrs.fat.helloworld")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/ibm/json/IBMJSON4JTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/ibm/json/IBMJSON4JTest.java
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
@@ -38,6 +39,7 @@ import componenttest.topology.impl.LibertyServer;
  * Not intended to test the com.ibm.json.* code.
  */
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class IBMJSON4JTest {
 
     @Server("com.ibm.ws.jaxrs.fat.ibmjson4j")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/jackson/JacksonPOJOTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/jackson/JacksonPOJOTest.java
@@ -23,10 +23,12 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class JacksonPOJOTest extends JacksonBaseTest {
 
     @Server("com.ibm.ws.jaxrs.fat.jackson")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/jackson1x/JacksonPOJOwithUserJacksonLib1xTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/jackson1x/JacksonPOJOwithUserJacksonLib1xTest.java
@@ -23,10 +23,12 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs20.fat.jackson.JacksonBaseTest;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class JacksonPOJOwithUserJacksonLib1xTest extends JacksonBaseTest {
 
     @Server("com.ibm.ws.jaxrs.fat.jackson1x")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/jackson2x/JacksonPOJOwithUserJacksonLib2xTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/jackson2x/JacksonPOJOwithUserJacksonLib2xTest.java
@@ -23,10 +23,12 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs20.fat.jackson.JacksonBaseTest;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class JacksonPOJOwithUserJacksonLib2xTest extends JacksonBaseTest {
 
     @Server("com.ibm.ws.jaxrs.fat.jackson2x")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/jacksonJsonIgnore/JacksonJsonIgnoreTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/jacksonJsonIgnore/JacksonJsonIgnoreTest.java
@@ -32,10 +32,12 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class JacksonJsonIgnoreTest {
 
     @Server("com.ibm.ws.jaxrs.fat.jacksonJsonIgnore")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/json/UTF8Test.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/json/UTF8Test.java
@@ -21,6 +21,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs20.fat.AbstractTest;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
@@ -29,6 +30,7 @@ import componenttest.topology.impl.LibertyServer;
  * INVALID UTF-8 middle byte error WITH DANISH CHARACTER SET
  */
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class UTF8Test extends AbstractTest {
 
     @Server("com.ibm.ws.jaxrs.fat.json")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/link/LinkHeaderTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/link/LinkHeaderTest.java
@@ -18,12 +18,14 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs.fat.linkheader.ClientTestServlet;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class LinkHeaderTest extends FATServletClient {
 
     private static final String app = "linkheader";

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/managedbeans/ManagedBeansTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/managedbeans/ManagedBeansTest.java
@@ -18,11 +18,13 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs.managedbeans.ManagedBeansTestServlet;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class ManagedBeansTest {
 
     @Server("JaxrsManagedBeansTestServer")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/paramconverter/ParamConverterTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/paramconverter/ParamConverterTest.java
@@ -18,12 +18,14 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs.fat.paramconverter.ClientTestServlet;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class ParamConverterTest extends FATServletClient {
 
     private static final String app = "paramconverter";

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/params/ParamsTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/params/ParamsTest.java
@@ -48,10 +48,12 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class ParamsTest {
 
     @Server("com.ibm.ws.jaxrs.fat.params")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/providercache/ProviderCacheTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/providercache/ProviderCacheTest.java
@@ -31,10 +31,12 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class ProviderCacheTest {
 
     @Server("com.ibm.ws.jaxrs.fat.providercache")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/readerwriterprovider/ReaderWriterProvidersTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/readerwriterprovider/ReaderWriterProvidersTest.java
@@ -31,6 +31,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
@@ -38,6 +39,8 @@ import componenttest.topology.impl.LibertyServer;
  * Centralized test for built-in standard providers required by the JAX-RS specification.
  */
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
+
 public class ReaderWriterProvidersTest {
 
     @Server("com.ibm.ws.jaxrs.fat.providers")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/resourcealgorithm/SearchPolicyTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/resourcealgorithm/SearchPolicyTest.java
@@ -23,10 +23,12 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs20.fat.AbstractTest;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class SearchPolicyTest extends AbstractTest {
 
     @Server("com.ibm.ws.jaxrs.fat.searchpolicy")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/restmetrics/RestMetricsTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/restmetrics/RestMetricsTest.java
@@ -40,10 +40,12 @@ import com.ibm.ws.jaxrs.fat.restmetrics.MetricsUnmappedUncheckedException;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class RestMetricsTest {
 
      // Array to hold the names that identify the methods in metrics 2.3

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/security/annotations/SecurityAnnotationsTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/security/annotations/SecurityAnnotationsTest.java
@@ -20,11 +20,13 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs.fat.security.servlet.SecurityAnnotationsTestServlet;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class SecurityAnnotationsTest {
 
     private static final String secwar = "security";

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/security/ssl/SecuritySSLTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/security/ssl/SecuritySSLTest.java
@@ -31,10 +31,12 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class SecuritySSLTest {
 
     @Server("com.ibm.ws.jaxrs.fat.security.ssl")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/securitycontext/CustomSecurityContextTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/securitycontext/CustomSecurityContextTest.java
@@ -20,11 +20,13 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs.fat.customsecuritycontext.servlet.CustomSecurityContextTestServlet;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class CustomSecurityContextTest {
 
 

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/securitycontext/SecurityContextTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/securitycontext/SecurityContextTest.java
@@ -20,11 +20,13 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs.fat.security.servlet.SecurityContextTestServlet;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class SecurityContextTest {
 
     private static final String secwar = "security";

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/service/scope/ServiceScopeTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/service/scope/ServiceScopeTest.java
@@ -30,10 +30,12 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class ServiceScopeTest {
 
     @Server("com.ibm.ws.jaxrs.fat.service.scope")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/servletcoexist/JAXRSServletCoexistTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/servletcoexist/JAXRSServletCoexistTest.java
@@ -28,10 +28,12 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class JAXRSServletCoexistTest {
     private static final String bvwar = "servletcoexist";
     private static final String bvwar1 = bvwar + "1";

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/standard/StandardProvidersTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/standard/StandardProvidersTest.java
@@ -48,6 +48,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
@@ -55,6 +56,7 @@ import componenttest.topology.impl.LibertyServer;
  * Centralized test for built-in standard providers required by the JAX-RS specification.
  */
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class StandardProvidersTest {
 
     @Server("com.ibm.ws.jaxrs.fat.providers")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/subresource/ExceptionsSubresourcesTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/subresource/ExceptionsSubresourcesTest.java
@@ -42,10 +42,12 @@ import com.ibm.ws.jaxrs.fat.subresource.CommentError;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class ExceptionsSubresourcesTest {
     private static final Class<?> c = ExceptionsSubresourcesTest.class;
 

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/thirdpartyjersey/JerseyTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/thirdpartyjersey/JerseyTest.java
@@ -29,10 +29,12 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class JerseyTest {
 
     @Server("com.ibm.ws.jaxrs.fat.thirdpartyjersey")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/thirdpartyjerseywithinjection/JerseyInjectionTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/thirdpartyjerseywithinjection/JerseyInjectionTest.java
@@ -38,10 +38,12 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class JerseyInjectionTest {
 
     @Server("com.ibm.ws.jaxrs.fat.thirdpartyjerseywithinjection")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/uriInfo/UriInfoTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/uriInfo/UriInfoTest.java
@@ -18,12 +18,14 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs.fat.uriInfo.ClientTestServlet;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class UriInfoTest extends FATServletClient {
 
     private static final String app = "uriInfo";

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/validation/ValidationTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/validation/ValidationTest.java
@@ -34,10 +34,12 @@ import com.ibm.ws.jaxrs20.fat.TestUtils;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class ValidationTest {
 
     @Server("com.ibm.ws.jaxrs.fat.validation")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/wadl/WADLTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/wadl/WADLTest.java
@@ -32,12 +32,14 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class WADLTest {
 
     @Server("com.ibm.ws.jaxrs.fat.wadl")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/webcontainer/JAXRSWebContainerTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/webcontainer/JAXRSWebContainerTest.java
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -40,6 +41,7 @@ import componenttest.topology.impl.LibertyServer;
  * Simple tests for web container spec compliance.
  */
 @RunWith(FATRunner.class)
+@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class JAXRSWebContainerTest {
 
     @Server("com.ibm.ws.jaxrs.fat.webcontainer")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.options/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.options/server.xml
@@ -5,5 +5,4 @@
     </featureManager>
 
   	<include location="../fatTestPorts.xml"/>
-
 </server>

--- a/dev/io.openliberty.org.jboss.resteasy.common/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.common/bnd.bnd
@@ -170,6 +170,8 @@ Include-Resource:\
 	org.jboss.resteasy:resteasy-multipart-provider;strategy=exact;version=4.5.2.Final,\
 	org.jboss.resteasy:resteasy-servlet-initializer;strategy=exact;version=4.5.2.Final,\
 	org.jboss.resteasy:resteasy-tracing-api;strategy=exact;version=1.0.0.Final,\
+	com.ibm.ws.org.apache.commons.io,\
+	com.ibm.ws.org.apache.httpcomponents,\
 	com.ibm.websphere.javaee.annotation.1.3,\
 	com.ibm.websphere.javaee.cdi.2.0,\
 	com.ibm.websphere.javaee.interceptor.1.2,\

--- a/dev/io.openliberty.org.jboss.resteasy.common/src/org/jboss/resteasy/client/jaxrs/engines/ManualClosingApacheHttpClient43Engine.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/org/jboss/resteasy/client/jaxrs/engines/ManualClosingApacheHttpClient43Engine.java
@@ -1,0 +1,751 @@
+package org.jboss.resteasy.client.jaxrs.engines;
+
+import org.apache.commons.io.output.DeferredFileOutputStream;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.Configurable;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.entity.AbstractHttpEntity;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.FileEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.protocol.HTTP;
+import org.jboss.resteasy.client.jaxrs.i18n.LogMessages;
+import org.jboss.resteasy.client.jaxrs.i18n.Messages;
+import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
+import org.jboss.resteasy.client.jaxrs.internal.ClientResponse;
+import org.jboss.resteasy.client.jaxrs.internal.FinalizedClientResponse;
+import org.jboss.resteasy.microprofile.config.ResteasyConfigProvider;
+import org.jboss.resteasy.util.CaseInsensitiveMap;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.management.ManagementFactory;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An Apache HTTP engine for use with the new Builder Config style.
+ */
+public class ManualClosingApacheHttpClient43Engine implements ApacheHttpClientEngine
+{
+
+   /**
+    * Used to build temp file prefix.
+    */
+   private static final String processId;
+   //Liberty Change:  Add doPriv  
+   static
+   {
+   		try {
+      		processId = AccessController.doPrivileged(new PrivilegedExceptionAction<String>() {
+      			@Override
+      			public String run() throws Exception {
+      				return ManagementFactory.getRuntimeMXBean().getName().replaceAll("[^0-9a-zA-Z]", "");
+      			}  	
+      		});
+     	} catch (PrivilegedActionException pae) {
+               throw new RuntimeException(pae);
+        }
+   }
+
+   protected final HttpClient httpClient;
+
+   protected boolean closed;
+
+   protected final boolean allowClosingHttpClient;
+
+   protected HttpContextProvider httpContextProvider;
+
+   protected SSLContext sslContext;
+
+   protected HostnameVerifier hostnameVerifier;
+
+   protected int responseBufferSize = 8192;
+
+   protected HttpHost defaultProxy = null;
+
+   protected boolean chunked = false;
+
+   protected boolean followRedirects = false;
+
+   /**
+    * For uploading File's over JAX-RS framework, this property, together with {@link #fileUploadMemoryUnit},
+    * defines the maximum File size allowed in memory. If fileSize exceeds this size, it will be stored to
+    * {@link #fileUploadTempFileDir}. <br>
+    * <br>
+    * Defaults to 1 MB
+    */
+   protected int fileUploadInMemoryThresholdLimit = 1;
+
+   /**
+    * The unit for {@link #fileUploadInMemoryThresholdLimit}. <br>
+    * <br>
+    * Defaults to MB.
+    *
+    * @see MemoryUnit
+    */
+   protected MemoryUnit fileUploadMemoryUnit = MemoryUnit.MB;
+
+   /**
+    * Temp directory to write output request stream to. Any file to be uploaded has to be written out to the
+    * output request stream to be sent to the service and when the File is too huge the output request stream is
+    * written out to the disk rather than to memory. <br>
+    * <br>
+    * Defaults to JVM temp directory.
+    */
+   protected File fileUploadTempFileDir = new File(ResteasyConfigProvider.getConfig().getOptionalValue("java.io.tmpdir", String.class).orElse(null));
+
+   public ManualClosingApacheHttpClient43Engine()
+   {
+      this.httpClient = createDefaultHttpClient();
+      this.allowClosingHttpClient = true;
+   }
+
+   public ManualClosingApacheHttpClient43Engine(final HttpHost defaultProxy)
+   {
+      this.defaultProxy = defaultProxy;
+      this.httpClient = createDefaultHttpClient();
+      this.allowClosingHttpClient = true;
+   }
+
+   public ManualClosingApacheHttpClient43Engine(final HttpClient httpClient)
+   {
+      this.httpClient = httpClient;
+      this.allowClosingHttpClient = true;
+   }
+
+   public ManualClosingApacheHttpClient43Engine(final HttpClient httpClient, final boolean closeHttpClient)
+   {
+      if (closeHttpClient && !(httpClient instanceof CloseableHttpClient))
+      {
+         throw new IllegalArgumentException(
+               "httpClient must be a CloseableHttpClient instance in order for allowing engine to close it!");
+      }
+      this.httpClient = httpClient;
+      this.allowClosingHttpClient = closeHttpClient;
+   }
+
+   public ManualClosingApacheHttpClient43Engine(final HttpClient httpClient, final HttpContextProvider httpContextProvider)
+   {
+      this.httpClient = httpClient;
+      this.httpContextProvider = httpContextProvider;
+      this.allowClosingHttpClient = true;
+   }
+
+   /**
+    * Response stream is wrapped in a BufferedInputStream.  Default is 8192.  Value of 0 will not wrap it.
+    * Value of -1 will use a SelfExpandingBufferedInputStream
+    *
+    * @return response buffer size
+    */
+   public int getResponseBufferSize()
+   {
+      return responseBufferSize;
+   }
+
+   /**
+    * Response stream is wrapped in a BufferedInputStream.  Default is 8192.  Value of 0 will not wrap it.
+    * Value of -1 will use a SelfExpandingBufferedInputStream
+    *
+    * @param responseBufferSize response buffer size
+    */
+   public void setResponseBufferSize(int responseBufferSize)
+   {
+      this.responseBufferSize = responseBufferSize;
+   }
+
+   /**
+    * Based on memory unit
+    * @return threshold limit
+    */
+   public int getFileUploadInMemoryThresholdLimit()
+   {
+      return fileUploadInMemoryThresholdLimit;
+   }
+
+   public void setFileUploadInMemoryThresholdLimit(int fileUploadInMemoryThresholdLimit)
+   {
+      this.fileUploadInMemoryThresholdLimit = fileUploadInMemoryThresholdLimit;
+   }
+
+   public MemoryUnit getFileUploadMemoryUnit()
+   {
+      return fileUploadMemoryUnit;
+   }
+
+   public void setFileUploadMemoryUnit(MemoryUnit fileUploadMemoryUnit)
+   {
+      this.fileUploadMemoryUnit = fileUploadMemoryUnit;
+   }
+
+   public File getFileUploadTempFileDir()
+   {
+      return fileUploadTempFileDir;
+   }
+
+   public void setFileUploadTempFileDir(File fileUploadTempFileDir)
+   {
+      this.fileUploadTempFileDir = fileUploadTempFileDir;
+   }
+
+   public HttpClient getHttpClient()
+   {
+      return httpClient;
+   }
+
+   @Override
+   public SSLContext getSslContext()
+   {
+      return sslContext;
+   }
+
+   public void setSslContext(SSLContext sslContext)
+   {
+      this.sslContext = sslContext;
+   }
+
+   @Override
+   public HostnameVerifier getHostnameVerifier()
+   {
+      return hostnameVerifier;
+   }
+
+   public void setHostnameVerifier(HostnameVerifier hostnameVerifier)
+   {
+      this.hostnameVerifier = hostnameVerifier;
+   }
+
+   public static CaseInsensitiveMap<String> extractHeaders(HttpResponse response)
+   {
+      final CaseInsensitiveMap<String> headers = new CaseInsensitiveMap<String>();
+
+      for (Header header : response.getAllHeaders())
+      {
+         headers.add(header.getName(), header.getValue());
+      }
+      return headers;
+   }
+
+   protected InputStream createBufferedStream(InputStream is)
+   {
+      if (responseBufferSize == 0)
+      {
+         return is;
+      }
+      if (responseBufferSize < 0)
+      {
+         return new SelfExpandingBufferredInputStream(is);
+      }
+      return new BufferedInputStream(is, responseBufferSize);
+   }
+
+   @Override
+   public Response invoke(Invocation inv)
+   {
+      ClientInvocation request = (ClientInvocation)inv;
+      String uri = request.getUri().toString();
+      final HttpRequestBase httpMethod = createHttpMethod(uri, request.getMethod());
+      final HttpResponse res;
+      try
+      {
+         loadHttpMethod(request, httpMethod);
+
+         if (System.getSecurityManager() == null) {
+            res = httpClient.execute(httpMethod,
+                    ((httpContextProvider == null)? null : httpContextProvider.getContext()));
+         } else {
+            try {
+               res = AccessController.doPrivileged(new PrivilegedExceptionAction<HttpResponse>() {
+                  @Override
+                  public HttpResponse run() throws Exception {
+                     return httpClient.execute(httpMethod,
+                             ((httpContextProvider == null)? null : httpContextProvider.getContext()));
+                  }
+               });
+            } catch (PrivilegedActionException pae) {
+               throw new RuntimeException(pae);
+            }
+         }
+      }
+      catch (Exception e)
+      {
+         LogMessages.LOGGER.clientSendProcessingFailure(e);
+         throw new ProcessingException(Messages.MESSAGES.unableToInvokeRequest(e.toString()), e);
+      }
+      finally
+      {
+         cleanUpAfterExecute(httpMethod);
+      }
+
+      ClientResponse response = new FinalizedClientResponse(request.getClientConfiguration(), request.getTracingLogger())
+      {
+         InputStream stream;
+
+         InputStream hc4Stream;
+
+         @Override
+         protected void setInputStream(InputStream is)
+         {
+            stream = is;
+            resetEntity();
+         }
+
+         public InputStream getInputStream()
+         {
+            if (stream == null)
+            {
+               HttpEntity entity = res.getEntity();
+               if (entity == null)
+                  return null;
+               try
+               {
+                  hc4Stream = entity.getContent();
+                  stream = createBufferedStream(hc4Stream);
+               }
+               catch (IOException e)
+               {
+                  throw new RuntimeException(e);
+               }
+            }
+            return stream;
+         }
+
+         @Override
+         public void releaseConnection() throws IOException
+         {
+            releaseConnection(true);
+         }
+
+         @Override
+         public void releaseConnection(boolean consumeInputStream) throws IOException
+         {
+            if (consumeInputStream)
+            {
+               // Apache Client 4 is stupid,  You have to get the InputStream and close it if there is an entity
+               // otherwise the connection is never released.  There is, of course, no close() method on response
+               // to make this easier.
+               try
+               {
+                  // Another stupid thing...TCK is testing a specific exception from stream.close()
+                  // so, we let it propagate up.
+                  if (stream != null)
+                  {
+                     stream.close();
+                  }
+                  else
+                  {
+                     InputStream is = getInputStream();
+                     if (is != null)
+                     {
+                        is.close();
+                     }
+                  }
+               }
+               finally
+               {
+                  // just in case the input stream was entirely replaced and not wrapped, we need
+                  // to close the apache client input stream.
+                  if (hc4Stream != null)
+                  {
+                     try
+                     {
+                        hc4Stream.close();
+                     }
+                     catch (IOException ignored)
+                     {
+
+                     }
+                  }
+                  else
+                  {
+                     try
+                     {
+                        HttpEntity entity = res.getEntity();
+                        if (entity != null)
+                           entity.getContent().close();
+                     }
+                     catch (IOException ignored)
+                     {
+                     }
+
+                  }
+
+               }
+            }
+            else if (res instanceof CloseableHttpResponse)
+            {
+               try
+               {
+                  ((CloseableHttpResponse) res).close();
+               }
+               catch (IOException e)
+               {
+                  LogMessages.LOGGER.warn(Messages.MESSAGES.couldNotCloseHttpResponse(), e);
+               }
+            }
+         }
+
+      };
+      response.setProperties(request.getMutableProperties());
+      response.setStatus(res.getStatusLine().getStatusCode());
+      response.setReasonPhrase(res.getStatusLine().getReasonPhrase());
+      response.setHeaders(extractHeaders(res));
+      response.setClientConfiguration(request.getClientConfiguration());
+      return response;
+   }
+
+   protected HttpRequestBase createHttpMethod(String url, String restVerb)
+   {
+      if ("GET".equals(restVerb))
+      {
+         return new HttpGet(url);
+      }
+      else if ("POST".equals(restVerb))
+      {
+         return new HttpPost(url);
+      }
+      else
+      {
+         final String verb = restVerb;
+         return new HttpPost(url)
+         {
+            @Override
+            public String getMethod()
+            {
+               return verb;
+            }
+         };
+      }
+   }
+
+   protected void loadHttpMethod(final ClientInvocation request, HttpRequestBase httpMethod) throws Exception
+   {
+      if (isFollowRedirects())
+      {
+         setRedirectRequired(request, httpMethod);
+      }
+      else
+      {
+         setRedirectNotRequired(request, httpMethod);
+      }
+
+      if (request.getEntity() != null)
+      {
+         if (httpMethod instanceof HttpGet)
+            throw new ProcessingException(Messages.MESSAGES.getRequestCannotHaveBody());
+
+         ByteArrayOutputStream baos = new ByteArrayOutputStream();
+         request.getDelegatingOutputStream().setDelegate(baos);
+         try
+         {
+            HttpEntity entity = buildEntity(request);
+            HttpPost post = (HttpPost) httpMethod;
+            commitHeaders(request, httpMethod);
+            post.setEntity(entity);
+         }
+         catch (IOException e)
+         {
+            throw new RuntimeException(e);
+         }
+      }
+      else // no body
+      {
+         commitHeaders(request, httpMethod);
+      }
+   }
+
+   protected void commitHeaders(ClientInvocation request, HttpRequestBase httpMethod)
+   {
+      MultivaluedMap<String, String> headers = request.getHeaders().asMap();
+      for (Map.Entry<String, List<String>> header : headers.entrySet())
+      {
+         List<String> values = header.getValue();
+         for (String value : values)
+         {
+            httpMethod.addHeader(header.getKey(), value);
+         }
+      }
+   }
+
+   public boolean isChunked()
+   {
+      return chunked;
+   }
+
+   public void setChunked(boolean chunked)
+   {
+      this.chunked = chunked;
+   }
+
+   public boolean isFollowRedirects()
+   {
+      return followRedirects;
+   }
+
+   public void setFollowRedirects(boolean followRedirects)
+   {
+      this.followRedirects = followRedirects;
+   }
+
+   /**
+    * If passed httpMethod is of type HttpPost then obtain its entity. If the entity has an enclosing File then
+    * delete it by invoking this method after the request has completed. The entity will have an enclosing File
+    * only if it was too huge to fit into memory.
+    *
+    * @param httpMethod - the httpMethod to clean up.
+    */
+   protected void cleanUpAfterExecute(final HttpRequestBase httpMethod)
+   {
+      if (httpMethod != null && httpMethod instanceof HttpPost)
+      {
+         HttpPost postMethod = (HttpPost) httpMethod;
+         HttpEntity entity = postMethod.getEntity();
+         if (entity != null && entity instanceof FileExposingFileEntity)
+         {
+            File tempRequestFile = ((FileExposingFileEntity) entity).getFile();
+            try
+            {
+               boolean isDeleted = tempRequestFile.delete();
+               if (!isDeleted)
+               {
+                  handleFileNotDeletedError(tempRequestFile, null);
+               }
+            }
+            catch (Exception ex)
+            {
+               handleFileNotDeletedError(tempRequestFile, ex);
+            }
+         }
+      }
+   }
+
+   /**
+    * Build the HttpEntity to be sent to the Service as part of (POST) request. Creates a off-memory
+    * {@link FileExposingFileEntity} or a regular in-memory {@link ByteArrayEntity} depending on if the request
+    * OutputStream fit into memory when built by calling.
+    *
+    * @param request -
+    * @return - the built HttpEntity
+    * @throws IOException -
+    */
+   protected HttpEntity buildEntity(final ClientInvocation request) throws IOException
+   {
+      AbstractHttpEntity entityToBuild = null;
+      DeferredFileOutputStream memoryManagedOutStream = writeRequestBodyToOutputStream(request);
+
+      if (memoryManagedOutStream.isInMemory())
+      {
+         ByteArrayEntity entityToBuildByteArray = new ByteArrayEntity(memoryManagedOutStream.getData());
+         entityToBuildByteArray
+               .setContentType(new BasicHeader(HTTP.CONTENT_TYPE, request.getHeaders().getMediaType().toString()));
+         entityToBuild = entityToBuildByteArray;
+      }
+      else
+      {
+         entityToBuild = new FileExposingFileEntity(memoryManagedOutStream.getFile(),
+               request.getHeaders().getMediaType().toString());
+      }
+      if (request.isChunked())
+      {
+         entityToBuild.setChunked(true);
+      }
+      return (HttpEntity) entityToBuild;
+   }
+
+   /**
+    * Creates the request OutputStream, to be sent to the end Service invoked, as a
+    * <a href="http://commons.apache.org/io/api-release/org/apache/commons/io/output/DeferredFileOutputStream.html"
+    * >DeferredFileOutputStream</a>.
+    *
+    *
+    * @param request -
+    * @return - DeferredFileOutputStream with the ClientRequest written out per HTTP specification.
+    * @throws IOException -
+    */
+   private DeferredFileOutputStream writeRequestBodyToOutputStream(final ClientInvocation request) throws IOException
+   {
+      DeferredFileOutputStream memoryManagedOutStream = new DeferredFileOutputStream(
+            this.fileUploadInMemoryThresholdLimit * getMemoryUnitMultiplier(), getTempfilePrefix(), ".tmp",
+            this.fileUploadTempFileDir);
+      request.getDelegatingOutputStream().setDelegate(memoryManagedOutStream);
+      request.writeRequestBody(request.getEntityStream());
+      memoryManagedOutStream.close();
+      return memoryManagedOutStream;
+   }
+
+   /**
+    * Use context information, which will include node name, to avoid conflicts in case of multiple VMS using same
+    * temp directory location.
+    *
+    * @return -
+    */
+   protected String getTempfilePrefix()
+   {
+      return processId;
+   }
+
+   /**
+    * @return - the constant to multiply {@link #fileUploadInMemoryThresholdLimit} with based on
+    *         {@link #fileUploadMemoryUnit} enumeration value.
+    */
+   private int getMemoryUnitMultiplier()
+   {
+      switch (this.fileUploadMemoryUnit)
+      {
+         case BY :
+            return 1;
+         case KB :
+            return 1024;
+         case MB :
+            return 1024 * 1024;
+         case GB :
+            return 1024 * 1024 * 1024;
+      }
+      return 1;
+   }
+
+   /**
+    * Log that the file did not get deleted but prevent the request from failing by eating the exception.
+    * Register the file to be deleted on exit, so it will get deleted eventually.
+    *
+    * @param tempRequestFile -
+    * @param ex - a null may be passed in which case this param gets ignored.
+    */
+   private void handleFileNotDeletedError(File tempRequestFile, Exception ex)
+   {
+      LogMessages.LOGGER.warn(Messages.MESSAGES.couldNotDeleteFile(tempRequestFile.getAbsolutePath()), ex);
+      tempRequestFile.deleteOnExit();
+   }
+
+   /**
+    * We use {@link org.apache.http.entity.FileEntity} as the {@link HttpEntity} implementation when the request OutputStream has been
+    * saved to a File on disk (because it was too large to fit into memory see however, we have to delete
+    * the File supporting the <code>FileEntity</code>, otherwise the disk will soon run out of space - remember
+    * that there can be very huge files, in GB range, processed on a regular basis - and FileEntity exposes its
+    * content File as a protected field. For the enclosing parent class ( {@link ApacheHttpClient4Engine} ) to be
+    * able to get a handle to this content File and delete it, this class expose the content File.<br>
+    * This class is private scoped to prevent access to this content File outside of the parent class.
+    *
+    * @author <a href="mailto:stikoo@digitalriver.com">Sandeep Tikoo</a>
+    */
+   private static class FileExposingFileEntity extends FileEntity
+   {
+      /**
+       * @param pFile -
+       * @param pContentType -
+       */
+      @SuppressWarnings("deprecation")
+      FileExposingFileEntity(final File pFile, final String pContentType)
+      {
+         super(pFile, pContentType);
+      }
+
+      /**
+       * @return - the content File enclosed by this FileEntity.
+       */
+      File getFile()
+      {
+         return this.file;
+      }
+   }
+
+   protected HttpClient createDefaultHttpClient()
+   {
+      final HttpClientBuilder builder = HttpClientBuilder.create();
+      RequestConfig.Builder requestBuilder = RequestConfig.custom();
+      if (defaultProxy != null)
+      {
+         requestBuilder.setProxy(defaultProxy);
+      }
+      builder.disableContentCompression();
+      builder.setDefaultRequestConfig(requestBuilder.build());
+      return builder.build();
+   }
+
+   public HttpHost getDefaultProxy()
+   {
+      Configurable clientConfiguration = (Configurable) httpClient;
+      return clientConfiguration.getConfig().getProxy();
+   }
+
+   protected void setRedirectRequired(final ClientInvocation request, final HttpRequestBase httpMethod)
+   {
+      RequestConfig.Builder requestBuilder = RequestConfig.copy(getCurrentConfiguration(request, httpMethod));
+      requestBuilder.setRedirectsEnabled(true);
+      httpMethod.setConfig(requestBuilder.build());
+   }
+
+   protected void setRedirectNotRequired(final ClientInvocation request, final HttpRequestBase httpMethod)
+   {
+      RequestConfig.Builder requestBuilder = RequestConfig.copy(getCurrentConfiguration(request, httpMethod));
+      requestBuilder.setRedirectsEnabled(false);
+      httpMethod.setConfig(requestBuilder.build());
+   }
+
+   private RequestConfig getCurrentConfiguration(final ClientInvocation request, final HttpRequestBase httpMethod)
+   {
+      RequestConfig baseConfig;
+      if (httpMethod != null && httpMethod.getConfig() != null)
+      {
+         baseConfig = httpMethod.getConfig();
+      }
+      else
+      {
+         ManualClosingApacheHttpClient43Engine engine = ((ManualClosingApacheHttpClient43Engine) request.getClient().httpEngine());
+         baseConfig = ((Configurable) engine.getHttpClient()).getConfig();
+         if (baseConfig == null)
+         {
+            Configurable clientConfiguration = (Configurable) httpClient;
+            baseConfig = clientConfiguration.getConfig();
+         }
+      }
+      return baseConfig;
+   }
+
+   public boolean isClosed()
+   {
+      return closed;
+   }
+
+   public void close()
+   {
+      if (closed)
+         return;
+
+      if (allowClosingHttpClient && httpClient != null)
+      {
+         try
+         {
+            ((CloseableHttpClient) httpClient).close();
+         }
+         catch (Exception e)
+         {
+            throw new RuntimeException(e);
+         }
+      }
+      closed = true;
+   }
+
+}


### PR DESCRIPTION
This PR is the first to enable EE9 testing for com.ibm.ws.jaxrs.2.0_fat testcases.   Tests that are skipped with the @SkipForRepeat("EE9_FEATURES") will be addressed in future PRs.