### PR TITLE
Don't produce FFDC when fallback throws exception 

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/FallbackStateImpl.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/src/com/ibm/ws/microprofile/faulttolerance20/state/impl/FallbackStateImpl.java
@@ -12,6 +12,7 @@ package com.ibm.ws.microprofile.faulttolerance20.state.impl;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.microprofile.faulttolerance.spi.FallbackPolicy;
 import com.ibm.ws.microprofile.faulttolerance20.impl.MethodResult;
 import com.ibm.ws.microprofile.faulttolerance20.impl.SyncExecutionContextImpl;
@@ -27,6 +28,7 @@ public class FallbackStateImpl implements FallbackState {
         this.policy = policy;
     }
 
+    @FFDCIgnore(Throwable.class)
     @SuppressWarnings("unchecked")
     @Override
     public <R> MethodResult<R> runFallback(MethodResult<R> result, SyncExecutionContextImpl executionContext) {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/FallbackServlet.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/FallbackServlet.java
@@ -13,7 +13,9 @@ package com.ibm.ws.microprofile.faulttolerance_fat.cdi;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.concurrent.Future;
@@ -96,6 +98,26 @@ public class FallbackServlet extends FATServlet {
         Connection connection = future.get();
         assertThat("Result data", connection.getData(), equalTo("fallbackAsync"));
         assertThat("Call count", bean.getConnectCountD(), equalTo(3));
+    }
+
+    @Test
+    public void testFallbackMethodThrowingException() {
+        try {
+            bean.fallbackMethodThrowsException();
+            fail("No Exception thrown");
+        } catch (RuntimeException e) {
+            assertEquals("FallbackBean.exceptionalFallbackMethod", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testFallbackHandlerThrowingException() {
+        try {
+            bean.fallbackHandlerThrowsException();
+            fail("No exception thrown");
+        } catch (RuntimeException e) {
+            assertEquals("ExceptionalHandler.handle", e.getMessage());
+        }
     }
 
 }

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/ParentFallbackBean.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/test-applications/CDIFaultTolerance.war/src/com/ibm/ws/microprofile/faulttolerance_fat/cdi/beans/ParentFallbackBean.java
@@ -13,10 +13,12 @@ package com.ibm.ws.microprofile.faulttolerance_fat.cdi.beans;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.RequestScoped;
 
 import org.eclipse.microprofile.faulttolerance.ExecutionContext;
 import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.FallbackHandler;
 import org.eclipse.microprofile.faulttolerance.Retry;
 
 import com.ibm.ws.microprofile.faulttolerance_fat.util.ConnectException;
@@ -64,6 +66,31 @@ public class ParentFallbackBean {
 
     public int getConnectCountB() {
         return connectCountB;
+    }
+
+    @Fallback(fallbackMethod = "exceptionalFallbackMethod")
+    public void fallbackMethodThrowsException() {
+        throw new RuntimeException("FallbackBean.fallbackMethodThrowsException");
+    }
+
+    @SuppressWarnings("unused")
+    private void exceptionalFallbackMethod() {
+        throw new RuntimeException("FallbackBean.exceptionalFallbackMethod");
+    }
+
+    @Fallback(ExceptionalHandler.class)
+    public Connection fallbackHandlerThrowsException() {
+        throw new RuntimeException("FallbackBean.fallbackHandlerThrowsException");
+    }
+
+    @ApplicationScoped
+    public static class ExceptionalHandler implements FallbackHandler<Connection> {
+
+        @Override
+        public Connection handle(ExecutionContext context) {
+            throw new RuntimeException("ExceptionalHandler.handle");
+        }
+
     }
 
 }


### PR DESCRIPTION
If the user's fallback handler or method throws an exception, we should not create an FFDC since this does not represent an internal failure.

Fixes #13073
