### PR TITLE
Rename existing MP features in MP 4.0 back to com.ibm.websphere.appserver

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jaxrsDefaultExceptionMapper-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jaxrsDefaultExceptionMapper-1.0.feature
@@ -3,7 +3,7 @@ symbolicName=com.ibm.websphere.appserver.jaxrsDefaultExceptionMapper-1.0
 Manifest-Version: 1.0
 visibility=private
 IBM-Provision-Capability: \
-  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.mpMetrics-3.0))", \
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-3.0))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.monitor-1.0)))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.jaxrs-2.0)(osgi.identity=com.ibm.websphere.appserver.jaxrs-2.1)))"
 IBM-Install-Policy: when-satisfied

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpRestClient1.0-cdi1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpRestClient1.0-cdi1.2.feature
@@ -4,7 +4,7 @@ visibility=private
 singleton=true
 IBM-API-Package: com.ibm.ws.microprofile.rest.client.cdi; type="internal"
 IBM-Provision-Capability: \
-  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.0)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.1)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.2)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.3)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.4)(osgi.identity=io.openliberty.mpRestClient-2.0)))", \
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.0)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.1)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.2)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.3)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.4)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-2.0)))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.cdi-1.2)(osgi.identity=com.ibm.websphere.appserver.cdi-2.0)))"
 -bundles=com.ibm.ws.microprofile.rest.client.cdi
 IBM-Install-Policy: when-satisfied

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpRestClient1.0-ssl1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.mpRestClient1.0-ssl1.0.feature
@@ -3,7 +3,7 @@ symbolicName=com.ibm.websphere.appserver.mpRestClient1.0-ssl1.0
 visibility=private
 IBM-App-ForceRestart: uninstall, \
  install
-IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.0)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.1)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.2)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.3)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.4)(osgi.identity=io.openliberty.mpRestClient-2.0)))", \
+IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.0)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.1)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.2)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.3)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-1.4)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-2.0)))", \
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.ssl-1.0))"
 IBM-Install-Policy: when-satisfied
 -features=com.ibm.websphere.appserver.jaxrsClient-2.0; ibm.tolerates:=2.1

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpFaultTolerance3.0-metrics.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpFaultTolerance3.0-metrics.feature
@@ -1,8 +1,8 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.mpFaultTolerance3.0-metrics
 singleton=true
-IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.mpFaultTolerance-3.0))", \
- osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.mpMetrics-3.0))"
+IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpFaultTolerance-3.0))", \
+ osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-3.0))"
 IBM-Install-Policy: when-satisfied
 -bundles=io.openliberty.microprofile.faulttolerance.3.0.internal.metrics
 kind=beta

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpJwtPropagation-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpJwtPropagation-1.2.feature
@@ -2,7 +2,7 @@
 symbolicName=io.openliberty.mpJwtPropagation-1.2
 visibility=private
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.jaxrsClient-2.1)))", \
- osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=io.openliberty.mpJwt-1.2)))"
+ osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpJwt-1.2)))"
 IBM-Install-Policy: when-satisfied 
 -bundles=io.openliberty.org.eclipse.microprofile.jwt.1.2; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:1.2-RC1",\
  com.ibm.ws.security.mp.jwt.propagation, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpMetrics-3.0-monitor-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpMetrics-3.0-monitor-1.0.feature
@@ -3,7 +3,7 @@ symbolicName=io.openliberty.mpMetrics-3.0-monitor-1.0
 visibility=private
 singleton=true
 IBM-Provision-Capability: \
-  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.mpMetrics-3.0))", \
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpMetrics-3.0))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.monitor-1.0)))"
 -bundles=io.openliberty.microprofile.metrics.internal.3.0.monitor
 IBM-Install-Policy: when-satisfied

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpOpenTracing2.0-mpRestClient2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpOpenTracing2.0-mpRestClient2.0.feature
@@ -3,8 +3,8 @@ symbolicName=io.openliberty.mpOpenTracing2.0-mpRestClient2.0
 visibility=private
 singleton=true
 IBM-Provision-Capability: \
-  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.mpOpenTracing-2.0))", \
-  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.mpRestClient-2.0))"
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpOpenTracing-2.0))", \
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.mpRestClient-2.0))"
 -bundles=io.openliberty.microprofile.opentracing.2.0.internal.rest.client
 IBM-Install-Policy: when-satisfied
 kind=beta

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-4.0/io.openliberty.microProfile-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-4.0/io.openliberty.microProfile-4.0.feature
@@ -14,13 +14,13 @@ Subsystem-Name: MicroProfile 4.0
   com.ibm.websphere.appserver.jaxrsClient-2.1, \
   com.ibm.websphere.appserver.jsonb-1.0, \
   com.ibm.websphere.appserver.jsonp-1.1, \
-  io.openliberty.mpConfig-2.0, \
-  io.openliberty.mpFaultTolerance-3.0, \
-  io.openliberty.mpHealth-3.0, \
-  io.openliberty.mpJwt-1.2, \
-  io.openliberty.mpMetrics-3.0, \
-  io.openliberty.mpOpenAPI-2.0, \
-  io.openliberty.mpOpenTracing-2.0, \
-  io.openliberty.mpRestClient-2.0
+  com.ibm.websphere.appserver.mpConfig-2.0, \
+  com.ibm.websphere.appserver.mpFaultTolerance-3.0, \
+  com.ibm.websphere.appserver.mpHealth-3.0, \
+  com.ibm.websphere.appserver.mpJwt-1.2, \
+  com.ibm.websphere.appserver.mpMetrics-3.0, \
+  com.ibm.websphere.appserver.mpOpenAPI-2.0, \
+  com.ibm.websphere.appserver.mpOpenTracing-2.0, \
+  com.ibm.websphere.appserver.mpRestClient-2.0
 kind=beta
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpConfig-2.0/com.ibm.websphere.appserver.mpConfig-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpConfig-2.0/com.ibm.websphere.appserver.mpConfig-2.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=io.openliberty.mpConfig-2.0
+symbolicName=com.ibm.websphere.appserver.mpConfig-2.0
 visibility=public
 singleton=true
 IBM-App-ForceRestart: install, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpFaultTolerance-3.0/com.ibm.websphere.appserver.mpFaultTolerance-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpFaultTolerance-3.0/com.ibm.websphere.appserver.mpFaultTolerance-3.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=io.openliberty.mpFaultTolerance-3.0
+symbolicName=com.ibm.websphere.appserver.mpFaultTolerance-3.0
 visibility=public
 singleton=true
 IBM-App-ForceRestart: install, \
@@ -11,7 +11,7 @@ Subsystem-Name: MicroProfile Fault Tolerance 3.0
 -features=io.openliberty.org.eclipse.microprofile.faulttolerance-3.0, \
  com.ibm.websphere.appserver.cdi-2.0, \
  com.ibm.websphere.appserver.concurrent-1.0, \
- io.openliberty.mpConfig-2.0
+ com.ibm.websphere.appserver.mpConfig-2.0
 -bundles=com.ibm.ws.microprofile.faulttolerance; apiJar=false; location:="lib/", \
  com.ibm.ws.microprofile.faulttolerance.2.0; apiJar=false; location:="lib/", \
  com.ibm.ws.microprofile.faulttolerance.spi; apiJar=false; location:="lib/", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpHealth-3.0/com.ibm.websphere.appserver.mpHealth-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpHealth-3.0/com.ibm.websphere.appserver.mpHealth-3.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=io.openliberty.mpHealth-3.0
+symbolicName=com.ibm.websphere.appserver.mpHealth-3.0
 visibility=public
 singleton=true
 IBM-App-ForceRestart: install, \
@@ -16,7 +16,7 @@ Subsystem-Name: MicroProfile Health 3.0
  com.ibm.websphere.appserver.jndi-1.0, \
  com.ibm.websphere.appserver.json-1.0, \
  com.ibm.websphere.appserver.servlet-4.0,\
- io.openliberty.mpConfig-2.0,\
+ com.ibm.websphere.appserver.mpConfig-2.0,\
  com.ibm.wsspi.appserver.webBundle-1.0 
 -bundles=com.ibm.websphere.jsonsupport, \
  com.ibm.ws.classloader.context, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpJwt-1.2/com.ibm.websphere.appserver.mpJwt-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpJwt-1.2/com.ibm.websphere.appserver.mpJwt-1.2.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=io.openliberty.mpJwt-1.2
+symbolicName=com.ibm.websphere.appserver.mpJwt-1.2
 visibility=public
 singleton=true
 IBM-ShortName: mpJwt-1.2
@@ -14,7 +14,7 @@ Subsystem-Name: MicroProfile JSON Web Token 1.2
   com.ibm.websphere.appserver.jwt-1.0, \
   com.ibm.websphere.appserver.jsonp-1.1, \
   com.ibm.websphere.appserver.httpcommons-1.0, \
-  io.openliberty.mpConfig-2.0
+  com.ibm.websphere.appserver.mpConfig-2.0
 -bundles=com.ibm.ws.security.mp.jwt,\
   io.openliberty.org.eclipse.microprofile.jwt.1.2; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:1.2-RC1",\
   com.ibm.ws.security.mp.jwt.cdi,\

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-3.0/com.ibm.websphere.appserver.mpMetrics-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpMetrics-3.0/com.ibm.websphere.appserver.mpMetrics-3.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=io.openliberty.mpMetrics-3.0
+symbolicName=com.ibm.websphere.appserver.mpMetrics-3.0
 visibility=public
 singleton=true
 IBM-API-Package: org.eclipse.microprofile.metrics.annotation;  type="stable", \
@@ -12,7 +12,7 @@ Subsystem-Name: MicroProfile Metrics 3.0
  com.ibm.websphere.appserver.restHandler-1.0, \
  com.ibm.websphere.appserver.monitor-1.0, \
  com.ibm.websphere.appserver.servlet-4.0,\
- io.openliberty.mpConfig-2.0
+ com.ibm.websphere.appserver.mpConfig-2.0
 -bundles=com.ibm.ws.microprofile.metrics.common, \
  io.openliberty.microprofile.metrics.internal.3.0, \
  io.openliberty.microprofile.metrics.internal.cdi.3.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-2.0/com.ibm.websphere.appserver.mpOpenAPI-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-2.0/com.ibm.websphere.appserver.mpOpenAPI-2.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=io.openliberty.mpOpenAPI-2.0
+symbolicName=com.ibm.websphere.appserver.mpOpenAPI-2.0
 visibility=public
 singleton=true
 IBM-App-ForceRestart: install, \
@@ -37,7 +37,7 @@ IBM-SPI-Package: \
     org.eclipse.microprofile.openapi.spi; type="stable"
 -features=\
     io.openliberty.org.eclipse.microprofile.openapi-2.0, \
-    io.openliberty.mpConfig-2.0, \
+    com.ibm.websphere.appserver.mpConfig-2.0, \
     com.ibm.websphere.appserver.servlet-4.0, \
     com.ibm.wsspi.appserver.webBundle-1.0, \
     com.ibm.websphere.appserver.jaxrs-2.1

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenTracing-2.0/com.ibm.websphere.appserver.mpOpenTracing-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenTracing-2.0/com.ibm.websphere.appserver.mpOpenTracing-2.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=io.openliberty.mpOpenTracing-2.0
+symbolicName=com.ibm.websphere.appserver.mpOpenTracing-2.0
 visibility=public
 singleton=true
 IBM-App-ForceRestart: install, \
@@ -9,9 +9,9 @@ Subsystem-Name: MicroProfile OpenTracing 2.0
 IBM-API-Package: \
     org.eclipse.microprofile.opentracing; type="stable"
 -features=\
-    io.openliberty.opentracing-2.0, \
+    com.ibm.websphere.appserver.opentracing-2.0, \
     io.openliberty.org.eclipse.microprofile.opentracing-2.0, \
-    io.openliberty.mpConfig-2.0
+    com.ibm.websphere.appserver.mpConfig-2.0
 -bundles=\
     io.openliberty.microprofile.opentracing.2.0.internal
 kind=beta

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpRestClient-2.0/com.ibm.websphere.appserver.mpRestClient-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpRestClient-2.0/com.ibm.websphere.appserver.mpRestClient-2.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=io.openliberty.mpRestClient-2.0
+symbolicName=com.ibm.websphere.appserver.mpRestClient-2.0
 visibility=public
 singleton=true
 IBM-App-ForceRestart: install, \
@@ -18,7 +18,7 @@ Subsystem-Name: MicroProfile Rest Client 2.0
  com.ibm.websphere.appserver.jaxrsClient-2.1, \
  com.ibm.websphere.appserver.jsonp-1.1, \
  com.ibm.websphere.appserver.org.reactivestreams.reactive-streams-1.0, \
- io.openliberty.mpConfig-2.0
+ com.ibm.websphere.appserver.mpConfig-2.0
 -bundles=com.ibm.ws.org.apache.cxf.cxf.rt.rs.mp.client.3.3; apiJar=false; location:="lib/"
 kind=beta
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-2.0/com.ibm.websphere.appserver.opentracing-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-2.0/com.ibm.websphere.appserver.opentracing-2.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=io.openliberty.opentracing-2.0
+symbolicName=com.ibm.websphere.appserver.opentracing-2.0
 visibility=public
 singleton=true
 IBM-App-ForceRestart: install, \
@@ -12,7 +12,7 @@ IBM-API-Package: io.opentracing;  type="third-party",\
                  io.openliberty.opentracing.spi.tracer; type="ibm-spi"
 -features=com.ibm.websphere.appserver.jaxrs-2.1, \
           com.ibm.websphere.appserver.cdi-2.0, \
-          io.openliberty.mpConfig-2.0
+          com.ibm.websphere.appserver.mpConfig-2.0
 -bundles=com.ibm.ws.jaxrs.defaultexceptionmapper, \
          io.openliberty.opentracing.2.0.internal, \
          io.openliberty.opentracing.2.0.internal.cdi, \

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/publish/files/features/io.openliberty.opentracing.mock-2.0.mf
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/publish/files/features/io.openliberty.opentracing.mock-2.0.mf
@@ -5,6 +5,6 @@ Subsystem-ManifestVersion: 1
 Subsystem-SymbolicName: io.openliberty.opentracing.mock-2.0; visibility:=public; singleton:=true
 Subsystem-Type: osgi.subsystem.feature
 Subsystem-Version: 1.0.0
-Subsystem-Content: io.openliberty.opentracing-2.0; type="osgi.subsystem.feature",
+Subsystem-Content: com.ibm.websphere.appserver.opentracing-2.0; type="osgi.subsystem.feature",
  io.openliberty.opentracing.mock-2.0; version="[1.0.0,1.0.200)"
 

--- a/dev/io.openliberty.opentracing.2.x_fat/publish/files/features/io.openliberty.opentracing.mock-2.0.mf
+++ b/dev/io.openliberty.opentracing.2.x_fat/publish/files/features/io.openliberty.opentracing.mock-2.0.mf
@@ -5,6 +5,6 @@ Subsystem-ManifestVersion: 1
 Subsystem-SymbolicName: io.openliberty.opentracing.mock-2.0; visibility:=public; singleton:=true
 Subsystem-Type: osgi.subsystem.feature
 Subsystem-Version: 1.0.0
-Subsystem-Content: io.openliberty.opentracing-2.0; type="osgi.subsystem.feature",
+Subsystem-Content: com.ibm.websphere.appserver.opentracing-2.0; type="osgi.subsystem.feature",
  io.openliberty.opentracing.mock-2.0; version="[1.0.0,1.0.200)"
 


### PR DESCRIPTION
- In order to allow for toleration between different MP features, it was decided to not use io.openliberty as a prefix.

The mpLRA features were left as io.openliberty since they are version 1.0

fixes #14641 
