### PR TITLE
fix gRPC service app start and server.xml update window

### DIFF
--- a/dev/io.openliberty.grpc.1.0.internal/src/io/openliberty/grpc/internal/servlet/GrpcServerComponent.java
+++ b/dev/io.openliberty.grpc.1.0.internal/src/io/openliberty/grpc/internal/servlet/GrpcServerComponent.java
@@ -143,7 +143,10 @@ public class GrpcServerComponent implements ServletContainerInitializer, Applica
 						}
 						if (!grpcServiceClasses.isEmpty()) {
 							// keep track of the current application so that we can restart it if <grpcService/> is updated
-					        ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+							ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+							if (cmd != null) {
+							 currentApp.setAppName(cmd.getJ2EEName().getApplication());
+							}
 							// register URL mappings for each gRPC service we've registered
 							for (BindableService service : grpcServiceClasses.values()) {
 								String serviceName = service.bindService().getServiceDescriptor().getName();
@@ -178,9 +181,6 @@ public class GrpcServerComponent implements ServletContainerInitializer, Applica
 								
 								Tr.info(tc, "service.available", cmd.getJ2EEName().getApplication(), urlPattern);
 							}
-					        if (cmd != null) {
-					            currentApp.setAppName(cmd.getJ2EEName().getApplication());
-					        }
 							return;
 						}
 					}


### PR DESCRIPTION
There is a very small timing window during app startup which can cause the wrong `<grpc/>` server.xml config to get used. I'll close that window here.