### PR TITLE
Issue 13959: MP JWT TCK TokenAsCookie fix in JwkRetriever

### DIFF
--- a/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JwKRetriever.java
+++ b/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JwKRetriever.java
@@ -224,18 +224,25 @@ public class JwKRetriever {
                     publicKey = getJwkFromJWKSet(classLoadingCacheSelector, kid, x5t, use, null);
                 }
                 if (publicKey == null) { // cache miss, read the jwk if we can,  &  update locationUsed
-                    InputStream is = getInputStream(jwkFile, fileSystemCacheSelector, location, classLoadingCacheSelector);
-                    if (is != null) {
-                        keyString = getKeyAsString(is);
-                        parseJwk(keyString, null, jwkSet, sigAlg); // also adds entry to cache.
-                        publicKey = getJwkFromJWKSet(locationUsed, kid, x5t, use, keyString);
+                    InputStream is = null;
+                    try {
+                        is = getInputStream(jwkFile, fileSystemCacheSelector, location, classLoadingCacheSelector);
+                        if (is != null) {
+                            keyString = getKeyAsString(is);
+                            parseJwk(keyString, null, jwkSet, sigAlg); // also adds entry to cache.
+                            publicKey = getJwkFromJWKSet(locationUsed, kid, x5t, use, keyString);
+                        }
+                    } finally {
+                        if (is != null) {
+                            is.close();
+                        }
                     }
                 }
             }
 
-        } catch (Exception e2) {
+        } catch (Exception e) {
             if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Caught exception opening file from location [" + location + "]: " + e2);
+                Tr.debug(tc, "Caught exception opening file from location [" + location + "]: " + e);
             }
         }
         return publicKey;

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/tck_suite_aud_noenv.xml
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/tck_suite_aud_noenv.xml
@@ -26,13 +26,11 @@
         </groups>
 		<classes>
 			<!-- MP JWT 1.1 tests - these all pass with empty server.xml and server.env, need audiences set -->
-
 			<class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationTest" />
 			<class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationURLTest" />
 			<class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKTest" />			
 			<class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKSTest" />
 			<class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsBase64JWKTest" />			
- 
 			
 			<!-- Note: MP JWT 1.1 - This test is included in aud_noenv2 as it requires a different location URL setup -->
 			<!-- <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationURLTest" />  -->
@@ -52,25 +50,21 @@
             <class name="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsPEMLocationTest" />
             <class name="org.eclipse.microprofile.jwt.tck.config.ECPublicKeyAsPEMTest" />
 
-            <!-- MP JWT 1.2 tests - TokenAsCookieTest - Blocked Issue 13959; EmptyTokenTest - Blocked 14011
             <class name="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieIgnoredTest" />
             <class name="org.eclipse.microprofile.jwt.tck.config.TokenAsCookieTest" />
-            --> 
 
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.RsaKeySignatureTest" />
-            <!-- 
+            <!-- EmptyTokenTest - Blocked 14011
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" />
             -->
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" />
        
-              
             <!-- MP JWT 1.2 - need to enable when JWE support is delivered 
             <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKClasspathTest" />
             <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKSClasspathTest" />
             <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsPEMClasspathTest" />
             -->
-              
-	
+
 
 		</classes>
     </test>


### PR DESCRIPTION
Resolves #13959

Per @Azquelt's investigation, it appears that the `JwKRetriever.getPublicKeyFromFile()` was holding onto the input stream when reading the MP Config properties from the application WAR file. This means the first WAR file reference remains in the zip cache, and when the second test application is installed the ZipCacheService will still return the old file when asked for the archive. Ensuring that the input stream is closed when we're done reading it resolves the issue we're seeing in the TCK.