### PR TITLE
Fix tests for JsonConfigBootstrapTest and make methods more generic for different servers

### DIFF
--- a/dev/com.ibm.ws.logging.json_fat/publish/files/appsWriteJsonDisabled.xml
+++ b/dev/com.ibm.ws.logging.json_fat/publish/files/appsWriteJsonDisabled.xml
@@ -10,14 +10,14 @@
  -->
 <server description="Server for testing Liberty logging in a server">
 
-	<logging consoleLogLevel="ERROR" consoleFormat="json" messageFormat="json"/>
+	<logging consoleFormat="json" messageFormat="json" appsWriteJson="false"/>
     <include location="../fatTestPorts.xml"/>
 
     <featureManager>
 	   <feature>jsp-2.2</feature>
     </featureManager>
     
-    <httpEndpoint id="defaultHttpEndpoint" httpPort="${bvt.prop.HTTP_default}" httpsPort="${bvt.prop.HTTP_default.secure}">
+     <httpEndpoint id="defaultHttpEndpoint" httpPort="${bvt.prop.HTTP_default}" httpsPort="${bvt.prop.HTTP_default.secure}">
         <accessLogging enabled="true"  filepath="${server.output.dir}/logs/http_defaultEndpoint_access.log" logFormat="%h %u %t &quot;%r&quot; %s %b %D %{User-agent}i"/>
     </httpEndpoint>
 

--- a/dev/com.ibm.ws.logging.json_fat/publish/files/appsWriteJsonEnabled.xml
+++ b/dev/com.ibm.ws.logging.json_fat/publish/files/appsWriteJsonEnabled.xml
@@ -10,7 +10,7 @@
  -->
 <server description="Server for testing Liberty logging in a server">
 
-	<logging consoleLogLevel="ERROR" consoleFormat="json" messageFormat="json" appsWriteJson="true"/>
+	<logging consoleFormat="json" messageFormat="json" appsWriteJson="true"/>
     <include location="../fatTestPorts.xml"/>
 
     <featureManager>


### PR DESCRIPTION
Fixes #14227 
Changes made:
- Removed consoleLogLevel=ERROR since stopServer can't find the message needed to stop successfully causing the next test using the server to fail.
- Made helper methods more generic to different servers
- Reorder test to make sure the failing test case runs successfully
- Include stop server for appsWriteJsonServer tearDown and tearDownClass