### PR TITLE
Update MP 4.0 API bundles to only load Jakarta EE 8 package versions

### DIFF
--- a/dev/io.openliberty.org.eclipse.microprofile/bnd.bnd
+++ b/dev/io.openliberty.org.eclipse.microprofile/bnd.bnd
@@ -24,6 +24,7 @@ publish.wlp.jar.suffix: dev/api/stable
 instrument.disabled: true
 
 -buildpath: \
+  com.ibm.websphere.javaee.annotation.1.3;version=latest,\
   com.ibm.websphere.javaee.cdi.2.0;version=latest,\
   com.ibm.websphere.javaee.interceptor.1.2;version=latest,\
   com.ibm.websphere.javaee.jaxrs.2.1;version=latest,\

--- a/dev/io.openliberty.org.eclipse.microprofile/config.2.0.bnd
+++ b/dev/io.openliberty.org.eclipse.microprofile/config.2.0.bnd
@@ -14,7 +14,6 @@ bVersion=1.0
 Bundle-SymbolicName: io.openliberty.org.eclipse.microprofile.config.2.0; singleton:=true
 
 Import-Package: \
-  javax.enterprise.util; version="[1.1,3)",\
   *
 
 Export-Package: \

--- a/dev/io.openliberty.org.eclipse.microprofile/metrics.3.0.bnd
+++ b/dev/io.openliberty.org.eclipse.microprofile/metrics.3.0.bnd
@@ -14,7 +14,6 @@ bVersion=1.0
 Bundle-SymbolicName: io.openliberty.org.eclipse.microprofile.metrics.3.0; singleton:=true
 
 Import-Package: \
-  javax.enterprise.util; version="[1.1,3)",\
   *
 
 Export-Package: \

--- a/dev/io.openliberty.org.eclipse.microprofile/opentracing.2.0.bnd
+++ b/dev/io.openliberty.org.eclipse.microprofile/opentracing.2.0.bnd
@@ -14,7 +14,6 @@ bVersion=1.0
 Bundle-SymbolicName: io.openliberty.org.eclipse.microprofile.opentracing.2.0; singleton:=true
 
 Import-Package: \
-  javax.enterprise.util; version="[1.1,3)",\
   *
 
 Export-Package: \

--- a/dev/io.openliberty.org.eclipse.microprofile/rest.client.2.0.bnd
+++ b/dev/io.openliberty.org.eclipse.microprofile/rest.client.2.0.bnd
@@ -22,12 +22,6 @@ Export-Package: \
   org.eclipse.microprofile.rest.client.spi;version=1.1.1
 
 Import-Package: \
-	javax.annotation;version='[1.3,2)',\
-	javax.enterprise.context;version='[2.0,2.1)',\
-	javax.enterprise.inject;version='[2.0,2.1)',\
-	javax.enterprise.util;version='[2.0,2.1)',\
-	javax.inject;version='[2.0,2.1)',\
-	javax.ws.rs.core;version='[2.1,3)',\
 	org.eclipse.microprofile.rest.client;version='[2.0,2.1)',\
 	org.eclipse.microprofile.rest.client.spi;version='[2.0,2.1)',\
 	*


### PR DESCRIPTION
- Update to no longer specify a range to support EE7 and EE8 of CDI
- Clean up rest client imports as well where we don't need to specify
the version.

RestClient changes:

before:
javax.enterprise.context;version="[2.0,2.1)"
javax.enterprise.inject;version="[2.0,2.1)"
javax.enterprise.util;version="[2.0,2.1)"
javax.inject;version="[2.0,2.1)"

after:
javax.enterprise.context;version="[2.0,3)"
javax.enterprise.inject;version="[2.0,3)"
javax.enterprise.util;version="[2.0,3)"
javax.inject;version="[1.0,2)"

Other bundle changed went from:  javax.enterprise.util;version="[1.1,3)" to: javax.enterprise.util;version="[2.0,3)"  