### PR TITLE
Re-enable mpOpenTracing Rest Client Tests

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpOpenTracing2.0-mpRestClient2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpOpenTracing2.0-mpRestClient2.0.feature
@@ -1,10 +1,10 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=io.openliberty.mpOpenTracing2.0-mpRestClient1.4
+symbolicName=io.openliberty.mpOpenTracing2.0-mpRestClient2.0
 visibility=private
 singleton=true
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.mpOpenTracing-2.0))", \
-  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.4))"
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.mpRestClient-2.0))"
 -bundles=io.openliberty.microprofile.opentracing.2.0.internal.rest.client
 IBM-Install-Policy: when-satisfied
 kind=beta

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.rest.client-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.org.eclipse.microprofile.rest.client-2.0.feature
@@ -6,6 +6,6 @@ singleton=true
  com.ibm.websphere.appserver.javax.jaxrs-2.1, \
  io.openliberty.org.eclipse.microprofile.config-2.0
 -bundles=io.openliberty.org.eclipse.microprofile.rest.client.2.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.rest.client:microprofile-rest-client-api:2.0-RC2"
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-4.0/io.openliberty.microProfile-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-4.0/io.openliberty.microProfile-4.0.feature
@@ -20,6 +20,7 @@ Subsystem-Name: MicroProfile 4.0
   io.openliberty.mpJwt-1.2, \
   io.openliberty.mpMetrics-3.0, \
   io.openliberty.mpOpenAPI-2.0, \
-  io.openliberty.mpOpenTracing-2.0
+  io.openliberty.mpOpenTracing-2.0, \
+  io.openliberty.mpRestClient-2.0
 kind=beta
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpRestClient-2.0/io.openliberty.mpRestClient-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpRestClient-2.0/io.openliberty.mpRestClient-2.0.feature
@@ -20,6 +20,6 @@ Subsystem-Name: MicroProfile Rest Client 2.0
  com.ibm.websphere.appserver.org.reactivestreams.reactive-streams-1.0, \
  io.openliberty.mpConfig-2.0
 -bundles=com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.3; apiJar=false; location:="lib/"
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/FATSuite.java
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/FATSuite.java
@@ -30,7 +30,7 @@ import componenttest.topology.impl.LibertyServerFactory;
     OpentracingTCKLauncher.class,
 // Temporary comment this out until MicroProfile-4.0 is available ... including MP Rest Client 2.0
 //    OpentracingTCKLauncherMicroProfile.class,
-    // OpentracingRestClientTCKLauncher.class //Disabled until MP Rest Client 2.0 is available
+    OpentracingRestClientTCKLauncher.class
 })
 public class FATSuite {
     private static final String FEATURE_NAME = "io.openliberty.opentracing.mock-2.0.mf";

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/publish/servers/OpentracingRestClientTCKServer/server.xml
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/publish/servers/OpentracingRestClientTCKServer/server.xml
@@ -10,7 +10,7 @@
         <feature>localConnector-1.0</feature>
         <feature>mpOpenTracing-2.0</feature>
         <feature>usr:opentracingMock-2.0</feature>
-        <feature>mpRestClient-1.4</feature>
+        <feature>mpRestClient-2.0</feature>
         <feature>arquillian-support-1.0</feature>
     </featureManager>
 


### PR DESCRIPTION
PR #13949 temporary disabled mpOT 2.0 rest client tests.  This PR re-enable them after mpRestClient-2.0 is delivered.

Fixes #14222 