### PR TITLE
Issue #14129: Fix EJB remote client auto feature

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.enterpriseBeansRemoteClientServer-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.enterpriseBeansRemoteClientServer-2.0.feature
@@ -5,7 +5,7 @@
 symbolicName=io.openliberty.enterpriseBeansRemoteClientServer-2.0
 visibility=private
 IBM-API-Package: com.ibm.ws.clientcontainer.remote.common;type="internal"
-IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.enterpriseBeansRemote-4.0))", \
+IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.enterpriseBeansRemote-4.0))", \
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.clientContainerRemoteSupportCommon-1.0))"
 IBM-Install-Policy: when-satisfied
 -features=com.ibm.websphere.appserver.clientContainerRemoteSupportCommon-1.0


### PR DESCRIPTION
EJB remote client auto feature incorrectly references com.ibm.websphere.appserver.enterpriseBeansRemote-4.0
which doesn't exist; replace with io.openliberty.enterpriseBeansRemote-4.0

fixes #14129 