### PR TITLE
Enable more MP JWT TCK tests

### DIFF
--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/tck_suite_aud_env.xml
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/tck_suite_aud_env.xml
@@ -36,10 +36,10 @@
 	          <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest" />
               <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest" />
 
- 			  <!-- MP JWT 1.2 JAXRS - needs investigation as fails when run with other tests   
+ 			  <!-- MP JWT 1.2 JAXRS tests   --> 
               <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrincipalInjectionTest" /> 
               <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" />
-              -->
+             
               
               <!--  MP JWT 1.2 JAXRS JWE tests  - Need to enable when JWE support is delivered
               <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedEncryptTest" />


### PR DESCRIPTION
This PR is used to enable more MP JWT 1.2 TCK tests since the fix to Issue 14413 addresses the problems there as well.
