### PR TITLE
Improve performance of config props in server.xml

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.3_fat/.classpath
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat/.classpath
@@ -7,6 +7,7 @@
 	<classpathentry kind="src" path="test-applications/serverXMLApp/resources"/>
 	<classpathentry kind="src" path="test-applications/variableServerXMLApp/src"/>
 	<classpathentry kind="src" path="test-applications/duplicateInServerXMLApp/src"/>
+	<classpathentry kind="src" path="test-applications/serverXMLWebApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat/bnd.bnd
@@ -18,7 +18,8 @@ src: \
 	test-applications/mapEnvVarApp/src,\
 	test-applications/hotAddMPConfigApp/src,\
 	test-applications/variableServerXMLApp/src,\
-	test-applications/duplicateInServerXMLApp/src
+	test-applications/duplicateInServerXMLApp/src,\
+	test-applications/serverXMLWebApp/src
 
 	
 fat.project: true

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat/fat/src/com/ibm/ws/microprofile/config13/test/ServerXMLTest.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat/fat/src/com/ibm/ws/microprofile/config13/test/ServerXMLTest.java
@@ -21,6 +21,7 @@ import com.ibm.ws.microprofile.config.fat.repeat.RepeatConfigActions.Version;
 import com.ibm.ws.microprofile.config13.duplicateInServerXML.web.DuplicateInServerXMLServlet;
 import com.ibm.ws.microprofile.config13.mapEnvVar.web.MapEnvVarServlet;
 import com.ibm.ws.microprofile.config13.serverXML.web.ServerXMLServlet;
+import com.ibm.ws.microprofile.config13.serverXMLWebApp.web.ServerXMLWebAppServlet;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -51,12 +52,14 @@ public class ServerXMLTest extends FATServletClient {
 
     public static final String SERVER_XML_APP_NAME = "serverXMLApp";
     public static final String DUPLICATE_IN_SERVER_XML_APP_NAME = "duplicateInServerXMLApp";
+    public static final String SERVER_XML_WEB_APP_NAME = "serverXMLWebApp";
     public static final String MAP_ENV_VAR_APP_NAME = "mapEnvVarApp";
 
     @Server("ServerXMLServer")
     @TestServlets({
                     @TestServlet(servlet = DuplicateInServerXMLServlet.class, contextRoot = DUPLICATE_IN_SERVER_XML_APP_NAME),
                     @TestServlet(servlet = ServerXMLServlet.class, contextRoot = SERVER_XML_APP_NAME),
+                    @TestServlet(servlet = ServerXMLWebAppServlet.class, contextRoot = SERVER_XML_WEB_APP_NAME),
                     @TestServlet(servlet = MapEnvVarServlet.class, contextRoot = MAP_ENV_VAR_APP_NAME) })
     public static LibertyServer server;
 
@@ -67,6 +70,7 @@ public class ServerXMLTest extends FATServletClient {
     public static void setUp() throws Exception {
         ShrinkHelper.defaultApp(server, SERVER_XML_APP_NAME, "com.ibm.ws.microprofile.config13.serverXML.*");
         ShrinkHelper.defaultApp(server, DUPLICATE_IN_SERVER_XML_APP_NAME, "com.ibm.ws.microprofile.config13.duplicateInServerXML.*");
+        ShrinkHelper.defaultApp(server, SERVER_XML_WEB_APP_NAME, "com.ibm.ws.microprofile.config13.serverXMLWebApp.*");
         ShrinkHelper.defaultApp(server, MAP_ENV_VAR_APP_NAME, "com.ibm.ws.microprofile.config13.mapEnvVar.*");
 
         server.startServer();

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat/publish/servers/ServerXMLServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat/publish/servers/ServerXMLServer/bootstrap.properties
@@ -1,3 +1,3 @@
 bootstrap.include=../testports.properties
 osgi.console=7773
-
+com.ibm.ws.logging.trace.specification=*=info:APPCONFIG=all

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat/publish/servers/ServerXMLServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat/publish/servers/ServerXMLServer/server.xml
@@ -36,5 +36,11 @@
 		</appProperties>
 	</application>
 	
+	<webApplication location="serverXMLWebApp.war">
+		<appProperties>
+			<property name="serverXMLKey1" value="serverXMLValue1" />
+		</appProperties>
+	</webApplication>
+	
 	<application location="mapEnvVarApp.war"/>
 </server>

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat/test-applications/serverXMLWebApp/src/com/ibm/ws/microprofile/config13/serverXMLWebApp/web/ServerXMLWebAppBean.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat/test-applications/serverXMLWebApp/src/com/ibm/ws/microprofile/config13/serverXMLWebApp/web/ServerXMLWebAppBean.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.config13.serverXMLWebApp.web;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+public class ServerXMLWebAppBean {
+
+    @Inject
+    @ConfigProperty(name = "serverXMLKey1")
+    private String value1;
+
+    public String getValue1() {
+        return value1;
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat/test-applications/serverXMLWebApp/src/com/ibm/ws/microprofile/config13/serverXMLWebApp/web/ServerXMLWebAppServlet.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat/test-applications/serverXMLWebApp/src/com/ibm/ws/microprofile/config13/serverXMLWebApp/web/ServerXMLWebAppServlet.java
@@ -1,0 +1,38 @@
+package com.ibm.ws.microprofile.config13.serverXMLWebApp.web;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+/**
+ *
+ */
+@SuppressWarnings("serial")
+@WebServlet("/ServerXMLWebAppServlet")
+public class ServerXMLWebAppServlet extends FATServlet {
+
+    @Inject
+    private ServerXMLWebAppBean bean;
+
+    @Test
+    public void testWebApplicationInjection() {
+        assertEquals("serverXMLValue1", bean.getValue1());
+    }
+
+}

--- a/dev/io.openliberty.microprofile.config.internal.serverxml/bnd.bnd
+++ b/dev/io.openliberty.microprofile.config.internal.serverxml/bnd.bnd
@@ -30,6 +30,9 @@ Include-Resource: \
 
 WS-TraceGroup: APPCONFIG
 
+-dsannotations: \
+        io.openliberty.microprofile.config.internal.serverxml.AppPropertiesTrackingComponent, \
+        io.openliberty.microprofile.config.internal.serverxml.AppPropertiesComponent
 
 -buildpath: \
 	com.ibm.websphere.org.eclipse.microprofile.config.1.1;version=latest, \

--- a/dev/io.openliberty.microprofile.config.internal.serverxml/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/io.openliberty.microprofile.config.internal.serverxml/resources/OSGI-INF/metatype/metatype.xml
@@ -20,7 +20,7 @@
 </Designate>
 
 <OCD id="com.ibm.ws.appconfig.appProperties" ibm:childAlias="appProperties"  ibm:parentPid="com.ibm.ws.app.manager" ibm:supportHiddenExtensions="true" name="%appProperties" description="%appProperties.desc" >
-    <AD id="property" name="%property" ibm:type="pid" ibm:reference="com.ibm.ws.appconfig.appProperties.property" required="false" type="String" cardinality="2147483647" default="" description="%property.desc"/>
+    <AD id="property" name="%property" ibm:type="pid" ibm:flat="true" ibm:reference="com.ibm.ws.appconfig.appProperties.property" required="false" type="String" cardinality="2147483647" default="" description="%property.desc"/>
     <AD id="id" type="String" default="appProperties" ibm:final="true" name="internal" description="internal use only"/>
 </OCD>
 

--- a/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/AppPropertiesComponent.java
+++ b/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/AppPropertiesComponent.java
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.config.internal.serverxml;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+
+/**
+ * Stores the properties from one appProperties element in server.xml.
+ */
+@Component(configurationPolicy = ConfigurationPolicy.REQUIRE, configurationPid = "com.ibm.ws.appconfig.appProperties", service = AppPropertiesComponent.class)
+public class AppPropertiesComponent {
+
+    /**
+     * Pattern matching property.(x).(key|value), used to extract properties from config
+     */
+    private static final Pattern keyValuePattern = Pattern.compile("property.(\\d+).(name|value)");
+
+    /**
+     * The current map of properties. This map must always be replaced rather than modified.
+     */
+    private volatile Map<String, String> properties = Collections.emptyMap();
+    private volatile String pid;
+
+    /**
+     * Returns the properties defined in the appProperties config element
+     * <p>
+     * The caller must not modify this map
+     *
+     * @return a map of the properties
+     */
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    /**
+     * Returns the PID for this appProperties config element
+     *
+     * @return the appProperties PID
+     */
+    public String getPid() {
+        return pid;
+    }
+
+    @Activate
+    protected void activate(Map<String, Object> properties) {
+        this.properties = processProperties(properties);
+        this.pid = (String) properties.get("service.pid");
+    }
+
+    @Modified
+    protected void modified(Map<String, Object> properties) {
+        this.properties = processProperties(properties);
+    }
+
+    @Deactivate
+    protected void deactivate(Map<String, Object> properties) {
+        this.pid = null;
+        this.properties = Collections.emptyMap();
+    }
+
+    /**
+     * Converts the properties from config into a simple key-value map
+     * <p>
+     * Properties arrive from config in the following form:
+     * <ul>
+     * <li>property.0.name=foo</li>
+     * <li>property.0.value=bar</li>
+     * <li>property.1.name=baz</li>
+     * <li>property.1.value=qux</li>
+     * <ul>
+     * <p>
+     * This method converts these values to the following form, ignoring any other properties:
+     * <ul>
+     * <li>foo=bar</li>
+     * <li>baz=qux</li>
+     * </ul>
+     *
+     * @param properties the properties as they're returned from config admin
+     * @return a simple map of properties
+     */
+    private Map<String, String> processProperties(Map<String, Object> properties) {
+
+        // Gather together matching name and value properties
+        HashMap<String, PropertyEntry> propertyEntries = new HashMap<>();
+        for (Entry<String, Object> entry : properties.entrySet()) {
+            if (!(entry.getValue() instanceof String)) {
+                continue;
+            }
+
+            Matcher m = keyValuePattern.matcher(entry.getKey());
+            if (m.matches()) {
+                String index = m.group(1);
+                PropertyEntry propertyEntry = propertyEntries.computeIfAbsent(index, k -> new PropertyEntry());
+                if (m.group(2).equals("name")) {
+                    propertyEntry.name = (String) entry.getValue();
+                } else {
+                    propertyEntry.value = (String) entry.getValue();
+                }
+            }
+        }
+
+        // Now put each name and value pair into a map
+        Map<String, String> result = new HashMap<>();
+        for (PropertyEntry entry : propertyEntries.values()) {
+            if (entry.name != null && entry.value != null) {
+                result.put(entry.name, entry.value);
+            }
+        }
+
+        return result;
+    }
+
+    private static class PropertyEntry {
+        private String name;
+        private String value;
+    }
+}

--- a/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/AppPropertiesTrackingComponent.java
+++ b/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/AppPropertiesTrackingComponent.java
@@ -1,0 +1,207 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.config.internal.serverxml;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import com.ibm.wsspi.application.Application;
+
+/**
+ * Tracks applications and their appProperties defined in server.xml
+ * <p>
+ * It's harder than you'd like to get the appProperties for an app out of config admin. This component takes the approach of tracking applications and their config separately, and
+ * then linking up the references afterwards.
+ * <ul>
+ * <li>It references {@link Application} to get information about the application from the service properties.
+ * <li>It references {@link AppPropertiesComponent} to get the information from appProperties.
+ * </ul>
+ * Whenever either of these references is updated, it checks which app references which appProperties config and builds the map of properties for any apps which have changed.
+ * <p>
+ * Note: I'm not sure if the locking is needed as I was unable to determine whether DS can call lifecycle methods concurrently, but it only affects updates which should be fairly
+ * infrequent.
+ * <p>
+ * Note: I originally tried to create a component using {@code configurationPid = "com.ibm.ws.app.manager"} to get the app config directly, but that configuration appears to get
+ * hidden from us by being bound to the app manager bundle.
+ */
+@Component(configurationPolicy = ConfigurationPolicy.IGNORE, immediate = true)
+public class AppPropertiesTrackingComponent {
+
+    /**
+     * The (singleton) instance of this component. Needed for access from non-osgi code.
+     */
+    private static volatile AppPropertiesTrackingComponent instance;
+
+    /**
+     * Map from an appProperties PID to its corresponding component
+     * <p>
+     * Must hold lock on {@code this} to access
+     */
+    private final Map<String, AppPropertiesComponent> propertiesComponentByPid = new HashMap<>();
+
+    /**
+     * Map from an application PID to the list of appProperties PIDs which it references
+     * <p>
+     * Entry for a given app may be missing if it has no appProperties configured
+     * <p>
+     * Must hold lock on {@code this} to access
+     */
+    private final Map<String, List<String>> propertyPidByApp = new HashMap<>();
+
+    /**
+     * Map from an application PID to the list of config properties defined for it
+     * <p>
+     * Entry for a given app may be missing if it has no appProperties configured
+     * <p>
+     * Must hold lock on {@code this} to <b>write</b>, but not to read
+     */
+    private final Map<String, Map<String, String>> propertiesByApp = new ConcurrentHashMap<>();
+
+    @Activate
+    protected void activate() {
+        instance = this;
+    }
+
+    @Deactivate
+    protected void deactivate() {
+        // Shouldn't be needed, there should only ever be one instance
+        if (instance == this) {
+            instance = null;
+        }
+    }
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
+    protected void addAppPropertiesComponent(AppPropertiesComponent apc) {
+        propertiesComponentByPid.put(apc.getPid(), apc);
+        updateAppsUsingProperties(apc.getPid());
+    }
+
+    protected void updatedAppPropertiesComponent(AppPropertiesComponent apc) {
+        updateAppsUsingProperties(apc.getPid());
+    }
+
+    protected void removeAppPropertiesComponent(AppPropertiesComponent apc) {
+        propertiesComponentByPid.remove(apc.getPid(), apc);
+        updateAppsUsingProperties(apc.getPid());
+    }
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY, service = Application.class)
+    protected void addApp(Map<String, Object> appProps) {
+        String appPid = (String) appProps.get("service.pid");
+        String[] appPropertiesPids = (String[]) appProps.get("appProperties");
+        if (appPid != null && appPropertiesPids != null) {
+            synchronized (this) {
+                propertyPidByApp.put(appPid, Arrays.asList(appPropertiesPids));
+                updateAppProperties(appPid);
+            }
+        }
+    }
+
+    protected void updatedApp(Map<String, Object> appProps) {
+        String appPid = (String) appProps.get("service.pid");
+        String[] appPropertiesPids = (String[]) appProps.get("appProperties");
+        if (appPid != null && appPropertiesPids != null) {
+            synchronized (this) {
+                propertyPidByApp.put(appPid, Arrays.asList(appPropertiesPids));
+                updateAppProperties(appPid);
+            }
+        }
+    }
+
+    protected void removeApp(Map<String, Object> appProps) {
+        String appPid = (String) appProps.get("service.pid");
+        if (appPid != null) {
+            synchronized (this) {
+                propertyPidByApp.remove(appPid);
+                updateAppProperties(appPid);
+            }
+        }
+    }
+
+    /**
+     * Update all applications which reference the given appProperties PID
+     * <p>
+     * Caller must hold lock on {@code this}.
+     *
+     * @param appPropertiesPid the appProperties PID
+     */
+    private void updateAppsUsingProperties(String appPropertiesPid) {
+        for (Entry<String, List<String>> entry : propertyPidByApp.entrySet()) {
+            if (entry.getValue().contains(appPropertiesPid)) {
+                updateAppProperties(entry.getKey());
+            }
+        }
+    }
+
+    /**
+     * Update the properties for an application.
+     * <p>
+     * Updates the {@link #propertiesByApp} map based on the data in {@link #propertyPidByApp} and {@link #propertiesComponentByPid}.
+     * <p>
+     * Caller must hold lock on {@code this}.
+     *
+     * @param appPid the PID for the application
+     */
+    private void updateAppProperties(String appPid) {
+        Map<String, String> newProperties = new HashMap<>();
+
+        List<String> properitesPids = propertyPidByApp.get(appPid);
+        if (properitesPids != null) {
+            for (String propertiesPid : properitesPids) {
+                AppPropertiesComponent propertiesComponent = propertiesComponentByPid.get(propertiesPid);
+                if (propertiesComponent != null) {
+                    newProperties.putAll(propertiesComponent.getProperties());
+                }
+            }
+        }
+
+        if (newProperties.isEmpty()) {
+            propertiesByApp.remove(appPid);
+        } else {
+            propertiesByApp.put(appPid, Collections.unmodifiableMap(newProperties));
+        }
+    }
+
+    /**
+     * Returns the app properties for an application
+     *
+     * @param appPid the PID of the application
+     * @return a read-only map of properties
+     */
+    public static Map<String, String> getAppProperties(String appPid) {
+        AppPropertiesTrackingComponent instance = AppPropertiesTrackingComponent.instance;
+        if (instance == null) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, String> properties = instance.propertiesByApp.get(appPid);
+
+        if (properties == null) {
+            return Collections.emptyMap();
+        }
+
+        return properties;
+    }
+}

--- a/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/OSGiConfigUtils.java
+++ b/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/OSGiConfigUtils.java
@@ -213,12 +213,7 @@ public class OSGiConfigUtils {
         if (FrameworkState.isValid()) {
             ServiceReference<?> appRef = getApplicationServiceRef(bundleContext, applicationName);
             if (appRef != null) {
-                //not actually sure what the difference is between service.pid and ibm.extends.source.pid but this is the way it is done everywhere else!
                 applicationPID = (String) appRef.getProperty(Constants.SERVICE_PID);
-                String sourcePid = (String) appRef.getProperty("ibm.extends.source.pid");
-                if (sourcePid != null) {
-                    applicationPID = sourcePid;
-                }
             }
         }
         return applicationPID;


### PR DESCRIPTION
Use a more efficient way of getting config properties defined using the
`<appProperties>` element in server.xml. Rather than querying every time,
register components which receive the config whenever it is updated.

For #13865