### PR TITLE
Enablement of jaxws-2.3 FAT tests in com.ibm.ws.jaxws.2.2.webcontainer_fat

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxws-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jaxws-2.3.feature
@@ -29,6 +29,7 @@ Subsystem-Name: Internal Java Web Services 2.3
  com.ibm.ws.org.apache.cxf.cxf.rt.wsdl.3.2, \
  com.ibm.ws.org.apache.cxf.cxf.tools.common.3.2, \
  com.ibm.ws.org.apache.cxf.cxf.tools.validator.3.2, \
+ com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2, \
  com.ibm.ws.org.jvnet.mimepull, \
  com.ibm.websphere.javaee.jws.1.0; require-java:="9"; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.jws:jsr181-api:1.0-MR1",\
  com.ibm.websphere.javaee.jaxws.2.3; location:="dev/api/spec/"; apiJar=false,\

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/bnd.bnd
@@ -49,7 +49,9 @@ src: \
 fat.project: true
 
 # These features get added programmatically
-#tested.features:
+tested.features: jaxws-2.3, \
+  jaxb-2.3, \
+  servlet-4.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.2,\

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/BindingTypeWsdlMismatchTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/BindingTypeWsdlMismatchTest.java
@@ -20,12 +20,14 @@ import org.junit.runner.RunWith;
 import com.ibm.ws.jaxws.fat.util.TestUtils;
 
 import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 
 /**
  * Test the binding type is align with the wsdl file if specified.
  */
 @RunWith(FATRunner.class)
+@SkipForRepeat("jaxws-2.3")
 public class BindingTypeWsdlMismatchTest extends BindingTypeWsdlMismatchTest_Lite {
 
     /**

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/BindingTypeWsdlMismatchTest_Lite.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/BindingTypeWsdlMismatchTest_Lite.java
@@ -20,11 +20,13 @@ import com.ibm.ws.jaxws.fat.util.ExplodedShrinkHelper;
 import com.ibm.ws.jaxws.fat.util.TestUtils;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.topology.impl.LibertyServer;
 
 /**
  * Test the binding type is align with the wsdl file if specified.
  */
+@SkipForRepeat("jaxws-2.3")
 public class BindingTypeWsdlMismatchTest_Lite {
 
     @Server("BindingTypeWsdlMismatchTestServer")

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/CatalogFacilityTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/CatalogFacilityTest.java
@@ -25,11 +25,13 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("jaxws-2.3")
 public class CatalogFacilityTest {
 
     @Server("CatalogFacilityTestServer")

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/EJBServiceRefBndTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/EJBServiceRefBndTest.java
@@ -33,12 +33,14 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxws.fat.util.ExplodedShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.HttpUtils;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("jaxws-2.3")
 public class EJBServiceRefBndTest {
     private static final int CONN_TIMEOUT = 5;
 

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/FATSuite.java
@@ -10,9 +10,13 @@
  *******************************************************************************/
 package com.ibm.ws.jaxws.fat;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -37,4 +41,8 @@ import org.junit.runners.Suite.SuiteClasses;
                 HandlerChainWithWebServiceClientTest.class,
                 VirtualHostTest.class
 })
-public class FATSuite {}
+public class FATSuite {
+    @ClassRule
+    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction().addFeature("jaxws-2.3").removeFeature("jaxws-2.2").removeFeature("jsp-2.2").withID("jaxws-2.3"));
+
+}

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/HandlerChainTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/HandlerChainTest.java
@@ -31,11 +31,13 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("jaxws-2.3")
 public class HandlerChainTest {
 
     private static final String CLIENT_APP_LOCATION_DROPINS = "dropins/testHandlerClient.war";

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/HandlerChainWithWebServiceClientTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/HandlerChainWithWebServiceClientTest.java
@@ -24,11 +24,13 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("jaxws-2.3")
 public class HandlerChainWithWebServiceClientTest {
 
     @Server("HandlerChainWithWebServiceClientTest")

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/HttpConduitPropertiesTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/HttpConduitPropertiesTest.java
@@ -32,11 +32,13 @@ import com.ibm.ws.jaxws.fat.util.ExplodedShrinkHelper;
 import com.ibm.ws.jaxws.fat.util.TestUtils;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("jaxws-2.3")
 public class HttpConduitPropertiesTest {
     private static final int CONN_TIMEOUT = 10;
 

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/MTOMTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/MTOMTest.java
@@ -30,6 +30,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
@@ -41,6 +42,7 @@ import componenttest.topology.utils.HttpUtils;
  * service.addPort(portName, SOAPBinding.SOAP11HTTP_MTOM_BINDING, mtom11URL) statement.
  */
 @RunWith(FATRunner.class)
+@SkipForRepeat("jaxws-2.3")
 public class MTOMTest {
     private static final int REQUEST_TIMEOUT = 10;
 

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/PortComponentRefTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/PortComponentRefTest.java
@@ -21,6 +21,7 @@ import com.ibm.ws.jaxws.fat.util.ExplodedShrinkHelper;
 import com.ibm.ws.jaxws.fat.util.TestUtils;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
@@ -28,6 +29,7 @@ import componenttest.topology.impl.LibertyServer;
  * This Test is to verify the functionality of the <port-component-ref> is working.
  */
 @RunWith(FATRunner.class)
+@SkipForRepeat("jaxws-2.3")
 public class PortComponentRefTest {
 
     @Server("PortComponentRefTestServer")

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/ServerSideStubClientTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/ServerSideStubClientTest.java
@@ -25,11 +25,13 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("jaxws-2.3")
 public class ServerSideStubClientTest {
 
     private static final int CONN_TIMEOUT = 5;

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/VirtualHostTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/VirtualHostTest.java
@@ -27,10 +27,12 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("jaxws-2.3")
 public class VirtualHostTest {
 
     @Server("com.ibm.ws.jaxws.virtualhost")

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceInWebXMLTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceInWebXMLTest.java
@@ -28,10 +28,12 @@ import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
+@SkipForRepeat("jaxws-2.3")
 public class WebServiceInWebXMLTest extends WebServiceInWebXMLTest_Lite {
     private final Class<?> c = WebServiceInWebXMLTest.class;
 

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceInWebXMLTest_Lite.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceInWebXMLTest_Lite.java
@@ -29,11 +29,13 @@ import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("jaxws-2.3")
 public class WebServiceInWebXMLTest_Lite {
 
     public static final int CONN_TIMEOUT = 5;

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceRefFeaturesTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceRefFeaturesTest.java
@@ -26,11 +26,13 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat("jaxws-2.3")
 public class WebServiceRefFeaturesTest {
 
     @Server("WebServiceRefFeaturesTestServer")

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceRefTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceRefTest.java
@@ -36,7 +36,6 @@ public class WebServiceRefTest {
 
     @Server("WebServiceRefTestServer")
     public static LibertyServer server;
-
     private static String BASE_URL;
     private static final int CONN_TIMEOUT = 5;
 

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WsBndEndpointOverrideTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WsBndEndpointOverrideTest.java
@@ -24,12 +24,14 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxws.fat.util.ExplodedShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.topology.impl.LibertyServer;
 
 /**
  * This test is to verify the custom binding file could override Endpoint address and EJB based Web Services context root.
  */
+@SkipForRepeat("jaxws-2.3")
 public class WsBndEndpointOverrideTest extends WsBndEndpointOverrideTest_Lite {
 
     @Server("EJBinWarOverrideServer")

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WsBndEndpointOverrideTest_Lite.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WsBndEndpointOverrideTest_Lite.java
@@ -27,6 +27,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxws.fat.util.ExplodedShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
@@ -35,6 +36,7 @@ import componenttest.topology.utils.HttpUtils;
  * This test is to verify the custom binding file could override Endpoint address and EJB based Web Services context root.
  */
 @RunWith(FATRunner.class)
+@SkipForRepeat("jaxws-2.3")
 public class WsBndEndpointOverrideTest_Lite {
     private static final int CONN_TIMEOUT = 5;
 

--- a/dev/com.ibm.ws.jaxws.common/src/com/ibm/ws/jaxws/support/LibertyHTTPTransportFactory.java
+++ b/dev/com.ibm.ws.jaxws.common/src/com/ibm/ws/jaxws/support/LibertyHTTPTransportFactory.java
@@ -19,6 +19,7 @@ import org.apache.cxf.service.model.EndpointInfo;
 import org.apache.cxf.transport.Conduit;
 import org.apache.cxf.transport.http.HTTPConduitConfigurer;
 import org.apache.cxf.transport.http.HTTPTransportFactory;
+import org.apache.cxf.transport.http.URLConnectionHTTPConduit;
 import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
 import org.apache.cxf.ws.addressing.EndpointReferenceType;
 
@@ -41,7 +42,7 @@ public class LibertyHTTPTransportFactory extends HTTPTransportFactory {
     @Override
     public Conduit getConduit(EndpointInfo endpointInfo, EndpointReferenceType target) throws IOException {
         //create our LibertyHTTPConduit so that we can set the TCCL when run the handleResponseInternal asynchronously
-        LibertyHTTPConduit conduit = new LibertyHTTPConduit(bus, endpointInfo, target);
+        URLConnectionHTTPConduit conduit = new URLConnectionHTTPConduit(bus, endpointInfo, target);
 
         //following are copied from the super class.
         //Spring configure the conduit.  

--- a/dev/com.ibm.ws.jaxws.common/src/com/ibm/ws/jaxws/support/LibertyHTTPTransportFactory.java
+++ b/dev/com.ibm.ws.jaxws.common/src/com/ibm/ws/jaxws/support/LibertyHTTPTransportFactory.java
@@ -19,7 +19,6 @@ import org.apache.cxf.service.model.EndpointInfo;
 import org.apache.cxf.transport.Conduit;
 import org.apache.cxf.transport.http.HTTPConduitConfigurer;
 import org.apache.cxf.transport.http.HTTPTransportFactory;
-import org.apache.cxf.transport.http.URLConnectionHTTPConduit;
 import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
 import org.apache.cxf.ws.addressing.EndpointReferenceType;
 
@@ -42,7 +41,7 @@ public class LibertyHTTPTransportFactory extends HTTPTransportFactory {
     @Override
     public Conduit getConduit(EndpointInfo endpointInfo, EndpointReferenceType target) throws IOException {
         //create our LibertyHTTPConduit so that we can set the TCCL when run the handleResponseInternal asynchronously
-        URLConnectionHTTPConduit conduit = new URLConnectionHTTPConduit(bus, endpointInfo, target);
+        LibertyHTTPConduit conduit = new LibertyHTTPConduit(bus, endpointInfo, target);
 
         //following are copied from the super class.
         //Spring configure the conduit.  

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/interceptor/SoapActionInInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/src/org/apache/cxf/binding/soap/interceptor/SoapActionInInterceptor.java
@@ -1,0 +1,283 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.binding.soap.interceptor;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import org.apache.cxf.attachment.AttachmentDeserializer;
+import org.apache.cxf.binding.soap.Soap11;
+import org.apache.cxf.binding.soap.Soap12;
+import org.apache.cxf.binding.soap.SoapBindingConstants;
+import org.apache.cxf.binding.soap.SoapMessage;
+import org.apache.cxf.binding.soap.jms.interceptor.SoapJMSInInterceptor;
+import org.apache.cxf.binding.soap.model.SoapOperationInfo;
+import org.apache.cxf.common.logging.LogUtils;
+import org.apache.cxf.common.util.StringUtils;
+import org.apache.cxf.endpoint.Endpoint;
+import org.apache.cxf.helpers.CastUtils;
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.message.Exchange;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageUtils;
+import org.apache.cxf.phase.Phase;
+import org.apache.cxf.service.model.BindingOperationInfo;
+import org.apache.cxf.service.model.OperationInfo;
+import org.apache.cxf.ws.addressing.JAXWSAConstants;
+
+public class SoapActionInInterceptor extends AbstractSoapInterceptor {
+
+    private static final Logger LOG = LogUtils.getL7dLogger(SoapActionInInterceptor.class);
+    private static final String ALLOW_NON_MATCHING_TO_DEFAULT = "allowNonMatchingToDefaultSoapAction";
+    private static final String CALCULATED_WSA_ACTION = SoapActionInInterceptor.class.getName() + ".ACTION";
+
+    public SoapActionInInterceptor() {
+        super(Phase.READ);
+        addAfter(ReadHeadersInterceptor.class.getName());
+        addAfter(EndpointSelectionInterceptor.class.getName());
+    }
+
+    public static String getSoapAction(Message m) {
+        if (!(m instanceof SoapMessage)) {
+            return null;
+        }
+        SoapMessage message = (SoapMessage)m;
+        if (message.getVersion() instanceof Soap11) {
+            Map<String, List<String>> headers
+                = CastUtils.cast((Map<?, ?>)message.get(Message.PROTOCOL_HEADERS));
+            if (headers != null) {
+                List<String> sa = headers.get(SoapBindingConstants.SOAP_ACTION);
+                if (sa != null && !sa.isEmpty()) {
+                    String action = sa.get(0);
+                    if (action.startsWith("\"") || action.startsWith("\'")) {
+                        action = action.substring(1, action.length() - 1);
+                    }
+                    return action;
+                }
+            }
+        } else if (message.getVersion() instanceof Soap12) {
+            String ct = (String) message.get(Message.CONTENT_TYPE);
+
+            if (ct == null) {
+                return null;
+            }
+
+            int start = ct.indexOf("action=");
+            if (start == -1 && ct.indexOf("multipart/related") == 0 && ct.indexOf("start-info") == -1) {
+                // the action property may not be found at the package's content-type for non-mtom multipart message
+                // but skip searching if the start-info property is set
+                List<String> cts = CastUtils.cast((List<?>)(((Map<?, ?>)
+                    message.get(AttachmentDeserializer.ATTACHMENT_PART_HEADERS)).get(Message.CONTENT_TYPE)));
+                if (cts != null && !cts.isEmpty()) {
+                    ct = cts.get(0);
+                    start = ct.indexOf("action=");
+                }
+            }
+            if (start != -1) {
+                int end;
+                char c = ct.charAt(start + 7);
+                // handle the extraction robustly
+                if (c == '\"') {
+                    start += 8;
+                    end = ct.indexOf('\"', start);
+                } else if (c == '\\' && ct.charAt(start + 8) == '\"') {
+                    start += 9;
+                    end = ct.indexOf('\\', start);
+                } else {
+                    start += 7;
+                    end = ct.indexOf(';', start);
+                    if (end == -1) {
+                        end = ct.length();
+                    }
+                }
+                return ct.substring(start, end);
+            }
+        }
+
+        // Return the Soap Action for the JMS Case
+        if (message.containsKey(SoapJMSInInterceptor.JMS_SOAP_ACTION_VALUE)) {
+            return (String)message.get(SoapJMSInInterceptor.JMS_SOAP_ACTION_VALUE);
+        }
+
+        return null;
+    }
+
+    public void handleMessage(SoapMessage message) throws Fault {
+        if (isRequestor(message)) {
+            return;
+        }
+
+        String action = getSoapAction(message);
+        if (!StringUtils.isEmpty(action)) {
+            getAndSetOperation(message, action);
+            message.put(SoapBindingConstants.SOAP_ACTION, action);
+        }
+    }
+
+    public static void getAndSetOperation(SoapMessage message, String action) {
+        getAndSetOperation(message, action, true);
+    }
+    public static void getAndSetOperation(SoapMessage message, String action, boolean strict) {
+        if (StringUtils.isEmpty(action)) {
+            return;
+        }
+
+        Exchange ex = message.getExchange();
+        Endpoint ep = ex.getEndpoint();
+        if (ep == null) {
+            return;
+        }
+
+        BindingOperationInfo bindingOp = null;
+
+        Collection<BindingOperationInfo> bops = ep.getEndpointInfo()
+            .getBinding().getOperations();
+        if (bops != null) {
+            for (BindingOperationInfo boi : bops) {
+                if (isActionMatch(message, boi, action)) {
+                    if (bindingOp != null) {
+                        //more than one op with the same action, will need to parse normally
+                        return;
+                    }
+                    bindingOp = boi;
+                }
+                if (matchWSAAction(boi, action)) {
+                    if (bindingOp != null && bindingOp != boi) {
+                        //more than one op with the same action, will need to parse normally
+                        return;
+                    }
+                    bindingOp = boi;
+                }
+            }
+        }
+
+        if (bindingOp == null) {
+            if (strict) {
+                //we didn't match the an operation, we'll try again later to make
+                //sure the incoming message did end up matching an operation.
+                //This could occur in some cases like WS-RM and WS-SecConv that will
+                //intercept the message with a new endpoint/operation
+                message.getInterceptorChain().add(new SoapActionInAttemptTwoInterceptor(action));
+            }
+            return;
+        }
+
+        ex.put(BindingOperationInfo.class, bindingOp);
+    }
+    private static boolean matchWSAAction(BindingOperationInfo boi, String action) {
+        Object o = getWSAAction(boi);
+        if (o != null) {
+            String oa = o.toString();
+            if (action.equals(oa)
+                || action.equals(oa + "Request")
+                || oa.equals(action + "Request")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String getWSAAction(BindingOperationInfo boi) {
+        Object o = boi.getOperationInfo().getInput().getProperty(CALCULATED_WSA_ACTION);
+        if (o == null) {
+            o = boi.getOperationInfo().getInput().getExtensionAttribute(JAXWSAConstants.WSAM_ACTION_QNAME);
+            if (o == null) {
+                o = boi.getOperationInfo().getInput().getExtensionAttribute(JAXWSAConstants.WSAW_ACTION_QNAME);
+            }
+            if (o == null) {
+                String start = getActionBaseUri(boi.getOperationInfo());
+                if (null == boi.getOperationInfo().getInputName()) {
+                    o = addPath(start, boi.getOperationInfo().getName().getLocalPart());
+                } else {
+                    o = addPath(start, boi.getOperationInfo().getInputName());
+                }
+            }
+            if (o != null) {
+                boi.getOperationInfo().getInput().setProperty(CALCULATED_WSA_ACTION, o);
+            }
+        }
+        return o.toString();
+    }
+    private static String getActionBaseUri(final OperationInfo operation) {
+        String interfaceName = operation.getInterface().getName().getLocalPart();
+        return addPath(operation.getName().getNamespaceURI(), interfaceName);
+    }
+    private static String getDelimiter(String uri) {
+        if (uri.startsWith("urn")) {
+            return ":";
+        }
+        return "/";
+    }
+
+    private static String addPath(String uri, String path) {
+        StringBuilder buffer = new StringBuilder();
+        buffer.append(uri);
+        String delimiter = getDelimiter(uri);
+        if (!uri.endsWith(delimiter) && !path.startsWith(delimiter)) {
+            buffer.append(delimiter);
+        }
+        buffer.append(path);
+        return buffer.toString();
+    }
+
+
+    public static class SoapActionInAttemptTwoInterceptor extends AbstractSoapInterceptor {
+        final String action;
+        public SoapActionInAttemptTwoInterceptor(String action) {
+            super(action, Phase.PRE_LOGICAL);
+            this.action = action;
+        }
+        public void handleMessage(SoapMessage message) throws Fault {
+            BindingOperationInfo boi = message.getExchange().getBindingOperationInfo();
+            if (boi == null) {
+                return;
+            }
+            if (StringUtils.isEmpty(action)) {
+                return;
+            }
+            if (isActionMatch(message, boi, action)) {
+                return;
+            }
+            if (matchWSAAction(boi, action)) {
+                return;
+            }
+            boolean synthetic = Boolean.TRUE.equals(boi.getProperty("operation.is.synthetic"));
+            if (!synthetic) {
+                throw new Fault("SOAP_ACTION_MISMATCH", LOG, null, action);
+            }
+        }
+    }
+
+    private static boolean isActionMatch(SoapMessage message, BindingOperationInfo boi, String action) {
+        SoapOperationInfo soi = boi.getExtensor(SoapOperationInfo.class);
+        if (soi == null) {
+            return false;
+        }
+        boolean allowNoMatchingToDefault = MessageUtils.getContextualBoolean(message,
+                                                                    ALLOW_NON_MATCHING_TO_DEFAULT,
+                                                                    false);
+        return action.equals(soi.getAction())
+               || (allowNoMatchingToDefault && StringUtils.isEmpty(soi.getAction())
+               || (message.getVersion() instanceof Soap12) && StringUtils.isEmpty(soi.getAction()));
+    }
+
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.3.2/.classpath
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.3.2/.classpath
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.3.2/bnd.bnd
@@ -16,6 +16,7 @@ cxfVersion=3.3.3
 
 -includeresource: \
   @${repo;org.apache.cxf:cxf-rt-frontend-jaxws;${cxfVersion};EXACT}!/!*-INF/*, \
+  org/apache/cxf=${bin}/org/apache/cxf,\
   META-INF=resources/META-INF
    
 -buildpath: \

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.3.2/src/org/apache/cxf/jaxws/interceptors/MessageModeOutInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.3.2/src/org/apache/cxf/jaxws/interceptors/MessageModeOutInterceptor.java
@@ -1,18 +1,382 @@
-/*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
- *******************************************************************************/
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.cxf.jaxws.interceptors;
 
-/**
- *
- */
-public class MessageModeOutInterceptor {
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+import javax.activation.DataSource;
+import javax.xml.namespace.QName;
+import javax.xml.soap.Detail;
+import javax.xml.soap.MessageFactory;
+import javax.xml.soap.SOAPException;
+import javax.xml.soap.SOAPFault;
+import javax.xml.soap.SOAPHeader;
+import javax.xml.soap.SOAPMessage;
+import javax.xml.soap.SOAPPart;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import javax.xml.transform.Source;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.validation.Schema;
+
+import org.w3c.dom.DocumentFragment;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+import org.apache.cxf.annotations.SchemaValidation.SchemaValidationType;
+import org.apache.cxf.attachment.AttachmentDeserializer;
+import org.apache.cxf.binding.soap.Soap12;
+import org.apache.cxf.binding.soap.SoapFault;
+import org.apache.cxf.binding.soap.SoapMessage;
+import org.apache.cxf.binding.soap.interceptor.AbstractSoapInterceptor;
+import org.apache.cxf.binding.soap.saaj.SAAJOutInterceptor;
+import org.apache.cxf.binding.soap.saaj.SAAJOutInterceptor.SAAJOutEndingInterceptor;
+import org.apache.cxf.binding.soap.saaj.SAAJStreamWriter;
+import org.apache.cxf.binding.soap.saaj.SAAJUtils;
+import org.apache.cxf.common.util.PropertyUtils;
+import org.apache.cxf.helpers.DOMUtils;
+import org.apache.cxf.helpers.IOUtils;
+import org.apache.cxf.helpers.ServiceUtils;
+import org.apache.cxf.interceptor.AbstractOutDatabindingInterceptor;
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.interceptor.StaxOutInterceptor;
+import org.apache.cxf.io.CachedOutputStream;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageContentsList;
+import org.apache.cxf.message.MessageImpl;
+import org.apache.cxf.phase.AbstractPhaseInterceptor;
+import org.apache.cxf.phase.Phase;
+import org.apache.cxf.service.model.BindingFaultInfo;
+import org.apache.cxf.service.model.BindingMessageInfo;
+import org.apache.cxf.service.model.BindingOperationInfo;
+import org.apache.cxf.staxutils.StaxUtils;
+import org.apache.cxf.staxutils.W3CDOMStreamWriter;
+import org.apache.cxf.ws.addressing.EndpointReferenceUtils;
+
+public class MessageModeOutInterceptor extends AbstractPhaseInterceptor<Message> {
+    MessageModeOutInterceptorInternal internal;
+    SAAJOutInterceptor saajOut;
+    Class<?> type;
+    QName bindingName;
+
+    public MessageModeOutInterceptor(SAAJOutInterceptor saajOut, QName bname) {
+        super(Phase.PREPARE_SEND);
+        this.saajOut = saajOut;
+        this.bindingName = bname;
+        internal = new MessageModeOutInterceptorInternal();
+    }
+    public MessageModeOutInterceptor(Class<?> t, QName bname) {
+        super(Phase.PREPARE_SEND);
+        type = t;
+        this.bindingName = bname;
+    }
+    public void handleMessage(Message message) throws Fault {
+        BindingOperationInfo bop = message.getExchange().getBindingOperationInfo();
+        if (bop != null && !bindingName.equals(bop.getBinding().getName())) {
+            return;
+        }
+        if (saajOut != null) {
+            doSoap(message);
+        } else if (DataSource.class.isAssignableFrom(type)) {
+            //datasource stuff, must check if multi-source
+            MessageContentsList list = (MessageContentsList)message.getContent(List.class);
+            DataSource ds = (DataSource)list.get(0);
+            String ct = ds.getContentType();
+            if (ct.toLowerCase().contains("multipart/related")) {
+                Message msg = new MessageImpl();
+                msg.setExchange(message.getExchange());
+                msg.put(Message.CONTENT_TYPE, ct);
+                try {
+                    msg.setContent(InputStream.class, ds.getInputStream());
+                    AttachmentDeserializer deser = new AttachmentDeserializer(msg);
+                    deser.initializeAttachments();
+                } catch (IOException ex) {
+                    throw new Fault(ex);
+                }
+                message.setAttachments(msg.getAttachments());
+                final InputStream in = msg.getContent(InputStream.class);
+                final String ct2 = (String)msg.get(Message.CONTENT_TYPE);
+                list.set(0, new DataSource() {
+
+                    public String getContentType() {
+                        return ct2;
+                    }
+
+                    public InputStream getInputStream() throws IOException {
+                        return in;
+                    }
+
+                    public String getName() {
+                        return ct2;
+                    }
+
+                    public OutputStream getOutputStream() throws IOException {
+                        return null;
+                    }
+
+                });
+            } else if (!ct.toLowerCase().contains("xml")) {
+                //not XML based, need to stream out directly.  This is a bit tricky as
+                //we don't want the stax stuff triggering and such
+                OutputStream out = message.getContent(OutputStream.class);
+                message.put(Message.CONTENT_TYPE, ct);
+                try {
+                    InputStream in = ds.getInputStream();
+                    IOUtils.copy(in, out);
+                    in.close();
+                    out.flush();
+                    out.close();
+                } catch (IOException e) {
+                    throw new Fault(e);
+                }
+                list.remove(0);
+                out = new CachedOutputStream();
+                message.setContent(OutputStream.class, out);
+                XMLStreamWriter writer = StaxUtils.createXMLStreamWriter(out);
+                message.setContent(XMLStreamWriter.class, writer);
+            }
+        } else if (ServiceUtils.isSchemaValidationEnabled(SchemaValidationType.OUT, message)
+            && Source.class.isAssignableFrom(type)) {
+            //if schema validation is on, we'll end up converting to a DOMSource anyway,
+            //let's convert and check for a fault
+            MessageContentsList list = (MessageContentsList)message.getContent(List.class);
+            Source ds = (Source)list.get(0);
+            if (!(ds instanceof DOMSource)) {
+                try {
+                    ds = new DOMSource(StaxUtils.read(ds));
+                } catch (XMLStreamException e) {
+                    throw new Fault(e);
+                }
+                list.set(0,  ds);
+                validatePossibleFault(message, bop, ((DOMSource)ds).getNode());
+            }
+        }
+
+    }
+
+
+    private void validatePossibleFault(Message message, BindingOperationInfo bop, Node ds) {
+        Element el = DOMUtils.getFirstElement(ds);
+        if (!"Fault".equals(el.getLocalName())) {
+            return;
+        }
+        message.put(Message.RESPONSE_CODE, 500);
+
+        el = DOMUtils.getFirstElement(el);
+        while (el != null && !"detail".equals(el.getLocalName())) {
+            el = DOMUtils.getNextElement(el);
+        }
+        if (el != null) {
+            Schema schema = EndpointReferenceUtils.getSchema(message.getExchange().getService()
+                                                             .getServiceInfos().get(0),
+                                                         message.getExchange().getBus());
+            try {
+                validateFaultDetail(el, schema, bop);
+            } catch (Exception e) {
+                throw new Fault(e);
+            }
+
+            //We validated what we can from a fault standpoint
+            message.put(Message.SCHEMA_VALIDATION_ENABLED, Boolean.FALSE);
+        }
+    }
+    private void validateFaultDetail(Element detail, Schema schema, BindingOperationInfo bop) throws Exception {
+        if (detail != null) {
+            Element el = DOMUtils.getFirstElement(detail);
+            while (el != null) {
+                QName qn = DOMUtils.getElementQName(el);
+                for (BindingFaultInfo bfi : bop.getFaults()) {
+                    if (bfi.getFaultInfo().getMessagePartByIndex(0).getConcreteName().equals(qn)) {
+                        //Found a fault with the correct QName, we can validate it
+                        schema.newValidator().validate(new DOMSource(DOMUtils.getDomElement(el)));
+                    }
+                }
+                el = DOMUtils.getNextElement(el);
+            }
+        }
+    }
+    private void validateFault(SoapMessage message, SOAPFault fault, BindingOperationInfo bop) {
+        if (ServiceUtils.isSchemaValidationEnabled(SchemaValidationType.OUT, message)) {
+            Schema schema = EndpointReferenceUtils.getSchema(message.getExchange().getService()
+                                                             .getServiceInfos().get(0),
+                                                         message.getExchange().getBus());
+            Detail d = fault.getDetail();
+            try {
+                validateFaultDetail(d, schema, bop);
+            } catch (Exception e) {
+                throw new SoapFault(e.getMessage(), e, message.getVersion().getReceiver());
+            }
+
+            //We validated what we can from a fault standpoint
+            message.put(Message.SCHEMA_VALIDATION_ENABLED, Boolean.FALSE);
+        }
+    }
+
+
+    private void doSoap(Message message) {
+        MessageContentsList list = (MessageContentsList)message.getContent(List.class);
+        if (list == null || list.isEmpty()) {
+            return;
+        }
+        Object o = list.get(0);
+        if (o instanceof SOAPMessage) {
+            SOAPMessage soapMessage = (SOAPMessage)o;
+
+            if (soapMessage.countAttachments() > 0) {
+                message.put("write.attachments", Boolean.TRUE);
+            }
+            try {
+                if (message instanceof org.apache.cxf.binding.soap.SoapMessage) {
+                    org.apache.cxf.binding.soap.SoapMessage cxfSoapMessage =
+                            (org.apache.cxf.binding.soap.SoapMessage)message;
+                    String cxfNamespace = cxfSoapMessage.getVersion().getNamespace();
+                    SOAPHeader soapHeader = soapMessage.getSOAPHeader();
+                    String namespace = soapHeader == null ? null : soapHeader.getNamespaceURI();
+                    if (Soap12.SOAP_NAMESPACE.equals(namespace) && !namespace.equals(cxfNamespace)) {
+                        cxfSoapMessage.setVersion(Soap12.getInstance());
+                        cxfSoapMessage.put(Message.CONTENT_TYPE, cxfSoapMessage.getVersion().getContentType());
+                    }
+                }
+            } catch (SOAPException e) {
+                //ignore
+            }
+            try {
+                Object enc = soapMessage.getProperty(SOAPMessage.CHARACTER_SET_ENCODING);
+                if (enc instanceof String) {
+                    message.put(Message.ENCODING, enc);
+                }
+            } catch (SOAPException e) {
+                //ignore
+            }
+            try {
+                Object xmlDec = soapMessage.getProperty(SOAPMessage.WRITE_XML_DECLARATION);
+                if (xmlDec != null) {
+                    boolean b = PropertyUtils.isTrue(xmlDec);
+                    message.put(StaxOutInterceptor.FORCE_START_DOCUMENT, b);
+                }
+            } catch (SOAPException e) {
+                //ignore
+            }
+        }
+        message.getInterceptorChain().add(internal);
+    }
+
+    private class MessageModeOutInterceptorInternal extends AbstractSoapInterceptor {
+        MessageModeOutInterceptorInternal() {
+            super(Phase.PRE_PROTOCOL);
+            addBefore(SAAJOutInterceptor.class.getName());
+        }
+
+        public void handleMessage(SoapMessage message) throws Fault {
+            MessageContentsList list = (MessageContentsList)message.getContent(List.class);
+            Object o = list.remove(0);
+            SOAPMessage soapMessage = null;
+
+            if (o instanceof SOAPMessage) {
+                soapMessage = (SOAPMessage)o;
+                if (soapMessage.countAttachments() > 0) {
+                    message.put("write.attachments", Boolean.TRUE);
+                }
+            } else {
+                try {
+                    MessageFactory factory = saajOut.getFactory(message);
+                    soapMessage = factory.createMessage();
+                    SOAPPart part = soapMessage.getSOAPPart();
+                    if (o instanceof Source) {
+                        StaxUtils.copy((Source)o, new SAAJStreamWriter(part));
+                    }
+                } catch (SOAPException | XMLStreamException e) {
+                    throw new SoapFault("Error creating SOAPMessage", e,
+                                        message.getVersion().getSender());
+                }
+            }
+
+            BindingOperationInfo bop = message.getExchange().getBindingOperationInfo();
+            DocumentFragment frag = soapMessage.getSOAPPart().createDocumentFragment();
+            try {
+                Node body = SAAJUtils.getBody(soapMessage);
+                Node nd = body.getFirstChild();
+                while (nd != null) {
+                    if (nd instanceof SOAPFault) {
+                        message.put(Message.RESPONSE_CODE, 500);
+                        validateFault(message, (SOAPFault)nd, bop);
+                    }
+                    body.removeChild(nd);
+                    nd = DOMUtils.getDomElement(nd);
+                    frag.appendChild(nd);
+                    nd = SAAJUtils.getBody(soapMessage).getFirstChild();
+                }
+
+                message.setContent(SOAPMessage.class, soapMessage);
+
+                if (!message.containsKey(SAAJOutInterceptor.ORIGINAL_XML_WRITER)) {
+                    XMLStreamWriter origWriter = message.getContent(XMLStreamWriter.class);
+                    message.put(SAAJOutInterceptor.ORIGINAL_XML_WRITER, origWriter);
+                }
+                W3CDOMStreamWriter writer = new SAAJStreamWriter(soapMessage.getSOAPPart());
+                // Replace stax writer with DomStreamWriter
+                message.setContent(XMLStreamWriter.class, writer);
+                message.setContent(SOAPMessage.class, soapMessage);
+
+                int index = 0;
+
+                boolean client = isRequestor(message);
+                BindingMessageInfo bmsg = null;
+
+                if (client && bop != null) {
+                    bmsg = bop.getInput();
+                } else if (bop != null && bop.getOutput() != null) {
+                    bmsg = bop.getOutput();
+                }
+                if (bmsg != null && bmsg.getMessageParts() != null
+                    && bmsg.getMessageParts().size() > 0) {
+                    index = bmsg.getMessageParts().get(0).getIndex();
+                }
+
+                list.set(index, frag);
+
+
+                //No need to buffer this as we're already a DOM,
+                //but only do so if someone hasn't actually configured this
+                Object buffer = message
+                    .getContextualProperty(AbstractOutDatabindingInterceptor.OUT_BUFFERING);
+                if (buffer == null) {
+                    message.put(AbstractOutDatabindingInterceptor.OUT_BUFFERING, Boolean.FALSE);
+                }
+
+            } catch (Exception ex) {
+                throw new Fault(ex);
+            }
+            if (bop != null && bop.isUnwrapped()) {
+                bop = bop.getWrappedOperation();
+                message.getExchange().put(BindingOperationInfo.class, bop);
+            }
+
+            // Add a final interceptor to write the message
+            message.getInterceptorChain().add(SAAJOutEndingInterceptor.INSTANCE);
+        }
+    }
+
+
 
 }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.3.2/src/org/apache/cxf/jaxws/interceptors/MessageModeOutInterceptor.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.3.2/src/org/apache/cxf/jaxws/interceptors/MessageModeOutInterceptor.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.apache.cxf.jaxws.interceptors;
+
+/**
+ *
+ */
+public class MessageModeOutInterceptor {
+
+}


### PR DESCRIPTION
Enable some of the jaxws-2.2 webcontainer FATs to be re-run with jaxws-2.3
