### PR TITLE
EL30 lookup improvement

### DIFF
--- a/dev/com.ibm.websphere.javaee.el.3.0/src/javax/el/ImportHandler.java
+++ b/dev/com.ibm.websphere.javaee.el.3.0/src/javax/el/ImportHandler.java
@@ -15,16 +15,20 @@
  * limitations under the License.
  */
 // wtlucy: Apache bug 57142 patch pulled in - file rev 1644523
+// epj: Apache bug 62453 for EL 3.0 perf improvement
 
-package javax.el; 
+package javax.el;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -32,34 +36,271 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class ImportHandler {
 
-    private List<String> packageNames = new ArrayList<>();
-    private Map<String,String> classNames = new ConcurrentHashMap<>();
-    private Map<String,Class<?>> clazzes = new ConcurrentHashMap<>();
-    private Map<String,Class<?>> statics = new ConcurrentHashMap<>();
+    private static final boolean IS_SECURITY_ENABLED = (System.getSecurityManager() != null);
 
+    private static final Map<String, Set<String>> standardPackages = new HashMap<>();
+
+    static {
+        // Servlet 4.0
+        Set<String> servletClassNames = new HashSet<>();
+        // Interfaces
+        servletClassNames.add("AsyncContext");
+        servletClassNames.add("AsyncListener");
+        servletClassNames.add("Filter");
+        servletClassNames.add("FilterChain");
+        servletClassNames.add("FilterConfig");
+        servletClassNames.add("FilterRegistration");
+        servletClassNames.add("FilterRegistration.Dynamic");
+        servletClassNames.add("ReadListener");
+        servletClassNames.add("Registration");
+        servletClassNames.add("Registration.Dynamic");
+        servletClassNames.add("RequestDispatcher");
+        servletClassNames.add("Servlet");
+        servletClassNames.add("ServletConfig");
+        servletClassNames.add("ServletContainerInitializer");
+        servletClassNames.add("ServletContext");
+        servletClassNames.add("ServletContextAttributeListener");
+        servletClassNames.add("ServletContextListener");
+        servletClassNames.add("ServletRegistration");
+        servletClassNames.add("ServletRegistration.Dynamic");
+        servletClassNames.add("ServletRequest");
+        servletClassNames.add("ServletRequestAttributeListener");
+        servletClassNames.add("ServletRequestListener");
+        servletClassNames.add("ServletResponse");
+        servletClassNames.add("SessionCookieConfig");
+        servletClassNames.add("SingleThreadModel");
+        servletClassNames.add("WriteListener");
+        // Classes
+        servletClassNames.add("AsyncEvent");
+        servletClassNames.add("GenericFilter");
+        servletClassNames.add("GenericServlet");
+        servletClassNames.add("HttpConstraintElement");
+        servletClassNames.add("HttpMethodConstraintElement");
+        servletClassNames.add("MultipartConfigElement");
+        servletClassNames.add("ServletContextAttributeEvent");
+        servletClassNames.add("ServletContextEvent");
+        servletClassNames.add("ServletInputStream");
+        servletClassNames.add("ServletOutputStream");
+        servletClassNames.add("ServletRequestAttributeEvent");
+        servletClassNames.add("ServletRequestEvent");
+        servletClassNames.add("ServletRequestWrapper");
+        servletClassNames.add("ServletResponseWrapper");
+        servletClassNames.add("ServletSecurityElement");
+        // Enums
+        servletClassNames.add("DispatcherType");
+        servletClassNames.add("SessionTrackingMode");
+        // Exceptions
+        servletClassNames.add("ServletException");
+        servletClassNames.add("UnavailableException");
+        standardPackages.put("javax.servlet", servletClassNames);
+
+        // Servlet 4.0
+        Set<String> servletHttpClassNames = new HashSet<>();
+        // Interfaces
+        servletHttpClassNames.add("HttpServletMapping");
+        servletHttpClassNames.add("HttpServletRequest");
+        servletHttpClassNames.add("HttpServletResponse");
+        servletHttpClassNames.add("HttpSession");
+        servletHttpClassNames.add("HttpSessionActivationListener");
+        servletHttpClassNames.add("HttpSessionAttributeListener");
+        servletHttpClassNames.add("HttpSessionBindingListener");
+        servletHttpClassNames.add("HttpSessionContext");
+        servletHttpClassNames.add("HttpSessionIdListener");
+        servletHttpClassNames.add("HttpSessionListener");
+        servletHttpClassNames.add("HttpUpgradeHandler");
+        servletHttpClassNames.add("Part");
+        servletHttpClassNames.add("PushBuilder");
+        servletHttpClassNames.add("WebConnection");
+        // Classes
+        servletHttpClassNames.add("Cookie");
+        servletHttpClassNames.add("HttpFilter");
+        servletHttpClassNames.add("HttpServlet");
+        servletHttpClassNames.add("HttpServletRequestWrapper");
+        servletHttpClassNames.add("HttpServletResponseWrapper");
+        servletHttpClassNames.add("HttpSessionBindingEvent");
+        servletHttpClassNames.add("HttpSessionEvent");
+        servletHttpClassNames.add("HttpUtils");
+        // Enums
+        servletHttpClassNames.add("MappingMatch");
+        standardPackages.put("javax.servlet.http", servletHttpClassNames);
+
+        // JSP 2.3
+        Set<String> servletJspClassNames = new HashSet<>();
+        //Interfaces
+        servletJspClassNames.add("HttpJspPage");
+        servletJspClassNames.add("JspApplicationContext");
+        servletJspClassNames.add("JspPage");
+        // Classes
+        servletJspClassNames.add("ErrorData");
+        servletJspClassNames.add("JspContext");
+        servletJspClassNames.add("JspEngineInfo");
+        servletJspClassNames.add("JspFactory");
+        servletJspClassNames.add("JspWriter");
+        servletJspClassNames.add("PageContext");
+        servletJspClassNames.add("Exceptions");
+        servletJspClassNames.add("JspException");
+        servletJspClassNames.add("JspTagException");
+        servletJspClassNames.add("SkipPageException");
+        standardPackages.put("javax.servlet.jsp", servletJspClassNames);
+
+        Set<String> javaLangClassNames = new HashSet<>();
+        // Taken from Java 14 EA27 Javadoc
+        // Interfaces
+        javaLangClassNames.add("Appendable");
+        javaLangClassNames.add("AutoCloseable");
+        javaLangClassNames.add("CharSequence");
+        javaLangClassNames.add("Cloneable");
+        javaLangClassNames.add("Comparable");
+        javaLangClassNames.add("Iterable");
+        javaLangClassNames.add("ProcessHandle");
+        javaLangClassNames.add("ProcessHandle.Info");
+        javaLangClassNames.add("Readable");
+        javaLangClassNames.add("Runnable");
+        javaLangClassNames.add("StackWalker.StackFrame");
+        javaLangClassNames.add("System.Logger");
+        javaLangClassNames.add("Thread.UncaughtExceptionHandler");
+        //Classes
+        javaLangClassNames.add("Boolean");
+        javaLangClassNames.add("Byte");
+        javaLangClassNames.add("Character");
+        javaLangClassNames.add("Character.Subset");
+        javaLangClassNames.add("Character.UnicodeBlock");
+        javaLangClassNames.add("Class");
+        javaLangClassNames.add("ClassLoader");
+        javaLangClassNames.add("ClassValue");
+        javaLangClassNames.add("Compiler");
+        javaLangClassNames.add("Double");
+        javaLangClassNames.add("Enum");
+        javaLangClassNames.add("Enum.EnumDesc");
+        javaLangClassNames.add("Float");
+        javaLangClassNames.add("InheritableThreadLocal");
+        javaLangClassNames.add("Integer");
+        javaLangClassNames.add("Long");
+        javaLangClassNames.add("Math");
+        javaLangClassNames.add("Module");
+        javaLangClassNames.add("ModuleLayer");
+        javaLangClassNames.add("ModuleLayer.Controller");
+        javaLangClassNames.add("Number");
+        javaLangClassNames.add("Object");
+        javaLangClassNames.add("Package");
+        javaLangClassNames.add("Process");
+        javaLangClassNames.add("ProcessBuilder");
+        javaLangClassNames.add("ProcessBuilder.Redirect");
+        javaLangClassNames.add("Record");
+        javaLangClassNames.add("Runtime");
+        javaLangClassNames.add("Runtime.Version");
+        javaLangClassNames.add("RuntimePermission");
+        javaLangClassNames.add("SecurityManager");
+        javaLangClassNames.add("Short");
+        javaLangClassNames.add("StackTraceElement");
+        javaLangClassNames.add("StackWalker");
+        javaLangClassNames.add("StrictMath");
+        javaLangClassNames.add("String");
+        javaLangClassNames.add("StringBuffer");
+        javaLangClassNames.add("StringBuilder");
+        javaLangClassNames.add("System");
+        javaLangClassNames.add("System.LoggerFinder");
+        javaLangClassNames.add("Thread");
+        javaLangClassNames.add("ThreadGroup");
+        javaLangClassNames.add("ThreadLocal");
+        javaLangClassNames.add("Throwable");
+        javaLangClassNames.add("Void");
+        //Enums
+        javaLangClassNames.add("Character.UnicodeScript");
+        javaLangClassNames.add("ProcessBuilder.Redirect.Type");
+        javaLangClassNames.add("StackWalker.Option");
+        javaLangClassNames.add("System.Logger.Level");
+        javaLangClassNames.add("Thread.State");
+        //Exceptions
+        javaLangClassNames.add("ArithmeticException");
+        javaLangClassNames.add("ArrayIndexOutOfBoundsException");
+        javaLangClassNames.add("ArrayStoreException");
+        javaLangClassNames.add("ClassCastException");
+        javaLangClassNames.add("ClassNotFoundException");
+        javaLangClassNames.add("CloneNotSupportedException");
+        javaLangClassNames.add("EnumConstantNotPresentException");
+        javaLangClassNames.add("Exception");
+        javaLangClassNames.add("IllegalAccessException");
+        javaLangClassNames.add("IllegalArgumentException");
+        javaLangClassNames.add("IllegalCallerException");
+        javaLangClassNames.add("IllegalMonitorStateException");
+        javaLangClassNames.add("IllegalStateException");
+        javaLangClassNames.add("IllegalThreadStateException");
+        javaLangClassNames.add("IndexOutOfBoundsException");
+        javaLangClassNames.add("InstantiationException");
+        javaLangClassNames.add("InterruptedException");
+        javaLangClassNames.add("LayerInstantiationException");
+        javaLangClassNames.add("NegativeArraySizeException");
+        javaLangClassNames.add("NoSuchFieldException");
+        javaLangClassNames.add("NoSuchMethodException");
+        javaLangClassNames.add("NullPointerException");
+        javaLangClassNames.add("NumberFormatException");
+        javaLangClassNames.add("ReflectiveOperationException");
+        javaLangClassNames.add("RuntimeException");
+        javaLangClassNames.add("SecurityException");
+        javaLangClassNames.add("StringIndexOutOfBoundsException");
+        javaLangClassNames.add("TypeNotPresentException");
+        javaLangClassNames.add("UnsupportedOperationException");
+        //Errors
+        javaLangClassNames.add("AbstractMethodError");
+        javaLangClassNames.add("AssertionError");
+        javaLangClassNames.add("BootstrapMethodError");
+        javaLangClassNames.add("ClassCircularityError");
+        javaLangClassNames.add("ClassFormatError");
+        javaLangClassNames.add("Error");
+        javaLangClassNames.add("ExceptionInInitializerError");
+        javaLangClassNames.add("IllegalAccessError");
+        javaLangClassNames.add("IncompatibleClassChangeError");
+        javaLangClassNames.add("InstantiationError");
+        javaLangClassNames.add("InternalError");
+        javaLangClassNames.add("LinkageError");
+        javaLangClassNames.add("NoClassDefFoundError");
+        javaLangClassNames.add("NoSuchFieldError");
+        javaLangClassNames.add("NoSuchMethodError");
+        javaLangClassNames.add("OutOfMemoryError");
+        javaLangClassNames.add("StackOverflowError");
+        javaLangClassNames.add("ThreadDeath");
+        javaLangClassNames.add("UnknownError");
+        javaLangClassNames.add("UnsatisfiedLinkError");
+        javaLangClassNames.add("UnsupportedClassVersionError");
+        javaLangClassNames.add("VerifyError");
+        javaLangClassNames.add("VirtualMachineError");
+        //Annotation Types
+        javaLangClassNames.add("Deprecated");
+        javaLangClassNames.add("FunctionalInterface");
+        javaLangClassNames.add("Override");
+        javaLangClassNames.add("SafeVarargs");
+        javaLangClassNames.add("SuppressWarnings");
+        standardPackages.put("java.lang", javaLangClassNames);
+
+    }
+
+    private final Map<String, Set<String>> packageNames = new ConcurrentHashMap<>();
+    private final Map<String, String> classNames = new ConcurrentHashMap<>();
+    private final Map<String, Class<?>> clazzes = new ConcurrentHashMap<>();
+    private final Map<String, Class<?>> statics = new ConcurrentHashMap<>();
 
     public ImportHandler() {
         importPackage("java.lang");
     }
-
 
     public void importStatic(String name) throws javax.el.ELException {
         int lastPeriod = name.lastIndexOf('.');
 
         if (lastPeriod < 0) {
             throw new ELException(Util.message(
-                    null, "importHandler.invalidStaticName", name));
+                                               null, "importHandler.invalidStaticName", name));
         }
 
         String className = name.substring(0, lastPeriod);
         String fieldOrMethodName = name.substring(lastPeriod + 1);
 
-        Class<?> clazz = findClass(className);
+        Class<?> clazz = findClass(className, true);
 
         if (clazz == null) {
             throw new ELException(Util.message(
-                    null, "importHandler.invalidClassNameForStatic",
-                    className, name));
+                                               null, "importHandler.invalidClassNameForStatic",
+                                               className, name));
         }
 
         boolean found = false;
@@ -68,7 +309,7 @@ public class ImportHandler {
             if (field.getName().equals(fieldOrMethodName)) {
                 int modifiers = field.getModifiers();
                 if (Modifier.isStatic(modifiers) &&
-                        Modifier.isPublic(modifiers)) {
+                    Modifier.isPublic(modifiers)) {
                     found = true;
                     break;
                 }
@@ -80,7 +321,7 @@ public class ImportHandler {
                 if (method.getName().equals(fieldOrMethodName)) {
                     int modifiers = method.getModifiers();
                     if (Modifier.isStatic(modifiers) &&
-                            Modifier.isPublic(modifiers)) {
+                        Modifier.isPublic(modifiers)) {
                         found = true;
                         break;
                     }
@@ -90,57 +331,52 @@ public class ImportHandler {
 
         if (!found) {
             throw new ELException(Util.message(null,
-                    "importHandler.staticNotFound", fieldOrMethodName,
-                    className, name));
+                                               "importHandler.staticNotFound", fieldOrMethodName,
+                                               className, name));
         }
 
         Class<?> conflict = statics.get(fieldOrMethodName);
         if (conflict != null) {
             throw new ELException(Util.message(null,
-                    "importHandler.ambiguousStaticImport", name,
-                    conflict.getName() + '.' +  fieldOrMethodName));
+                                               "importHandler.ambiguousStaticImport", name,
+                                               conflict.getName() + '.' + fieldOrMethodName));
         }
 
         statics.put(fieldOrMethodName, clazz);
     }
-
 
     public void importClass(String name) throws javax.el.ELException {
         int lastPeriodIndex = name.lastIndexOf('.');
 
         if (lastPeriodIndex < 0) {
             throw new ELException(Util.message(
-                    null, "importHandler.invalidClassName", name));
+                                               null, "importHandler.invalidClassName", name));
         }
 
         String unqualifiedName = name.substring(lastPeriodIndex + 1);
-        String currentName = ((ConcurrentHashMap<String, String>) classNames).putIfAbsent(unqualifiedName, name);
+        String currentName = classNames.putIfAbsent(unqualifiedName, name);
 
         if (currentName != null && !currentName.equals(name)) {
             // Conflict. Same unqualifiedName, different fully qualified names
             throw new ELException(Util.message(null,
-                    "importHandler.ambiguousImport", name, currentName));
+                                               "importHandler.ambiguousImport", name, currentName));
         }
     }
-
 
     public void importPackage(String name) {
         // Import ambiguity is handled at resolution, not at import
-        Package p = Package.getPackage(name);
-        if (p == null) {
-            // Either the package does not exist or no class has been loaded
-            // from that package. Check if the package exists.
-            ClassLoader cl = Thread.currentThread().getContextClassLoader();
-            String path = name.replace('.', '/');
-            URL url = cl.getResource(path);
-            if (url == null) {
-                throw new ELException(Util.message(
-                        null, "importHandler.invalidPackage", name));
-            }
+        // Whether the package exists is not checked,
+        // a) for sake of performance when used in JSPs (BZ 57142),
+        // b) java.lang.Package.getPackage(name) is not reliable (BZ 57574),
+        // c) such check is not required by specification.
+        Set<String> preloaded = standardPackages.get(name);
+        if (preloaded == null) {
+            Set<String> s = Collections.emptySet();
+            packageNames.put(name, s);
+        } else {
+            packageNames.put(name, preloaded);
         }
-        packageNames.add(name);
     }
-
 
     public java.lang.Class<?> resolveClass(String name) {
         if (name == null || name.contains(".")) {
@@ -151,63 +387,137 @@ public class ImportHandler {
         Class<?> result = clazzes.get(name);
 
         if (result != null) {
-            return result;
+            if (NotFound.class.equals(result)) {
+                return null;
+            } else {
+                return result;
+            }
         }
 
         // Search the class imports
         String className = classNames.get(name);
         if (className != null) {
-            Class<?> clazz = findClass(className);
+            Class<?> clazz = findClass(className, true);
             if (clazz != null) {
-                clazzes.put(className, clazz);
+                clazzes.put(name, clazz);
                 return clazz;
             }
         }
 
         // Search the package imports - note there may be multiple matches
         // (which correctly triggers an error)
-        for (String p : packageNames) {
-            className = p + '.' + name;
-            Class<?> clazz = findClass(className);
+        for (Map.Entry<String, Set<String>> entry : packageNames.entrySet()) {
+            if (!entry.getValue().isEmpty()) {
+                // Standard package where we know all the class names
+                if (!entry.getValue().contains(name)) {
+                    // Requested name isn't in the list so it isn't in this
+                    // package so move on to next package. This allows the
+                    // class loader look-up to be skipped.
+                    continue;
+                }
+            }
+            className = entry.getKey() + '.' + name;
+            Class<?> clazz = findClass(className, false);
             if (clazz != null) {
                 if (result != null) {
                     throw new ELException(Util.message(null,
-                            "importHandler.ambiguousImport", className,
-                            result.getName()));
+                                                       "importHandler.ambiguousImport", className,
+                                                       result.getName()));
                 }
                 result = clazz;
             }
         }
-        if (result != null) {
+        if (result == null) {
+            // Cache NotFound results to save repeated calls to findClass()
+            // which is relatively slow
+            clazzes.put(name, NotFound.class);
+        } else {
             clazzes.put(name, result);
         }
 
         return result;
     }
 
-
     public java.lang.Class<?> resolveStatic(String name) {
         return statics.get(name);
     }
 
-
-    private Class<?> findClass(String name) {
+    private Class<?> findClass(String name, boolean throwException) {
         Class<?> clazz;
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        ClassLoader cl = Util.getContextClassLoader();
+        String path = name.replace('.', '/') + ".class";
         try {
-             clazz = cl.loadClass(name);
+            /*
+             * Given that findClass() has to be called for every imported
+             * package and that getResource() is a lot faster then loadClass()
+             * for resources that don't exist, the overhead of the getResource()
+             * for the case where the class does exist is a lot less than the
+             * overhead we save by not calling loadClass().
+             */
+            if (IS_SECURITY_ENABLED) {
+                // Webapps don't have read permission for JAVA_HOME (and
+                // possibly other sources of classes). Only need to know if the
+                // class exists at this point. Class loading occurs with
+                // standard SecurityManager policy next.
+                if (!AccessController.doPrivileged(new PrivilegedResourceExists(cl, path)).booleanValue()) {
+                    return null;
+                }
+            } else {
+                if (cl.getResource(path) == null) {
+                    return null;
+                }
+            }
+        } catch (ClassCircularityError cce) {
+            // May happen under a security manager. Ignore it and try loading
+            // the class normally.
+        }
+        try {
+            clazz = cl.loadClass(name);
         } catch (ClassNotFoundException e) {
             return null;
         }
 
-        // Class must be public, non-abstract and not an interface
+        // Class must be public, non-abstract, not an interface and (for
+        // Java 9+) in an exported package
+        JreCompat jreCompat = JreCompat.getInstance();
         int modifiers = clazz.getModifiers();
         if (!Modifier.isPublic(modifiers) || Modifier.isAbstract(modifiers) ||
-                Modifier.isInterface(modifiers)) {
-            throw new ELException(Util.message(
-                    null, "importHandler.invalidClass", name));
+            Modifier.isInterface(modifiers) || !jreCompat.isExported(clazz)) {
+            if (throwException) {
+                throw new ELException(Util.message(
+                                                   null, "importHandler.invalidClass", name));
+            } else {
+                return null;
+            }
         }
 
         return clazz;
+    }
+
+    /*
+     * Marker class used because null values are not permitted in a
+     * ConcurrentHashMap.
+     */
+    private static class NotFound {
+    }
+
+    private static class PrivilegedResourceExists implements PrivilegedAction<Boolean> {
+
+        private final ClassLoader cl;
+        private final String name;
+
+        public PrivilegedResourceExists(ClassLoader cl, String name) {
+            this.cl = cl;
+            this.name = name;
+        }
+
+        @Override
+        public Boolean run() {
+            if (cl.getResource(name) == null) {
+                return Boolean.FALSE;
+            } else {
+                return Boolean.TRUE;
+            }
+        }
     }
 }

--- a/dev/com.ibm.websphere.javaee.el.3.0/src/javax/el/Jre9Compat.java
+++ b/dev/com.ibm.websphere.javaee.el.3.0/src/javax/el/Jre9Compat.java
@@ -1,0 +1,83 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package javax.el;
+
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Method;
+
+/*
+ * This is a cut down version of org.apache.tomcat.util.Jre9Compat that provides
+ * only the methods required by the EL implementation.
+ *
+ * This class is duplicated in org.apache.el.util
+ * When making changes keep the two in sync.
+ */
+class Jre9Compat extends JreCompat {
+
+    private static final Method canAccessMethod;
+    private static final Method getModuleMethod;
+    private static final Method isExportedMethod;
+
+    static {
+        Method m1 = null;
+        Method m2 = null;
+        Method m3 = null;
+
+        try {
+            m1 = AccessibleObject.class.getMethod("canAccess", Object.class);
+            m2 = Class.class.getMethod("getModule");
+            Class<?> moduleClass = Class.forName("java.lang.Module");
+            m3 = moduleClass.getMethod("isExported", String.class);
+        } catch (NoSuchMethodException e) {
+            // Expected for Java 8
+        } catch (ClassNotFoundException e) {
+            // Can't log this so...
+            throw new RuntimeException(e);
+        }
+
+        canAccessMethod = m1;
+        getModuleMethod = m2;
+        isExportedMethod = m3;
+    }
+
+
+    public static boolean isSupported() {
+        return canAccessMethod != null;
+    }
+
+
+    @Override
+    public boolean canAccess(Object base, AccessibleObject accessibleObject) {
+        try {
+            return ((Boolean) canAccessMethod.invoke(accessibleObject, base)).booleanValue();
+        } catch (ReflectiveOperationException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+
+    @Override
+    public boolean isExported(Class<?> type) {
+        try {
+            String packageName = type.getPackage().getName();
+            Object module = getModuleMethod.invoke(type);
+            return ((Boolean) isExportedMethod.invoke(module, packageName)).booleanValue();
+        } catch (ReflectiveOperationException e) {
+            return false;
+        }
+    }
+}

--- a/dev/com.ibm.websphere.javaee.el.3.0/src/javax/el/JreCompat.java
+++ b/dev/com.ibm.websphere.javaee.el.3.0/src/javax/el/JreCompat.java
@@ -1,0 +1,73 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package javax.el;
+
+import java.lang.reflect.AccessibleObject;
+
+/*
+ * This is cut down version of org.apache.tomcat.util.JreCompat that provides
+ * only the methods required by the EL implementation.
+ *
+ * This class is duplicated in org.apache.el.util
+ * When making changes keep the two in sync.
+ */
+class JreCompat {
+
+    private static final JreCompat instance;
+
+    static {
+        if (Jre9Compat.isSupported()) {
+            instance = new Jre9Compat();
+        } else {
+            instance = new JreCompat();
+        }
+    }
+
+
+    public static JreCompat getInstance() {
+        return instance;
+    }
+
+
+    /**
+     * Is the accessibleObject accessible (as a result of appropriate module
+     * exports) on the provided instance?
+     *
+     * @param base  The specific instance to be tested.
+     * @param accessibleObject  The method/field/constructor to be tested.
+     *
+     * @return {code true} if the AccessibleObject can be accessed otherwise
+     *         {code false}
+     */
+    public boolean canAccess(Object base, AccessibleObject accessibleObject) {
+        // Java 8 doesn't support modules so default to true
+        return true;
+    }
+
+
+    /**
+     * Is the given class in an exported package?
+     *
+     * @param type  The class to test
+     *
+     * @return Always {@code true} for Java 8. {@code true} if the enclosing
+     *         package is exported for Java 9+
+     */
+    public boolean isExported(Class<?> type) {
+        return true;
+    }
+}

--- a/dev/com.ibm.websphere.javaee.el.3.0/src/javax/el/StaticFieldELResolver.java
+++ b/dev/com.ibm.websphere.javaee.el.3.0/src/javax/el/StaticFieldELResolver.java
@@ -23,6 +23,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Iterator;
+import java.util.Objects;
 
 /**
  * @since EL 3.0
@@ -31,10 +32,7 @@ public class StaticFieldELResolver extends ELResolver {
 
     @Override
     public Object getValue(ELContext context, Object base, Object property) {
-
-        if (context == null) {
-            throw new NullPointerException();
-        }
+        Objects.requireNonNull(context);
 
         if (base instanceof ELClass && property instanceof String) {
             context.setPropertyResolved(base, property);
@@ -45,8 +43,10 @@ public class StaticFieldELResolver extends ELResolver {
             try {
                 Field field = clazz.getField(name);
                 int modifiers = field.getModifiers();
+                JreCompat jreCompat = JreCompat.getInstance();
                 if (Modifier.isStatic(modifiers) &&
-                        Modifier.isPublic(modifiers)) {
+                        Modifier.isPublic(modifiers) &&
+                        jreCompat.canAccess(null, field)) {
                     return field.get(null);
                 }
             } catch (IllegalArgumentException | IllegalAccessException
@@ -68,10 +68,7 @@ public class StaticFieldELResolver extends ELResolver {
     @Override
     public void setValue(ELContext context, Object base, Object property,
             Object value) {
-
-        if (context == null) {
-            throw new NullPointerException();
-        }
+        Objects.requireNonNull(context);
 
         if (base instanceof ELClass && property instanceof String) {
             Class<?> clazz = ((ELClass) base).getKlass();
@@ -87,10 +84,7 @@ public class StaticFieldELResolver extends ELResolver {
     @Override
     public Object invoke(ELContext context, Object base, Object method,
             Class<?>[] paramTypes, Object[] params) {
-
-        if (context == null) {
-            throw new NullPointerException();
-        }
+        Objects.requireNonNull(context);
 
         if (base instanceof ELClass && method instanceof String) {
             context.setPropertyResolved(base, method);
@@ -116,15 +110,19 @@ public class StaticFieldELResolver extends ELResolver {
                     Throwable cause = e.getCause();
                     Util.handleThrowable(cause);
                     throw new ELException(cause);
+                } catch (ReflectiveOperationException e) {
+                    throw new ELException(e);
                 }
                 return result;
 
             } else {
-                Method match =
-                        Util.findMethod(clazz, methodName, paramTypes, params);
+                // Static method so base should be null
+                Method match = Util.findMethod(clazz, null, methodName, paramTypes, params);
 
-                int modifiers = match.getModifiers();
-                if (!Modifier.isStatic(modifiers)) {
+                // Note: On Java 9 and above, the isStatic check becomes
+                // unnecessary because the canAccess() call in Util.findMethod()
+                // effectively performs the same check
+                if (match == null || !Modifier.isStatic(match.getModifiers())) {
                     throw new MethodNotFoundException(Util.message(context,
                             "staticFieldELResolver.methodNotFound", methodName,
                             clazz.getName()));
@@ -151,9 +149,7 @@ public class StaticFieldELResolver extends ELResolver {
 
     @Override
     public Class<?> getType(ELContext context, Object base, Object property) {
-        if (context == null) {
-            throw new NullPointerException();
-        }
+        Objects.requireNonNull(context);
 
         if (base instanceof ELClass && property instanceof String) {
             context.setPropertyResolved(base, property);
@@ -164,8 +160,10 @@ public class StaticFieldELResolver extends ELResolver {
             try {
                 Field field = clazz.getField(name);
                 int modifiers = field.getModifiers();
+                JreCompat jreCompat = JreCompat.getInstance();
                 if (Modifier.isStatic(modifiers) &&
-                        Modifier.isPublic(modifiers)) {
+                        Modifier.isPublic(modifiers) &&
+                        jreCompat.canAccess(null, field)) {
                     return field.getType();
                 }
             } catch (IllegalArgumentException | NoSuchFieldException |
@@ -186,9 +184,7 @@ public class StaticFieldELResolver extends ELResolver {
 
     @Override
     public boolean isReadOnly(ELContext context, Object base, Object property) {
-        if (context == null) {
-            throw new NullPointerException();
-        }
+        Objects.requireNonNull(context);
 
         if (base instanceof ELClass && property instanceof String) {
             context.setPropertyResolved(base, property);

--- a/dev/com.ibm.ws.org.apache.jasper.el/src/org/apache/el/util/Jre9Compat.java
+++ b/dev/com.ibm.ws.org.apache.jasper.el/src/org/apache/el/util/Jre9Compat.java
@@ -1,0 +1,58 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.el.util;
+
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Method;
+
+/*
+ * This is a cut down version of org.apache.tomcat.util.Jre9Compat that provides
+ * only the methods required by the EL implementation.
+ *
+* This class is duplicated in jakarta.el
+ * When making changes keep the two in sync.
+ */
+class Jre9Compat extends JreCompat {
+
+    private static final Method canAccessMethod;
+
+
+    static {
+        Method m1 = null;
+        try {
+            m1 = AccessibleObject.class.getMethod("canAccess", new Class<?>[] { Object.class });
+        } catch (NoSuchMethodException e) {
+            // Expected for Java 8
+        }
+        canAccessMethod = m1;
+    }
+
+
+    public static boolean isSupported() {
+        return canAccessMethod != null;
+    }
+
+
+    @Override
+    public boolean canAccess(Object base, AccessibleObject accessibleObject) {
+        try {
+            return ((Boolean) canAccessMethod.invoke(accessibleObject, base)).booleanValue();
+        } catch (ReflectiveOperationException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/dev/com.ibm.ws.org.apache.jasper.el/src/org/apache/el/util/JreCompat.java
+++ b/dev/com.ibm.ws.org.apache.jasper.el/src/org/apache/el/util/JreCompat.java
@@ -1,0 +1,62 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.el.util;
+
+import java.lang.reflect.AccessibleObject;
+
+/*
+ * This is cut down version of org.apache.tomcat.util.JreCompat that provides
+ * only the methods required by the EL implementation.
+ *
+ * This class is duplicated in org.apache.el.util
+ * When making changes keep the two in sync.
+ */
+class JreCompat {
+
+    private static final JreCompat instance;
+
+    static {
+        if (Jre9Compat.isSupported()) {
+            instance = new Jre9Compat();
+        } else {
+            instance = new JreCompat();
+        }
+    }
+
+
+    public static JreCompat getInstance() {
+        return instance;
+    }
+
+
+    /**
+     * Is the accessibleObject accessible (as a result of appropriate module
+     * exports) on the provided instance?
+     *
+     * @param base  The specific instance to be tested.
+     * @param accessibleObject  The method/field/constructor to be tested.
+     *
+     * @return {code true} if the AccessibleObject can be accessed otherwise
+     *         {code false}
+     */
+    public boolean canAccess(Object base, AccessibleObject accessibleObject) {
+        // Java 8 doesn't support modules so default to true
+        return true;
+    }
+
+
+}

--- a/dev/com.ibm.ws.org.apache.jasper.el/src/org/apache/el/util/ReflectionUtil.java
+++ b/dev/com.ibm.ws.org.apache.jasper.el/src/org/apache/el/util/ReflectionUtil.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.el.ELException;
-import javax.el.MethodNotFoundException;
+import javax.el.MethodNotFoundException; 
 
 import org.apache.el.lang.ELSupport;
 import org.apache.el.lang.EvaluationContext;
@@ -238,7 +238,7 @@ public class ReflectionUtil {
             // If a method is found where every parameter matches exactly,
             // return it
             if (exactMatch == paramCount) {
-                return getMethod(base.getClass(), m);
+                return getMethod(base.getClass(), base, m);
             }
 
             candidates.put(m, new MatchResult(
@@ -285,7 +285,7 @@ public class ReflectionUtil {
                         paramString(paramTypes)));
         }
 
-        return getMethod(base.getClass(), match);
+        return getMethod(base.getClass(), base, match);
     }
 
     /*
@@ -414,8 +414,9 @@ public class ReflectionUtil {
      * This class duplicates code in javax.el.Util. When making changes keep
      * the code in sync.
      */
-    private static Method getMethod(Class<?> type, Method m) {
-        if (m == null || Modifier.isPublic(type.getModifiers())) {
+    private static Method getMethod(Class<?> type, Object base, Method m) {
+        JreCompat jreCompat = JreCompat.getInstance();
+        if (m == null || (Modifier.isPublic(type.getModifiers()) && jreCompat.canAccess(base, m))) {
             return m;
         }
         Class<?>[] inf = type.getInterfaces();
@@ -423,7 +424,7 @@ public class ReflectionUtil {
         for (int i = 0; i < inf.length; i++) {
             try {
                 mp = inf[i].getMethod(m.getName(), m.getParameterTypes());
-                mp = getMethod(mp.getDeclaringClass(), mp);
+                mp = getMethod(mp.getDeclaringClass(), base, mp);
                 if (mp != null) {
                     return mp;
                 }
@@ -435,7 +436,7 @@ public class ReflectionUtil {
         if (sup != null) {
             try {
                 mp = sup.getMethod(m.getName(), m.getParameterTypes());
-                mp = getMethod(mp.getDeclaringClass(), mp);
+                mp = getMethod(mp.getDeclaringClass(), base, mp);
                 if (mp != null) {
                     return mp;
                 }


### PR DESCRIPTION
fixes #14175 
By optimizing EL 3.0 context handling and classloader calls, the evaluations of EL unscoped and static expressions perform
better with this fix.  This is a port of Apache bug fix 62453.  Also includes 63781 to support newer java levels.