### PR TITLE
Update to not format method parameters when audit isn't enabled

### DIFF
--- a/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/event/EJBAuthorizationEvent.java
+++ b/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/event/EJBAuthorizationEvent.java
@@ -25,6 +25,7 @@ import com.ibm.websphere.security.audit.AuditAuthenticationResult;
 import com.ibm.websphere.security.audit.AuditConstants;
 import com.ibm.websphere.security.audit.AuditEvent;
 import com.ibm.ws.security.audit.utils.AuditUtils;
+import com.ibm.ws.security.audit.utils.ParameterUtils;
 import com.ibm.ws.webcontainer.security.WebRequest;
 
 /**
@@ -125,7 +126,7 @@ public class EJBAuthorizationEvent extends AuditEvent {
             }
 
             if (request.get("methodParameters") != null) {
-                set(AuditEvent.TARGET_EJB_METHOD_PARAMETERS, request.get("methodParameters").toString());
+                set(AuditEvent.TARGET_EJB_METHOD_PARAMETERS, ParameterUtils.format(request.get("methodParameters")).toString());
             }
 
             if (request.get(AuditEvent.REASON_TYPE) != null)

--- a/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/event/JACCEJBAuthorizationEvent.java
+++ b/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/event/JACCEJBAuthorizationEvent.java
@@ -25,6 +25,7 @@ import com.ibm.websphere.security.audit.AuditAuthenticationResult;
 import com.ibm.websphere.security.audit.AuditConstants;
 import com.ibm.websphere.security.audit.AuditEvent;
 import com.ibm.ws.security.audit.utils.AuditUtils;
+import com.ibm.ws.security.audit.utils.ParameterUtils;
 import com.ibm.ws.webcontainer.security.WebRequest;
 
 /**
@@ -125,7 +126,7 @@ public class JACCEJBAuthorizationEvent extends AuditEvent {
             }
 
             if (request.get("methodParameters") != null) {
-                set(AuditEvent.TARGET_EJB_METHOD_PARAMETERS, request.get("methodParameters").toString());
+                set(AuditEvent.TARGET_EJB_METHOD_PARAMETERS, ParameterUtils.format(request.get("methodParameters")).toString());
             }
 
             set(AuditEvent.REASON_TYPE, AuditEvent.EJB);

--- a/dev/com.ibm.ws.security.audit.utils/src/com/ibm/ws/security/audit/utils/ParameterUtils.java
+++ b/dev/com.ibm.ws.security.audit.utils/src/com/ibm/ws/security/audit/utils/ParameterUtils.java
@@ -51,11 +51,11 @@ public class ParameterUtils {
 
     static private String ToString(Object object) {
         String value = null;
-        // it is potential that toString() method throws an exception.
-        // so if that's the case, catch it and substitution. 
-        try {
+        if (object instanceof Number || object instanceof Boolean) {
             value = object.toString();
-        } catch (Exception e) {
+        } else if (object instanceof String){
+            value = (String) object;
+        } else {
             value = object.getClass().getName() + '@' + System.identityHashCode(object);
         }
         return value;

--- a/dev/com.ibm.ws.security.audit.utils/test/com/ibm/ws/security/audit/utils/ParameterUtilsTest.java
+++ b/dev/com.ibm.ws.security.audit.utils/test/com/ibm/ws/security/audit/utils/ParameterUtilsTest.java
@@ -68,7 +68,9 @@ public class ParameterUtilsTest {
         TestObject[] nestedparam = { new TestObject("nested1"), new TestObject("nested2") };
         Object[] param = { nestedparam, new TestObject("root1") };
         StringBuffer output = ParameterUtils.format(param);
-        assertEquals("The output does not match.", "[[TestObject-nested1, TestObject-nested2], TestObject-root1]", output.toString());
+        assertEquals("The output does not match.", "[[com.ibm.ws.security.audit.utils.ParameterUtilsTest$TestObject@" + System.identityHashCode(nestedparam[0]) + 
+                ", com.ibm.ws.security.audit.utils.ParameterUtilsTest$TestObject@" + System.identityHashCode(nestedparam[1]) + 
+                "], com.ibm.ws.security.audit.utils.ParameterUtilsTest$TestObject@" + System.identityHashCode(param[1]) + "]", output.toString());
     }
 
     @Test


### PR DESCRIPTION
- Whether audit is enabled or not we were formatting the method parameters.  Moved to do the formatting where it is actually used.
- Additionally the maps used for the passing of ejb invocation data were class scoped which is wrong and should have been method scoped.  This could result into memory leaks as was fixed in PR #7987 and hang
conditions when multiple threads are accessing the HashMap concurrently since it is not thread safe.
- Update to not call toString on the method parameters, but instead use the default toString to avoid expensive toString operations.

fixes #14597