### PR TITLE
Various fixes for Logstash FAT with Testcontainers

### DIFF
--- a/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashCollectorTest.java
+++ b/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashCollectorTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertNotNull;
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -185,6 +186,7 @@ public abstract class LogstashCollectorTest {
                     .withFileFromFile("/usr/share/logstash/config/logstash.key", new File(PATH_TO_AUTOFVT_TESTFILES + "logstash.key"), 644) //
                     .withFileFromFile("/usr/share/logstash/config/logstash.crt", new File(PATH_TO_AUTOFVT_TESTFILES + "logstash.crt"), 644)) //
                                     .withExposedPorts(5043) //
+                                    .withStartupTimeout(Duration.ofSeconds(90)) //
                                     .withLogConsumer(LogstashCollectorTest::log); //
 
     // This helper method is passed into `withLogConsumer()` of the container

--- a/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
+++ b/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
@@ -158,7 +158,7 @@ public class LogstashSSLTest extends LogstashCollectorTest {
 
         createMessageEvent(testName);
 
-        assertNotNull("Cannot find TRAS0218I from messages.log", server.waitForStringInLogUsingMark("TRAS0218I", 10000));
+        assertNotNull("Cannot find TRAS0218I from messages.log", server.waitForStringInLogUsingMark("TRAS0218I"));
         assertNotNull("Did not find " + LIBERTY_MESSAGE, waitForStringInContainerOutput(LIBERTY_MESSAGE));
     }
 
@@ -170,7 +170,7 @@ public class LogstashSSLTest extends LogstashCollectorTest {
 
         createAccessLogEvent(testName);
 
-        assertNotNull("Cannot find TRAS0218I from messages.log", server.waitForStringInLogUsingMark("TRAS0218I", 10000));
+        assertNotNull("Cannot find TRAS0218I from messages.log", server.waitForStringInLogUsingMark("TRAS0218I"));
         assertNotNull("Did not find " + LIBERTY_ACCESSLOG, waitForStringInContainerOutput(testName));
     }
 
@@ -207,7 +207,7 @@ public class LogstashSSLTest extends LogstashCollectorTest {
         createFFDCEvent(3);
         Log.info(c, testName, "------> finished ffdc3(ArrayIndexOutOfBoundsException)");
         exceptions.add("ArrayIndexOutOfBoundsException");
-        assertNotNull("Cannot find TRAS0218I from messages.log", server.waitForStringInLogUsingMark("TRAS0218I", 10000));
+        assertNotNull("Cannot find TRAS0218I from messages.log", server.waitForStringInLogUsingMark("TRAS0218I"));
 
         assertNotNull(LIBERTY_FFDC + " not found", waitForStringInContainerOutput(LIBERTY_FFDC));
         assertNotNull("ArithmeticException not found", waitForStringInContainerOutput("ArithmeticException"));

--- a/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
+++ b/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
@@ -429,8 +429,8 @@ public class LogstashSSLTest extends LogstashCollectorTest {
             }
             Log.info(c, testName, " jar file for health center under path " + JAVA_HOME + "/lib/ext/healthcenter.jar exist:"
                                   + new File(JAVA_HOME + "/lib/ext/healthcenter.jar").exists());
-        } else if (JAVA_HOME.endsWith("bin")) {
-            healthCenterInstalled = findHealthCenterDirecotry(JAVA_HOME.substring(0, JAVA_HOME.indexOf("bin") + 1));
+        } else if ((JAVA_HOME.endsWith("/bin")) || (JAVA_HOME.endsWith("\\bin"))) {
+            healthCenterInstalled = findHealthCenterDirecotry(JAVA_HOME.substring(0, JAVA_HOME.length() - 4));
             if (!healthCenterInstalled) {
                 Log.info(c, testName, " unable to find heathcenter.jar, thus unable to produce gc events. Thus, this check will be by-passed");
             }
@@ -449,19 +449,24 @@ public class LogstashSSLTest extends LogstashCollectorTest {
 
     private boolean findHealthCenterDirecotry(String directoryPath) {
         boolean jarFileExist = false;
-        File[] files = new File(directoryPath).listFiles();
-        for (File file : files) {
-            if (file.isDirectory()) {
-                jarFileExist = findHealthCenterDirecotry(file.getAbsolutePath());
-                if (jarFileExist == true) {
-                    return true;
-                }
-            } else {
-                if (file.getAbsolutePath().contains("healthcenter.jar")) {
-                    Log.info(c, testName, " healthcetner.jar is found under path " + file.getAbsolutePath());
-                    return true;
+        File dirFile = new File(directoryPath);
+        if (dirFile.exists()) {
+            File[] files = dirFile.listFiles();
+            for (File file : files) {
+                if (file.isDirectory()) {
+                    jarFileExist = findHealthCenterDirecotry(file.getAbsolutePath());
+                    if (jarFileExist == true) {
+                        return true;
+                    }
+                } else {
+                    if (file.getAbsolutePath().contains("healthcenter.jar")) {
+                        Log.info(c, testName, " healthcetner.jar is found under path " + file.getAbsolutePath());
+                        return true;
+                    }
                 }
             }
+        } else {
+            Log.info(c, "findHealthCenterDirecotry", "directoryPath " + directoryPath + " does not exist");
         }
         return jarFileExist;
     }

--- a/dev/com.ibm.ws.logstash.collector_fat/publish/files/logstash.yml
+++ b/dev/com.ibm.ws.logstash.collector_fat/publish/files/logstash.yml
@@ -1,1 +1,2 @@
 xpack.monitoring.enabled: false
+pipeline.batch.size: 1


### PR DESCRIPTION
Increase container startup timeout to 90 seconds.
fixes #14202 

Java 14's JAVA_HOME contains "_bin".  Added "/" when checking the JAVA_HOME ending with "bin" directory.
fixes #14201 

Add a loop to retry until the expected number of events are found
fixes #14200 

Add `pipeline.batch.size: 1` to `logstash.yml` and hopefully this will reduce the delay of events.
fixes #14199