### PR TITLE
Implement config_ordinal consistently for built in sources

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.1/src/com/ibm/ws/microprofile/config/sources/EnvConfigSource.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1/src/com/ibm/ws/microprofile/config/sources/EnvConfigSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,13 +30,6 @@ public class EnvConfigSource extends InternalConfigSource implements StaticConfi
 
     private static final TraceComponent tc = Tr.register(EnvConfigSource.class);
 
-    /**
-     * @param ordinal
-     */
-    public EnvConfigSource() {
-        super(getEnvOrdinal(), Tr.formatMessage(tc, "environment.variables.config.source"));
-    }
-
     /** {@inheritDoc} */
     @Override
     public ConcurrentMap<String, String> getProperties() {
@@ -52,26 +45,18 @@ public class EnvConfigSource extends InternalConfigSource implements StaticConfi
         return new ConcurrentHashMap<>(props);
     }
 
+    /** {@inheritDoc} */
+    @Override
     @Trivial
-    public static int getEnvOrdinal() {
-        String ordinalProp = getOrdinalEnvVar();
-        int ordinal = ConfigConstants.ORDINAL_ENVIRONMENT_VARIABLES;
-        if (ordinalProp != null) {
-            ordinal = Integer.parseInt(ordinalProp);
-        }
-        return ordinal;
+    public String getName() {
+        return Tr.formatMessage(tc, "environment.variables.config.source");
     }
 
+    /** {@inheritDoc} */
+    @Override
     @Trivial
-    private static String getOrdinalEnvVar() {
-        String prop = AccessController.doPrivileged(new PrivilegedAction<String>() {
-            @Override
-            @Trivial
-            public String run() {
-                return System.getenv(ConfigConstants.ORDINAL_PROPERTY);
-            }
-        });
-        return prop;
+    protected int getDefaultOrdinal() {
+        return ConfigConstants.ORDINAL_ENVIRONMENT_VARIABLES;
     }
 
     @Override

--- a/dev/com.ibm.ws.microprofile.config.1.1/src/com/ibm/ws/microprofile/config/sources/PropertiesConfigSource.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1/src/com/ibm/ws/microprofile/config/sources/PropertiesConfigSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ package com.ibm.ws.microprofile.config.sources;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -32,6 +31,7 @@ public class PropertiesConfigSource extends InternalConfigSource implements Stat
     private static final TraceComponent tc = Tr.register(PropertiesConfigSource.class);
 
     private final ConcurrentMap<String, String> properties;
+    private final String id;
 
     @Trivial
     public PropertiesConfigSource(URL resource) {
@@ -40,27 +40,27 @@ public class PropertiesConfigSource extends InternalConfigSource implements Stat
 
     @Trivial
     public PropertiesConfigSource(ConcurrentMap<String, String> properties, String id) {
-        this(properties, getPropsOrdinal(properties), Tr.formatMessage(tc, "properties.file.config.source", id));
+        this.id = Tr.formatMessage(tc, "properties.file.config.source", id);
+        this.properties = properties;
     }
 
-    public PropertiesConfigSource(ConcurrentMap<String, String> properties, int ordinal, String id) {
-        super(ordinal, id);
-        this.properties = properties;
+    /** {@inheritDoc} */
+    @Override
+    @Trivial
+    public String getName() {
+        return this.id;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @Trivial
+    protected int getDefaultOrdinal() {
+        return ConfigConstants.ORDINAL_PROPERTIES_FILE;
     }
 
     @Override
     public ConcurrentMap<String, String> getProperties() {
         return this.properties;
-    }
-
-    @Trivial
-    public static int getPropsOrdinal(Map<String, String> properties) {
-        String ordinalProp = properties.get(ConfigConstants.ORDINAL_PROPERTY);
-        int ordinal = ConfigConstants.ORDINAL_PROPERTIES_FILE;
-        if (ordinalProp != null) {
-            ordinal = Integer.parseInt(ordinalProp);
-        }
-        return ordinal;
     }
 
     public static ConcurrentMap<String, String> loadProperties(URL resource) {
@@ -76,7 +76,6 @@ public class PropertiesConfigSource extends InternalConfigSource implements Stat
             for (String name : propNames) {
                 props.put(name, properties.getProperty(name));
             }
-
         } catch (IOException e) {
             throw new ConfigException(e);
         } finally {

--- a/dev/com.ibm.ws.microprofile.config.1.1/src/com/ibm/ws/microprofile/config/sources/SystemConfigSource.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1/src/com/ibm/ws/microprofile/config/sources/SystemConfigSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,8 +31,18 @@ public class SystemConfigSource extends InternalConfigSource implements StaticCo
 
     private static final TraceComponent tc = Tr.register(SystemConfigSource.class);
 
-    public SystemConfigSource() {
-        super(getSystemOrdinal(), Tr.formatMessage(tc, "system.properties.config.source"));
+    /** {@inheritDoc} */
+    @Override
+    @Trivial
+    public String getName() {
+        return Tr.formatMessage(tc, "system.properties.config.source");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @Trivial
+    protected int getDefaultOrdinal() {
+        return ConfigConstants.ORDINAL_SYSTEM_PROPERTIES;
     }
 
     /** {@inheritDoc} */
@@ -51,28 +61,6 @@ public class SystemConfigSource extends InternalConfigSource implements StaticCo
         }
 
         return props;
-    }
-
-    @Trivial
-    public static int getSystemOrdinal() {
-        String ordinalProp = getOrdinalSystemProperty();
-        int ordinal = ConfigConstants.ORDINAL_SYSTEM_PROPERTIES;
-        if (ordinalProp != null) {
-            ordinal = Integer.parseInt(ordinalProp);
-        }
-        return ordinal;
-    }
-
-    @Trivial
-    private static String getOrdinalSystemProperty() {
-        String prop = AccessController.doPrivileged(new PrivilegedAction<String>() {
-            @Override
-            @Trivial
-            public String run() {
-                return System.getProperty(ConfigConstants.ORDINAL_PROPERTY);
-            }
-        });
-        return prop;
     }
 
     @Trivial

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat/.classpath
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat/.classpath
@@ -8,6 +8,8 @@
 	<classpathentry kind="src" path="test-applications/variableServerXMLApp/src"/>
 	<classpathentry kind="src" path="test-applications/duplicateInServerXMLApp/src"/>
 	<classpathentry kind="src" path="test-applications/serverXMLWebApp/src"/>
+	<classpathentry kind="src" path="test-applications/configOrdinalServerXMLApp/src"/>
+	<classpathentry kind="src" path="test-applications/configOrdinalServerXMLApp/resources"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat/bnd.bnd
@@ -19,8 +19,9 @@ src: \
 	test-applications/hotAddMPConfigApp/src,\
 	test-applications/variableServerXMLApp/src,\
 	test-applications/duplicateInServerXMLApp/src,\
-	test-applications/serverXMLWebApp/src
-
+	test-applications/serverXMLWebApp/src,\
+	test-applications/configOrdinalServerXMLApp/src,\
+	test-applications/configOrdinalServerXMLApp/resources
 	
 fat.project: true
 

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat/fat/src/com/ibm/ws/microprofile/config13/test/ConfigOrdinalServerXMLTest.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat/fat/src/com/ibm/ws/microprofile/config13/test/ConfigOrdinalServerXMLTest.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.config13.test;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.microprofile.config.fat.repeat.RepeatConfigActions;
+import com.ibm.ws.microprofile.config.fat.repeat.RepeatConfigActions.Version;
+import com.ibm.ws.microprofile.config13.configOrdinalServerXMLWebApp.web.ConfigOrdinalServerXMLServlet;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+/**
+ * Test that server.xml config sources respect config_ordinal
+ * <p>
+ * The following config sources should be present with the following ordinals:
+ * <ul>
+ * <li>microprofile-config.properties (100)
+ * <li>server.xml variables (150)
+ * <li>environment variables (300)
+ * <li>server.xml appProperties (350)
+ * <li>system properties (400)
+ * </ul>
+ * The following keys are defined.
+ * <ul>
+ * <li>key_config_props
+ * <li>key_serverxml_vars
+ * <li>key_env_vars
+ * <li>key_serverxml_app_props
+ * <li>key_system_props
+ * </ul>
+ *
+ * Each config source defines a property for itself and a property for each config source of a higher ordinal, with the value always being the name of the config source.
+ * <p>
+ * E.g. the following environment variables are defined:
+ *
+ * <pre>
+ * key_env_vars=env_vars
+ * key_serverxml_app_props=env_vars
+ * key_system_props=env_vars
+ * </pre>
+ *
+ * <p>
+ * In this way, it's sufficient to test that {@code key_foo == foo} for each key name
+ */
+@RunWith(FATRunner.class)
+public class ConfigOrdinalServerXMLTest extends FATServletClient {
+
+    public static final String APP_NAME = "configOrdinalServerXMLApp";
+    public static final String SERVER = "ServerXMLConfigOrdinalServer";
+
+    @Server(SERVER)
+    @TestServlet(servlet = ConfigOrdinalServerXMLServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = RepeatConfigActions.repeat(SERVER, Version.LATEST, Version.CONFIG13_EE8);
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultApp(server, APP_NAME, "com.ibm.ws.microprofile.config13.configOrdinalServerXMLWebApp.*");
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat/publish/servers/ServerXMLConfigOrdinalServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat/publish/servers/ServerXMLConfigOrdinalServer/bootstrap.properties
@@ -1,0 +1,6 @@
+bootstrap.include=../testports.properties
+osgi.console=7773
+com.ibm.ws.logging.trace.specification=*=info:APPCONFIG=all
+
+# See ConfigOrdinalServerXMLTest
+key_system_props=system_props

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat/publish/servers/ServerXMLConfigOrdinalServer/server.env
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat/publish/servers/ServerXMLConfigOrdinalServer/server.env
@@ -1,0 +1,6 @@
+server_env_property=server.env.value
+
+# See ConfigOrdinalServerXMLTest
+key_env_vars=env_vars
+key_serverxml_app_props=env_vars
+key_system_props=env_vars

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat/publish/servers/ServerXMLConfigOrdinalServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat/publish/servers/ServerXMLConfigOrdinalServer/server.xml
@@ -1,0 +1,28 @@
+<server description="Server for testing config_ordinal in appProperties and variables">
+
+    <include location="../fatTestPorts.xml" />
+
+    <featureManager>
+        <feature>cdi-2.0</feature>
+        <feature>servlet-4.0</feature>
+        <feature>componentTest-1.0</feature>
+        <feature>mpConfig-1.4</feature>
+    </featureManager>
+
+    <!-- See ConfigOrdinalServerXMLTest for explanation of defined properties-->
+
+    <application location="configOrdinalServerXMLApp.war">
+       <appProperties>
+            <property name="key_serverxml_app_props" value="serverxml_app_props" />
+            <property name="key_system_props" value="serverxml_app_props" />
+            <property name="config_ordinal" value="350"/>
+       </appProperties>
+    </application>
+    
+    <variable name="key_serverxml_vars" value="serverxml_vars" />
+    <variable name="key_env_vars" value="serverxml_vars" />
+    <variable name="key_serverxml_app_props" value="serverxml_vars" />
+    <variable name="key_system_props" value="serverxml_vars" />
+    <variable name="config_ordinal" value="150"/>
+    
+</server>

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat/test-applications/configOrdinalServerXMLApp/resources/META-INF/microprofile-config.properties
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat/test-applications/configOrdinalServerXMLApp/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,6 @@
+# See ConfigOrdinalServerXMLTest
+key_config_props=config_props
+key_serverxml_vars=config_props
+key_env_vars=config_props
+key_serverxml_app_props=config_props
+key_system_props=config_props

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat/test-applications/configOrdinalServerXMLApp/src/com/ibm/ws/microprofile/config13/configOrdinalServerXMLWebApp/web/ConfigOrdinalServerXMLServlet.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat/test-applications/configOrdinalServerXMLApp/src/com/ibm/ws/microprofile/config13/configOrdinalServerXMLWebApp/web/ConfigOrdinalServerXMLServlet.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.config13.configOrdinalServerXMLWebApp.web;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+
+import org.eclipse.microprofile.config.Config;
+import org.junit.Test;
+
+import com.ibm.ws.microprofile.config13.test.ConfigOrdinalServerXMLTest;
+
+import componenttest.app.FATServlet;
+
+/**
+ * See {@link ConfigOrdinalServerXMLTest} for test details
+ */
+@SuppressWarnings("serial")
+@WebServlet("/ConfigOrdinalServerXML")
+public class ConfigOrdinalServerXMLServlet extends FATServlet {
+
+    @Inject
+    private Config config;
+
+    @Test
+    public void testServerXmlConfigOrdinal() {
+        assertEquals("config_props", config.getValue("key_config_props", String.class));
+        assertEquals("serverxml_vars", config.getValue("key_serverxml_vars", String.class));
+        assertEquals("env_vars", config.getValue("key_env_vars", String.class));
+        assertEquals("serverxml_app_props", config.getValue("key_serverxml_app_props", String.class));
+        assertEquals("system_props", config.getValue("key_system_props", String.class));
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat/test-applications/configOrdinalServerXMLApp/src/com/ibm/ws/microprofile/config13/configOrdinalServerXMLWebApp/web/DummyBean.java
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat/test-applications/configOrdinalServerXMLApp/src/com/ibm/ws/microprofile/config13/configOrdinalServerXMLWebApp/web/DummyBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,19 +8,14 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.microprofile.config13.test;
+package com.ibm.ws.microprofile.config13.configOrdinalServerXMLWebApp.web;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import javax.enterprise.context.ApplicationScoped;
 
-@RunWith(Suite.class)
-@SuiteClasses({
-                HotAddMPConfig.class, //FULL
-                ServerXMLTest.class, //FULL
-                VariableServerXMLTest.class, //LITE
-                ConfigOrdinalServerXMLTest.class // FULL
-})
-public class FATSuite {
+/**
+ * A bean is needed so that CDI does any injection...
+ */
+@ApplicationScoped
+public class DummyBean {
 
 }

--- a/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/sources/EnvConfig14Source.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/sources/EnvConfig14Source.java
@@ -13,25 +13,21 @@ package com.ibm.ws.microprofile.config14.sources;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Map;
-import java.util.Set;
 import java.util.regex.Pattern;
-
-import org.eclipse.microprofile.config.spi.ConfigSource;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.microprofile.config.interfaces.ConfigConstants;
 
+import io.openliberty.microprofile.config.internal.common.InternalConfigSource;
+
 /**
  *
  */
-public class EnvConfig14Source implements ConfigSource {
+public class EnvConfig14Source extends InternalConfigSource {
 
     private static final TraceComponent tc = Tr.register(EnvConfig14Source.class);
-
-    private final int ordinal;
-    private final String name;
 
     private static Pattern p = null;
 
@@ -50,32 +46,25 @@ public class EnvConfig14Source implements ConfigSource {
         });
 
         p = Pattern.compile(ConfigConstants.CONFIG13_ALLOWABLE_CHARS_IN_ENV_VAR_SOURCE);
-
-    }
-
-    public EnvConfig14Source() {
-        ordinal = getEnvOrdinal();
-        name = Tr.formatMessage(tc, "environment.variables.config.source");
     }
 
     @Override
+    @Trivial
     public String getName() {
-        return name;
+        return Tr.formatMessage(tc, "environment.variables.config.source");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @Trivial
+    protected int getDefaultOrdinal() {
+        return ConfigConstants.ORDINAL_ENVIRONMENT_VARIABLES;
     }
 
     @Override
-    public int getOrdinal() {
-        return ordinal;
-    }
-
-    @Override
+    @Trivial
     public Map<String, String> getProperties() {
         return env;
-    }
-
-    @Override
-    public Set<String> getPropertyNames() {
-        return env.keySet();
     }
 
     @Override
@@ -107,16 +96,6 @@ public class EnvConfig14Source implements ConfigSource {
         if (p != null)
             modifiedName = p.matcher(name).replaceAll("_");
         return modifiedName;
-    }
-
-    @Trivial
-    public static int getEnvOrdinal() {
-        String ordinalProp = env.get(ConfigConstants.ORDINAL_PROPERTY);
-        int ordinal = ConfigConstants.ORDINAL_ENVIRONMENT_VARIABLES;
-        if (ordinalProp != null) {
-            ordinal = Integer.parseInt(ordinalProp);
-        }
-        return ordinal;
     }
 
     @Override

--- a/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/sources/SystemConfig14Source.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/sources/SystemConfig14Source.java
@@ -22,30 +22,27 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.kernel.service.util.SecureAction;
 import com.ibm.ws.microprofile.config.interfaces.ConfigConstants;
 
+import io.openliberty.microprofile.config.internal.common.InternalConfigSource;
+
 /**
  *
  */
-public class SystemConfig14Source implements ExtendedConfigSource {
+public class SystemConfig14Source extends InternalConfigSource implements ExtendedConfigSource {
 
     private static final TraceComponent tc = Tr.register(SystemConfig14Source.class);
     static final SecureAction priv = AccessController.doPrivileged(SecureAction.get());
 
-    private final int ordinal;
-    private final String name;
-
-    public SystemConfig14Source() {
-        ordinal = getSystemOrdinal();
-        name = Tr.formatMessage(tc, "system.properties.config.source");
-    }
-
     @Override
+    @Trivial
     public String getName() {
-        return name;
+        return Tr.formatMessage(tc, "system.properties.config.source");
     }
 
+    /** {@inheritDoc} */
     @Override
-    public int getOrdinal() {
-        return ordinal;
+    @Trivial
+    protected int getDefaultOrdinal() {
+        return ConfigConstants.ORDINAL_SYSTEM_PROPERTIES;
     }
 
     @Override
@@ -62,6 +59,9 @@ public class SystemConfig14Source implements ExtendedConfigSource {
         return getProperties().keySet();
     }
 
+    /*
+     * Overridden for performance to avoid calling getProperties which would make a copy of the map
+     */
     @Override
     public String getValue(String key) {
         return priv.getProperty(key);
@@ -85,26 +85,6 @@ public class SystemConfig14Source implements ExtendedConfigSource {
         }
 
         return result;
-    }
-
-    @Trivial
-    public static int getSystemOrdinal() {
-        String ordinalProp = getOrdinalSystemProperty();
-        int ordinal = ConfigConstants.ORDINAL_SYSTEM_PROPERTIES;
-        if (ordinalProp != null) {
-            ordinal = Integer.parseInt(ordinalProp);
-        }
-        return ordinal;
-    }
-
-    @Trivial
-    private static String getOrdinalSystemProperty() {
-        return priv.getProperty(ConfigConstants.ORDINAL_PROPERTY);
-    }
-
-    @Override
-    public String toString() {
-        return "System Properties Config Source";
     }
 
 }

--- a/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/AppPropertyConfigSource.java
+++ b/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/AppPropertyConfigSource.java
@@ -14,12 +14,13 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
-import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.osgi.framework.BundleContext;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 
 import io.openliberty.microprofile.config.internal.common.InternalConfigSource;
 
@@ -47,16 +48,40 @@ import io.openliberty.microprofile.config.internal.common.InternalConfigSource;
  * Note that serverXMLKey1 was listed three times and the last entry "won"
  *
  */
-public class AppPropertyConfigSource extends InternalConfigSource implements ConfigSource { //extends InternalConfigSource implements DynamicConfigSource {
+public class AppPropertyConfigSource extends InternalConfigSource {
 
     private static final TraceComponent tc = Tr.register(AppPropertyConfigSource.class);
+
     private final PrivilegedAction<String> getApplicationPidAction = new GetApplicationPidAction();
+
     private BundleContext bundleContext;
     private String applicationName;
     private String applicationPID;
 
-    public AppPropertyConfigSource() {
-        super(ServerXMLConstants.APP_PROPERTY_ORDINAL, Tr.formatMessage(tc, "server.xml.appproperties.config.source"));
+    /** {@inheritDoc} */
+    @Override
+    @Trivial
+    public String getName() {
+        return Tr.formatMessage(tc, "server.xml.appproperties.config.source");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @Trivial
+    protected int getDefaultOrdinal() {
+        return ServerXMLConstants.APP_PROPERTY_ORDINAL;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Set<String> getPropertyNames() {
+        return getProperties().keySet();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getValue(String key) {
+        return getProperties().get(key);
     }
 
     /** {@inheritDoc} */

--- a/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/ServerXMLDefaultVariableConfigSource.java
+++ b/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/ServerXMLDefaultVariableConfigSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import java.util.Map;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.config.xml.ConfigVariables;
 
 /**
@@ -27,8 +28,19 @@ public class ServerXMLDefaultVariableConfigSource extends ServerXMLVariableConfi
 
     private static final TraceComponent tc = Tr.register(ServerXMLDefaultVariableConfigSource.class);
 
-    public ServerXMLDefaultVariableConfigSource() {
-        super(ServerXMLConstants.SERVER_XML_DEFAULT_VARIABLE_ORDINAL, Tr.formatMessage(tc, "server.xml.default.variables.config.source"));
+    /** {@inheritDoc} */
+    @Override
+    @Trivial
+    public int getOrdinal() {
+        // Don't respect the config_ordinal parameter for serverXML _default_ variables
+        return ServerXMLConstants.SERVER_XML_DEFAULT_VARIABLE_ORDINAL;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @Trivial
+    public String getName() {
+        return Tr.formatMessage(tc, "server.xml.default.variables.config.source");
     }
 
     @Override

--- a/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/ServerXMLVariableConfigSource.java
+++ b/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/ServerXMLVariableConfigSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@ import org.osgi.framework.BundleContext;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.config.xml.ConfigVariables;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
@@ -38,12 +39,18 @@ public class ServerXMLVariableConfigSource extends InternalConfigSource implemen
     private BundleContext bundleContext;
     private ConfigVariables configVariables;
 
-    public ServerXMLVariableConfigSource() {
-        this(ServerXMLConstants.SERVER_XML_VARIABLE_ORDINAL, Tr.formatMessage(tc, "server.xml.variables.config.source"));
+    /** {@inheritDoc} */
+    @Override
+    @Trivial
+    public String getName() {
+        return Tr.formatMessage(tc, "server.xml.variables.config.source");
     }
 
-    protected ServerXMLVariableConfigSource(int ordinal, String id) {
-        super(ordinal, id);
+    /** {@inheritDoc} */
+    @Override
+    @Trivial
+    protected int getDefaultOrdinal() {
+        return ServerXMLConstants.SERVER_XML_VARIABLE_ORDINAL;
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Currently some of our config sources respect `config_ordinal` and some don't and each source has its own logic to look up this variable.

Make the code that does this common and use it for all built in config sources.

Fixes #14377 