### PR TITLE
Fix various timing problems in the new Logstash collector FAT

### DIFF
--- a/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/CustomizedTagTest.java
+++ b/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/CustomizedTagTest.java
@@ -110,7 +110,10 @@ public class CustomizedTagTest extends LogstashCollectorTest {
 
         // Create FFDC and access log event
         createFFDCEvent(1);
+        assertNotNull(waitForStringInContainerOutput(LIBERTY_MESSAGE));
+        assertNotNull(waitForStringInContainerOutput(LIBERTY_TRACE));
         assertNotNull(waitForStringInContainerOutput(LIBERTY_FFDC));
+        assertNotNull(waitForStringInContainerOutput(LIBERTY_ACCESSLOG));
 
         // Check results
         List<JSONObject> jObjList = parseJsonInContainerOutput();

--- a/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashCollectorTest.java
+++ b/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashCollectorTest.java
@@ -147,6 +147,11 @@ public abstract class LogstashCollectorTest {
         runApp(url);
     }
 
+    protected void createGCEvent() {
+        String url = getAppUrl() + "?gc=true";
+        runApp(url);
+    }
+
     private static void runApp(String url) {
         String method = "runApp";
         Log.info(c, method, "---> Running the application with url : " + url);

--- a/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
+++ b/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
@@ -145,6 +145,7 @@ public class LogstashSSLTest extends LogstashCollectorTest {
         assertNotNull(LIBERTY_FFDC + " not found", waitForStringInContainerOutput(LIBERTY_FFDC));
         assertNotNull(LIBERTY_ACCESSLOG + " not found", waitForStringInContainerOutput(LIBERTY_ACCESSLOG));
         if (!checkGcSpecialCase()) {
+            createGCEvent();
             assertNotNull(LIBERTY_GC + " not found", waitForStringInContainerOutput(LIBERTY_GC));
         }
     }
@@ -186,6 +187,7 @@ public class LogstashSSLTest extends LogstashCollectorTest {
         for (int i = 1; i <= 10; i++) {
             createMessageEvent(testName + " " + i);
         }
+        createGCEvent();
         assertNotNull(LIBERTY_GC + " not found", waitForStringInContainerOutput(LIBERTY_GC));
     }
 

--- a/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
+++ b/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
@@ -93,6 +93,8 @@ public class LogstashSSLTest extends LogstashCollectorTest {
     public void testLogstashDefaultConfig() throws Exception {
         testName = "testLogstashDefaultConfig";
         setConfig("server_default_conf.xml");
+        assertNotNull("Cannot find TRAS0218I from messages.log", server.waitForStringInLogUsingMark("TRAS0218I"));
+
         clearContainerOutput();
 
         int numOfMsg = 10;
@@ -102,8 +104,6 @@ public class LogstashSSLTest extends LogstashCollectorTest {
             createMessageEvent(testName + " " + i);
             checkSet.add(MESSAGE_PREFIX + " " + testName + " " + i);
         }
-
-        assertNotNull("Cannot find TRAS0218I from messages.log", server.waitForStringInLogUsingMark("TRAS0218I"));
 
         assertEquals(numOfMsg, waitForContainerOutputSize(numOfMsg));
         assertNotNull("Cannot find message " + testName + " from Logstash output", waitForStringInContainerOutput(testName));

--- a/dev/com.ibm.ws.logstash.collector_fat/test-applications/LogstashApp/src/com/ibm/logs/LogstashServlet.java
+++ b/dev/com.ibm.ws.logstash.collector_fat/test-applications/LogstashApp/src/com/ibm/logs/LogstashServlet.java
@@ -49,24 +49,33 @@ public class LogstashServlet extends HttpServlet {
             myString.toString();
         }
         String secondFFDC = req.getParameter("secondFFDC");
-
         if ((secondFFDC != null) && (secondFFDC.equalsIgnoreCase("true"))) {
             int i = 10 / 0;
         }
 
         String thirdFFDC = req.getParameter("thirdFFDC");
-
         if ((thirdFFDC != null) && (thirdFFDC.equalsIgnoreCase("true"))) {
-
             int[] a = { 0, 1, 2, 3 };
             a[6] = 10;
         }
 
+        String gc = req.getParameter("gc");
+        if ((gc != null) && (gc.equalsIgnoreCase("true"))) {
+            performGC();
+        }
+
         res.setContentType("text/html");
-
         out = res.getWriter();
-
         out.println("<HTML><HEAD><TITLE>Just a Servlet</TITLE></HEAD><BODY BGCOLOR=\"#FFFFEE\">");
 
+    }
+
+    private void performGC() {
+        String[] sa = new String[1000];
+        for (int i = 0; i < 1000; i++) {
+            sa[i] = "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789";
+        }
+        sa = null;
+        System.gc();
     }
 }


### PR DESCRIPTION
- Moved up wait for TRAS0218I so that the container output will only contain the 10 messages.
fixes #14128 

- Added more wait for the events
fixes #14142 

- Added a createGCEvent() method to create GC events
fixes #14143 