### PR TITLE
Various fixes for Logstash Testcontainer FAT

### DIFF
--- a/dev/com.ibm.ws.logstash.collector_fat/bnd.bnd
+++ b/dev/com.ibm.ws.logstash.collector_fat/bnd.bnd
@@ -23,5 +23,5 @@ fat.project: true
     httpunit:httpunit;version=1.5.4,\
     org.json:json;version=20080701,\
     org.rnorth.duct-tape:duct-tape;version=1.0.7,\
-    org.testcontainers:testcontainers;version=1.12.0,\
+    org.testcontainers:testcontainers;version=1.14.0,\
     org.slf4j:slf4j-api;version=1.7.7

--- a/dev/com.ibm.ws.logstash.collector_fat/build.gradle
+++ b/dev/com.ibm.ws.logstash.collector_fat/build.gradle
@@ -9,13 +9,13 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 dependencies {
-    requiredLibs 'org.testcontainers:testcontainers:1.12.0',
-        'org.apache.commons:commons-compress:1.19',
-        'org.rnorth.duct-tape:duct-tape:1.0.7',
-        'org.rnorth.visible-assertions:visible-assertions:2.1.2',
-        'org.rnorth:tcp-unix-socket-proxy:1.0.2',
-        'net.java.dev.jna:jna:5.2.0',
-        'org.slf4j:slf4j-api:1.7.7',
-        'org.slf4j:slf4j-jdk14:1.7.7',
-        'org.json:json:20080701'
+  requiredLibs 'org.testcontainers:testcontainers:1.14.0',
+               'org.apache.commons:commons-compress:1.19',
+               'org.rnorth.duct-tape:duct-tape:1.0.7',
+               'org.rnorth.visible-assertions:visible-assertions:2.1.2',
+               'org.rnorth:tcp-unix-socket-proxy:1.0.2',
+               'net.java.dev.jna:jna:5.2.0',
+               'org.slf4j:slf4j-api:1.7.7',
+               'org.slf4j:slf4j-jdk14:1.7.7',
+               'org.json:json:20080701'
 }

--- a/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
+++ b/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
@@ -185,9 +185,8 @@ public class LogstashSSLTest extends LogstashCollectorTest {
 
         // Do some work and hopefully some GC events will be created
         for (int i = 1; i <= 10; i++) {
-            createMessageEvent(testName + " " + i);
+            createGCEvent();
         }
-        createGCEvent();
         assertNotNull(LIBERTY_GC + " not found", waitForStringInContainerOutput(LIBERTY_GC));
     }
 
@@ -410,7 +409,7 @@ public class LogstashSSLTest extends LogstashCollectorTest {
     }
 
     private boolean checkGcSpecialCase() {
-        Log.info(c, testName, "Cannot find event type liberty_gc in logstash output file");
+        Log.info(c, testName, "checkGcSpecialCase");
         /**
          * Check if if belongs to the special case where build machine does not have Health centre installed, which prevents gc event to be produced
          * by checking 1. whether the operating system is Mac or linux 2. whether the machine is running IBM JDK

--- a/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
+++ b/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
@@ -94,7 +94,7 @@ public class LogstashSSLTest extends LogstashCollectorTest {
         testName = "testLogstashDefaultConfig";
         setConfig("server_default_conf.xml");
         assertNotNull("Cannot find TRAS0218I from messages.log", server.waitForStringInLogUsingMark("TRAS0218I"));
-
+        assertNotNull("Cannot find TRAS0218I from Logstash output", waitForStringInContainerOutput("TRAS0218I"));
         clearContainerOutput();
 
         int numOfMsg = 10;


### PR DESCRIPTION
Fixes #14348 
- Update testcontainer to 1.14.0
- Wait for TRAS0218I to show up in container log before clearing it

- Updated the testLogstashForGCEvent test