### PR TITLE
MP JWT 1.2 update for audience handling

### DIFF
--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/config/JwtConsumerConfig.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/config/JwtConsumerConfig.java
@@ -26,6 +26,8 @@ public interface JwtConsumerConfig {
 
     List<String> getAudiences();
 
+    boolean ignoreAudClaimIfNotConfigured();
+
     String getSignatureAlgorithm();
 
     String getTrustStoreRef();
@@ -51,6 +53,6 @@ public interface JwtConsumerConfig {
     boolean getTokenReuse();
 
     boolean getUseSystemPropertiesForHttpClientConnections();
-    
-	List<String> getAMRClaim();
+
+    List<String> getAMRClaim();
 }

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/ConsumerUtil.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/ConsumerUtil.java
@@ -449,12 +449,7 @@ public class ConsumerUtil {
 
         validateIssuer(config.getId(), issuer, jwtClaims.getIssuer());
 
-        List<String> allowedAudiences = getConfiguredAudiences(config);
-        if (!validateAudience(allowedAudiences, jwtClaims.getAudience())) {
-            String msg = Tr.formatMessage(tc, "JWT_AUDIENCE_NOT_TRUSTED",
-                    new Object[] { jwtClaims.getAudience(), config.getId(), allowedAudiences });
-            throw new InvalidClaimException(msg);
-        }
+        validateAudience(config, jwtClaims.getAudience());
 
         if (!validateAMRClaim(config.getAMRClaim(), getJwtAMRList(jwtClaims))) {
             String msg = Tr.formatMessage(tc, "JWT_AMR_CLAIM_NOT_VALID",
@@ -541,6 +536,17 @@ public class ConsumerUtil {
             }
         }
         return audiences;
+    }
+
+    void validateAudience(JwtConsumerConfig config, List<String> audiences) throws InvalidClaimException {
+        List<String> allowedAudiences = getConfiguredAudiences(config);
+        if (allowedAudiences == null && config.ignoreAudClaimIfNotConfigured()) {
+            return;
+        }
+        if (!validateAudience(allowedAudiences, audiences)) {
+            String msg = Tr.formatMessage(tc, "JWT_AUDIENCE_NOT_TRUSTED", new Object[] { audiences, config.getId(), allowedAudiences });
+            throw new InvalidClaimException(msg);
+        }
     }
 
     /**

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/JwtConsumerConfigImpl.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/JwtConsumerConfigImpl.java
@@ -139,6 +139,11 @@ public class JwtConsumerConfigImpl implements JwtConsumerConfig {
     }
 
     @Override
+    public boolean ignoreAudClaimIfNotConfigured() {
+        return false;
+    }
+
+    @Override
     public String getSignatureAlgorithm() {
         return sigAlg;
     }

--- a/dev/com.ibm.ws.security.jwtsso/src/com/ibm/ws/security/jwtsso/internal/JwtSsoComponent.java
+++ b/dev/com.ibm.ws.security.jwtsso/src/com/ibm/ws/security/jwtsso/internal/JwtSsoComponent.java
@@ -284,6 +284,11 @@ public class JwtSsoComponent implements JwtSsoConfig {
 		return null;
 	}
 
+    @Override
+    public boolean ignoreAudClaimIfNotConfigured() {
+        return false;
+    }
+
 	/** {@inheritDoc} */
 	@Override
 	public String getSignatureAlgorithm() {

--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/impl/MicroProfileJwtConfigImpl.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/impl/MicroProfileJwtConfigImpl.java
@@ -84,6 +84,8 @@ public class MicroProfileJwtConfigImpl implements MicroProfileJwtConfig {
     public static final String KEY_AUDIENCE = "audiences";
     String[] audience = null;
 
+    boolean ignoreAudClaimIfNotConfigured = false;
+
     public static final String CFG_KEY_HOST_NAME_VERIFICATION_ENABLED = "hostNameVerificationEnabled";
     protected boolean hostNameVerificationEnabled = false;
 
@@ -205,15 +207,7 @@ public class MicroProfileJwtConfigImpl implements MicroProfileJwtConfig {
     }
 
     void loadConfigValuesForHigherVersions(ComponentContext cc, Map<String, Object> props) {
-        MpJwtRuntimeVersion runtimeVersion = getMpJwtRuntimeVersion();
-        if (runtimeVersion == null) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Failed to find runtime version");
-            }
-            return;
-        }
-        Version version = runtimeVersion.getVersion();
-        if (version.compareTo(MpJwtRuntimeVersion.VERSION_1_2) < 0) {
+        if (!isRuntimeVersionAtLeast(MpJwtRuntimeVersion.VERSION_1_2)) {
             return;
         }
         if (tc.isDebugEnabled()) {
@@ -221,6 +215,21 @@ public class MicroProfileJwtConfigImpl implements MicroProfileJwtConfig {
         }
         tokenHeader = configUtils.getConfigAttribute(props, KEY_TOKEN_HEADER);
         cookieName = configUtils.getConfigAttribute(props, KEY_COOKIE_NAME);
+        // Ensure that for MP JWT 1.2 and above that "aud" claim is allowed in tokens even if audiences or
+        // mp.jwt.verify.audiences are not configured
+        ignoreAudClaimIfNotConfigured = true;
+    }
+
+    boolean isRuntimeVersionAtLeast(Version minimumVersionRequired) {
+        MpJwtRuntimeVersion runtimeVersion = getMpJwtRuntimeVersion();
+        if (runtimeVersion == null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Failed to find runtime version");
+            }
+            return false;
+        }
+        Version version = runtimeVersion.getVersion();
+        return (version.compareTo(minimumVersionRequired) < 0);
     }
 
     MpJwtRuntimeVersion getMpJwtRuntimeVersion() {
@@ -286,6 +295,11 @@ public class MicroProfileJwtConfigImpl implements MicroProfileJwtConfig {
         } else {
             return null;
         }
+    }
+
+    @Override
+    public boolean ignoreAudClaimIfNotConfigured() {
+        return ignoreAudClaimIfNotConfigured;
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/OidcLoginConfigImpl.java
@@ -466,6 +466,11 @@ public class OidcLoginConfigImpl extends Oauth2LoginConfigImpl implements JwtCon
         return audiences;
     }
 
+    @Override
+    public boolean ignoreAudClaimIfNotConfigured() {
+        return false;
+    }
+
     /** {@inheritDoc} */
     @Override
     public boolean isValidationRequired() { // TODO may need to be set from configuration


### PR DESCRIPTION
Updates how MP JWT 1.2 will handle verifying `"aud"` claims in tokens. The existing behavior is to fail token validation if the JWT includes an `"aud"` claim without `audiences` being configured in the server configuration. Since the MP JJWT spec indicates the `"aud"` claim is optional, we're updating the token validation logic to allow this scenario for MP JWT versions 1.2 and above.