### PR TITLE
Clear container output in the beginning of each test class

### DIFF
--- a/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/CustomizedTagTest.java
+++ b/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/CustomizedTagTest.java
@@ -69,6 +69,7 @@ public class CustomizedTagTest extends LogstashCollectorTest {
             return;
         }
 
+        clearContainerOutput();
         String host = logstashContainer.getContainerIpAddress();
         String port = String.valueOf(logstashContainer.getMappedPort(5043));
         Log.info(c, "setUp", "Logstash container: host=" + host + "  port=" + port);

--- a/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogStashWithBinaryLoggingTest.java
+++ b/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogStashWithBinaryLoggingTest.java
@@ -52,6 +52,7 @@ public class LogStashWithBinaryLoggingTest extends LogstashCollectorTest {
             return;
         }
 
+        clearContainerOutput();
         String host = logstashContainer.getContainerIpAddress();
         String port = String.valueOf(logstashContainer.getMappedPort(5043));
         Log.info(c, "setUp", "Logstash container: host=" + host + "  port=" + port);

--- a/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashCollectorIndependentTest.java
+++ b/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashCollectorIndependentTest.java
@@ -40,6 +40,7 @@ public class LogstashCollectorIndependentTest extends LogstashCollectorTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        clearContainerOutput();
         String host = logstashContainer.getContainerIpAddress();
         String port = String.valueOf(logstashContainer.getMappedPort(5043));
         Log.info(c, "setUp", "Logstash container: host=" + host + "  port=" + port);

--- a/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
+++ b/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
@@ -67,6 +67,7 @@ public class LogstashSSLTest extends LogstashCollectorTest {
             return;
         }
 
+        clearContainerOutput();
         String host = logstashContainer.getContainerIpAddress();
         String port = String.valueOf(logstashContainer.getMappedPort(5043));
         Log.info(c, "setUp", "Logstash container: host=" + host + "  port=" + port);

--- a/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/MaxFieldLengthTest.java
+++ b/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/MaxFieldLengthTest.java
@@ -56,6 +56,7 @@ public class MaxFieldLengthTest extends LogstashCollectorTest {
             return;
         }
 
+        clearContainerOutput();
         String host = logstashContainer.getContainerIpAddress();
         String port = String.valueOf(logstashContainer.getMappedPort(5043));
         Log.info(c, "setUp", "Logstash container: host=" + host + "  port=" + port);

--- a/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/ThrottleMaxEventsTest.java
+++ b/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/ThrottleMaxEventsTest.java
@@ -63,6 +63,7 @@ public class ThrottleMaxEventsTest extends LogstashCollectorTest {
             return;
         }
 
+        clearContainerOutput();
         String host = logstashContainer.getContainerIpAddress();
         String port = String.valueOf(logstashContainer.getMappedPort(5043));
         Log.info(c, "setUp", "Logstash container: host=" + host + "  port=" + port);


### PR DESCRIPTION
Clear container output in the beginning of each test class so that the output from previous test class will not be read in the following test class.