### PR TITLE
Issue #13663: Add KnownAs ejbPersistentTimer-4.0

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/enterpriseBeansPersistentTimer-4.0/io.openliberty.enterpriseBeansPersistentTimer-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/enterpriseBeansPersistentTimer-4.0/io.openliberty.enterpriseBeansPersistentTimer-4.0.feature
@@ -4,6 +4,7 @@ visibility=public
 IBM-App-ForceRestart: install, \
  uninstall
 IBM-ShortName: enterpriseBeansPersistentTimer-4.0
+WLP-AlsoKnownAs: ejbPersistentTimer-4.0
 Subsystem-Name: Jakarta Enterprise Beans Persistent Timers 4.0
 -features=io.openliberty.persistentExecutorSubset-2.0, \
  com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:=4.3, \


### PR DESCRIPTION
Updated enterpriseBeansPersistentTimer-4.0 with the new KnownAs information to help users identify the correct name to use.

for #13663 
