### PR TITLE
Shorten EJBCustomBinding metatype labels

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.ejbcontainer/resources/OSGI-INF/l10n/metatype.properties
@@ -44,18 +44,18 @@ timerService=EJB Timer Service
 timerService.desc=Defines the behavior of the EJB timer service.
 
 #Do not translate "ejblocal:", "local:", "ibm-ejb-jar-bnd.xml", "ibm-ejb-jar-bnd.xmi", "server.xml", or "JNDI"
-bindToServerRoot=Bind enterprise beans to the server root namespace by using default or custom JNDI names
+bindToServerRoot=Bind enterprise beans to the server root
 bindToServerRoot.desc=This property configures whether enterprise beans are available for lookup in the server root, \
 ejblocal:, and local: namespaces. Default JNDI names are used unless custom JNDI names are configured in an \
 ibm-ejb-jar-bnd.xml, ibm-ejb-jar-bnd.xmi, or server.xml file.
 
 #Do not translate "java:global", "java:app", "java:module", or "JNDI"
-bindToJavaGlobal=Bind enterprise beans to contexts in the java: namespace by using specification defined JNDI names
+bindToJavaGlobal=Bind enterprise beans to the java: namespaces
 bindToJavaGlobal.desc=This property configures whether enterprise beans are available for lookup in the java:global, \
 java:app, and java:module namespaces. The JNDI names that are defined in the enterprise bean specification are used.
 
 #Do not translate "ejblocal:", "local:", or "JNDI"
-disableShortDefaultBindings=Disable binding of enterprise beans by using interface as JNDI name
+disableShortDefaultBindings=Disable short default binding of enterprise beans
 disableShortDefaultBindings.desc=This property configures whether enterprise beans are available for lookup in the \
 server root and ejblocal: namespaces by using the short form default JNDI names. The short form default JNDI name \
 is the enterprise bean interface name. The value is either a ':' separated list of applications to disable short default \


### PR DESCRIPTION
@OpenLiberty/message-reviewer So Apparently the label field can't be more than 50 characters so I have to shorten them.


#14265