### PR TITLE
Redo rest.client.2.0.bnd file changes

### DIFF
--- a/dev/io.openliberty.org.eclipse.microprofile/rest.client.2.0.bnd
+++ b/dev/io.openliberty.org.eclipse.microprofile/rest.client.2.0.bnd
@@ -22,25 +22,9 @@ Export-Package: \
   org.eclipse.microprofile.rest.client.spi;version=1.1.1
 
 Import-Package: \
-  javax.annotation;version="[1.3,2)",\
-  javax.enterprise.context;version="[2.0,2.1)",\
-  javax.enterprise.inject;version="[2.0,2.1)",\
-  javax.enterprise.util;version="[2.0,2.1)",\
-  javax.inject;version="[1.0,2.1)",\
-  javax.ws.rs.core;version="[2.1,3)",\
   org.eclipse.microprofile.rest.client;version="[1.4,1.5)",\
   org.eclipse.microprofile.rest.client.spi;version="[1.1.1,1.2)",\
   *
 
 Include-Resource: \
   @${repo;org.eclipse.microprofile.rest.client:microprofile-rest-client-api;2.0.0.RC2;EXACT}
-
--buildpath: \
-  com.ibm.websphere.javaee.annotation.1.3;version=latest, \
-  com.ibm.websphere.javaee.cdi.2.0;version=latest, \
-  com.ibm.websphere.javaee.jaxrs.2.1;version=latest, \
-  com.ibm.ws.org.osgi.annotation.versioning;version=latest
-
-instrument.disabled: true
-
-publish.wlp.jar.suffix: dev/api/stable


### PR DESCRIPTION
- Remove variables that are only processed in bnd.bnd file, i.e. buildpath, instrument.disabled and public.wlp.jar.suffix.  This redoes the work that was done with PR #13265
- Remove Imports that can be inherited from the buildpath.  This redoes the work that was done with PR #14369
