### PR TITLE
Issue 14655: Only check on baseEntries after config processed

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.server/bnd.bnd
+++ b/dev/com.ibm.ws.security.openidconnect.server/bnd.bnd
@@ -184,6 +184,8 @@ Include-Resource: \
 	com.ibm.ws.org.slf4j.api.1.7.7;version=latest,\
 	com.ibm.ws.org.apache.commons.codec;version=latest,\
 	com.ibm.ws.security.token;version=latest,\
-	com.ibm.ws.security.jwt;version=latest
+	com.ibm.ws.security.jwt;version=latest, \
+	com.ibm.ws.runtime.update;version=latest, \
+	com.ibm.ws.threading;verison=latest
 
 

--- a/dev/com.ibm.ws.security.wim.core/bnd.bnd
+++ b/dev/com.ibm.ws.security.wim.core/bnd.bnd
@@ -63,7 +63,9 @@ instrument.classesExcludes: com/ibm/ws/security/wim/util/resources/*.class
 	com.ibm.websphere.appserver.spi.ssl;version=latest,\
 	com.ibm.wsspi.org.osgi.service.metatype.annotations;version=latest,\
 	com.ibm.ws.bnd.annotations;version=latest, \
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
+	com.ibm.ws.runtime.update;version=latest, \
+	com.ibm.ws.threading;verison=latest
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file,\

--- a/dev/com.ibm.ws.security.wim.core/src/com/ibm/ws/security/wim/ConfigManager.java
+++ b/dev/com.ibm.ws.security.wim.core/src/com/ibm/ws/security/wim/ConfigManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Future;
 
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -26,6 +27,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -33,8 +35,13 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.websphere.security.wim.ras.WIMMessageHelper;
 import com.ibm.websphere.security.wim.ras.WIMMessageKey;
 import com.ibm.ws.config.xml.internal.nester.Nester;
+import com.ibm.ws.runtime.update.RuntimeUpdateListener;
+import com.ibm.ws.runtime.update.RuntimeUpdateManager;
+import com.ibm.ws.runtime.update.RuntimeUpdateNotification;
 import com.ibm.ws.security.wim.util.StringUtil;
 import com.ibm.ws.security.wim.util.UniqueNameHelper;
+import com.ibm.ws.threading.FutureMonitor;
+import com.ibm.ws.threading.listeners.CompletionListener;
 import com.ibm.wsspi.security.wim.SchemaConstants;
 import com.ibm.wsspi.security.wim.exception.InvalidArgumentException;
 import com.ibm.wsspi.security.wim.exception.WIMException;
@@ -47,9 +54,9 @@ import com.ibm.wsspi.security.wim.model.PersonAccount;
 
 @Component(configurationPid = "com.ibm.ws.security.wim.core.config",
            configurationPolicy = ConfigurationPolicy.OPTIONAL,
-           service = { ConfigManager.class },
+           service = { ConfigManager.class, RuntimeUpdateListener.class },
            property = { "service.vendor=IBM", "com.ibm.ws.security.registry.type=WIM", "config.id=default-WIM" })
-public class ConfigManager {
+public class ConfigManager implements RuntimeUpdateListener {
 
     private static final TraceComponent tc = Tr.register(ConfigManager.class);
 
@@ -101,6 +108,11 @@ public class ConfigManager {
 
     private RepositoryManager repositoryManager = null;
 
+    private volatile boolean modified = false;
+
+    // futureMonitor is needed to track the outcome of the configFuture
+    private volatile FutureMonitor _futureMonitor;
+
     @Activate
     protected void activate(ComponentContext cc, Map<String, Object> properties) {
         this.originalConfig = properties;
@@ -111,15 +123,13 @@ public class ConfigManager {
     protected void modify(ComponentContext cc, Map<String, Object> newProperties) {
         this.originalConfig = newProperties;
         config = processConfig();
-        if (listeners != null) {
-            for (RealmConfigChangeListener listener : listeners)
-                listener.notifyRealmConfigChange();
-        }
+        modified = true;
     }
 
     @Deactivate
     protected void deactivate(ComponentContext cc,
                               Map<String, Object> newProperties) {
+        modified = false;
         originalConfig = null;
         config = null;
         listeners.clear();
@@ -425,9 +435,18 @@ public class ConfigManager {
     }
 
     /**
+     * Deregister a RealmConfigChangeListener by removing it from the list of listeners.
+     *
+     * @param listener
+     */
+    public void deregisterRealmConfigChangeListener(RealmConfigChangeListener listener) {
+        listeners.remove(listener);
+    }
+
+    /**
      * Gets the default parent node that is for the specified entity type in specified realm.
      *
-     * @param entType The entity type. e.g. Person, Group...
+     * @param entType   The entity type. e.g. Person, Group...
      * @param realmName The name of the realm
      * @return The default parent node.
      */
@@ -496,4 +515,57 @@ public class ConfigManager {
     void setRepositoryManager(RepositoryManager repositoryManager) {
         this.repositoryManager = repositoryManager;
     }
+
+    /**
+     * Set service to capture completed configuration checks
+     */
+    @Reference(service = FutureMonitor.class)
+    protected void setFutureMonitor(FutureMonitor futureMonitor) {
+        _futureMonitor = futureMonitor;
+    }
+
+    /**
+     * Unset service to capture completed configuration checks
+     */
+    protected void unsetFutureMonitor(FutureMonitor futureMonitor) {
+        _futureMonitor = null;
+    }
+
+    /**
+     * After a configuration modification, run a RealConfigChange check which will verify the participatingBaseEntries.
+     *
+     * We used to do this directly from the modify command, but timing change during startup/modify and we would process the check
+     * before the user registries activated, leading to misleading error messages being printed.
+     */
+    @Trivial
+    @Override
+    public void notificationCreated(RuntimeUpdateManager updateManager, RuntimeUpdateNotification notification) {
+        if (RuntimeUpdateNotification.CONFIG_UPDATES_DELIVERED.equals(notification.getName())) {
+            _futureMonitor.onCompletion(notification.getFuture(), new CompletionListener<Boolean>() {
+                @Override
+                public void successfulCompletion(Future<Boolean> future, Boolean result) {
+                    if (modified) {
+                        if (tc.isDebugEnabled()) {
+                            Tr.debug(this, tc, "RuntimeUpdate completed on config update, calling notifyRealmConfigChange. " + notification.getName());
+                        }
+                        if (listeners != null) {
+                            for (RealmConfigChangeListener listener : listeners)
+                                listener.notifyRealmConfigChange();
+                        }
+                    }
+                }
+
+                @Override
+                public void failedCompletion(Future<Boolean> future, Throwable t) {
+                    if (tc.isDebugEnabled()) {
+                        Tr.debug(this, tc, "RuntimeUpdate completed with error on config update, not calling notifyRealmConfigChange, "
+                                           + notification.getName());
+                    }
+                }
+
+            });
+
+        }
+    }
+
 }

--- a/dev/com.ibm.ws.security.wim.core/src/com/ibm/ws/security/wim/VMMService.java
+++ b/dev/com.ibm.ws.security.wim.core/src/com/ibm/ws/security/wim/VMMService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014 IBM Corporation and others.
+ * Copyright (c) 2012, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -42,7 +42,8 @@ import com.ibm.wsspi.security.wim.model.Root;
 @ObjectClassDefinition(factoryPid = "com.ibm.wsspi.security.wim.CustomRepository", name = Ext.INTERNAL, description = Ext.INTERNAL_DESC, localization = Ext.LOCALIZATION)
 @Ext.Alias("customRepository")
 @Ext.ObjectClassClass(CustomRepository.class)
-@interface CustomRepositoryMarker {}
+@interface CustomRepositoryMarker {
+}
 
 @ObjectClassDefinition(pid = "com.ibm.ws.security.wim.VMMService", name = Ext.INTERNAL, description = Ext.INTERNAL_DESC, localization = Ext.LOCALIZATION)
 @interface VMMServiceConfig {
@@ -164,6 +165,8 @@ public class VMMService implements Service, RealmConfigChangeListener {
         if (tc.isInfoEnabled())
             Tr.info(tc, "FEDERATED_MANAGER_SERVICE_STOPPED");
         notifyListeners();
+
+        getConfigManager().deregisterRealmConfigChangeListener(this);
     }
 
     /**
@@ -286,8 +289,12 @@ public class VMMService implements Service, RealmConfigChangeListener {
 
                 if (participatingEntries != null) {
                     for (String baseEntry : participatingEntries) {
-                        if (!baseEntries.contains(baseEntry))
+                        if (!baseEntries.contains(baseEntry)) {
+                            if (tc.isDebugEnabled()) {
+                                Tr.debug(tc, "Did not find participating " + baseEntry + " in list of existing repos " + baseEntries);
+                            }
                             Tr.error(tc, WIMMessageKey.INVALID_PARTICIPATING_BASE_ENTRY_DEFINITION, baseEntry);
+                        }
                     }
                 }
             }

--- a/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/ConfigManagerInitModifyTest.java
+++ b/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/ConfigManagerInitModifyTest.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.security.wim.core.fat;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
+
+/**
+ * Test that we aren't printing out missing participatingBaseEntries messages at the incorrect times (CWIMK0004E)
+ *
+ * For example, before the user registries are loaded.
+ */
+@RunWith(FATRunner.class)
+@Mode(TestMode.LITE)
+public class ConfigManagerInitModifyTest {
+
+    private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.security.wim.core.fat.mod");
+    private static final Class<?> c = ConfigManagerInitModifyTest.class;
+
+    private static final String ADD_REG = "dynamicUpdate/basic_reg.xml";
+    private static final String NO_REG = "dynamicUpdate/no_reg.xml";
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        Log.info(c, "setUp", "Starting the server... (will wait for userRegistry servlet to start)");
+
+        server.startServer(c.getName() + ".log");
+        assertNotNull("Server did not came up",
+                      server.waitForStringInLog("CWWKF0011I"));
+
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        Log.info(c, "tearDown", "Stopping the server...");
+
+        server.stopServer("CWIMK0004E");
+
+    }
+
+    /**
+     * This is an internal method used to set the server.xml
+     */
+    private static void setServerConfiguration(String serverXML) throws Exception {
+
+        // Update server.xml
+        Log.info(c, "setServerConfiguration", "setServerConfigurationFile to : " + serverXML);
+
+        // set a new mark
+        server.setMarkToEndOfLog(server.getDefaultLogFile());
+
+        // Update the server xml
+        server.setServerConfigurationFile("/" + serverXML);
+
+        // Wait for CWWKG0017I and CWWKF0008I to appear in logs after we started the config update
+        Log.info(c, "setServerConfiguration",
+                 "waitForStringInLogUsingMark: CWWKG0017I: The server configuration was successfully updated.");
+        server.waitForStringInLogUsingMark("CWWKG0017I"); //CWWKG0017I: The server configuration was successfully updated in 0.2 seconds.
+
+    }
+
+    /**
+     * Add a registry and update the participating base entries, we should not print a CWIMK0004E message indicating we're missing
+     * base entries. Then update the config again and remote the registry, we should print out a CWIMK0004E message.
+     */
+    @Test
+    public void testParticipatingBaseEntriesVerification() throws Exception {
+        Log.info(c, "testParticipatingBaseEntriesVerification", "Entering test testParticipatingBaseEntriesVerification");
+
+        /*
+         * Update to a config with a BasicRegistry and update the participatingBaseEntries to cause a modify to ConfigManager
+         */
+        Log.info(c, "testParticipatingBaseEntriesVerification", "Adding BasicRegistry with updated participatingBaseEntries");
+        setServerConfiguration(ADD_REG);
+
+        assertTrue("Should not find CWIMK0004E in the logs", server.findStringsInLogs("CWIMK0004E").isEmpty());
+
+        /*
+         * Update to a config and remove the BasicRegistry, intentionally causing missing baseEntries
+         */
+        Log.info(c, "testParticipatingBaseEntriesVerification", "Update to only a FedRepo config, missing the matching participatingBaseEntries");
+        setServerConfiguration(NO_REG);
+
+        assertNotNull("Should find CWIMK0004E in the logs.", server.waitForStringInLog("CWIMK0004E"));
+
+    }
+
+}

--- a/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/FATSuite.java
@@ -20,7 +20,8 @@ import org.junit.runners.Suite.SuiteClasses;
                 MaxSearchResultTest.class,
                 DynamicUpdateTest.class,
                 NoRegistryConfiguredTest.class,
-                WimCoreRegressionTest.class
+                WimCoreRegressionTest.class,
+                ConfigManagerInitModifyTest.class
 })
 /**
  * Purpose: This suite collects and runs all known good test suites.

--- a/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/basic_reg.xml
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/basic_reg.xml
@@ -1,0 +1,37 @@
+<server description="new server">
+
+	<include location="../fatTestPorts.xml"/>
+    <!-- Enable features -->
+    <featureManager>
+        <feature>appSecurity-1.0</feature>
+	</featureManager>
+
+        <basicRegistry id="basic" realm="SampleBasicRealm">
+        <user name="vmmuser1" password="password123" />
+        <user name="vmmuser2" password="password123" />
+        <user name="vmmuser3" password="password123" />
+        <user name="admin" password="password123" />
+        <group name="memberlessGroup" />
+        <group name="adminGroup">
+            <member name="vmmuser3"/>
+        </group>
+        <group name="users">
+            <member name="vmmuser1"/>
+            <member name="vmmuser2"/>
+        </group>
+        <group name="vmmgroup1"/>
+        <group name="vmmgroup2"/>
+        <group name="vmmgroup3"/>
+    </basicRegistry>
+		
+	<administrator-role>
+		<user>vmmuser1</user>
+	</administrator-role>
+	
+    <federatedRepository>
+        <primaryRealm name="WIMRegistry">
+            <participatingBaseEntry name="o=SampleBasicRealm"/>
+        </primaryRealm>
+    </federatedRepository>
+
+</server>

--- a/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/no_reg.xml
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/no_reg.xml
@@ -1,0 +1,16 @@
+<server description="new server">
+
+	<include location="../fatTestPorts.xml"/>
+    <!-- Enable features -->
+    <featureManager>
+        <feature>appSecurity-1.0</feature>
+	</featureManager>
+
+       <federatedRepository>
+        <primaryRealm name="NewReg">
+            <participatingBaseEntry name="o=NoRegistry"/>
+        </primaryRealm>
+    </federatedRepository>
+
+
+</server>

--- a/dev/com.ibm.ws.security.wim.core_fat/publish/servers/com.ibm.ws.security.wim.core.fat.mod/bootstrap.properties
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/servers/com.ibm.ws.security.wim.core.fat.mod/bootstrap.properties
@@ -1,0 +1,3 @@
+com.ibm.ws.logging.trace.specification=*=info=enabled:com.ibm.ws.security.*=all=enabled
+com.ibm.ws.logging.max.file.size=0
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.security.wim.core_fat/publish/servers/com.ibm.ws.security.wim.core.fat.mod/server.xml
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/servers/com.ibm.ws.security.wim.core.fat.mod/server.xml
@@ -1,0 +1,14 @@
+<server description="new server">
+
+	<include location="../fatTestPorts.xml"/>
+    <!-- Enable features -->
+    <featureManager>
+        <feature>appSecurity-1.0</feature>
+	</featureManager>
+    
+    <federatedRepository>
+        <primaryRealm name="WIMRegistry">
+            <participatingBaseEntry name="o=invalid"/>
+    	</primaryRealm>
+    </federatedRepository>
+</server>

--- a/dev/com.ibm.ws.security.wim.registry/bnd.bnd
+++ b/dev/com.ibm.ws.security.wim.registry/bnd.bnd
@@ -43,7 +43,9 @@ instrument.classesExcludes: com/ibm/ws/security/wim/registry/util/resources/*.cl
 	com.ibm.ws.logging;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.wsspi.org.osgi.service.metatype.annotations;version=latest, \
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
+	com.ibm.ws.runtime.update;version=latest, \
+	com.ibm.ws.threading;verison=latest
 
 -testpath: \
 	org.hamcrest:hamcrest-all;version=1.3, \


### PR DESCRIPTION
Fixes #14655 

The previous behavior was that the ConfigManager sent out a notification to Listeners only after receiving a Modify. When VMMService (the only implemented listener) received the event, it checks that the participatingBaseEntries listed match a registry. If a registry isn't found, an error message is issued (`CWIMK0004E`).

The startup timing has changed such that sometimes we process the config as an empty initialize then call modify when we may or may not have finished processing the registries (such as BasicRegistry or LdapRegistry). This caused a false negative on the error messages.

To match previous behavior and avoid the baseEntry check happening too early. I did the following:
- Add a listener for checking when server config modifications are complete
- Toggle when we're past init phase and modify is being called (otherwise, `URAPIs_RealmPropertyMappingTest` failed because we received a config complete check before initializing the CustomRegistry/CustomRepository features in that test -- I think this matches more closely to the original behavior).
- Added a call to deregister in VMMService or we ended up with a new and old VMMService to call from ConfigManager
- Added a new FAT test that recreates the failing scenario and intentional creates a scenario that should log the `CWIMK0004E`