### PR TITLE
Issue #13663: Move ejbPersistentTimer-4.0 to beta

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.persistence-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.persistence-3.0.feature
@@ -5,6 +5,6 @@ IBM-Process-Types: server, \
  client
 -features=io.openliberty.jakarta.persistence.base-3.0
 -bundles=com.ibm.websphere.appserver.thirdparty.eclipselink.3.0; apiJar=false; location:=dev/api/third-party/; mavenCoordinates="org.eclipse.persistence:eclipselink:3.0.0"
-kind=noship
-edition=full
+kind=beta
+edition=base
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.persistenceService-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.persistenceService-2.0.feature
@@ -17,6 +17,6 @@ IBM-API-Package: com.ibm.websphere.persistence.mbean; type="ibm-api"
  bin/tools/ws-generateddlutil.jar, \
  bin/ddlGen.bat, \
  bin/ddlGen; ibm.file.encoding:=ebcdic
-kind=noship
-edition=full
+kind=beta
+edition=base
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.persistentExecutorSubset-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.persistentExecutorSubset-2.0.feature
@@ -3,7 +3,7 @@ symbolicName=io.openliberty.persistentExecutorSubset-2.0
 visibility=private
 -features=com.ibm.websphere.appserver.appLifecycle-1.0, \
  com.ibm.websphere.appserver.contextService-1.0, \
- com.ibm.websphere.appserver.jdbc-4.3; ibm.tolerates:="4.2, 4.1", \
+ com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:="4.3, 4.1", \
  com.ibm.websphere.appserver.transaction-2.0, \
  io.openliberty.jakarta.annotation-2.0,\
  io.openliberty.persistenceService-2.0
@@ -11,5 +11,6 @@ visibility=private
  io.openliberty.jakarta.concurrency.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api:2.0.0", \
  com.ibm.ws.resource, \
  com.ibm.ws.concurrent.persistent.jakarta
-kind=noship
-edition=full
+kind=beta
+edition=base
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/enterpriseBeans-4.0/io.openliberty.enterpriseBeans-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/enterpriseBeans-4.0/io.openliberty.enterpriseBeans-4.0.feature
@@ -10,6 +10,7 @@ Subsystem-Category: JakartaEE9Application
 -features= \
  io.openliberty.enterpriseBeansHome-4.0, \
  io.openliberty.enterpriseBeansLite-4.0, \
+ io.openliberty.enterpriseBeansPersistentTimer-4.0, \
  com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:=4.3, \
  io.openliberty.mdb-4.0, \
  com.ibm.websphere.appserver.transaction-2.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/enterpriseBeansPersistentTimer-4.0/io.openliberty.enterpriseBeansPersistentTimer-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/enterpriseBeansPersistentTimer-4.0/io.openliberty.enterpriseBeansPersistentTimer-4.0.feature
@@ -6,11 +6,11 @@ IBM-App-ForceRestart: install, \
 IBM-ShortName: enterpriseBeansPersistentTimer-4.0
 WLP-AlsoKnownAs: ejbPersistentTimer-4.0
 Subsystem-Name: Jakarta Enterprise Beans Persistent Timers 4.0
--features=io.openliberty.persistentExecutorSubset-2.0, \
- com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:=4.3, \
+-features=com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:=4.3, \
  io.openliberty.enterpriseBeansLite-4.0, \
+ io.openliberty.persistentExecutorSubset-2.0, \
  com.ibm.websphere.appserver.transaction-2.0
 -bundles=com.ibm.ws.ejbcontainer.timer.persistent.jakarta
-kind=noship
-edition=full
+kind=beta
+edition=base
 WLP-Activation-Type: parallel


### PR DESCRIPTION
Move enterpriseBeansPersistentTimer-4.0 and all included features to beta.

Also include in enterpriseBeans-4.0 convenience feature (which is in jakartaee-9.0 convenience feature)

for #13663 