### PR TITLE
Issue #14282: Ignore CWWKG0014E in EJB FAT

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.async_fat/fat/src/com/ibm/ws/ejbcontainer/async/fat/tests/AsyncConfigTests.java
+++ b/dev/com.ibm.ws.ejbcontainer.async_fat/fat/src/com/ibm/ws/ejbcontainer/async/fat/tests/AsyncConfigTests.java
@@ -99,7 +99,10 @@ public class AsyncConfigTests extends AbstractTest {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        server.stopServer();
+        // CWWKG0014E - intermittently caused by server.xml being momentarily missing during server reconfig
+        if (server != null && server.isStarted()) {
+            server.stopServer("CWWKG0014E");
+        }
     }
 
     /**

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/RemoteTests.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/RemoteTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -240,7 +240,10 @@ public class RemoteTests extends AbstractTest {
         // CNTR5101W - testEJBHomeRecursiveStubs
         // CWNEN0028E - testAnnInjectionFailure, testAnnDependsOnFailure
         // WTRN0074E - testBusinessRMITransactionException, testBusinessRemoteTransactionException
-        server.stopServer("CNTR0019E", "CNTR0020E", "CNTR0021E", "CNTR0328W", "CNTR5101W", "CWNEN0028E", "WTRN0074E");
+        // CWWKG0014E - intermittently caused by server.xml being momentarily missing during server reconfig
+        if (server != null && server.isStarted()) {
+            server.stopServer("CNTR0019E", "CNTR0020E", "CNTR0021E", "CNTR0328W", "CNTR5101W", "CWNEN0028E", "WTRN0074E", "CWWKG0014E");
+        }
     }
 
     private void updateServerConfiguration(ServerConfiguration config) throws Exception {

--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/PersistentTimerCoreTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/PersistentTimerCoreTest.java
@@ -103,8 +103,9 @@ public class PersistentTimerCoreTest extends FATServletClient {
         // CWWKC1501W : testSLTimerServiceEJBTimeoutSessionContextCMT - PersistentExecutor rolled back a task
         // CWWKC1506E : testSLTimerServiceEJBTimeoutSessionContextCMT - Transaction is marked for rollback
         // CWWKG0032W : testMissedTimerActionBadValueNoFailover - Unexpected value [Blah]
+        // CWWKG0014E - intermittently caused by server.xml being momentarily missing during server reconfig
         if (server != null && server.isStarted()) {
-            server.stopServer(expectedFailures("CNTR0333W", "CWWKC1500W", "CWWKC1501W", "CWWKC1506E", "CWWKG0032W.*Blah"));
+            server.stopServer(expectedFailures("CNTR0333W", "CWWKC1500W", "CWWKC1501W", "CWWKC1506E", "CWWKG0032W.*Blah", "CWWKG0014E"));
         }
     }
 


### PR DESCRIPTION
CWWKG0014E occurs when the FAT updates server.xml while the server
is running and the kernel begins to process the file before it
is fully written. The kernel will retry and the test will run
fine, so the error is just an odd timing problem and may be ignroed.

Updating all EJB Container FAT that does frequent server config
changes while the server is running.

fixes #14282 