### PR TITLE
Ignore Tx failure during server stop for EJB FAT

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/PersistentTimerTestHelper.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/PersistentTimerTestHelper.java
@@ -49,7 +49,16 @@ public class PersistentTimerTestHelper {
         // persistent.internal.InvokerTask run starts for a persistent timer during server shutdown,
         // but datasource has already been shutdown; can occur without any timers, just by database poll.
         ignoreList.add("DSRA0304E");
-        ignoreList.add("DSRA0302E.*XA_RBROLLBACK");
+        ignoreList.add("DSRA0302E");
+
+        // DSRA0230E: Attempt to perform operation XAResource.end() is not allowed because transaction state is TRANSACTION_FAIL.
+        // DSRA0302E:  XAException occurred.  Error code is: XAER_NOTA (-4).  Exception is: null
+        // DSRA0302E:  XAException occurred.  Error code is: XAER_RMFAIL (-7).  Exception is: No current connection.
+        //
+        // persistent.internal.InvokerTask run starts for a persistent timer during server shutdown,
+        // but timer fails because server stopping, then attempt to rollback fails because transaction
+        // service has already stopped.
+        ignoreList.add("DSRA0230E.*TRANSACTION_FAIL");
 
         // J2CA0027E: An exception occurred while invoking end on an XA Resource Adapter from DataSource
         //            dataSource[DefaultDataSource], within transaction ID {XidImpl: formatId(57415344),


### PR DESCRIPTION
In flight EJB timer attempts to rollback during server stop
but transaction service has already stopped; ignore this error.

