### PR TITLE
Update mpJWt FATs to use shared key tools and reduce server reconfigs

### DIFF
--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/MPJwtApplicationAndSessionScopedClaimInjectionTests.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/MPJwtApplicationAndSessionScopedClaimInjectionTests.java
@@ -21,7 +21,6 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
-import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.actions.TestActions;
 import com.ibm.ws.security.fat.common.expectations.Expectations;
 import com.ibm.ws.security.fat.common.expectations.ServerMessageExpectation;
@@ -103,16 +102,6 @@ public class MPJwtApplicationAndSessionScopedClaimInjectionTests extends CommonM
     }
 
     /**
-     * Don't restore between tests
-     * All of the tests in this class will reconfigure the server
-     */
-    @Override
-    public void restoreTestServers() {
-        Log.info(thisClass, "restoreTestServersWithCheck", "* Skipping server restore **");
-        logTestCaseInServerLogs("** Skipping server restore **");
-    }
-
-    /**
      * Gets the resource server up and running.
      * Sets properties in bootstrap.properties that will affect server behavior
      * Sets up and installs the test apps (does not start them)
@@ -137,6 +126,7 @@ public class MPJwtApplicationAndSessionScopedClaimInjectionTests extends CommonM
 
         generateRSServerTestApps(server);
         serverTracker.addServer(server);
+        skipRestoreServerTracker.addServer(server);
         server.startServerUsingExpandedConfiguration(configFile, commonStartMsgs);
         SecurityFatHttpUtils.saveServerPorts(server, MpJwtFatConstants.BVT_SERVER_1_PORT_NAME_ROOT);
         server.addIgnoredErrors(Arrays.asList(MpJwtMessageConstants.CWWKW1001W_CDI_RESOURCE_SCOPE_MISMATCH));

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/MPJwtBasicTests.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/MPJwtBasicTests.java
@@ -80,6 +80,7 @@ public class MPJwtBasicTests extends CommonMpJwtFat {
         bootstrapUtils.writeBootstrapProperty(server, "mpJwt_authHeaderPrefix", FATSuite.authHeaderPrefix + " ");
         deployRSServerApiTestApps(server);
         serverTracker.addServer(server);
+        skipRestoreServerTracker.addServer(server);
         server.startServerUsingExpandedConfiguration(configFile, commonStartMsgs);
         SecurityFatHttpUtils.saveServerPorts(server, MpJwtFatConstants.BVT_SERVER_1_PORT_NAME_ROOT);
         server.addIgnoredErrors(Arrays.asList(MpJwtMessageConstants.CWWKW1001W_CDI_RESOURCE_SCOPE_MISMATCH, MpJwtMessageConstants.CWWKS6055W_BETA_SIGNATURE_ALGORITHM_USED));

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/MPJwtConfigUsingBuilderTests.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/MPJwtConfigUsingBuilderTests.java
@@ -781,6 +781,10 @@ public class MPJwtConfigUsingBuilderTests extends MPJwt11MPConfigTests {
         // Try to use the token again - this time, in a different conversation
         genericConfigTest(builtToken, expectations);
 
+        // On fast machines - tests that follow create an identical token and it's basically marked logged
+        // out before it's created.  Sleep so the next test gets a unique token
+        Thread.sleep(1000);
+
     }
 
     /******************************** userNameAttribute ***************************************/

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/configInAppTests/MPJwtMPConfigInApp_BadIssuerMPJwtConfigInServerXml_Tests.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/configInAppTests/MPJwtMPConfigInApp_BadIssuerMPJwtConfigInServerXml_Tests.java
@@ -48,6 +48,7 @@ public class MPJwtMPConfigInApp_BadIssuerMPJwtConfigInServerXml_Tests extends MP
         // let's pick a default config - use a pemFile located in the app
         MP11ConfigSettings mpConfigSettings = new MP11ConfigSettings(MP11ConfigSettings.PemFile, MP11ConfigSettings.PublicKeyNotSet, MP11ConfigSettings.IssuerNotSet, MpJwtFatConstants.X509_CERT);
         setUpAndStartRSServerForTests(resourceServer, "rs_server_AltConfigInApp_badServerXmlIssuer.xml", mpConfigSettings, MPConfigLocation.IN_APP);
+        skipRestoreServerTracker.addServer(resourceServer);
 
     }
 
@@ -64,8 +65,8 @@ public class MPJwtMPConfigInApp_BadIssuerMPJwtConfigInServerXml_Tests extends MP
     public void MPJwtMPConfigInApp_BadIssuerMPJwtConfigInServerXml_GoodMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadIssuerExpectations(resourceServer));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadIssuerExpectations(resourceServer));
 
     }
 
@@ -80,8 +81,8 @@ public class MPJwtMPConfigInApp_BadIssuerMPJwtConfigInServerXml_Tests extends MP
     public void MPJwtMPConfigInApp_BadIssuerMPJwtConfigInServerXml_GoodMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadIssuerExpectations(resourceServer));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadIssuerExpectations(resourceServer));
 
     }
 
@@ -96,8 +97,8 @@ public class MPJwtMPConfigInApp_BadIssuerMPJwtConfigInServerXml_Tests extends MP
     public void MPJwtMPConfigInApp_BadIssuerMPJwtConfigInServerXml_GoodIssuerInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_ISSUER_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadIssuerExpectations(resourceServer));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadIssuerExpectations(resourceServer));
 
     }
 
@@ -112,8 +113,8 @@ public class MPJwtMPConfigInApp_BadIssuerMPJwtConfigInServerXml_Tests extends MP
     public void MPJwtMPConfigInApp_BadIssuerMPJwtConfigInServerXml_GoodIssuerInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_ISSUER_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadIssuerExpectations(resourceServer));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadIssuerExpectations(resourceServer));
 
     }
 
@@ -128,8 +129,8 @@ public class MPJwtMPConfigInApp_BadIssuerMPJwtConfigInServerXml_Tests extends MP
     public void MPJwtMPConfigInApp_BadIssuerMPJwtConfigInServerXml_BadIssuerInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_ISSUER_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadIssuerExpectations(resourceServer));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadIssuerExpectations(resourceServer));
 
     }
 
@@ -144,8 +145,8 @@ public class MPJwtMPConfigInApp_BadIssuerMPJwtConfigInServerXml_Tests extends MP
     public void MPJwtMPConfigInApp_BadIssuerMPJwtConfigInServerXml_BadIssuerInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_ISSUER_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadIssuerExpectations(resourceServer));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadIssuerExpectations(resourceServer));
 
     }
 

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/configInAppTests/MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/configInAppTests/MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests.java
@@ -48,7 +48,7 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
         // let's pick a default config - use a pemFile located in the app
         MP11ConfigSettings mpConfigSettings = new MP11ConfigSettings(MP11ConfigSettings.PemFile, MP11ConfigSettings.PublicKeyNotSet, MP11ConfigSettings.IssuerNotSet, MpJwtFatConstants.X509_CERT);
         setUpAndStartRSServerForTests(resourceServer, "rs_server_AltConfigInApp_badServerXmlJwksUri.xml", mpConfigSettings, MPConfigLocation.IN_APP);
-
+        skipRestoreServerTracker.addServer(resourceServer);
     }
 
     /******************************************** tests **************************************/
@@ -64,8 +64,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_GoodMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -80,8 +80,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_GoodMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -98,8 +98,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_BadIssuerInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_ISSUER_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -115,8 +115,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_BadIssuerInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_ISSUER_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -131,8 +131,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_GoodSimplePublicKeyInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_SIMPLE_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -147,8 +147,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_GoodSimplePublicKeyInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_SIMPLE_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -163,8 +163,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_GoodComplexPublicKeyInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_COMPLEX_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -179,8 +179,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_GoodComplexPublicKeyInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_COMPLEX_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -195,8 +195,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_BadPublicKeyInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -211,8 +211,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_BadPublicKeyInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -227,8 +227,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_GoodRelativePublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_RELATIVE_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -243,8 +243,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_GoodRelativePublicKeyLocationInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_RELATIVE_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -259,8 +259,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_GoodFilePublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_FILE_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -275,8 +275,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_GoodFilePublicKeyLocationInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_FILE_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -291,8 +291,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_GoodUrlPublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_URL_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -307,8 +307,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_GoodUrlPublicKeyLocationInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_URL_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -323,8 +323,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_GoodJwksUriPublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_JWKSURI_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -339,8 +339,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_GoodJwksUriPublicKeyLocationInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_JWKSURI_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -355,8 +355,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_GoodRelativeComplexPublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_RELATIVE_COMPLEX_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -371,8 +371,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_GoodFileComplexPublicKeyLocationInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_FILE_COMPLEX_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -387,8 +387,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_BadFilePublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_FILE_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -403,8 +403,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_BadUrlPublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_URL_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -419,8 +419,8 @@ public class MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadJwksUriMPJwtConfigInServerXml_BadRelativePublicKeyLocationInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_RELATIVE_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/configInAppTests/MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/configInAppTests/MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests.java
@@ -50,6 +50,7 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
         // let's pick a default config - use a pemFile located in the app
         MP11ConfigSettings mpConfigSettings = new MP11ConfigSettings(MP11ConfigSettings.PemFile, MP11ConfigSettings.PublicKeyNotSet, MP11ConfigSettings.IssuerNotSet, MpJwtFatConstants.X509_CERT);
         setUpAndStartRSServerForTests(resourceServer, "rs_server_AltConfigInApp_badServerXmlKeyName.xml", mpConfigSettings, MPConfigLocation.IN_APP);
+        skipRestoreServerTracker.addServer(resourceServer);
 
     }
 
@@ -66,7 +67,7 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_GoodMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_CONFIG_IN_META_INF_ROOT_CONTEXT, MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP,
-                         MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF, setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF, setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 
@@ -81,8 +82,8 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_GoodMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 
@@ -98,8 +99,8 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_BadIssuerInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_ISSUER_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 
@@ -114,8 +115,8 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_BadIssuerInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_ISSUER_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 
@@ -130,8 +131,8 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_GoodSimplePublicKeyInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_SIMPLE_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 
@@ -146,8 +147,8 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_GoodSimplePublicKeyInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_SIMPLE_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 
@@ -162,8 +163,8 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_GoodComplexPublicKeyInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_COMPLEX_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 
@@ -178,8 +179,8 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_GoodComplexPublicKeyInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_COMPLEX_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 
@@ -194,8 +195,8 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_BadPublicKeyInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 
@@ -210,8 +211,8 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_BadPublicKeyInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 
@@ -226,8 +227,8 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_GoodRelativePublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_RELATIVE_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 
@@ -242,8 +243,8 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_GoodRelativePublicKeyLocationInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_RELATIVE_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 
@@ -258,8 +259,8 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_GoodFilePublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_FILE_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 
@@ -274,8 +275,8 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_GoodFilePublicKeyLocationInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_FILE_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 
@@ -290,8 +291,8 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_GoodUrlPublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_URL_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 
@@ -306,8 +307,8 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_GoodUrlPublicKeyLocationInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_URL_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 
@@ -322,8 +323,8 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_GoodJwksUriPublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_JWKSURI_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 
@@ -338,8 +339,8 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_GoodJwksUriPublicKeyLocationInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_JWKSURI_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 
@@ -354,8 +355,8 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_GoodRelativeComplexPublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_RELATIVE_COMPLEX_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 
@@ -370,8 +371,8 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_GoodFileComplexPublicKeyLocationInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_FILE_COMPLEX_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 
@@ -386,8 +387,8 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_BadFilePublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_FILE_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 
@@ -402,8 +403,8 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_BadUrlPublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_URL_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 
@@ -419,8 +420,8 @@ public class MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_Tests extends M
     public void MPJwtMPConfigInApp_BadKeyNameMPJwtConfigInServerXml_BadRelativePublicKeyLocationInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_RELATIVE_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.X509_CERT));
 
     }
 

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/configInAppTests/MPJwtMPConfigInApp_GoodMPJwtConfigInServerXml_Tests.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/configInAppTests/MPJwtMPConfigInApp_GoodMPJwtConfigInServerXml_Tests.java
@@ -48,6 +48,7 @@ public class MPJwtMPConfigInApp_GoodMPJwtConfigInServerXml_Tests extends MPJwt11
         // server has an empty mpJwt config
         MP11ConfigSettings mpConfigSettings = new MP11ConfigSettings(MP11ConfigSettings.PemFile, MP11ConfigSettings.PublicKeyNotSet, MP11ConfigSettings.IssuerNotSet, MpJwtFatConstants.X509_CERT);
         setUpAndStartRSServerForTests(resourceServer, "rs_server_AltConfigInApp_goodServerXmlConfig.xml", mpConfigSettings, MPConfigLocation.IN_APP);
+        skipRestoreServerTracker.addServer(resourceServer);
 
     }
 
@@ -65,7 +66,7 @@ public class MPJwtMPConfigInApp_GoodMPJwtConfigInServerXml_Tests extends MPJwt11
     public void MPJwtMPConfigInApp_GoodMPJwtConfigInServerXml_GoodMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -80,7 +81,7 @@ public class MPJwtMPConfigInApp_GoodMPJwtConfigInServerXml_Tests extends MPJwt11
     public void MPJwtMPConfigInApp_GoodMPJwtConfigInServerXml_GoodMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -95,7 +96,7 @@ public class MPJwtMPConfigInApp_GoodMPJwtConfigInServerXml_Tests extends MPJwt11
     public void MPJwtMPConfigInApp_GoodMPJwtConfigInServerXml_BadIssuerInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_ISSUER_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -110,7 +111,7 @@ public class MPJwtMPConfigInApp_GoodMPJwtConfigInServerXml_Tests extends MPJwt11
     public void MPJwtMPConfigInApp_GoodMPJwtConfigInServerXml_BadIssuerInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_ISSUER_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -125,7 +126,7 @@ public class MPJwtMPConfigInApp_GoodMPJwtConfigInServerXml_Tests extends MPJwt11
     public void MPJwtMPConfigInApp_GoodMPJwtConfigInServerXml_BadPublicKeyInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -140,7 +141,7 @@ public class MPJwtMPConfigInApp_GoodMPJwtConfigInServerXml_Tests extends MPJwt11
     public void MPJwtMPConfigInApp_GoodMPJwtConfigInServerXml_BadPublicKeyInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -155,7 +156,7 @@ public class MPJwtMPConfigInApp_GoodMPJwtConfigInServerXml_Tests extends MPJwt11
     public void MPJwtMPConfigInApp_GoodMPJwtConfigInServerXml_BadFilePublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_FILE_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -170,7 +171,7 @@ public class MPJwtMPConfigInApp_GoodMPJwtConfigInServerXml_Tests extends MPJwt11
     public void MPJwtMPConfigInApp_GoodMPJwtConfigInServerXml_BadUrlPublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_URL_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -186,7 +187,7 @@ public class MPJwtMPConfigInApp_GoodMPJwtConfigInServerXml_Tests extends MPJwt11
     public void MPJwtMPConfigInApp_GoodMPJwtConfigInServerXml_BadRelativePublicKeyLocationInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_RELATIVE_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/configInAppTests/MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/configInAppTests/MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests.java
@@ -53,6 +53,7 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
         MP11ConfigSettings mpConfigSettings = new MP11ConfigSettings(MP11ConfigSettings.PemFile, MP11ConfigSettings.PublicKeyNotSet, MP11ConfigSettings
                         .buildDefaultIssuerString(jwtBuilderServer), MpJwtFatConstants.X509_CERT);
         setUpAndStartRSServerForTests(resourceServer, "rs_server_AltConfigInApp_noServerXmlConfig.xml", mpConfigSettings, MPConfigLocation.IN_APP);
+        skipRestoreServerTracker.addServer(resourceServer);
 
     }
 
@@ -69,7 +70,7 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_GoodMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -85,7 +86,7 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_GoodMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -100,7 +101,7 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_GoodIssuerInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_ISSUER_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -115,7 +116,7 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_GoodIssuerInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_ISSUER_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -131,7 +132,7 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_BadIssuerInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_ISSUER_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF, setBadIssuerExpectations(resourceServer));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF, setBadIssuerExpectations(resourceServer));
 
     }
 
@@ -147,8 +148,8 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_BadIssuerInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_ISSUER_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadIssuerExpectations(resourceServer));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadIssuerExpectations(resourceServer));
 
     }
 
@@ -164,7 +165,7 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_GoodSimplePublicKeyInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_SIMPLE_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -180,7 +181,7 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_GoodSimplePublicKeyInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_SIMPLE_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -195,7 +196,7 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_GoodComplexPublicKeyInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_COMPLEX_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -211,7 +212,7 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_GoodComplexPublicKeyInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_COMPLEX_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -226,8 +227,8 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_BadPublicKeyInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -242,8 +243,8 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_BadPublicKeyInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -258,7 +259,7 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_GoodRelativePublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_RELATIVE_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -274,7 +275,7 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_GoodRelativePublicKeyLocationInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_RELATIVE_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -289,7 +290,7 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_GoodFilePublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_FILE_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -304,7 +305,7 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_GoodFilePublicKeyLocationInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_FILE_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -320,7 +321,7 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_GoodUrlPublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_URL_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -335,7 +336,7 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_GoodUrlPublicKeyLocationInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_URL_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -350,7 +351,7 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_GoodJwksUriPublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_JWKSURI_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -365,7 +366,7 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_GoodJwksUriPublicKeyLocationInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_JWKSURI_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -381,7 +382,7 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_GoodRelativeComplexPublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_RELATIVE_COMPLEX_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -397,7 +398,7 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_GoodFileComplexPublicKeyLocationInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.GOOD_FILE_COMPLEX_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -413,8 +414,8 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_BadFilePublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_FILE_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, "other"));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, "other"));
 
     }
 
@@ -429,8 +430,8 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_BadUrlPublicKeyLocationInMPConfigInMetaInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_URL_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 
@@ -446,8 +447,8 @@ public class MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_Tests extends MPJwt11MP
     public void MPJwtMPConfigInApp_NoMPJwtConfigInServerXml_BadRelativePublicKeyLocationInMPConfigUnderWebInf_test() throws Exception {
 
         standard11TestFlow(resourceServer, MpJwtFatConstants.BAD_RELATIVE_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, MpJwtFatConstants.JWK_CERT));
 
     }
 

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/configInAppTests/MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Tests.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/configInAppTests/MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Tests.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.security.fat.common.jwt.utils.JwtKeyTools;
 import com.ibm.ws.security.jwt.fat.mpjwt.MpJwtFatConstants;
 import com.ibm.ws.security.mp.jwt11.fat.sharedTests.MPJwt11MPConfigTests;
 import com.ibm.ws.security.mp.jwt11.fat.utils.MP11ConfigSettings;
@@ -35,7 +36,6 @@ import componenttest.topology.impl.LibertyServer;
  *
  **/
 
-@SuppressWarnings("restriction")
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
 public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Tests extends MPJwt11MPConfigTests {
@@ -68,60 +68,60 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
         String thisMethod = "deployRSServerMPConfigInAppApps";
         try {
             String fixedJwksUri = resolvedJwksUri(jwtBuilderServer, MP11ConfigSettings.jwksUri);
-            String fileLoc = MP11ConfigSettings.getDefaultKeyFileLoc(server);
+            String fileLoc = JwtKeyTools.getDefaultKeyFileLoc(server);
 
             // publicKey (NOT keyLocation)
             setupUtils.deployRSServerMPConfigInAppInMetaInfApp(server, MpJwtFatConstants.GOOD_RS256_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                                                               buildMPConfigFileContent(MP11ConfigSettings.getComplexKey(server, MP11ConfigSettings.rs256PubKey),
+                                                               buildMPConfigFileContent(JwtKeyTools.getComplexPublicKeyForSigAlg(server, MpJwtFatConstants.SIGALG_RS256),
                                                                                         MP11ConfigSettings.PublicKeyLocationNotSet,
                                                                                         mpConfigSettings.getIssuer()));
             setupUtils.deployRSServerMPConfigInAppUnderWebInfApp(server, MpJwtFatConstants.GOOD_RS256_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                                                                 buildMPConfigFileContent(MP11ConfigSettings.getComplexKey(server, MP11ConfigSettings.rs256PubKey),
+                                                                 buildMPConfigFileContent(JwtKeyTools.getComplexPublicKeyForSigAlg(server, MpJwtFatConstants.SIGALG_RS256),
                                                                                           MP11ConfigSettings.PublicKeyLocationNotSet,
                                                                                           mpConfigSettings.getIssuer()));
 
             setupUtils.deployRSServerMPConfigInAppInMetaInfApp(server, MpJwtFatConstants.GOOD_RS384_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                                                               buildMPConfigFileContent(MP11ConfigSettings.getComplexKey(server, MP11ConfigSettings.rs384PubKey),
+                                                               buildMPConfigFileContent(JwtKeyTools.getComplexPublicKeyForSigAlg(server, MpJwtFatConstants.SIGALG_RS384),
                                                                                         MP11ConfigSettings.PublicKeyLocationNotSet,
                                                                                         mpConfigSettings.getIssuer()));
             setupUtils.deployRSServerMPConfigInAppUnderWebInfApp(server, MpJwtFatConstants.GOOD_RS384_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                                                                 buildMPConfigFileContent(MP11ConfigSettings.getComplexKey(server, MP11ConfigSettings.rs384PubKey),
+                                                                 buildMPConfigFileContent(JwtKeyTools.getComplexPublicKeyForSigAlg(server, MpJwtFatConstants.SIGALG_RS384),
                                                                                           MP11ConfigSettings.PublicKeyLocationNotSet,
                                                                                           mpConfigSettings.getIssuer()));
 
             setupUtils.deployRSServerMPConfigInAppInMetaInfApp(server, MpJwtFatConstants.GOOD_RS512_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                                                               buildMPConfigFileContent(MP11ConfigSettings.getComplexKey(server, MP11ConfigSettings.rs512PubKey),
+                                                               buildMPConfigFileContent(JwtKeyTools.getComplexPublicKeyForSigAlg(server, MpJwtFatConstants.SIGALG_RS512),
                                                                                         MP11ConfigSettings.PublicKeyLocationNotSet,
                                                                                         mpConfigSettings.getIssuer()));
             setupUtils.deployRSServerMPConfigInAppUnderWebInfApp(server, MpJwtFatConstants.GOOD_RS512_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                                                                 buildMPConfigFileContent(MP11ConfigSettings.getComplexKey(server, MP11ConfigSettings.rs512PubKey),
+                                                                 buildMPConfigFileContent(JwtKeyTools.getComplexPublicKeyForSigAlg(server, MpJwtFatConstants.SIGALG_RS512),
                                                                                           MP11ConfigSettings.PublicKeyLocationNotSet,
                                                                                           mpConfigSettings.getIssuer()));
 
             setupUtils.deployRSServerMPConfigInAppInMetaInfApp(server, MpJwtFatConstants.GOOD_ES256_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                                                               buildMPConfigFileContent(MP11ConfigSettings.getComplexKey(server, MP11ConfigSettings.es256PubKey),
+                                                               buildMPConfigFileContent(JwtKeyTools.getComplexPublicKeyForSigAlg(server, MpJwtFatConstants.SIGALG_ES256),
                                                                                         MP11ConfigSettings.PublicKeyLocationNotSet,
                                                                                         mpConfigSettings.getIssuer()));
             setupUtils.deployRSServerMPConfigInAppUnderWebInfApp(server, MpJwtFatConstants.GOOD_ES256_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                                                                 buildMPConfigFileContent(MP11ConfigSettings.getComplexKey(server, MP11ConfigSettings.es256PubKey),
+                                                                 buildMPConfigFileContent(JwtKeyTools.getComplexPublicKeyForSigAlg(server, MpJwtFatConstants.SIGALG_ES256),
                                                                                           MP11ConfigSettings.PublicKeyLocationNotSet,
                                                                                           mpConfigSettings.getIssuer()));
 
             setupUtils.deployRSServerMPConfigInAppInMetaInfApp(server, MpJwtFatConstants.GOOD_ES384_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                                                               buildMPConfigFileContent(MP11ConfigSettings.getComplexKey(server, MP11ConfigSettings.es384PubKey),
+                                                               buildMPConfigFileContent(JwtKeyTools.getComplexPublicKeyForSigAlg(server, MpJwtFatConstants.SIGALG_ES384),
                                                                                         MP11ConfigSettings.PublicKeyLocationNotSet,
                                                                                         mpConfigSettings.getIssuer()));
             setupUtils.deployRSServerMPConfigInAppUnderWebInfApp(server, MpJwtFatConstants.GOOD_ES384_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                                                                 buildMPConfigFileContent(MP11ConfigSettings.getComplexKey(server, MP11ConfigSettings.es384PubKey),
+                                                                 buildMPConfigFileContent(JwtKeyTools.getComplexPublicKeyForSigAlg(server, MpJwtFatConstants.SIGALG_ES384),
                                                                                           MP11ConfigSettings.PublicKeyLocationNotSet,
                                                                                           mpConfigSettings.getIssuer()));
 
             setupUtils.deployRSServerMPConfigInAppInMetaInfApp(server, MpJwtFatConstants.GOOD_ES512_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                                                               buildMPConfigFileContent(MP11ConfigSettings.getComplexKey(server, MP11ConfigSettings.es512PubKey),
+                                                               buildMPConfigFileContent(JwtKeyTools.getComplexPublicKeyForSigAlg(server, MpJwtFatConstants.SIGALG_ES512),
                                                                                         MP11ConfigSettings.PublicKeyLocationNotSet,
                                                                                         mpConfigSettings.getIssuer()));
             setupUtils.deployRSServerMPConfigInAppUnderWebInfApp(server, MpJwtFatConstants.GOOD_ES512_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                                                                 buildMPConfigFileContent(MP11ConfigSettings.getComplexKey(server, MP11ConfigSettings.es512PubKey),
+                                                                 buildMPConfigFileContent(JwtKeyTools.getComplexPublicKeyForSigAlg(server, MpJwtFatConstants.SIGALG_ES512),
                                                                                           MP11ConfigSettings.PublicKeyLocationNotSet,
                                                                                           mpConfigSettings.getIssuer()));
 
@@ -158,31 +158,39 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
             // publicKeyLocation (NOT publicKey)
             // not testing all locations (relative, file, url, jwksuri) with all signature algorithms
             setupUtils.deployRSServerMPConfigInAppInMetaInfApp(server, MpJwtFatConstants.GOOD_RELATIVE_ES512_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                                                               buildMPConfigFileContent(MP11ConfigSettings.PublicKeyNotSet, MP11ConfigSettings.es512PubKey,
+                                                               buildMPConfigFileContent(MP11ConfigSettings.PublicKeyNotSet,
+                                                                                        JwtKeyTools.getPublicKeyFileNameForAlg(MpJwtFatConstants.SIGALG_ES512),
                                                                                         mpConfigSettings.getIssuer()));
             setupUtils.deployRSServerMPConfigInAppUnderWebInfApp(server, MpJwtFatConstants.GOOD_RELATIVE_RS256_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                                                                 buildMPConfigFileContent(MP11ConfigSettings.PublicKeyNotSet, MP11ConfigSettings.rs256PubKey,
+                                                                 buildMPConfigFileContent(MP11ConfigSettings.PublicKeyNotSet,
+                                                                                          JwtKeyTools.getPublicKeyFileNameForAlg(MpJwtFatConstants.SIGALG_RS256),
                                                                                           mpConfigSettings.getIssuer()));
 // TODO - enable when PS algs supported
 //            setupUtils.deployRSServerMPConfigInAppUnderWebInfApp(server, MpJwtFatConstants.GOOD_RELATIVE_PS384_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
 //                                                                 buildMPConfigFileContent(MPConfigSettings.PublicKeyNotSet, MPConfigSettings.ps384PubKey, mpConfigSettings.getIssuer()));
 
             setupUtils.deployRSServerMPConfigInAppInMetaInfApp(server, MpJwtFatConstants.GOOD_FILE_RS256_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                                                               buildMPConfigFileContent(MP11ConfigSettings.PublicKeyNotSet, fileLoc + MP11ConfigSettings.rs256PubKey,
+                                                               buildMPConfigFileContent(MP11ConfigSettings.PublicKeyNotSet,
+                                                                                        fileLoc + JwtKeyTools.getPublicKeyFileNameForAlg(MpJwtFatConstants.SIGALG_RS256),
                                                                                         mpConfigSettings.getIssuer()));
             // TODO - enable when PS algs supported
 //            setupUtils.deployRSServerMPConfigInAppInMetaInfApp(server, MpJwtFatConstants.GOOD_FILE_PS384_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
 //                                                               buildMPConfigFileContent(MPConfigSettings.PublicKeyNotSet, fileLoc + MPConfigSettings.ps384PubKey,
 //                                                                                        mpConfigSettings.getIssuer()));
             setupUtils.deployRSServerMPConfigInAppUnderWebInfApp(server, MpJwtFatConstants.GOOD_FILE_ES512_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                                                                 buildMPConfigFileContent(MP11ConfigSettings.PublicKeyNotSet, fileLoc + MP11ConfigSettings.es512PubKey,
+                                                                 buildMPConfigFileContent(MP11ConfigSettings.PublicKeyNotSet,
+                                                                                          fileLoc + JwtKeyTools.getPublicKeyFileNameForAlg(MpJwtFatConstants.SIGALG_ES512),
                                                                                           mpConfigSettings.getIssuer()));
 
             setupUtils.deployRSServerMPConfigInAppInMetaInfApp(server, MpJwtFatConstants.GOOD_URL_RS384_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                                                               buildMPConfigFileContent(MP11ConfigSettings.PublicKeyNotSet, "file:///" + fileLoc + MP11ConfigSettings.rs384PubKey,
+                                                               buildMPConfigFileContent(MP11ConfigSettings.PublicKeyNotSet,
+                                                                                        "file:///" + fileLoc + JwtKeyTools
+                                                                                                        .getPublicKeyFileNameForAlg(MpJwtFatConstants.SIGALG_RS384),
                                                                                         mpConfigSettings.getIssuer()));
             setupUtils.deployRSServerMPConfigInAppUnderWebInfApp(server, MpJwtFatConstants.GOOD_URL_ES256_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                                                                 buildMPConfigFileContent(MP11ConfigSettings.PublicKeyNotSet, "file:///" + fileLoc + MP11ConfigSettings.es256PubKey,
+                                                                 buildMPConfigFileContent(MP11ConfigSettings.PublicKeyNotSet,
+                                                                                          "file:///" + fileLoc + JwtKeyTools
+                                                                                                          .getPublicKeyFileNameForAlg(MpJwtFatConstants.SIGALG_ES256),
                                                                                           mpConfigSettings.getIssuer()));
             // TODO - enable when PS algs supported
 //            setupUtils.deployRSServerMPConfigInAppUnderWebInfApp(server, MpJwtFatConstants.GOOD_URL_PS512_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
@@ -228,7 +236,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_RS256InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_RS256, resourceServer, MpJwtFatConstants.GOOD_RS256_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -245,7 +253,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_RS256InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_RS256, resourceServer, MpJwtFatConstants.GOOD_RS256_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -261,7 +269,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_RS384InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_RS384, resourceServer, MpJwtFatConstants.GOOD_RS384_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -278,7 +286,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_RS384InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_RS384, resourceServer, MpJwtFatConstants.GOOD_RS384_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -294,7 +302,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_RS512InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_RS512, resourceServer, MpJwtFatConstants.GOOD_RS512_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -311,7 +319,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_RS512InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_RS512, resourceServer, MpJwtFatConstants.GOOD_RS512_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -329,7 +337,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_ES256InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_ES256, resourceServer, MpJwtFatConstants.GOOD_ES256_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -346,7 +354,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_ES256InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_ES256, resourceServer, MpJwtFatConstants.GOOD_ES256_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -362,7 +370,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_ES384InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_ES384, resourceServer, MpJwtFatConstants.GOOD_ES384_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -379,7 +387,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_ES384InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_ES384, resourceServer, MpJwtFatConstants.GOOD_ES384_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -395,7 +403,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_ES512InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_ES512, resourceServer, MpJwtFatConstants.GOOD_ES512_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -412,7 +420,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_ES512InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_ES512, resourceServer, MpJwtFatConstants.GOOD_ES512_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -430,7 +438,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_PS256InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_PS256, resourceServer, MpJwtFatConstants.GOOD_PS256_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -447,7 +455,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_PS256InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_PS256, resourceServer, MpJwtFatConstants.GOOD_PS256_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -463,7 +471,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_PS384InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_PS384, resourceServer, MpJwtFatConstants.GOOD_PS384_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -480,7 +488,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_PS384InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_PS384, resourceServer, MpJwtFatConstants.GOOD_PS384_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -496,7 +504,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_PS512InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_PS512, resourceServer, MpJwtFatConstants.GOOD_PS512_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -513,7 +521,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_PS512InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_PS512, resourceServer, MpJwtFatConstants.GOOD_PS512_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
     // end PS
@@ -535,7 +543,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_ES512InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_ES512, resourceServer, MpJwtFatConstants.GOOD_RELATIVE_ES512_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -552,7 +560,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_RS256InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_RS256, resourceServer, MpJwtFatConstants.GOOD_RELATIVE_RS256_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -569,7 +577,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_PS384InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_PS384, resourceServer, MpJwtFatConstants.GOOD_RELATIVE_PS384_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -585,7 +593,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_RS256InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_RS256, resourceServer, MpJwtFatConstants.GOOD_FILE_RS256_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -601,7 +609,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_PS384InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_PS384, resourceServer, MpJwtFatConstants.GOOD_FILE_PS384_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -617,7 +625,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_ES512InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_ES512, resourceServer, MpJwtFatConstants.GOOD_FILE_ES512_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -634,7 +642,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_RS384InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_RS384, resourceServer, MpJwtFatConstants.GOOD_URL_RS384_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -650,7 +658,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_ES256InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_ES256, resourceServer, MpJwtFatConstants.GOOD_URL_ES256_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -666,7 +674,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_PS512InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_PS512, resourceServer, MpJwtFatConstants.GOOD_URL_PS512_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -682,7 +690,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_PS256InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_PS256, resourceServer, MpJwtFatConstants.GOOD_JWKSURI_PS256_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -698,7 +706,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_RS512InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_RS512, resourceServer, MpJwtFatConstants.GOOD_JWKSURI_RS512_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF);
 
     }
 
@@ -714,7 +722,7 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_ES384InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_ES384, resourceServer, MpJwtFatConstants.GOOD_JWKSURI_ES384_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF);
 
     }
 
@@ -732,8 +740,8 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_RS384InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_RS384, resourceServer, MpJwtFatConstants.GOOD_RELATIVE_ES512_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, BadKey));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, BadKey));
 
     }
 
@@ -750,8 +758,8 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_ES512InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_ES512, resourceServer, MpJwtFatConstants.GOOD_RELATIVE_RS256_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, BadKey));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, BadKey));
 
     }
 
@@ -768,8 +776,8 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_ES512InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_ES512, resourceServer, MpJwtFatConstants.GOOD_RELATIVE_PS384_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, BadKey));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, BadKey));
 
     }
 
@@ -786,8 +794,8 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_ES512InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_ES512, resourceServer, MpJwtFatConstants.GOOD_FILE_RS256_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, BadKey));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, BadKey));
 
     }
 
@@ -804,8 +812,8 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_ES512InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_ES512, resourceServer, MpJwtFatConstants.GOOD_FILE_PS384_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, BadKey));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, BadKey));
 
     }
 
@@ -822,8 +830,8 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_RS384InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_RS384, resourceServer, MpJwtFatConstants.GOOD_FILE_ES512_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, BadKey));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, BadKey));
 
     }
 
@@ -841,8 +849,8 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_ES256InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_ES256, resourceServer, MpJwtFatConstants.GOOD_URL_RS384_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, BadKey));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, BadKey));
 
     }
 
@@ -859,8 +867,8 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_RS384InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_RS384, resourceServer, MpJwtFatConstants.GOOD_URL_ES256_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, BadKey));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, BadKey));
 
     }
 
@@ -877,8 +885,8 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_RS384InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_RS384, resourceServer, MpJwtFatConstants.GOOD_URL_PS512_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, BadKey));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, BadKey));
 
     }
 
@@ -895,8 +903,8 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_ES384InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_ES384, resourceServer, MpJwtFatConstants.GOOD_JWKSURI_PS256_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, BadKey));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, BadKey));
 
     }
 
@@ -913,8 +921,8 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_ES384InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_ES384, resourceServer, MpJwtFatConstants.GOOD_JWKSURI_RS512_KEYLOCATION_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, BadKey));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, BadKey));
 
     }
 
@@ -931,8 +939,8 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_RS256InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_RS256, resourceServer, MpJwtFatConstants.GOOD_JWKSURI_ES384_KEYLOCATION_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, BadKey));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, BadKey));
 
     }
 
@@ -950,8 +958,8 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_RS256InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_RS512, resourceServer, MpJwtFatConstants.GOOD_RS256_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, KeyMismatch));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, KeyMismatch));
 
     }
 
@@ -969,8 +977,8 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_RS384InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_ES384, resourceServer, MpJwtFatConstants.GOOD_RS384_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, KeyMismatch));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, KeyMismatch));
 
     }
 
@@ -987,8 +995,8 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_RS512InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_PS256, resourceServer, MpJwtFatConstants.GOOD_RS512_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, KeyMismatch));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, KeyMismatch));
 
     }
 
@@ -1006,8 +1014,8 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_ES256InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_PS256, resourceServer, MpJwtFatConstants.GOOD_ES256_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, KeyMismatch));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, KeyMismatch));
 
     }
 
@@ -1024,8 +1032,8 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_ES384InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_RS512, resourceServer, MpJwtFatConstants.GOOD_ES384_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, KeyMismatch));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, KeyMismatch));
 
     }
 
@@ -1043,8 +1051,8 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_ES512InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_ES384, resourceServer, MpJwtFatConstants.GOOD_ES512_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, KeyMismatch));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, KeyMismatch));
 
     }
 
@@ -1061,8 +1069,8 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_PS256InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_ES384, resourceServer, MpJwtFatConstants.GOOD_PS256_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, KeyMismatch));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, KeyMismatch));
 
     }
 
@@ -1080,8 +1088,8 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_PS384InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_PS256, resourceServer, MpJwtFatConstants.GOOD_PS384_PUBLICKEY_IN_CONFIG_UNDER_WEB_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
-                         setBadCertExpectations(resourceServer, KeyMismatch));
+                           MpJwtFatConstants.MP_CONFIG_UNDER_WEB_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_UNDER_WEB_INF,
+                           setBadCertExpectations(resourceServer, KeyMismatch));
 
     }
 
@@ -1098,8 +1106,8 @@ public class MPJwtMPOtherSigAlgConfigInApp_SigAlgOnlyMPJwtConfigInServerXml_Test
 
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_AltConfigInApp_PS512InServerXmlConfig.xml");
         standard11TestFlow(MpJwtFatConstants.SIGALG_RS512, resourceServer, MpJwtFatConstants.GOOD_PS512_PUBLICKEY_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,
-                         MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
-                         setBadCertExpectations(resourceServer, KeyMismatch));
+                           MpJwtFatConstants.MP_CONFIG_IN_META_INF_TREE_APP, MpJwtFatConstants.MPJWT_APP_CLASS_MP_CONFIG_IN_META_INF,
+                           setBadCertExpectations(resourceServer, KeyMismatch));
 
     }
 

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/envVarsTests/MPJwtGoodMPConfigAsEnvVars_NoPublicKey_UseKeyLocES256RelativeFile.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/envVarsTests/MPJwtGoodMPConfigAsEnvVars_NoPublicKey_UseKeyLocES256RelativeFile.java
@@ -14,6 +14,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.ibm.ws.security.fat.common.jwt.utils.JwtKeyTools;
 import com.ibm.ws.security.jwt.fat.mpjwt.MpJwtFatConstants;
 import com.ibm.ws.security.mp.jwt11.fat.sharedTests.MPJwtWithGoodAltSigAlgMPConfig;
 import com.ibm.ws.security.mp.jwt11.fat.utils.MP11ConfigSettings;
@@ -48,7 +49,7 @@ public class MPJwtGoodMPConfigAsEnvVars_NoPublicKey_UseKeyLocES256RelativeFile e
     public static void setUp() throws Exception {
 
         String sigAlg = MpJwtFatConstants.SIGALG_ES256;
-        commonSetup(envVarsResourceServer, sigAlg, MP11ConfigSettings.getKeyFileNameForAlg(sigAlg), MP11ConfigSettings.PublicKeyNotSet, MPConfigLocation.ENV_VAR);
+        commonSetup(envVarsResourceServer, sigAlg, JwtKeyTools.getPublicKeyFileNameForAlg(sigAlg), MP11ConfigSettings.PublicKeyNotSet, MPConfigLocation.ENV_VAR);
 
     }
 

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/envVarsTests/MPJwtGoodMPConfigAsEnvVars_NoPublicKey_UseKeyLocRS384Url.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/envVarsTests/MPJwtGoodMPConfigAsEnvVars_NoPublicKey_UseKeyLocRS384Url.java
@@ -14,6 +14,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.ibm.ws.security.fat.common.jwt.utils.JwtKeyTools;
 import com.ibm.ws.security.jwt.fat.mpjwt.MpJwtFatConstants;
 import com.ibm.ws.security.mp.jwt11.fat.sharedTests.MPJwtWithGoodAltSigAlgMPConfig;
 import com.ibm.ws.security.mp.jwt11.fat.utils.MP11ConfigSettings;
@@ -48,7 +49,7 @@ public class MPJwtGoodMPConfigAsEnvVars_NoPublicKey_UseKeyLocRS384Url extends MP
     public static void setUp() throws Exception {
 
         String sigAlg = MpJwtFatConstants.SIGALG_RS384;
-        commonSetup(envVarsResourceServer, sigAlg, "file:///" + MP11ConfigSettings.getDefaultKeyFileLoc(envVarsResourceServer) + MP11ConfigSettings.getKeyFileNameForAlg(sigAlg),
+        commonSetup(envVarsResourceServer, sigAlg, "file:///" + JwtKeyTools.getDefaultKeyFileLoc(envVarsResourceServer) + JwtKeyTools.getPublicKeyFileNameForAlg(sigAlg),
                     MP11ConfigSettings.PublicKeyNotSet, MPConfigLocation.ENV_VAR);
 
     }

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/envVarsTests/MPJwtGoodMPConfigAsEnvVars_NoPublicKey_UseKeyLocRS512File.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/envVarsTests/MPJwtGoodMPConfigAsEnvVars_NoPublicKey_UseKeyLocRS512File.java
@@ -14,6 +14,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.ibm.ws.security.fat.common.jwt.utils.JwtKeyTools;
 import com.ibm.ws.security.jwt.fat.mpjwt.MpJwtFatConstants;
 import com.ibm.ws.security.mp.jwt11.fat.sharedTests.MPJwtWithGoodAltSigAlgMPConfig;
 import com.ibm.ws.security.mp.jwt11.fat.utils.MP11ConfigSettings;
@@ -48,7 +49,7 @@ public class MPJwtGoodMPConfigAsEnvVars_NoPublicKey_UseKeyLocRS512File extends M
     public static void setUp() throws Exception {
 
         String sigAlg = MpJwtFatConstants.SIGALG_RS512;
-        commonSetup(envVarsResourceServer, sigAlg, MP11ConfigSettings.getDefaultKeyFileLoc(envVarsResourceServer) + MP11ConfigSettings.getKeyFileNameForAlg(sigAlg),
+        commonSetup(envVarsResourceServer, sigAlg, JwtKeyTools.getDefaultKeyFileLoc(envVarsResourceServer) + JwtKeyTools.getPublicKeyFileNameForAlg(sigAlg),
                     MP11ConfigSettings.PublicKeyNotSet, MPConfigLocation.ENV_VAR);
 
     }

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/envVarsTests/MPJwtGoodMPConfigAsEnvVars_UseES384PublicKey_NoKeyLoc.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/envVarsTests/MPJwtGoodMPConfigAsEnvVars_UseES384PublicKey_NoKeyLoc.java
@@ -14,6 +14,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.ibm.ws.security.fat.common.jwt.utils.JwtKeyTools;
 import com.ibm.ws.security.jwt.fat.mpjwt.MpJwtFatConstants;
 import com.ibm.ws.security.mp.jwt11.fat.sharedTests.MPJwtWithGoodAltSigAlgMPConfig;
 import com.ibm.ws.security.mp.jwt11.fat.utils.MP11ConfigSettings;
@@ -48,7 +49,7 @@ public class MPJwtGoodMPConfigAsEnvVars_UseES384PublicKey_NoKeyLoc extends MPJwt
     public static void setUp() throws Exception {
 
         String sigAlg = MpJwtFatConstants.SIGALG_ES384;
-        commonSetup(envVarsResourceServer, sigAlg, MP11ConfigSettings.PublicKeyLocationNotSet, MP11ConfigSettings.getComplexKeyForSigAlg(envVarsResourceServer, sigAlg),
+        commonSetup(envVarsResourceServer, sigAlg, MP11ConfigSettings.PublicKeyLocationNotSet, JwtKeyTools.getComplexPublicKeyForSigAlg(envVarsResourceServer, sigAlg),
                     MPConfigLocation.ENV_VAR);
 
     }

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/sharedTests/MPJwt11MPConfigTests.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/sharedTests/MPJwt11MPConfigTests.java
@@ -19,6 +19,7 @@ import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.expectations.Expectations;
+import com.ibm.ws.security.fat.common.jwt.utils.JwtKeyTools;
 import com.ibm.ws.security.fat.common.utils.CommonIOUtils;
 import com.ibm.ws.security.fat.common.utils.SecurityFatHttpUtils;
 import com.ibm.ws.security.jwt.fat.mpjwt.MpJwtFatConstants;
@@ -227,7 +228,7 @@ public class MPJwt11MPConfigTests extends MPJwtMPConfigTests {
 
         try {
             String fixedJwksUri = resolvedJwksUri(jwtBuilderServer, MP11ConfigSettings.jwksUri);
-            String fileLoc = mpConfigSettings.getDefaultKeyFileLoc(server);
+            String fileLoc = JwtKeyTools.getDefaultKeyFileLoc(server);
 
             // the microprofile-config.properties files will have xxx_<attr>_xxx values that need to be replaced
             setupUtils.deployRSServerMPConfigInAppInMetaInfApp(server, MpJwtFatConstants.GOOD_CONFIG_IN_META_INF_ROOT_CONTEXT,

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/sharedTests/MPJwtLoginConfig_VariationTests.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/sharedTests/MPJwtLoginConfig_VariationTests.java
@@ -83,6 +83,7 @@ public class MPJwtLoginConfig_VariationTests extends CommonMpJwtFat {
         bootstrapUtils.writeBootstrapProperty(server, "mpJwt_jwksUri", "");
         deployRSServerLoginConfigApps(server);
         serverTracker.addServer(server);
+        skipRestoreServerTracker.addServer(server);
         server.startServerUsingExpandedConfiguration(configFile, commonStartMsgs);
         SecurityFatHttpUtils.saveServerPorts(server, MpJwtFatConstants.BVT_SERVER_1_PORT_NAME_ROOT);
     }

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/sharedTests/MPJwtWithGoodAltSigAlgMPConfig.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/sharedTests/MPJwtWithGoodAltSigAlgMPConfig.java
@@ -57,6 +57,7 @@ public class MPJwtWithGoodAltSigAlgMPConfig extends MPJwt11MPConfigTests {
 
         // set signatureAlgorithm attribute in server.xml
         ServerInstanceUtils.setOneVar(resourceServer, "sigAlg", requestedSigAlg);
+        skipRestoreServerTracker.addServer(resourceServer);
     }
 
     /**
@@ -70,7 +71,7 @@ public class MPJwtWithGoodAltSigAlgMPConfig extends MPJwt11MPConfigTests {
     public void genericGoodTest() throws Exception {
 
         standard11TestFlow(sigAlg, resourceServer, MpJwtFatConstants.NO_MP_CONFIG_IN_APP_ROOT_CONTEXT,
-                         MpJwtFatConstants.NO_MP_CONFIG_IN_APP_APP, MpJwtFatConstants.MPJWT_APP_CLASS_NO_MP_CONFIG_IN_APP);
+                           MpJwtFatConstants.NO_MP_CONFIG_IN_APP_APP, MpJwtFatConstants.MPJWT_APP_CLASS_NO_MP_CONFIG_IN_APP);
 
     }
 

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/systemPropertiesTests/MPJwtGoodMPConfigAsSystemProperties_NoPublicKey_UseKeyLocES2564Url.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/systemPropertiesTests/MPJwtGoodMPConfigAsSystemProperties_NoPublicKey_UseKeyLocES2564Url.java
@@ -14,6 +14,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.ibm.ws.security.fat.common.jwt.utils.JwtKeyTools;
 import com.ibm.ws.security.jwt.fat.mpjwt.MpJwtFatConstants;
 import com.ibm.ws.security.mp.jwt11.fat.sharedTests.MPJwtWithGoodAltSigAlgMPConfig;
 import com.ibm.ws.security.mp.jwt11.fat.utils.MP11ConfigSettings;
@@ -48,7 +49,7 @@ public class MPJwtGoodMPConfigAsSystemProperties_NoPublicKey_UseKeyLocES2564Url 
     public static void setUp() throws Exception {
 
         String sigAlg = MpJwtFatConstants.SIGALG_ES256;
-        commonSetup(sysPropResourceServer, sigAlg, "file:///" + MP11ConfigSettings.getDefaultKeyFileLoc(sysPropResourceServer) + MP11ConfigSettings.getKeyFileNameForAlg(sigAlg),
+        commonSetup(sysPropResourceServer, sigAlg, "file:///" + JwtKeyTools.getDefaultKeyFileLoc(sysPropResourceServer) + JwtKeyTools.getPublicKeyFileNameForAlg(sigAlg),
                     MP11ConfigSettings.PublicKeyNotSet, MPConfigLocation.SYSTEM_PROP);
 
     }

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/systemPropertiesTests/MPJwtGoodMPConfigAsSystemProperties_NoPublicKey_UseKeyLocES384File.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/systemPropertiesTests/MPJwtGoodMPConfigAsSystemProperties_NoPublicKey_UseKeyLocES384File.java
@@ -14,6 +14,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.ibm.ws.security.fat.common.jwt.utils.JwtKeyTools;
 import com.ibm.ws.security.jwt.fat.mpjwt.MpJwtFatConstants;
 import com.ibm.ws.security.mp.jwt11.fat.sharedTests.MPJwtWithGoodAltSigAlgMPConfig;
 import com.ibm.ws.security.mp.jwt11.fat.utils.MP11ConfigSettings;
@@ -48,7 +49,7 @@ public class MPJwtGoodMPConfigAsSystemProperties_NoPublicKey_UseKeyLocES384File 
     public static void setUp() throws Exception {
 
         String sigAlg = MpJwtFatConstants.SIGALG_ES384;
-        commonSetup(sysPropResourceServer, sigAlg, MP11ConfigSettings.getDefaultKeyFileLoc(sysPropResourceServer) + MP11ConfigSettings.getKeyFileNameForAlg(sigAlg),
+        commonSetup(sysPropResourceServer, sigAlg, JwtKeyTools.getDefaultKeyFileLoc(sysPropResourceServer) + JwtKeyTools.getPublicKeyFileNameForAlg(sigAlg),
                     MP11ConfigSettings.PublicKeyNotSet, MPConfigLocation.SYSTEM_PROP);
 
     }

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/systemPropertiesTests/MPJwtGoodMPConfigAsSystemProperties_NoPublicKey_UseKeyLocES512RelativeFile.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/systemPropertiesTests/MPJwtGoodMPConfigAsSystemProperties_NoPublicKey_UseKeyLocES512RelativeFile.java
@@ -14,6 +14,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.ibm.ws.security.fat.common.jwt.utils.JwtKeyTools;
 import com.ibm.ws.security.jwt.fat.mpjwt.MpJwtFatConstants;
 import com.ibm.ws.security.mp.jwt11.fat.sharedTests.MPJwtWithGoodAltSigAlgMPConfig;
 import com.ibm.ws.security.mp.jwt11.fat.utils.MP11ConfigSettings;
@@ -48,7 +49,7 @@ public class MPJwtGoodMPConfigAsSystemProperties_NoPublicKey_UseKeyLocES512Relat
     public static void setUp() throws Exception {
 
         String sigAlg = MpJwtFatConstants.SIGALG_ES512;
-        commonSetup(sysPropResourceServer, sigAlg, MP11ConfigSettings.getKeyFileNameForAlg(sigAlg), MP11ConfigSettings.PublicKeyNotSet, MPConfigLocation.SYSTEM_PROP);
+        commonSetup(sysPropResourceServer, sigAlg, JwtKeyTools.getPublicKeyFileNameForAlg(sigAlg), MP11ConfigSettings.PublicKeyNotSet, MPConfigLocation.SYSTEM_PROP);
 
     }
 

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/systemPropertiesTests/MPJwtGoodMPConfigAsSystemProperties_UseRS384PublicKey_NoKeyLoc.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/systemPropertiesTests/MPJwtGoodMPConfigAsSystemProperties_UseRS384PublicKey_NoKeyLoc.java
@@ -14,6 +14,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.ibm.ws.security.fat.common.jwt.utils.JwtKeyTools;
 import com.ibm.ws.security.jwt.fat.mpjwt.MpJwtFatConstants;
 import com.ibm.ws.security.mp.jwt11.fat.sharedTests.MPJwtWithGoodAltSigAlgMPConfig;
 import com.ibm.ws.security.mp.jwt11.fat.utils.MP11ConfigSettings;
@@ -48,7 +49,7 @@ public class MPJwtGoodMPConfigAsSystemProperties_UseRS384PublicKey_NoKeyLoc exte
     public static void setUp() throws Exception {
 
         String sigAlg = MpJwtFatConstants.SIGALG_RS384;
-        commonSetup(sysPropResourceServer, sigAlg, MP11ConfigSettings.PublicKeyLocationNotSet, MP11ConfigSettings.getComplexKeyForSigAlg(sysPropResourceServer, sigAlg),
+        commonSetup(sysPropResourceServer, sigAlg, MP11ConfigSettings.PublicKeyLocationNotSet, JwtKeyTools.getComplexPublicKeyForSigAlg(sysPropResourceServer, sigAlg),
                     MPConfigLocation.SYSTEM_PROP);
 
     }

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/utils/MP11ConfigSettings.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/utils/MP11ConfigSettings.java
@@ -12,13 +12,10 @@ package com.ibm.ws.security.mp.jwt11.fat.utils;
 
 import java.net.InetAddress;
 
-import com.ibm.websphere.simplicity.log.Log;
-import com.ibm.ws.security.fat.common.utils.CommonIOUtils;
 import com.ibm.ws.security.jwt.fat.mpjwt.MpJwtFatConstants;
 
 import componenttest.topology.impl.LibertyServer;
 
-@SuppressWarnings("restriction")
 public class MP11ConfigSettings {
 
     public static Class<?> thisClass = MP11ConfigSettings.class;
@@ -42,17 +39,6 @@ public class MP11ConfigSettings {
     String publicKey = ComplexPublicKey;
     String issuer = IssuerNotSet;
     String certType = MpJwtFatConstants.X509_CERT;
-
-    /* key file names */
-    public static final String rs256PubKey = "RS256public-key.pem";
-    public static final String rs384PubKey = "RS384public-key.pem";
-    public static final String rs512PubKey = "RS512public-key.pem";
-    public static final String es256PubKey = "ES256public-key.pem";
-    public static final String es384PubKey = "ES384public-key.pem";
-    public static final String es512PubKey = "ES512public-key.pem";
-    public static final String ps256PubKey = "PS256public-key.pem";
-    public static final String ps384PubKey = "PS384public-key.pem";
-    public static final String ps512PubKey = "PS512public-key.pem";
 
     public MP11ConfigSettings() {
     }
@@ -95,66 +81,6 @@ public class MP11ConfigSettings {
 
     public String getCertType() {
         return certType;
-    }
-
-    public static String getComplexKeyForSigAlg(LibertyServer server, String sigAlg) throws Exception {
-
-        return getComplexKey(server, getKeyFileNameForAlg(sigAlg));
-    }
-
-    public static String getKeyFileNameForAlg(String sigAlg) throws Exception {
-
-        switch (sigAlg) {
-            case MpJwtFatConstants.SIGALG_RS256:
-                return rs256PubKey;
-            case MpJwtFatConstants.SIGALG_RS384:
-                return rs384PubKey;
-            case MpJwtFatConstants.SIGALG_RS512:
-                return rs512PubKey;
-            case MpJwtFatConstants.SIGALG_ES256:
-                return es256PubKey;
-            case MpJwtFatConstants.SIGALG_ES384:
-                return es384PubKey;
-            case MpJwtFatConstants.SIGALG_ES512:
-                return es512PubKey;
-            case MpJwtFatConstants.SIGALG_PS256:
-                return ps256PubKey;
-            case MpJwtFatConstants.SIGALG_PS384:
-                return ps384PubKey;
-            case MpJwtFatConstants.SIGALG_PS512:
-                return ps512PubKey;
-            default:
-                return rs256PubKey;
-        }
-
-    }
-
-    public static String getComplexKey(LibertyServer server, String fileName) throws Exception {
-        Log.info(thisClass, "getComplexKey", "fileName: " + fileName);
-        return getKeyFromFile(server, fileName);
-    }
-
-    public String getSimpleKey(LibertyServer server, String fileName) throws Exception {
-        String rawKey = getKeyFromFile(server, fileName);
-        if (rawKey != null) {
-            return rawKey.replace(rsaPrefix, "").replace(rsaSuffix, "");
-        }
-        return rawKey;
-    }
-
-    public static String getKeyFromFile(LibertyServer server, String fileName) throws Exception {
-
-        String fullPathToFile = getDefaultKeyFileLoc(server) + fileName;
-
-        CommonIOUtils cioTools = new CommonIOUtils();
-        String key = cioTools.readFileAsString(fullPathToFile);
-
-        return key;
-    }
-
-    public static String getDefaultKeyFileLoc(LibertyServer server) throws Exception {
-
-        return server.getServerRoot() + "/";
     }
 
     public static String buildDefaultIssuerString(LibertyServer server) throws Exception {

--- a/dev/com.ibm.ws.security.mp.jwt.1.2_fat/fat/src/com/ibm/ws/security/mp/jwt12/fat/sharedTests/MPJwt12MPConfigTests.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.2_fat/fat/src/com/ibm/ws/security/mp/jwt12/fat/sharedTests/MPJwt12MPConfigTests.java
@@ -23,6 +23,7 @@ import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.expectations.Expectations;
 import com.ibm.ws.security.fat.common.expectations.ResponseStatusExpectation;
 import com.ibm.ws.security.fat.common.expectations.ServerMessageExpectation;
+import com.ibm.ws.security.fat.common.jwt.utils.JwtKeyTools;
 import com.ibm.ws.security.fat.common.utils.CommonIOUtils;
 import com.ibm.ws.security.jwt.fat.mpjwt.MpJwt12FatConstants;
 import com.ibm.ws.security.jwt.fat.mpjwt.MpJwtFatConstants;
@@ -349,8 +350,8 @@ public class MPJwt12MPConfigTests extends MPJwtMPConfigTests {
                                                                  buildMPConfigFileContent(mpConfigSettings, MpJwt12FatConstants.AUTHORIZATION, MP12ConfigSettings.CookieNotSet,
                                                                                           mpConfigSettings.getAudience(), MpJwt12FatConstants.SIGALG_ES256));
             // let's create an app with mp config properties that over ride the 1.1 and 1.2 alg settings
-            MP12ConfigSettings overrideMpConfigSettings = new MP12ConfigSettings(mpConfigSettings.getPublicKeyLocation(), MP12ConfigSettings
-                            .getComplexKey(server, MP12ConfigSettings.es256PubKey), mpConfigSettings
+            MP12ConfigSettings overrideMpConfigSettings = new MP12ConfigSettings(mpConfigSettings.getPublicKeyLocation(), JwtKeyTools
+                            .getComplexPublicKeyForSigAlg(server, MpJwtFatConstants.SIGALG_ES256), mpConfigSettings
                                             .getIssuer(), MpJwt12FatConstants.X509_CERT, mpConfigSettings
                                                             .getHeader(), mpConfigSettings.getCookie(), mpConfigSettings.getAudience(), mpConfigSettings.getAlgorithm());
             setupUtils.deployRSServerMPConfigInAppInMetaInfApp(server, MpJwt12FatConstants.GOOD_KEY_AND_ALGORITHM_IN_CONFIG_IN_META_INF_ROOT_CONTEXT,


### PR DESCRIPTION
I moved some of the key store tools (finding and loading the keys from files) to com.ibm.ws.security.fat.common and com.ibm.ws.security.fat.common.jwt while working on the builder FATs.
These changes will remove the original function from the mp.jwt.1.1 FAT project and make the mp jwt 1.1 and 1.2 FATs use the common tooling instead.
I'm also updating a few test classes to not restore the server config between tests.  When no update is needed, there is a hang in the LibertyServer that really slows test execution.

#build