### PR TITLE
Use in-memory derby DB for concurrent.persistent_fat_failovertimers bucket

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/fat/src/com/ibm/ws/concurrent/persistent/fat/failovertimers/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/fat/src/com/ibm/ws/concurrent/persistent/fat/failovertimers/FATSuite.java
@@ -18,11 +18,8 @@ import org.junit.runners.Suite.SuiteClasses;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
-import componenttest.topology.database.DerbyNetworkUtilities;
 import componenttest.topology.database.container.DatabaseContainerFactory;
 import componenttest.topology.database.container.DatabaseContainerType;
-import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.ExternalTestServiceDockerClientStrategy;
 
 @RunWith(Suite.class)
@@ -32,7 +29,6 @@ import componenttest.topology.utils.ExternalTestServiceDockerClientStrategy;
 })
 public class FATSuite {
 
-    // By default run on DerbyClient and not DerbyEmbedded
     static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create(DatabaseContainerType.DerbyClient);
 
     @BeforeClass
@@ -40,20 +36,11 @@ public class FATSuite {
         //Allows local tests to switch between using a local docker client, to using a remote docker client.
         ExternalTestServiceDockerClientStrategy.clearTestcontainersConfig();
 
-        // Remove databases that were created by previous executions of this test bucket when running with Derby.
-        LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.concurrent.persistent.fat.failovertimers.serverA");
-        server.deleteDirectoryFromLibertyInstallRoot("usr/shared/resources/data/failovertimersdb");
-        server.deleteDirectoryFromLibertyInstallRoot("usr/shared/resources/data/failovertimers2db");
-
         testContainer.start();
-
-        DerbyNetworkUtilities.startDerbyNetwork();
     }
 
     @AfterClass
     public static void afterSuite() throws Exception {
-        DerbyNetworkUtilities.stopDerbyNetwork();
-
         testContainer.stop();
     }
 }

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/publish/servers/com.ibm.ws.concurrent.persistent.fat.failovertimers.serverA/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/publish/servers/com.ibm.ws.concurrent.persistent.fat.failovertimers.serverA/server.xml
@@ -28,7 +28,7 @@
   <dataSource id="DefaultDataSource" fat.modify="true">
     <jdbcDriver libraryRef="jdbcLib"/>
     <!-- properties modified by fat-suite during database rotation -->
-    <properties.derby.client createDatabase="create" databaseName="${shared.resource.dir}/data/failovertimersdb" user="dbuser1" password="dbwpd1"/>
+    <properties.derby.client createDatabase="create" databaseName="memory:failovertimersdb" user="dbuser1" password="dbwpd1"/>
   </dataSource>
 
   <library id="jdbcLib">

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/publish/servers/com.ibm.ws.concurrent.persistent.fat.failovertimers.serverB/server.xml
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/publish/servers/com.ibm.ws.concurrent.persistent.fat.failovertimers.serverB/server.xml
@@ -28,7 +28,7 @@
   <dataSource id="DefaultDataSource" fat.modify="true">
     <jdbcDriver libraryRef="jdbcLib"/>
     <!-- properties modified by fat-suite during database rotation -->
-    <properties.derby.client createDatabase="create" databaseName="${shared.resource.dir}/data/failovertimersdb" user="dbuser1" password="dbwpd1"/>
+    <properties.derby.client createDatabase="create" databaseName="memory:failovertimersdb" user="dbuser1" password="dbwpd1"/>
   </dataSource>
 
   <library id="jdbcLib">

--- a/dev/fattest.databases/src/componenttest/topology/database/container/DatabaseContainerType.java
+++ b/dev/fattest.databases/src/componenttest/topology/database/container/DatabaseContainerType.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package componenttest.topology.database.container;
 
-import static org.junit.Assert.fail;
-
 import java.lang.reflect.Constructor;
 
 import org.testcontainers.containers.JdbcDatabaseContainer;
@@ -25,34 +23,34 @@ import com.ibm.websphere.simplicity.log.Log;
  */
 @SuppressWarnings("rawtypes")
 public enum DatabaseContainerType {
-    DB2("jcc.jar", "org.testcontainers.containers.", "Db2Container", "Properties_db2_jcc"),
-    Derby("derby.jar", "componenttest.topology.database.container.", "DerbyNoopContainer", "Properties_derby_embedded"),
-    DerbyClient("derbyclient.jar", "componenttest.topology.database.container.", "DerbyClientNoopContainer", "Properties_derby_client"),
-    Oracle("ojdbc8_g.jar", "componenttest.topology.database.container.", "OracleContainer", "Properties_oracle"),
-    Postgres("postgresql.jar", "org.testcontainers.containers.", "PostgreSQLContainer", "Properties_postgresql"),
-    SQLServer("mssql-jdbc.jar", "componenttest.topology.database.container.", "SQLServerContainer", "Properties_microsoft_sqlserver");
+    DB2("jcc.jar", "org.testcontainers.containers.Db2Container", "Properties_db2_jcc"),
+    Derby("derby.jar", "componenttest.topology.database.container.DerbyNoopContainer", "Properties_derby_embedded"),
+    DerbyClient("derbyclient.jar", "componenttest.topology.database.container.DerbyClientContainer", "Properties_derby_client"),
+    Oracle("ojdbc8_g.jar", "componenttest.topology.database.container.OracleContainer", "Properties_oracle"),
+    Postgres("postgresql.jar", "org.testcontainers.containers.PostgreSQLContainer", "Properties_postgresql"),
+    SQLServer("mssql-jdbc.jar", "componenttest.topology.database.container.SQLServerContainer", "Properties_microsoft_sqlserver");
 
-    private String driverName;
-    private Class<DataSourceProperties> dsPropsClass;
-    private Class<? extends JdbcDatabaseContainer> containerClass;
+    private final String driverName;
+    private final Class<DataSourceProperties> dsPropsClass;
+    private final Class<? extends JdbcDatabaseContainer> containerClass;
     
 
     @SuppressWarnings("unchecked")
-	DatabaseContainerType(final String driverName, final String packageName, final String containerClassName, final String dataSourcePropertiesClassName) {
+	DatabaseContainerType(final String driverName, final String containerClassName, final String dataSourcePropertiesClassName) {
         this.driverName = driverName;
         
         //Use reflection to get classes at runtime.
         Class containerClass = null, dsPropsClass  = null;
 		try {
-			containerClass = (Class<? extends JdbcDatabaseContainer>) Class.forName(packageName + containerClassName);
+			containerClass = (Class<? extends JdbcDatabaseContainer>) Class.forName(containerClassName);
 		} catch (ClassNotFoundException e) {
-			fail("Could not find the container class: " + containerClassName + " for testconatiner type: " + this.name());
+			throw new IllegalArgumentException("Could not find the container class: " + containerClassName + " for testconatiner type: " + this.name(), e);
 		}
 		
 		try {
 			dsPropsClass = (Class<DataSourceProperties>) Class.forName("com.ibm.websphere.simplicity.config.dsprops." + dataSourcePropertiesClassName);
 		} catch (ClassNotFoundException e) {
-			fail("Could not find the datasource properties class: " + dataSourcePropertiesClassName + " for testconatiner type: " + this.name());
+			throw new IllegalArgumentException("Could not find the datasource properties class: " + dataSourcePropertiesClassName + " for testconatiner type: " + this.name(), e);
 		}
 		
         this.containerClass = containerClass;
@@ -121,6 +119,6 @@ public enum DatabaseContainerType {
         String msg = frame.getUtf8String();
         if (msg.endsWith("\n"))
             msg = msg.substring(0, msg.length() - 1);
-        Log.info(this.containerClass, "output", msg);
+        Log.info(this.containerClass, "[" + name() + "]", msg);
     }
 }

--- a/dev/fattest.databases/src/componenttest/topology/database/container/DerbyClientContainer.java
+++ b/dev/fattest.databases/src/componenttest/topology/database/container/DerbyClientContainer.java
@@ -12,20 +12,21 @@ package componenttest.topology.database.container;
 
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
+import componenttest.topology.database.DerbyNetworkUtilities;
+
 /**
  * This is a Derby Client no-op database test container that is returned
  * when attempting to test against derby client.
  *
- * This test container overrides the start and stop methods
- * to prevent the creation of a docker container.
- *
+ * This class will start and stop a Derby Network instance (although locally, not in a container)
  */
-class DerbyClientNoopContainer<SELF extends DerbyClientNoopContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
+class DerbyClientContainer extends JdbcDatabaseContainer<DerbyClientContainer> {
+	
+	private String user = "dbuser";
+	private String pass = "dbpass";
+	private String dbname = "memory:testdb";
 
-    /**
-     * @see DerbyClientNoopContainer
-     */
-    public DerbyClientNoopContainer() {
+    public DerbyClientContainer() {
         super("");
     }
 
@@ -36,7 +37,11 @@ class DerbyClientNoopContainer<SELF extends DerbyClientNoopContainer<SELF>> exte
 
     @Override
     public void start() {
-        //DO NOTHING
+    	try {
+			DerbyNetworkUtilities.startDerbyNetwork();
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
     }
 
     @Override
@@ -46,7 +51,11 @@ class DerbyClientNoopContainer<SELF extends DerbyClientNoopContainer<SELF>> exte
 
     @Override
     public void stop() {
-        //DO NOTHING
+    	try {
+			DerbyNetworkUtilities.stopDerbyNetwork();
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
     }
 
     @Override
@@ -56,32 +65,55 @@ class DerbyClientNoopContainer<SELF extends DerbyClientNoopContainer<SELF>> exte
 
 	@Override
 	public String getJdbcUrl() {
-		throw new UnsupportedOperationException();
+		return "jdbc:derby://" + getContainerIpAddress() + ":" + getFirstMappedPort() + "/" + getDatabaseName();
+	}
+	
+	@Override
+	public DerbyClientContainer withUsername(String username) {
+		user = username;
+		return self();
 	}
 
 	@Override
 	public String getUsername() {
-		throw new UnsupportedOperationException();
+		return user;
+	}
+	
+	@Override
+	public DerbyClientContainer withPassword(String password) {
+		pass = password;
+		return self();
 	}
 
 	@Override
 	public String getPassword() {
-		throw new UnsupportedOperationException();
+		return pass;
+	}
+	
+	@Override
+	public DerbyClientContainer withDatabaseName(String dbName) {
+		dbname = dbName;
+		return self();
+	}
+	
+	@Override
+	public String getDatabaseName() {
+		return dbname;
 	}
 
 	@Override
 	public Integer getFirstMappedPort() {
-		throw new UnsupportedOperationException();
+		return 1527;
 	}
 
 	@Override
 	public String getContainerIpAddress() {
-		throw new UnsupportedOperationException();
+		return "localhost";
 	}
 
 	@Override
 	public String getDriverClassName() {
-		throw new UnsupportedOperationException();
+		return "org.apache.derby.jdbc.ClientDriver";
 	}
 
 	@Override


### PR DESCRIPTION
#build 