### PR TITLE
Ignore CWWKC1503W in EJB Timer FAT

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/PersistentTimerTestHelper.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/PersistentTimerTestHelper.java
@@ -59,6 +59,14 @@ public class PersistentTimerTestHelper {
         // but transaction service has already been shutdown.
         ignoreList.add("J2CA0027E");
 
+        // CWWKC1503W: Persistent executor [EJBPersistentTimerExecutor] rolled back task [task id]
+        //             (!EJBTimerP![j2eename]) due to failure javax.ejb.EJBException: Timeout method
+        //             [method name] will not be invoked because server is stopping
+        //
+        // persistent.internal.InvokerTask run starts for a persistent timer during server shutdown,
+        // but EJB timer service throws exception due to server stopping.
+        ignoreList.add("CWWKC1503W.*server is stopping");
+
         String[] stringArr = new String[ignoreList.size()];
         return ignoreList.toArray(stringArr);
     }


### PR DESCRIPTION
The test creates persistent timers and then restarts the server to
verify the behavior; it is normal for CWWKC1503W to occur if an attempt
is made to run a timer while the server is shutting down; ignore.