### PR TITLE
Fix some FATs that were failing in GH Actions builds

### DIFF
--- a/.github/workflow-scripts/run-fat-build.sh
+++ b/.github/workflow-scripts/run-fat-build.sh
@@ -9,6 +9,13 @@ chmod +x gradlew
 chmod 777 build.image/wlp/bin/*
 echo "org.gradle.daemon=false" >> gradle.properties
 
+echo "Environment dump:"
+env
+echo "Ant version:"
+ant -v
+echo "Java version:"
+java -version
+
 FAT_ARGS=""
 
 # If this is the special 'MODIFIED_FULL_MODE' job, figure out which buckets 

--- a/.github/workflows/openliberty-ci.yml
+++ b/.github/workflows/openliberty-ci.yml
@@ -98,11 +98,11 @@ jobs:
     name: FAT Tests - ${{matrix.category}}
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 90
     strategy:
       fail-fast: false
-      max-parallel: 18
+      max-parallel: 19
       matrix:
+        category: [ MODIFIED_FULL_MODE, GENERAL, MISC, CDI_1, APPCLIENT, CONCURRENT_1, EJB_1, WEBCONTAINER_1, JAXRS_1, JDBC, JPA_1, TRANSACTION_1, MP_GRAPHQL, MP_REACTIVE, MP_JWT_1, SECURITY_3 ]
         include:
           # This is a special category that runs directly modfied FATs in FULL mode
           - category: MODIFIED_FULL_MODE
@@ -112,10 +112,10 @@ jobs:
               com.ibm.ws.java11_fat
               build.featureStart_fat
           - category: MISC
+            # com.ibm.ws.mongo_fat // disabled: requires Consul
             fat-buckets: >
               com.ibm.ws.cloudant_fat
               com.ibm.ws.couchdb_fat
-              com.ibm.ws.mongo_fat
               com.ibm.ws.jmx_fat
               com.ibm.ws.springboot.support_fat
           - category: KERNEL_1
@@ -576,9 +576,7 @@ jobs:
         name: liberty-image
         path: dev/build.image/wlp/
     - name: Run FAT buckets
-      # Set timeout to 5m less than the timeout for the overall job. This ensures that if
-      # FATs time out, there is a little time leftover in the overall job to collect logs
-      timeout-minutes: 85
+      timeout-minutes: 180
       shell: bash
       env:
         FAT_BUCKETS: ${{matrix.fat-buckets}}

--- a/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/build.gradle
+++ b/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.2/build.gradle
@@ -32,8 +32,7 @@ def appBuildDir = "${buildDir}/test-application"
  ******************************************************************
  ******************************************************************/
 task securityejb_EAR (type: Zip) { 
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:securityejb_WAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJB_JAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build ear file (securityejb.ear) for tests with role mapping in server.xml'
   destinationDirectory = new File(appBuildDir)
@@ -57,7 +56,7 @@ task securityejb_EAR (type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbinwar_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:ejbinwarservlet_WAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build EJB in WAR (pure ann) ear file (securityejbinwar.ear) with role mapping in server.xml'
   destinationDir file(appBuildDir)
@@ -81,8 +80,7 @@ task securityejbinwar_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbXML_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:securityejb_WAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJB_JAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build ear file for tests with role mapping in ibm-application-bnd.xml only'
   destinationDir file(appBuildDir)
@@ -106,7 +104,7 @@ task securityejbXML_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbInWarEarXML_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:ejbinwarservlet_WAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build EJB in WAR ear file (securityejbInWarEarXML) for pure ann tests with role mapping in ibm-application-bnd.xml only'
   destinationDir file(appBuildDir)
@@ -130,8 +128,7 @@ task securityejbInWarEarXML_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbXMLmerge_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:securityejb_WAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJB_JAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build ear file (securityejbXMLmerge.ear) for pure ann tests with role mapping in mix of server.xml and ibm-application-bnd.xml'
   destinationDir file(appBuildDir)
@@ -155,7 +152,7 @@ task securityejbXMLmerge_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbInWarEarXMLMerge_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:ejbinwarservlet_WAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build EJB in WAR ear file (securityejbInWarEarXMLMerge) for pure ann tests with role mapping in mix of server.xml and ibm-application-bnd.xml'
   destinationDir file(appBuildDir)
@@ -179,19 +176,7 @@ task securityejbInWarEarXMLMerge_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbjar_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:securityejb_WAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBX01_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBX02_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBX03_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM01_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM02_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM03_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM04_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM05_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM07_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM08_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM09_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM10_JAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build ear file (securityejbjar.ear) for tests with ejb-jar.xml testing with role mapping in server.xml'
   destinationDir file(appBuildDir)
@@ -219,19 +204,7 @@ task securityejbjar_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbjarXMLmerge_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:securityejb_WAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBX01_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBX02_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBX03_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM01_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM02_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM03_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM04_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM05_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM07_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM08_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM09_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM10_JAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build ear file (securityejbjarXMLmerge.ear) for tests with ejb-jar.xml testing with role mapping in server.xml and ibm-application-bnd.xml'
   destinationDir file(appBuildDir)
@@ -259,8 +232,7 @@ task securityejbjarXMLmerge_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbjarMC_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:securityejb_WAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBMC06_JAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build EJB in WAR ear file (securityejbInWarEarXML) for pure ann tests with role mapping in ibm-application-bnd.xml only'
   destinationDir file(appBuildDir)
@@ -284,7 +256,7 @@ task securityejbjarMC_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbjarInWarEarX01_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:ejbinwarservletX01_WAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build EJB in WAR ear file (securityejbjarInWarEarX01) for tests with ejb-jar.xml only'
   destinationDir file(appBuildDir)
@@ -308,7 +280,7 @@ task securityejbjarInWarEarX01_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbjarInWarEarM01_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:ejbinwarservletM01_WAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build EJB in WAR ear file (securityejbjarInWarEarM01) for tests with ejb-jar.xml and mixed annotations'
   destinationDir file(appBuildDir)
@@ -332,7 +304,7 @@ task securityejbjarInWarEarM01_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbjarInWarEarMC06_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:ejbinwarservletMC06_WAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build EJB in WAR ear file (securityejbInWarEarXML) for pure ann tests with role mapping in ibm-application-bnd.xml only'
   destinationDir file(appBuildDir)
@@ -356,7 +328,7 @@ task securityejbjarInWarEarMC06_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbjarInWarEarM07_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:ejbinwarservletM07_WAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build EJB in WAR ear file (securityejbjarInWarEarM07) for tests with ejb-jar.xml and mixed annotations and run-as extension file'
   destinationDir file(appBuildDir)
@@ -380,7 +352,7 @@ task securityejbjarInWarEarM07_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbjarInWarEarM07XMLmerge_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:ejbinwarservletM07_WAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build EJB in WAR ear file (securityejbjarInWarEarM07XMLmerge) for tests with ejb-jar.xml and mixed annotations and run-as extension file with bindings in server.xml and ibm-application-bnd'
   destinationDir file(appBuildDir)
@@ -425,8 +397,8 @@ assemble {
  **
  ******************************************************************
  ******************************************************************/
-autoFVT.dependsOn ':com.ibm.ws.security.authorization.jacc.testprovider:jar'
-autoFVT.dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:ejbinstandalone_WAR'
+autoFVT.dependsOn ':com.ibm.ws.security.authorization.jacc.testprovider:assemble'
+autoFVT.dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 autoFVT.doLast {
 
   /*

--- a/dev/com.ibm.ws.ejbcontainer.security.jacc_fat/build.gradle
+++ b/dev/com.ibm.ws.ejbcontainer.security.jacc_fat/build.gradle
@@ -32,8 +32,7 @@ def appBuildDir = "${buildDir}/test-application"
  ******************************************************************
  ******************************************************************/
 task securityejb_EAR (type: Zip) { 
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:securityejb_WAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJB_JAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build ear file (securityejb.ear) for tests with role mapping in server.xml'
   destinationDirectory = new File(appBuildDir)
@@ -57,7 +56,7 @@ task securityejb_EAR (type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbinwar_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:ejbinwarservlet_WAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build EJB in WAR (pure ann) ear file (securityejbinwar.ear) with role mapping in server.xml'
   destinationDir file(appBuildDir)
@@ -81,8 +80,7 @@ task securityejbinwar_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbXML_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:securityejb_WAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJB_JAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build ear file for tests with role mapping in ibm-application-bnd.xml only'
   destinationDir file(appBuildDir)
@@ -106,7 +104,7 @@ task securityejbXML_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbInWarEarXML_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:ejbinwarservlet_WAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build EJB in WAR ear file (securityejbInWarEarXML) for pure ann tests with role mapping in ibm-application-bnd.xml only'
   destinationDir file(appBuildDir)
@@ -130,8 +128,7 @@ task securityejbInWarEarXML_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbXMLmerge_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:securityejb_WAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJB_JAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build ear file (securityejbXMLmerge.ear) for pure ann tests with role mapping in mix of server.xml and ibm-application-bnd.xml'
   destinationDir file(appBuildDir)
@@ -155,7 +152,7 @@ task securityejbXMLmerge_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbInWarEarXMLMerge_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:ejbinwarservlet_WAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build EJB in WAR ear file (securityejbInWarEarXMLMerge) for pure ann tests with role mapping in mix of server.xml and ibm-application-bnd.xml'
   destinationDir file(appBuildDir)
@@ -179,19 +176,7 @@ task securityejbInWarEarXMLMerge_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbjar_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:securityejb_WAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBX01_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBX02_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBX03_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM01_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM02_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM03_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM04_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM05_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM07_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM08_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM09_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM10_JAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build ear file (securityejbjar.ear) for tests with ejb-jar.xml testing with role mapping in server.xml'
   destinationDir file(appBuildDir)
@@ -219,19 +204,7 @@ task securityejbjar_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbjarXMLmerge_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:securityejb_WAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBX01_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBX02_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBX03_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM01_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM02_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM03_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM04_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM05_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM07_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM08_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM09_JAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBM10_JAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build ear file (securityejbjarXMLmerge.ear) for tests with ejb-jar.xml testing with role mapping in server.xml and ibm-application-bnd.xml'
   destinationDir file(appBuildDir)
@@ -259,8 +232,7 @@ task securityejbjarXMLmerge_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbjarMC_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:securityejb_WAR'
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:SecurityEJBMC06_JAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build EJB in WAR ear file (securityejbInWarEarXML) for pure ann tests with role mapping in ibm-application-bnd.xml only'
   destinationDir file(appBuildDir)
@@ -284,7 +256,7 @@ task securityejbjarMC_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbjarInWarEarX01_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:ejbinwarservletX01_WAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build EJB in WAR ear file (securityejbjarInWarEarX01) for tests with ejb-jar.xml only'
   destinationDir file(appBuildDir)
@@ -308,7 +280,7 @@ task securityejbjarInWarEarX01_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbjarInWarEarM01_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:ejbinwarservletM01_WAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build EJB in WAR ear file (securityejbjarInWarEarM01) for tests with ejb-jar.xml and mixed annotations'
   destinationDir file(appBuildDir)
@@ -332,7 +304,7 @@ task securityejbjarInWarEarM01_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbjarInWarEarMC06_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:ejbinwarservletMC06_WAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build EJB in WAR ear file (securityejbInWarEarXML) for pure ann tests with role mapping in ibm-application-bnd.xml only'
   destinationDir file(appBuildDir)
@@ -356,7 +328,7 @@ task securityejbjarInWarEarMC06_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbjarInWarEarM07_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:ejbinwarservletM07_WAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build EJB in WAR ear file (securityejbjarInWarEarM07) for tests with ejb-jar.xml and mixed annotations and run-as extension file'
   destinationDir file(appBuildDir)
@@ -380,7 +352,7 @@ task securityejbjarInWarEarM07_EAR(type: Zip) {
  ******************************************************************
  ******************************************************************/
 task securityejbjarInWarEarM07XMLmerge_EAR(type: Zip) {
-  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:ejbinwarservletM07_WAR'
+  dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 
   description 'Build EJB in WAR ear file (securityejbjarInWarEarM07XMLmerge) for tests with ejb-jar.xml and mixed annotations and run-as extension file with bindings in server.xml and ibm-application-bnd'
   destinationDir file(appBuildDir)
@@ -425,8 +397,8 @@ assemble {
  **
  ******************************************************************
  ******************************************************************/
-autoFVT.dependsOn ':com.ibm.ws.security.authorization.jacc.testprovider:jar'
-autoFVT.dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:ejbinstandalone_WAR'
+autoFVT.dependsOn ':com.ibm.ws.security.authorization.jacc.testprovider:assemble'
+autoFVT.dependsOn ':com.ibm.ws.ejbcontainer.security_test.servlets:assemble'
 autoFVT.doLast {
 
   /*

--- a/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/ServicesTest.java
+++ b/dev/com.ibm.ws.install.packaging_fat/fat/src/com/ibm/ws/install/packaging/fat/ServicesTest.java
@@ -78,17 +78,17 @@ public class ServicesTest extends InstallPackagesToolTest {
         Log.info(c, METHOD_NAME, "Starting defaultServer");
 
         ProgramOutput po2 = serviceCommand(METHOD_NAME, "start", "defaultServer");
-        wait(2000);
+        Thread.sleep(2000);
         ProgramOutput po2a = serviceCommand(METHOD_NAME, "status", "defaultServer");
         
         Log.info(c, METHOD_NAME, "Stopping defaultServer");
         ProgramOutput po3 = serviceCommand(METHOD_NAME, "stop", "defaultServer");
-        wait(2000);
+        Thread.sleep(2000);
         ProgramOutput po3a = serviceCommand(METHOD_NAME, "status", "defaultServer");
 
         Log.info(c, METHOD_NAME, "Re-starting defaultServer");
         ProgramOutput po4 = serviceCommand(METHOD_NAME, "restart", "defaultServer");
-        wait(2000);
+        Thread.sleep(2000);
         ProgramOutput po4a = serviceCommand(METHOD_NAME, "status", "defaultServer");
         Log.info(c, METHOD_NAME, "Stopping defaultServer");
         ProgramOutput po5 = serviceCommand(METHOD_NAME, "stop", "defaultServer");

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/internal/commands/PackageCommandTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/internal/commands/PackageCommandTest.java
@@ -18,6 +18,8 @@ import static org.junit.Assume.assumeTrue;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -370,6 +372,10 @@ public class PackageCommandTest {
         try {
 
             server.getFileFromLibertyInstallRoot("lib/extract");
+
+            // Ensure the usr/shared dir exists
+            Path sharedPath = Paths.get(server.getServerSharedPath());
+            sharedPath.toFile().mkdirs();
 
             String[] cmd = new String[] { "--archive=" + archivePackage,
                                           "--include=usr",

--- a/dev/com.ibm.ws.security.jaspic_fat/build.gradle
+++ b/dev/com.ibm.ws.security.jaspic_fat/build.gradle
@@ -246,8 +246,8 @@ assemble.dependsOn JASPIWrappingServlet_WAR
  **
  ******************************************************************
  ******************************************************************/
-autoFVT.dependsOn ':com.ibm.ws.security.authorization.jacc.testprovider:jar'
-autoFVT.dependsOn ':com.ibm.ws.security.jaspic.test:jar'
+autoFVT.dependsOn ':com.ibm.ws.security.authorization.jacc.testprovider:assemble'
+autoFVT.dependsOn ':com.ibm.ws.security.jaspic.test:assemble'
 autoFVT.doLast {
 
   /*

--- a/dev/com.ibm.ws.springboot.support_fat/bnd.bnd
+++ b/dev/com.ibm.ws.springboot.support_fat/bnd.bnd
@@ -14,19 +14,38 @@ bVersion=1.0
 src: \
 	fat/src
 
-
 fat.project: true
 
-tested.features: springBoot-1.5, springBoot-2.0, servlet-3.1, servlet-4.0, transportSecurity-1.0, jsp-2.3, websocket-1.1, appSecurity-2.0, cdi-1.2, javaee-7.0, javaee-8.0
+tested.features: \
+  springBoot-1.5, \
+  springBoot-2.0, \
+  servlet-3.1, \
+  servlet-4.0, \
+  transportSecurity-1.0, \
+  jsp-2.3, \
+  websocket-1.1, \
+  appSecurity-2.0, \
+  cdi-1.2, \
+  javaee-7.0, \
+  javaee-8.0
 
-# Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
-#      or binaries from Artifactory (e.g. commons-logging:commons-logging)
-# For all project names that match the pattern "*_fat*", dependencies for junit,
-# fattest.simplicity, and componenttest-1.0 will be automatically added to the buildpath
 -buildpath: \
     org.apache.httpcomponents:httpcore;strategy=exact;version=4.3,\
     org.apache.httpcomponents:httpclient;strategy=exact;version=4.3.1,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
+	com.ibm.ws.springboot.support.version15.test.app;version=latest,\
+	com.ibm.ws.springboot.support.version20.test.app;version=latest,\
+    com.ibm.ws.springboot.support.version20.test.war.app;version=latest,\
+    com.ibm.ws.springboot.support.version20.test.java.app;version=latest,\
+    com.ibm.ws.springboot.support.version20.test.webanno.app;version=latest,\
+    com.ibm.ws.springboot.support.version20.test.websocket.app;version=latest,\
+    com.ibm.ws.springboot.support.version20.test.actuator.app;version=latest,\
+    com.ibm.ws.springboot.support.version20.test.webflux.app;version=latest,\
+    com.ibm.ws.springboot.support.version20.test.webflux.wrong.version.app;version=latest,\
+    com.ibm.ws.springboot.support.version20.test.multi.context.app;version=latest,\
+    com.ibm.ws.springboot.support.version21.test.app;version=latest,\
+    com.ibm.ws.springboot.support.version22.test.app;version=latest,\
+    com.ibm.ws.springboot.support.version23.test.app;version=latest,\
 	commons-logging:commons-logging;version=1.1.3,\
 	net.sourceforge.htmlunit:htmlunit;version=2.27,\
 	com.ibm.websphere.javaee.websocket.1.1;version=latest

--- a/dev/com.ibm.ws.springboot.support_fat/build.gradle
+++ b/dev/com.ibm.ws.springboot.support_fat/build.gradle
@@ -26,11 +26,23 @@
       'org.eclipse.jetty.websocket:websocket-api:9.4.5.v20170502',
       'org.eclipse.jetty.websocket:websocket-common:9.4.5.v20170502',
       'org.eclipse.jetty:jetty-util:9.4.7.RC0'  
-   }
- 
-addRequiredLibraries {
 }
-      
+
+autoFVT.dependsOn ':wlp.lib.extract:build'
+autoFVT.dependsOn ':com.ibm.ws.springboot.support.version15.test.app:build'
+autoFVT.dependsOn ':com.ibm.ws.springboot.support.version20.test.app:build'
+autoFVT.dependsOn ':com.ibm.ws.springboot.support.version20.test.war.app:build'
+autoFVT.dependsOn ':com.ibm.ws.springboot.support.version20.test.java.app:build'
+autoFVT.dependsOn ':com.ibm.ws.springboot.support.version20.test.webanno.app:build'
+autoFVT.dependsOn ':com.ibm.ws.springboot.support.version20.test.websocket.app:build'
+autoFVT.dependsOn ':com.ibm.ws.springboot.support.version20.test.actuator.app:build'
+autoFVT.dependsOn ':com.ibm.ws.springboot.support.version20.test.webflux.app:build'
+autoFVT.dependsOn ':com.ibm.ws.springboot.support.version20.test.webflux.wrong.version.app:build'
+autoFVT.dependsOn ':com.ibm.ws.springboot.support.version20.test.multi.context.app:build'
+autoFVT.dependsOn ':com.ibm.ws.springboot.support.version21.test.app:build'
+autoFVT.dependsOn ':com.ibm.ws.springboot.support.version22.test.app:build'
+autoFVT.dependsOn ':com.ibm.ws.springboot.support.version23.test.app:build'
+
 autoFVT.doLast {
 
   /*
@@ -40,7 +52,6 @@ autoFVT.doLast {
   	from new File('../wlp.lib.extract/build/libs', 'wlp.lib.extract.jar')
   	into new File(autoFvtDir, 'lib/LibertyFATTestFiles')
   }
-  
   
   /*
    * Copy the test application jars into appropriate test servers.

--- a/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/build.gradle
+++ b/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/build.gradle
@@ -386,9 +386,9 @@ assemble {
  **
  ******************************************************************
  ******************************************************************/
-autoFVT.dependsOn ':com.ibm.ws.security.authorization.jacc.testprovider:jar'
-autoFVT.dependsOn ':com.ibm.ws.security.registry_test.custom:jar'
-autoFVT.dependsOn ':com.ibm.ws.org.apache.directory.server:jar' // Probably don't need.
+autoFVT.dependsOn ':com.ibm.ws.security.authorization.jacc.testprovider:assemble'
+autoFVT.dependsOn ':com.ibm.ws.security.registry_test.custom:assemble'
+autoFVT.dependsOn ':com.ibm.ws.org.apache.directory.server:assemble' // Probably don't need.
 autoFVT.doLast {
 
   /*

--- a/dev/fattest.simplicity/build.gradle
+++ b/dev/fattest.simplicity/build.gradle
@@ -26,7 +26,8 @@ task assembleBinaryDependencies() {
         // task of every FAT bucket, effectively making all of fattest.simplicty's dependencies transitive
         sourceSets.main.runtimeClasspath.each {
             def path = it.getAbsolutePath()
-            if((path.contains('.m2') || path.contains('.ibmartifactory')) && !(new File(buildDirLib, it.getName()).exists())) {
+            if((path.contains('.m2') || path.contains('.ibmartifactory') || path.contains('.ibmdhe')) && 
+               !(new File(buildDirLib, it.getName()).exists())) {
                 copy {
                     from path
                     into buildDirLib

--- a/dev/fattest.simplicity/src/componenttest/custom/junit/runner/FATRunner.java
+++ b/dev/fattest.simplicity/src/componenttest/custom/junit/runner/FATRunner.java
@@ -67,7 +67,7 @@ public class FATRunner extends BlockJUnit4ClassRunner {
     private static final Class<?> c = FATRunner.class;
 
     // Used to reduce timeouts to a sensible level when FATs are running locally
-    public static final boolean FAT_TEST_LOCALRUN = Boolean.getBoolean("fat.test.localrun");
+    public static final boolean FAT_TEST_LOCALRUN = Boolean.getBoolean("fat.test.localrun") && !Boolean.parseBoolean(System.getenv("CI"));
 
     private static final int MAX_FFDC_LINES = 1000;
     private static final boolean DISABLE_FFDC_CHECKING = Boolean.getBoolean("disable.ffdc.checking");
@@ -632,7 +632,7 @@ public class FATRunner extends BlockJUnit4ClassRunner {
             if (JakartaEE9Action.isActive()) {
                 String[] exceptionClasses = ffdc.value();
                 for (String exceptionClass : exceptionClasses) {
-                    if(ee9Helper == null){
+                    if (ee9Helper == null) {
                         ee9Helper = new EE9PackageReplacementHelper();
                     }
                     exceptionClass = ee9Helper.replacePackages(exceptionClass);
@@ -682,7 +682,7 @@ public class FATRunner extends BlockJUnit4ClassRunner {
                 if (JakartaEE9Action.isActive()) {
                     String[] exceptionClasses = ffdc.value();
                     for (String exceptionClass : exceptionClasses) {
-                        if(ee9Helper == null){
+                        if (ee9Helper == null) {
                             ee9Helper = new EE9PackageReplacementHelper();
                         }
                         exceptionClass = ee9Helper.replacePackages(exceptionClass);
@@ -762,7 +762,7 @@ public class FATRunner extends BlockJUnit4ClassRunner {
                 serverField.set(testClass, serv);
                 Log.info(c, method, "Injected LibertyServer " + serv.getServerName() + " to class " + testClass.getCanonicalName());
             } catch (Exception e) {
-                
+
                 throw new RuntimeException(e);
             }
         }

--- a/dev/wlp-gradle/bndSettings.gradle
+++ b/dev/wlp-gradle/bndSettings.gradle
@@ -123,27 +123,11 @@ if (addAll) {
     println 'Preparing all bnd projects in the workspace (this can take a while)'
 }
 
-/**
- * This method is a hardcoded method that assumes if a project is
- * a multi module project, it will have a module named "module"
- **/
-def includeModuleIfExists(projectName) {
-    File module = new File(rootDir, projectName + '/module')
-    if (module.exists()) {
-        include projectName + ':' + module.getName()
-    }
-}
-
 def allBndProjects = workspace.getAllProjects().collect { project ->
     if (!project.name.startsWith('.')) {
         if (addAll) {
             project.prepare()
             include project.name
-
-            if (new File(rootDir, project.name + '/springboot.gradle').exists()) {
-                includeModuleIfExists(project.name)
-            }
-
         }
         return project.name
     } else {
@@ -169,12 +153,11 @@ projectNames.each { projectName ->
         workspace.getProject(projectName).getDependson()*.getName().each {
             include it
         }
-
-        if (new File(rootDir, projectName + '/springboot.gradle').exists()) {
-            includeModuleIfExists(projectName)
-        }
     }
 }
+
+// A non-standared project. Just include it all the time
+include ':com.ibm.ws.springboot.support.version20.test.war.app:module'
 
 private boolean parseBoolean(String value) {
     return 'on'.equalsIgnoreCase(value) || 'true'.equalsIgnoreCase(value)


### PR DESCRIPTION
This should result in the following FAT categories going from red -> green:

- MISC
- KERNEL_2
- CDI_2
- EJB_2