### PR TITLE
Add check for SRVE0242I 

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -422,6 +422,8 @@ public class TestEnableDisableFeaturesTest {
     	serverEDF11.setMarkToEndOfLog();
     	serverEDF11.setServerConfigurationFile("server_noJDBC.xml");
     	Assert.assertNotNull("CWWKF0008I NOT FOUND",serverEDF11.waitForStringInLogUsingMark("CWWKF0008I"));
+    	//This message ID indicates the Pub/Priv Rest Handler has been initialized
+    	Assert.assertNotNull("SRVE0242I NOT FOUND",serverEDF11.waitForStringInLogUsingMark("SRVE0242I.*(\\[/metrics\\])")); 
     	Log.info(c, testName, "------- connectionpool metrics should not be available ------");
     	checkStrings(getHttpsServlet("/metrics/vendor",serverEDF11), 
     		new String[] { "vendor_" },

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -402,6 +402,8 @@ public class TestEnableDisableFeaturesTest {
     	serverEDF11.setMarkToEndOfLog();
     	serverEDF11.setServerConfigurationFile("server_noJDBC.xml");
     	Assert.assertNotNull("CWWKF0008I NOT FOUND",serverEDF11.waitForStringInLogUsingMark("CWWKF0008I"));
+    	//This message ID indicates the Pub/Priv Rest Handler has been initialized
+    	Assert.assertNotNull("SRVE0242I NOT FOUND",serverEDF11.waitForStringInLogUsingMark("SRVE0242I.*(\\[/metrics\\])")); 
     	Log.info(c, testName, "------- connectionpool metrics should not be available ------");
     	checkStrings(getHttpsServlet("/metrics/vendor",serverEDF11), 
     		new String[] { "vendor:" },       	

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -408,6 +408,8 @@ public class TestEnableDisableFeaturesTest {
         serverEDF11.setMarkToEndOfLog();
         serverEDF11.setServerConfigurationFile("server_noJDBC.xml");
         Assert.assertNotNull("CWWKF0008I NOT FOUND", serverEDF11.waitForStringInLogUsingMark("CWWKF0008I"));
+    	//This message ID indicates the Pub/Priv Rest Handler has been initialized
+    	Assert.assertNotNull("SRVE0242I NOT FOUND",serverEDF11.waitForStringInLogUsingMark("SRVE0242I.*(\\[/metrics\\])")); 
         Log.info(c, testName, "------- connectionpool metrics should not be available ------");
         checkStrings(getHttpsServlet("/metrics/vendor", serverEDF11), new String[] { "vendor_" },
                 new String[] { "vendor_connectionpool", "vendor_servlet", "{servlet=\"testJDBCApp\"}" });


### PR DESCRIPTION
The issue with 14228 appears to be that the test sends a REST request to check the `/metrics/vendor` endpoint before the Private/Public RestHandler is available (after the server configuration change).

The check for `SRVE0242I` before the check should fix it.
fix #14228 
#build