### PR TITLE
Jms20 fat dcf

### DIFF
--- a/dev/com.ibm.ws.injection/src/com/ibm/ws/injectionengine/osgi/internal/IndirectJndiLookupObjectFactory.java
+++ b/dev/com.ibm.ws.injection/src/com/ibm/ws/injectionengine/osgi/internal/IndirectJndiLookupObjectFactory.java
@@ -37,6 +37,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.jndi.JNDIConstants;
 
 import com.ibm.ejs.util.Util;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.container.service.naming.JavaColonNamingHelper;
@@ -100,6 +101,23 @@ public class IndirectJndiLookupObjectFactory implements ObjectFactory {
         return getObjectInstance(c, envmt, ref.getClassName(), ref.bindingName, ref.resourceInfo, ref);
     }
 
+    private static final String prefix = "getObjectInstance: ";
+
+    @Trivial
+    private static void debug(String text) {
+        System.out.println(prefix + text);
+    }
+
+    @Trivial
+    private static void debug(String text, Object value) {
+        System.out.println(prefix + text + " [ " + value + " ]");
+    }
+
+    @Trivial
+    private static void debug(String text, Object value1, Object value2) {
+        System.out.println(prefix + text + " [ " + value1 + " ] [ " + value2 + " ]");
+    }
+
     /**
      * Get an indirect object instance.
      *
@@ -115,7 +133,14 @@ public class IndirectJndiLookupObjectFactory implements ObjectFactory {
      * @param ref the actual Reference for diagnostic information
      */
     @FFDCIgnore(Exception.class)
-    private Object getObjectInstance(Context c, Hashtable<?, ?> envmt, String className, String bindingName, ResourceInfo resourceRefInfo, IndirectReference ref) throws Exception {
+    private Object getObjectInstance(
+        Context c,
+        Hashtable<?, ?> envmt,
+        String className, String bindingName,
+        ResourceInfo resourceRefInfo, IndirectReference ref) throws Exception {
+
+        debug("ENTER", className, bindingName);
+
         try {
             // References are supposed to always have a type, but we tolerate
             // references declared in XML that don't have a type, so it's possible
@@ -123,85 +148,138 @@ public class IndirectJndiLookupObjectFactory implements ObjectFactory {
             // target type the same as an actual JNDI lookup.
 
             boolean hasJNDIScheme;
-            if (bindingName.startsWith("java:")) {
+            if ( bindingName.startsWith("java:") ) {
+                debug("Trying java lookup");
+
                 Object instance = getJavaObjectInstance(c, envmt, className, bindingName, resourceRefInfo, ref);
-                if (instance != null) {
+                if ( instance != null ) {
+                    debug("RETURN (java lookup)", instance);
                     return instance;
+                } else {
+                    debug("Failed java lookup");
+                    hasJNDIScheme = true;
                 }
 
-                hasJNDIScheme = true;
             } else {
+                debug("Trying non-java lookup");
+
                 Object resource = createResource(ref.name, className, bindingName, resourceRefInfo);
+                if ( resource != null ) {
+                    debug("RETURN (typed create resource)", resource);
+                    return resource;
+                } else {
+                    debug("Failed typed create resource");
+                }
 
                 // If not found and the customer explicitly provided a binding, then
                 // try again without specifying type. This is for the case where the
                 // actual object produced by the factory is assignable to the reference
                 // type, but not an exact match.
-                if (resource == null && !ref.defaultBinding) {
-                    resource = createResource(ref.name, null, bindingName, resourceRefInfo);
-                }
 
-                if (resource != null) {
-                    return resource;
+                if ( !ref.defaultBinding ) {
+                    debug("Non-default binding; trying untyped create resource");
+                    resource = createResource(ref.name, null, bindingName, resourceRefInfo);               
+                    if ( resource != null ) {
+                        debug("RETURN (untyped non-default create resource)", resource);
+                        return resource;
+                    } else {
+                        debug("Failed untyped create resource");
+                    }
+                } else {
+                    debug("Default binding; skipped untyped create resource");
                 }
 
                 hasJNDIScheme = JNDIHelper.hasJNDIScheme(bindingName);
-                if (!hasJNDIScheme) {
+                if ( !hasJNDIScheme ) {
+                    debug("Tryping non-JNDI service lookup");
                     Object service = getJNDIServiceObjectInstance(className, bindingName, envmt);
-                    if (service != null) {
+                    if ( service != null ) {
+                        debug("RETURN (service lookup)", resource);
                         return service;
+                    } else {
+                        debug("Failed service lookup");
                     }
+                } else {
+                    debug("JNDI; skipped non-JNDI service lookup");
                 }
+
+                debug("Non-java lookup failed");
             }
 
             // If all else fails, try JNDI, which will fail if not enabled.  We only
             // attempt if the binding name has a scheme; we already checked the
             // service registry above, and we want to avoid JNDI if it might use a
             // non-ResourceFactory when a ResourceFactory is available.
-            if (hasJNDIScheme) {
+            if ( hasJNDIScheme ) {
+                debug("Trying context lookup");
                 try {
-                    if (c == null) {
+                    if ( c == null ) {
                         c = new InitialContext(envmt);
+                        debug("Created initial context", c);
+                    } else {
+                        debug("Using context", c);
                     }
-                    return c.lookup(bindingName);
+
+                    Object result = c.lookup(bindingName);
+                    debug("RETURN (JNDI lookup)", result);
+                    return result;
+
                 } catch (NoInitialContextException e) {
                     // The object was not found.
                 } catch (NameNotFoundException e) {
                     // The object was not found.
                 }
+            } else {
+                debug("Skipped context lookup");
             }
-        } catch (Exception e) {
-            String message = Tr.formatMessage(tc, "INDIRECT_LOOKUP_FAILED_CWNEN1006E",
-                                              bindingName, className,
-                                              e instanceof InjectionException ? e.getLocalizedMessage() : e);
+
+        } catch ( Exception e ) {
+            debug("FAILED", e.getMessage());
+
+            String message = Tr.formatMessage(tc,
+                "INDIRECT_LOOKUP_FAILED_CWNEN1006E",
+                 bindingName, className,
+                 ((e instanceof InjectionException) ? e.getLocalizedMessage() : e) );
             throw new InjectionException(message, e);
         }
 
         // If this was a default binding and EE 7 default resource support is
         // enabled, then try to create a default resource.
-        if (ref.defaultBinding && javaCompDefaultEnabled) {
+        if ( !ref.defaultBinding ) {
+            debug("Skipped default resource create: Not a default binding");
+        } else if ( !javaCompDefaultEnabled ) {
+            debug("Skipped default resource create: 'javaCompDefault' not enabled");
+        } else {
+            debug("Trying default resource create");
             Object resource = createDefaultResource(className, resourceRefInfo);
-            if (resource != null) {
+            if ( resource != null ) {
+                debug("RETURN (created default resource)", resource);
                 return resource;
+            } else {
+                debug("Failed default resource create");
             }
         }
 
         // We failed to find an object.
 
         String refName = InjectionScope.denormalize(ref.name);
+        debug("FAILED", refName);
 
-        if (ref.defaultBinding) {
-            throw new InjectionException(Tr.formatMessage(tc, "DEFAULT_BINDING_OBJECT_NOT_FOUND_CWNEN1004E",
-                                                          bindingName, className, refName));
+        String message;
+        if ( ref.defaultBinding ) {
+            message = Tr.formatMessage(tc,
+                "DEFAULT_BINDING_OBJECT_NOT_FOUND_CWNEN1004E",
+                bindingName, className, refName);
+        } else if ( ref.bindingListenerName != null ) {
+            message = Tr.formatMessage(tc,
+                "LISTENER_BINDING_OBJECT_NOT_FOUND_CWNEN1005E",
+                bindingName, className, refName, ref.bindingListenerName);
+        } else {
+            message = Tr.formatMessage(tc,
+                "BINDING_OBJECT_NOT_FOUND_CWNEN1003E",
+                bindingName, className, refName);
         }
-
-        if (ref.bindingListenerName != null) {
-            throw new InjectionException(Tr.formatMessage(tc, "LISTENER_BINDING_OBJECT_NOT_FOUND_CWNEN1005E",
-                                                          bindingName, className, refName, ref.bindingListenerName));
-        }
-
-        throw new InjectionException(Tr.formatMessage(tc, "BINDING_OBJECT_NOT_FOUND_CWNEN1003E",
-                                                      bindingName, className, refName));
+        throw new InjectionException(message);
     }
 
     /**

--- a/dev/com.ibm.ws.messaging.open_jms20_fat/fat/src/com/ibm/ws/messaging/JMS20/fat/FATSuite.java
+++ b/dev/com.ibm.ws.messaging.open_jms20_fat/fat/src/com/ibm/ws/messaging/JMS20/fat/FATSuite.java
@@ -37,94 +37,33 @@ import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-
                 DummyTest.class,
-                    // LiteBucketSet1Test.class,
-                    // LiteBucketSet2Test.class,
 
-                // Fully disabled for jakarta.  j2ee-management is not supported by jakarta, and
-                // is not compatible with the jakarta features used by the test class.
-                // JMSMBeanTest.class,
+                LiteBucketSet1Test.class,
+                LiteBucketSet2Test.class,
 
-                // JMSProducerTest_118071.class, //full
-                // JMSProducerTest_118073.class, //full
-                // SharedSubscriptionTest_129623.class,
+                JMSMBeanTest.class, // javax only; j2ee-management is not available in jakarta
 
-                // JMSConsumerTest_118076.class, //full
-                // JMSConsumerTest_118077.class, //full
-                // JMSRedeliveryTest_120846.class,
+                JMSProducerTest_118071.class, //full
+                JMSProducerTest_118073.class, //full
+                SharedSubscriptionTest_129623.class,
 
-                // SharedSubscriptionWithMsgSelTest_129623.class,
-                // SharedSubscriptionWithMsgSelTest_129626.class, //full 2nd
-                // SharedSubscriptionTest_129626.class, //full 2nd
-                // JMSProducer_Test118073.class, //full
+                JMSConsumerTest_118076.class, //full
+                JMSConsumerTest_118077.class, //full
+                JMSRedeliveryTest_120846.class,
 
-                // DurableUnsharedTest.class,
+                SharedSubscriptionWithMsgSelTest_129623.class,
+                SharedSubscriptionWithMsgSelTest_129626.class, //full 2nd
+                SharedSubscriptionTest_129626.class, //full 2nd
+                JMSProducer_Test118073.class, //full
 
-                // JMSContextInjectTest.class, //full
-
-// Stack Dump = javax.naming.NameNotFoundException: javax.naming.NameNotFoundException: java:comp/DefaultJMSConnectionFactory
-// at com.ibm.ws.jndi.url.contexts.javacolon.internal.JavaURLContext.lookup(JavaURLContext.java:355)
-// at com.ibm.ws.jndi.url.contexts.javacolon.internal.JavaURLContext.lookup(JavaURLContext.java:370)
-// at org.apache.aries.jndi.DelegateContext.lookup(DelegateContext.java:149)
-// at javax.naming.InitialContext.lookup(InitialContext.java:428)
-// at com.ibm.ws.injectionengine.osgi.internal.IndirectJndiLookupObjectFactory.getObjectInstance(IndirectJndiLookupObjectFactory.java:166)
-// at com.ibm.ws.injectionengine.osgi.internal.IndirectJndiLookupObjectFactory.getObjectInstance(IndirectJndiLookupObjectFactory.java:100)
-// at com.ibm.wsspi.injectionengine.InjectionBinding.getInjectionObjectInstance(InjectionBinding.java:1552)
-// at com.ibm.wsspi.injectionengine.InjectionBinding.getInjectionObject(InjectionBinding.java:1428)
-// at com.ibm.wsspi.injectionengine.InjectionBinding.getInjectableObject(InjectionBinding.java:1368)
-// at com.ibm.wsspi.injectionengine.InjectionTarget.inject(InjectionTarget.java:104)
-// at com.ibm.ws.cdi.impl.weld.injection.WebSphereInjectionServicesImpl.inject(WebSphereInjectionServicesImpl.java:198)
-// at com.ibm.ws.cdi.impl.weld.injection.WebSphereInjectionServicesImpl.inject(WebSphereInjectionServicesImpl.java:150)
-// at com.ibm.ws.cdi.impl.weld.injection.WebSphereInjectionServicesImpl.access$000(WebSphereInjectionServicesImpl.java:74)
-// at com.ibm.ws.cdi.impl.weld.injection.WebSphereInjectionServicesImpl$1.run(WebSphereInjectionServicesImpl.java:134)
-// at com.ibm.ws.cdi.impl.weld.injection.WebSphereInjectionServicesImpl$1.run(WebSphereInjectionServicesImpl.java:130)
-// at java.security.AccessController.doPrivileged(AccessController.java:694)
-// at com.ibm.ws.cdi.impl.weld.injection.WebSphereInjectionServicesImpl.callInject(WebSphereInjectionServicesImpl.java:130)
-// at com.ibm.ws.cdi.impl.weld.injection.WebSphereInjectionServicesImpl.injectJavaEEResources(WebSphereInjectionServicesImpl.java:112)
-// at com.ibm.ws.cdi.impl.weld.injection.WebSphereInjectionServicesImpl.aroundInject(WebSphereInjectionServicesImpl.java:317)
-// at org.jboss.weld.injection.InjectionContextImpl.run(InjectionContextImpl.java:46)
-// at org.jboss.weld.injection.producer.ResourceInjector.inject(ResourceInjector.java:71)
-// at org.jboss.weld.injection.producer.BasicInjectionTarget.inject(BasicInjectionTarget.java:117)
-// at com.ibm.ws.cdi.impl.managedobject.CDIManagedObject.cdiInjection(CDIManagedObject.java:202)
-// at com.ibm.ws.cdi.impl.managedobject.CDIManagedObject.inject(CDIManagedObject.java:175)
-// at com.ibm.ws.cdi.impl.managedobject.CDIManagedObject.inject(CDIManagedObject.java:153)
-// at com.ibm.ws.webcontainer.osgi.webapp.WebApp.inject(WebApp.java:1277)
-// at com.ibm.ws.webcontainer.osgi.webapp.WebApp.injectAndPostConstruct(WebApp.java:1418)
-// at com.ibm.ws.webcontainer.osgi.webapp.WebApp.injectAndPostConstruct(WebApp.java:1406)
-// at com.ibm.ws.webcontainer.osgi.servlet.ServletWrapper.createTarget(ServletWrapper.java:63)
-// at com.ibm.ws.webcontainer.servlet.ServletWrapper$1.run(ServletWrapper.java:1515)
-// at java.security.AccessController.doPrivileged(AccessController.java:694)
-// at com.ibm.ws.webcontainer.servlet.ServletWrapper.loadServlet(ServletWrapper.java:1483)
-// at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:573)
-// at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:426)
-// at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1226)
-// at com.ibm.ws.webcontainer.webapp.WebApp.handleRequest(WebApp.java:5057)
-// at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.handleRequest(DynamicVirtualHost.java:314)
-// at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:1005)
-// at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:279)
-// at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1134)
-// at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:415)
-// at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:374)
-// at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:565)
-// at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:499)
-// at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:359)
-// at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.ready(HttpInboundLink.java:326)
-// at com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.sendToDiscriminators(NewConnectionInitialReadCallback.java:167)
-// at com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.complete(NewConnectionInitialReadCallback.java:75)
-// at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:504)
-// at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:574)
-// at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:958)
-// at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1047)
-// at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:239)
-// at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1160)
-// at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
-// at java.lang.Thread.run(Thread.java:811)
+                DurableUnsharedTest.class,
+                JMSContextInjectTest.class, //full
 
                 JMSDCFTest.class,
-                    // JMSDCFVarTest.class, //full 2nd
+                JMSDCFVarTest.class, //full 2nd
 
-                    // JMSEjbJarXmlMdbTest.class
+                JMSEjbJarXmlMdbTest.class
 })
 
 public class FATSuite {
@@ -133,7 +72,6 @@ public class FATSuite {
     // repeat can be re-enabled in open-liberty.
 
     @ClassRule
-    public static RepeatTests repeater = RepeatTests
-        .withoutModification()
-        .andWith( new JakartaEE9Action() );
+    public static RepeatTests repeater =
+        RepeatTests.with( new JakartaEE9Action() );
 }

--- a/dev/com.ibm.ws.messaging.open_jms20_fat/fat/src/com/ibm/ws/messaging/JMS20/fat/FATSuite.java
+++ b/dev/com.ibm.ws.messaging.open_jms20_fat/fat/src/com/ibm/ws/messaging/JMS20/fat/FATSuite.java
@@ -22,7 +22,7 @@ import com.ibm.ws.messaging.JMS20.fat.JMSConsumerTest.JMSConsumerTest_118077;
 import com.ibm.ws.messaging.JMS20.fat.JMSContextTest.JMSEjbJarXmlMdbTest;
 import com.ibm.ws.messaging.JMS20.fat.JMSContextTest.JMSRedeliveryTest_120846;
 import com.ibm.ws.messaging.JMS20.fat.JMSDCFTest.JMSDCFVarTest;
-//import com.ibm.ws.messaging.JMS20.fat.JMSDCFTest.JMSDCFTest;
+import com.ibm.ws.messaging.JMS20.fat.JMSDCFTest.JMSDCFTest;
 import com.ibm.ws.messaging.JMS20.fat.JMSMBeanTest.JMSMBeanTest;
 import com.ibm.ws.messaging.JMS20.fat.JMSProducerTest.JMSProducerTest_118071;
 import com.ibm.ws.messaging.JMS20.fat.JMSProducerTest.JMSProducerTest_118073;
@@ -39,29 +39,29 @@ import componenttest.rules.repeater.RepeatTests;
 @SuiteClasses({
 
                 DummyTest.class,
-                LiteBucketSet1Test.class,
-                LiteBucketSet2Test.class,
+                    // LiteBucketSet1Test.class,
+                    // LiteBucketSet2Test.class,
 
                 // Fully disabled for jakarta.  j2ee-management is not supported by jakarta, and
                 // is not compatible with the jakarta features used by the test class.
-                JMSMBeanTest.class,
+                // JMSMBeanTest.class,
 
-                JMSProducerTest_118071.class, //full
-                JMSProducerTest_118073.class, //full
-                SharedSubscriptionTest_129623.class,
+                // JMSProducerTest_118071.class, //full
+                // JMSProducerTest_118073.class, //full
+                // SharedSubscriptionTest_129623.class,
 
-                JMSConsumerTest_118076.class, //full
-                JMSConsumerTest_118077.class, //full
-                JMSRedeliveryTest_120846.class,
+                // JMSConsumerTest_118076.class, //full
+                // JMSConsumerTest_118077.class, //full
+                // JMSRedeliveryTest_120846.class,
 
-                SharedSubscriptionWithMsgSelTest_129623.class,
-                SharedSubscriptionWithMsgSelTest_129626.class, //full 2nd
-                SharedSubscriptionTest_129626.class, //full 2nd
-                JMSProducer_Test118073.class, //full
+                // SharedSubscriptionWithMsgSelTest_129623.class,
+                // SharedSubscriptionWithMsgSelTest_129626.class, //full 2nd
+                // SharedSubscriptionTest_129626.class, //full 2nd
+                // JMSProducer_Test118073.class, //full
 
-                DurableUnsharedTest.class,
+                // DurableUnsharedTest.class,
 
-                JMSContextInjectTest.class, //full
+                // JMSContextInjectTest.class, //full
 
 // Stack Dump = javax.naming.NameNotFoundException: javax.naming.NameNotFoundException: java:comp/DefaultJMSConnectionFactory
 // at com.ibm.ws.jndi.url.contexts.javacolon.internal.JavaURLContext.lookup(JavaURLContext.java:355)
@@ -121,10 +121,10 @@ import componenttest.rules.repeater.RepeatTests;
 // at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
 // at java.lang.Thread.run(Thread.java:811)
 
-// xx                JMSDCFTest.class,
-                JMSDCFVarTest.class, //full 2nd
+                JMSDCFTest.class,
+                    // JMSDCFVarTest.class, //full 2nd
 
-                JMSEjbJarXmlMdbTest.class
+                    // JMSEjbJarXmlMdbTest.class
 })
 
 public class FATSuite {
@@ -132,9 +132,8 @@ public class FATSuite {
     // the tests are removed from WS-CD-Open, the pre-jakarta
     // repeat can be re-enabled in open-liberty.
 
-// TODO: Remove
-//    public static RepeatTests r = RepeatTests.with(new JakartaEE9Action());
-
     @ClassRule
-    public static RepeatTests repeater = RepeatTests.withoutModification().andWith(new JakartaEE9Action());
+    public static RepeatTests repeater = RepeatTests
+        .withoutModification()
+        .andWith( new JakartaEE9Action() );
 }

--- a/dev/com.ibm.ws.messaging.open_jms20_fat/fat/src/com/ibm/ws/messaging/JMS20/fat/JMSDCFTest/JMSDCFTest.java
+++ b/dev/com.ibm.ws.messaging.open_jms20_fat/fat/src/com/ibm/ws/messaging/JMS20/fat/JMSDCFTest/JMSDCFTest.java
@@ -28,8 +28,10 @@ import componenttest.topology.impl.LibertyServerFactory;
 
 public class JMSDCFTest {
 
-    private static final LibertyServer engineServer = LibertyServerFactory.getLibertyServer("JMSDCFEngine");
-    private static final LibertyServer clientServer = LibertyServerFactory.getLibertyServer("JMSDCFClient");
+    private static final LibertyServer engineServer =
+        LibertyServerFactory.getLibertyServer("JMSDCFEngine");
+    private static final LibertyServer clientServer =
+        LibertyServerFactory.getLibertyServer("JMSDCFClient");
 
     private static final int clientPort = clientServer.getHttpDefaultPort();
     private static final String clientHostName = clientServer.getHostname();
@@ -44,12 +46,10 @@ public class JMSDCFTest {
 
     @BeforeClass
     public static void testConfigFileChange() throws Exception {
-        engineServer.copyFileToLibertyInstallRoot(
-                                                  "lib/features", "features/testjmsinternals-1.0.mf");
+        engineServer.copyFileToLibertyInstallRoot("lib/features", "features/testjmsinternals-1.0.mf");
         engineServer.setServerConfigurationFile("JMSDCFEngine.xml");
 
-        clientServer.copyFileToLibertyInstallRoot(
-                                                  "lib/features", "features/testjmsinternals-1.0.mf");
+        clientServer.copyFileToLibertyInstallRoot( "lib/features", "features/testjmsinternals-1.0.mf");
         clientServer.setServerConfigurationFile("JMSDCFClient.xml");
         TestUtils.addDropinsWebApp(clientServer, dcfAppName, dcfPackages);
 

--- a/dev/com.ibm.ws.messaging.open_jms20_fat/fat/src/com/ibm/ws/messaging/JMS20/fat/JMSDCFTest/JMSDCFTest.java
+++ b/dev/com.ibm.ws.messaging.open_jms20_fat/fat/src/com/ibm/ws/messaging/JMS20/fat/JMSDCFTest/JMSDCFTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -56,7 +57,7 @@ public class JMSDCFTest {
         clientServer.startServer();
     }
 
-    @org.junit.AfterClass
+    @AfterClass
     public static void tearDown() {
         try {
             clientServer.stopServer();

--- a/dev/com.ibm.ws.messaging.open_jms20_fat/publish/files/JMSDCFClient.xml
+++ b/dev/com.ibm.ws.messaging.open_jms20_fat/publish/files/JMSDCFClient.xml
@@ -2,15 +2,18 @@
 
   <variable name="onError" value="FAIL"/>
 
+  <!--
   <logging
     traceSpecification="*=info:com.ibm.ws.jndi.*=all:jmx.rest.server.connector=all:com.ibm.ws.jmx.connector.server.rest.*=all:Naming=all:NamingService=all:SIBCommunications=all:SIBJFapChannel=all:SIBJms*=all:SIBJmsRa=all:SIBMatchSpace=all:SIBMessageStore=all:SIBMessageTrace=all:SIBMfp=all:SIBProcessor=all:SIBRa=all:SIBTrm=all:com.ibm.ws.jndi*=all:com.ibm.ws.injectionengine*=all"
     maxFileSize="200"/>
+    -->
 
   <featureManager>
     <feature>jndi-1.0</feature>
     <feature>servlet-3.1</feature>
     <feature>cdi-1.2</feature>
 
+    <feature>wasJmsServer-1.0</feature>
     <feature>wasJmsClient-2.0</feature>
     <feature>testjmsinternals-1.0</feature>
 
@@ -34,17 +37,21 @@
   <!-- Avoid MissingDoPrivDetectionSecurityManager warnings -->
   <javaPermission className="java.net.SocketPermission" name="*" actions="resolve,connect"/>
 
-  <!-- JMS endpoint configuration -->
+  <!-- JMS engine configuration -->
 
-  <!-- jmsConnectionFactory jndiName="DefaultJMSConnectionFactory" -->
+  <messagingEngine id="CLIENT_ME">
+    <queue id="QUEUE1" maxRedeliveryCount="2"/>
+  </messagingEngine>
+
+  <!-- JMS endpoint configuration -->
 
   <!-- Required binding, since the messaging engine was moved to a different server. -->
   <jmsConnectionFactory jndiName="DefaultJMSConnectionFactory" connectionManagerRef="ConMgr6">
-    <properties.wasJms remoteServerAddress="localhost:${bvt.prop.jms.1}:BootstrapBasicMessaging"/> 
+    <properties.wasJms remoteServerAddress="localhost:${bvt.prop.jms.1}:BootstrapBasicMessaging"/>
   </jmsConnectionFactory>
   <connectionManager id="ConMgr6" maxPoolSize="2"/>
 
-  <jmsQueue jndiName="jndi_INPUT_Q">
+  <jmsQueue id="jndi_INPUT_Q" jndiName="jndi_INPUT_Q">
     <properties.wasJms queueName="QUEUE1"/>
   </jmsQueue>
 

--- a/dev/com.ibm.ws.messaging.open_jms20_fat/publish/files/JMSDCFClient.xml
+++ b/dev/com.ibm.ws.messaging.open_jms20_fat/publish/files/JMSDCFClient.xml
@@ -2,11 +2,9 @@
 
   <variable name="onError" value="FAIL"/>
 
-  <!--
   <logging
-    traceSpecification="*=info:com.ibm.ws.jndi.*=all:jmx.rest.server.connector=all:com.ibm.ws.jmx.connector.server.rest.*=all:Naming=all:NamingService=all:SIBCommunications=all:SIBJFapChannel=all:SIBJms*=all:SIBJmsRa=all:SIBMatchSpace=all:SIBMessageStore=all:SIBMessageTrace=all:SIBMfp=all:SIBProcessor=all:SIBRa=all:SIBTrm=all"
+    traceSpecification="*=info:com.ibm.ws.jndi.*=all:jmx.rest.server.connector=all:com.ibm.ws.jmx.connector.server.rest.*=all:Naming=all:NamingService=all:SIBCommunications=all:SIBJFapChannel=all:SIBJms*=all:SIBJmsRa=all:SIBMatchSpace=all:SIBMessageStore=all:SIBMessageTrace=all:SIBMfp=all:SIBProcessor=all:SIBRa=all:SIBTrm=all:com.ibm.ws.jndi*=all:com.ibm.ws.injectionengine*=all"
     maxFileSize="200"/>
-   -->
 
   <featureManager>
     <feature>jndi-1.0</feature>
@@ -37,6 +35,8 @@
   <javaPermission className="java.net.SocketPermission" name="*" actions="resolve,connect"/>
 
   <!-- JMS endpoint configuration -->
+
+  <!-- jmsConnectionFactory jndiName="DefaultJMSConnectionFactory" -->
 
   <!-- Required binding, since the messaging engine was moved to a different server. -->
   <jmsConnectionFactory jndiName="DefaultJMSConnectionFactory" connectionManagerRef="ConMgr6">

--- a/dev/com.ibm.ws.messaging.open_jms20_fat/publish/files/JMSDCFEngine.xml
+++ b/dev/com.ibm.ws.messaging.open_jms20_fat/publish/files/JMSDCFEngine.xml
@@ -37,7 +37,7 @@
 
   <!-- JMS engine configuration -->
 
-  <messagingEngine id="defaultME">
+  <messagingEngine id="ENGINE_ME">
     <queue id="QUEUE1" maxRedeliveryCount="2"/>
   </messagingEngine>
 


### PR DESCRIPTION
FAT enablement change, only.

This pull request enables the test class "JMSDCFTest.java", one of the test classes under FAT project "com.ibm.ws.messaging.open_jms20_fat".

The test is running locally in both javax and jakarta modes, but with questionable configuration settings.

A messaging engine is enabled on both the client server (JMSDCFClient.xml) and on the engine server (JMSDCFEngine.xml).  I was unable to get the tests to run without having both a client server and an engine server, and with a messaging engine on both servers.  I tried but was unable to get the tests running using a single server configuration.

---

Pre-Jakarta, use of client configuration that does not have a server element results in an injection failure of:

```
  @Resource(name = "myJMSCF")

  Stack Dump = com.ibm.wsspi.injectionengine.InjectionException: 
      CWNEN1004E: The server was unable to find the myJMSCF default binding
      with the javax.jms.ConnectionFactory type for the java:comp/env/myJMSCF reference.
          at com.ibm.ws.injectionengine.osgi.internal.IndirectJndiLookupObjectFactory.
          getObjectInstance(IndirectJndiLookupObjectFactory.java:282)
```

Still pre-Jakarta, adding a server element fixes the default injection:

`  <feature>wasJmsServer-1.0</feature>`

But queue lookup fails:

```
  jmsQueue = (Queue) new InitialContext().lookup("java:comp/env/jndi_INPUT_Q");

  Stack Dump = javax.servlet.ServletException: Failed JMS initialization
      at jmsdcf.web.JMSDCFServlet.init(JMSDCFServlet.java
```

A modification to the lookup enables most tests to succeed:

`  jmsQueue = (Queue) new InitialContext().lookup("jndi_INPUT_Q");`

Note the client configuration has this queue binding:

```
  <jmsQueue id="jndi_INPUT_Q" jndiName="jndi_INPUT_Q">
    <properties.wasJms queueName="QUEUE1"/>
  </jmsQueue>
```

One test still fails "testP2P_B_SecOff_inject":

```
  Caused by: com.ibm.ws.sib.processor.exceptions.SIMPNotPossibleInCurrentConfigurationException:
    CWSIK0015E: The destination QUEUE1 was not found on messaging engine defaultME.
    at com.ibm.ws.sib.processor.impl.DestinationManager.checkDestinationHandlerExists(DestinationManager.javva:4146)
```

Adding a queue element to the client configuration messaging engine enables this test to pass:

```
  <messagingEngine id="CLIENT_ME">
    <queue id="QUEUE1" maxRedeliveryCount="2"/>
  </messagingEngine>
```

Note that the element was already present in the engine configuration messaging engine:

```
  <messagingEngine id="ENGINE_ME">
    <queue id="QUEUE1" maxRedeliveryCount="2"/>
  </messagingEngine>
```


