### PR TITLE
Run jwtsso FAT bucket with mpJwt 1.1 and 1.2

### DIFF
--- a/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/BuilderTests.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/BuilderTests.java
@@ -22,6 +22,7 @@ import javax.json.JsonObject;
 import javax.json.JsonReader;
 
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -34,14 +35,18 @@ import com.ibm.ws.security.fat.common.actions.TestActions;
 import com.ibm.ws.security.fat.common.expectations.Expectations;
 import com.ibm.ws.security.fat.common.utils.CommonWaitForAppChecks;
 import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
+import com.ibm.ws.security.jwtsso.fat.actions.JwtFatActions;
+import com.ibm.ws.security.jwtsso.fat.actions.RunWithMpJwtVersion;
 import com.ibm.ws.security.jwtsso.fat.utils.CommonExpectations;
-import com.ibm.ws.security.jwtsso.fat.utils.JwtFatActions;
 import com.ibm.ws.security.jwtsso.fat.utils.JwtFatConstants;
+import com.ibm.ws.security.jwtsso.fat.utils.JwtFatUtils;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.custom.junit.runner.RepeatTestFilter;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 
 @Mode(TestMode.FULL)
@@ -50,11 +55,15 @@ public class BuilderTests extends CommonSecurityFat {
 
     protected static Class<?> thisClass = BuilderTests.class;
 
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(new RunWithMpJwtVersion("mpJwt11")).andWith(new RunWithMpJwtVersion("mpJwt12"));
+
     @Server("com.ibm.ws.security.jwtsso.fat")
     public static LibertyServer server;
 
     private final JwtFatActions actions = new JwtFatActions();
     private final TestValidationUtils validationUtils = new TestValidationUtils();
+    private static JwtFatUtils fatUtils = new JwtFatUtils();
 
     String protectedUrl = "https://" + server.getHostname() + ":" + server.getHttpDefaultSecurePort() + JwtFatConstants.SIMPLE_SERVLET_PATH;
     String defaultUser = JwtFatConstants.TESTUSER;
@@ -62,6 +71,9 @@ public class BuilderTests extends CommonSecurityFat {
 
     @BeforeClass
     public static void setUp() throws Exception {
+
+        fatUtils.updateFeatureFile(server, "jwtSsoFeatures", RepeatTestFilter.CURRENT_REPEAT_ACTION);
+
         server.addInstalledAppForValidation(JwtFatConstants.APP_FORMLOGIN);
         serverTracker.addServer(server);
         server.startServerUsingExpandedConfiguration("server_withFeature.xml", CommonWaitForAppChecks.getSSLChannelReadyMsgs());

--- a/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/CookieExpirationTests.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/CookieExpirationTests.java
@@ -11,6 +11,7 @@
 package com.ibm.ws.security.jwtsso.fat;
 
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -23,15 +24,19 @@ import com.ibm.ws.security.fat.common.actions.TestActions;
 import com.ibm.ws.security.fat.common.expectations.Expectations;
 import com.ibm.ws.security.fat.common.utils.CommonWaitForAppChecks;
 import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
+import com.ibm.ws.security.jwtsso.fat.actions.JwtFatActions;
+import com.ibm.ws.security.jwtsso.fat.actions.RunWithMpJwtVersion;
 import com.ibm.ws.security.jwtsso.fat.utils.CommonExpectations;
-import com.ibm.ws.security.jwtsso.fat.utils.JwtFatActions;
 import com.ibm.ws.security.jwtsso.fat.utils.JwtFatConstants;
+import com.ibm.ws.security.jwtsso.fat.utils.JwtFatUtils;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.custom.junit.runner.RepeatTestFilter;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 
 @Mode(TestMode.FULL)
@@ -40,11 +45,15 @@ public class CookieExpirationTests extends CommonSecurityFat {
 
     protected static Class<?> thisClass = CookieExpirationTests.class;
 
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(new RunWithMpJwtVersion("mpJwt11")).andWith(new RunWithMpJwtVersion("mpJwt12"));
+
     @Server("com.ibm.ws.security.jwtsso.fat")
     public static LibertyServer server;
 
     private final JwtFatActions actions = new JwtFatActions();
     private final TestValidationUtils validationUtils = new TestValidationUtils();
+    private static JwtFatUtils fatUtils = new JwtFatUtils();
 
     String protectedUrl = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + JwtFatConstants.SIMPLE_SERVLET_PATH;
     String defaultUser = JwtFatConstants.TESTUSER;
@@ -52,6 +61,9 @@ public class CookieExpirationTests extends CommonSecurityFat {
 
     @BeforeClass
     public static void setUp() throws Exception {
+
+        fatUtils.updateFeatureFile(server, "jwtSsoFeatures", RepeatTestFilter.CURRENT_REPEAT_ACTION);
+
         server.addInstalledAppForValidation(JwtFatConstants.APP_FORMLOGIN);
         serverTracker.addServer(server);
         server.startServerUsingExpandedConfiguration("server_withFeature.xml", CommonWaitForAppChecks.getSSLChannelReadyMsgs());

--- a/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/FATSuite.java
@@ -23,4 +23,5 @@ import org.junit.runners.Suite.SuiteClasses;
                 CookieExpirationTests.class,
                 BuilderTests.class,
 })
-public class FATSuite {}
+public class FATSuite {
+}

--- a/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/ReplayCookieTests.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/ReplayCookieTests.java
@@ -22,6 +22,7 @@ import javax.json.JsonReader;
 import javax.servlet.http.HttpServletResponse;
 
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -47,9 +48,11 @@ import com.ibm.ws.security.fat.common.utils.CommonWaitForAppChecks;
 import com.ibm.ws.security.fat.common.utils.SecurityFatHttpUtils;
 import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
 import com.ibm.ws.security.fat.common.web.WebResponseUtils;
+import com.ibm.ws.security.jwtsso.fat.actions.JwtFatActions;
+import com.ibm.ws.security.jwtsso.fat.actions.RunWithMpJwtVersion;
 import com.ibm.ws.security.jwtsso.fat.utils.CommonExpectations;
-import com.ibm.ws.security.jwtsso.fat.utils.JwtFatActions;
 import com.ibm.ws.security.jwtsso.fat.utils.JwtFatConstants;
+import com.ibm.ws.security.jwtsso.fat.utils.JwtFatUtils;
 import com.ibm.ws.security.jwtsso.fat.utils.MessageConstants;
 
 import componenttest.annotation.AllowedFFDC;
@@ -58,6 +61,8 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.custom.junit.runner.RepeatTestFilter;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 
 @Mode(TestMode.FULL)
@@ -65,6 +70,9 @@ import componenttest.topology.impl.LibertyServer;
 public class ReplayCookieTests extends CommonSecurityFat {
 
     protected static Class<?> thisClass = ReplayCookieTests.class;
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(new RunWithMpJwtVersion("mpJwt11")).andWith(new RunWithMpJwtVersion("mpJwt12"));
 
     @Server("com.ibm.ws.security.jwtsso.fat")
     public static LibertyServer server;
@@ -76,6 +84,7 @@ public class ReplayCookieTests extends CommonSecurityFat {
 
     private final JwtFatActions actions = new JwtFatActions();
     private final TestValidationUtils validationUtils = new TestValidationUtils();
+    private static JwtFatUtils fatUtils = new JwtFatUtils();
 
     static final String DEFAULT_CONFIG = "server_withBuilderApp.xml";
     static final String APP_NAME_JWT_BUILDER = "jwtbuilder";
@@ -88,6 +97,9 @@ public class ReplayCookieTests extends CommonSecurityFat {
 
     @BeforeClass
     public static void setUp() throws Exception {
+
+        fatUtils.updateFeatureFile(server, "jwtSsoFeatures", RepeatTestFilter.CURRENT_REPEAT_ACTION);
+
         bootstrapUtils.writeBootstrapProperty(server, BOOTSTRAP_PROP_FAT_SERVER_HOSTNAME, SecurityFatHttpUtils.getServerHostName());
         bootstrapUtils.writeBootstrapProperty(server, BOOTSTRAP_PROP_FAT_SERVER_HOSTIP, SecurityFatHttpUtils.getServerHostIp());
 

--- a/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/actions/JwtFatActions.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/actions/JwtFatActions.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.security.jwtsso.fat.utils;
+package com.ibm.ws.security.jwtsso.fat.actions;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -18,6 +18,8 @@ import com.gargoylesoftware.htmlunit.util.Cookie;
 import com.ibm.ws.security.fat.common.actions.TestActions;
 import com.ibm.ws.security.fat.common.expectations.Expectations;
 import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
+import com.ibm.ws.security.jwtsso.fat.utils.CommonExpectations;
+import com.ibm.ws.security.jwtsso.fat.utils.JwtFatConstants;
 
 public class JwtFatActions extends TestActions {
 

--- a/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/actions/RunWithMpJwtVersion.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/actions/RunWithMpJwtVersion.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.jwtsso.fat.actions;
+
+import com.ibm.ws.security.fat.common.servers.ServerBootstrapUtils;
+
+import componenttest.rules.repeater.RepeatTestAction;
+import componenttest.topology.impl.LibertyServer;
+
+public class RunWithMpJwtVersion implements RepeatTestAction {
+
+    protected static Class<?> thisClass = RunWithMpJwtVersion.class;
+
+    protected static ServerBootstrapUtils bootstrapUtils = new ServerBootstrapUtils();
+
+    protected String currentID = null;
+
+    public RunWithMpJwtVersion(String version, LibertyServer... servers) {
+
+        currentID = version;
+
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public void setup() throws Exception {
+
+    }
+
+    @Override
+    public String toString() {
+        return currentID;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see componenttest.rules.repeater.RepeatTestAction#getID()
+     */
+    @Override
+    public String getID() {
+        if (currentID != null) {
+            return currentID;
+        } else {
+            return toString();
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/utils/JwtFatUtils.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/utils/JwtFatUtils.java
@@ -20,6 +20,9 @@ import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.utils.FatStringUtils;
 import com.ibm.ws.security.fat.common.web.WebResponseUtils;
 
+import componenttest.topology.impl.LibertyFileManager;
+import componenttest.topology.impl.LibertyServer;
+
 public class JwtFatUtils {
 
     protected static Class<?> thisClass = JwtFatUtils.class;
@@ -50,4 +53,13 @@ public class JwtFatUtils {
         }
     }
 
+    public void updateFeatureFile(LibertyServer server, String fileNameBase, String version) throws Exception {
+
+        String loc = server.getServerSharedPath();
+        String toLoc = loc + "config/";
+        String toFile = fileNameBase + ".xml";
+        String fromFile = loc + "config/" + fileNameBase + "_" + version + ".xml";
+        LibertyFileManager.copyFileIntoLiberty(server.getMachine(), toLoc, toFile, fromFile);
+
+    }
 }

--- a/dev/com.ibm.ws.security.jwtsso_fat/publish/shared/config/jwtSsoFeatures_mpJwt11.xml
+++ b/dev/com.ibm.ws.security.jwtsso_fat/publish/shared/config/jwtSsoFeatures_mpJwt11.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2018 IBM Corporation and others.
+    Copyright (c) 2018, 2020 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@
         <feature>jsp-2.3</feature>
         <feature>jwtSso-1.0</feature>
         <feature>componenttest-1.0</feature>
+        <feature>mpJwt-1.1</feature>
     </featureManager>
 
 </server>

--- a/dev/com.ibm.ws.security.jwtsso_fat/publish/shared/config/jwtSsoFeatures_mpJwt12.xml
+++ b/dev/com.ibm.ws.security.jwtsso_fat/publish/shared/config/jwtSsoFeatures_mpJwt12.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2018, 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+    <featureManager>
+        <feature>jsp-2.3</feature>
+        <feature>jwtSso-1.0</feature>
+        <feature>componenttest-1.0</feature>
+        <feature>mpJwt-1.2</feature>
+    </featureManager>
+
+</server>

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -2738,7 +2738,9 @@ public class LibertyServer implements LogMonitorClient {
                                     || toCopy.getName().contains("Snap")
                                     || toCopy.getName().contains(serverToUse + ".dump");
 
-                    if (moveFile && isLog) {
+                    boolean isConfigBackup = absPath.contains("serverConfigBackups");
+
+                    if (moveFile && (isLog || isConfigBackup)) {
                         boolean copied = false;
 
                         // If we're local, try to rename the file instead..


### PR DESCRIPTION
Use the repeat actions to run the jwtsso FAT with both mpJwt 1.1 and 1.2.

Have the tests use  RepeatTests.with(new RunWithMpJwtVersion("mpJwt11")).andWith(new RunWithMpJwtVersion("mpJwt12"));

In the setup of each test class, copy and rename either the   jwtSsoFeatures_mpJwt11.xml  or  jwtSsoFeatures_mpJwt12.xml to jwtSsoFeatures.xml.  The server config's import the jwtSsoFeatures.xml file and will result in the server running with either mpJwt-1.1 or mpJwt1.2...

#11022 