### PR TITLE
[14611] Tolerate mpConfig-2.0

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL-1.0/com.ibm.websphere.appserver.mpGraphQL-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL-1.0/com.ibm.websphere.appserver.mpGraphQL-1.0.feature
@@ -9,7 +9,7 @@ IBM-API-Package: org.eclipse.microprofile.graphql; type="stable", \
 IBM-ShortName: mpGraphQL-1.0
 Subsystem-Name: MicroProfile GraphQL 1.0
 -features=com.ibm.websphere.appserver.org.eclipse.microprofile.graphql-1.0, \
- com.ibm.websphere.appserver.mpConfig-1.4,\
+ com.ibm.websphere.appserver.mpConfig-1.4; ibm.tolerates:=2.0,\
  com.ibm.websphere.appserver.cdi-2.0,\
  com.ibm.websphere.appserver.javax.annotation-1.3, \
  com.ibm.websphere.appserver.jsonb-1.0, \

--- a/dev/com.ibm.ws.io.smallrye.graphql/bnd.bnd
+++ b/dev/com.ibm.ws.io.smallrye.graphql/bnd.bnd
@@ -19,6 +19,9 @@ Bundle-Description: SmallRye implementation of MicroProfile GraphQL
 
 Import-Package: \
   graphql.util,\
+  org.eclipse.microprofile.config;version="[1.0,2.1)",\
+  org.eclipse.microprofile.config.inject;version="[1.0,2.1)",\
+  org.eclipse.microprofile.config.spi;version="[1.0,2.1)",\
   !io.smallrye.metrics,\
   !io.opentracing,\
   !io.smallrye.common.annotation,\

--- a/dev/com.ibm.ws.io.smallrye.graphql/src/com/ibm/ws/io/smallrye/graphql/component/GraphQLServletContainerInitializer.java
+++ b/dev/com.ibm.ws.io.smallrye.graphql/src/com/ibm/ws/io/smallrye/graphql/component/GraphQLServletContainerInitializer.java
@@ -16,6 +16,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -130,13 +131,15 @@ public class GraphQLServletContainerInitializer implements ServletContainerIniti
 
         	@Override
             public Optional<List<String>> getHideErrorMessageList() {
-                return Optional.ofNullable(ConfigFacade.getOptionalValue(ConfigKey.EXCEPTION_BLACK_LIST, List.class)
+                return Optional.ofNullable(ConfigFacade.getOptionalValue(ConfigKey.EXCEPTION_BLACK_LIST, String.class)
+                		                               .map(s -> Arrays.asList(s.split(",")))
                                                        .orElse(null));
             }
 
         	@Override
             public Optional<List<String>> getShowErrorMessageList() {
-                return Optional.ofNullable(ConfigFacade.getOptionalValue(ConfigKey.EXCEPTION_WHITE_LIST, List.class)
+                return Optional.ofNullable(ConfigFacade.getOptionalValue(ConfigKey.EXCEPTION_WHITE_LIST, String.class)
+                		                               .map(s -> Arrays.asList(s.split(",")))
                                                        .orElse(null));
             }
 

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/bnd.bnd
@@ -32,7 +32,7 @@ src: \
 fat.project: true
 
 
-tested.features: mpMetrics-2.0
+tested.features: mpMetrics-2.0, mpConfig-2.0, mpMetrics-3.0, mpRestClient-2.0
 
 -buildpath: \
   com.ibm.websphere.javaee.annotation.1.2;version=latest,\

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/FATSuite.java
@@ -13,9 +13,13 @@ package com.ibm.ws.microprofile.graphql.fat;
 import java.io.File;
 
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
 
 
 @RunWith(Suite.class)
@@ -38,6 +42,13 @@ import org.junit.runners.Suite.SuiteClasses;
                 VoidQueryTest.class
 })
 public class FATSuite {
+    @ClassRule
+    public static RepeatTests r = RepeatTests.withoutModification()
+                                             .andWith(new FeatureReplacementAction("mpConfig-1.4", "mpConfig-2.0")
+                                                      .addFeature("mpMetrics-3.0").removeFeature("mpMetrics-2.3")
+                                                      .addFeature("mpRestClient-2.0").removeFeature("mpRestClient-1.4")
+                                                      .withID("mp4.0"));
+
     public static void addSmallRyeGraphQLClientLibraries(WebArchive webArchive) {
         File libs = new File("publish/shared/resources/smallryeGraphQLClient/");
         webArchive.addAsLibraries(libs.listFiles());

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/JarInWarTest.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/JarInWarTest.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package com.ibm.ws.microprofile.graphql.fat;
 
-import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/RolesAuthTest.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/RolesAuthTest.java
@@ -12,7 +12,6 @@ package com.ibm.ws.microprofile.graphql.fat;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -20,8 +19,6 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
@@ -31,10 +28,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 @RunWith(FATRunner.class)
 public class RolesAuthTest extends FATServletClient {
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(new FeatureReplacementAction("appSecurity-3.0", "appSecurity-2.0"));
 
     private static final String SERVER = "mpGraphQL10.rolesAuth";
     private static final String APP_NAME = "rolesAuthApp";

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.basicMutation/server.xml
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.basicMutation/server.xml
@@ -1,9 +1,9 @@
 <server>
   <featureManager>
     <feature>componenttest-1.0</feature>
-    <feature>mpRestClient-1.2</feature>
+    <feature>mpRestClient-1.4</feature>
     <feature>mpGraphQL-1.0</feature>
-    <feature>mpMetrics-1.1</feature>
+    <feature>mpMetrics-2.3</feature>
     <feature>jaxrsClient-2.1</feature>
     <feature>jsonp-1.1</feature>
     <feature>jsonb-1.0</feature>

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.basicQuery/server.xml
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.basicQuery/server.xml
@@ -1,7 +1,7 @@
 <server>
   <featureManager>
     <feature>componenttest-1.0</feature>
-    <feature>mpRestClient-1.2</feature>
+    <feature>mpRestClient-1.4</feature>
     <feature>mpGraphQL-1.0</feature>
     <feature>jaxrsClient-2.1</feature>
     <feature>jsonp-1.1</feature>
@@ -9,13 +9,6 @@
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>
-
-  <keyStore id="defaultKeyStore" password="passw0rd" />
-
-  <!--  the self-signed cert from the server should only be available in the client keystore -->
-  <ssl id="mySSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" />
-  <keyStore id="clientKeyStore" location="key.jks" type="JKS" password="passw0rd" />
-  <keyStore id="clientTrustStore" location="trust.jks" type="JKS" password="passw0rd" />
 
   <!--  Required to read the server's port system property -->
   <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.basicQueryWithConfig/server.xml
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.basicQueryWithConfig/server.xml
@@ -11,13 +11,6 @@
 
   <include location="../fatTestPorts.xml"/>
 
-  <keyStore id="defaultKeyStore" password="passw0rd" />
-
-  <!--  the self-signed cert from the server should only be available in the client keystore -->
-  <ssl id="mySSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" />
-  <keyStore id="clientKeyStore" location="key.jks" type="JKS" password="passw0rd" />
-  <keyStore id="clientTrustStore" location="trust.jks" type="JKS" password="passw0rd" />
-
   <!--  Required to read the server's port system property -->
   <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
 

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.defaultvalue/server.xml
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.defaultvalue/server.xml
@@ -1,7 +1,7 @@
 <server>
   <featureManager>
     <feature>componenttest-1.0</feature>
-    <feature>mpRestClient-1.2</feature>
+    <feature>mpRestClient-1.4</feature>
     <feature>mpGraphQL-1.0</feature>
     <feature>jaxrsClient-2.1</feature>
     <feature>jsonp-1.1</feature>
@@ -9,13 +9,6 @@
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>
-
-  <keyStore id="defaultKeyStore" password="passw0rd" />
-
-  <!--  the self-signed cert from the server should only be available in the client keystore -->
-  <ssl id="mySSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" />
-  <keyStore id="clientKeyStore" location="key.jks" type="JKS" password="passw0rd" />
-  <keyStore id="clientTrustStore" location="trust.jks" type="JKS" password="passw0rd" />
 
   <!--  Required to read the server's port system property -->
   <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.deprecation/server.xml
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.deprecation/server.xml
@@ -1,7 +1,7 @@
 <server>
   <featureManager>
     <feature>componenttest-1.0</feature>
-    <feature>mpRestClient-1.2</feature>
+    <feature>mpRestClient-1.4</feature>
     <feature>mpGraphQL-1.0</feature>
     <feature>jaxrsClient-2.1</feature>
     <feature>jsonp-1.1</feature>
@@ -9,13 +9,6 @@
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>
-
-  <keyStore id="defaultKeyStore" password="passw0rd" />
-
-  <!--  the self-signed cert from the server should only be available in the client keystore -->
-  <ssl id="mySSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" />
-  <keyStore id="clientKeyStore" location="key.jks" type="JKS" password="passw0rd" />
-  <keyStore id="clientTrustStore" location="trust.jks" type="JKS" password="passw0rd" />
 
   <!--  Required to read the server's port system property -->
   <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.graphQLInterface/server.xml
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.graphQLInterface/server.xml
@@ -1,7 +1,7 @@
 <server>
   <featureManager>
     <feature>componenttest-1.0</feature>
-    <feature>mpRestClient-1.2</feature>
+    <feature>mpRestClient-1.4</feature>
     <feature>mpGraphQL-1.0</feature>
     <feature>jaxrsClient-2.1</feature>
     <feature>jsonp-1.1</feature>
@@ -9,13 +9,6 @@
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>
-
-  <keyStore id="defaultKeyStore" password="passw0rd" />
-
-  <!--  the self-signed cert from the server should only be available in the client keystore -->
-  <ssl id="mySSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" />
-  <keyStore id="clientKeyStore" location="key.jks" type="JKS" password="passw0rd" />
-  <keyStore id="clientTrustStore" location="trust.jks" type="JKS" password="passw0rd" />
 
   <!--  Required to read the server's port system property -->
   <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.iface/server.xml
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.iface/server.xml
@@ -1,7 +1,7 @@
 <server>
   <featureManager>
     <feature>componenttest-1.0</feature>
-    <feature>mpRestClient-1.2</feature>
+    <feature>mpRestClient-1.4</feature>
     <feature>mpGraphQL-1.0</feature>
     <feature>jaxrsClient-2.1</feature>
     <feature>jsonp-1.1</feature>
@@ -9,13 +9,6 @@
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>
-
-  <keyStore id="defaultKeyStore" password="passw0rd" />
-
-  <!--  the self-signed cert from the server should only be available in the client keystore -->
-  <ssl id="mySSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" />
-  <keyStore id="clientKeyStore" location="key.jks" type="JKS" password="passw0rd" />
-  <keyStore id="clientTrustStore" location="trust.jks" type="JKS" password="passw0rd" />
 
   <!--  Required to read the server's port system property -->
   <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.ignore/server.xml
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.ignore/server.xml
@@ -1,7 +1,7 @@
 <server>
   <featureManager>
     <feature>componenttest-1.0</feature>
-    <feature>mpRestClient-1.2</feature>
+    <feature>mpRestClient-1.4</feature>
     <feature>mpGraphQL-1.0</feature>
     <feature>jaxrsClient-2.1</feature>
     <feature>jsonp-1.1</feature>
@@ -9,13 +9,6 @@
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>
-
-  <keyStore id="defaultKeyStore" password="passw0rd" />
-
-  <!--  the self-signed cert from the server should only be available in the client keystore -->
-  <ssl id="mySSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" />
-  <keyStore id="clientKeyStore" location="key.jks" type="JKS" password="passw0rd" />
-  <keyStore id="clientTrustStore" location="trust.jks" type="JKS" password="passw0rd" />
 
   <!--  Required to read the server's port system property -->
   <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.inputFields/server.xml
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.inputFields/server.xml
@@ -1,7 +1,7 @@
 <server>
   <featureManager>
     <feature>componenttest-1.0</feature>
-    <feature>mpRestClient-1.2</feature>
+    <feature>mpRestClient-1.4</feature>
     <feature>mpGraphQL-1.0</feature>
     <feature>jaxrsClient-2.1</feature>
     <feature>jsonp-1.1</feature>
@@ -9,13 +9,6 @@
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>
-
-  <keyStore id="defaultKeyStore" password="passw0rd" />
-
-  <!--  the self-signed cert from the server should only be available in the client keystore -->
-  <ssl id="mySSLConfig" keyStoreRef="clientKeyStore" trustStoreRef="clientTrustStore" />
-  <keyStore id="clientKeyStore" location="key.jks" type="JKS" password="passw0rd" />
-  <keyStore id="clientTrustStore" location="trust.jks" type="JKS" password="passw0rd" />
 
   <!--  Required to read the server's port system property -->
   <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.metrics/server.xml
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.metrics/server.xml
@@ -1,7 +1,7 @@
 <server>
   <featureManager>
     <feature>componenttest-1.0</feature>
-    <feature>mpRestClient-1.2</feature>
+    <feature>mpRestClient-1.4</feature>
     <feature>mpGraphQL-1.0</feature>
     <feature>mpMetrics-2.3</feature>
     <feature>jaxrsClient-2.1</feature>

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.outputFields/server.xml
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.outputFields/server.xml
@@ -1,7 +1,7 @@
 <server>
   <featureManager>
     <feature>componenttest-1.0</feature>
-    <feature>mpRestClient-1.2</feature>
+    <feature>mpRestClient-1.4</feature>
     <feature>mpGraphQL-1.0</feature>
     <feature>jaxrsClient-2.1</feature>
     <feature>jsonp-1.1</feature>

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.rolesAuth/server.xml
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.rolesAuth/server.xml
@@ -1,7 +1,7 @@
 <server>
    <featureManager>
      <feature>componenttest-1.0</feature>
-     <feature>mpRestClient-1.2</feature>
+     <feature>mpRestClient-1.4</feature>
      <feature>mpGraphQL-1.0</feature>
      <feature>jaxrsClient-2.1</feature>
      <feature>jsonp-1.1</feature>

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.types/server.xml
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.types/server.xml
@@ -1,7 +1,7 @@
 <server>
   <featureManager>
     <feature>componenttest-1.0</feature>
-    <feature>mpRestClient-1.2</feature>
+    <feature>mpRestClient-1.4</feature>
     <feature>mpGraphQL-1.0</feature>
     <feature>jaxrsClient-2.1</feature>
     <feature>jsonp-1.1</feature>

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.voidQuery/server.xml
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/publish/servers/mpGraphQL10.voidQuery/server.xml
@@ -1,7 +1,7 @@
 <server>
   <featureManager>
     <feature>componenttest-1.0</feature>
-    <feature>mpRestClient-1.2</feature>
+    <feature>mpRestClient-1.4</feature>
     <feature>mpGraphQL-1.0</feature>
     <feature>jaxrsClient-2.1</feature>
     <feature>jsonp-1.1</feature>

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/MetricsTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/test-applications/metricsApp/src/mpGraphQL10/metrics/MetricsTestServlet.java
@@ -41,6 +41,7 @@ import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
+import mpGraphQL10.metrics.Stats.SimpleTimerStat;
 
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = "/MetricsTestServlet")
@@ -112,7 +113,10 @@ public class MetricsTestServlet extends FATServlet {
         
         Stats stats = statsBuilder.register(LoggingFilter.class).build(StatsClient.class).getVendorStats();
         assertNotNull(stats);
-        assertEquals(3, stats.getCount().getCount());
+        SimpleTimerStat stat = stats.getCount();
+        if (stat != null) {
+            assertEquals(3, stat.getCount());
+        } //stat will be null when using MP 4.0, so only check it in MP 3.3
     }
 
     @Test
@@ -161,11 +165,13 @@ public class MetricsTestServlet extends FATServlet {
         //TODO: check mpMetrics shows that (1.5s + someBuffer) >= time_from_mpMetrics >= time_from_widget 
         Stats stats = statsBuilder.build(StatsClient.class).getVendorStats();
         assertNotNull(stats);
-        assertNotNull(stats.getTime());
-        assertEquals(3, stats.getTime().getCount());
-        Duration metricsDuration = Duration.ofNanos((long)stats.getTime().getElapsedTime());
-        Duration maxTimeDuration = Duration.ofMillis(1500 + PADDING_TIME);
-        assertTrue( maxTimeDuration.compareTo(metricsDuration) >= 0 );
-        assertTrue( Math.abs(metricsDuration.minus(runningDuration).toMillis()) <= PADDING_TIME);
+        SimpleTimerStat stat = stats.getTime();
+        if (stat != null) {
+            assertEquals(3, stat.getCount());
+            Duration metricsDuration = Duration.ofNanos((long)stat.getElapsedTime());
+            Duration maxTimeDuration = Duration.ofMillis(1500 + PADDING_TIME);
+            assertTrue( maxTimeDuration.compareTo(metricsDuration) >= 0 );
+            assertTrue( Math.abs(metricsDuration.minus(runningDuration).toMillis()) <= PADDING_TIME);
+        } //stat will be null when using MP 4.0, so only check it in MP 3.3
     }
 }

--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/fat/src/org/eclipse/microprofile/graphql/tck/GraphQLTckPackageTest.java
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/fat/src/org/eclipse/microprofile/graphql/tck/GraphQLTckPackageTest.java
@@ -12,12 +12,15 @@ package org.eclipse.microprofile.graphql.tck;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.MvnUtils;
 
@@ -27,6 +30,10 @@ import componenttest.topology.utils.MvnUtils;
  */
 @RunWith(FATRunner.class)
 public class GraphQLTckPackageTest {
+
+	@ClassRule
+	public static RepeatTests r = RepeatTests.withoutModification()
+	    .andWith(new FeatureReplacementAction("mpConfig-1.4", "mpConfig-2.0"));
 
     @Server("FATServer")
     public static LibertyServer server;


### PR DESCRIPTION
Be able to tolerate mpConfig-2.0 (MP 4.0) in mpGraphQL-1.0.

Fixes #14611 

Do not merge until solution is found for multiple mpConfig features installed at the same time.