### PR TITLE
Issue #14475: Fix AmbiguousEJBReferenceException in App Client

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.ejbRemoteClient-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.ejbRemoteClient-1.0.feature
@@ -2,6 +2,7 @@
 symbolicName=com.ibm.websphere.appserver.ejbRemoteClient-1.0
 WLP-DisableAllFeatures-OnConflict: false
 visibility=private
+IBM-API-Package: com.ibm.websphere.ejbcontainer; type="internal"
 -features=com.ibm.websphere.appserver.javaeePlatform-7.0, \
  com.ibm.websphere.appserver.ejbCore-1.0, \
  com.ibm.websphere.appserver.javax.ejb-3.2, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.enterpriseBeansRemoteClient-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.enterpriseBeansRemoteClient-2.0.feature
@@ -1,6 +1,7 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.enterpriseBeansRemoteClient-2.0
 visibility=private
+IBM-API-Package: com.ibm.websphere.ejbcontainer; type="internal"
 -features=io.openliberty.jakartaeePlatform-9.0, \
  io.openliberty.ejbCore-2.0, \
  io.openliberty.jakarta.ejb-4.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/enterpriseBeansLite-4.0/io.openliberty.enterpriseBeansLite-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/enterpriseBeansLite-4.0/io.openliberty.enterpriseBeansLite-4.0.feature
@@ -6,7 +6,8 @@ IBM-App-ForceRestart: install, \
  uninstall
 IBM-ShortName: enterpriseBeansLite-4.0
 WLP-AlsoKnownAs: ejbLite-4.0
-IBM-API-Package: com.ibm.websphere.ejbcontainer.mbean; type="ibm-api"
+IBM-API-Package: com.ibm.websphere.ejbcontainer.mbean; type="ibm-api", \
+ com.ibm.websphere.ejbcontainer; type="internal"
 Subsystem-Category: JakartaEE9Application
 -features=io.openliberty.jakartaeePlatform-9.0, \
  io.openliberty.jakarta.ejb-4.0, \

--- a/dev/com.ibm.ws.ejbcontainer.remote.client_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.remote.client_fat/bnd.bnd
@@ -37,4 +37,5 @@ tested.features: \
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.ejb.3.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
+	com.ibm.websphere.appserver.api.ejbcontainer;version=latest,\
 	com.ibm.websphere.security;version=latest

--- a/dev/com.ibm.ws.ejbcontainer.remote.client_fat/test-applications/EjbLinkClient.jar/src/com/ibm/ws/ejbcontainer/ejblink/client/EjbLinkClient.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote.client_fat/test-applications/EjbLinkClient.jar/src/com/ibm/ws/ejbcontainer/ejblink/client/EjbLinkClient.java
@@ -13,9 +13,9 @@ package com.ibm.ws.ejbcontainer.ejblink.client;
 
 import java.util.logging.Logger;
 
-import javax.ejb.EJBException;
 import javax.naming.InitialContext;
 
+import com.ibm.websphere.ejbcontainer.AmbiguousEJBReferenceException;
 import com.ibm.ws.ejbcontainer.ejblink.ejb.EjbLinkDriverRemote;
 
 /**
@@ -86,7 +86,6 @@ public class EjbLinkClient {
     private static final Logger logger = Logger.getLogger(CLASS_NAME);
 
     private static final String PASSED = "Passed";
-    private static final String EXCEPTION_CLASS_NAME = "AmbiguousEJBReferenceException";
 
     // Name of application and modules... for lookup.
     private static final String Application = "EjbLinkTest";
@@ -902,8 +901,7 @@ public class EjbLinkClient {
                                                                                                         JarModule, "TestDupBean");
 
             bean.verifyStyle1BeanInJarAndWar();
-            // Change to AmbiguousEJBReferenceException once defect 174107 is resolved
-        } catch (EJBException exc) {
+        } catch (AmbiguousEJBReferenceException exc) {
             exc.printStackTrace();
             result = PASSED;
         }
@@ -1049,8 +1047,7 @@ public class EjbLinkClient {
                 return;
 
             bean.verifyAutoLinkToOtherJarAndWar();
-            // Change to AmbiguousEJBReferenceException once defect 174107 is resolved
-        } catch (EJBException exc) {
+        } catch (AmbiguousEJBReferenceException exc) {
             result = PASSED;
         }
 
@@ -1073,8 +1070,7 @@ public class EjbLinkClient {
                 return;
 
             bean.verifyAutoLinkToWarAndOtherWar();
-            // Change to AmbiguousEJBReferenceException once defect 174107 is resolved
-        } catch (EJBException exc) {
+        } catch (AmbiguousEJBReferenceException exc) {
             result = PASSED;
         }
 
@@ -1127,8 +1123,7 @@ public class EjbLinkClient {
                 return;
 
             bean.verifyAutoLinkToOtherJarAndWar();
-            // Change to AmbiguousEJBReferenceException once defect 174107 is resolved
-        } catch (EJBException exc) {
+        } catch (AmbiguousEJBReferenceException exc) {
             result = PASSED;
         }
 
@@ -1151,8 +1146,7 @@ public class EjbLinkClient {
                 return;
 
             bean.verifyAutoLinkToJarAndOtherJar();
-            // Change to AmbiguousEJBReferenceException once defect 174107 is resolved
-        } catch (EJBException exc) {
+        } catch (AmbiguousEJBReferenceException exc) {
             result = PASSED;
         }
 
@@ -1176,8 +1170,7 @@ public class EjbLinkClient {
                 return;
 
             bean.verifyAmbiguousEJBReferenceException();
-            // Change to AmbiguousEJBReferenceException once defect 174107 is resolved
-        } catch (EJBException exc) {
+        } catch (AmbiguousEJBReferenceException exc) {
             result = PASSED;
         } finally {
             if (result.equals(PASSED)) {
@@ -1202,8 +1195,7 @@ public class EjbLinkClient {
                 return;
 
             bean.verifyAmbiguousEJBReferenceException();
-            // Change to AmbiguousEJBReferenceException once defect 174107 is resolved
-        } catch (EJBException exc) {
+        } catch (AmbiguousEJBReferenceException exc) {
             result = PASSED;
         }
 
@@ -1227,8 +1219,7 @@ public class EjbLinkClient {
                 return;
 
             bean.verifyAmbiguousEJBReferenceException();
-            // Change to AmbiguousEJBReferenceException once defect 174107 is resolved
-        } catch (EJBException exc) {
+        } catch (AmbiguousEJBReferenceException exc) {
             result = PASSED;
         }
 
@@ -1252,8 +1243,7 @@ public class EjbLinkClient {
                 return;
 
             bean.verifyAmbiguousEJBReferenceException();
-            // Change to AmbiguousEJBReferenceException once defect 174107 is resolved
-        } catch (EJBException exc) {
+        } catch (AmbiguousEJBReferenceException exc) {
             result = PASSED;
         }
 
@@ -1278,8 +1268,7 @@ public class EjbLinkClient {
                 return;
 
             bean.verifyAmbiguousEJBReferenceException();
-            // Change to AmbiguousEJBReferenceException once defect 174107 is resolved
-        } catch (EJBException exc) {
+        } catch (AmbiguousEJBReferenceException exc) {
             result = PASSED;
         }
 
@@ -1303,8 +1292,7 @@ public class EjbLinkClient {
                 return;
 
             bean.verifyAmbiguousEJBReferenceException();
-            // Change to AmbiguousEJBReferenceException once defect 174107 is resolved
-        } catch (EJBException exc) {
+        } catch (AmbiguousEJBReferenceException exc) {
             result = PASSED;
         }
 


### PR DESCRIPTION
Expose this Liberty API class in the app client just like it is
exposed in the app server. This will allow an app client application
class to catch this exception if it is thrown by the server process
becauase the lookup or injection of an EJB is ambiguous (i.e. multiple
EJB implementations match the criteria).

Also fix a similar problem for a Jakarta EE server process.

fixes #14475 