### PR TITLE
wait for the LTPA service to be ready when starting the test server

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/securitycontext/CustomSecurityContextTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/securitycontext/CustomSecurityContextTest.java
@@ -44,6 +44,7 @@ public class CustomSecurityContextTest {
         try {
             server.startServer();
             assertNotNull("FeatureManager did not report update was complete", server.waitForStringInLog("CWWKF0008I"));
+            assertNotNull("LTPA configuration should report it is ready", server.waitForStringInLog("CWWKS4105I"));
         } catch (Exception e) {
             System.out.println(e.toString());
         }


### PR DESCRIPTION
Fixes build break https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=278101

We have to wait for the LTPA service when starting the server.