### PR TITLE
Get the jboss properties file into the coord war

### DIFF
--- a/dev/io.openliberty.org.jboss.narayana.rts.lra-coordinator/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.narayana.rts.lra-coordinator/bnd.bnd
@@ -52,9 +52,13 @@ Import-Package: \
 
 instrument.disabled: true
 
+# The coordinator jar is added via includeresource, as it means that non-class files get
+# pulled in, specifically the the jbossts properties file
+-includeresource: \
+  @${repo;org.jboss.narayana.rts:lra-coordinator-jar;5.10.6.Final;EXACT}!/!(META-INF/*)
+
 -buildpath: \
   org.jboss.logging:jboss-logging;version=3.4.1.Final, \
-  org.jboss.narayana.rts:lra-coordinator-jar;version=${narayanaVersion}.Final, \
   org.jboss.narayana.arjunacore:arjuna;version=${narayanaVersion}.Final, \
   org.jboss.narayana:common;version=${narayanaVersion}.Final, \
   org.jboss.narayana.rts:lra-service-base;version=${narayanaVersion}.Final, \


### PR DESCRIPTION
Use includeresource to pull in the lra-coordinator jar from maven
rather than putting it on the buildpath. This means that files which
aren't class files get included as well

