### PR TITLE
convert persistent executors timers buckets to use jakarta persistent timers

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/bnd.bnd
@@ -27,13 +27,13 @@ fat.test.databases: true
 #fat.test.use.remote.docker: true
 
 -buildpath: \
+	com.ibm.ws.componenttest.2.0;version=latest,\
 	fattest.databases;version=latest,\
-	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
-	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
-	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
-	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
-	com.ibm.websphere.javaee.ejb.3.2,\
-	com.ibm.ws.concurrent.persistent;version=latest,\
+	io.openliberty.jakarta.annotation.2.0;version=latest,\
+	io.openliberty.jakarta.concurrency.2.0;version=latest,\
+	io.openliberty.jakarta.ejb.4.0,\
+	io.openliberty.jakarta.servlet.5.0;version=latest,\
+	io.openliberty.jakarta.transaction.2.0;version=latest,\
 	org.testcontainers:database-commons;version=1.14.0,\
 	org.testcontainers:jdbc;version=1.14.0,\
 	org.testcontainers:testcontainers;version=1.14.0,\

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/publish/servers/com.ibm.ws.concurrent.persistent.fat.demo.timers/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/publish/servers/com.ibm.ws.concurrent.persistent.fat.demo.timers/server.xml
@@ -10,9 +10,9 @@
  -->
 <server>
   <featureManager>
-    <feature>ejbPersistentTimer-3.2</feature>
-    <feature>servlet-3.1</feature>
-    <feature>componenttest-1.0</feature>
+    <feature>componenttest-2.0</feature>
+    <feature>enterpriseBeansPersistentTimer-4.0</feature>
+    <feature>servlet-5.0</feature>
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticDatabase.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticDatabase.java
@@ -16,14 +16,14 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.Resource;
-import javax.ejb.Schedule;
-import javax.ejb.SessionContext;
-import javax.ejb.Stateless;
-import javax.ejb.Timer;
-import javax.ejb.TransactionAttribute;
-import javax.ejb.TransactionAttributeType;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.Resource;
+import jakarta.ejb.Schedule;
+import jakarta.ejb.SessionContext;
+import jakarta.ejb.Stateless;
+import jakarta.ejb.Timer;
+import jakarta.ejb.TransactionAttribute;
+import jakarta.ejb.TransactionAttributeType;
 import javax.sql.DataSource;
 
 /**

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticIO.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticIO.java
@@ -17,11 +17,11 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 
-import javax.annotation.Resource;
-import javax.ejb.Schedule;
-import javax.ejb.SessionContext;
-import javax.ejb.Stateless;
-import javax.ejb.Timer;
+import jakarta.annotation.Resource;
+import jakarta.ejb.Schedule;
+import jakarta.ejb.SessionContext;
+import jakarta.ejb.Stateless;
+import jakarta.ejb.Timer;
 
 /**
  * This class uses the @Schedule annotation.

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticMemory.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticMemory.java
@@ -12,11 +12,11 @@ package ejb.timers;
 
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.Resource;
-import javax.ejb.Schedule;
-import javax.ejb.SessionContext;
-import javax.ejb.Stateless;
-import javax.ejb.Timer;
+import jakarta.annotation.Resource;
+import jakarta.ejb.Schedule;
+import jakarta.ejb.SessionContext;
+import jakarta.ejb.Stateless;
+import jakarta.ejb.Timer;
 
 /**
  * This class uses the @Schedule annotation.

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticScheduler.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/AutomaticScheduler.java
@@ -10,12 +10,12 @@
  *******************************************************************************/
 package ejb.timers;
 
-import javax.annotation.Resource;
-import javax.ejb.EJB;
-import javax.ejb.Schedule;
-import javax.ejb.SessionContext;
-import javax.ejb.Singleton;
-import javax.ejb.Timer;
+import jakarta.annotation.Resource;
+import jakarta.ejb.EJB;
+import jakarta.ejb.Schedule;
+import jakarta.ejb.SessionContext;
+import jakarta.ejb.Singleton;
+import jakarta.ejb.Timer;
 
 /**
  * This class uses the @Schedule annotation.

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/PersistentDemoTimersServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/PersistentDemoTimersServlet.java
@@ -12,8 +12,8 @@ package ejb.timers;
 
 import java.util.concurrent.TimeUnit;
 
-import javax.ejb.EJB;
-import javax.servlet.annotation.WebServlet;
+import jakarta.ejb.EJB;
+import jakarta.servlet.annotation.WebServlet;
 
 import org.junit.Test;
 

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/ProgrammaticTimer.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/test-application/demotimers/src/ejb/timers/ProgrammaticTimer.java
@@ -10,13 +10,13 @@
  *******************************************************************************/
 package ejb.timers;
 
-import javax.annotation.Resource;
-import javax.ejb.ScheduleExpression;
-import javax.ejb.Stateless;
-import javax.ejb.Timeout;
-import javax.ejb.Timer;
-import javax.ejb.TimerConfig;
-import javax.ejb.TimerService;
+import jakarta.annotation.Resource;
+import jakarta.ejb.ScheduleExpression;
+import jakarta.ejb.Stateless;
+import jakarta.ejb.Timeout;
+import jakarta.ejb.Timer;
+import jakarta.ejb.TimerConfig;
+import jakarta.ejb.TimerService;
 
 /**
  * This class uses the @Timeout annotation.

--- a/dev/com.ibm.ws.concurrent.persistent_fat_timers/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_timers/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -27,14 +27,14 @@ fat.test.databases: true
 #fat.test.use.remote.docker: true
 
 -buildpath: \
+	com.ibm.ws.componenttest.2.0;version=latest,\
 	fattest.databases;version=latest,\
+	io.openliberty.jakarta.annotation.2.0;version=latest,\
+	io.openliberty.jakarta.concurrency.2.0;version=latest,\
+	io.openliberty.jakarta.ejb.4.0,\
+	io.openliberty.jakarta.servlet.5.0;version=latest,\
+	io.openliberty.jakarta.transaction.2.0;version=latest,\
 	org.slf4j:slf4j-api;version=1.7.7,\
-	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
-	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
-	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
-	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
-	com.ibm.ws.concurrent.persistent;version=latest,\
-	com.ibm.websphere.javaee.ejb.3.1,\
 	org.testcontainers:database-commons;version=1.14.0,\
 	org.testcontainers:jdbc;version=1.14.0,\
 	org.testcontainers:testcontainers;version=1.14.0

--- a/dev/com.ibm.ws.concurrent.persistent_fat_timers/publish/servers/com.ibm.ws.concurrent.persistent.fat.timers/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_timers/publish/servers/com.ibm.ws.concurrent.persistent.fat.timers/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2015, 2019 IBM Corporation and others.
+    Copyright (c) 2015, 2020 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -10,10 +10,10 @@
  -->
 <server>
   <featureManager>
-    <feature>ejbPersistentTimer-3.2</feature>
+    <feature>enterpriseBeansPersistentTimer-4.0</feature>
     <!-- <feature>osgiConsole-1.0</feature> -->
-    <feature>servlet-3.1</feature>
-    <feature>componenttest-1.0</feature>
+    <feature>servlet-5.0</feature>
+    <feature>componenttest-2.0</feature>
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>

--- a/dev/com.ibm.ws.concurrent.persistent_fat_timers/test-applications/timersapp/src/ejb/AutoTimer.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_timers/test-applications/timersapp/src/ejb/AutoTimer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package ejb;
 
-import javax.annotation.Resource;
-import javax.ejb.Schedule;
-import javax.ejb.SessionContext;
-import javax.ejb.Singleton;
-import javax.ejb.Timer;
+import jakarta.annotation.Resource;
+import jakarta.ejb.Schedule;
+import jakarta.ejb.SessionContext;
+import jakarta.ejb.Singleton;
+import jakarta.ejb.Timer;
 
 @Singleton
 public class AutoTimer {

--- a/dev/com.ibm.ws.concurrent.persistent_fat_timers/test-applications/timersapp/src/ejb/MyTimer.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_timers/test-applications/timersapp/src/ejb/MyTimer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,14 +12,14 @@ package ejb;
 
 import java.util.Date;
 
-import javax.annotation.Resource;
-import javax.ejb.EJB;
-import javax.ejb.SessionContext;
-import javax.ejb.Stateless;
-import javax.ejb.Timeout;
-import javax.ejb.Timer;
-import javax.ejb.TimerConfig;
-import javax.ejb.TimerService;
+import jakarta.annotation.Resource;
+import jakarta.ejb.EJB;
+import jakarta.ejb.SessionContext;
+import jakarta.ejb.Stateless;
+import jakarta.ejb.Timeout;
+import jakarta.ejb.Timer;
+import jakarta.ejb.TimerConfig;
+import jakarta.ejb.TimerService;
 
 @Stateless
 public class MyTimer {

--- a/dev/com.ibm.ws.concurrent.persistent_fat_timers/test-applications/timersapp/src/ejb/MyTimerTracker.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_timers/test-applications/timersapp/src/ejb/MyTimerTracker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,7 @@ package ejb;
 
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.ejb.Singleton;
+import jakarta.ejb.Singleton;
 
 /**
  * Counts the number of times a timer runs

--- a/dev/com.ibm.ws.concurrent.persistent_fat_timers/test-applications/timersapp/src/web/PersistentTimersTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_timers/test-applications/timersapp/src/web/PersistentTimersTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,11 +13,11 @@ package web;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.Resource;
-import javax.ejb.EJB;
-import javax.ejb.Timer;
-import javax.servlet.annotation.WebServlet;
-import javax.transaction.UserTransaction;
+import jakarta.annotation.Resource;
+import jakarta.ejb.EJB;
+import jakarta.ejb.Timer;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.transaction.UserTransaction;
 
 import org.junit.Test;
 


### PR DESCRIPTION
Convert the persistent executor timers and demo timers buckets to use Enterprise Beans persistent timers from Jakarta EE 9