### PR TITLE
Move ThirdPartyServer to in memory DB

### DIFF
--- a/dev/com.ibm.ws.cdi.third.party_fat/publish/servers/cdiThirdPartyServer/server.xml
+++ b/dev/com.ibm.ws.cdi.third.party_fat/publish/servers/cdiThirdPartyServer/server.xml
@@ -27,7 +27,7 @@
 
   <dataSource jndiName="jdbc/jpaDataSource" id="jpaDataSource">
       <jdbcDriver libraryRef="derbyJDBCLib" />
-      <properties.derby.embedded databaseName="TestDB" createDatabase="create"/>
+      <properties.derby.embedded databaseName="memory:TestDB" createDatabase="create"/>
   </dataSource> 
 
     <SSLDefault/>


### PR DESCRIPTION
For https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=278454

I am hopeful that this test failed because something went wrong with the HD and so moving the DB to memory will prevent it happening again. 

Even if I'm wrong memory DBs are the best practice for CDI fats. 