### PR TITLE
Issue #14069: Enable JSF 2.2 tests for Jakarta EE9

### DIFF
--- a/dev/com.ibm.ws.jsf.2.2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jsf.2.2_fat/bnd.bnd
@@ -62,7 +62,18 @@ src: \
     test-applications/FunctionMapper.war/src
 
 fat.project: true
-tested.features: servlet-4.0, jsf-2.3, cdi-2.0, beanValidation-2.0
+
+tested.features: \
+    servlet-4.0,\
+    jsf-2.3,\
+    cdi-2.0,\
+    beanValidation-2.0,\
+    el-4.0,\
+    servlet-5.0,\
+    faces-3.0,\
+    jsp-3.0,\
+    cdi-3.0,\
+    beanvalidation-3.0
 
 
 -buildpath: \

--- a/dev/com.ibm.ws.jsf.2.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jsf.2.2_fat/build.gradle
@@ -21,4 +21,5 @@ dependencies {
       'xml-apis:xml-apis:1.4.01'
     }
 
+addRequiredLibraries.dependsOn addJakartaTransformer
 

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/FATSuite.java
@@ -10,10 +10,6 @@
  */
 package com.ibm.ws.jsf22.fat;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -51,6 +47,7 @@ import com.ibm.ws.jsf22.fat.tests.JSFHtmlUnit;
 import com.ibm.ws.jsf22.fat.tests.JSFServerTest;
 import com.ibm.ws.jsf22.fat.tests.JSFSimpleHtmlUnit;
 
+import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 
@@ -109,16 +106,12 @@ public class FATSuite {
         FatLogHandler.generateHelpFile();
     }
 
-    static Set<String> removeFeatures = new HashSet<>(Arrays.asList("jsf-2.2", "cdi-1.2", "beanValidation-1.1"));
-    static Set<String> addFeatures = new HashSet<>(Arrays.asList("jsf-2.3", "cdi-2.0", "beanValidation-2.0"));
-
     /**
      * Run the tests again with the jsf-2.3 feature. Tests should be skipped where appropriate
      * using @SkipForRepeat("JSF-2.3").
      */
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(new FeatureReplacementAction(removeFeatures, addFeatures)
-                                    .withID("JSF-2.3")
-                                    .forceAddFeatures(false));
+    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly())
+                    .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly())
+                    .andWith(FeatureReplacementAction.EE9_FEATURES());
 }

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/CDIConfigByACPTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/CDIConfigByACPTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,8 @@
  */
 package com.ibm.ws.jsf22.fat.tests;
 
-import com.ibm.websphere.simplicity.ShrinkHelper;
-import com.ibm.ws.jsf22.fat.CDITestBase;
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -21,6 +21,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.jsf22.fat.CDITestBase;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
@@ -39,7 +42,7 @@ import componenttest.topology.impl.LibertyServer;
  * As a result, these tests were modified to run in the JSF 2.3 FAT bucket without constructor injection.
  */
 @Mode(TestMode.FULL)
-@SkipForRepeat("JSF-2.3")
+@SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
 @RunWith(FATRunner.class)
 public class CDIConfigByACPTests extends CDITestBase {
     @Rule

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/CDIFacesInMetaInfTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/CDIFacesInMetaInfTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,9 @@
  *     IBM Corporation - initial API and implementation
  */
 package com.ibm.ws.jsf22.fat.tests;
+
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -37,7 +40,7 @@ import componenttest.topology.impl.LibertyServer;
  * As a result, these tests were modified to run in the JSF 2.3 FAT bucket without constructor injection.
  */
 @Mode(TestMode.FULL)
-@SkipForRepeat("JSF-2.3")
+@SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
 @RunWith(FATRunner.class)
 public class CDIFacesInMetaInfTests extends CDITestBase {
     @Rule

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/CDIFacesInWebXMLTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/CDIFacesInWebXMLTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019 IBM Corporation and others.
+ * Copyright (c) 2015, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,9 @@
  *     IBM Corporation - initial API and implementation
  */
 package com.ibm.ws.jsf22.fat.tests;
+
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
@@ -38,7 +41,7 @@ import componenttest.topology.impl.LibertyServer;
  * As a result, these tests were modified to run in the JSF 2.3 FAT bucket without constructor injection.
  */
 @Mode(TestMode.FULL)
-@SkipForRepeat("JSF-2.3")
+@SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
 @RunWith(FATRunner.class)
 public class CDIFacesInWebXMLTests extends CDITestBase {
     @Rule

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/CDITests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/CDITests.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.ws.jsf22.fat.tests;
 
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
@@ -47,6 +49,7 @@ import junit.framework.Assert;
  * As a result, these tests were modified to run in the JSF 2.3 FAT bucket without constructor injection.
  */
 @RunWith(FATRunner.class)
+@SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
 public class CDITests extends CDITestBase {
     @Rule
     public TestName name = new TestName();
@@ -85,7 +88,6 @@ public class CDITests extends CDITestBase {
      * @throws Exception. Content of the response should show if a specific injection failed.
      *
      */
-    @SkipForRepeat("JSF-2.3")
     @Test
     public void testActionListenerInjection_CDITests() throws Exception {
         testActionListenerInjectionByApp("CDITests", jsfCDIServer);
@@ -99,7 +101,6 @@ public class CDITests extends CDITestBase {
      * @throws Exception. Content of the response should show if a specific injection failed.
      *
      */
-    @SkipForRepeat("JSF-2.3")
     @Test
     public void testNavigationHandlerInjection_CDITests() throws Exception {
         testNavigationHandlerInjectionByApp("CDITests", jsfCDIServer);
@@ -113,7 +114,6 @@ public class CDITests extends CDITestBase {
      * @throws Exception. Content of the response should show if a specific injection failed.
      *
      */
-    @SkipForRepeat("JSF-2.3")
     @Test
     public void testELResolverInjection_CDITests() throws Exception {
         testELResolverInjectionByApp("CDITests", jsfCDIServer);
@@ -126,7 +126,6 @@ public class CDITests extends CDITestBase {
      *
      * @throws Exception
      */
-    @SkipForRepeat("JSF-2.3")
     @Test
     public void testCustomResourceHandlerInjections_CDITests() throws Exception {
         testCustomResourceHandlerInjectionsByApp("CDITests", jsfCDIServer);
@@ -140,7 +139,6 @@ public class CDITests extends CDITestBase {
      *
      * @throws Exception
      */
-    @SkipForRepeat("JSF-2.3")
     @Test
     public void testCustomStateManagerInjections_CDITests() throws Exception {
         testCustomStateManagerInjectionsByApp("CDITests", jsfCDIServer);
@@ -153,7 +151,6 @@ public class CDITests extends CDITestBase {
      *
      * @throws Exception
      */
-    @SkipForRepeat("JSF-2.3")
     @Test
     public void testFactoryAndOtherScopeInjections_CDITests() throws Exception {
         testFactoryAndOtherAppScopedInjectionsByApp("CDITests", jsfCDIServer);
@@ -168,7 +165,6 @@ public class CDITests extends CDITestBase {
      *
      * @throws Exception
      */
-    @SkipForRepeat("JSF-2.3")
     @Test
     public void testInjectionProvider() throws Exception {
         String msgToSearchFor1 = "Using InjectionProvider com.ibm.ws.jsf.spi.impl.WASCDIAnnotationDelegateInjectionProvider";
@@ -200,7 +196,6 @@ public class CDITests extends CDITestBase {
      * @throws Exception. Content of the response should show if a specific injection failed.
      *
      */
-    @SkipForRepeat("JSF-2.3")
     @Test
     public void testBeanInjection() throws Exception {
         this.verifyResponse("CDITests", "TestBean.jsf", jsfCDIServer,
@@ -216,7 +211,6 @@ public class CDITests extends CDITestBase {
      * Test CDI injections on CDI ViewScope. Tests constructor, field, and method injections with app, session, request, and dependent scopes.
      * Does some simple verifications of the 4 scopes and instances ( through hashcode) are what is expected for multiple requests.
      */
-    @SkipForRepeat("JSF-2.3")
     @Test
     public void testViewScopeInjections() throws Exception {
         try (WebClient webClient = new WebClient(); WebClient webClient2 = new WebClient()) {
@@ -287,7 +281,6 @@ public class CDITests extends CDITestBase {
         return retValue;
     }
 
-    @SkipForRepeat("JSF-2.3")
     @Test
     public void testPreDestroyInjection() throws Exception {
         // Drive requests to ensure all injected objected are created.

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22AparTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22AparTests.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.ws.jsf22.fat.tests;
 
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -47,6 +49,7 @@ import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import junit.framework.Assert;
 
@@ -869,7 +872,7 @@ public class JSF22AparTests {
             HtmlForm statefulForm = page.getFormByName("statefulForm");
 
             // Change the value of ViewState to stateless
-            HtmlHiddenInput viewStateInput = (HtmlHiddenInput) statefulForm.getInputByName("javax.faces.ViewState");
+            HtmlHiddenInput viewStateInput = (HtmlHiddenInput) statefulForm.getInputByName((JakartaEE9Action.isActive() ? "jakarta." : "javax.") + "faces.ViewState");
             viewStateInput.setValueAttribute("stateless");
 
             // Get the button and then click it
@@ -881,7 +884,7 @@ public class JSF22AparTests {
 
             // Check that a FacesException is thrown
             assertTrue("PI89168: FacesException was not thrown!\n" + page.asText(),
-                       page.asText().contains("javax.faces.FacesException: unable to create view \"/statefulView.xhtml\""));
+                       page.asText().contains((JakartaEE9Action.isActive() ? "jakarta." : "javax.") + "faces.FacesException: unable to create view \"/statefulView.xhtml\""));
         }
     }
 
@@ -1011,7 +1014,7 @@ public class JSF22AparTests {
      *
      * @throws Exception
      */
-    @SkipForRepeat("JSF-2.3")
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     @Test
     public void testPI90507NonBindingCase() throws Exception {
         try (WebClient webClient = new WebClient()) {
@@ -1055,7 +1058,7 @@ public class JSF22AparTests {
      *
      * @throws Exception
      */
-    @SkipForRepeat("JSF-2.3")
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     @Test
     public void testPI90507BindingCase() throws Exception {
         try (WebClient webClient = new WebClient()) {

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22BeanValidationTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22BeanValidationTests.java
@@ -31,6 +31,7 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import junit.framework.Assert;
 
@@ -73,21 +74,25 @@ public class JSF22BeanValidationTests {
      */
     @Test
     public void testBeanValidation11Enabled() throws Exception {
-        String methodName = "testBeanValidation11Enabled";
+        String msgToSearchFor = "MyFaces Bean Validation support enabled";
+        String msgToSearchForMyFaces30 = "MyFaces Core Bean Validation support enabled";
 
         try (WebClient webClient = new WebClient()) {
 
             URL url = JSFUtils.createHttpUrl(jsf22beanvalServer, contextRoot, "BeanValidation.jsf");
-            HtmlPage page = (HtmlPage) webClient.getPage(url);
+            webClient.getPage(url);
 
             Log.info(c, name.getMethodName(), "Navigating to: /BeanValidationTests/BeanValidation.jsf");
 
-            Log.info(c, name.getMethodName(), "Looking for message \"MyFaces Bean Validation support enabled\" in the logs");
-
-            String logMessage = jsf22beanvalServer.waitForStringInLog("MyFaces Bean Validation support enabled");
-
+            String logMessage;
+            if (JakartaEE9Action.isActive()) {
+                Log.info(c, name.getMethodName(), "Looking for message " + msgToSearchForMyFaces30 + " in the logs");
+                logMessage = jsf22beanvalServer.waitForStringInLog(msgToSearchForMyFaces30);
+            } else {
+                Log.info(c, name.getMethodName(), "Looking for message " + msgToSearchFor + " in the logs");
+                logMessage = jsf22beanvalServer.waitForStringInLog(msgToSearchFor);
+            }
             Log.info(c, name.getMethodName(), "Message found in the logs : " + logMessage);
-
             Assert.assertNotNull("Correct message not found", logMessage);
         }
     }
@@ -107,8 +112,6 @@ public class JSF22BeanValidationTests {
      */
     @Test
     public void testValidationBeanTagBinding() throws Exception {
-        String methodName = "testValidationBeanTagBinding";
-
         try (WebClient webClient = new WebClient()) {
 
             URL url = JSFUtils.createHttpUrl(jsf22beanvalServer, contextRoot, "BeanValidation.jsf");

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22MiscLifecycleTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22MiscLifecycleTests.java
@@ -38,6 +38,7 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
 /**
@@ -140,13 +141,21 @@ public class JSF22MiscLifecycleTests {
 
             webClient.setAjaxController(new NicelyResynchronizingAjaxController());
             URL url = JSFUtils.createHttpUrl(jsfTestServer1, contextRoot, "simpleForm.jsf");
-            HtmlPage page = (HtmlPage) webClient.getPage(url);
 
             Log.info(c, name.getMethodName(), "Navigating to: /JSF22ActionListener/simpleForm.jsf");
-            HtmlHiddenInput hidden = (HtmlHiddenInput) page.getElementByName("javax.faces.ViewState");
+            HtmlPage page = (HtmlPage) webClient.getPage(url);
+            Log.info(c, name.getMethodName(), "Page output: " + page.asXml());
 
-            Log.info(c, name.getMethodName(), "The ViewState hidden field has an id of: " + hidden.getAttribute("id"));
-            assertFalse("javax.faces.ViewState".equals(hidden.getAttribute("id")));
+            HtmlHiddenInput hidden;
+            if (JakartaEE9Action.isActive()) {
+                hidden = (HtmlHiddenInput) page.getElementByName("jakarta.faces.ViewState");
+                Log.info(c, name.getMethodName(), "The ViewState hidden field has an id of: " + hidden.getAttribute("id"));
+                assertFalse("jakarta.faces.ViewState".equals(hidden.getAttribute("id")));
+            } else {
+                hidden = (HtmlHiddenInput) page.getElementByName("javax.faces.ViewState");
+                Log.info(c, name.getMethodName(), "The ViewState hidden field has an id of: " + hidden.getAttribute("id"));
+                assertFalse("javax.faces.ViewState".equals(hidden.getAttribute("id")));
+            }
         }
     }
 }

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22MiscellaneousTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22MiscellaneousTests.java
@@ -37,6 +37,7 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import junit.framework.Assert;
 
@@ -49,7 +50,8 @@ public class JSF22MiscellaneousTests {
     @Rule
     public TestName name = new TestName();
 
-    String contextRoot = "JSF22Miscellaneous";
+    String contextRootMiscellaneous = "JSF22Miscellaneous";
+    String contextRootMiscellaneousSerialize = "JSF22MiscellaneousSerialize";
 
     protected static final Class<?> c = JSF22MiscellaneousTests.class;
 
@@ -98,7 +100,7 @@ public class JSF22MiscellaneousTests {
     public void testSimple() throws Exception {
         try (WebClient webClient = new WebClient()) {
 
-            URL url = JSFUtils.createHttpUrl(jsf22MiscellaneousServer, contextRoot, "testSimple.xhtml");
+            URL url = JSFUtils.createHttpUrl(jsf22MiscellaneousServer, contextRootMiscellaneous, "testSimple.xhtml");
             HtmlPage page = (HtmlPage) webClient.getPage(url);
 
             if (page == null) {
@@ -118,7 +120,7 @@ public class JSF22MiscellaneousTests {
     public void testAPI() throws Exception {
         try (WebClient webClient = new WebClient()) {
 
-            URL url = JSFUtils.createHttpUrl(jsf22MiscellaneousServer, contextRoot, "testAPI.xhtml");
+            URL url = JSFUtils.createHttpUrl(jsf22MiscellaneousServer, contextRootMiscellaneous, "testAPI.xhtml");
             HtmlPage page = (HtmlPage) webClient.getPage(url);
 
             // Make sure the page initially renders correctly
@@ -171,7 +173,7 @@ public class JSF22MiscellaneousTests {
             // Use a synchronizing ajax controller to allow proper ajax updating
             webClient.setAjaxController(new NicelyResynchronizingAjaxController());
 
-            URL url = JSFUtils.createHttpUrl(jsf22MiscellaneousServer, contextRoot, "testResetValues.xhtml");
+            URL url = JSFUtils.createHttpUrl(jsf22MiscellaneousServer, contextRootMiscellaneous, "testResetValues.xhtml");
             HtmlPage page = (HtmlPage) webClient.getPage(url);
 
             // Make sure the page initially renders correctly
@@ -217,7 +219,7 @@ public class JSF22MiscellaneousTests {
     public void testCSRF() throws Exception {
         try (WebClient webClient = new WebClient(); WebClient webClient2 = new WebClient()) {
 
-            URL url = JSFUtils.createHttpUrl(jsf22MiscellaneousServer, contextRoot, "testCSRF.xhtml");
+            URL url = JSFUtils.createHttpUrl(jsf22MiscellaneousServer, contextRootMiscellaneous, "testCSRF.xhtml");
             HtmlPage page = (HtmlPage) webClient.getPage(url);
 
             // Make sure the page initially renders correctly
@@ -251,7 +253,7 @@ public class JSF22MiscellaneousTests {
             if (!page.asText().contains("This is a protected page.")) {
                 Assert.fail("Invalid response from server.  The protected page was not retrieved = " + page.asText());
             }
-            if (!page.getUrl().toString().contains("javax.faces.Token=")) {
+            if (!page.getUrl().toString().contains((JakartaEE9Action.isActive() ? "jakarta." : "javax.") + "faces.Token=")) {
                 Assert.fail("Invalid response from server.  This page does NOT contain the token = " + page.asText());
             }
 
@@ -259,7 +261,7 @@ public class JSF22MiscellaneousTests {
             try {
                 // Turn off printing for this webClient.   We know there will very likely be an error.
                 webClient2.getOptions().setPrintContentOnFailingStatusCode(false);
-                url = JSFUtils.createHttpUrl(jsf22MiscellaneousServer, contextRoot, "protectedPage.xhtml");
+                url = JSFUtils.createHttpUrl(jsf22MiscellaneousServer, contextRootMiscellaneous, "protectedPage.xhtml");
                 webClient2.getPage(url);
                 Assert.fail("Protected page was retrieved.   This should not occur.");
             } catch (Exception ex1) {
@@ -281,7 +283,7 @@ public class JSF22MiscellaneousTests {
     public void testViewScopeBinding() throws Exception {
         try (WebClient webClient = new WebClient()) {
 
-            URL url = JSFUtils.createHttpUrl(jsf22MiscellaneousServer, contextRoot, "testViewScopeBinding.jsf");
+            URL url = JSFUtils.createHttpUrl(jsf22MiscellaneousServer, contextRootMiscellaneous, "testViewScopeBinding.jsf");
             HtmlPage page = (HtmlPage) webClient.getPage(url);
 
             // Make sure the page initially renders correctly
@@ -312,7 +314,7 @@ public class JSF22MiscellaneousTests {
     public void testViewScopeBindingSerialize() throws Exception {
         try (WebClient webClient = new WebClient()) {
 
-            URL url = JSFUtils.createHttpUrl(jsf22MiscellaneousServer, contextRoot, "testViewScopeBinding.jsf");
+            URL url = JSFUtils.createHttpUrl(jsf22MiscellaneousServer, contextRootMiscellaneousSerialize, "testViewScopeBinding.jsf");
             HtmlPage page = (HtmlPage) webClient.getPage(url);
 
             // Make sure the page initially renders correctly
@@ -343,7 +345,7 @@ public class JSF22MiscellaneousTests {
     public void testViewScopeMyFaces() throws Exception {
         try (WebClient webClient = new WebClient()) {
 
-            URL url = JSFUtils.createHttpUrl(jsf22MiscellaneousServer, contextRoot, "testViewScopeMyFaces.jsf");
+            URL url = JSFUtils.createHttpUrl(jsf22MiscellaneousServer, contextRootMiscellaneous, "testViewScopeMyFaces.jsf");
             HtmlPage page = (HtmlPage) webClient.getPage(url);
 
             System.out.println(page.asText());
@@ -423,7 +425,7 @@ public class JSF22MiscellaneousTests {
     public void testExpressionFactoryImplConsistency() throws Exception {
         try (WebClient webClient = new WebClient()) {
 
-            URL url = JSFUtils.createHttpUrl(jsf22MiscellaneousServer, contextRoot, "testExpressionFactoryImplConsistency.jsf");
+            URL url = JSFUtils.createHttpUrl(jsf22MiscellaneousServer, contextRootMiscellaneous, "testExpressionFactoryImplConsistency.jsf");
             HtmlPage page = (HtmlPage) webClient.getPage(url);
 
             // Make sure the page initially renders correctly
@@ -438,19 +440,19 @@ public class JSF22MiscellaneousTests {
         }
     }
 
-      /**
-     * 
-     * Ensure FunctionMapper is set on the ELContext 
+    /**
+     *
+     * Ensure FunctionMapper is set on the ELContext
      * - MyFaces 4333
      *
      * @throws Exception
      */
     @Test
     public void testFunctionMapper() throws Exception {
-        String contextRoot = "FunctionMapper";
+        String contextRootMiscellaneous = "FunctionMapper";
         try (WebClient webClient = new WebClient()) {
-    
-            URL url = JSFUtils.createHttpUrl(jsf22MiscellaneousServer, contextRoot, "index.xhtml");
+
+            URL url = JSFUtils.createHttpUrl(jsf22MiscellaneousServer, contextRootMiscellaneous, "index.xhtml");
 
             HtmlPage page = (HtmlPage) webClient.getPage(url);
 

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22ResourceLibraryContractHtmlUnit.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSF22ResourceLibraryContractHtmlUnit.java
@@ -190,11 +190,9 @@ public class JSF22ResourceLibraryContractHtmlUnit {
 
         try (WebClient webClient = new WebClient()) {
             URL url = JSFUtils.createHttpUrl(jsfTestServer1, "TestResourceContracts", "faces/developers/index1.xhtml");
-            HtmlPage page = null;
 
             try {
-                page = (HtmlPage) webClient.getPage(url);
-
+                webClient.getPage(url);
             } catch (FailingHttpStatusCodeException fsc) {
                 Log.info(c, name.getMethodName(), "Test5_Contract_viaURL_UnavailableContract :: , statusCode -->" + fsc.getStatusCode());
                 assertTrue(fsc.getStatusCode() == 500);
@@ -303,11 +301,9 @@ public class JSF22ResourceLibraryContractHtmlUnit {
     public void Test13_MyContract_viaURL_UnavailableContract() throws Exception {
         try (WebClient webClient = new WebClient()) {
             URL url = JSFUtils.createHttpUrl(jsfTestServer1, "TestResourceContractsDirectory", "faces/developers/index1.xhtml");
-            HtmlPage Page;
 
             try {
-                HtmlPage page = (HtmlPage) webClient.getPage(url);
-
+                webClient.getPage(url);
             } catch (FailingHttpStatusCodeException fsc) {
                 Log.info(c, name.getMethodName(), "Test13_MyContract_viaURL_UnavailableContract :: , statusCode -->" + fsc.getStatusCode());
                 assertTrue(fsc.getStatusCode() == 500);

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSFCompELTests.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSFCompELTests.java
@@ -34,6 +34,7 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import junit.framework.Assert;
 
@@ -156,7 +157,8 @@ public class JSFCompELTests {
             }
 
             //Test case on the server, which is ELExceptionBean intentionally throws exception for valueChangeListener. Hence check if it's in the log
-            String msgToSearchFor = "javax.servlet.ServletException: javax.el.ELException: java.lang.NullPointerException";
+            String msgToSearchFor = (JakartaEE9Action.isActive() ? "jakarta." : "javax.") + "servlet.ServletException: " + (JakartaEE9Action.isActive() ? "jakarta." : "javax.")
+                                    + "el.ELException: java.lang.NullPointerException";
             List<String> msgs = jsfTestServer2.findStringsInLogs(msgToSearchFor);
 
             //There should be a match so fail if there is not.

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSFServerTest.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSFServerTest.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.ws.jsf22.fat.tests;
 
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -31,6 +33,7 @@ import com.ibm.ws.jsf22.fat.JSFUtils;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
 /*
@@ -94,7 +97,7 @@ public class JSFServerTest {
      * @throws Exception
      */
     @Test
-    @SkipForRepeat("JSF-2.3")
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testLibertyWebConfigProviderFactory() throws Exception {
         String msgToSearchFor = "getWebConfigProvider Entry";
 
@@ -113,12 +116,12 @@ public class JSFServerTest {
      * @throws Exception
      */
     @Test
-    @SkipForRepeat("JSF-2.3")
+    @SkipForRepeat({ EE8_FEATURES, EE9_FEATURES })
     public void testLibertyWebConfigProvider() throws Exception {
         try (WebClient webClient = new WebClient()) {
             URL url = JSFUtils.createHttpUrl(jsfTestServer1, contextRoot, "");
             // Ensure the isErrorPagePresent message is logged in the trace during the RESTORE_VIEW phase.
-            HtmlPage page = (HtmlPage) webClient.getPage(url);
+            webClient.getPage(url);
 
             String msgToSearchFor = "isErrorPagePresent ENTRY";
 
@@ -211,15 +214,27 @@ public class JSFServerTest {
     @Test
     public void testBeanValidation11Disabled() throws Exception {
         String msgToSearchFor = "MyFaces Bean Validation support disabled";
+        String msgToSearchForMyFaces30 = "MyFaces Core Bean Validation support disabled";
 
-        Log.info(c, name.getMethodName(), "Looking for : " + msgToSearchFor);
-        // Check the trace.log to see if the LibertyWebConfigProviderFactory has any entry trace.
-        String isBeanValidationDisabled = jsfTestServer1.waitForStringInLog(msgToSearchFor);
+        if (JakartaEE9Action.isActive()) {
+            Log.info(c, name.getMethodName(), "Looking for : " + msgToSearchForMyFaces30);
+            // Check the trace.log to see if the LibertyWebConfigProviderFactory has any entry trace.
+            String isBeanValidationDisabled = jsfTestServer1.waitForStringInLog(msgToSearchForMyFaces30);
 
-        Log.info(c, name.getMethodName(), "Message found after searching logs : " + isBeanValidationDisabled);
+            Log.info(c, name.getMethodName(), "Message found after searching logs : " + isBeanValidationDisabled);
 
-        // There should be a match so fail if there is not.
-        assertNotNull("The following message was not found in the trace log: " + msgToSearchFor, isBeanValidationDisabled);
+            // There should be a match so fail if there is not.
+            assertNotNull("The following message was not found in the trace log: " + msgToSearchForMyFaces30, isBeanValidationDisabled);
+        } else {
+            Log.info(c, name.getMethodName(), "Looking for : " + msgToSearchFor);
+            // Check the trace.log to see if the LibertyWebConfigProviderFactory has any entry trace.
+            String isBeanValidationDisabled = jsfTestServer1.waitForStringInLog(msgToSearchFor);
+
+            Log.info(c, name.getMethodName(), "Message found after searching logs : " + isBeanValidationDisabled);
+
+            // There should be a match so fail if there is not.
+            assertNotNull("The following message was not found in the trace log: " + msgToSearchFor, isBeanValidationDisabled);
+        }
     }
 
     /**

--- a/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSFSimpleHtmlUnit.java
+++ b/dev/com.ibm.ws.jsf.2.2_fat/fat/src/com/ibm/ws/jsf22/fat/tests/JSFSimpleHtmlUnit.java
@@ -34,6 +34,7 @@ import com.ibm.ws.jsf22.fat.JSFUtils;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
 /**
@@ -234,7 +235,7 @@ public class JSFSimpleHtmlUnit {
             // Make a request to a dummy page to ensure that MyFaces initializes if it has not done so already
             URL url = JSFUtils.createHttpUrl(jsfTestServer1, contextRoot, "dummy.jsf");
 
-            String msg = "No context init parameter 'javax.faces.FACELETS_BUFFER_SIZE' found, using default value '1024'";
+            String msg = "No context init parameter '" + (JakartaEE9Action.isActive() ? "jakarta" : "javax") + ".faces.FACELETS_BUFFER_SIZE' found, using default value '1024'";
             // Check the trace.log
             // There should be a match so fail if there is not.
             assertFalse(msg, jsfTestServer1.findStringsInLogs(msg).isEmpty());

--- a/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22FlashEvents.war/resources/WEB-INF/faces-config.xml
+++ b/dev/com.ibm.ws.jsf.2.2_fat/test-applications/JSF22FlashEvents.war/resources/WEB-INF/faces-config.xml
@@ -15,25 +15,25 @@
     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_2.xsd"
     version="2.2">
 
-	<application>
-	<system-event-listener>
-		<system-event-listener-class>com.ibm.ws.jsf22.fat.flashevents.listener.PostPutFlashValueEventListener</system-event-listener-class>
-		<system-event-class>javax.faces.event.PostPutFlashValueEvent</system-event-class>    					
-	</system-event-listener> 
-	<system-event-listener>
-		<system-event-listener-class>com.ibm.ws.jsf22.fat.flashevents.listener.PostKeepFlashValueEventListener</system-event-listener-class>
-		<system-event-class>javax.faces.event.PostKeepFlashValueEvent</system-event-class>    					
-	</system-event-listener>
-	<system-event-listener>
-		<system-event-listener-class>com.ibm.ws.jsf22.fat.flashevents.listener.PreClearFlashEventListener</system-event-listener-class>
-		<system-event-class>javax.faces.event.PreClearFlashEvent</system-event-class>    					
-	</system-event-listener>
-	<system-event-listener>
-		<system-event-listener-class>com.ibm.ws.jsf22.fat.flashevents.listener.PreRemoveFlashValueEventListener</system-event-listener-class>
-		<system-event-class>javax.faces.event.PreRemoveFlashValueEvent</system-event-class>    					
-	</system-event-listener>	
-	</application>
-	<factory>
-		<flash-factory>com.ibm.ws.jsf22.fat.flashevents.factory.TestFlashFactory</flash-factory>
-	</factory>
+    <application>
+    <system-event-listener>
+        <system-event-listener-class>com.ibm.ws.jsf22.fat.flashevents.listener.PostPutFlashValueEventListener</system-event-listener-class>
+        <system-event-class>javax.faces.event.PostPutFlashValueEvent</system-event-class>
+    </system-event-listener>
+    <system-event-listener>
+        <system-event-listener-class>com.ibm.ws.jsf22.fat.flashevents.listener.PostKeepFlashValueEventListener</system-event-listener-class>
+        <system-event-class>javax.faces.event.PostKeepFlashValueEvent</system-event-class>
+    </system-event-listener>
+    <system-event-listener>
+        <system-event-listener-class>com.ibm.ws.jsf22.fat.flashevents.listener.PreClearFlashEventListener</system-event-listener-class>
+        <system-event-class>javax.faces.event.PreClearFlashEvent</system-event-class>
+    </system-event-listener>
+    <system-event-listener>
+        <system-event-listener-class>com.ibm.ws.jsf22.fat.flashevents.listener.PreRemoveFlashValueEventListener</system-event-listener-class>
+        <system-event-class>javax.faces.event.PreRemoveFlashValueEvent</system-event-class>
+    </system-event-listener>
+    </application>
+    <factory>
+        <flash-factory>com.ibm.ws.jsf22.fat.flashevents.factory.TestFlashFactory</flash-factory>
+    </factory>
 </faces-config>

--- a/dev/wlp-jakartaee-transform/rules/jakarta-faces-config.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-faces-config.properties
@@ -4,3 +4,7 @@ javax.faces.event.PostConstructViewMapEvent=jakarta.faces.event.PostConstructVie
 javax.faces.ViewRoot=jakarta.faces.ViewRoot
 javax.faces.event.PostConstructApplicationEvent=jakarta.faces.event.PostConstructApplicationEvent
 javax.faces.event.PreDestroyApplicationEvent=jakarta.faces.event.PreDestroyApplicationEvent
+javax.faces.event.PostPutFlashValueEvent=jakarta.faces.event.PostPutFlashValueEvent
+javax.faces.event.PostKeepFlashValueEvent=jakarta.faces.event.PostKeepFlashValueEvent
+javax.faces.event.PreClearFlashEvent=jakarta.faces.event.PreClearFlashEvent
+javax.faces.event.PreRemoveFlashValueEvent=jakarta.faces.event.PreRemoveFlashValueEvent

--- a/dev/wlp-jakartaee-transform/rules/jakarta-xml-dd.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-xml-dd.properties
@@ -33,5 +33,8 @@ javax.faces.CONFIG_FILES=jakarta.faces.CONFIG_FILES
 javax.faces.STATE_SAVING_METHOD=jakarta.faces.STATE_SAVING_METHOD
 javax.faces.validator.ENABLE_VALIDATE_WHOLE_BEAN=jakarta.faces.validator.ENABLE_VALIDATE_WHOLE_BEAN
 javax.faces.INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL=jakarta.faces.INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL
+javax.faces.WEBAPP_CONTRACTS_DIRECTORY=jakarta.faces.WEBAPP_CONTRACTS_DIRECTORY
+javax.faces.CLIENT_WINDOW_MODE=jakarta.faces.CLIENT_WINDOW_MODE
+javax.faces.SERIALIZE_SERVER_STATE=jakarta.faces.SERIALIZE_SERVER_STATE
 
 javax.resource.spi.security.PasswordCredential=jakarta.resource.spi.security.PasswordCredential


### PR DESCRIPTION
fixes #14069

Enabling the jsf 2.2 FAT for Jakarta EE9 faces-3.0 feature.

In addition I did some minor clean up of the tests. 

One test in particular `JSF22MiscellaneousTests.java ` was driving a request to the wrong context root for test `testViewScopeBindingSerialize`