### PR TITLE
Update to not reference na.artifactory directly in build.gradle files.

### DIFF
--- a/dev/com.ibm.ws.cdi.third.party_fat/build.gradle
+++ b/dev/com.ibm.ws.cdi.third.party_fat/build.gradle
@@ -17,7 +17,7 @@ repositories {
         username userProps.getProperty("artifactory.download.user")
         password userProps.getProperty("artifactory.download.token")
       }
-      url ("https://na.artifactory.swg-devops.com/artifactory/wasliberty-maven-remote")
+      url ("https://" + gradle.userProps.getProperty("artifactory.download.server") + "/artifactory/wasliberty-maven-remote")
     }
   } else {
     mavenCentral()

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/build.gradle
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/build.gradle
@@ -15,7 +15,7 @@ repositories {
         username userProps.getProperty("artifactory.download.user")
         password userProps.getProperty("artifactory.download.token")
       }
-      url ("https://na.artifactory.swg-devops.com/artifactory/wasliberty-maven-remote")
+      url ("https://" + gradle.userProps.getProperty("artifactory.download.server") + "/artifactory/wasliberty-maven-remote")
     }
   } else {
     mavenCentral()

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/build.gradle
@@ -16,7 +16,7 @@ repositories {
         username userProps.getProperty("artifactory.download.user")
         password userProps.getProperty("artifactory.download.token")
       }
-      url ("https://na.artifactory.swg-devops.com/artifactory/wasliberty-maven-remote")
+      url ("https://" + gradle.userProps.getProperty("artifactory.download.server") + "/artifactory/wasliberty-maven-remote")
     }
   } else {
     mavenCentral()

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/build.gradle
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/build.gradle
@@ -16,7 +16,7 @@ repositories {
         username userProps.getProperty("artifactory.download.user")
         password userProps.getProperty("artifactory.download.token")
       }
-      url ("https://na.artifactory.swg-devops.com/artifactory/wasliberty-maven-remote")
+      url ("https://" + gradle.userProps.getProperty("artifactory.download.server") + "/artifactory/wasliberty-maven-remote")
     }
   } else {
     mavenCentral()

--- a/dev/com.ibm.ws.jaxrs.2.1_fat/build.gradle
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat/build.gradle
@@ -16,7 +16,7 @@ repositories {
         username userProps.getProperty("artifactory.download.user")
         password userProps.getProperty("artifactory.download.token")
       }
-      url ("https://na.artifactory.swg-devops.com/artifactory/wasliberty-maven-remote")
+      url ("https://" + gradle.userProps.getProperty("artifactory.download.server") + "/artifactory/wasliberty-maven-remote")
     }
   } else {
     mavenCentral()

--- a/dev/com.ibm.ws.jaxrs.2.x.webcontainer_fat/build.gradle
+++ b/dev/com.ibm.ws.jaxrs.2.x.webcontainer_fat/build.gradle
@@ -16,7 +16,7 @@ repositories {
         username userProps.getProperty("artifactory.download.user")
         password userProps.getProperty("artifactory.download.token")
       }
-      url ("https://na.artifactory.swg-devops.com/artifactory/wasliberty-maven-remote")
+      url ("https://" + gradle.userProps.getProperty("artifactory.download.server") + "/artifactory/wasliberty-maven-remote")
     }
   } else {
     mavenCentral()

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/build.gradle
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/build.gradle
@@ -16,7 +16,7 @@ repositories {
         username userProps.getProperty("artifactory.download.user")
         password userProps.getProperty("artifactory.download.token")
       }
-      url ("https://na.artifactory.swg-devops.com/artifactory/wasliberty-maven-remote")
+      url ("https://" + gradle.userProps.getProperty("artifactory.download.server") + "/artifactory/wasliberty-maven-remote")
     }
   } else {
     mavenCentral()

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/build.gradle
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/build.gradle
@@ -15,7 +15,7 @@ repositories {
         username userProps.getProperty("artifactory.download.user")
         password userProps.getProperty("artifactory.download.token")
       }
-      url ("https://na.artifactory.swg-devops.com/artifactory/wasliberty-maven-remote")
+      url ("https://" + gradle.userProps.getProperty("artifactory.download.server") + "/artifactory/wasliberty-maven-remote")
     }
   } else {
     mavenCentral()

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/build.gradle
@@ -15,7 +15,7 @@ repositories {
         username userProps.getProperty("artifactory.download.user")
         password userProps.getProperty("artifactory.download.token")
       }
-      url ("https://na.artifactory.swg-devops.com/artifactory/wasliberty-maven-remote")
+      url ("https://" + gradle.userProps.getProperty("artifactory.download.server") + "/artifactory/wasliberty-maven-remote")
     }
   } else {
     mavenCentral()

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/build.gradle
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/build.gradle
@@ -5,7 +5,7 @@ repositories {
         username userProps.getProperty("artifactory.download.user")
         password userProps.getProperty("artifactory.download.token")
       }
-      url ("https://na.artifactory.swg-devops.com/artifactory/wasliberty-maven-remote")
+      url ("https://" + gradle.userProps.getProperty("artifactory.download.server") + "/artifactory/wasliberty-maven-remote")
     }
   } else {
     mavenCentral()


### PR DESCRIPTION
- Change to look up the artifactory server location instead of being
hardcoded to na.  This allows to use either na or eu server depending on
configuration.
