### PR TITLE
Issue 13655: Add parallel bundle activation to mpJwt-1.* features

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpJwt-1.0/com.ibm.websphere.appserver.mpJwt-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpJwt-1.0/com.ibm.websphere.appserver.mpJwt-1.0.feature
@@ -19,3 +19,4 @@ Subsystem-Name: MicroProfile JSON Web Token 1.0
   com.ibm.ws.security.mp.jwt.cdi
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpJwt-1.1/com.ibm.websphere.appserver.mpJwt-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpJwt-1.1/com.ibm.websphere.appserver.mpJwt-1.1.feature
@@ -23,3 +23,4 @@ Subsystem-Name: MicroProfile JSON Web Token 1.1
   com.ibm.ws.security.mp.jwt.1.1.config
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpJwt-1.2/io.openliberty.mpJwt-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpJwt-1.2/io.openliberty.mpJwt-1.2.feature
@@ -22,3 +22,4 @@ Subsystem-Name: MicroProfile JSON Web Token 1.2
   com.ibm.ws.security.mp.jwt.1.1.config
 kind=beta
 edition=core
+WLP-Activation-Type: parallel


### PR DESCRIPTION
Resolves #13655

Adds
```
WLP-Activation-Type: parallel
```
to the `mpJwt-1.0`, `mpJwt-1.1`, and `mpJwt-1.2` feature manifests.