### PR TITLE
Updated remaining javax references

### DIFF
--- a/dev/wlp-jakartaee-transform/rules/jakarta-xml-master.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-xml-master.properties
@@ -70,3 +70,22 @@ faces-config1.xml=jakarta-faces-config.properties
 com.ibm.ws.security.inflow.context.provider.xml=jakarta-connectors.properties
 com.ibm.ws.jca17.processor.service.ConnectionFactoryResourceBuilder.xml=jakarta-resource.properties
 com.ibm.ws.security.javaeesec.cdi.extensions.JavaEESecCDIExtension.xml=jakarta-xml-securityEnterprise.properties
+# Webcontainer
+application-client_1_3.dtd=jakarta-xml-webcontainer-jsp-renames.properties
+connector_1_0.dtd=jakarta-xml-webcontainer-jsp-renames.properties
+connector_1_5.xsd=jakarta-xml-webcontainer-jsp-renames.properties
+ejb-jar_2_0.dtd=jakarta-xml-webcontainer-jsp-renames.properties
+ejb-jar_2_1.xsd=jakarta-xml-webcontainer-jsp-renames.properties
+j2ee_1_4.xsd=jakarta-xml-webcontainer-jsp-renames.properties
+web-jsptaglibrary_1_1.dtd=jakarta-xml-webcontainer-jsp-renames.properties
+web-jsptaglibrary_1_2.dtd=jakarta-xml-webcontainer-jsp-renames.properties
+web-app_2_3.dtd=jakarta-xml-webcontainer-jsp-renames.properties
+web-jsptaglibrary_2_0.xsd=jakarta-xml-webcontainer-jsp-renames.properties
+# Pages
+c-1_1.tld=jakarta-xml-webcontainer-jsp-renames.properties
+c.tld=jakarta-xml-webcontainer-jsp-renames.properties
+fmt.tld=jakarta-xml-webcontainer-jsp-renames.properties
+sql.tld=jakarta-xml-webcontainer-jsp-renames.properties
+x.tld=jakarta-xml-webcontainer-jsp-renames.properties
+Resources.properties=jakarta-xml-webcontainer-jsp-renames.properties
+Resources_ja.properties=jakarta-xml-webcontainer-jsp-renames.properties

--- a/dev/wlp-jakartaee-transform/rules/jakarta-xml-webcontainer-jsp-renames.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-xml-webcontainer-jsp-renames.properties
@@ -1,0 +1,18 @@
+javax.jms.Destination=jakarta.jms.Destination
+javax.jms.MessageListener=jakarta.jms.MessageListener
+javax.jms.Queue=jakarta.jms.Queue
+javax.jms.Topic=jakarta.jms.Topic
+javax.resource.cci.ConnectionFactory=jakarta.resource.cci.ConnectionFactory
+javax.resource.cci.Connection=jakarta.resource.cci.Connection
+javax.resource.spi.ActivationSpec=jakarta.resource.spi.ActivationSpec
+javax.resource.spi.ManagedConnectionFactory=jakarta.resource.spi.ManagedConnectionFactory
+javax.resource.spi.ResourceAdapter=jakarta.resource.spi.ResourceAdapter
+javax.resource.spi.security.PasswordCredential=jakarta.resource.spi.security.PasswordCredential
+javax.resource.spi.security.GenericCredential=jakarta.resource.spi.security.GenericCredential
+javax.servlet.jsp.jstl=jakarta.servlet.jsp.jstl
+javax.servlet.jsp.tagext=jakarta.servlet.jsp.tagext
+# Misspelled corrections
+javax.serlvet.jsp.tagext=jakarta.servlet.jsp.tagext
+javax.jsp.tagext=jakarta.servlet.jsp.tagext
+# Incomplete strings interrupted by endline
+javax.resource.spi.Managed=jakarta.resource.spi.Managed


### PR DESCRIPTION
fixes #13974
Updated all remaining files that contained javax references in projects com.ibm.ws.webcontainer and com.ibm.websphere.javaee.jsp.tld.2.2
- xsd files
- tld files
- dtd files
- properties files
