### PR TITLE
Correct ddmodel fat

### DIFF
--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTest.jar/resources/META-INF/MANIFEST.MF
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTest.jar/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,11 @@
+Manifest-Version: 1.0
+Specification-Vendor: IBM Corp.
+Ant-Version: Apache Ant 1.6.5
+Implementation-Vendor: IBM Corp.
+Class-Path: 
+Created-By: 2.4 (IBM Corporation)
+Implementation-Version: 1.0
+Implementation-Title: EJBTest.jar
+Specification-Version: 1.0
+Specification-Title: EJBTest.jar
+

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTest.jar/resources/META-INF/ejb-jar.xml
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTest.jar/resources/META-INF/ejb-jar.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ejb-jar id="ejb-jar_ID" version="2.1" xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/ejb-jar_2_1.xsd">
+
+    <display-name>EJBTest</display-name>
+
+    <enterprise-beans>
+        <session id="TestBean">
+            <ejb-name>TestBean</ejb-name>
+            <home>ejbtest.ejb.ITestHome</home>
+            <remote>ejbtest.ejb.ITestRemote</remote>
+            <local-home>ejbtest.ejb.TestBeanLocalHome</local-home>
+            <local>ejbtest.ejb.TestBeanLocal</local>
+            <ejb-class>ejbtest.ejb.TestBean</ejb-class>
+            <session-type>Stateful</session-type>
+            <transaction-type>Bean</transaction-type>
+        </session>
+    </enterprise-beans>
+
+</ejb-jar>

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTest.jar/resources/META-INF/ibm-ejb-jar-bnd.xmi
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTest.jar/resources/META-INF/ibm-ejb-jar-bnd.xmi
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ejbbnd:EJBJarBinding xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ejb="ejb.xmi" xmlns:ejbbnd="ejbbnd.xmi" xmi:id="EJBJarBinding_1200691865843">
+
+  <ejbJar href="META-INF/ejb-jar.xml#ejb-jar_ID"/>
+
+  <ejbBindings xmi:id="EnterpriseBeanBinding_1200691865843" jndiName="/ejb/TestEJB">
+    <enterpriseBean xmi:type="ejb:Session" href="META-INF/ejb-jar.xml#TestBean"/>
+  </ejbBindings>
+
+</ejbbnd:EJBJarBinding>

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTest.jar/resources/META-INF/ibm-ejb-jar-ext.xmi
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTest.jar/resources/META-INF/ibm-ejb-jar-ext.xmi
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ejbext:EJBJarExtension xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ejbext="ejbext.xmi" xmi:id="EJBJarExtension_1200691865859">
+
+  <ejbJar href="META-INF/ejb-jar.xml#ejb-jar_ID"/>
+
+</ejbext:EJBJarExtension>

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTest.jar/resources/META-INF/ibm-managed-bean-bnd.xml
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTest.jar/resources/META-INF/ibm-managed-bean-bnd.xml
@@ -1,0 +1,7 @@
+<managed-bean-bnd version="1.0" xmlns="http://websphere.ibm.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-managed-bean-bnd_1_0.xsd">
+
+    <managed-bean class="com.ibm.jcdi.libs.PojoTwo">
+        <resource-ref name="jdbc/myBinding" binding-name="jdbc/TestDataSource" />
+    </managed-bean>
+
+</managed-bean-bnd>

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTest.jar/resources/META-INF/ibm_ejbext.properties
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTest.jar/resources/META-INF/ibm_ejbext.properties
@@ -1,0 +1,2 @@
+#Fri Jan 18 17:46:09 EST 2008
+containsTimedObject=false

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTest.jar/src/ejbtest/ejb/ITestHome.java
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTest.jar/src/ejbtest/ejb/ITestHome.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2012,2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package ejbtest.ejb;
+
+import javax.ejb.CreateException;
+import javax.ejb.EJBHome;
+import java.rmi.RemoteException;
+
+/**
+ * Home interface for Enterprise Bean: TestBean
+ */
+public interface ITestHome extends EJBHome {
+    /**
+     * Creates a default instance of Session Bean: TestBean
+     */
+    ITestRemote create(String ID) throws CreateException, RemoteException;
+}

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTest.jar/src/ejbtest/ejb/ITestRemote.java
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTest.jar/src/ejbtest/ejb/ITestRemote.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2012,2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package ejbtest.ejb;
+
+import javax.ejb.EJBObject;
+import java.rmi.RemoteException;
+
+/**
+ * Remote interface for Enterprise Bean: TestBean
+ */
+public interface ITestRemote extends EJBObject {
+    int getTotal() throws RemoteException;
+    int getAlive() throws RemoteException;
+    int getActive() throws RemoteException;
+}

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTest.jar/src/ejbtest/ejb/TestBean.java
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTest.jar/src/ejbtest/ejb/TestBean.java
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * Copyright (c) 2012,2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package ejbtest.ejb;
+
+import javax.ejb.CreateException;
+import javax.ejb.SessionBean;
+import javax.ejb.SessionContext;
+
+/**
+ * Bean implementation class for Enterprise Bean: TestBean
+ */
+public class TestBean implements SessionBean {
+
+    static final long serialVersionUID = 3206093459760846163L;
+
+    //
+
+    private static int total = 0;
+    private static int alive = 0;
+    private static int active = 0;
+
+    public int getTotal() {
+        int useTotal = total;
+        System.out.println("getTotal " + useTotal);
+        return useTotal;
+    }
+
+    public int getAlive() {
+        int useAlive = alive;
+        System.out.println("getAlive " + useAlive);
+        return useAlive;
+    }
+
+    public int getActive() {
+        int useActive = active;
+        System.out.println("getActive " + useActive);
+        return useActive;
+    }
+
+    //
+
+    private SessionContext mySessionCtx;
+
+    public SessionContext getSessionContext() {
+        return mySessionCtx;
+    }
+
+    public void setSessionContext(SessionContext ctx) {
+        mySessionCtx = ctx;
+    }
+
+    //
+
+    private String ID = null;
+
+    public void ejbCreate(String ID) throws CreateException {
+        this.ID = ID;
+
+        int useTotal, useAlive, useActive;
+
+        synchronized( TestBean.class ) {
+            total++;
+            alive++;
+            active++;
+
+            useTotal = total;
+            useAlive = alive;
+            useActive = active;
+        }
+
+        System.out.println("ejbCreate " + useTotal + "/" + useAlive + "/" + useActive);
+    }
+
+    public void ejbActivate() {
+        int useTotal, useAlive, useActive;
+
+        synchronized( TestBean.class ) {
+            active++;
+
+            useTotal = total;
+            useAlive = alive;
+            useActive = active;
+        }
+
+        System.out.println("ejbActivate " + useTotal + "/" + useAlive + "/" + useActive);
+    }
+
+    public void ejbPassivate() {
+        int useTotal, useAlive, useActive;
+
+        synchronized( TestBean.class ) {
+            active--;
+
+            useTotal = total;
+            useAlive = alive;
+            useActive = active;
+        }
+
+        System.out.println("ejbPassivate " + useTotal + "/" + useAlive + "/" + useActive);
+    }
+
+    public void ejbRemove() {
+        int useTotal, useAlive, useActive;
+
+        synchronized( TestBean.class ) {
+            active--;
+            alive--;
+
+            useTotal = total;
+            useAlive = alive;
+            useActive = active;
+        }
+
+        System.out.println("ejbRemove " + useTotal + "/" + useAlive + "/" + useActive);
+    }
+}

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTest.jar/src/ejbtest/ejb/TestBeanLocal.java
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTest.jar/src/ejbtest/ejb/TestBeanLocal.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2012,2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package ejbtest.ejb;
+
+import javax.ejb.EJBLocalObject;
+
+/**
+ * Local interface for Enterprise Bean: TestBean
+ */
+public interface TestBeanLocal extends EJBLocalObject {
+    int getTotal();
+    int getAlive();
+    int getActive();
+}

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTest.jar/src/ejbtest/ejb/TestBeanLocalHome.java
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTest.jar/src/ejbtest/ejb/TestBeanLocalHome.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2012,2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package ejbtest.ejb;
+
+import javax.ejb.EJBLocalHome;
+import javax.ejb.CreateException;
+
+/**
+ * Local Home interface for Enterprise Bean: TestBean
+ */
+public interface TestBeanLocalHome extends EJBLocalHome {
+    /**
+     * Creates a default instance of Session Bean: TestBean
+     */
+    TestBeanLocal create(String ID) throws CreateException;
+}

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTestNoBnd.jar/src/ejbtestnobnd/ejb/EJBBndAmbiguousBean1.java
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTestNoBnd.jar/src/ejbtestnobnd/ejb/EJBBndAmbiguousBean1.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2012,2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package ejbtestnobnd.ejb;
+
+import javax.ejb.Local;
+import javax.ejb.Stateless;
+
+/**
+ * Session Bean implementation class EJBBndAbiguousBean1
+ */
+@Stateless
+@Local(EJBBndAmbiguousLocal.class)
+public class EJBBndAmbiguousBean1 implements EJBBndAmbiguousLocal {
+    public EJBBndAmbiguousBean1() {
+        // EMPTY
+    }
+
+    @Override
+    public String getName() {
+        return "bean1";
+    }
+}

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTestNoBnd.jar/src/ejbtestnobnd/ejb/EJBBndAmbiguousBean2.java
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTestNoBnd.jar/src/ejbtestnobnd/ejb/EJBBndAmbiguousBean2.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2012,2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package ejbtestnobnd.ejb;
+
+import javax.ejb.Local;
+import javax.ejb.Stateless;
+
+/**
+ * Session Bean implementation class EJBBndAbiguousBean1
+ */
+@Stateless
+@Local(EJBBndAmbiguousLocal.class)
+public class EJBBndAmbiguousBean2 implements EJBBndAmbiguousLocal {
+    public EJBBndAmbiguousBean2() {
+        // EMPTY
+    }
+
+    @Override
+    public String getName() {
+        return "bean2";
+    }
+}

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTestNoBnd.jar/src/ejbtestnobnd/ejb/EJBBndAmbiguousLocal.java
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTestNoBnd.jar/src/ejbtestnobnd/ejb/EJBBndAmbiguousLocal.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2012,2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package ejbtestnobnd.ejb;
+
+public interface EJBBndAmbiguousLocal {
+    String getName();
+}

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTestNoBnd.jar/src/ejbtestnobnd/ejb/EJBBndLocal.java
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTestNoBnd.jar/src/ejbtestnobnd/ejb/EJBBndLocal.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2012,2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package ejbtestnobnd.ejb;
+
+public interface EJBBndLocal {
+    Class<?> getEJBClass();
+
+    void verifyEnvEntryBinding();
+    void verifyResourceBinding() throws Exception;
+    void verifyDataSourceBinding() throws Exception;
+    void verifyResourceIsolationBindingMerge() throws Exception;
+    void verifyEJBRef();
+    void verifyInterceptor();
+}

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTestNoBnd.jar/src/ejbtestnobnd/ejb/EJBBndStatefulBean.java
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/EJBTestNoBnd.jar/src/ejbtestnobnd/ejb/EJBBndStatefulBean.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2012,2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package ejbtestnobnd.ejb;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.annotation.Resource;
+import javax.annotation.sql.DataSourceDefinition;
+import javax.ejb.EJB;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateful;
+import javax.interceptor.Interceptors;
+import javax.sql.DataSource;
+
+import org.junit.Assert;
+
+@Stateful
+@DataSourceDefinition(name = "jdbc/dsdOverrideBinding", className = "invalid")
+public class EJBBndStatefulBean implements EJBBndLocal {
+    @Resource
+    SessionContext context;
+
+    @EJB(name = "ejb/stateless/ambiguous1")
+    EJBBndAmbiguousLocal ambiguousStateless1;
+  
+    // Checking interceptor's method
+    protected static boolean isPostConstructCalled;
+    protected static boolean isAroundInvokeCalled;
+    protected static boolean isPreDestroyCalled;
+
+    @Override
+    public Class<?> getEJBClass() {
+        return getClass();
+    }
+
+    @Resource(name = "boolAnnotationInjectionBinding")
+    private boolean boolAnnotationInjectionBinding;
+
+    @Override
+    public void verifyEnvEntryBinding() {
+        Assert.assertTrue("Interceptor should have set flag.", isAroundInvokeCalled);
+        Assert.assertTrue("EnvEntry not retrieved from bindings.", boolAnnotationInjectionBinding);
+    }
+
+    @Resource(name = "jdbc/ejbResRefDefaultIsoDS")
+    private DataSource _bindEJBDefaultDS;  
+    
+    @Resource(name = "jdbc/ejbResRefEjbIsoDS")
+    private DataSource _bindEjbEjbTransactionReadUncommitDS;  
+           
+    @Resource(name = "jdbc/dupBindingDS")
+    private DataSource _bindDupTranactionReadUncommitDS; 
+    
+    @Override
+    public void verifyResourceBinding() throws Exception {
+        Assert.assertTrue("Interceptor should have set flag.", isAroundInvokeCalled);
+        verifyDataSource(_bindEJBDefaultDS, Connection.TRANSACTION_REPEATABLE_READ);  
+    }
+    
+    @Override
+    public void verifyResourceIsolationBindingMerge() throws Exception {
+        Assert.assertTrue("Interceptor should have set flag.", isAroundInvokeCalled);
+        verifyDataSource(_bindEjbEjbTransactionReadUncommitDS, Connection.TRANSACTION_READ_UNCOMMITTED);
+        verifyDataSource(_bindDupTranactionReadUncommitDS, Connection.TRANSACTION_READ_UNCOMMITTED); 
+    }
+    
+    @Override 
+    public void verifyEJBRef() {
+        Assert.assertTrue("ambiguousStateless1 should have been bound", ambiguousStateless1!=null);
+        Assert.assertEquals("Name should have been bean1.", "bean1", ambiguousStateless1.getName());
+    }
+    
+    public static void verifyDataSource(DataSource ds, int expectedIsolationLevel) throws SQLException {
+        if (ds == null) {
+            throw new IllegalStateException("DataSource is null");
+        }
+
+        // verify that a connection can be obtained from the data source
+        Connection conn = ds.getConnection();
+        if (conn == null) {
+            throw new IllegalStateException("Failed to get connection");
+        }
+
+        try {
+            // Verify that the isolation level is read from the extension file
+            // the Derby default isolation level is TRANSACTION_REPEATABLE_READ=4.
+            int isolationLevel = conn.getTransactionIsolation();
+            Assert.assertEquals("Isolation level should have been set.", expectedIsolationLevel, isolationLevel);
+            conn.close();
+        } catch (Exception e) {
+            // swallow this exception
+        }
+    }
+
+    @Override
+    public void verifyInterceptor() {
+        // nothing to do here. See EJBBndInterceptor.java
+    }
+
+    @Override
+    public void verifyDataSourceBinding() throws Exception {
+        // EMPTY
+    }
+}

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/ServletTest.war/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/ServletTest.war/resources/META-INF/permissions.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd" version="7">
+
+    <permission>
+        <class-name>org.osgi.framework.AdminPermission</class-name>
+        <name>*</name>
+        <actions>*</actions>
+    </permission>
+
+    <permission>
+        <class-name>org.osgi.service.cm.ConfigurationPermission</class-name>
+        <name>*</name>
+        <actions>configure</actions>
+    </permission>
+
+    <permission>
+        <class-name>org.osgi.framework.ServicePermission</class-name>
+        <name>*</name>
+        <actions>register,get</actions>
+    </permission>
+
+    <permission>
+        <class-name>org.osgi.framework.AdaptPermission</class-name>
+        <name>*</name>
+        <actions>adapt</actions>
+    </permission>
+
+</permissions>

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/ServletTest.war/resources/WEB-INF/ibm-web-bnd.xml
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/ServletTest.war/resources/WEB-INF/ibm-web-bnd.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-bnd xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://websphere.ibm.com/xml/ns/javaee" xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-bnd_1_0.xsd" version="1.0">
+
+  <virtual-host name="fromApp"/>
+
+  <ejb-ref name="ejb/PriceSession" binding-name="ejb/com/ibm/svt/populateModule/grade/PriceSessionHome"/>
+
+  <ejb-ref name="SSBR" binding-name="ejb/GasNet/Station#com.ibm.svt.stationModule.gas.station.StationSessionBeanRemote"/>
+  <ejb-ref name="GMSBR" binding-name="ejb/GasNet/GasMaint#com.ibm.svt.stationModule.gas.maintenance.GasMaintenanceSessionBeanRemote"/>
+
+  <ejb-ref name="SeqSBR" binding-name="ejb/GasNet/Seq#com.ibm.svt.stationModule.sequence.SequenceSessionBeanRemote"/>
+
+  <ejb-ref name="SMBR" binding-name="ejb/GasNet/StoreMaint#com.ibm.svt.stationModule.store.maintenance.StoreMaintenanceBeanRemote"/>
+  <ejb-ref name="SCartBR" binding-name="ejb/GasNet/Cart#com.ibm.svt.stationModule.store.storeSessions.ShoppingCartBeanRemote"/>
+  <ejb-ref name="StoreSBR" binding-name="ejb/GasNet/StationStore#com.ibm.svt.stationModule.store.storeSessions.StationStoreSessionBeanRemote"/>
+
+  <ejb-ref name="FLSBR" binding-name="ejb/GasNet/Failure#com.ibm.svt.stationModule.failureLog.FailureLogSessionBeanRemote"/>
+
+  <resource-ref name="FuelDS" binding-name="jdbc/FuelDS"/>
+
+</web-bnd>

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/ServletTest.war/resources/WEB-INF/ibm-web-ext.xml
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/ServletTest.war/resources/WEB-INF/ibm-web-ext.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-ext xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://websphere.ibm.com/xml/ns/javaee" xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-ext_1_0.xsd" version="1.0">
+
+    <servlet name="Auto Servlet">
+        <local-transaction boundary="BEAN_METHOD" resolver="CONTAINER_AT_BOUNDARY" unresolved-action="COMMIT"/>
+    </servlet>  
+  
+    <reload-interval value="3"/>
+    <enable-directory-browsing value="false"/>
+    <enable-file-serving value="true"/>
+    <enable-reloading value="true"/>
+    <enable-serving-servlets-by-class-name value="true"/>
+
+</web-ext>
+

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/ServletTest.war/resources/WEB-INF/ibm-ws-bnd.xml
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/ServletTest.war/resources/WEB-INF/ibm-ws-bnd.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<webservices-bnd xmlns="http://websphere.ibm.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-ws-bnd_1_0.xsd" version="1.0">
+
+    <!-- 0 to many endpoint descriptions -->
+    <webservice-endpoint port-component-name="HelloFromBnd" address="/hi2"/>
+
+    <http-publishing>
+        <webservice-security>
+            <security-constraint>
+                <web-resource-collection>
+                    <web-resource-name>Resource for SayHelloService</web-resource-name>
+                    <url-pattern>/SayHelloService</url-pattern>
+                </web-resource-collection>
+                <auth-constraint>
+                    <description>Only role23 is allowed</description>
+                    <role-name>role23</role-name>
+                </auth-constraint>
+            </security-constraint>
+            <security-constraint>
+                <web-resource-collection>
+                    <web-resource-name>Resource for SecuredSayHelloService</web-resource-name>
+                    <url-pattern>/SecuredSayHelloService</url-pattern>
+                </web-resource-collection>
+                <auth-constraint>
+                    <description>Only role23 is allowed</description>
+                    <role-name>role23</role-name>
+                </auth-constraint>
+            </security-constraint>
+
+            <security-role>
+                <role-name>role23</role-name>
+            </security-role>
+
+            <login-config>
+                <auth-method>BASIC</auth-method>
+            </login-config>
+        </webservice-security>
+    </http-publishing>
+
+    <service-ref name="service/SayHelloPojoServiceFromBnd">
+        <port name="SayHelloPojoFromBndPort"
+              namespace="http://ibm.com/ws/jaxws/transport/security/"
+              username="employee0" password="emp0pwd"/>
+        <properties http.conduit.tlsClientParameters.disableCNCheck="true"/>
+    </service-ref>
+
+</webservices-bnd>

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/ServletTest.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/ServletTest.war/resources/WEB-INF/web.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd" id="WebApp_ID" version="3.0">
+
+    <display-name>Bindings and Extensions Override Test Web Application</display-name>
+    <description>Used to run override tests for various bindings and extensions</description>
+
+    <servlet id="Default">
+        <description>Print's to log... that's it!.</description>
+        <servlet-name>Auto Servlet</servlet-name>      
+        <servlet-class>servlettest.web.AutoServlet</servlet-class>
+        <load-on-startup></load-on-startup>
+    </servlet>
+
+    <servlet-mapping id="ServletMapping_Default">
+        <servlet-name>Auto Servlet</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+
+</web-app>

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/ServletTest.war/src/servlettest/web/AutoServlet.java
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/ServletTest.war/src/servlettest/web/AutoServlet.java
@@ -1,0 +1,864 @@
+/*******************************************************************************
+ * Copyright (c) 2012,2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package servlettest.web;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+import com.ibm.ws.javaee.dd.appbnd.ApplicationBnd;
+import com.ibm.ws.javaee.dd.appbnd.SecurityRole;
+import com.ibm.ws.javaee.dd.appext.ApplicationExt;
+import com.ibm.ws.javaee.dd.commonbnd.AuthenticationAlias;
+import com.ibm.ws.javaee.dd.commonbnd.EJBRef;
+import com.ibm.ws.javaee.dd.commonbnd.Interceptor;
+import com.ibm.ws.javaee.dd.commonbnd.ResourceRef;
+import com.ibm.ws.javaee.dd.ejbbnd.EJBJarBnd;
+import com.ibm.ws.javaee.dd.ejbext.EJBJarExt;
+import com.ibm.ws.javaee.dd.ejbext.EnterpriseBean;
+import com.ibm.ws.javaee.dd.ejbext.TimeOut;
+import com.ibm.ws.javaee.dd.managedbean.ManagedBean;
+import com.ibm.ws.javaee.dd.managedbean.ManagedBeanBnd;
+import com.ibm.ws.javaee.dd.web.common.LoginConfig;
+import com.ibm.ws.javaee.dd.web.common.SecurityConstraint;
+import com.ibm.ws.javaee.dd.web.common.UserDataConstraint;
+import com.ibm.ws.javaee.dd.webbnd.VirtualHost;
+import com.ibm.ws.javaee.dd.webbnd.WebBnd;
+import com.ibm.ws.javaee.dd.webext.WebExt;
+import com.ibm.ws.javaee.ddmodel.fat.ContainerHelper;
+import com.ibm.ws.javaee.ddmodel.wsbnd.HttpPublishing;
+import com.ibm.ws.javaee.ddmodel.wsbnd.Port;
+import com.ibm.ws.javaee.ddmodel.wsbnd.ServiceRef;
+import com.ibm.ws.javaee.ddmodel.wsbnd.WebserviceDescription;
+import com.ibm.ws.javaee.ddmodel.wsbnd.WebserviceEndpoint;
+import com.ibm.ws.javaee.ddmodel.wsbnd.WebserviceSecurity;
+import com.ibm.ws.javaee.ddmodel.wsbnd.WebservicesBnd;
+import com.ibm.wsspi.adaptable.module.Container;
+import com.ibm.wsspi.adaptable.module.UnableToAdaptException;
+
+@SuppressWarnings("serial")
+public class AutoServlet extends HttpServlet {
+    public static final String APP_BINDINGS_CONFIG = "com.ibm.ws.javaee.dd.appbnd.ApplicationBnd";
+    public static final String APP_EXTENSIONS_CONFIG = "com.ibm.ws.javaee.dd.appext.ApplicationExt";
+    public static final String SECURITY_ROLE_CONFIG = "com.ibm.ws.javaee.dd.appbnd.SecurityRole";
+    public static final String WEB_EXTENSION_CONFIG = "com.ibm.ws.javaee.dd.webext.WebExt";
+    public static final String WEB_BINDINGS_CONFIG = "com.ibm.ws.javaee.dd.webbnd.WebBnd";
+    public static final String EJB_EXTENSION_CONFIG = "com.ibm.ws.javaee.dd.ejbext.EJBJarExt";
+    public static final String EJB_BINDINGS_CONFIG = "com.ibm.ws.javaee.dd.ejbbnd.EJBJarBnd";
+
+    public static final String AutoMessage = "This is AutoServlet.";
+
+    private static final String TEST_NAME = "testName";
+    private static final String OK = "OK";
+    private static final String FAIL = "Test failed, check logs for output";
+
+    private static final String TEST_WAR = "ServletTest";
+    private static final String TEST_WAR_NO_BINDINGS = "ServletTestNoBnd";
+
+    private static final String TEST_EJB = "EJBTest.jar";
+    private static final String TEST_EJB_NO_BINDINGS = "EJBTestNoBnd.jar";
+
+    private BundleContext bundleContext;
+    private final ArrayList<ServiceReference<?>> references = new ArrayList<ServiceReference<?>>();
+
+    /**
+     * A simple servlet that when it received a request it simply outputs the
+     * message as defined by the static field.
+     */
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        Bundle bundle = FrameworkUtil.getBundle(HttpServlet.class);
+
+        this.bundleContext = bundle.getBundleContext();
+
+        String testName = request.getParameter(TEST_NAME);
+        PrintWriter writer = response.getWriter();
+
+        try {
+            if (testName == null) {
+                writer.println(AutoMessage);
+                writer.flush();
+                writer.close();
+            } else {
+                System.out.println("Starting test: " + testName);
+                writer.println(getClass().getMethod(testName).invoke(this));
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            writer.println(FAIL);
+            writer.println("Caught exception: " + e.getMessage());
+        } finally {
+            for (ServiceReference<?> ref : references) {
+                bundleContext.ungetService(ref);
+            }
+            references.clear();
+            writer.flush();
+            writer.close();
+        }
+
+    }
+
+    public String testAutoInstall() {
+        return OK;
+    }
+
+    public String testConfigurationSide() throws Exception {
+        // Simple check to make sure the component impl is present for each
+        // configured type
+        ConfigurationAdmin ca = getConfigurationAdmin();
+        Configuration[] configs = ca.listConfigurations(getFilter(APP_BINDINGS_CONFIG, true));
+        Configuration[] securityRoleConfigs = ca.listConfigurations(getFilter(SECURITY_ROLE_CONFIG, true));
+        Configuration[] extensionConfigs = ca.listConfigurations(getFilter(APP_EXTENSIONS_CONFIG, true));
+        Configuration[] webBndConfigs = ca.listConfigurations(getFilter(WEB_BINDINGS_CONFIG, true));
+        Configuration[] webExtConfigs = ca.listConfigurations(getFilter(WEB_EXTENSION_CONFIG, true));
+        Configuration[] ejbBndConfigs = ca.listConfigurations(getFilter(EJB_BINDINGS_CONFIG, true));
+        Configuration[] ejbExtConfigs = ca.listConfigurations(getFilter(EJB_EXTENSION_CONFIG, true));
+        try {
+            validateConfig(configs, APP_BINDINGS_CONFIG, 1);
+            validateConfig(securityRoleConfigs, SECURITY_ROLE_CONFIG, 1);
+            validateConfig(extensionConfigs, APP_EXTENSIONS_CONFIG, 1);
+            validateConfig(webBndConfigs, WEB_BINDINGS_CONFIG, 2);
+            validateConfig(webExtConfigs, WEB_EXTENSION_CONFIG, 2);
+            validateConfig(ejbBndConfigs, EJB_BINDINGS_CONFIG, 2);
+            validateConfig(ejbExtConfigs, EJB_EXTENSION_CONFIG, 2);
+        } catch (TestFailedException ex) {
+            return ex.getMessage();
+        }
+
+        return OK;
+
+    }
+
+    private Container getEarContainer() {
+        ServiceReference<ContainerHelper> chRef = bundleContext.getServiceReference(ContainerHelper.class);
+        if (chRef == null)
+            throw new IllegalStateException("Could not find ContainerHelper reference");
+
+        ContainerHelper ch = bundleContext.getService(chRef);
+
+        return ch.getContainer();
+    }
+
+    public Container getWarContainer(String warName) throws UnableToAdaptException {
+        ServiceReference<ContainerHelper> chRef = bundleContext.getServiceReference(ContainerHelper.class);
+        if (chRef == null)
+            return null;
+
+        ContainerHelper ch = bundleContext.getService(chRef);
+
+        return ch.getModuleContainer(warName);
+    }
+
+    private Container getEJBJarContainer(String jarName) throws UnableToAdaptException {
+        ServiceReference<ContainerHelper> chRef = bundleContext.getServiceReference(ContainerHelper.class);
+        if (chRef == null)
+            return null;
+
+        ContainerHelper ch = bundleContext.getService(chRef);
+
+        return ch.getModuleContainer(jarName);
+
+    }
+
+    public String testWebExtensions() throws Exception {
+        return testWebExtensions(TEST_WAR);
+    }
+
+    public String testWebExtensionsNoBindings() throws Exception {
+        return testWebExtensions(TEST_WAR_NO_BINDINGS);
+    }
+
+    private String testWebExtensions(String testWar) throws Exception {
+        Container warContainer = getWarContainer(testWar);
+
+        WebExt webExt = warContainer.adapt(WebExt.class);
+        if (webExt == null)
+            return "Could not adapt WebExt";
+
+        if (!webExt.isEnableFileServing()) {
+            // app: true config: true
+            return "Invalid value for enable-file-serving: false";
+        }
+
+        if (!"somePage".equals(webExt.getDefaultErrorPage())) {
+            // app: undefined config: somePage
+            return "Invalid value for default error page: " + webExt.getDefaultErrorPage();
+        }
+
+        return OK;
+    }
+
+    public String testWebBindings() throws Exception {
+        return testWebBindings(TEST_WAR);
+    }
+
+    public String testWebBindingsNoBnd() throws Exception {
+        return testWebBindings(TEST_WAR_NO_BINDINGS);
+    }
+
+    public String testWebBindings(String warName) throws Exception {
+        Container warContainer = getWarContainer(warName);
+        WebBnd webBnd = warContainer.adapt(WebBnd.class);
+        if (webBnd == null)
+            return "Could not adapt WebBnd";
+
+        VirtualHost vh = webBnd.getVirtualHost();
+        if (vh == null)
+            return "Could not find virtual host";
+
+        if (!"default_host".equals(vh.getName())) {
+            // app: fromApp config: default_host
+            return "Invalid value for virtual host: " + vh.getName();
+        }
+
+        List<EJBRef> ejbRefs = webBnd.getEJBRefs();
+        if (ejbRefs == null || ejbRefs.isEmpty()) {
+            return "EJB refs not found";
+        } else if (ejbRefs.size() != 9) {
+            // 8 in app, 1 in config
+            return "Invalid number of ejb refs: " + ejbRefs.size();
+        } else {
+            EJBRef fromConfig = null;
+
+            if (warName.equals(TEST_WAR)) {
+                fromConfig = ejbRefs.get(8);
+            } else {
+                // no guarantees of order from configured entries, so look for
+                // the right one
+                for (EJBRef ref : ejbRefs) {
+                    if ("ejb/fromConfig".equals(ref.getName())) {
+                        fromConfig = ref;
+                        break;
+                    }
+                }
+                if (fromConfig == null)
+                    return "Could not find any configured ejb ref with name ejb/fromConfig";
+            }
+
+            if (!"ejb/fromConfig".equals(fromConfig.getName()))
+                return "Invalid ejbRef name: " + fromConfig.getName();
+            if (!"ejb/com/ibm/ConfigHome".equals(fromConfig.getBindingName()))
+                return "Invalid ejbRef binding name: " + fromConfig.getBindingName();
+        }
+
+        List<ResourceRef> resourceRefs = webBnd.getResourceRefs();
+        if (resourceRefs == null || resourceRefs.isEmpty())
+            return "Could not find resource refs";
+        else if (resourceRefs.size() != 1)
+            return "Invalid number of resource refs: " + resourceRefs.size();
+        else {
+            ResourceRef fromApp = resourceRefs.get(0);
+            if (!"FuelDS".equals(fromApp.getName()))
+                return "Invalid resource refname: " + fromApp.getName();
+            if (!"jdbc/FuelDS".equals(fromApp.getBindingName()))
+                return "Invalid resource ref binding name: " + fromApp.getBindingName();
+        }
+
+        int size = webBnd.getDataSources().size() + webBnd.getResourceEnvRefs().size() + webBnd.getEnvEntries().size()
+                + webBnd.getMessageDestinationRefs().size();
+        if (size != 0)
+            return "Found a resource ref, resource env ref, message destination ref, data source, or env entry that shouldn't exist";
+
+        return OK;
+    }
+
+    public String testEJBExtensions() throws Exception {
+        Container ejbContainer = getEJBJarContainer(TEST_EJB);
+
+        EJBJarExt extensions = ejbContainer.adapt(EJBJarExt.class);
+        if (extensions == null)
+            return "Could not adapt EJB jar extensions";
+
+        List<EnterpriseBean> ejbs = extensions.getEnterpriseBeans();
+        if (ejbs == null || ejbs.isEmpty())
+            return "Could not find enterprise beans in ejb jar extensions";
+
+        if (ejbs.size() != 1) {
+            return "Invalid number of enterprise beans: " + ejbs.size();
+        } else {
+            EnterpriseBean ejb = ejbs.get(0);
+            if (!"TestBean".equals(ejb.getName()))
+                return "Invalid ejb name: " + ejb.getName();
+            List<com.ibm.ws.javaee.dd.commonext.ResourceRef> refs = ejb.getResourceRefs();
+            if (refs.size() != 4)
+                return "Invalid number of resource refs: " + refs.size();
+
+            if (ejb.getStartAtAppStart() != null)
+                return "Start at app start should not be specified";
+            if (!(ejb instanceof com.ibm.ws.javaee.dd.ejbext.Session))
+                return "The enterprise bean shoudl be a session bean";
+
+            com.ibm.ws.javaee.dd.ejbext.Session session = (com.ibm.ws.javaee.dd.ejbext.Session) ejb;
+            TimeOut t = session.getTimeOut();
+
+            if (t == null)
+                return "Time out should be specified on session bean";
+
+            if (t.getValue() != 42)
+                return "THe time out value should be 42";
+        }
+        return OK;
+    }
+
+    public String testEJBBindings() throws Exception {
+        Container ejbContainer = getEJBJarContainer(TEST_EJB);
+
+        EJBJarBnd bindings = ejbContainer.adapt(EJBJarBnd.class);
+        if (bindings == null)
+            return "Could not adapt EJB jar bindings";
+
+        List<com.ibm.ws.javaee.dd.ejbbnd.EnterpriseBean> ejbs = bindings.getEnterpriseBeans();
+        if (ejbs == null || ejbs.isEmpty())
+            return "Could not find enterprise beans in ejb jar extensions";
+
+        if (ejbs.size() != 2) {
+            return "Invalid number of enterprise beans: " + ejbs.size();
+        } else {
+            com.ibm.ws.javaee.dd.ejbbnd.EnterpriseBean fromApp = ejbs.get(0);
+            com.ibm.ws.javaee.dd.ejbbnd.EnterpriseBean fromConfig = ejbs.get(1);
+
+            if (!"TestBean".equals(fromConfig.getName()))
+                return "Invalid ejb name: " + fromConfig.getName();
+
+            if (!"TestBean".equals(fromApp.getName()))
+                return "Invalid ejb name: " + fromApp.getName();
+
+            List<ResourceRef> refs = fromConfig.getResourceRefs();
+            if (refs == null || refs.size() != 3)
+                return "Invalid number of resource refs";
+
+            boolean foundAuthAlias = false;
+            for (ResourceRef ref : refs) {
+                if (ref.getAuthenticationAlias() != null) {
+                    foundAuthAlias = true;
+                    AuthenticationAlias alias = ref.getAuthenticationAlias();
+                    if (!("resRefAuthData".equals(alias.getName()))) {
+                        return "Invalid auth alias name: " + alias.getName();
+                    }
+                }
+            }
+
+            if (!foundAuthAlias)
+                return "Could not find authentication alias";
+
+        }
+        return OK;
+    }
+
+    public String testEJBBindingsNoBnd() throws Exception {
+        Container ejbContainer = getEJBJarContainer(TEST_EJB_NO_BINDINGS);
+
+        EJBJarBnd bindings = ejbContainer.adapt(EJBJarBnd.class);
+        if (bindings == null)
+            return "Could not adapt EJB jar bindings";
+
+        List<com.ibm.ws.javaee.dd.ejbbnd.EnterpriseBean> ejbs = bindings.getEnterpriseBeans();
+        if (ejbs == null || ejbs.isEmpty())
+            return "Could not find enterprise beans in ejb jar extensions";
+
+        if (ejbs.size() != 1) {
+            return "Invalid number of enterprise beans: " + ejbs.size();
+        } else {
+            com.ibm.ws.javaee.dd.ejbbnd.EnterpriseBean fromConfig = ejbs.get(0);
+
+            if (!"EJBBndStatefulBean".equals(fromConfig.getName()))
+                return "Invalid ejb name: " + fromConfig.getName();
+
+        }
+        return OK;
+    }
+
+    public String testEJBExtensionsNoBnd() throws Exception {
+        Container ejbContainer = getEJBJarContainer(TEST_EJB_NO_BINDINGS);
+
+        EJBJarExt extensions = ejbContainer.adapt(EJBJarExt.class);
+        if (extensions == null)
+            return "Could not adapt EJB jar extensions";
+
+        List<EnterpriseBean> ejbs = extensions.getEnterpriseBeans();
+        if (ejbs == null || ejbs.isEmpty())
+            return "Could not find enterprise beans in ejb jar extensions";
+
+        if (ejbs.size() != 1) {
+            return "Invalid number of enterprise beans: " + ejbs.size();
+        } else {
+            EnterpriseBean ejb = ejbs.get(0);
+            if (!"EJBBndStatefulBean".equals(ejb.getName()))
+                return "Invalid ejb name: " + ejb.getName();
+            List<com.ibm.ws.javaee.dd.commonext.ResourceRef> refs = ejb.getResourceRefs();
+            if (refs.size() != 4)
+                return "Invalid number of resource refs: " + refs.size();
+
+            if (ejb.getStartAtAppStart() != null)
+                return "Start at app start should not be specified";
+
+        }
+        return OK;
+    }
+
+    public String testApplicationExtensionFromWebApp() throws Exception {
+        Container earContainer = getWarContainer(TEST_WAR);
+
+        ApplicationExt appExt = earContainer.adapt(ApplicationExt.class);
+        if (appExt == null)
+            return "Could not adapt ApplicationExt";
+
+        if (appExt.isSharedSessionContext()) {
+            // app: true config: false
+            return "Invalid value for shared-session-context: true";
+        }
+
+        return OK;
+    }
+
+    public String testApplicationExtensions() throws Exception {
+        Container earContainer = getEarContainer();
+
+        ApplicationExt appExt = earContainer.adapt(ApplicationExt.class);
+        if (appExt == null)
+            return "Could not adapt ApplicationExt";
+
+        if (appExt.isSharedSessionContext()) {
+            // app: true config: false
+            return "Invalid value for shared-session-context: true";
+        }
+
+        return OK;
+    }
+
+    public String testSecurityRoleOverrides() throws Exception {
+        Container earContainer = getEarContainer();
+
+        ApplicationBnd appBnd = earContainer.adapt(ApplicationBnd.class);
+        if (appBnd == null)
+            return "Could not adapt ApplicationBnd";
+
+        List<SecurityRole> securityRoles = appBnd.getSecurityRoles();
+        if (securityRoles == null)
+            return "Could not adapt security roles";
+
+        // There should be two security roles. The first should be from the app,
+        // the second should be from config.
+        if (securityRoles.size() != 2) {
+            return "Invalid number of security roles found: " + securityRoles.size();
+        }
+        SecurityRole fromApp = securityRoles.get(0);
+        if (!fromApp.getName().equals("snooping")) {
+            return "Invalid security role name: " + fromApp.getName();
+        }
+
+        SecurityRole fromConfig = securityRoles.get(1);
+        if (!fromConfig.getName().equals("user")) {
+            return "Invalid security role name: " + fromConfig.getName();
+        }
+
+        return OK;
+
+    }
+
+    public String testSecurityRoleOverridesFromWebApp() throws Exception {
+        Container earContainer = getWarContainer(TEST_WAR);
+
+        ApplicationBnd appBnd = earContainer.adapt(ApplicationBnd.class);
+        if (appBnd == null)
+            return "Could not adapt ApplicationBnd";
+
+        List<SecurityRole> securityRoles = appBnd.getSecurityRoles();
+        if (securityRoles == null)
+            return "Could not adapt security roles";
+
+        // There should be two security roles in server.xml
+        if (securityRoles.size() != 2) {
+            return "Invalid number of security roles found: " + securityRoles.size();
+        }
+
+        for (SecurityRole role : securityRoles) {
+            if (!role.getName().equals("snooping") && !role.getName().equals("user"))
+                return "Invalid security role name: " + role.getName();
+        }
+
+        return OK;
+
+    }
+
+    public String testManagedBeanBindings() throws Exception {
+        Container ejbContainer = getEJBJarContainer(TEST_EJB);
+
+        ManagedBeanBnd binding = ejbContainer.adapt(ManagedBeanBnd.class);
+        if (binding == null)
+            return "Could not adapt ManagedBeanBnd";
+
+        List<Interceptor> interceptors = binding.getInterceptors();
+        if (!interceptors.isEmpty())
+            return "Found invalid interceptor";
+
+        List<ManagedBean> beans = binding.getManagedBeans();
+        if (beans == null || beans.isEmpty())
+            return "Could not find managed bean from bindings";
+
+        if (beans.size() != 1)
+            return "Invalid number of managed beans: " + beans.size();
+        ManagedBean bean = beans.get(0);
+        List<ResourceRef> refs = bean.getResourceRefs();
+        if (refs == null || refs.isEmpty())
+            return "Could not find resource reference";
+
+        if (refs.size() != 1)
+            return "Invalid number of resource references on managed bean: " + refs.size();
+
+        ResourceRef ref = refs.get(0);
+        if (!ref.getName().equals("jdbc/myBinding"))
+            return "Invalid name for resource reference: " + ref.getName();
+        if (!ref.getBindingName().equals("jdbc/TestDataSource"))
+            return "Invalid bidning name for resource reference: " + ref.getBindingName();
+
+        return OK;
+    }
+
+    public String testWebserviceBindingsNoBnd() throws Exception {
+        Container warContainer = getWarContainer(TEST_WAR_NO_BINDINGS);
+
+        WebservicesBnd wsbnd = warContainer.adapt(WebservicesBnd.class);
+        if (wsbnd == null)
+            return "Could not adapt web service binding";
+
+        HttpPublishing httpPublishing = wsbnd.getHttpPublishing();
+        if (httpPublishing == null)
+            return "Could not find HttpPublishing";
+
+        String contextRoot = httpPublishing.getContextRoot();
+        if (contextRoot == null || !contextRoot.equals("someContextRoot"))
+            return "Invalid value for context root: " + contextRoot;
+
+        WebserviceSecurity wssec = httpPublishing.getWebserviceSecurity();
+        if (wssec == null)
+            return "Could not find web service security";
+
+        LoginConfig loginConfig = wssec.getLoginConfig();
+        if (loginConfig == null)
+            return "Could not find login config";
+
+        String authMethod = loginConfig.getAuthMethod();
+        if (authMethod == null || !authMethod.equals("BASIC"))
+            return "Invalid value for auth method on login config: " + authMethod;
+
+        if (loginConfig.getFormLoginConfig() != null)
+            return "Found a FormLoginConfig element that should be null";
+
+        List<SecurityConstraint> securityConstraints = wssec.getSecurityConstraints();
+        if (securityConstraints == null)
+            return "Could not find security constraints";
+        if (securityConstraints.size() != 1)
+            return "Invalid number of security constraints: " + securityConstraints.size();
+
+        SecurityConstraint securityConstraint = securityConstraints.get(0);
+        if (securityConstraint.getAuthConstraint() == null)
+            return "Could not find auth constraint";
+
+        if (securityConstraint.getWebResourceCollections() == null)
+            return "Could not find web resource collection";
+
+        if (securityConstraint.getUserDataConstraint() == null)
+            return "Could not find user data constraint";
+
+        UserDataConstraint udc = securityConstraint.getUserDataConstraint();
+        if (udc.getTransportGuarantee() != 1)
+            return "Invalid value for transport guarantee: " + udc.getTransportGuarantee();
+
+        List<com.ibm.ws.javaee.dd.common.SecurityRole> securityRoles = wssec.getSecurityRoles();
+        if (securityRoles == null)
+            return "Could not find security roles";
+        if (securityRoles.size() != 1)
+            return "Found invalid number of security roles: " + securityRoles.size();
+        if (securityRoles.get(0).getRoleName() == null)
+            return "Could not find role name for security role";
+
+        List<ServiceRef> serviceRefs = wsbnd.getServiceRefs();
+        if (serviceRefs == null)
+            return "Could not find service refs";
+        if (serviceRefs.size() != 3)
+            return "Invalid number of service-ref elements: " + serviceRefs.size();
+
+        for (ServiceRef serviceRef : serviceRefs) {
+            Map<String, String> props = serviceRef.getProperties();
+            if (props == null)
+                return "Could not find serviceRef properties";
+            String property = props.get("http.conduit.tlsClientParameters.disableCNCheck");
+            if (property == null)
+                return "Could not find disableCNCheck property";
+            if (!property.equals("true"))
+                return "Invalid value for property: " + property;
+
+            String name = serviceRef.getName();
+            if (name == null)
+                return "Could not find a name for serviceRef";
+
+            List<Port> ports = serviceRef.getPorts();
+            if (ports == null || ports.isEmpty())
+                return "Could not find ports for serviceRef";
+            if (ports.size() != 1)
+                return "Invalid number of ports: " + ports.size();
+            Port port = ports.get(0);
+            if (!"employee0".equals(port.getUserName()))
+                return "Invalid username for port: " + port.getUserName();
+            if (!"http://ibm.com/ws/jaxws/transport/security/".equals(port.getNamespace()))
+                return "Invalid namespace for port: " + port.getNamespace();
+            String password = new String(port.getPassword().getChars());
+            if (!"emp0pwd".equals(password))
+                return "Invalid password for port: " + password;
+            if (port.getName() == null)
+                return "Could not find port name";
+
+            if ("service/SayHelloPojoService".equals(name)) {
+                if (!port.getName().equals("SayHelloPojoPort"))
+                    return "Invalid port name value: " + port.getName();
+            } else if ("service/SayHelloStatelessService".equals(name)) {
+                if (!port.getName().equals("SayHelloStatelessPort"))
+                    return "Invalid port name value: " + port.getName();
+            } else if ("service/SayHelloSingletonService".equals(name)) {
+                if (!port.getName().equals("SayHelloSingletonPort"))
+                    return "Invalid port name value: " + port.getName();
+            } else {
+                return "Found unexpected serviceRef name: " + name;
+            }
+        }
+
+        List<WebserviceEndpoint> wsEndpoints = wsbnd.getWebserviceEndpoints();
+        if (wsEndpoints == null)
+            return "Could not find webservice endpoints";
+        if (wsEndpoints.size() != 1)
+            return "Invalid number of ws endpoints: " + wsEndpoints.size();
+        WebserviceEndpoint wsep = wsEndpoints.get(0);
+        String portComponentName = wsep.getPortComponentName();
+        String address = wsep.getAddress();
+        if (portComponentName == null)
+            return "Could not find port component name";
+        if (address == null)
+            return "Could not find address for wsep";
+
+        if (!portComponentName.equals("Hello"))
+            return "Invalid port component name: " + portComponentName;
+        if (!address.equals("/hi"))
+            return "Invalid address: " + address;
+
+        Map<String, String> wsEpProps = wsbnd.getWebserviceEndpointProperties();
+        if (wsEpProps == null)
+            return "Could not find webservice endpoint properties";
+        if (wsEpProps.size() != 1)
+            return "Invalid number of ws endpoint properties: " + wsEpProps.size();
+        String value = wsEpProps.get("someAttribute");
+        if (value == null)
+            return "Could not find value for property someAttribute";
+        if (!value.equals("test"))
+            return "Invalid value for property someAttribute: " + value;
+
+        return OK;
+    }
+
+    public String testWebserviceBindings() throws Exception {
+        Container warContainer = getWarContainer(TEST_WAR);
+
+        WebservicesBnd wsbnd = warContainer.adapt(WebservicesBnd.class);
+        if (wsbnd == null)
+            return "Could not adapt web service binding";
+
+        HttpPublishing httpPublishing = wsbnd.getHttpPublishing();
+        if (httpPublishing == null)
+            return "Could not find HttpPublishing";
+
+        String contextRoot = httpPublishing.getContextRoot();
+        if (contextRoot == null || !contextRoot.equals("someContextRoot"))
+            return "Invalid value for context root: " + contextRoot;
+
+        WebserviceSecurity wssec = httpPublishing.getWebserviceSecurity();
+        if (wssec == null)
+            return "Could not find web service security";
+
+        LoginConfig loginConfig = wssec.getLoginConfig();
+        if (loginConfig == null)
+            return "Could not find login config";
+
+        String authMethod = loginConfig.getAuthMethod();
+        if (authMethod == null || !authMethod.equals("BASIC"))
+            return "Invalid value for auth method on login config: " + authMethod;
+
+        if (loginConfig.getFormLoginConfig() != null)
+            return "Found a FormLoginConfig element that should be null";
+
+        List<SecurityConstraint> securityConstraints = wssec.getSecurityConstraints();
+        if (securityConstraints == null)
+            return "Could not find security constraints";
+        if (securityConstraints.size() != 1)
+            return "Invalid number of security constraints: " + securityConstraints.size();
+
+        SecurityConstraint securityConstraint = securityConstraints.get(0);
+        if (securityConstraint.getAuthConstraint() == null)
+            return "Could not find auth constraint";
+
+        if (securityConstraint.getWebResourceCollections() == null)
+            return "Could not find web resource collection";
+
+        if (securityConstraint.getUserDataConstraint() == null)
+            return "Could not find user data constraint";
+
+        UserDataConstraint udc = securityConstraint.getUserDataConstraint();
+        if (udc.getTransportGuarantee() != 1)
+            return "Invalid value for transport guarantee: " + udc.getTransportGuarantee();
+
+        List<com.ibm.ws.javaee.dd.common.SecurityRole> securityRoles = wssec.getSecurityRoles();
+        if (securityRoles == null)
+            return "Could not find security roles";
+        if (securityRoles.size() != 1)
+            return "Found invalid number of security roles: " + securityRoles.size();
+        if (securityRoles.get(0).getRoleName() == null)
+            return "Could not find role name for security role";
+
+        List<ServiceRef> serviceRefs = wsbnd.getServiceRefs();
+        if (serviceRefs == null)
+            return "Could not find service refs";
+        if (serviceRefs.size() != 4)
+            return "Invalid number of service-ref elements: " + serviceRefs.size();
+
+        for (ServiceRef serviceRef : serviceRefs) {
+            Map<String, String> props = serviceRef.getProperties();
+            if (props == null)
+                return "Could not find serviceRef properties";
+            String property = props.get("http.conduit.tlsClientParameters.disableCNCheck");
+            if (property == null)
+                return "Could not find disableCNCheck property";
+            if (!property.equals("true"))
+                return "Invalid value for property: " + property;
+
+            String name = serviceRef.getName();
+            if (name == null)
+                return "Could not find a name for serviceRef";
+
+            List<Port> ports = serviceRef.getPorts();
+            if (ports == null || ports.isEmpty())
+                return "Could not find ports for serviceRef";
+            if (ports.size() != 1)
+                return "Invalid number of ports: " + ports.size();
+            Port port = ports.get(0);
+            if (!"employee0".equals(port.getUserName()))
+                return "Invalid username for port: " + port.getUserName();
+            if (!"http://ibm.com/ws/jaxws/transport/security/".equals(port.getNamespace()))
+                return "Invalid namespace for port: " + port.getNamespace();
+            String password = new String(port.getPassword().getChars());
+            if (!"emp0pwd".equals(password))
+                return "Invalid password for port: " + password;
+            if (port.getName() == null)
+                return "Could not find port name";
+
+            if ("service/SayHelloPojoService".equals(name)) {
+                if (!port.getName().equals("SayHelloPojoPort"))
+                    return "Invalid port name value: " + port.getName();
+            } else if ("service/SayHelloPojoServiceFromBnd".equals(name)) {
+                if (!port.getName().equals("SayHelloPojoFromBndPort"))
+                    return "Invalid portnamevalue: " + port.getName();
+            } else if ("service/SayHelloStatelessService".equals(name)) {
+                if (!port.getName().equals("SayHelloStatelessPort"))
+                    return "Invalid port name value: " + port.getName();
+            } else if ("service/SayHelloSingletonService".equals(name)) {
+                if (!port.getName().equals("SayHelloSingletonPort"))
+                    return "Invalid port name value: " + port.getName();
+            } else {
+                return "Found unexpected serviceRef name: " + name;
+            }
+        }
+
+        List<WebserviceEndpoint> wsEndpoints = wsbnd.getWebserviceEndpoints();
+        if (wsEndpoints == null)
+            return "Could not find webservice endpoints";
+        if (wsEndpoints.size() != 2)
+            return "Invalid number of ws endpoints: " + wsEndpoints.size();
+        for (WebserviceEndpoint wsep : wsEndpoints) {
+            String portComponentName = wsep.getPortComponentName();
+            String address = wsep.getAddress();
+            if (portComponentName == null)
+                return "Could not find port component name";
+            if (address == null)
+                return "Could not find address for wsep";
+
+            if (!portComponentName.equals("Hello") && !portComponentName.equals("HelloFromBnd"))
+                return "Invalid port component name: " + portComponentName;
+            if (!address.equals("/hi") && !address.equals("/hi2") )
+                return "Invalid address: " + address;
+        }
+        
+        Map<String, String> wsEpProps = wsbnd.getWebserviceEndpointProperties();
+        if (wsEpProps == null)
+            return "Could not find webservice endpoint properties";
+        if (wsEpProps.size() != 1)
+            return "Invalid number of ws endpoint properties: " + wsEpProps.size();
+        String value = wsEpProps.get("someAttribute");
+        if (value == null)
+            return "Could not find value for property someAttribute";
+        if (!value.equals("test"))
+            return "Invalid value for property someAttribute: " + value;
+
+        return OK;
+    }
+
+    private static class TestFailedException extends Exception {
+        public TestFailedException(String string) {
+            super(string);
+        }
+    }
+
+    private void validateConfig(Configuration[] configs, String pid, int numberOfConfigs) throws TestFailedException {
+        if (configs == null) {
+            throw new TestFailedException("Could not find config for pid " + pid);
+        }
+
+        if (configs.length != numberOfConfigs) {
+            throw new TestFailedException("Invalid number of configurations for pid " + pid + ": " + configs.length);
+        }
+    }
+
+    public String testBasicBindingConfiguration() {
+        return OK;
+    }
+
+    private ConfigurationAdmin getConfigurationAdmin() throws Exception {
+        ServiceReference<ConfigurationAdmin> ref = this.bundleContext.getServiceReference(ConfigurationAdmin.class);
+        if (ref == null) {
+            throw new IllegalStateException("No ConfigurationAdmin service");
+        }
+
+        references.add(ref);
+        return this.bundleContext.getService(ref);
+    }
+
+    private String getFilter(String pid, boolean isFactory) {
+        if (isFactory) {
+            return "(" + ConfigurationAdmin.SERVICE_FACTORYPID + "=" + pid + ")";
+        } else {
+            return "(" + Constants.SERVICE_PID + "=" + pid + ")";
+        }
+    }
+}

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/ServletTestNoBnd.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/ServletTestNoBnd.war/resources/WEB-INF/web.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd" id="WebApp_ID" version="3.0">
+
+    <display-name>Bindings and Extensions Override Test Web Applicaton</display-name>
+    <description>Used to run override tests for various bindings and extensions</description>
+
+    <servlet id="Default">
+        <description>Print's to log... that's it!.</description>
+        <servlet-name>Auto Servlet</servlet-name>            
+        <servlet-class>servlettestnobnd.web.AutoServlet</servlet-class>
+        <load-on-startup></load-on-startup>
+    </servlet>
+
+    <servlet-mapping id="ServletMapping_Default">
+        <servlet-name>Auto Servlet</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+
+</web-app>

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/ServletTestNoBnd.war/src/servlettestnobnd/web/AutoServlet.java
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/ServletTestNoBnd.war/src/servlettestnobnd/web/AutoServlet.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2012,2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package servlettestnobnd.web;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+import com.ibm.ws.javaee.dd.appbnd.ApplicationBnd;
+import com.ibm.ws.javaee.dd.appbnd.SecurityRole;
+import com.ibm.ws.javaee.dd.appext.ApplicationExt;
+import com.ibm.ws.javaee.dd.commonbnd.EJBRef;
+import com.ibm.ws.javaee.dd.commonbnd.Interceptor;
+import com.ibm.ws.javaee.dd.commonbnd.ResourceRef;
+import com.ibm.ws.javaee.dd.ejbbnd.EJBJarBnd;
+import com.ibm.ws.javaee.dd.ejbext.EJBJarExt;
+import com.ibm.ws.javaee.dd.ejbext.EnterpriseBean;
+import com.ibm.ws.javaee.dd.managedbean.ManagedBean;
+import com.ibm.ws.javaee.dd.managedbean.ManagedBeanBnd;
+import com.ibm.ws.javaee.dd.webbnd.VirtualHost;
+import com.ibm.ws.javaee.dd.webbnd.WebBnd;
+import com.ibm.ws.javaee.dd.webext.WebExt;
+import com.ibm.ws.javaee.ddmodel.fat.ContainerHelper;
+import com.ibm.wsspi.adaptable.module.Container;
+import com.ibm.wsspi.adaptable.module.Entry;
+import com.ibm.wsspi.adaptable.module.UnableToAdaptException;
+
+@SuppressWarnings("serial")
+public class AutoServlet extends HttpServlet {
+    
+    public static final String AutoMessage = "This is AutoServlet.";
+
+    /**
+     * A simple servlet that when it received a request it simply outputs the
+     * message as defined by the static field.
+     */
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+        throws ServletException, IOException {
+    
+        PrintWriter writer = response.getWriter();
+
+        try {
+            writer.println(AutoMessage);
+            writer.flush();
+            writer.close();
+        } catch (Exception e) {
+            e.printStackTrace();    
+            writer.println("Caught exception: " + e.getMessage());
+        } finally {         
+            writer.flush();
+            writer.close();
+        }
+    }   
+}

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/Test.ear/resources/META-INF/application.xml
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/Test.ear/resources/META-INF/application.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application id="Application_ID" version="5"
+    xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_5.xsd">
+
+    <display-name>Deployment Descriptor FAT Enterprise Application</display-name>
+
+    <module>
+        <web>
+            <web-uri>ServletTest.war</web-uri>
+            <context-root>autoctx</context-root>
+        </web>
+    </module>
+
+    <module>
+        <web>
+            <web-uri>ServletTestNoBnd.war</web-uri>
+            <context-root>nobindings</context-root>
+        </web>
+    </module>
+
+    <module>
+        <ejb>EJBTest.jar</ejb>
+    </module>
+
+    <module>
+        <ejb>EJBTestNoBnd.jar</ejb>
+    </module>
+
+</application> 

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/Test.ear/resources/META-INF/ibm-application-bnd.xml
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/Test.ear/resources/META-INF/ibm-application-bnd.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application-bnd xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-application-bnd_1_0.xsd"
+    version="1.0">
+
+    <security-role name="snooping">
+        <special-subject type="ALL_AUTHENTICATED_USERS" />
+    </security-role>
+
+</application-bnd>

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/Test.ear/resources/META-INF/ibm-application-ext.xml
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/Test.ear/resources/META-INF/ibm-application-ext.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application-ext xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-application-ext_1_1.xsd"
+    version="1.1">
+
+    <shared-session-context value="true"/>
+
+</application-ext>

--- a/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/Test.ear/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.javaee.ddmodel_fat/test-applications/Test.ear/resources/META-INF/permissions.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+    version="7">
+
+    <permission>
+        <class-name>org.osgi.framework.AdminPermission</class-name>
+        <name>*</name>
+        <actions>*</actions>
+    </permission>
+
+    <permission>
+        <class-name>org.osgi.service.cm.ConfigurationPermission</class-name>
+        <name>*</name>
+        <actions>configure</actions>
+    </permission>
+
+    <permission>
+        <class-name>org.osgi.framework.ServicePermission</class-name>
+        <name>*</name>
+        <actions>register,get</actions>
+    </permission>
+
+    <permission>
+        <class-name>org.osgi.framework.AdaptPermission</class-name>
+        <name>*</name>
+        <actions>adapt</actions>
+    </permission>
+
+</permissions>


### PR DESCRIPTION
Testing only update.

This update stages the migration of "com.ibm.ws.javaee.ddmodel_fat" from WS-CD-Open.  The run of this FAT bucket is blocked by the presence of the same-named FAT bucket in WS-CD-Open.

Following the merge of this FAT bucket, the FAT bucket will be removed from WS-CD-Open to complete the migration.

