### PR TITLE
Issue #14421: Avoid EJB Persistent Timers after quiesce

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/PersistentTimerTestHelper.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/PersistentTimerTestHelper.java
@@ -51,6 +51,14 @@ public class PersistentTimerTestHelper {
         ignoreList.add("DSRA0304E");
         ignoreList.add("DSRA0302E.*XA_RBROLLBACK");
 
+        // J2CA0027E: An exception occurred while invoking end on an XA Resource Adapter from DataSource
+        //            dataSource[DefaultDataSource], within transaction ID {XidImpl: formatId(57415344),
+        //            gtrid_length(36), bqual_length(54),
+        //
+        // persistent.internal.InvokerTask run starts for a persistent timer during server shutdown,
+        // but transaction service has already been shutdown.
+        ignoreList.add("J2CA0027E");
+
         String[] stringArr = new String[ignoreList.size()];
         return ignoreList.toArray(stringArr);
     }


### PR DESCRIPTION
The EJB Timer Service should not attempt to start an EJB persistent timer
running once server quiesce has started (i.e. server shutting down).

Update PersistentTimerTaskHandler to match corresponding code already
in place for non-persistent timers and similar to async methods.

Also, update the test to ignore an error from J2C that occurs if the
PersistentExecutor attempts to run a timer after the transaction
service has already been stopped. Should be less likely, but
could still occur.

fixes #14421 