### PR TITLE
Remove finalize() on WSRdbManagedConnectionImpl

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
@@ -840,41 +840,6 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
     }
 
     /**
-     * Finalize is invoked by the garbage collector when no more references to this object
-     * exist. If this ManagedConnection was never destroyed because handles were never closed
-     * by the application, notify all listeners with a connectionClosed ConnectionEvent, to
-     * give the connection manager an opportunity to avoid leaking connections.
-     * 
-     * @throws Throwable if something terrible happens.
-     * 
-     */
-    @Override
-    protected void finalize() throws Throwable {
-        final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
-
-        if (isTraceOn && tc.isEntryEnabled())
-            Tr.entry(this, tc, "finalize"); 
-
-        super.finalize(); // no-op, only adding to make findbugs stop complaining.
-
-        if (numHandlesInUse > 0) {
-            // Cause cleanup to fail, to ensure the Connection Manager destroys the connection.
-            fatalErrorCount = -1;
-
-            if (isTraceOn && tc.isDebugEnabled())
-                Tr.debug(this, tc, 
-                         numHandlesInUse + " connection handles were left open by the application.");
-
-            cleaningUpHandles = false; 
-            while (numHandlesInUse > 0)
-                processConnectionClosedEvent(handlesInUse[0]);
-        }
-
-        if (isTraceOn && tc.isEntryEnabled())
-            Tr.exit(this, tc, "finalize"); 
-    }
-
-    /**
      * @return the current value of the catalog property.
      */
     public final String getCatalog() throws SQLException 


### PR DESCRIPTION
I recently noticed that our managed connection class (`WSRdbManagedConnectionImpl`) was overriding the `finalize()` method. The `finalize` method has been deprecated in Java 9 because it is inherently problematic.

If an object overrides finalize, the GC processing for the object is much slower:

> An object that overrides finalize() is treated specially by the garbage collector. Usually, an object is immediately destroyed during the collection cycle after the object is no longer in scope. However, finalizable objects are instead moved to a queue, where separate finalization threads will drain the queue and run the finalize() method on each object. Once the finalize() method terminates, the object will at last be ready for garbage collection in the next cycle.

It is also dangerous that the finalize method for our managed connections call out to any connection event listeners to process the close event, meaning that we are potentially performing a new and unknown amount of work during GC.

According to the JDK deprecation notice:

> Finalizers are inherently problematic and their use can lead to performance issues, 
deadlocks, hangs, and other problematic behavior. 
>
> Furthermore the timing of finalization is unpredictable with no guarantee that a finalizer will be called. 
Classes whose instances hold non-heap resources should provide a method
to enable explicit release of those resources, and they should also implement 
java.lang.AutoCloseable if appropriate.

For detailed reference see: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8165641
