### PR TITLE
grpcClient config update

### DIFF
--- a/dev/com.ibm.ws.grpc_fat/publish/servers/ConsumerServer/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/ConsumerServer/server.xml
@@ -91,11 +91,11 @@
 		issuer="testIssuerBad"
 		 />
 		
-	<grpcClient path="test.g3store.grpc.AppConsumerService/getAppInfo" headersToPropagate="authorization"/>
-	<grpcClient path="test.g3store.grpc.AppConsumerService/getAllAppNames" headersToPropagate="authorization"/>
-	<grpcClient path="test.g3store.grpc.AppConsumerService/getAppNameSetBadRoles" headersToPropagate="authorization"/>
-	<grpcClient path="test.g3store.grpc.AppConsumerService/getNameCookieJWTHeader" headersToPropagate="Cookie"/>
-	<grpcClient path="test.g3store.grpc.AppConsumerService/getAppSetBadRoleCookieJWTHeader" headersToPropagate="Cookie"/>
+	<grpcClient host="*" path="test.g3store.grpc.AppConsumerService/getAppInfo" headersToPropagate="authorization"/>
+	<grpcClient host="*" path="test.g3store.grpc.AppConsumerService/getAllAppNames" headersToPropagate="authorization"/>
+	<grpcClient host="*" path="test.g3store.grpc.AppConsumerService/getAppNameSetBadRoles" headersToPropagate="authorization"/>
+	<grpcClient host="*" path="test.g3store.grpc.AppConsumerService/getNameCookieJWTHeader" headersToPropagate="Cookie"/>
+	<grpcClient host="*" path="test.g3store.grpc.AppConsumerService/getAppSetBadRoleCookieJWTHeader" headersToPropagate="Cookie"/>
 	
 	<!-- <grpcClient path="test.g3store.grpc.AppConsumerService/getAllAppNames" authnToken="jwt"/> -->
 </server>

--- a/dev/io.openliberty.grpc.1.0.internal.client/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/io.openliberty.grpc.1.0.internal.client/resources/OSGI-INF/metatype/metatype.xml
@@ -22,7 +22,7 @@
               Also drives the documentation for them based on metatype.properties 
               and makes pretty panels in wdt. 
          -->
-        <AD id="host" name="%host" description="%host.desc" required="false" type="String" default="*" />
+        <AD id="host" name="%host" description="%host.desc" required="true" type="String" />
         <AD id="path" name="%path" description="%path.desc" required="false" type="String" default="*" />
         <AD id="headersToPropagate" name="%headersToPropagate" description="%headersToPropagate.desc" required="false" type="String" />
         <AD id="keepAliveTime" name="%keepAliveTime" description="%keepAliveTime.desc" required="false" type="String" ibm:type="duration(s)" min="1" />


### PR DESCRIPTION
The `host` parameter in `<grpcClient/>` should be required so that users are required to know the scope of a given `grpcClient` config. This will be consistent with the `target` configuration in `<grpc/>`. For #10090 