### PR TITLE
Create ConversationScopedTest in jsfContainer 2.3 FAT

### DIFF
--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/.classpath
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/.classpath
@@ -13,6 +13,7 @@
 	<classpathentry kind="src" path="test-applications/JSF22CDIFacesFlows/src"/>
 	<classpathentry kind="src" path="test-applications/JSF22StatelessView/src"/>
 	<classpathentry kind="src" path="test-applications/noJsfApp/src"/>
+	<classpathentry kind="src" path="test-applications/ConversationScopedTest/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/bnd.bnd
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -25,7 +25,8 @@ src: \
     test-applications/noJsfApp/src,\
     test-applications/PostRenderViewEvent/src,\
     test-applications/ViewHandlerTest/src,\
-    test-applications/WebSocket/src
+    test-applications/WebSocket/src,\
+    test-applications/ConversationScopedTest/src
 
 fat.project: true
 
@@ -41,4 +42,3 @@ fat.project: true
 	com.ibm.websphere.javaee.validation.2.0;version=latest,\
 	net.sourceforge.htmlunit:htmlunit;version=2.20,\
 	xml-apis:xml-apis;version=1.4.01
-

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConversationScopedTest/resources/WEB-INF/faces-config.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConversationScopedTest/resources/WEB-INF/faces-config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<faces-config
+    xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_3.xsd"
+    version="2.3">
+
+</faces-config>

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConversationScopedTest/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConversationScopedTest/resources/WEB-INF/web.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<web-app id="WebApp_ID" version="4.0"
+    xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd">
+
+    <servlet>
+        <servlet-name>faces</servlet-name>
+        <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>faces</servlet-name>
+        <url-pattern>*.xhtml</url-pattern>
+    </servlet-mapping>
+
+</web-app>

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConversationScopedTest/resources/index.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConversationScopedTest/resources/index.xhtml
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<html xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:h="http://xmlns.jcp.org/jsf/html">
+<h:head>
+    <title> ConversationScoped Test </title>
+</h:head>
+<h:body>
+    <h:form  id="form1">
+        <h:outputText value="Value is #{conversationScopedBean.count}" />
+        <h:commandButton  id="incrementButton" action="#{conversationScopedBean.incrementCount}" value="Increment" />
+        <h:commandButton  id="continueButton" action="#{conversationScopedBean.nextPage}" value="Continue" />
+    </h:form>
+</h:body>
+</html>

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConversationScopedTest/resources/page2.xhtml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConversationScopedTest/resources/page2.xhtml
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<html xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:h="http://xmlns.jcp.org/jsf/html">
+<h:head>
+      <title> ConversationScoped Test </title>
+</h:head>
+<h:body>
+    <h:form  id="form2" >
+        <h:outputText value="Value is #{conversationScopedBean.count}" />
+        <h:commandButton  id="endButton" action="#{conversationScopedBean.end}" value="End Conversation" />
+    </h:form>
+</h:body>
+</html>

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConversationScopedTest/src/com/ibm/ws/jsf/conversationscoped/bean/ConversationScopedBean.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/test-applications/ConversationScopedTest/src/com/ibm/ws/jsf/conversationscoped/bean/ConversationScopedBean.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jsf.conversationscoped.bean;
+
+import java.io.Serializable;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Conversation;
+import javax.enterprise.context.ConversationScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named
+@ConversationScoped
+public class ConversationScopedBean implements Serializable {
+
+    @Inject
+    private Conversation conversation;
+
+    private int count;
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+
+    @PostConstruct
+    public void init(){
+          conversation.begin();
+          count = 0;
+    }
+
+    public Conversation getConversation() {
+        return conversation;
+    }
+
+    public void incrementCount(){
+        this.count++;
+    }
+
+    public String nextPage(){
+        return "page2?faces-redirect=true";
+    }
+
+    public String end(){
+        conversation.end();
+        return "index?faces-redirect=true";
+    }
+
+}


### PR DESCRIPTION
Fixes #14527

ConversationScopedTest is needed to ensure the ConversationScoped Beans works properly when  using the IBMViewHandlerProxy & FacesUrlTransformer classes. 

See them here: https://github.com/OpenLiberty/open-liberty/tree/464735a8588770d8ce055a4505f53c9a029b12ab/dev/com.ibm.ws.jsfContainer/src/com/ibm/ws/jsf/container/cdi