### PR TITLE
Log derby network start

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/database/DerbyNetworkUtilities.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/database/DerbyNetworkUtilities.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,43 +16,47 @@ import java.net.UnknownHostException;
 
 import org.apache.derby.drda.NetworkServerControl;
 
+import com.ibm.websphere.simplicity.log.Log;
+
 /**
  * Provides methods for starting and stopping Derby Network.
  * The server is checked a number of times to be sure it has started,
  * otherwise the exception returned from the ping is thrown.
  */
 public class DerbyNetworkUtilities {
+    private static final Class<?> c = DerbyNetworkUtilities.class;
 
     static final int NUMBER_OF_PINGS = 10;
     static final int SLEEP_BETWEEN_PINGS = 10000;
-    // TODO serverName and portNumber are hard coded, 
+    // TODO serverName and portNumber are hard coded,
     // but in the future should be taken from bootstrapping.properties if specified
     static final String serverName = "localhost";
     static final int portNumber = 1527;
 
     static public void startDerbyNetwork() throws UnknownHostException, Exception {
-        NetworkServerControl serverControl =
-                        new NetworkServerControl(InetAddress.getByName(serverName), portNumber);
+        final String m = "startDerbyNetwork";
+        NetworkServerControl serverControl = new NetworkServerControl(InetAddress.getByName(serverName), portNumber);
         serverControl.start(new PrintWriter(System.out));
         for (int i = 1; i <= NUMBER_OF_PINGS; i++) {
             try {
-                System.out.println("Attempt " + i + " to see if Derby Network server started");
+                Log.info(c, m, "Attempt " + i + " to see if Derby Network server started");
                 serverControl.ping();
                 break;
             } catch (Exception ex) {
                 if (i == NUMBER_OF_PINGS) {
-                    System.out.println("Derby Network server failed to start");
-                    ex.printStackTrace();
+                    Log.info(c, m, "Derby Network server failed to start");
+                    Log.error(c, m, ex);
                     throw ex;
+                } else {
+                    Log.warning(c, "Attempt " + i + " failed due to exception: " + System.lineSeparator() + ex.getMessage());
+                    Thread.sleep(SLEEP_BETWEEN_PINGS);
                 }
-                Thread.sleep(SLEEP_BETWEEN_PINGS);
             }
         }
     }
 
     static public void stopDerbyNetwork() throws Exception {
-        NetworkServerControl serverControl =
-                        new NetworkServerControl(InetAddress.getByName(serverName), portNumber);
+        NetworkServerControl serverControl = new NetworkServerControl(InetAddress.getByName(serverName), portNumber);
         serverControl.shutdown();
     }
 


### PR DESCRIPTION
Currently when we test to ensure that Derby Network has started correctly output it sent to system out instead of properly to our test output.  

This will help if there are any delays in starting derby network and hopefully make triaging these issues easier. 

