### PR TITLE
Issue #14251: Move all EJB 4 feature to parallel activation

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.cdi3.0-ejb4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.cdi3.0-ejb4.0.feature
@@ -8,3 +8,4 @@ IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature
 IBM-Install-Policy: when-satisfied
 kind=beta
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.ejbliteJPA-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.ejbliteJPA-2.0.feature
@@ -8,3 +8,4 @@ IBM-Install-Policy: when-satisfied
 -bundles=com.ibm.ws.ejbcontainer.jpa.jakarta
 kind=beta
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.enterpriseBeansRemoteClientServer-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.enterpriseBeansRemoteClientServer-2.0.feature
@@ -13,3 +13,4 @@ IBM-Install-Policy: when-satisfied
 IBM-Process-Types: server
 kind=beta
 edition=base
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.enterpriseBeansRemoteClient-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.enterpriseBeansRemoteClient-2.0.feature
@@ -13,3 +13,4 @@ visibility=private
 -files=clients/ejbRemotePortable.jakarta.jar
 kind=beta
 edition=base
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/enterpriseBeans-4.0/io.openliberty.enterpriseBeans-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/enterpriseBeans-4.0/io.openliberty.enterpriseBeans-4.0.feature
@@ -16,3 +16,4 @@ Subsystem-Category: JakartaEE9Application
  io.openliberty.enterpriseBeansRemote-4.0
 kind=beta
 edition=base
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/enterpriseBeansHome-4.0/io.openliberty.enterpriseBeansHome-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/enterpriseBeansHome-4.0/io.openliberty.enterpriseBeansHome-4.0.feature
@@ -11,3 +11,4 @@ Subsystem-Name: Jakarta Enterprise Beans Home Interfaces 4.0
 -bundles=com.ibm.ws.ejbcontainer.ejb2x
 kind=beta
 edition=base
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/enterpriseBeansRemote-4.0/io.openliberty.enterpriseBeansRemote-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/enterpriseBeansRemote-4.0/io.openliberty.enterpriseBeansRemote-4.0.feature
@@ -14,3 +14,4 @@ Subsystem-Name: Jakarta Enterprise Beans Remote 4.0
 -files=clients/ejbRemotePortable.jakarta.jar
 kind=beta
 edition=base
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mdb-4.0/io.openliberty.mdb-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mdb-4.0/io.openliberty.mdb-4.0.feature
@@ -18,3 +18,4 @@ Subsystem-Category: JakartaEE9Application
 Subsystem-Name: Message-Driven Beans 4.0
 kind=beta
 edition=base
+WLP-Activation-Type: parallel


### PR DESCRIPTION
All new features for Jakarta Enterprise Beans 4.0 should use parallel activation:

WLP-Activation-Type: parallel

fixes #14251 