### PR TITLE
Update group validation for operational attribute membership

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1782,16 +1782,6 @@
       <version>1.4</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.microprofile.config</groupId>
-      <artifactId>microprofile-config-api</artifactId>
-      <version>2.0-RC1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.microprofile.config</groupId>
-      <artifactId>microprofile-config-tck</artifactId>
-      <version>2.0-RC1</version>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.microprofile.context-propagation</groupId>
       <artifactId>microprofile-context-propagation-api</artifactId>
       <version>1.0</version>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapAdapter.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapAdapter.java
@@ -1467,8 +1467,10 @@ public class LdapAdapter extends BaseRepository implements ConfiguredRepository 
                     while (groups.hasMore()) {
                         if (entity != null) {
                             String groupDN = String.valueOf(groups.next());
-                            LdapEntry grpEntry = iLdapConn.getEntityByIdentifier(groupDN, null, null, iLdapConfigMgr.getGroupTypes(), propNames, false, false);
-                            createEntityFromLdapEntry(entity, SchemaConstants.DO_GROUP, grpEntry, supportedProps);
+                            if (LdapHelper.isUnderBases(groupDN, bases)) {
+                                LdapEntry grpEntry = iLdapConn.getEntityByIdentifier(groupDN, null, null, iLdapConfigMgr.getGroupTypes(), propNames, false, false);
+                                createEntityFromLdapEntry(entity, SchemaConstants.DO_GROUP, grpEntry, supportedProps);
+                            }
                         }
                     }
                 } catch (NamingException e) {

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/build.gradle
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/build.gradle
@@ -105,6 +105,7 @@ autoFVT.doLast {
     'com.ibm.ws.security.wim.adapter.ldap.fat.federation',
     'com.ibm.ws.security.wim.adapter.ldap.fat.input.output.mapping',
     'com.ibm.ws.security.wim.adapter.ldap.fat.multipleldaps',
+    'com.ibm.ws.security.wim.adapter.ldap.fat.operationalattribute',
     'com.ibm.ws.security.wim.adapter.ldap.fat.realm.mapping',
     'com.ibm.ws.security.wim.adapter.ldap.fat.referral',
     'com.ibm.ws.security.wim.adapter.ldap.fat.search.paging',

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FATSuite.java
@@ -81,7 +81,8 @@ import org.junit.runners.Suite.SuiteClasses;
                 RacfSdbmLdapWithBasicTest.class,
                 ADNestedGroupsWithRange.class,
                 JNDIOutputTest.class,
-                LDAPMemberAttributeScopeTest.class
+                LDAPMemberAttributeScopeTest.class,
+                OperationalAttributeTest.class
 })
 public class FATSuite extends CommonLocalLDAPServerSuite {
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/OperationalAttributeTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/OperationalAttributeTest.java
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.security.wim.adapter.ldap.fat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.security.registry.test.UserRegistryServletConnection;
+
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
+import componenttest.topology.utils.LDAPUtils;
+
+/**
+ * Test operational attribute group membership. The InMemoryLDAPServer does not have operational
+ * attribute support, so this test uses the physical TDS server. Additionally, in order to hit
+ * getGroupsByOperationalAttribute in the code, we must define groupMemeberIdMap in server.xml.
+ * This is why we use idsFilters instead of groupProperties.
+ */
+@RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
+public class OperationalAttributeTest {
+    private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.security.wim.adapter.ldap.fat.operationalattribute");
+    private static final Class<?> c = OperationalAttributeTest.class;
+    private static UserRegistryServletConnection servlet;
+
+    /**
+     * Updates the sample, which is expected to be at the hard-coded path.
+     * If this test is failing, check this path is correct.
+     */
+    @BeforeClass
+    public static void setUp() throws Exception {
+        // Add LDAP variables to bootstrap properties file
+        LDAPUtils.addLDAPVariables(server);
+        Log.info(c, "setUp", "Starting the server... (will wait for userRegistry servlet to start)");
+        server.copyFileToLibertyInstallRoot("lib/features", "internalfeatures/securitylibertyinternals-1.0.mf");
+        server.addInstalledAppForValidation("userRegistry");
+        server.startServer(c.getName() + ".log");
+
+        //Make sure the application has come up before proceeding
+        assertNotNull("Application userRegistry does not appear to have started.",
+                      server.waitForStringInLog("CWWKZ0001I:.*userRegistry"));
+        assertNotNull("Security service did not report it was ready",
+                      server.waitForStringInLog("CWWKS0008I"));
+        assertNotNull("Server did not came up",
+                      server.waitForStringInLog("CWWKF0011I"));
+
+        Log.info(c, "setUp", "Creating servlet connection the server");
+        servlet = new UserRegistryServletConnection(server.getHostname(), server.getHttpDefaultPort());
+
+        if (servlet.getRealm() == null) {
+            Thread.sleep(5000);
+            servlet.getRealm();
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        Log.info(c, "tearDown", "Stopping the server...");
+        try {
+            server.stopServer("CWIML4529E", "CWIML4537E");
+        } finally {
+            server.deleteFileFromLibertyInstallRoot("lib/features/internalfeatures/securitylibertyinternals-1.0.mf");
+        }
+    }
+
+    /**
+     * Call getGroupsForUser on vmmtestuser. vmmtestuser is part of groups outside
+     * of the specified group search base of ou=jgroups,o=ibm,c=us. These groups should
+     * not be returned. This test will fail without the additional group validation
+     * for operational attributes.
+     */
+    @Test
+    public void getGroupsForUserWithInvalidUser() throws Exception {
+        String user = "vmmtestuser";
+        Log.info(c, "getGroupsForUserWithInvalidUser", "Checking with an invalid user.");
+        List<String> list = servlet.getGroupsForUser(user);
+        assertTrue(list.isEmpty());
+    }
+
+    /**
+     * Call getUniqueGroupIdsForUser on vmmtestuser. vmmtestuser is part of groups outside
+     * of the specified group search base of ou=jgroups,o=ibm,c=us. These groups should
+     * not be returned. This test will fail without the additional group validation
+     * for operational attributes.
+     */
+    @Test
+    public void getUniqueGroupIdsOutsideSearchBase() throws Exception {
+        String user = "vmmtestuser";
+        Log.info(c, "getUniqueGroupIdsForUser", "Checking with a valid user.");
+        List<String> list = servlet.getUniqueGroupIdsForUser(user);
+        assertTrue(list.isEmpty());
+    }
+
+    /**
+     * Call getGroupsForUser on eddard_vmmUser. This user does have groups within
+     * the group search base of ou=jgroups,o=ibm,c=us. Ensure that these groups
+     * are returned. This test verifies group membership is still functioning
+     * properly. This test will not work with local LDAP as operational
+     * attributes are not supported.
+     */
+    @Test
+    public void getGroupsForUser() throws Exception {
+        Assume.assumeTrue(!LDAPUtils.USE_LOCAL_LDAP_SERVER);
+        String user = "eddard_vmmUser";
+        Log.info(c, "getGroupsForUser", "Checking with a valid user.");
+        List<String> list = servlet.getGroupsForUser(user);
+        assertTrue(list.contains("cn=stark_vmmGroup,ou=jGroups,o=ibm,c=us"));
+        assertEquals("We expected exactly 1 entry returned.", 1, list.size());
+    }
+
+    /**
+     * Call getUniqueGroupIdsForUser on eddard_vmmUser. This user does have groups within
+     * the group search base of ou=jgroups,o=ibm,c=us. Ensure that these groups
+     * are returned. This test verifies group membership is still functioning
+     * properly. This test will not work with local LDAP as operational
+     * attributes are not supported.
+     */
+    @Test
+    public void getUniqueGroupIdsForUser() throws Exception {
+        Assume.assumeTrue(!LDAPUtils.USE_LOCAL_LDAP_SERVER);
+        String user = "uid=eddard_vmmUser,ou=jUsers,o=ibm,c=us";
+        Log.info(c, "getUniqueGroupIds", "Checking with a valid user.");
+        List<String> list = servlet.getUniqueGroupIdsForUser(user);
+        assertTrue(list.contains("cn=stark_vmmGroup,ou=jGroups,o=ibm,c=us"));
+        assertEquals("We expected exactly 1 entry returned.", 1, list.size());
+    }
+}

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.operationalattribute/bootstrap.properties
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.operationalattribute/bootstrap.properties
@@ -1,0 +1,13 @@
+###############################################################################
+# Copyright (c) 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+com.ibm.ws.logging.trace.specification=*=info=enabled:com.ibm.ws.security.*=all=enabled
+com.ibm.ws.logging.max.file.size=0
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.operationalattribute/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.operationalattribute/server.xml
@@ -1,0 +1,41 @@
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="com.ibm.ws.wim.adapter.ldap.fat.operationalattribute">
+	<featureManager>
+		<feature>appSecurity-2.0</feature>
+		<feature>ldapRegistry-3.0</feature>
+		<feature>servlet-3.1</feature>
+		<feature>securitylibertyinternals-1.0</feature>
+	</featureManager>
+
+	<!-- Test operational attribute group membership. groupMemberIdMap is required to hit getGroupsByOperationalAttribute -->
+	<ldapRegistry id="LDAP" realm="TDSRealm" host="${ldap.server.4.name}" port="${ldap.server.4.port}" ignoreCase="true"
+		baseDN="o=ibm,c=us"
+		ldapType="IBM Tivoli Directory Server"
+		searchTimeout="8m">
+	  <ldapEntityType name="PersonAccount">
+        <objectClass>ePerson</objectClass>
+      </ldapEntityType>
+	  <ldapEntityType name="Group">
+        <objectClass>groupOfNames</objectClass>
+		<searchBase>ou=jgroups,o=ibm,c=us</searchBase> 
+      </ldapEntityType>
+		<idsFilters
+			groupMemberIdMap="ibm-allGroups:member;ibm-allGroups:uniqueMember;groupOfNames:member;groupOfUniqueNames:uniqueMember" />
+		<failoverServers name="failoverLdapServers">
+      		<server host="${ldap.server.7.name}" port="${ldap.server.7.port}"/>
+			<server host="${ldap.server.8.name}" port="${ldap.server.8.port}"/>
+       </failoverServers>	
+	</ldapRegistry> 
+
+	<include location="../fatTestPorts.xml"/>
+
+</server>


### PR DESCRIPTION
When a group search base is defined, only groups within this search base should be returned when retrieving a user's groups. This is not the case for operational attributes, eg. ibm-allgroups. We need to take into account the group search base when resolving membership just as we do with non-operational attribute membership. 