### PR TITLE
Add mpRestClient-2.0 to beta and microprofile-4.0 feature

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.rest.client-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.rest.client-2.0.feature
@@ -6,6 +6,6 @@ singleton=true
  com.ibm.websphere.appserver.javax.jaxrs-2.1, \
  io.openliberty.org.eclipse.microprofile.config-2.0
 -bundles=io.openliberty.org.eclipse.microprofile.rest.client.2.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.rest.client:microprofile-rest-client-api:2.0-RC2"
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-4.0/io.openliberty.microProfile-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-4.0/io.openliberty.microProfile-4.0.feature
@@ -20,6 +20,7 @@ Subsystem-Name: MicroProfile 4.0
   io.openliberty.mpJwt-1.2, \
   io.openliberty.mpMetrics-3.0, \
   io.openliberty.mpOpenAPI-2.0, \
-  io.openliberty.mpOpenTracing-2.0
+  io.openliberty.mpOpenTracing-2.0, \
+  io.openliberty.mpRestClient-2.0
 kind=beta
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpRestClient-2.0/io.openliberty.mpRestClient-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpRestClient-2.0/io.openliberty.mpRestClient-2.0.feature
@@ -20,6 +20,6 @@ Subsystem-Name: MicroProfile Rest Client 2.0
  com.ibm.websphere.appserver.org.reactivestreams.reactive-streams-1.0, \
  io.openliberty.mpConfig-2.0
 -bundles=com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.3; apiJar=false; location:="lib/"
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/publish/servers/OpentracingRestClientTCKServer/server.xml
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/publish/servers/OpentracingRestClientTCKServer/server.xml
@@ -10,7 +10,7 @@
         <feature>localConnector-1.0</feature>
         <feature>mpOpenTracing-2.0</feature>
         <feature>usr:opentracingMock-2.0</feature>
-        <feature>mpRestClient-1.4</feature>
+        <feature>mpRestClient-2.0</feature>
         <feature>arquillian-support-1.0</feature>
     </featureManager>
 


### PR DESCRIPTION
Move MP Rest Client 2.0 feature to beta and into the `microprofile-4.0` convenience feature.