### PR TITLE
allow components to add additional features when using EE9 repeat action

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/FeatureReplacementAction.java
@@ -101,6 +101,7 @@ public class FeatureReplacementAction implements RepeatTestAction {
     private final Set<String> clients = new HashSet<>(Arrays.asList(ALL_CLIENTS));
     private final Set<String> removeFeatures = new HashSet<>();
     private final Set<String> addFeatures = new HashSet<>();
+    private final Set<String> alwaysAddFeatures = new HashSet<>();
     private TestMode testRunMode = TestMode.LITE;
 
     public FeatureReplacementAction() {}
@@ -166,6 +167,28 @@ public class FeatureReplacementAction implements RepeatTestAction {
      */
     public FeatureReplacementAction addFeatures(Set<String> addFeatures) {
         addFeatures.forEach(this::addFeature);
+        return this;
+    }
+
+    /**
+     * Add features to the set to be added - these features will always be added to the server configuration, even if
+     * {@code forceAddFeatures} is set to false.
+     *
+     * @param alwaysAddedFeatures the features to be added regardless of {@code forceAddFeatures}
+     */
+    public FeatureReplacementAction alwaysAddFeatures(Set<String> alwaysAddedFeatures) {
+        alwaysAddedFeatures.forEach(this::alwaysAddFeature);
+        return this;
+    }
+
+    /**
+     * Add a feature to the set to be added - this features will always be added to the server configuration, even if
+     * {@code forceAddFeatures} is set to false.
+     *
+     * @param alwaysAddedFeature the feature to be added regardless of {@code forceAddFeatures}
+     */
+    public FeatureReplacementAction alwaysAddFeature(String alwaysAddedFeature) {
+        alwaysAddFeatures.add(alwaysAddedFeature);
         return this;
     }
 
@@ -400,6 +423,7 @@ public class FeatureReplacementAction implements RepeatTestAction {
                     }
                 }
             }
+            alwaysAddFeatures.forEach(s -> features.add(s));
             Log.info(c, m, "Resulting features: " + features);
 
             if (isServerConfig) {


### PR DESCRIPTION
Allow FAT projects to use repeat actions with EE9 features and add additional features - i.e. jaxrs-2.1 -> restfulWS-3.0 + jsonb-2.0