### PR TITLE
7056: Allow all HTTP methods with Http/2

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpRequestMessageImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpRequestMessageImpl.java
@@ -319,7 +319,7 @@ public class HttpRequestMessageImpl extends HttpBaseMessageImpl implements HttpR
         for (Entry<String, String> entry : pseudoHeaders.entrySet()) {
             H2HeaderField header = new H2HeaderField(entry.getKey(), entry.getValue());
             if (!isValidPseudoHeader(header)) {
-                ProtocolException pe = new ProtocolException("Invalid pseudo-header for decompression context: " + header.toString()); 
+                ProtocolException pe = new ProtocolException("Invalid pseudo-header for decompression context: " + header.toString());
                 pe.setConnectionError(false); // mark this as a stream error so we'll generate an RST_STREAM
                 throw pe;
             }
@@ -327,7 +327,7 @@ public class HttpRequestMessageImpl extends HttpBaseMessageImpl implements HttpR
 
         //Authority is not required to be present, check if it is.
         if (pseudoHeaders.containsKey(HpackConstants.METHOD)) {
-            this.setMethod(pseudoHeaders.get(HpackConstants.METHOD));
+            this.setMethod(MethodValues.find(pseudoHeaders.get(HpackConstants.METHOD)));
         }
         if (pseudoHeaders.containsKey(HpackConstants.PATH)) {
             this.setRequestURI(pseudoHeaders.get(HpackConstants.PATH));
@@ -2169,14 +2169,15 @@ public class HttpRequestMessageImpl extends HttpBaseMessageImpl implements HttpR
 
     /**
      * Check the to see if the current remote host is allowed to send a private header
-     * @see HttpDispatcher.usePrivateHeaders()
      * 
-     * @param key WAS private header 
+     * @see HttpDispatcher.usePrivateHeaders()
+     *
+     * @param key WAS private header
      * @return true if the remote host is allowed to send key
      */
     private boolean isPrivateHeaderTrusted(HeaderKeys key) {
         HttpServiceContextImpl hisc = getServiceContext();
-        InetAddress remoteAddr = null;       
+        InetAddress remoteAddr = null;
         String address = null;
         if (hisc != null && (remoteAddr = hisc.getRemoteAddr()) != null) {
             address = remoteAddr.getHostAddress();

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpRequestMessageImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpRequestMessageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2019 IBM Corporation and others.
+ * Copyright (c) 2004, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -2169,7 +2169,7 @@ public class HttpRequestMessageImpl extends HttpBaseMessageImpl implements HttpR
 
     /**
      * Check the to see if the current remote host is allowed to send a private header
-     * 
+     *
      * @see HttpDispatcher.usePrivateHeaders()
      *
      * @param key WAS private header


### PR DESCRIPTION
Http/2 and Http/1.1 are behaving differently with regards to non-standard http methods.

Http/1.1 allows the PATCH method to go through while Http/2 gives a 501 unimplemented error.

Change this so that any method will be accepted at this layer for both protocols.

