### PR TITLE
fix http2_fat Http2SecureTests timeout issue

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -347,16 +347,6 @@
       <version>2.0.0-RC5</version>
     </dependency>
     <dependency>
-      <groupId>com.sun.mail</groupId>
-      <artifactId>javax.mail</artifactId>
-      <version>1.5.6</version>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.mail</groupId>
-      <artifactId>javax.mail</artifactId>
-      <version>1.6.2</version>
-    </dependency>
-    <dependency>
       <groupId>com.sun.xml.bind.external</groupId>
       <artifactId>relaxng-datatype</artifactId>
       <version>3.0.0-M4</version>
@@ -1444,17 +1434,17 @@
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
-      <version>5.0</version>
+      <version>5.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5-h2</artifactId>
-      <version>5.0</version>
+      <version>5.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5</artifactId>
-      <version>5.0</version>
+      <version>5.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -282,9 +282,9 @@ org.apache.felix:org.apache.felix.scr:2.1.24
 org.apache.felix:org.osgi.service.obr:1.0.2
 org.apache.geronimo.specs:geronimo-jaxb_2.2_spec:1.0.1
 org.apache.geronimo.specs:geronimo-jta_1.1_spec:1.1.1
-org.apache.httpcomponents.client5:httpclient5:5.0
-org.apache.httpcomponents.core5:httpcore5-h2:5.0
-org.apache.httpcomponents.core5:httpcore5:5.0
+org.apache.httpcomponents.client5:httpclient5:5.0.2
+org.apache.httpcomponents.core5:httpcore5-h2:5.0.2
+org.apache.httpcomponents.core5:httpcore5:5.0.2
 org.apache.httpcomponents:fluent-hc:4.3.1
 org.apache.httpcomponents:httpclient-cache:4.1.2
 org.apache.httpcomponents:httpclient-cache:4.3.1

--- a/dev/com.ibm.ws.anno_fat/bnd.bnd
+++ b/dev/com.ibm.ws.anno_fat/bnd.bnd
@@ -35,5 +35,5 @@ fat.project: true
     commons-httpclient:commons-httpclient;version=3.1, \
     httpunit:httpunit;version=1.5.4, \
     net.sf.jtidy:jtidy;version=9.3.8, \
-    org.apache.httpcomponents.client5:httpclient5;version=5.0, \
-    org.apache.httpcomponents.core5:httpcore5;version=5.0
+    org.apache.httpcomponents.client5:httpclient5;version=5.0.2, \
+    org.apache.httpcomponents.core5:httpcore5;version=5.0.2

--- a/dev/com.ibm.ws.anno_fat/build.gradle
+++ b/dev/com.ibm.ws.anno_fat/build.gradle
@@ -13,8 +13,8 @@
 dependencies {
   requiredLibs 'httpunit:httpunit:1.5.4',
     'net.sf.jtidy:jtidy:9.3.8',	
-    'org.apache.httpcomponents.client5:httpclient5:5.0',
-    'org.apache.httpcomponents.core5:httpcore5:5.0',
+    'org.apache.httpcomponents.client5:httpclient5:5.0.2',
+    'org.apache.httpcomponents.core5:httpcore5:5.0.2',
     'commons-logging:commons-logging:1.1.3',
     'commons-codec:commons-codec:1.6'
 }

--- a/dev/com.ibm.ws.transport.http2_fat/bnd.bnd
+++ b/dev/com.ibm.ws.transport.http2_fat/bnd.bnd
@@ -23,6 +23,6 @@ fat.project: true
 	com.ibm.websphere.javaee.servlet.4.0;version=latest,\
 	com.ibm.ws.transport.http;version=latest,\
 	com.ibm.ws.channelfw;version=latest,\
-	org.apache.httpcomponents.client5:httpclient5;version=5.0,\
-	org.apache.httpcomponents.core5:httpcore5;version=5.0,\
-	org.apache.httpcomponents.core5:httpcore5-h2;version=5.0
+	org.apache.httpcomponents.client5:httpclient5;version=5.0.2,\
+	org.apache.httpcomponents.core5:httpcore5;version=5.0.2,\
+	org.apache.httpcomponents.core5:httpcore5-h2;version=5.0.2

--- a/dev/com.ibm.ws.transport.http2_fat/build.gradle
+++ b/dev/com.ibm.ws.transport.http2_fat/build.gradle
@@ -11,9 +11,9 @@
 
 // Define G:A:V coordinates of each dependency
 dependencies {
-  requiredLibs  'org.apache.httpcomponents.client5:httpclient5:5.0',
-    'org.apache.httpcomponents.core5:httpcore5:5.0',
-    'org.apache.httpcomponents.core5:httpcore5-h2:5.0',
+  requiredLibs  'org.apache.httpcomponents.client5:httpclient5:5.0.2',
+    'org.apache.httpcomponents.core5:httpcore5:5.0.2',
+    'org.apache.httpcomponents.core5:httpcore5-h2:5.0.2',
     'commons-logging:commons-logging:1.1.3',
     'commons-codec:commons-codec:1.6'
 }

--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2SecureTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2SecureTests.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package test.server.transport.http2;
 
+import static org.junit.Assert.assertNotNull;
+
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
@@ -52,7 +54,8 @@ public class Http2SecureTests extends FATServletClient {
             LOGGER.logp(Level.INFO, CLASS_NAME, "before()", "Starting servers...");
         }
         H2FATApplicationHelper.addWarToServerDropins(server, "H2TestModule.war", true, "http2.test.war.servlets");
-        server.startServer(true, true);
+        server.startServer(Http2SecureTests.class.getSimpleName() + ".log");
+        assertNotNull("CWWKO0219I.*ssl not recieved", server.waitForStringInLog("CWWKO0219I.*ssl"));
         client = new SecureHttp2Client();
     }
 
@@ -68,6 +71,7 @@ public class Http2SecureTests extends FATServletClient {
      * Test Coverage: Client requests a servlet that will generate a push request
      * Test Outcome: Server pushes a resource to the client
      * Note: JDK9+ required here for ALPN
+     *
      * @throws Exception
      */
     @Test
@@ -84,6 +88,7 @@ public class Http2SecureTests extends FATServletClient {
      * Test Coverage: Client makes multiple requests to a servlet that will generate a push request
      * Test Outcome: Server pushes multiple resources to the client
      * Note: JDK9+ required here for ALPN
+     *
      * @throws Exception
      */
     @Test
@@ -102,6 +107,7 @@ public class Http2SecureTests extends FATServletClient {
      * Test Coverage: Client makes a request to a servlet with a simple body
      * Test Outcome: Server responds with the servlet body
      * Note: JDK9+ required here for ALPN
+     *
      * @throws Exception
      */
     @Test
@@ -118,6 +124,7 @@ public class Http2SecureTests extends FATServletClient {
      * Test Coverage: Client makes multiple requests to a servlet with a simple body
      * Test Outcome: Server responds multiple times
      * Note: JDK9+ required here for ALPN
+     *
      * @throws Exception
      */
     @Test

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/bnd.bnd
@@ -46,5 +46,5 @@ tested.features:\
     commons-httpclient:commons-httpclient;version=3.1,\
     httpunit:httpunit;version=1.5.4,\
     net.sf.jtidy:jtidy;version=9.3.8,\
-    org.apache.httpcomponents.client5:httpclient5;version=5.0,\
-    org.apache.httpcomponents.core5:httpcore5;version=5.0
+    org.apache.httpcomponents.client5:httpclient5;version=5.0.2,\
+    org.apache.httpcomponents.core5:httpcore5;version=5.0.2

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/build.gradle
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/build.gradle
@@ -13,8 +13,8 @@
 dependencies {
   requiredLibs 'httpunit:httpunit:1.5.4',
     'net.sf.jtidy:jtidy:9.3.8',	
-    'org.apache.httpcomponents.client5:httpclient5:5.0',
-    'org.apache.httpcomponents.core5:httpcore5:5.0',
+    'org.apache.httpcomponents.client5:httpclient5:5.0.2',
+    'org.apache.httpcomponents.core5:httpcore5:5.0.2',
     'commons-logging:commons-logging:1.1.3',
     'commons-codec:commons-codec:1.6'
 }


### PR DESCRIPTION
* update apache httpcomponents httpcore5 and httpclient5 to version 5.0.2
* increase the HTTP/2 connection timeout in `SecureHttp2Client` ; in some cases the first test in `Http2SecureTests` - `testSimplePushSecure` would time out due to slow server/app initialization