### PR TITLE
direct lookups and add more basic tests

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/ext/ConcurrencyExtensionProvider.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/ext/ConcurrencyExtensionProvider.java
@@ -15,7 +15,7 @@ import com.ibm.wsspi.resource.ResourceInfo;
 
 /**
  * Interface by which a single provider implementation can be plugged in
- * to intercept and replace resource reference lookups for
+ * to intercept and replace JNDI lookups of
  * <code>managedExecutorService</code> and
  * <code>managedScheduledExecutorService</code>.
  *
@@ -32,9 +32,8 @@ public interface ConcurrencyExtensionProvider {
      *
      * @param executor     managed executor instance that would normally be used for the
      *                         resource reference lookup.
-     * @param resourceInfo resource reference information.
-     * @return managed executor instance to use instead as the result of the
-     *         resource reference lookup.
+     * @param resourceInfo resource reference information. Null if a direct lookup.
+     * @return managed executor instance to use instead as the result of the JNDI lookup.
      */
     ManagedExecutorExtension provide(WSManagedExecutorService executor, ResourceInfo resourceInfo);
 }

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
@@ -424,7 +424,7 @@ public class ManagedExecutorServiceImpl implements ExecutorService, //
             applications.add(cData.getJ2EEName().getApplication());
 
         ConcurrencyExtensionProvider provider = concurrencySvc.extensionProvider;
-        if (provider == null || ref == null)
+        if (provider == null)
             return this;
         else
             return provider.provide(this, ref);

--- a/dev/com.ibm.ws.concurrent_fat_work/publish/servers/com.ibm.ws.concurrent.fat.work/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_work/publish/servers/com.ibm.ws.concurrent.fat.work/server.xml
@@ -9,16 +9,29 @@
         IBM Corporation - initial API and implementation
  -->
 <server>
-    <featureManager>
-        <feature>componenttest-1.0</feature>
-        <feature>jndi-1.0</feature>
-        <!--<feature>osgiconsole-1.0</feature>-->
-        <feature>servlet-4.0</feature>
-        <feature>usr:workManager-1.0</feature>
-    </featureManager>
+  <featureManager>
+    <feature>componenttest-1.0</feature>
+    <feature>jndi-1.0</feature>
+    <!--<feature>osgiconsole-1.0</feature>-->
+    <feature>servlet-4.0</feature>
+    <feature>usr:workManager-1.0</feature>
+  </featureManager>
 
-    <include location="../fatTestPorts.xml"/>
+  <include location="../fatTestPorts.xml"/>
 
-    <managedExecutorService jndiName="wm/executor"/>
-    <managedScheduledExecutorService jndiName="wm/scheduledExecutor"/>
+  <managedExecutorService jndiName="wm/executor">
+    <contextService>
+      <classloaderContext/>
+    </contextService>
+  </managedExecutorService>
+
+  <managedScheduledExecutorService jndiName="wm/scheduledExecutor">
+    <contextService>
+      <classloaderContext/>
+      <jeeMetadataContext/>
+    </contextService>
+  </managedScheduledExecutorService>
+
+  <javaPermission codebase="${server.config.dir}/dropins/WorkTestApp.war" className="java.lang.RuntimePermission" name="getClassLoader"/>
+
 </server>

--- a/dev/com.ibm.ws.concurrent_fat_work/publish/servers/com.ibm.ws.concurrent.fat.work/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_work/publish/servers/com.ibm.ws.concurrent.fat.work/server.xml
@@ -20,12 +20,14 @@
   <include location="../fatTestPorts.xml"/>
 
   <managedExecutorService jndiName="wm/executor">
+    <concurrencyPolicy max="1" maxQueueSize="2"/>
     <contextService>
       <classloaderContext/>
     </contextService>
   </managedExecutorService>
 
   <managedScheduledExecutorService jndiName="wm/scheduledExecutor">
+    <concurrencyPolicy max="2" maxQueueSize="1"/>
     <contextService>
       <classloaderContext/>
       <jeeMetadataContext/>

--- a/dev/com.ibm.ws.concurrent_fat_work/test-applications/WorkTestApp/resources/.gitignore
+++ b/dev/com.ibm.ws.concurrent_fat_work/test-applications/WorkTestApp/resources/.gitignore
@@ -1,0 +1,1 @@
+/META-INF

--- a/dev/com.ibm.ws.concurrent_fat_work/test-applications/WorkTestApp/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.concurrent_fat_work/test-applications/WorkTestApp/resources/WEB-INF/web.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app id="WebApp_ID" version="3.1" 
+	xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+
+  <resource-ref>
+    <res-ref-name>java:comp/env/wm/scheduledExecutorRef</res-ref-name>
+    <res-type>test.concurrent.work.WorkManager</res-type>
+    <lookup-name>wm/scheduledExecutor</lookup-name>
+  </resource-ref>
+  
+</web-app>

--- a/dev/com.ibm.ws.concurrent_fat_work/test-applications/WorkTestApp/src/test/concurrent/work/app/WorkTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_work/test-applications/WorkTestApp/src/test/concurrent/work/app/WorkTestServlet.java
@@ -10,12 +10,18 @@
  *******************************************************************************/
 package test.concurrent.work.app;
 
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.Phaser;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.Resource;
 import javax.enterprise.concurrent.ManagedExecutorService;
@@ -39,6 +45,7 @@ import test.concurrent.work.Work;
 import test.concurrent.work.WorkCompletedException;
 import test.concurrent.work.WorkItem;
 import test.concurrent.work.WorkManager;
+import test.concurrent.work.WorkRejectedException;
 
 @SuppressWarnings("serial")
 @WebServlet("/*")
@@ -62,8 +69,49 @@ public class WorkTestServlet extends FATServlet {
     @Resource(lookup = "wm/executor", name = "java:global/env/wm/wmExecutorRef")
     private WorkManager wmExecutor;
 
-    @Resource(lookup = "wm/scheduledExecutor", name = "java:comp/env/wm/wmScheduledExecutorRef")
+    @Resource(lookup = "wm/scheduledExecutor")
     private WorkManager wmScheduledExecutor;
+
+    // Defined in web.xml: java:comp/env/wm/scheduledExecutorRef
+
+    /**
+     * Direct lookup of a configured managedExecutorService as a WorkManager.
+     */
+    @Test
+    public void testDirectLookupManagedExecutorServiceAsWorkManager(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        WorkManager wm = InitialContext.doLookup("wm/executor");
+        assertNotNull(wm);
+        assertTrue(wm.toString(), wm instanceof ExecutorService);
+        assertTrue(wm.toString(), wm instanceof ManagedExecutorService);
+
+        // Verify that work runs when scheduled
+        CompletableFuture<Boolean> result = new CompletableFuture<Boolean>();
+        wm.schedule(() -> result.complete(true));
+        assertTrue(result.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+    }
+
+    /**
+     * Direct lookup of a configured managedScheduledExecutorService as a WorkManager.
+     */
+    @Test
+    public void testDirectLookupManagedScheduledExecutorServiceAsWorkManager(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        WorkManager wm = InitialContext.doLookup("wm/scheduledExecutor");
+        assertNotNull(wm);
+        assertTrue(wm.toString(), wm instanceof ScheduledExecutorService);
+        assertTrue(wm.toString(), wm instanceof ManagedScheduledExecutorService);
+
+        // Verify that work runs with the submitting application's context when scheduled
+        CompletableFuture<WorkManager> result = new CompletableFuture<WorkManager>();
+        wm.schedule(() -> {
+            try {
+                // Requires JEE metadata context of the application:
+                result.complete(InitialContext.doLookup("java:app/env/wm/scheduledExecutorServiceRef"));
+            } catch (NamingException x) {
+                throw new CompletionException(x);
+            }
+        });
+        assertNotNull(result.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+    }
 
     /**
      * Inject a configured managedExecutorService and cast it to WorkManager
@@ -188,5 +236,201 @@ public class WorkTestServlet extends FATServlet {
         for (long start = System.nanoTime(); (w = item.getResult()) == null && System.nanoTime() - start < TIMEOUT_NS; )
             Thread.sleep(POLL_INTERVAL);
         assertEquals(work, w);
+    }
+
+    /**
+     * Look up the default instance java:comp/DefaultManagedExecutorService as a WorkManager.
+     */
+    @Test
+    public void testLookUpDefaultManagedExecutorServiceAsWorkManager(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        WorkManager wm = InitialContext.doLookup("java:comp/DefaultManagedExecutorService");
+        assertNotNull(wm);
+        assertTrue(wm.toString(), wm instanceof ExecutorService);
+        assertTrue(wm.toString(), wm instanceof ManagedExecutorService);
+
+        // Schedule 3 work items to run at the same time
+        AtomicReference<Object> resultRef = new AtomicReference<Object>();
+        CyclicBarrier allWorkRunning = new CyclicBarrier(3, () -> {
+            try {
+                // Requires JEE metadata context of the test app:
+                resultRef.getAndSet(InitialContext.doLookup("java:app/env/wm/scheduledExecutorServiceRef"));
+            } catch (NamingException x) {
+                resultRef.getAndSet(x);
+            }
+        });
+
+        Work work = () -> {
+            try {
+                allWorkRunning.await(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+            } catch (BrokenBarrierException | InterruptedException | TimeoutException x) {
+                throw new CompletionException(x);
+            }
+        };
+
+        WorkItem item1 = wm.schedule(work);
+        WorkItem item2 = wm.schedule(work);
+        WorkItem item3 = wm.schedule(work);
+
+        for (long start = System.nanoTime(); //
+                (item1.getResult() == null || item2.getResult() == null || item3.getResult() == null) && System.nanoTime() - start < TIMEOUT_NS; )
+            Thread.sleep(POLL_INTERVAL);
+
+        assertEquals(work, item1.getResult());
+        assertEquals(work, item2.getResult());
+        assertEquals(work, item3.getResult());
+
+        Object result = resultRef.get();
+        assertNotNull(result);
+        if (result instanceof Throwable)
+            throw new Exception((Throwable) result);
+        assertTrue(result.toString(), result instanceof WorkManager);
+    }
+
+    /**
+     * Look up the default instance java:comp/DefaultManagedScheduledExecutorService as a WorkManager.
+     */
+    @Test
+    public void testLookUpDefaultManagedScheduledExecutorServiceAsWorkManager(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        WorkManager wm = InitialContext.doLookup("java:comp/DefaultManagedScheduledExecutorService");
+        assertNotNull(wm);
+        assertTrue(wm.toString(), wm instanceof ScheduledExecutorService);
+        assertTrue(wm.toString(), wm instanceof ManagedScheduledExecutorService);
+
+        LinkedBlockingQueue<Object> resultQueue = new LinkedBlockingQueue<Object>();
+
+        Work lookupWork = () -> {
+            try {
+                // Requires JEE metadata context:
+                resultQueue.add(InitialContext.doLookup("java:comp/env/wm/scheduledExecutorRef"));
+            } catch (NamingException x) {
+                resultQueue.add(x);
+            }
+        };
+
+        Work schedulingWork = () -> {
+            try {
+                wm.schedule(lookupWork);
+            } catch (WorkRejectedException x) {
+                throw new CompletionException(x);
+            }
+        };
+
+        wm.schedule(schedulingWork);
+
+        Object result = resultQueue.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+        assertNotNull(result);
+        if (result instanceof Throwable)
+            throw new Exception((Throwable) result);
+        assertTrue(result.toString(), result instanceof WorkManager);
+    }
+
+    /**
+     * Perform a lookup of a managedExecutorService using an annotatively-defined resource reference
+     * that specifies the resource type as WorkManager.
+     */
+    @Test
+    public void testWorkManagerResourceReferenceLookupOfManagedExecutorService(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        WorkManager wm = InitialContext.doLookup("java:global/env/wm/wmExecutorRef");
+        assertNotNull(wm);
+        assertTrue(wm.toString(), wm instanceof ExecutorService);
+        assertTrue(wm.toString(), wm instanceof ManagedExecutorService);
+
+        Phaser workStarted = new Phaser(1);
+
+        // Attempt to exceed the configured maxQueueSize of 2
+
+        // First, schedule work to use up the single thread (max concurrency is 1) that is available to the work manager
+        CountDownLatch blocker = new CountDownLatch(1);
+        Work blockingWork = () -> {
+            try {
+                workStarted.arrive();
+                assertTrue(blocker.await(TIMEOUT_NS * 2, TimeUnit.NANOSECONDS));
+            } catch (InterruptedException x) {
+                throw new CompletionException(x);
+            }
+        };
+        WorkItem blockingItem = wm.schedule(blockingWork);
+
+        // Queue up 2 work items
+        Work blockedWork = () -> workStarted.arrive();
+        WorkItem blockedItem1 = wm.schedule(blockedWork);
+        assertEquals(1, workStarted.awaitAdvanceInterruptibly(0, TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        WorkItem blockedItem2 = wm.schedule(blockedWork);
+
+        // Attempt to queue up 3rd work item, which should be rejected, per maxQueueSize=2 config
+        try {
+            WorkItem blockedWork3 = wm.schedule(blockedWork);
+            fail("Should not be able to queue 3rd work item: " + blockedWork3);
+        } catch (WorkRejectedException x) {
+            // expected
+        }
+
+        // unblock and expect queued items to run
+        blocker.countDown();
+        workStarted.awaitAdvanceInterruptibly(1, TIMEOUT_NS, TimeUnit.NANOSECONDS);
+        workStarted.awaitAdvanceInterruptibly(2, TIMEOUT_NS, TimeUnit.NANOSECONDS);
+
+        Work w;
+        for (long start = System.nanoTime(); (w = blockedItem2.getResult()) == null && System.nanoTime() - start < TIMEOUT_NS; )
+            Thread.sleep(POLL_INTERVAL);
+        assertEquals(blockedWork, w);
+        assertEquals(blockedWork, blockedItem1.getResult());
+        assertEquals(blockingWork, blockingItem.getResult());
+        assertEquals(3, workStarted.getPhase());
+    }
+
+    /**
+     * Perform a lookup of a managedExecutorService using deployment descriptor defined resource reference
+     * that specifies the resource type as WorkManager.
+     */
+    @Test
+    public void testWorkManagerResourceReferenceLookupOfManagedScheduledExecutorService(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        WorkManager wm = InitialContext.doLookup("java:comp/env/wm/scheduledExecutorRef");
+        assertNotNull(wm);
+        assertTrue(wm.toString(), wm instanceof ScheduledExecutorService);
+        assertTrue(wm.toString(), wm instanceof ManagedScheduledExecutorService);
+
+        Phaser workStarted = new Phaser(1);
+
+        // Attempt to exceed the configured maxQueueSize of 1
+
+        // First, schedule work to use up the two threads (max concurrency is 2) that are available to the work manager
+        CountDownLatch blocker = new CountDownLatch(1);
+        Work blockingWork = () -> {
+            try {
+                workStarted.arrive();
+                assertTrue(blocker.await(TIMEOUT_NS * 2, TimeUnit.NANOSECONDS));
+            } catch (InterruptedException x) {
+                throw new CompletionException(x);
+            }
+        };
+        WorkItem blockingItem1 = wm.schedule(blockingWork);
+        assertEquals(1, workStarted.awaitAdvanceInterruptibly(0, TIMEOUT_NS, TimeUnit.NANOSECONDS));
+        WorkItem blockingItem2 = wm.schedule(blockingWork);
+        assertEquals(2, workStarted.awaitAdvanceInterruptibly(1, TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        // Queue up 1 more work item
+        Work blockedWork = () -> workStarted.arrive();
+        WorkItem blockedItem1 = wm.schedule(blockedWork);
+
+        // Attempt to queue up 2nd work item, which should be rejected, per maxQueueSize=1 config
+        try {
+            WorkItem blockedWork2 = wm.schedule(blockedWork);
+            fail("Should not be able to queue 3rd work item: " + blockedWork2);
+        } catch (WorkRejectedException x) {
+            // expected
+        }
+
+        // unblock and expect queued item to run
+        blocker.countDown();
+        assertEquals(3, workStarted.awaitAdvanceInterruptibly(2, TIMEOUT_NS, TimeUnit.NANOSECONDS));
+
+        Work w;
+        for (long start = System.nanoTime(); (w = blockedItem1.getResult()) == null && System.nanoTime() - start < TIMEOUT_NS; )
+            Thread.sleep(POLL_INTERVAL);
+        assertEquals(blockedWork, w);
+        assertEquals(blockingWork, blockingItem1.getResult());
+        assertEquals(blockingWork, blockingItem2.getResult());
+        assertEquals(3, workStarted.getPhase());
     }
 }

--- a/dev/com.ibm.ws.concurrent_fat_work/test-applications/WorkTestApp/src/test/concurrent/work/app/WorkTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_work/test-applications/WorkTestApp/src/test/concurrent/work/app/WorkTestServlet.java
@@ -10,15 +10,18 @@
  *******************************************************************************/
 package test.concurrent.work.app;
 
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Resource;
 import javax.enterprise.concurrent.ManagedExecutorService;
 import javax.enterprise.concurrent.ManagedScheduledExecutorService;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -50,11 +53,17 @@ public class WorkTestServlet extends FATServlet {
      */
     private static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(2);
 
-    @Resource(lookup = "wm/executor")
+    @Resource(lookup = "wm/executor", name = "java:module/env/wm/executorServiceRef")
     private ExecutorService executorService;
 
-    @Resource(lookup = "wm/scheduledExecutor")
+    @Resource(lookup = "wm/scheduledExecutor", name = "java:app/env/wm/scheduledExecutorServiceRef")
     private ScheduledExecutorService scheduledExecutorService;
+
+    @Resource(lookup = "wm/executor", name = "java:global/env/wm/wmExecutorRef")
+    private WorkManager wmExecutor;
+
+    @Resource(lookup = "wm/scheduledExecutor", name = "java:comp/env/wm/wmScheduledExecutorRef")
+    private WorkManager wmScheduledExecutor;
 
     /**
      * Inject a configured managedExecutorService and cast it to WorkManager
@@ -94,9 +103,90 @@ public class WorkTestServlet extends FATServlet {
 
             fail("Work " + work + " did not run and raise expected error within the allotted interval.");
         } catch (WorkCompletedException x) {
-            if (x.getCause() == null || !(x.getCause() instanceof ExecutionException) //
-                    || !(x.getCause().getCause() instanceof ArrayIndexOutOfBoundsException))
+            if (x.getCause() == null || !(x.getCause() instanceof ArrayIndexOutOfBoundsException))
                 throw x;
         }
+    }
+
+    /**
+     * Inject a configured managedExecutorService as a WorkManager.
+     */
+    @Test
+    public void testInjectManagedExecutorAsWorkManager(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        assertNotNull(wmExecutor);
+        assertTrue(wmExecutor.toString(), wmExecutor instanceof ExecutorService);
+        assertTrue(wmExecutor.toString(), wmExecutor instanceof ManagedExecutorService);
+
+        Work work = () -> {
+            try {
+                // requires the classloader context:
+                ClassLoader loader = Thread.currentThread().getContextClassLoader();
+                assertEquals(WorkTestServlet.class, loader.loadClass(WorkTestServlet.class.getName()));
+
+                // requires the JEE metadata context, which we intentionally didn't configure
+                Object lookupResult = InitialContext.doLookup("java:module/env/wm/executorServiceRef");
+                fail("Without JEE metadata context, it should not be possible to look up " + lookupResult);
+            } catch (ClassNotFoundException x) {
+                throw new CompletionException(x);
+            } catch (NamingException x) {
+                throw new CompletionException(x);
+            }
+        };
+
+        WorkItem item = wmExecutor.schedule(work);
+        try {
+            for (long start = System.nanoTime(); item.getResult() == null && System.nanoTime() - start < TIMEOUT_NS; )
+                Thread.sleep(POLL_INTERVAL);
+
+            fail("Work " + work + " did not run and raise expected error within the allotted interval.");
+        } catch (WorkCompletedException x) {
+            if (x.getCause() == null || !(x.getCause() instanceof CompletionException)
+                    || !(x.getCause().getCause() instanceof NamingException))
+                throw x;
+        }
+    }
+
+    /**
+     * Inject a configured managedScheduledExecutorService as a WorkManager.
+     */
+    @Test
+    public void testInjectManagedScheduledExecutorAsWorkManager(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        assertNotNull(wmScheduledExecutor);
+        assertTrue(wmScheduledExecutor.toString(), wmScheduledExecutor instanceof ScheduledExecutorService);
+        assertTrue(wmScheduledExecutor.toString(), wmScheduledExecutor instanceof ManagedScheduledExecutorService);
+
+        LinkedBlockingQueue<Object> results = new LinkedBlockingQueue<Object>();
+
+        Work work = () -> {
+            try {
+                // requires the JEE metadata context:
+                results.add(InitialContext.doLookup("java:module/env/wm/executorServiceRef"));
+
+                // requires the classloader context:
+                ClassLoader loader = Thread.currentThread().getContextClassLoader();
+                results.add(loader.loadClass(WorkTestServlet.class.getName()));
+            } catch (ClassNotFoundException x) {
+                throw new CompletionException(x);
+            } catch (NamingException x) {
+                throw new CompletionException(x);
+            }
+        };
+
+        WorkItem item = wmScheduledExecutor.schedule(work);
+
+        Object lookupResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+        if (lookupResult == null)
+            fail("Work did not run within allotted interval. Result is now: " + item.getResult());
+        assertNotNull(lookupResult);
+
+        Object classLoadResult = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+        if (classLoadResult == null)
+            fail("Work did not finish within allotted interval. Result is now: " + item.getResult());
+        assertEquals(WorkTestServlet.class, classLoadResult);
+
+        Work w;
+        for (long start = System.nanoTime(); (w = item.getResult()) == null && System.nanoTime() - start < TIMEOUT_NS; )
+            Thread.sleep(POLL_INTERVAL);
+        assertEquals(work, w);
     }
 }

--- a/dev/com.ibm.ws.concurrent_fat_work/test-bundles/workMgrProvider/src/test/concurrent/work/WorkItem.java
+++ b/dev/com.ibm.ws.concurrent_fat_work/test-bundles/workMgrProvider/src/test/concurrent/work/WorkItem.java
@@ -28,7 +28,10 @@ public class WorkItem {
             try {
                 return future.get();
             } catch (ExecutionException x) {
-                throw new WorkCompletedException(x);
+                if (x.getCause() == null)
+                    throw new WorkCompletedException(x);
+                else
+                    throw new WorkCompletedException(x.getCause());
             } catch (InterruptedException x) {
                 throw new RuntimeException(x);
             }

--- a/dev/com.ibm.ws.concurrent_fat_work/test-bundles/workMgrProvider/src/test/concurrent/work/WorkRejectedException.java
+++ b/dev/com.ibm.ws.concurrent_fat_work/test-bundles/workMgrProvider/src/test/concurrent/work/WorkRejectedException.java
@@ -10,9 +10,10 @@
  *******************************************************************************/
 package test.concurrent.work;
 
-/**
- * A mock work manager interface
- */
-public interface WorkManager {
-    public WorkItem schedule(Work work) throws WorkRejectedException;
+public class WorkRejectedException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    public WorkRejectedException(Throwable cause) {
+        super(cause);
+    }
 }

--- a/dev/com.ibm.ws.concurrent_fat_work/test-bundles/workMgrProvider/src/test/concurrent/work/wm/SchedulingWorkManagerImpl.java
+++ b/dev/com.ibm.ws.concurrent_fat_work/test-bundles/workMgrProvider/src/test/concurrent/work/wm/SchedulingWorkManagerImpl.java
@@ -12,6 +12,7 @@ package test.concurrent.work.wm;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.osgi.framework.BundleContext;
@@ -28,6 +29,7 @@ import test.concurrent.work.Work;
 import test.concurrent.work.WorkCompletedException;
 import test.concurrent.work.WorkItem;
 import test.concurrent.work.WorkManager;
+import test.concurrent.work.WorkRejectedException;
 
 /**
  * An oversimplified work manager that redirects work to a managed executor.
@@ -40,11 +42,15 @@ public class SchedulingWorkManagerImpl extends ManagedScheduledExecutorExtension
         this.executor = executor;
     }
 
-    public WorkItem schedule(Work work) {
-        Future<Work> future = ((ExecutorService) executor).submit(() -> {
-            work.run();
-            return work;
-        });
-        return new WorkItem(future);
+    public WorkItem schedule(Work work) throws WorkRejectedException {
+        try {
+            Future<Work> future = ((ExecutorService) executor).submit(() -> {
+                work.run();
+                return work;
+            });
+            return new WorkItem(future);
+        } catch (RejectedExecutionException x) {
+            throw new WorkRejectedException(x);
+        }
     }
 }


### PR DESCRIPTION
Make modifications to the extension pattern so that direct lookups can work.  Add a variety of tests around direct lookups and resource references specifying the WorkManager interface rather than an executor interface.