### PR TITLE
add a dopriv to ReferencingAuthenticator in jaxrs-2.0 for java 2 security

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/transport/http/ReferencingAuthenticator.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/transport/http/ReferencingAuthenticator.java
@@ -1,0 +1,136 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.transport.http;
+
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+
+import org.apache.cxf.common.util.ReflectionUtil;
+
+public class ReferencingAuthenticator extends Authenticator {
+    final Reference<Authenticator> auth;
+    final Authenticator wrapped;
+    public ReferencingAuthenticator(Authenticator cxfauth, Authenticator wrapped) {
+        this.auth = new WeakReference<Authenticator>(cxfauth);
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    protected PasswordAuthentication getPasswordAuthentication() {
+        Authenticator cxfauth = auth.get();
+        if (cxfauth == null) {
+            remove();
+        }
+        PasswordAuthentication pauth = null;
+        if (wrapped != null) {
+            try {
+                pauth = tryWith(wrapped);
+                if (pauth != null) {
+                    return pauth;
+                }
+            } catch (Exception e) {
+                pauth = null;
+            }
+        }
+        if (cxfauth != null) {
+            try {
+                pauth = tryWith(cxfauth);
+            } catch (Exception e1) {
+                pauth = null;
+            }
+        }
+        return pauth;
+    }
+    
+    public final void check() {
+        Authenticator cxfauth = auth.get();
+        if (cxfauth == null) {
+            remove();
+        }
+        if (wrapped != null && wrapped.getClass().getName().equals(ReferencingAuthenticator.class.getName())) {
+            try {
+                Method m = wrapped.getClass().getMethod("check");
+                m.setAccessible(true);
+                m.invoke(wrapped);
+            } catch (Throwable t) {
+                //ignore
+            }
+        }
+    }
+    private void remove() {
+        try {
+            for (final Field f : Authenticator.class.getDeclaredFields()) {
+                if (f.getType().equals(Authenticator.class)) {
+                    try {
+                        f.setAccessible(true);
+                        Authenticator o = (Authenticator)f.get(null);
+                        if (o == this) {
+                            //this is at the root of any chain of authenticators
+                            Authenticator.setDefault(wrapped);
+                        } else {
+                            removeFromChain(o);
+                        }
+                    } catch (Exception e) {
+                        //ignore
+                    }
+                }
+            }
+        } catch (Throwable t) {
+            //ignore
+        }
+    }
+    private void removeFromChain(Authenticator a) {
+        try {
+            if (a.getClass().getName().equals(ReferencingAuthenticator.class.getName())) {
+                //multiple referencing authenticators, we can remove ourself
+                Field f2 = a.getClass().getDeclaredField("wrapped");
+                f2.setAccessible(true);
+                Authenticator a2 = (Authenticator)f2.get(a);
+                if (a2 == this) {
+                    f2.set(a, wrapped);
+                } else {
+                    removeFromChain(a2);
+                }
+            }
+        } catch (Throwable t) {
+            //ignore
+        }
+    }
+    
+    PasswordAuthentication tryWith(Authenticator a) throws Exception {
+        if (a == null) {
+            return null;
+        }
+        for (final Field f : ReflectionUtil.getDeclaredFields(Authenticator.class)) { // Liberty Change
+            if (!Modifier.isStatic(f.getModifiers())) {
+                f.setAccessible(true);
+                Object o = f.get(this);
+                f.set(a, o);
+            }
+        } 
+        final Method m = Authenticator.class.getDeclaredMethod("getPasswordAuthentication");
+        m.setAccessible(true);
+        return (PasswordAuthentication)m.invoke(a);
+    }
+}


### PR DESCRIPTION
```ReferencingAuthenticator.tryWith()``` makes a call to ```Authenticator.class.getDeclaredFields()``` which can cause the following error:
```CWWKE0921W: Current Java 2 Security policy reported a potential violation of Java 2 Security Permission. The application needs to have permissions addedPermission: 
("java.lang.RuntimePermission" "accessDeclaredMembers")
Stack: 
java.security.AccessControlException: Access denied ("java.lang.RuntimePermission" "accessDeclaredMembers")java.base/java.security.AccessController.throwACE(AccessController.java:176)
java.base/java.security.AccessController.checkPermissionHelper(AccessController.java:238)
java.base/java.security.AccessController.checkPermission(AccessController.java:385)
java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:322)
com.ibm.ws.kernel.launch.internal.MissingDoPrivDetectionSecurityManager.checkPermission(MissingDoPrivDetectionSecurityManager.java:45)
java.base/java.lang.Class.checkMemberAccess(Class.java:245)
java.base/java.lang.Class.getDeclaredFields(Class.java:934)
org.apache.cxf.transport.http.ReferencingAuthenticator.tryWith(ReferencingAuthenticator.java:123)
org.apache.cxf.transport.http.ReferencingAuthenticator.getPasswordAuthentication(ReferencingAuthenticator.java:56)
java.base/java.net.Authenticator.requestPasswordAuthenticationInstance(Authenticator.java:461)
java.base/java.net.Authenticator.requestPasswordAuthentication(Authenticator.java:412)
java.base/sun.net.www.protocol.http.HttpURLConnection$1.run(HttpURLConnection.java:455)
java.base/sun.net.www.protocol.http.HttpURLConnection$1.run(HttpURLConnection.java:450)
java.base/java.security.AccessController.doPrivileged(AccessController.java:678)
java.base/sun.net.www.protocol.http.HttpURLConnection.privilegedRequestPasswordAuthentication(HttpURLConnection.java:449)
java.base/sun.net.www.protocol.http.HttpURLConnection.getServerAuthentication(HttpURLConnection.java:2476)
java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1761)
java.base/sun.net.www.protocol.http.HttpURLConnection$9.run(HttpURLConnection.java:1507)
java.base/sun.net.www.protocol.http.HttpURLConnection$9.run(HttpURLConnection.java:1505)
java.base/java.security.AccessController.doPrivileged(AccessController.java:942)
java.base/java.security.AccessController.doPrivilegedWithCombiner(AccessController.java:984)
java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1504)
java.base/java.net.HttpURLConnection.getResponseCode(HttpURLConnection.java:527)
org.apache.cxf.transport.http.URLConnectionHTTPConduit$URLConnectionWrappedOutputStream$2.run(URLConnectionHTTPConduit.java:427)
org.apache.cxf.transport.http.URLConnectionHTTPConduit$URLConnectionWrappedOutputStream$2.run(URLConnectionHTTPConduit.java:423)
java.base/java.security.AccessController.doPrivileged(AccessController.java:734)
org.apache.cxf.transport.http.URLConnectionHTTPConduit$URLConnectionWrappedOutputStream.getResponseCode(URLConnectionHTTPConduit.java:423)
org.apache.cxf.transport.http.HTTPConduit$WrappedOutputStream.doProcessResponseCode(HTTPConduit.java:1647)
org.apache.cxf.transport.http.HTTPConduit$WrappedOutputStream.handleResponseInternal(HTTPConduit.java:1676)
org.apache.cxf.transport.http.HTTPConduit$WrappedOutputStream.handleResponse(HTTPConduit.java:1620)
org.apache.cxf.transport.http.HTTPConduit$WrappedOutputStream.close(HTTPConduit.java:1417)
org.apache.cxf.io.AbstractWrappedOutputStream.close(AbstractWrappedOutputStream.java:77)
org.apache.cxf.transport.AbstractConduit.close(AbstractConduit.java:56)
org.apache.cxf.transport.http.HTTPConduit.close(HTTPConduit.java:685)
org.apache.cxf.interceptor.MessageSenderInterceptor$MessageSenderEndingInterceptor.handleMessage(MessageSenderInterceptor.java:63)
org.apache.cxf.phase.PhaseInterceptorChain.doIntercept(PhaseInterceptorChain.java:309)
org.apache.cxf.jaxrs.client.AbstractClient.doRunInterceptorChain(AbstractClient.java:715)
org.apache.cxf.jaxrs.client.WebClient.doChainedInvocation(WebClient.java:1038)
org.apache.cxf.jaxrs.client.WebClient.doInvoke(WebClient.java:894)
org.apache.cxf.jaxrs.client.WebClient.doInvoke(WebClient.java:862)
org.apache.cxf.jaxrs.client.WebClient.invoke(WebClient.java:427)
org.apache.cxf.jaxrs.client.WebClient$SyncInvokerImpl.method(WebClient.java:1551)
org.apache.cxf.jaxrs.client.WebClient$SyncInvokerImpl.method(WebClient.java:1546)
org.apache.cxf.jaxrs.client.WebClient$SyncInvokerImpl.get(WebClient.java:1466)
org.apache.cxf.jaxrs.client.spec.InvocationBuilderImpl.get(InvocationBuilderImpl.java:84)
com.ibm.ws.jaxrs.fat.rolesallowed.servlet.RolesAllowedTestServlet.testEveryoneAllowed(RolesAllowedTestServlet.java:51)
java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
java.base/java.lang.reflect.Method.invoke(Method.java:566)
componenttest.app.FATServlet.doGet(FATServlet.java:71)
javax.servlet.http.HttpServlet.service(HttpServlet.java:687)
javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
com.ibm.ws.webcontainer.servlet.ServletWrapper.service(ServletWrapper.java:1230)
com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:729)
com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:426)
com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1226)
com.ibm.ws.webcontainer.webapp.WebApp.handleRequest(WebApp.java:5057)
com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.handleRequest(DynamicVirtualHost.java:314)
com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:1005)
com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:279)
com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1134)
com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:415)
com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:374)
com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:577)
com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:511)
com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:359)
com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.ready(HttpInboundLink.java:326)
com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.sendToDiscriminators(NewConnectionInitialReadCallback.java:167)
com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.complete(NewConnectionInitialReadCallback.java:75)
com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:504)
com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:574)
com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:958)
com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1047)
com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:239)
java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
java.base/java.lang.Thread.run(Th```