### PR TITLE
None as a configurable mpcontext type

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.1_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp.1.1_fat_tck/publish/tckRunner/pom.xml
@@ -38,6 +38,12 @@
                 <version>1.2</version>
             </dependency>
             <dependency>
+	            <groupId>jakarta.transaction</groupId>
+	            <artifactId>jakarta.transaction-api</artifactId>
+	            <version>1.3.3</version>
+	            <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
                 <version>${arquillian.version}</version>

--- a/dev/com.ibm.ws.concurrent.mp.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -75,6 +75,13 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+            <version>1.3.3</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>6.9.9</version>

--- a/dev/com.ibm.ws.microprofile.contextpropagation.1.0/src/com/ibm/ws/microprofile/contextpropagation/MPConfigAccessorImpl.java
+++ b/dev/com.ibm.ws.microprofile.contextpropagation.1.0/src/com/ibm/ws/microprofile/contextpropagation/MPConfigAccessorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -51,7 +51,7 @@ public class MPConfigAccessorImpl implements MPConfigAccessor {
             // an empty String array or a size 1 String array where the element is the empty string.
             // Allow for both possibilities,
             String[] arr = ((String[]) value);
-            if (arr.length == 1 && arr[0].length() == 0) {
+            if (arr.length == 1 && (arr[0].length() == 0 || "None".equals(arr[0]))) {
                 if (defaultValue instanceof Set)
                     value = (T) Collections.EMPTY_SET;
                 else // TODO remove if config annotations are removed


### PR DESCRIPTION
MP Config 2.0 is getting rid of type ability to specify an empty list/array/String as a value for config properties. This will now indicate unspecified.  MP Context Propagation is adding a new way to specify an empty context list -- the value "None" -- under https://github.com/eclipse/microprofile-context-propagation/issues/160 / https://github.com/eclipse/microprofile-context-propagation/pull/198 .

This pull is open to align OpenLiberty with that by supporting the value None.  Make sure not to merge this pull until the corresponding MP Context Propagation spec pull is merged first.