### PR TITLE
Application context path can not end with a slash

### DIFF
--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/FATSuite.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corporation and others.
+ * Copyright (c) 2012, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.fat.util.FatLogHandler;
+import com.ibm.ws.fat.wc.tests.WC5GetContextPath;
 import com.ibm.ws.fat.wc.tests.WC5JakartaServletTest;
 import com.ibm.ws.fat.wc.tests.WCAddJspFileTest;
 import com.ibm.ws.fat.wc.tests.WCApplicationMBeanStatusTest;
@@ -83,7 +84,8 @@ import componenttest.rules.repeater.RepeatTests;
                 WCServletPathForDefaultMappingFalse.class,
                 WCGetMappingSlashStarTest.class,
                 WCSendRedirectRelativeURLTrue.class,
-                WCSendRedirectRelativeURLDefault.class
+                WCSendRedirectRelativeURLDefault.class,
+                WC5GetContextPath.class
 })
 
 public class FATSuite {

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WC5GetContextPath.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WC5GetContextPath.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.fat.wc.tests;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.logging.Logger;
+
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * Test ServletContext.getContextPath() and HttpServletRequest.getContextPath().
+ * The application is purposely configured with an illegal ending slash (/) via the server.xml's webApplication element
+ * The above APIs should return WITHOUT the ending slash.
+ * The target JSP file will do all the query, verify, and response with PASS or FAIL for each API.
+ * Should only run in EE9.
+ */
+@RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
+@SkipForRepeat(SkipForRepeat.NO_MODIFICATION)
+public class WC5GetContextPath {
+
+    private static final Logger LOG = Logger.getLogger(WC5GetContextPath.class.getName());
+    private static final String APP_NAME = "Servlet5TestApp";
+
+    @Server("servlet50_GetContextPath")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void before() throws Exception {
+        LOG.info("Setup : add " + APP_NAME + " war to the server's apps folder if not already present.");
+
+        ShrinkHelper.defaultApp(server, APP_NAME + ".war", "servlet5snoop.war.servlets");
+
+        // Start the server and use the class name so we can find logs easily.
+        server.startServer(WC5GetContextPath.class.getSimpleName() + ".log");
+        LOG.info("Setup : complete, ready for Tests");
+    }
+
+    @AfterClass
+    public static void testCleanup() throws Exception {
+        LOG.info("testCleanUp : stop server");
+        // Stop the server
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+    /**
+     * Request to testGetContextPath.jsp
+     *
+     * @throws Exception
+     */
+    @Test
+    public void test_Servlet5_GetContextPath() throws Exception {
+        String url = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/" + "TestGetContextPathRoot" + "/testGetContextPath.jsp";
+
+        LOG.info("url: " + url);
+        LOG.info("expectedResponse: Verify that no FAIL in the response text");
+
+        HttpGet getMethod = new HttpGet(url);
+
+        try (final CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            try (final CloseableHttpResponse response = client.execute(getMethod)) {
+                String responseText = EntityUtils.toString(response.getEntity());
+                LOG.info("\n" + "Response Text:");
+                LOG.info("\n" + responseText);
+
+                assertTrue("The response did not contain the following String: ",
+                           responseText.contains("request.getContextPath()=[PASS]") && responseText.contains("servletContext.getContextPath()=[PASS]"));
+            }
+        }
+    }
+}

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet50_GetContextPath/bootstrap.properties
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet50_GetContextPath/bootstrap.properties
@@ -1,0 +1,4 @@
+bootstrap.include=../testports.properties
+osgi.console=7777
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.webcontainer*=all:com.ibm.wsspi.webcontainer*=all:GenericBNF=all
+com.ibm.ws.classloading.tcclLockWaitTimeMillis=60000

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet50_GetContextPath/server.xml
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet50_GetContextPath/server.xml
@@ -1,0 +1,29 @@
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+-->
+<server description="Server for testing Servlet 50 jakarta.servlet">
+
+  <include location="../fatTestPorts.xml"/>
+
+  <featureManager>
+    <feature>servlet-5.0</feature>
+    <feature>pages-3.0</feature>
+  </featureManager>
+
+ <!-- the contextRoot value is configured to PURPOSELY ending with a slash -->
+  <webApplication contextRoot="TestGetContextPathRoot/" location="Servlet5TestApp.war"/>
+
+  <logging
+    traceSpecification="*=info=enabled:com.ibm.ws.webcontainer*=all:com.ibm.wsspi.webcontainer*=all:GenericBNF=all"
+    maxFileSize="20"
+    maxFiles="10"
+    traceFormat="BASIC"/>
+
+</server>

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/Servlet5TestApp.war/resources/testGetContextPath.jsp
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/Servlet5TestApp.war/resources/testGetContextPath.jsp
@@ -1,0 +1,40 @@
+<%-- 
+  Copyright (c) 2021 IBM Corporation and others.
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the Eclipse Public License v1.0
+  which accompanies this distribution, and is available at
+  http://www.eclipse.org/legal/epl-v10.html
+ 
+  Contributors:
+      IBM Corporation - initial API and implementation
+--%>
+<%@ page  import="java.io.PrintWriter" %>
+<%@ page  import="java.io.OutputStreamWriter" %>
+<%
+	PrintWriter localOut;
+    String requestGetContextPath = request.getContextPath();
+    String contextGetContextPath = getServletContext().getContextPath();
+    StringBuffer testMessage = new StringBuffer("Results: ");
+	try {
+		localOut = response.getWriter();
+	} catch (IllegalStateException e) {
+		localOut = new PrintWriter(new OutputStreamWriter(response.getOutputStream(), response.getCharacterEncoding()));
+	}
+
+    testMessage.append("Test request.getContextPath()=");
+    if (requestGetContextPath != null && requestGetContextPath.endsWith("/")){
+        testMessage.append("[FAIL]");
+        System.out.println("Test request.getContextPath() FAIL");
+    }else
+         testMessage.append("[PASS]");
+
+    testMessage.append(".  Test servletContext.getContextPath()=");
+    if (contextGetContextPath != null && contextGetContextPath.endsWith("/")){
+        testMessage.append("[FAIL]");
+        System.out.println("Test servletContext.getContextPath() FAIL");
+    }else
+         testMessage.append("[PASS]");
+    
+    localOut.println(testMessage.toString());
+%>
+

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebGroupConfiguration.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebGroupConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2006 IBM Corporation and others.
+ * Copyright (c) 1997, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,10 +10,17 @@
  *******************************************************************************/
 package com.ibm.ws.webcontainer.webapp;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import com.ibm.ws.container.BaseConfiguration;
 import com.ibm.ws.webcontainer.VirtualHost;
+import com.ibm.wsspi.webcontainer.logging.LoggerFactory;
 
 public class WebGroupConfiguration extends BaseConfiguration {
+    
+    protected static final Logger logger = LoggerFactory.getInstance().getLogger("com.ibm.ws.webcontainer.webapp");
+    protected static final String CLASS_NAME = "com.ibm.ws.webcontainer.webapp.WebGroupConfiguration";
 	
 	private String contextRoot;
 	private VirtualHost webAppHost;
@@ -37,7 +44,14 @@ public class WebGroupConfiguration extends BaseConfiguration {
 	 * @param contextRoot The contextRoot to set
 	 */
 	public void setContextRoot(String contextRoot) {
-		this.contextRoot = contextRoot;
+	    if (contextRoot.endsWith("/") && !contextRoot.equals("/")) {
+	        logger.logp(Level.FINE, CLASS_NAME, "setContextRoot", "context root [" + contextRoot + "] cannot end with a slash (/)");
+
+	        contextRoot = contextRoot.substring(0, contextRoot.length() - 1);
+	    }
+
+	    logger.logp(Level.FINE, CLASS_NAME, "setContextRoot", " [" + contextRoot + "]");
+	    this.contextRoot = contextRoot;
 	}
 
 	/**


### PR DESCRIPTION
fixes #14345

getContextPath() should return a context path of the application.  The context path starts with a "/" character but does not end with a "/" character.

Check, remove the trailing slash (if applicable), and also log a message.  The flow is not interrupted.

A workaround: remove the ending / in the application's context root configuration.