### PR TITLE
Issue 14582: Prevent jsonp-1.0 and jsonpContainer-1.1 from both starting

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jsonpImpl-1.0.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jsonpImpl-1.0.0.feature
@@ -1,0 +1,11 @@
+# This private impl feature corresponds to JSON-P 1.0 with the Glassfish implementation
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=com.ibm.websphere.appserver.jsonpImpl-1.0.0
+WLP-DisableAllFeatures-OnConflict: false
+singleton=true
+visibility=private
+-bundles=com.ibm.websphere.javaee.jsonp.1.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.json:javax.json-api:1.0", \
+ com.ibm.ws.org.glassfish.json.1.0
+kind=ga
+edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jsonpImpl-1.1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jsonpImpl-1.1.0.feature
@@ -7,6 +7,6 @@ singleton=true
 visibility=private
 -features=com.ibm.websphere.appserver.bells-1.0,\
   com.ibm.websphere.appserver.eeCompatible-8.0
--bundles=com.ibm.websphere.javaee.jsonp.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.json:javax.json-api:1.1.2"
+-bundles=com.ibm.websphere.javaee.jsonp.1.1; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.json:javax.json-api:1.1.3"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsonp-1.0/com.ibm.websphere.appserver.jsonp-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsonp-1.0/com.ibm.websphere.appserver.jsonp-1.0.feature
@@ -8,8 +8,7 @@ IBM-API-Package: javax.json; type="spec", \
  javax.json.spi; type="spec"
 IBM-ShortName: jsonp-1.0
 Subsystem-Name: JavaScript Object Notation Processing 1.0
--bundles=com.ibm.websphere.javaee.jsonp.1.0; location:="dev/api/spec/,lib/"; mavenCoordinates="javax.json:javax.json-api:1.0", \
- com.ibm.ws.org.glassfish.json.1.0
+-features=com.ibm.websphere.appserver.jsonpImpl-1.0.0
 kind=ga
 edition=core
 WLP-Activation-Type: parallel


### PR DESCRIPTION
Make jsonp-1.0 and jsonpContainer-1.1 throw the following error when both are configured in server xml:

`[10/20/20, 11:13:37:020 CDT] 0000002b com.ibm.ws.kernel.feature.internal.FeatureManager            E CWWKF0033E: The singleton features com.ibm.websphere.appserver.jsonpImpl-1.1.0 and com.ibm.websphere.appserver.jsonpImpl-1.0.0 cannot be loaded at the same time.  The configured features jsonpContainer-1.1 and jsonp-1.0 include one or more features that cause the conflict. Your configuration is not supported; update server.xml to remove incompatible features.

[10/20/20, 11:13:37:025 CDT] 0000002b com.ibm.ws.logging.internal.impl.IncidentImpl                I FFDC1015I: An FFDC Incident has been created: "java.lang.IllegalArgumentException: Unable to load conflicting versions of features "com.ibm.websphere.appserver.jsonpImpl-1.1.0" and "com.ibm.websphere.appserver.jsonpImpl-1.0.0".  The feature dependency chains that led to the conflict are: com.ibm.websphere.appserver.jsonpContainer-1.1 -> com.ibm.websphere.appserver.jsonpImpl-1.1.0 and com.ibm.websphere.appserver.jsonp-1.0 -> com.ibm.websphere.appserver.jsonpImpl-1.0.0 com.ibm.ws.kernel.feature.internal.FeatureManager reportErrors" at ffdc_20.10.20_11.13.37.0.log
`

fixes https://github.com/OpenLiberty/open-liberty/issues/14582