### PR TITLE
Disable all features on conflict

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.core/resources/com/ibm/ws/kernel/feature/internal/resources/ProvisionerMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.feature.core/resources/com/ibm/ws/kernel/feature/internal/resources/ProvisionerMessages.nlsprops
@@ -222,9 +222,9 @@ MISSING_FEATURE_HAS_ALT_NAME=CWWKF0045E: An existing feature definition, {1}, is
 MISSING_FEATURE_HAS_ALT_NAME.explanation=The feature manager cannot find a definition for a feature specified in the server configuration. The name specified might match an existing feature definition.
 MISSING_FEATURE_HAS_ALT_NAME.useraction=Consider specifying the named, existing feature definition instead. 
 
-UPDATE_DISABLED_FEATURES_ON_CONFLICT=CWWKF0046W: The configuration includes an incompatible combination of features that is not supported. As a result the feature manager has not installed any features.
-UPDATE_DISABLED_FEATURES_ON_CONFLICT.explanation=The configuration includes an incompatible combination of features. To avoid invalid behavior the feature manager has disabled all features.
-UPDATE_DISABLED_FEATURES_ON_CONFLICT.useraction=Try to specify a different version of the configured features that caused the conflict.
+UPDATE_DISABLED_FEATURES_ON_CONFLICT=CWWKF0046W: The configuration includes an incompatible combination of features. As a result, the feature manager has not installed any features.
+UPDATE_DISABLED_FEATURES_ON_CONFLICT.explanation=The configuration includes an incompatible combination of features. To avoid invalid behavior, the feature manager has disabled all features.
+UPDATE_DISABLED_FEATURES_ON_CONFLICT.useraction=Specify a different version of the configured features that caused the conflict.
 
 #   Messages in the range CWWKF1000 are reserved for the FeatureToolMessages.
 

--- a/dev/com.ibm.ws.kernel.feature.core/resources/com/ibm/ws/kernel/feature/internal/resources/ProvisionerMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.feature.core/resources/com/ibm/ws/kernel/feature/internal/resources/ProvisionerMessages.nlsprops
@@ -222,7 +222,7 @@ MISSING_FEATURE_HAS_ALT_NAME=CWWKF0045E: An existing feature definition, {1}, is
 MISSING_FEATURE_HAS_ALT_NAME.explanation=The feature manager cannot find a definition for a feature specified in the server configuration. The name specified might match an existing feature definition.
 MISSING_FEATURE_HAS_ALT_NAME.useraction=Consider specifying the named, existing feature definition instead. 
 
-UPDATE_DISABLED_FEATURES_ON_CONFLICT=CWWKF0046W: The configuration includes an incompatible combination of features. As a result, the feature manager did not installed any features.
+UPDATE_DISABLED_FEATURES_ON_CONFLICT=CWWKF0046W: The configuration includes an incompatible combination of features. As a result, the feature manager did not install any features.
 UPDATE_DISABLED_FEATURES_ON_CONFLICT.explanation=The configuration includes an incompatible combination of features. To avoid invalid behavior, the feature manager disabled all features.
 UPDATE_DISABLED_FEATURES_ON_CONFLICT.useraction=Specify a different version of the configured features that caused the conflict.
 

--- a/dev/com.ibm.ws.kernel.feature.core/resources/com/ibm/ws/kernel/feature/internal/resources/ProvisionerMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.feature.core/resources/com/ibm/ws/kernel/feature/internal/resources/ProvisionerMessages.nlsprops
@@ -222,6 +222,10 @@ MISSING_FEATURE_HAS_ALT_NAME=CWWKF0045E: An existing feature definition, {1}, is
 MISSING_FEATURE_HAS_ALT_NAME.explanation=The feature manager cannot find a definition for a feature specified in the server configuration. The name specified might match an existing feature definition.
 MISSING_FEATURE_HAS_ALT_NAME.useraction=Consider specifying the named, existing feature definition instead. 
 
+UPDATE_DISABLED_FEATURES_ON_CONFLICT=CWWKF0046W: The configuration includes an incompatible combination of features that is not supported. As a result the feature manager has not installed any features.
+UPDATE_DISABLED_FEATURES_ON_CONFLICT.explanation=The configuration includes an incompatible combination of features. To avoid invalid behavior the feature manager has disabled all features.
+UPDATE_DISABLED_FEATURES_ON_CONFLICT.useraction=Try to specify a different version of the configured features that caused the conflict.
+
 #   Messages in the range CWWKF1000 are reserved for the FeatureToolMessages.
 
 tool.feature.exists=CWWKF1000I: The feature {0} already exists. It will not be reinstalled. To modify an existing feature, you need to manually uninstall it first.

--- a/dev/com.ibm.ws.kernel.feature.core/resources/com/ibm/ws/kernel/feature/internal/resources/ProvisionerMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.feature.core/resources/com/ibm/ws/kernel/feature/internal/resources/ProvisionerMessages.nlsprops
@@ -222,8 +222,8 @@ MISSING_FEATURE_HAS_ALT_NAME=CWWKF0045E: An existing feature definition, {1}, is
 MISSING_FEATURE_HAS_ALT_NAME.explanation=The feature manager cannot find a definition for a feature specified in the server configuration. The name specified might match an existing feature definition.
 MISSING_FEATURE_HAS_ALT_NAME.useraction=Consider specifying the named, existing feature definition instead. 
 
-UPDATE_DISABLED_FEATURES_ON_CONFLICT=CWWKF0046W: The configuration includes an incompatible combination of features. As a result, the feature manager has not installed any features.
-UPDATE_DISABLED_FEATURES_ON_CONFLICT.explanation=The configuration includes an incompatible combination of features. To avoid invalid behavior, the feature manager has disabled all features.
+UPDATE_DISABLED_FEATURES_ON_CONFLICT=CWWKF0046W: The configuration includes an incompatible combination of features. As a result, the feature manager did not installed any features.
+UPDATE_DISABLED_FEATURES_ON_CONFLICT.explanation=The configuration includes an incompatible combination of features. To avoid invalid behavior, the feature manager disabled all features.
 UPDATE_DISABLED_FEATURES_ON_CONFLICT.useraction=Specify a different version of the configured features that caused the conflict.
 
 #   Messages in the range CWWKF1000 are reserved for the FeatureToolMessages.

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureDefinitionUtils.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureDefinitionUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -75,6 +75,7 @@ public class FeatureDefinitionUtils {
     public static final String IBM_PROCESS_TYPES = "IBM-Process-Types";
     public static final String IBM_ACTIVATION_TYPE = "WLP-Activation-Type";
     public static final String IBM_ALT_NAMES = "WLP-AlsoKnownAs";
+    public static final String IBM_DISABLE_ALL_FEATURES_ON_CONFLICT = "WLP-DisableAllFeatures-OnConflict";
 
     static final String FILTER_ATTR_NAME = "filter";
     static final String FILTER_FEATURE_KEY = "osgi.identity";
@@ -119,6 +120,7 @@ public class FeatureDefinitionUtils {
         final boolean hasSpiPackages;
         final boolean hasApiServices;
         final boolean isSingleton;
+        final boolean disableOnConflict;
         final File featureFile;
         final long lastModified;
         final long length;
@@ -139,6 +141,7 @@ public class FeatureDefinitionUtils {
                             boolean hasApiPackages,
                             boolean hasSpiPackages,
                             boolean isSingleton,
+                            boolean disableOnConflict,
                             EnumSet<ProcessType> processType,
                             ActivationType activationType) {
 
@@ -159,6 +162,7 @@ public class FeatureDefinitionUtils {
             this.hasApiPackages = hasApiPackages;
             this.hasSpiPackages = hasSpiPackages;
             this.isSingleton = isSingleton;
+            this.disableOnConflict = disableOnConflict;
 
             this.featureFile = featureFile;
             this.lastModified = lastModified;
@@ -321,6 +325,8 @@ public class FeatureDefinitionUtils {
             activationType = activationTypeHeader == null ? ActivationType.SEQUENTIAL : ActivationType.fromString(activationTypeHeader);
         }
 
+        boolean disableOnConflict = Boolean.parseBoolean(details.getCachedRawHeader(IBM_DISABLE_ALL_FEATURES_ON_CONFLICT));
+
         ImmutableAttributes iAttr = new ImmutableAttributes(repoType,
                                                             symbolicName,
                                                             nullIfEmpty(shortName),
@@ -334,6 +340,7 @@ public class FeatureDefinitionUtils {
                                                             featureFile == null ? -1 : featureFile.length(),
                                                             isAutoFeature, hasApiServices,
                                                             hasApiPackages, hasSpiPackages, isSingleton,
+                                                            disableOnConflict,
                                                             processTypes,
                                                             activationType);
 

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureRepository.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -66,7 +66,7 @@ import com.ibm.wsspi.kernel.service.location.WsResource;
  */
 public final class FeatureRepository implements FeatureResolver.Repository {
     private static final TraceComponent tc = Tr.register(FeatureRepository.class);
-    private static final int FEATURE_CACHE_VERSION = 2;
+    private static final int FEATURE_CACHE_VERSION = 3;
     private static final String EMPTY = "";
 
     /**
@@ -129,6 +129,14 @@ public final class FeatureRepository implements FeatureResolver.Repository {
      */
     public String matchesAlternate(String featureName) {
         return alternateFeatureNameToPublicName.get(lowerFeature(featureName));
+    }
+
+    public boolean disableAllFeaturesOnConflict(String featureName) {
+        SubsystemFeatureDefinitionImpl feature = (SubsystemFeatureDefinitionImpl) getFeature(featureName);
+        if (feature != null) {
+            return feature.getImmutableAttributes().disableOnConflict;
+        }
+        return false;
     }
 
     /**
@@ -376,6 +384,7 @@ public final class FeatureRepository implements FeatureResolver.Repository {
         out.writeBoolean(iAttr.hasApiPackages);
         out.writeBoolean(iAttr.hasSpiPackages);
         out.writeBoolean(iAttr.isSingleton);
+        out.writeBoolean(iAttr.disableOnConflict);
 
         out.writeInt(iAttr.processTypes.size());
         for (ProcessType type : iAttr.processTypes) {
@@ -453,6 +462,7 @@ public final class FeatureRepository implements FeatureResolver.Repository {
         boolean hasApiPackages = in.readBoolean();
         boolean hasSpiPackages = in.readBoolean();
         boolean isSingleton = in.readBoolean();
+        boolean disableOnConflict = in.readBoolean();
 
         int processTypeNum = in.readInt();
         EnumSet<ProcessType> processTypes = EnumSet.noneOf(ProcessType.class);
@@ -467,7 +477,7 @@ public final class FeatureRepository implements FeatureResolver.Repository {
         }
         return new ImmutableAttributes(repositoryType, symbolicName, shortName, altNames, featureVersion, visibility, appRestart,
                                        version, featureFile, lastModified, fileSize, isAutoFeature, hasApiServices, hasApiPackages,
-                                       hasSpiPackages, isSingleton, processTypes, activationType);
+                                       hasSpiPackages, isSingleton, disableOnConflict, processTypes, activationType);
     }
 
     /**

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/resolver/FeatureResolver.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/resolver/FeatureResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,7 +38,7 @@ public interface FeatureResolver {
         /**
          * Returns all known liberty features contained in this repository
          * which are considered to be auto features.
-         * 
+         *
          * @return a collection of auto features.
          */
         Collection<ProvisioningFeatureDefinition> getAutoFeatures();
@@ -48,7 +48,7 @@ public interface FeatureResolver {
          * be the short name (if it is a public feature) or the full
          * symbolic name. The full symbolic name will include the version
          * (e.g. com.ibm.ws.something_1.0)
-         * 
+         *
          * @param featureName the feature name
          * @return the feature with the specified name or {@code null}.
          */
@@ -62,7 +62,7 @@ public interface FeatureResolver {
          * a list [1.0, 1.1, 1.2] to indicate that all features that include a
          * version of com.ibm.ws.something also can tolerate versions
          * 1.0, 1.1 and 1.2. This is a way to override the tolerates.
-         * 
+         *
          * @param baseSymbolicName a feature base symbolic name to allow more tolerations for.
          * @return The additional versions of the feature that can be tolerated.
          */
@@ -75,21 +75,21 @@ public interface FeatureResolver {
     public interface Result {
         /**
          * The set of feature names that are required to resolve an initial set of root features.
-         * 
+         *
          * @return the feature names that are resolved
          */
         Set<String> getResolvedFeatures();
 
         /**
          * The required features that could not be found while trying to resolve root features.
-         * 
+         *
          * @return the missing features
          */
         Set<String> getMissing();
 
         /**
          * The set of root features must be public. This will return any that are not
-         * 
+         *
          * @return the non public root features
          */
         Set<String> getNonPublicRoots();
@@ -99,21 +99,21 @@ public interface FeatureResolver {
          * is the base name of the feature that has conflicting versions required.
          * The value is a collection of dependency {@link Chain}s that transitively
          * lead to the conflicting versions of the feature.
-         * 
+         *
          * @return
          */
         Map<String, Collection<Chain>> getConflicts();
 
         /**
          * Not really used yet
-         * 
+         *
          * @return
          */
         Map<String, Chain> getWrongProcessTypes();
 
         /**
          * A quick check to tell if there are any errors in the result.
-         * 
+         *
          * @return
          * @see #getMissing()
          * @see #getNonPublicRoots()
@@ -134,10 +134,10 @@ public interface FeatureResolver {
 
         /**
          * Creates a dependency chain.
-         * 
-         * @param chain The chain of feature names that have lead to a requirement on a singleton feature
-         * @param candidates The tolerated candidates that were found which may satisfy the feature requirement
-         * @param preferredVersion The preferred version
+         *
+         * @param chain              The chain of feature names that have lead to a requirement on a singleton feature
+         * @param candidates         The tolerated candidates that were found which may satisfy the feature requirement
+         * @param preferredVersion   The preferred version
          * @param originalFeatureReq The full feature name that is required.
          */
         public Chain(Collection<String> chain, List<String> candidates, String preferredVersion, String originalFeatureReq) {
@@ -202,40 +202,46 @@ public interface FeatureResolver {
      * Resolves a collection of root features against a repository.
      * This is a convenience method that effectively does the following:
      * <code>
-     * resolveFeatures(repository, Collections.emptySet(), rootFeatures, preResolved, allowMultipleVersions)
+     * resolveFeatures(repository, Collections.emptySet(), rootFeatures, preResolved, allowMultipleVersions);
      * </code>
-     * 
-     * @param repository the feature repository to use
-     * @param rootFeatures the root features to resolve
-     * @param preResolved the set of already resolved features to base the resolution delta off of
+     *
+     * @param repository            the feature repository to use
+     * @param rootFeatures          the root features to resolve
+     * @param preResolved           the set of already resolved features to base the resolution delta off of
      * @param allowMultipleVersions a flag that allows multiple versions (this flag will effectively ignore singletons)
      * @return the resolution result
      */
     public Result resolveFeatures(Repository repository, Collection<String> rootFeatures, Set<String> preResolved, boolean allowMultipleVersions);
-    
+
     /**
-     * Resolves a collection of root features against a repository
-     * 
-     * @param repository the feature repository to use
-     * @param kernelFeatures the set of kernel features to use for auto-feature processing
-     * @param rootFeatures the root features to resolve
-     * @param preResolved the set of already resolved features to base the resolution delta off of
+     * Resolves a collection of root features against a repository.
+     * This is a convenience method that effectively does the following:
+     * <code>
+     * resolveFeatures(repository, kernelFeatures, rootFeatures, preResolved, allowMultipleVersions, EnumSet.allOf(ProcessType.class));
+     * </code>
+     *
+     * @param repository            the feature repository to use
+     * @param kernelFeatures        the set of kernel features to use for auto-feature processing
+     * @param rootFeatures          the root features to resolve
+     * @param preResolved           the set of already resolved features to base the resolution delta off of
      * @param allowMultipleVersions a flag that allows multiple versions (this flag will effectively ignore singletons)
      * @return the resolution result
      */
-    public Result resolveFeatures(Repository repository, Collection<ProvisioningFeatureDefinition> kernelFeatures, Collection<String> rootFeatures, Set<String> preResolved, boolean allowMultipleVersions);
+    public Result resolveFeatures(Repository repository, Collection<ProvisioningFeatureDefinition> kernelFeatures, Collection<String> rootFeatures, Set<String> preResolved,
+                                  boolean allowMultipleVersions);
 
     /**
-     * Not really used
-     * 
-     * @param repository
-     * @param kernelFeatures
-     * @param rootFeatures
-     * @param preResolved
-     * @param allowMultipleVersions
-     * @param supportedProcessTypes
-     * @return
+     * Resolves a collection of root features against a repository.
+     *
+     * @param repository            the feature repository to use
+     * @param kernelFeatures        the set of kernel features to use for auto-feature processing
+     * @param rootFeatures          the root features to resolve
+     * @param preResolved           the set of already resolved features to base the resolution delta off of
+     * @param allowMultipleVersions a flag that allows multiple versions (this flag will effectively ignore singletons)
+     * @param supportedProcessTypes the supported process types to allow to be resolved
+     * @return the resolution result
      */
-    public Result resolveFeatures(Repository repository, Collection<ProvisioningFeatureDefinition> kernelFeatures, Collection<String> rootFeatures, Set<String> preResolved, boolean allowMultipleVersions,
+    public Result resolveFeatures(Repository repository, Collection<ProvisioningFeatureDefinition> kernelFeatures, Collection<String> rootFeatures, Set<String> preResolved,
+                                  boolean allowMultipleVersions,
                                   EnumSet<ProcessType> supportedProcessTypes);
 }

--- a/dev/com.ibm.ws.kernel.feature_fat/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.feature_fat/bnd.bnd
@@ -42,7 +42,9 @@ tested.features: needsNewEe-1.0, newEe-1.0, \
 	servlet-5.0, ssl-1.0, \
 	wasJmsClient-2.0, wasJmsSecurity-1.0, wasJmsServer-1.0, webProfile-8.0, websocket-1.1, \
 	featuref-1.0, productauto:pfeaturen-1.0, productauto:pfeaturem-1.0, featuree-1.0, productauto:pfeaturel-1.0, featureg-1.0, productauto:pfeaturef-1.0, productauto:pfeatureg-1.0, productauto:pfeaturee-1.0, capabilityc-1.0, badpathtool-1.0, emptyiconheader-1.0, goldenpathtool-1.0, icondirectivestool-1.0, noheadertool-1.0, missingiconstool-1.0, jwt-1.0, servlet-3.1, \
-	appclientsupport-2.0, appsecurity-4.0, enterprisebeansremote-4.0, jakartaee-9.0, enterprisebeanshome-4.0, cdi-3.0, enterprisebeanslite-4.0, jacc-2.0
+	appclientsupport-2.0, appsecurity-4.0, enterprisebeansremote-4.0, jakartaee-9.0, enterprisebeanshome-4.0, cdi-3.0, enterprisebeanslite-4.0, jacc-2.0, \
+    falseb-1.0, falsea-1.0, falsec-1.0, falsed-1.0, falsee-1.0, \
+    trueA-1.0, trueB-1.0, trueC-1.0, trueConflict-1.0
 
 -buildpath: \
 	org.eclipse.osgi;version=latest,\

--- a/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/DisableAllFeaturesOnConflictTest.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/DisableAllFeaturesOnConflictTest.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.kernel.feature.fat;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import componenttest.annotation.ExpectedFFDC;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
+
+@RunWith(FATRunner.class)
+public class DisableAllFeaturesOnConflictTest {
+    private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.kernel.feature.disable.onconflict");
+    private static final Collection<String> TEST_FEATURES = Arrays.asList("test.disable.all.features.on.conflict.false.a",
+                                                                          "test.disable.all.features.on.conflict.false.b",
+                                                                          "test.disable.all.features.on.conflict.false.c",
+                                                                          "test.disable.all.features.on.conflict.false.d",
+                                                                          "test.disable.all.features.on.conflict.false.e",
+                                                                          "test.disable.all.features.on.conflict.falseConflict-1.0",
+                                                                          "test.disable.all.features.on.conflict.falseConflict-2.0",
+                                                                          "test.disable.all.features.on.conflict.falseConflict-3.0",
+                                                                          "test.disable.all.features.on.conflict.true.a",
+                                                                          "test.disable.all.features.on.conflict.true.b",
+                                                                          "test.disable.all.features.on.conflict.true.c",
+                                                                          "test.disable.all.features.on.conflict.true.d",
+                                                                          "test.disable.all.features.on.conflict.trueConflict-1.0",
+                                                                          "test.disable.all.features.on.conflict.trueConflict-2.0");
+    static final String INSTALLED_FEATURES = "CWWKF0012I.*";
+    static final String REMOVED_FEATURES = "CWWKF0013I.*";
+    static final String CONFLICT = "CWWKF0033E.*";
+    static final String NO_FEATURES = "CWWKF0046W.*";
+
+    @Test
+    @ExpectedFFDC({ "java.lang.IllegalArgumentException", "com.ibm.ws.timedexit.internal.RequiredTimedExitFeatureStoppedException" })
+    public void testDisableAllFeaturesOnConflict() throws Exception {
+
+        // NOTE that we use smallest timeout because we first wait for config update
+        // message.  This is the last message and all messages we expect will happen
+        // before the config update message.
+        server.startServer();
+        server.setMarkToEndOfLog();
+
+        verifyFeaturesEnabled(Arrays.asList("falseA-1.0", "falseD-1.0"), Arrays.asList("falseA-1.0", "falseB-1.0", "falseC-1.0", "falseD-1.0"));
+
+        verifyFeaturesDisabled(Arrays.asList("falseA-1.0", "falseD-1.0", "trueConflict-1.0"), Arrays.asList("falseA-1.0", "falseB-1.0", "falseC-1.0", "falseD-1.0"));
+
+        verifyFeaturesEnabled(Arrays.asList("falseA-1.0", "falseD-1.0"), Arrays.asList("falseA-1.0", "falseB-1.0", "falseC-1.0", "falseD-1.0"));
+
+        verifyFeaturesDisabled(Arrays.asList("falseA-1.0", "falseD-1.0", "falseE-1.0"), Arrays.asList("falseA-1.0", "falseB-1.0", "falseC-1.0", "falseD-1.0"));
+
+        verifyFeaturesEnabled(Arrays.asList("trueA-1.0"), Arrays.asList("trueA-1.0", "trueB-1.0", "trueC-1.0", "trueConflict-1.0"));
+
+        verifyFeaturesDisabled(Arrays.asList("trueA-1.0", "trueD-1.0"), Arrays.asList("trueA-1.0", "trueB-1.0", "trueC-1.0", "trueConflict-1.0"));
+
+    }
+
+    private void verifyFeaturesEnabled(List<String> rootFeatures, List<String> expectedInstalledFeatures) throws Exception {
+        server.changeFeatures(rootFeatures);
+        server.waitForConfigUpdateInLogUsingMark(Collections.<String> emptySet());
+        assertNull("Expected some features to be installed.", server.waitForStringInLog(NO_FEATURES, 1));
+        String installedFeatures = server.waitForStringInLogUsingMark(INSTALLED_FEATURES, 1);
+        expectedInstalledFeatures.forEach((f) -> {
+            assertTrue("Server should have installed the feature: " + f, installedFeatures.contains(f));
+        });
+        server.setMarkToEndOfLog();
+    }
+
+    private void verifyFeaturesDisabled(List<String> rootFeatures, List<String> expectedRemovedFeatures) throws Exception {
+        server.changeFeatures(rootFeatures);
+        server.waitForConfigUpdateInLogUsingMark(Collections.<String> emptySet());
+        assertNotNull("Expected no features to be installed.", server.waitForStringInLog(NO_FEATURES, 1));
+        String removedFeatures = server.waitForStringInLogUsingMark(REMOVED_FEATURES, 1);
+        expectedRemovedFeatures.forEach((f) -> {
+            assertTrue("Server should have removed the feature: " + f, removedFeatures.contains(f));
+        });
+        String installedFeatures = server.waitForStringInLogUsingMark(INSTALLED_FEATURES, 1);
+        assertNull("Should be no features installed.", installedFeatures);
+        server.setMarkToEndOfLog();
+    }
+
+    @BeforeClass
+    public static void installFeatures() throws Exception {
+        TEST_FEATURES.forEach((f) -> {
+            try {
+                server.installSystemFeature(f);
+            } catch (Exception e) {
+                sneakyThrow(e);
+            }
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <E extends Throwable> void sneakyThrow(Throwable e) throws E {
+        throw (E) e;
+    }
+
+    @AfterClass
+    public static void uninstallFeatures() throws Exception {
+        TEST_FEATURES.forEach((f) -> {
+            try {
+                server.uninstallSystemFeature(f);
+            } catch (Exception e) {
+                sneakyThrow(e);
+            }
+        });
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (server != null && server.isStarted()) {
+            server.stopServer(CONFLICT, NO_FEATURES);
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/EECompatibilityTest.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/EECompatibilityTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.kernel.feature.fat;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -17,7 +18,9 @@ import java.util.Arrays;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 import componenttest.annotation.ExpectedFFDC;
@@ -30,7 +33,8 @@ import componenttest.topology.impl.LibertyServerFactory;
  */
 @RunWith(FATRunner.class)
 public class EECompatibilityTest {
-
+    @Rule
+    public TestName name = new TestName();
     private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.kernel.feature.compatibility");
 
     @BeforeClass
@@ -65,6 +69,7 @@ public class EECompatibilityTest {
 
     static final String RESOLUTION_ERROR = "CWWKE0702E.*";
     static final String INSTALLED_FEATURES = "CWWKF0012I.*";
+    static final String NO_FEATURES = "CWWKF0046W.*";
 
     private static String msg;
     private static long shortTimeOut = 5 * 1000;
@@ -104,25 +109,23 @@ public class EECompatibilityTest {
                    msg == null);
         msg = server.waitForStringInLogUsingMark(INSTALLED_FEATURES, shortTimeOut);
         assertTrue("The server should not install the conflicting features servlet-4.0 nor servlet-3.1 , but it did: " + msg,
-                   msg != null || !msg.contains("servlet-4.0") && !msg.contains("servlet-3.1"));
+                   msg != null && !msg.contains("servlet-4.0") && !msg.contains("servlet-3.1"));
         server.stopServer(ANY_CONFLICT + "|" + RESOLUTION_ERROR);
     }
 
     @Test
-    @ExpectedFFDC("java.lang.IllegalArgumentException")
+    @ExpectedFFDC({ "java.lang.IllegalArgumentException" })
     public void testConflictingRootFeaturesEE9and8() throws Exception {
         server.changeFeatures(Arrays.asList("servlet-5.0", "servlet-4.0"));
-        server.startServer();
+        server.startServer(name.getMethodName() + ".log", true, true, false);
         msg = server.waitForStringInLogUsingMark(CONFLICT, shortTimeOut);
         assertTrue("The feature manager should report a singleton conflict for the root (i.e. configured) features, but it did not: msg=" + msg,
                    msg != null && msg.contains("servlet-5.0") && msg.contains("servlet-4.0"));
         msg = server.waitForStringInLogUsingMark(EE_CONFLICT, shortTimeOut);
         assertTrue("The feature manager should not report an EE compatibility conflict for the root features, but it did: msg=" + msg,
                    msg == null);
-        msg = server.waitForStringInLogUsingMark(INSTALLED_FEATURES, shortTimeOut);
-        assertTrue("The server should not install the conflicting features servlet-5.0 nor servlet-4.0 , but it did: " + msg,
-                   msg != null || !msg.contains("servlet-5.0") && !msg.contains("servlet-4.0"));
-        server.stopServer(ANY_CONFLICT + "|" + RESOLUTION_ERROR);
+        assertNotNull("Expected no features to be installed.", server.waitForStringInLog(NO_FEATURES, shortTimeOut));
+        server.stopServer(ANY_CONFLICT + "|" + NO_FEATURES);
     }
 
     @Test
@@ -136,7 +139,7 @@ public class EECompatibilityTest {
                    msg != null && msg.contains("jsfContainer-2.3") && msg.contains("jsp-2.2"));
         msg = server.waitForStringInLogUsingMark(INSTALLED_FEATURES, shortTimeOut);
         assertTrue("The server should not install conflicting features jsp-2.3 nor jsp-2.2, but it did: " + msg,
-                   msg != null || !msg.contains("jsp-2.3") && !msg.contains("jsp-2.2"));
+                   msg != null && !msg.contains("jsp-2.3") && !msg.contains("jsp-2.2"));
         server.stopServer(ANY_CONFLICT + "|" + RESOLUTION_ERROR);
     }
 
@@ -163,61 +166,59 @@ public class EECompatibilityTest {
     }
 
     @Test
-    @ExpectedFFDC("java.lang.IllegalArgumentException")
+    @ExpectedFFDC({ "java.lang.IllegalArgumentException" })
     public void testConflictingEeCompatibleFeaturesEE9andJakartaEE8() throws Exception {
         // This configuration requires you add many, many features to the
         // tested.features property in the bnd.bnd file
         server.changeFeatures(Arrays.asList("servlet-5.0", "jakartaee-8.0"));
-        server.startServer();
+        server.startServer(name.getMethodName() + ".log", true, true, false);
         msg = server.waitForStringInLogUsingMark(DIFF_EE_CONFLICT, shortTimeOut);
         // Note that feature jakartaee-8.0 is actually ee8 compatible, so we expect
         // some Java EE feature to conflict.
         assertTrue("The feature manager should report an EE compatibility conflict for the configured servlet-5.0(EE9) and a dependent feature of jakartaee-8.0(EE8), but it did not: msg="
                    + msg, msg != null && msg.contains("servlet-5.0") && msg.contains("Jakarta EE 9") && msg.contains("Java EE"));
-        server.stopServer(ANY_CONFLICT + "|" + RESOLUTION_ERROR + "|" + "CWWKG0059E.*");
+        assertNotNull("Expected no features to be installed.", server.waitForStringInLog(NO_FEATURES, shortTimeOut));
+        server.stopServer(ANY_CONFLICT + "|" + NO_FEATURES);
     }
 
     @Test
-    @ExpectedFFDC("java.lang.IllegalArgumentException")
+    @ExpectedFFDC({ "java.lang.IllegalArgumentException" })
     public void testConflictingHelperFeaturesJakartaEE9and8() throws Exception {
         server.changeFeatures(Arrays.asList("jakartaee-9.0", "jakartaee-8.0"));
-        server.startServer();
+        server.startServer(name.getMethodName() + ".log", true, true, false);
         // The server reports a singleton conflict and installs neither helper feature!
         msg = server.waitForStringInLogUsingMark(DIFF_EE_CONFLICT, shortTimeOut);
         assertTrue("The feature manager should report a singleton conflict for the incompatible jakartaee helper features, but it did not: msg="
                    + msg, msg != null && msg.contains("jakartaee-9.0") && msg.contains("Jakarta EE 9") && msg.contains("Java EE"));
-        server.stopServer(ANY_CONFLICT + "|" + RESOLUTION_ERROR + "|" + "CWWKG0059E.*" + "|" + "CWWKG0026E.*");
+        assertNotNull("Expected no features to be installed.", server.waitForStringInLog(NO_FEATURES, shortTimeOut));
+        server.stopServer(ANY_CONFLICT + "|" + NO_FEATURES);
     }
 
     @Test
-    @ExpectedFFDC("java.lang.IllegalArgumentException")
+    @ExpectedFFDC({ "java.lang.IllegalArgumentException" })
     public void testConflictingEeCompatibleFeaturesEE9and8() throws Exception {
         // These configuration causes one conflict, only: the ee conflict
         server.changeFeatures(Arrays.asList("jpaContainer-3.0", "jsf-2.3")); // Conflict: -->ee9, -->ee8
-        server.startServer();
+        server.startServer(name.getMethodName() + ".log", true, true, false);
         msg = server.waitForStringInLogUsingMark(DIFF_EE_CONFLICT, shortTimeOut);
         assertTrue("The feature manager should report an EE compatibility conflict for the configured jpaContainer-3.0 (jakarta) and jsf-2.3 (javaee) features, but it did not: msg="
                    + msg, msg != null && msg.contains("jpaContainer-3.0") && msg.contains("jsf-2.3"));
-        msg = server.waitForStringInLogUsingMark(INSTALLED_FEATURES, shortTimeOut);
-        assertTrue("The server should not install the conflicting features jpaContainer-3.0 nor jsf-2.3 , but it did: " + msg,
-                   msg != null && !msg.contains("jpaContainer-3.0") && !msg.contains("jsf-2.3"));
-        server.stopServer(ANY_CONFLICT + "|" + RESOLUTION_ERROR);
+        assertNotNull("Expected no features to be installed.", server.waitForStringInLog(NO_FEATURES, shortTimeOut));
+        server.stopServer(ANY_CONFLICT + "|" + NO_FEATURES);
     }
 
     // Re-purpose this test and NewEe features for early
     // development on new EE versions
     @Test
-    @ExpectedFFDC("java.lang.IllegalArgumentException")
+    @ExpectedFFDC({ "java.lang.IllegalArgumentException" })
     public void testConflictingEeCompatibleFeaturesNewEEand8() throws Exception {
         // This configuration causes more than one conflict, including the ee conflict.
         server.changeFeatures(Arrays.asList("needsNewEe-1.0", "jsf-2.3")); // Conflict: -->newEe-1.0-->ee9, jsf-2.3-->ee8
-        server.startServer();
+        server.startServer(name.getMethodName() + ".log", true, true, false);
         msg = server.waitForStringInLogUsingMark(DIFF_EE_CONFLICT, shortTimeOut);
         assertTrue("The feature manager should report an EE compatibility conflict for the configured jakarta and javaee features, but it did not: msg=" + msg,
                    msg != null && msg.contains("newEe-1.0") && msg.contains("jsf-2.3"));
-        msg = server.waitForStringInLogUsingMark(INSTALLED_FEATURES, shortTimeOut);
-        assertTrue("The server should not install the conflicting features newEe-1.0 nor jsf-2.3 , but it did: " + msg,
-                   msg != null && !msg.contains("newEe-1.0") && !msg.contains("jsf-2.3"));
-        server.stopServer(ANY_CONFLICT + "|" + RESOLUTION_ERROR);
+        assertNotNull("Expected no features to be installed.", server.waitForStringInLog(NO_FEATURES, shortTimeOut));
+        server.stopServer(ANY_CONFLICT + "|" + NO_FEATURES);
     }
 }

--- a/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/FATSuite.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/FATSuite.java
@@ -35,7 +35,8 @@ import org.junit.runners.Suite.SuiteClasses;
                 RegionProvisioningTest.class,
                 RemoteServerInclude.class,
                 EECompatibilityTest.class,
-                AlternateFeatureNamesTest.class
+                AlternateFeatureNamesTest.class,
+                DisableAllFeaturesOnConflictTest.class
 })
 /**
  * Purpose: This suite collects and runs all known good test suites.

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.false.a.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.false.a.mf
@@ -1,0 +1,8 @@
+IBM-Feature-Version: 2
+Subsystem-ManifestVersion: 1
+Subsystem-Type: osgi.subsystem.feature
+Subsystem-Version: 1.0.0
+Subsystem-SymbolicName: falseA-1.0; visibility:=public; singleton:=true
+Subsystem-Content: falseB-1.0; type="osgi.subsystem.feature"
+WLP-DisableAllFeatures-OnConflict: false
+

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.false.b.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.false.b.mf
@@ -1,0 +1,7 @@
+IBM-Feature-Version: 2
+Subsystem-ManifestVersion: 1
+Subsystem-Type: osgi.subsystem.feature
+Subsystem-Version: 1.0.0
+Subsystem-SymbolicName: falseB-1.0; visibility:=public; singleton:=true
+Subsystem-Content: falseC-1.0; type="osgi.subsystem.feature"
+

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.false.c.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.false.c.mf
@@ -1,0 +1,8 @@
+IBM-Feature-Version: 2
+Subsystem-ManifestVersion: 1
+Subsystem-Type: osgi.subsystem.feature
+Subsystem-Version: 1.0.0
+Subsystem-SymbolicName: falseC-1.0; visibility:=public; singleton:=true
+Subsystem-Content: falseConflict-1.0; type="osgi.subsystem.feature"
+WLP-DisableAllFeatures-OnConflict: false
+

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.false.d.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.false.d.mf
@@ -1,0 +1,8 @@
+IBM-Feature-Version: 2
+Subsystem-ManifestVersion: 1
+Subsystem-Type: osgi.subsystem.feature
+Subsystem-Version: 1.0.0
+Subsystem-SymbolicName: falseD-1.0; visibility:=public; singleton:=true
+Subsystem-Content: falseConflict-2.0; type="osgi.subsystem.feature"; ibm.tolerates:=3.0
+WLP-DisableAllFeatures-OnConflict: false
+

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.false.e.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.false.e.mf
@@ -1,0 +1,8 @@
+IBM-Feature-Version: 2
+Subsystem-ManifestVersion: 1
+Subsystem-Type: osgi.subsystem.feature
+Subsystem-Version: 1.0.0
+Subsystem-SymbolicName: falseE-1.0; visibility:=public; singleton:=true
+Subsystem-Content: falseConflict-3.0; type="osgi.subsystem.feature"
+WLP-DisableAllFeatures-OnConflict: false
+

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.falseConflict-1.0.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.falseConflict-1.0.mf
@@ -1,0 +1,6 @@
+IBM-Feature-Version: 2
+Subsystem-ManifestVersion: 1
+Subsystem-Type: osgi.subsystem.feature
+Subsystem-Version: 1.0.0
+Subsystem-SymbolicName: falseConflict-1.0; visibility:=public; singleton:=true
+

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.falseConflict-2.0.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.falseConflict-2.0.mf
@@ -1,0 +1,6 @@
+IBM-Feature-Version: 2
+Subsystem-ManifestVersion: 1
+Subsystem-Type: osgi.subsystem.feature
+Subsystem-Version: 1.0.0
+Subsystem-SymbolicName: falseConflict-2.0; visibility:=public; singleton:=true
+

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.falseConflict-3.0.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.falseConflict-3.0.mf
@@ -1,0 +1,6 @@
+IBM-Feature-Version: 2
+Subsystem-ManifestVersion: 1
+Subsystem-Type: osgi.subsystem.feature
+Subsystem-Version: 1.0.0
+Subsystem-SymbolicName: falseConflict-3.0; visibility:=public; singleton:=true
+WLP-DisableAllFeatures-OnConflict: true

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.true.a.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.true.a.mf
@@ -1,0 +1,8 @@
+IBM-Feature-Version: 2
+Subsystem-ManifestVersion: 1
+Subsystem-Type: osgi.subsystem.feature
+Subsystem-Version: 1.0.0
+Subsystem-SymbolicName: trueA-1.0; visibility:=public; singleton:=true
+Subsystem-Content: trueB-1.0; type="osgi.subsystem.feature"
+WLP-DisableAllFeatures-OnConflict: true
+

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.true.b.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.true.b.mf
@@ -1,0 +1,8 @@
+IBM-Feature-Version: 2
+Subsystem-ManifestVersion: 1
+Subsystem-Type: osgi.subsystem.feature
+Subsystem-Version: 1.0.0
+Subsystem-SymbolicName: trueB-1.0; visibility:=public; singleton:=true
+Subsystem-Content: trueC-1.0; type="osgi.subsystem.feature"
+WLP-DisableAllFeatures-OnConflict: true
+

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.true.c.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.true.c.mf
@@ -1,0 +1,8 @@
+IBM-Feature-Version: 2
+Subsystem-ManifestVersion: 1
+Subsystem-Type: osgi.subsystem.feature
+Subsystem-Version: 1.0.0
+Subsystem-SymbolicName: trueC-1.0; visibility:=public; singleton:=true
+Subsystem-Content: trueConflict-1.0; type="osgi.subsystem.feature"
+WLP-DisableAllFeatures-OnConflict: true
+

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.true.d.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.true.d.mf
@@ -1,0 +1,8 @@
+IBM-Feature-Version: 2
+Subsystem-ManifestVersion: 1
+Subsystem-Type: osgi.subsystem.feature
+Subsystem-Version: 1.0.0
+Subsystem-SymbolicName: trueD-1.0; visibility:=public; singleton:=true
+Subsystem-Content: trueConflict-2.0; type="osgi.subsystem.feature"
+WLP-DisableAllFeatures-OnConflict: true
+

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.trueConflict-1.0.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.trueConflict-1.0.mf
@@ -1,0 +1,7 @@
+IBM-Feature-Version: 2
+Subsystem-ManifestVersion: 1
+Subsystem-Type: osgi.subsystem.feature
+Subsystem-Version: 1.0.0
+Subsystem-SymbolicName: trueConflict-1.0; visibility:=public; singleton:=true
+WLP-DisableAllFeatures-OnConflict: true
+

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.trueConflict-2.0.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/test.disable.all.features.on.conflict.trueConflict-2.0.mf
@@ -1,0 +1,7 @@
+IBM-Feature-Version: 2
+Subsystem-ManifestVersion: 1
+Subsystem-Type: osgi.subsystem.feature
+Subsystem-Version: 1.0.0
+Subsystem-SymbolicName: trueConflict-2.0; visibility:=public; singleton:=true
+WLP-DisableAllFeatures-OnConflict: true
+

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.feature.disable.onconflict/.gitignore
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.feature.disable.onconflict/.gitignore
@@ -1,0 +1,1 @@
+/dropins

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.feature.disable.onconflict/bootstrap.properties
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.feature.disable.onconflict/bootstrap.properties
@@ -1,0 +1,1 @@
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.feature.disable.onconflict/server.xml
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/servers/com.ibm.ws.kernel.feature.disable.onconflict/server.xml
@@ -1,0 +1,8 @@
+<server>
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+    </featureManager>
+    
+</server>


### PR DESCRIPTION
A new feature header is introduced

`WLP-DisableAllFeatures-OnConflict: true|false`

If not specified the default is false.

When the configured feature set has a singleton conflict
and the resolved feature set or the conflicting candidates
has a feature with a value of true for this new heade then
all features will be disabled.  In other words,
no features will be installed for the server/client
instance.
