### PR TITLE
Fix unit tests that fail in isolation

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1787,6 +1787,11 @@
       <version>1.0</version>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.microprofile.context-propagation</groupId>
+      <artifactId>microprofile-context-propagation-api</artifactId>
+      <version>1.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
       <artifactId>microprofile-fault-tolerance-api</artifactId>
       <version>1.0</version>

--- a/dev/com.ibm.websphere.javaee.management.j2ee.1.1/build.gradle
+++ b/dev/com.ibm.websphere.javaee.management.j2ee.1.1/build.gradle
@@ -16,3 +16,7 @@ task rmic(type: Exec, dependsOn: compileJava) {
     executable 'rmic'
     args '-iiop', '-keep', '-d', compileJava.destinationDir, '-classpath', rmicClasspath, 'javax.management.j2ee.Management', 'javax.management.j2ee.ManagementHome'
 }
+
+//Unit tests assert the checksum of the bundle jar so ensure jar is done first.
+//Unit testing alone does not require assembling the jar. 
+test.dependsOn 'jar'

--- a/dev/com.ibm.ws.security.fat.common/build.gradle
+++ b/dev/com.ibm.ws.security.fat.common/build.gradle
@@ -8,11 +8,12 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-apply from: '../wlp-gradle/subprojects/fat.gradle'
+// This doesn't seem to be necessary and fails during unit-test assembly 
+//apply from: '../wlp-gradle/subprojects/fat.gradle'
 
-dependencies {
-  requiredLibs 'commons-logging:commons-logging:1.1.3'
-}
+//dependencies {
+//  requiredLibs 'commons-logging:commons-logging:1.1.3'
+//}
 
 /*
  * This is where all application ZIP and WARs will be built.

--- a/dev/com.ibm.ws.security.openidconnect.client/test/com/ibm/ws/security/openidconnect/client/web/OidcRedirectServletTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/test/com/ibm/ws/security/openidconnect/client/web/OidcRedirectServletTest.java
@@ -83,7 +83,11 @@ public class OidcRedirectServletTest {
 
     @Before
     public void setUp() throws Exception {
-        OidcClientUtil.setReferrerURLCookieHandler(null);// reset the ReferrerURLCookieHandler which was set in previous tests
+        try {
+            OidcClientUtil.setReferrerURLCookieHandler(null);// reset the ReferrerURLCookieHandler which was set in previous tests
+        } catch (NullPointerException npe) {
+            //Ignore this indicates that this test class is being run in isolation.
+        }
         OidcClientUtil.setWebAppSecurityConfig(webAppSecurityConfig);
         mock.checking(new Expectations() {
             {


### PR DESCRIPTION
com.ibm.websphere.javaee.management.j2ee.1.1 -> assumes jar of project already exists, but won't if you just run gradle :test 

com.ibm.ws.security.fat.common -> fails during assembly on my local system and on the GH actions build. Looks to have unnecessary import and library.

com.ibm.ws.security.openidconnect.client -> assumes that one of the other unit tests runs before another which isn't always the case. 
