### PR TITLE
Trace config profile

### DIFF
--- a/dev/io.openliberty.io.smallrye.config/bnd.bnd
+++ b/dev/io.openliberty.io.smallrye.config/bnd.bnd
@@ -54,4 +54,5 @@ Export-Package: \
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
   com.ibm.ws.cdi.interfaces;version=latest,\
   com.ibm.websphere.org.osgi.service.component;version=latest,\
-  com.ibm.ws.org.jboss.logging;version=latest
+  com.ibm.ws.org.jboss.logging;version=latest,\
+  com.ibm.ws.logging;version=latest

--- a/dev/io.openliberty.io.smallrye.config/src/io/openliberty/microprofile/config/internal/extension/package-info.java
+++ b/dev/io.openliberty.io.smallrye.config/src/io/openliberty/microprofile/config/internal/extension/package-info.java
@@ -1,0 +1,12 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+@com.ibm.websphere.ras.annotation.TraceOptions(traceGroup = "APPCONFIG")
+package io.openliberty.microprofile.config.internal.extension;


### PR DESCRIPTION
Trace the configured config profile whenever a Config is created for MP
Config 2.0.

We don't usually have FAT tests for trace strings and I have manually verified that the trace is emitted.

Fixes #14520 