### PR TITLE
Allow config timeout and skip addl OpenJDK for ACME fats

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSwapDirectoriesTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSwapDirectoriesTest.java
@@ -225,7 +225,7 @@ public class AcmeSwapDirectoriesTest {
 			/*
 			 * Stop the server.
 			 */
-			stopServer("CWPKI2038W");
+			stopServer("CWPKI2038W", "CWWKG0027W");
 		}
 	}
 	/**
@@ -325,7 +325,7 @@ public class AcmeSwapDirectoriesTest {
 			/*
 			 * Stop the server.
 			 */
-			stopServer("CWPKI2038W", "CWPKI2072W");
+			stopServer("CWPKI2038W", "CWPKI2072W", "CWWKG0027W");
 		}
 	}
 	/**
@@ -403,7 +403,7 @@ public class AcmeSwapDirectoriesTest {
 			/*
 			 * Stop the server.
 			 */
-			stopServer("CWPKI2038W");
+			stopServer("CWPKI2038W", "CWWKG0027W");
 		}
 	}
 	

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
@@ -883,7 +883,7 @@ public class AcmeFatUtils {
 				"Checking os.name: " + os + " java.vendor: " + javaVendor + " java.version: " + javaVersion);
 		if (os.startsWith("win") && (javaVendor.contains("openjdk") || javaVendor.contains(("oracle")))
 				&& (javaVersion.equals("11.0.5") || javaVersion.equals("14.0.1") || javaVersion.equals("11")
-						|| javaVersion.equals("1.8.0_181"))) {
+						|| javaVersion.equals("1.8.0_181") || javaVersion.equals("15"))) {
 			/*
 			 * On Windows with OpenJDK 11.0.5 (and others), we sometimes get an exception
 			 * deleting the Acme related files.


### PR DESCRIPTION
Fix two build breaks with FAT fixes.

- Hit a config timeout -- I can't change the warning time in the FAT tests even though we do complete the update -- the ACME call just takes longer sometimes. `CWWKG0027W`

- Hit another Win/JDK combo where we can't remove files programmatically