### PR TITLE
Fix relative path for referencing public visibility feature folders.

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/build.gradle
+++ b/dev/com.ibm.websphere.appserver.features/build.gradle
@@ -74,7 +74,7 @@ task copyFeaturePiiFiles {
       Properties featureProps = map[featureName]
       if ('public'.equals(featureProps['visibility'])) {
         copy {
-          from project.file('public/' + featureProps['IBM-ShortName'] + '/resources')
+          from project.file('visibility/public/' + featureProps['IBM-ShortName'] + '/resources')
           into rootProject.file('build.pii.package/nlssrc/' + featureName)
           include 'l10n/*.properties'
         }


### PR DESCRIPTION
The relative path in the `build.gradle` file for `com.ibm.websphere.appserver.features` used during the task which copies the PII files incorrectly references itself from the `visibility` folder and not the root of the project. This commit simply tweaks the relative path to make it correct, which should allow these feature PII files to show up in the `build.pii.package` folder during proceessing.