### PR TITLE
extension point for WorkManager built on managed executors

### DIFF
--- a/dev/com.ibm.ws.concurrent/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent/bnd.bnd
@@ -21,7 +21,12 @@ IBM-Default-Config: OSGI-INF/wlp/defaultInstances.xml
 
 Export-Package:\
   com.ibm.ws.concurrent,\
+  com.ibm.ws.concurrent.ext,\
   com.ibm.ws.concurrent.mp.spi.*
+
+Import-Package:\
+  org.eclipse.microprofile.context; version="[1.0.0,2.0.0)",\
+  *
 
 Private-Package:\
   com.ibm.ws.concurrent.internal.*,\
@@ -33,6 +38,7 @@ Include-Resource:\
 jakartaeeMe: true
 
 -dsannotations: \
+  com.ibm.ws.concurrent.internal.ConcurrencyService,\
   com.ibm.ws.concurrent.internal.ContextServiceImpl,\
   com.ibm.ws.concurrent.internal.ManagedExecutorServiceImpl,\
   com.ibm.ws.concurrent.internal.ManagedScheduledExecutorServiceImpl
@@ -66,7 +72,6 @@ instrument.classesExcludes: com/ibm/ws/concurrent/resources/*.class
 	com.ibm.websphere.appserver.spi.kernel.service,\
 	com.ibm.websphere.appserver.spi.logging,\
 	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
-	com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.0,\
 	com.ibm.websphere.org.osgi.core,\
 	com.ibm.websphere.org.osgi.service.component,\
 	com.ibm.ws.app.manager.lifecycle;version=latest,\
@@ -80,4 +85,5 @@ instrument.classesExcludes: com/ibm/ws/concurrent/resources/*.class
 	com.ibm.ws.resource;version=latest,\
 	com.ibm.ws.threading;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations,\
-	com.ibm.wsspi.org.osgi.service.metatype.annotations;version=latest
+	com.ibm.wsspi.org.osgi.service.metatype.annotations;version=latest,\
+	io.openliberty.org.eclipse.microprofile.contextpropagation.1.1

--- a/dev/com.ibm.ws.concurrent/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.concurrent/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017,2020 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -88,6 +88,18 @@
   <AD id="maxPriority"                        type="Integer" required="false" max="10" min="1" name="%maxPriority" description="%maxPriority.desc"/>
   <AD id="service.ranking"                    type="Integer" default="-1000" name="internal" description="internal use only"/>
   <AD id="javaCompDefaultName"                type="String"  required="false" name="internal" description="internal use only" />  
+ </OCD>
+
+ <!-- Concurrency Service (internal) -->
+
+ <Designate pid="com.ibm.ws.concurrent.internal.ConcurrencyService">
+  <Object ocdref="com.ibm.ws.concurrent.service"/>
+ </Designate>
+
+ <OCD id="com.ibm.ws.concurrent.service" ibm:alias="concurrencyService" name="internal" description="internal use only">
+  <AD id="extensionProvider.cardinality.minimum" type="String"  ibm:final="true" default="${count(extensionProvider.component.name)}" name="internal" description="internal use only"/>
+  <AD id="extensionProvider.component.name"      type="String"  required="false" name="internal" description="internal use only"/>
+  <AD id="extensionProvider.target"              type="String"  ibm:final="true" default="(component.name=${extensionProvider.component.name})" name="internal" description="internal use only"/>
  </OCD>
 
 </metatype:MetaData>

--- a/dev/com.ibm.ws.concurrent/resources/OSGI-INF/wlp/defaultInstances.xml
+++ b/dev/com.ibm.ws.concurrent/resources/OSGI-INF/wlp/defaultInstances.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017,2020 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
         IBM Corporation - initial API and implementation
  -->
 <server>
+  <concurrencyService/>
 
   <contextService id="DefaultContextService" javaCompDefaultName="DefaultContextService" service.ranking="100">
     <classloaderContext/>

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/ext/ConcurrencyExtensionProvider.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/ext/ConcurrencyExtensionProvider.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.ext;
+
+import com.ibm.ws.concurrent.WSManagedExecutorService;
+import com.ibm.wsspi.resource.ResourceInfo;
+
+/**
+ * Interface by which a single provider implementation can be plugged in
+ * to intercept and replace resource reference lookups for
+ * <code>managedExecutorService</code> and
+ * <code>managedScheduledExecutorService</code>.
+ *
+ * At most one provider implementation can be supplied across the entire system.
+ * A feature that provides this extension point makes itself incompatible
+ * with every other feature that provides this extension point.
+ * Do not implement if this restriction is unacceptable.
+ */
+public interface ConcurrencyExtensionProvider {
+    /**
+     * Invoked by ResourceFactory.createResource as an extension point,
+     * whereby the implementer of this method can supply the managed executor
+     * instance that is returned to the application for resource reference lookups.
+     *
+     * @param executor     managed executor instance that would normally be used for the
+     *                         resource reference lookup.
+     * @param resourceInfo resource reference information.
+     * @return managed executor instance to use instead as the result of the
+     *         resource reference lookup.
+     */
+    ManagedExecutorExtension provide(WSManagedExecutorService executor, ResourceInfo resourceInfo);
+}

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/ext/ManagedExecutorExtension.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/ext/ManagedExecutorExtension.java
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.ext;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+import javax.enterprise.concurrent.ManagedExecutorService;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.eclipse.microprofile.context.ThreadContext;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.concurrent.WSManagedExecutorService;
+import com.ibm.ws.threading.CompletionStageExecutor;
+import com.ibm.ws.threading.PolicyExecutor;
+import com.ibm.wsspi.resource.ResourceInfo;
+import com.ibm.wsspi.threadcontext.WSContextService;
+
+/**
+ * Extend this interface to intercept and replace resource reference lookups for
+ * <code>managedExecutorService</code>.
+ *
+ * At most one extension implementation can be supplied across the entire system.
+ * A feature that provides this extension point makes itself incompatible
+ * with every other feature that also provides this extension point.
+ * Do not implement if this restriction is unacceptable.
+ */
+@Trivial
+public class ManagedExecutorExtension implements CompletionStageExecutor, ManagedExecutor, ManagedExecutorService, WSManagedExecutorService {
+    private final WSManagedExecutorService executor;
+
+    protected ManagedExecutorExtension(WSManagedExecutorService executor, ResourceInfo resourceInfo) {
+        this.executor = executor;
+    }
+
+    @Override
+    public final boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return ((ExecutorService) executor).awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public final <U> CompletableFuture<U> completedFuture(U value) {
+        return ((ManagedExecutor) executor).completedFuture(value);
+    }
+
+    @Override
+    public final <U> CompletionStage<U> completedStage(U value) {
+        return ((ManagedExecutor) executor).completedStage(value);
+    }
+
+    @Override
+    public final <T> CompletableFuture<T> copy(CompletableFuture<T> future) {
+        return ((ManagedExecutor) executor).copy(future);
+    }
+
+    @Override
+    public final <T> CompletionStage<T> copy(CompletionStage<T> stage) {
+        return ((ManagedExecutor) executor).copy(stage);
+    }
+
+    @Override
+    public final void execute(Runnable command) {
+        ((ExecutorService) executor).execute(command);
+    }
+
+    @Override
+    public final <U> CompletableFuture<U> failedFuture(Throwable x) {
+        return ((ManagedExecutor) executor).failedFuture(x);
+    }
+
+    @Override
+    public final <U> CompletionStage<U> failedStage(Throwable x) {
+        return ((ManagedExecutor) executor).failedStage(x);
+    }
+
+    @Override
+    public final WSContextService getContextService() {
+        return executor.getContextService();
+    }
+
+    @Override
+    public final PolicyExecutor getNormalPolicyExecutor() {
+        return executor.getNormalPolicyExecutor();
+    }
+
+    @Override
+    public final ThreadContext getThreadContext() {
+        return ((ManagedExecutor) executor).getThreadContext();
+    }
+
+    @Override
+    public final <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return ((ExecutorService) executor).invokeAll(tasks);
+    }
+
+    @Override
+    public final <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+        return ((ExecutorService) executor).invokeAll(tasks, timeout, unit);
+    }
+
+    @Override
+    public final <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return ((ExecutorService) executor).invokeAny(tasks);
+    }
+
+    @Override
+    public final <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return ((ExecutorService) executor).invokeAny(tasks, timeout, unit);
+    }
+
+    @Override
+    public final boolean isShutdown() {
+        return ((ExecutorService) executor).isShutdown();
+    }
+
+    @Override
+    public final boolean isTerminated() {
+        return ((ExecutorService) executor).isTerminated();
+    }
+
+    @Override
+    public final <T> CompletableFuture<T> newIncompleteFuture() {
+        return ((ManagedExecutor) executor).newIncompleteFuture();
+    }
+
+    @Override
+    public final CompletableFuture<Void> runAsync(Runnable action) {
+        return ((ManagedExecutor) executor).runAsync(action);
+    }
+
+    @Override
+    public final void shutdown() {
+        ((ExecutorService) executor).shutdown();
+    }
+
+    @Override
+    public final List<Runnable> shutdownNow() {
+        return ((ExecutorService) executor).shutdownNow();
+    }
+
+    @Override
+    public final <T> Future<T> submit(Callable<T> task) {
+        return ((ExecutorService) executor).submit(task);
+    }
+
+    @Override
+    public final <T> Future<T> submit(Runnable task, T result) {
+        return ((ExecutorService) executor).submit(task, result);
+    }
+
+    @Override
+    public final Future<?> submit(Runnable task) {
+        return ((ExecutorService) executor).submit(task);
+    }
+
+    @Override
+    public final <T> CompletableFuture<T> supplyAsync(Supplier<T> supplier) {
+        return ((ManagedExecutor) executor).supplyAsync(supplier);
+    }
+}

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/ext/ManagedScheduledExecutorExtension.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/ext/ManagedScheduledExecutorExtension.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.ext;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import javax.enterprise.concurrent.ManagedScheduledExecutorService;
+import javax.enterprise.concurrent.Trigger;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.concurrent.WSManagedExecutorService;
+import com.ibm.wsspi.resource.ResourceInfo;
+
+/**
+ * Extend this interface to intercept and replace resource reference lookups for
+ * <code>managedScheduledExecutorService</code>.
+ *
+ * At most one extension implementation can be supplied across the entire system.
+ * A feature that provides this extension point makes itself incompatible
+ * with every other feature that also provides this extension point.
+ * Do not implement if this restriction is unacceptable.
+ */
+@Trivial
+public class ManagedScheduledExecutorExtension extends ManagedExecutorExtension implements ManagedScheduledExecutorService {
+    private final ManagedScheduledExecutorService scheduledExecutor;
+
+    protected ManagedScheduledExecutorExtension(WSManagedExecutorService executor, ResourceInfo resourceInfo) {
+        super(executor, resourceInfo);
+        this.scheduledExecutor = (ManagedScheduledExecutorService) executor;
+    }
+
+    @Override
+    public final <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        return scheduledExecutor.schedule(callable, delay, unit);
+    }
+
+    @Override
+    public final <V> ScheduledFuture<V> schedule(Callable<V> callable, Trigger trigger) {
+        return scheduledExecutor.schedule(callable, trigger);
+    }
+
+    @Override
+    public final ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        return scheduledExecutor.schedule(command, delay, unit);
+    }
+
+    @Override
+    public final ScheduledFuture<?> schedule(Runnable command, Trigger trigger) {
+        return scheduledExecutor.schedule(command, trigger);
+    }
+
+    @Override
+    public final ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        return scheduledExecutor.scheduleAtFixedRate(command, initialDelay, period, unit);
+    }
+
+    @Override
+    public final ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        return scheduledExecutor.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+    }
+}

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/ext/package-info.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/ext/package-info.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+@TraceOptions(traceGroup = "concurrent", messageBundle = "com.ibm.ws.concurrent.resources.CWWKCMessages")
+package com.ibm.ws.concurrent.ext;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ConcurrencyService.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ConcurrencyService.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.internal;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+
+import com.ibm.ws.concurrent.ext.ConcurrencyExtensionProvider;
+
+@Component(configurationPolicy = ConfigurationPolicy.REQUIRE, service = ConcurrencyService.class)
+public class ConcurrencyService {
+    @Reference(policy = ReferencePolicy.STATIC, cardinality = ReferenceCardinality.OPTIONAL, target = "(id=unbound)")
+    ConcurrencyExtensionProvider extensionProvider;
+}

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedScheduledExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedScheduledExecutorServiceImpl.java
@@ -207,6 +207,13 @@ public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceI
     }
 
     @Override
+    @Reference(policy = ReferencePolicy.STATIC)
+    @Trivial
+    protected void setConcurrencyService(ConcurrencyService svc) {
+        super.setConcurrencyService(svc);
+    }
+
+    @Override
     @Reference(policy = ReferencePolicy.DYNAMIC, target = "(id=unbound)")
     @Trivial
     protected void setContextService(ServiceReference<WSContextService> ref) {
@@ -246,6 +253,12 @@ public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceI
     @Trivial
     protected void unsetConcurrencyPolicy(ConcurrencyPolicy svc) {
         super.unsetConcurrencyPolicy(svc);
+    }
+
+    @Override
+    @Trivial
+    protected void unsetConcurrencyService(ConcurrencyService svc) {
+        super.unsetConcurrencyService(svc);
     }
 
     @Override


### PR DESCRIPTION
Create an extension point so that a feature can be written on top of the managed executors and context service to provide an implementation of CommonJ WorkManager.