### PR TITLE
 Dynamically generate FAT categories

### DIFF
--- a/.github/GenerateCategories.java
+++ b/.github/GenerateCategories.java
@@ -1,0 +1,107 @@
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+public class GenerateCategories {
+
+    /*
+     *
+     * Generate a JSON string in the format of:
+     //@formatter:off
+     {
+       "include": [
+         { "category": "foo" },
+         { "category": "bar" }
+       ]
+     }
+     //@formatter:on
+     */
+
+    static final boolean DEBUG = false;
+
+    public static void main(String args[]) throws Exception {
+
+        debug("Starting");
+
+        debug("Inputs are: " + Arrays.toString(args));
+        Path prSummaryPath = null;
+        if (args != null && args.length > 0) {
+            prSummaryPath = Paths.get(args[0]);
+            if (!prSummaryPath.toFile().exists())
+                throw new FileNotFoundException(prSummaryPath.toAbsolutePath().toString());
+        }
+        debug("Received PR summary path: " + prSummaryPath);
+        String prSummary = prSummaryPath == null ? ""
+                : Files.readAllLines(prSummaryPath).stream().collect(Collectors.joining("\n"));
+        debug("PR summary text is:");
+        debug("=====================");
+        debug(prSummary);
+        debug("=====================");
+
+        // Discover all categories by checking for files under .github/test-categories/
+        SortedSet<String> allCategories = new TreeSet<>();
+        for (File categoryFile : Paths.get(".github/test-categories").toFile().listFiles()) {
+            allCategories.add(categoryFile.getName().toUpperCase());
+        }
+        debug("All discovered categories are: " + allCategories);
+
+        // Any categories that were mentioned in the PR summary should run first
+        TreeMap<Integer, String> menteiondCategories = new TreeMap<>();
+        for (String category : allCategories) {
+            int categoryIndex = prSummary.indexOf(category);
+            if (categoryIndex >= 0) {
+                debug("PR summary mentioned category: " + category + " at index " + categoryIndex);
+                menteiondCategories.put(categoryIndex, category);
+            }
+        }
+        debug("Explicitly mentioned categories were: " + menteiondCategories.values());
+
+        List<String> finalCategories = new ArrayList<>();
+        // special categories that run directly modified buckets
+        finalCategories.add("MODIFIED_LITE_MODE");
+        finalCategories.add("MODIFIED_FULL_MODE");
+        // now add mentioned categories in order
+        finalCategories.addAll(menteiondCategories.values());
+        // finally add all remaining categories
+        SortedSet<String> unmentionedCategories = new TreeSet<>(allCategories);
+        unmentionedCategories.removeAll(menteiondCategories.values());
+        finalCategories.addAll(unmentionedCategories);
+
+        debug("Final categories are:");
+        debug(finalCategories);
+
+        // Generate the result JSON
+        String result = "{ \"include\": [";
+        boolean first = true;
+        for (String category : finalCategories) {
+            if (first)
+                first = false;
+            else
+                result += ", ";
+            result += "{ \"category\": \"" + category + "\" } ";
+        }
+
+        result += "] }";
+
+        debug("Result is:");
+        System.out.println(result);
+        debug("Done");
+
+    }
+
+    private static void debug(Object msg) {
+        if (!DEBUG)
+            return;
+        System.out.println(msg);
+    }
+
+}

--- a/.github/test-categories/CDI_1
+++ b/.github/test-categories/CDI_1
@@ -1,0 +1,6 @@
+com.ibm.ws.cdi.2.0_fat
+com.ibm.ws.cdi.annotations_fat
+com.ibm.ws.cdi.api_fat
+com.ibm.ws.cdi.beansxml.implicit_fat
+com.ibm.ws.cdi.beansxml_fat
+com.ibm.ws.cdi.ejb_fat

--- a/.github/test-categories/CDI_2
+++ b/.github/test-categories/CDI_2
@@ -1,0 +1,7 @@
+com.ibm.ws.cdi.extension_fat
+com.ibm.ws.cdi.jee_fat
+com.ibm.ws.cdi.jndi_fat
+com.ibm.ws.cdi.lifecycle_fat
+com.ibm.ws.cdi.noncontextual_fat
+com.ibm.ws.cdi.third.party_fat
+com.ibm.ws.cdi.visibility_fat

--- a/.github/test-categories/CONCURRENT_1
+++ b/.github/test-categories/CONCURRENT_1
@@ -1,0 +1,14 @@
+com.ibm.ws.concurrent.mp.1.1_fat_tck
+com.ibm.ws.concurrent.mp_fat
+com.ibm.ws.concurrent.mp_fat_tck
+com.ibm.ws.concurrent.persistent_fat
+com.ibm.ws.concurrent.persistent_fat_auto_pollinterval
+com.ibm.ws.concurrent.persistent_fat_compat
+com.ibm.ws.concurrent.persistent_fat_compatibility
+com.ibm.ws.concurrent.persistent_fat_configupdate
+com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore
+com.ibm.ws.concurrent.persistent_fat_delayexec
+com.ibm.ws.concurrent.persistent_fat_demo
+com.ibm.ws.concurrent.persistent_fat_demo_timers
+com.ibm.ws.concurrent.persistent_fat_errorpaths
+

--- a/.github/test-categories/CONCURRENT_2
+++ b/.github/test-categories/CONCURRENT_2
@@ -1,0 +1,12 @@
+com.ibm.ws.concurrent.persistent_fat_execdisabled
+com.ibm.ws.concurrent.persistent_fat_failover1serv
+com.ibm.ws.concurrent.persistent_fat_failovertimers
+com.ibm.ws.concurrent.persistent_fat_feature
+com.ibm.ws.concurrent.persistent_fat_initial_polling
+com.ibm.ws.concurrent.persistent_fat_jca
+com.ibm.ws.concurrent.persistent_fat_locking
+com.ibm.ws.concurrent.persistent_fat_mbean
+com.ibm.ws.concurrent.persistent_fat_multiple
+com.ibm.ws.concurrent.persistent_fat_multiserver
+com.ibm.ws.concurrent.persistent_fat_oneexec
+

--- a/.github/test-categories/CONCURRENT_3
+++ b/.github/test-categories/CONCURRENT_3
@@ -1,0 +1,13 @@
+com.ibm.ws.concurrent.persistent_fat_retry
+com.ibm.ws.concurrent.persistent_fat_simctrl
+com.ibm.ws.concurrent.persistent_fat_timers
+com.ibm.ws.concurrent_fat
+com.ibm.ws.concurrent_fat_cdi
+com.ibm.ws.concurrent_fat_config
+com.ibm.ws.concurrent_fat_db
+com.ibm.ws.concurrent_fat_demo
+com.ibm.ws.concurrent_fat_ejb
+com.ibm.ws.concurrent_fat_policy
+com.ibm.ws.context_fat
+com.ibm.ws.context_fat_customproviders
+com.ibm.ws.context_fat_serialization

--- a/.github/test-categories/EJB_1
+++ b/.github/test-categories/EJB_1
@@ -1,0 +1,9 @@
+com.ibm.ws.ejbcontainer.async_fat
+com.ibm.ws.ejbcontainer.bindings_fat
+com.ibm.ws.ejbcontainer.cdi_fat
+com.ibm.ws.ejbcontainer.exception_fat
+com.ibm.ws.ejbcontainer.injection_fat
+com.ibm.ws.ejbcontainer.interceptor.v32_fat
+com.ibm.ws.ejbcontainer.interceptor_fat
+com.ibm.ws.ejbcontainer.legacy_fat
+com.ibm.ws.ejbcontainer.mdb.ra_fat

--- a/.github/test-categories/EJB_2
+++ b/.github/test-categories/EJB_2
@@ -1,0 +1,10 @@
+com.ibm.ws.ejbcontainer.remote.client_fat
+com.ibm.ws.ejbcontainer.remote_fat
+com.ibm.ws.ejbcontainer.security.jacc_fat
+com.ibm.ws.ejbcontainer.security.jacc_fat.2
+com.ibm.ws.ejbcontainer.session.async_fat
+com.ibm.ws.ejbcontainer.session.passivation_fat
+com.ibm.ws.ejbcontainer.timer.persistent_fat
+com.ibm.ws.ejbcontainer.tx_fat
+com.ibm.ws.injection_fat
+com.ibm.ws.managedbeans_fat

--- a/.github/test-categories/GENERAL
+++ b/.github/test-categories/GENERAL
@@ -1,0 +1,4 @@
+build.example_fat
+com.ibm.ws.java11_fat
+build.featureStart_fat
+

--- a/.github/test-categories/INSTALL
+++ b/.github/test-categories/INSTALL
@@ -1,0 +1,5 @@
+com.ibm.ws.install.featureUtility_fat
+com.ibm.ws.install.packaging_fat
+com.ibm.ws.os.packaging_fat
+com.ibm.ws.repository_fat
+wlp.lib.extract_fat

--- a/.github/test-categories/JAVAEE
+++ b/.github/test-categories/JAVAEE
@@ -1,0 +1,7 @@
+com.ibm.ws.beanvalidation.v11_fat
+com.ibm.ws.beanvalidation.v20_fat
+com.ibm.ws.el.3.0_fat
+com.ibm.ws.javaee.7.0_fat
+com.ibm.ws.javaee.8.0_fat
+com.ibm.ws.javamail.1.6_fat
+com.ibm.ws.jaxb_fat

--- a/.github/test-categories/JAXRS_1
+++ b/.github/test-categories/JAXRS_1
@@ -1,0 +1,6 @@
+com.ibm.ws.jaxrs.2.1_fat_extended
+com.ibm.ws.jaxrs.2.x.webcontainer_fat
+com.ibm.ws.jaxrs.2.x_fat_clientProps
+io.openliberty.jakarta.restfulWS.3.0.api_fat
+io.openliberty.restfulWS.3.0.client_fat
+io.openliberty.restfulWS.3.0_fat

--- a/.github/test-categories/JAXRS_2
+++ b/.github/test-categories/JAXRS_2
@@ -1,0 +1,4 @@
+com.ibm.ws.jaxrs.2.1.client_fat
+com.ibm.ws.jaxrs.2.1.sse_fat
+com.ibm.ws.jaxrs.2.1_fat
+com.ibm.ws.jaxrs.2.1_fat_executor

--- a/.github/test-categories/JAXRS_3
+++ b/.github/test-categories/JAXRS_3
@@ -1,0 +1,4 @@
+com.ibm.ws.jaxrs.2.0.cdi.1.2_fat
+com.ibm.ws.jaxrs.2.0.client_fat
+com.ibm.ws.jaxrs.2.0_fat
+com.ibm.ws.jaxrs.2.1.cdi.2.0_fat

--- a/.github/test-categories/JAXWS
+++ b/.github/test-categories/JAXWS
@@ -1,0 +1,6 @@
+com.ibm.ws.jaxws.2.2.webcontainer_fat
+com.ibm.ws.jaxws.cdi_fat
+com.ibm.ws.jaxws.clientcontainer_fat
+com.ibm.ws.jaxws.ejb_fat
+com.ibm.ws.jbatch.cdi_fat
+com.ibm.ws.jbatch.misc_fat

--- a/.github/test-categories/JCA
+++ b/.github/test-categories/JCA
@@ -1,0 +1,10 @@
+com.ibm.ws.jca_fat
+com.ibm.ws.jca_fat_bval
+com.ibm.ws.jca_fat_classloading
+com.ibm.ws.jca_fat_configprops
+com.ibm.ws.jca_fat_derbyra
+com.ibm.ws.jca_fat_duplicates
+com.ibm.ws.jca_fat_dynamicConfig
+com.ibm.ws.jca_fat_enterpriseApp
+com.ibm.ws.jca_fat_errorpaths
+com.ibm.ws.jca_fat_example_anno

--- a/.github/test-categories/JDBC
+++ b/.github/test-categories/JDBC
@@ -1,0 +1,11 @@
+com.ibm.ws.jdbc_fat
+com.ibm.ws.jdbc_fat_db2
+com.ibm.ws.jdbc_fat_derby
+com.ibm.ws.jdbc_fat_driver
+com.ibm.ws.jdbc_fat_krb5
+com.ibm.ws.jdbc_fat_loadfromapp
+com.ibm.ws.jdbc_fat_oracle
+com.ibm.ws.jdbc_fat_postgresql
+com.ibm.ws.jdbc_fat_sqlserver
+com.ibm.ws.jdbc_fat_v41
+com.ibm.ws.jdbc_fat_v43

--- a/.github/test-categories/JPA_1
+++ b/.github/test-categories/JPA_1
@@ -1,0 +1,6 @@
+com.ibm.ws.jpa.container.ormdiagnostics_fat
+com.ibm.ws.jpa_22_fat
+com.ibm.ws.jpa_eclipselink_fat
+com.ibm.ws.jpa_ol_fat
+com.ibm.ws.jpa_spec10_injection_fat
+com.ibm.ws.jpa_spec10_part01_fat

--- a/.github/test-categories/JPA_2
+++ b/.github/test-categories/JPA_2
@@ -1,0 +1,5 @@
+com.ibm.ws.jpa_spec10_part02_fat
+com.ibm.ws.jpa_spec10_query_fat
+com.ibm.ws.jpa_spec20_fat
+com.ibm.ws.jpa_spec21_fat
+com.ibm.ws.persistence_fat

--- a/.github/test-categories/JSF_JSP
+++ b/.github/test-categories/JSF_JSP
@@ -1,0 +1,5 @@
+com.ibm.ws.jsf.2.2_fat
+com.ibm.ws.jsf.2.3_fat
+com.ibm.ws.jsfContainer_fat_2.2
+com.ibm.ws.jsfContainer_fat_2.3
+com.ibm.ws.jsp.2.3_fat

--- a/.github/test-categories/JSON
+++ b/.github/test-categories/JSON
@@ -1,0 +1,3 @@
+com.ibm.ws.jsonb_fat
+com.ibm.ws.jsonp.1.1_fat
+com.ibm.ws.jsonp_fat

--- a/.github/test-categories/KERNEL_1
+++ b/.github/test-categories/KERNEL_1
@@ -1,0 +1,5 @@
+com.ibm.ws.anno_fat
+com.ibm.ws.app.manager.wab.installer_fat
+com.ibm.ws.app.manager_fat
+com.ibm.ws.artifact_fat
+com.ibm.ws.artifact_fat_bvt

--- a/.github/test-categories/KERNEL_2
+++ b/.github/test-categories/KERNEL_2
@@ -1,0 +1,3 @@
+com.ibm.ws.config_fat
+com.ibm.ws.kernel.boot_fat
+com.ibm.ws.kernel.feature_fat

--- a/.github/test-categories/KERNEL_3
+++ b/.github/test-categories/KERNEL_3
@@ -1,0 +1,7 @@
+com.ibm.ws.kernel.filemonitor_fat
+com.ibm.ws.osgi.console_fat
+com.ibm.ws.rest.handler.config_fat
+com.ibm.ws.rest.handler.validator.cloudant_fat
+com.ibm.ws.rest.handler.validator_fat
+com.ibm.ws.runtime.update_fat
+com.ibm.ws.threading_policy_fat

--- a/.github/test-categories/LOGGING_1
+++ b/.github/test-categories/LOGGING_1
@@ -1,0 +1,5 @@
+com.ibm.ws.event.logging_fat
+com.ibm.ws.logging.hpel_fat
+com.ibm.ws.logging.json_fat
+com.ibm.ws.logging_fat
+com.ibm.ws.logstash.collector_fat

--- a/.github/test-categories/LOGGING_2
+++ b/.github/test-categories/LOGGING_2
@@ -1,0 +1,4 @@
+com.ibm.ws.request.probe.jdbc_fat
+com.ibm.ws.request.probe.servlet_fat
+com.ibm.ws.request.probes_fat
+com.ibm.ws.request.timing_fat

--- a/.github/test-categories/MESSAGING
+++ b/.github/test-categories/MESSAGING
@@ -1,0 +1,4 @@
+com.ibm.ws.messaging.open_clientcontainer_fat
+com.ibm.ws.messaging.open_comms_fat
+com.ibm.ws.messaging.open_fat
+com.ibm.ws.messaging.open_jms20_fat

--- a/.github/test-categories/MISC
+++ b/.github/test-categories/MISC
@@ -1,0 +1,4 @@
+com.ibm.ws.cloudant_fat
+com.ibm.ws.couchdb_fat
+com.ibm.ws.jmx_fat
+com.ibm.ws.springboot.support_fat

--- a/.github/test-categories/MP_CONFIG
+++ b/.github/test-categories/MP_CONFIG
@@ -1,0 +1,11 @@
+com.ibm.ws.microprofile.config.1.1_fat
+com.ibm.ws.microprofile.config.1.1_fat_tck
+com.ibm.ws.microprofile.config.1.2_fat
+com.ibm.ws.microprofile.config.1.2_fat_tck
+com.ibm.ws.microprofile.config.1.3_fat
+com.ibm.ws.microprofile.config.1.3_fat_tck
+com.ibm.ws.microprofile.config.1.4_fat
+com.ibm.ws.microprofile.config.1.4_fat_tck
+com.ibm.ws.microprofile.config_git_fat_tck
+io.openliberty.microprofile.config.2.0.internal_fat
+io.openliberty.microprofile.config.2.0.internal_fat_tck

--- a/.github/test-categories/MP_FAULT_TOLERANCE
+++ b/.github/test-categories/MP_FAULT_TOLERANCE
@@ -1,0 +1,8 @@
+com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck
+com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck
+com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck
+com.ibm.ws.microprofile.faulttolerance.cdi_fat
+com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics
+com.ibm.ws.microprofile.faulttolerance_fat_tck
+com.ibm.ws.microprofile.faulttolerance_git_fat_tck
+io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck

--- a/.github/test-categories/MP_GRAPHQL
+++ b/.github/test-categories/MP_GRAPHQL
@@ -1,0 +1,2 @@
+com.ibm.ws.microprofile.graphql.1.0_fat
+com.ibm.ws.microprofile.graphql_fat_tck

--- a/.github/test-categories/MP_HEALTH
+++ b/.github/test-categories/MP_HEALTH
@@ -1,0 +1,8 @@
+com.ibm.ws.microprofile.health.1.0_fat_tck
+com.ibm.ws.microprofile.health.2.0_fat
+com.ibm.ws.microprofile.health.2.0_fat_tck
+com.ibm.ws.microprofile.health.2.1_fat_tck
+com.ibm.ws.microprofile.health.2.2_fat_tck
+com.ibm.ws.microprofile.health_fat
+io.openliberty.microprofile.health.3.0.internal_fat
+io.openliberty.microprofile.health.3.0.internal_fat_tck

--- a/.github/test-categories/MP_JWT_1
+++ b/.github/test-categories/MP_JWT_1
@@ -1,0 +1,2 @@
+com.ibm.ws.security.jwt_fat.builder
+com.ibm.ws.security.jwt_fat.consumer

--- a/.github/test-categories/MP_JWT_2
+++ b/.github/test-categories/MP_JWT_2
@@ -1,0 +1,2 @@
+com.ibm.ws.security.jwtsso_fat
+com.ibm.ws.security.mp.jwt_fat_tck

--- a/.github/test-categories/MP_METRICS_1
+++ b/.github/test-categories/MP_METRICS_1
@@ -1,0 +1,5 @@
+com.ibm.ws.microprofile.metrics.1.1.noAuth_fat_tck
+com.ibm.ws.microprofile.metrics.1.1_fat_tck
+com.ibm.ws.microprofile.metrics.2.0_fat_tck
+com.ibm.ws.microprofile.metrics.2.2_fat_tck
+com.ibm.ws.microprofile.metrics.2.3_fat_tck

--- a/.github/test-categories/MP_METRICS_2
+++ b/.github/test-categories/MP_METRICS_2
@@ -1,0 +1,7 @@
+com.ibm.ws.microprofile.metrics.2.x.monitor_fat
+com.ibm.ws.microprofile.metrics.monitor_fat
+com.ibm.ws.microprofile.metrics_fat
+com.ibm.ws.microprofile.metrics_fat_tck
+com.ibm.ws.microprofile.mpjwt.1.1_fat_tck
+io.openliberty.microprofile.metrics.internal.3.0_fat_tck
+io.openliberty.microprofile.metrics.internal.3.x.monitor_fat

--- a/.github/test-categories/MP_MISC
+++ b/.github/test-categories/MP_MISC
@@ -1,0 +1,3 @@
+com.ibm.ws.microprofile.1.0_fat
+com.ibm.ws.microprofile.1.2_fat
+io.openliberty.microprofile.lra.1.0.internal_fat_tck

--- a/.github/test-categories/MP_OPENAPI
+++ b/.github/test-categories/MP_OPENAPI
@@ -1,0 +1,10 @@
+com.ibm.ws.microprofile.openapi.1.1_fat_tck
+com.ibm.ws.microprofile.openapi_fat
+com.ibm.ws.microprofile.openapi_fat_tck
+com.ibm.ws.microprofile.opentracing.1.1_fat_tck
+com.ibm.ws.microprofile.opentracing.1.2_fat_tck
+com.ibm.ws.microprofile.opentracing.1.3_fat_tck
+com.ibm.ws.microprofile.opentracing.jaeger_fat
+com.ibm.ws.microprofile.opentracing_fat_tck
+io.openliberty.microprofile.openapi.2.0.internal_fat
+io.openliberty.microprofile.openapi.2.0.internal_fat_tck

--- a/.github/test-categories/MP_REACTIVE
+++ b/.github/test-categories/MP_REACTIVE
@@ -1,0 +1,5 @@
+com.ibm.ws.microprofile.reactive.messaging_fat
+com.ibm.ws.microprofile.reactive.messaging_fat_tck
+com.ibm.ws.microprofile.reactive.messaging_git_fat_tck
+com.ibm.ws.microprofile.reactive.streams.operators_fat
+com.ibm.ws.microprofile.reactive.streams.operators_fat_tck

--- a/.github/test-categories/MP_REST_CLIENT_1
+++ b/.github/test-categories/MP_REST_CLIENT_1
@@ -1,0 +1,4 @@
+com.ibm.ws.microprofile.rest.client.FT_fat
+com.ibm.ws.microprofile.rest.client11_fat_tck
+com.ibm.ws.microprofile.rest.client12_fat_tck
+com.ibm.ws.microprofile.rest.client13_fat_tck

--- a/.github/test-categories/MP_REST_CLIENT_2
+++ b/.github/test-categories/MP_REST_CLIENT_2
@@ -1,0 +1,3 @@
+com.ibm.ws.microprofile.rest.client14_fat_tck
+com.ibm.ws.microprofile.rest.client_fat
+com.ibm.ws.microprofile.rest.client_fat_tck

--- a/.github/test-categories/OPENTRACING
+++ b/.github/test-categories/OPENTRACING
@@ -1,0 +1,5 @@
+com.ibm.ws.opentracing.1.x_fat
+com.ibm.ws.opentracing_fat
+io.openliberty.microprofile.opentracing.2.0.internal.jaeger_fat
+io.openliberty.microprofile.opentracing.2.0.internal_fat_tck
+io.openliberty.opentracing.2.x_fat

--- a/.github/test-categories/SECURITY_1
+++ b/.github/test-categories/SECURITY_1
@@ -1,0 +1,2 @@
+com.ibm.ws.security.acme_fat
+com.ibm.ws.security.jaspic_fat

--- a/.github/test-categories/SECURITY_2
+++ b/.github/test-categories/SECURITY_2
@@ -1,0 +1,3 @@
+com.ibm.ws.security.javaeesec_fat
+com.ibm.ws.security.javaeesec_fat.2
+com.ibm.ws.security.javaeesec_fat.3

--- a/.github/test-categories/SECURITY_3
+++ b/.github/test-categories/SECURITY_3
@@ -1,0 +1,3 @@
+com.ibm.ws.security.registry.basic_fat
+com.ibm.ws.security.social_fat
+com.ibm.ws.security.wim.adapter.file_fat

--- a/.github/test-categories/SECURITY_4
+++ b/.github/test-categories/SECURITY_4
@@ -1,0 +1,6 @@
+com.ibm.ws.security.wim.adapter.ldap_fat
+com.ibm.ws.security.wim.core_fat
+com.ibm.ws.security.wim.registry_fat
+com.ibm.ws.security.wim.scim.2.0_fat
+com.ibm.ws.ssl_fat_keystoreGen
+com.ibm.ws.ssl_fat_pkcs12

--- a/.github/test-categories/SESSIONS
+++ b/.github/test-categories/SESSIONS
@@ -1,0 +1,6 @@
+com.ibm.ws.jcache_fat
+com.ibm.ws.session.cache_fat
+com.ibm.ws.session.cache_fat_config
+com.ibm.ws.session.cache_fat_config_infinispan
+com.ibm.ws.session.cache_fat_infinispan
+com.ibm.ws.session.cache_fat_infinispan_container

--- a/.github/test-categories/TRANSACTION_1
+++ b/.github/test-categories/TRANSACTION_1
@@ -1,0 +1,9 @@
+com.ibm.ws.jta_fat
+com.ibm.ws.transaction.HADB_fat
+com.ibm.ws.transaction.cloud_fat.1
+com.ibm.ws.transaction.cloud_fat.2
+com.ibm.ws.transaction.cloud_fat.3
+com.ibm.ws.transaction.cloud_fat.4
+com.ibm.ws.transaction.cloud_fat.5
+com.ibm.ws.transaction.cloud_fat.6
+com.ibm.ws.transaction.cloud_fat.7

--- a/.github/test-categories/TRANSACTION_2
+++ b/.github/test-categories/TRANSACTION_2
@@ -1,0 +1,9 @@
+com.ibm.ws.transaction.core_fat.1
+com.ibm.ws.transaction.core_fat.2
+com.ibm.ws.transaction.core_fat.3
+com.ibm.ws.transaction.core_fat.4
+com.ibm.ws.transaction.core_fat.5
+com.ibm.ws.transaction.core_fat.6
+com.ibm.ws.transaction.core_fat.7
+com.ibm.ws.transaction.core_fat.8
+com.ibm.ws.transaction.core_fat.9

--- a/.github/test-categories/TRANSACTION_3
+++ b/.github/test-categories/TRANSACTION_3
@@ -1,0 +1,6 @@
+com.ibm.ws.transaction.db_fat
+com.ibm.ws.transaction.recovery_fat.1
+com.ibm.ws.transaction.recovery_fat.2
+com.ibm.ws.transaction.recovery_fat.3
+com.ibm.ws.tx.jta_fat
+com.ibm.ws.tx.jta_fat_hibernate

--- a/.github/test-categories/WEBCONTAINER_1
+++ b/.github/test-categories/WEBCONTAINER_1
@@ -1,0 +1,5 @@
+com.ibm.ws.grpc_fat
+com.ibm.ws.transport.http.compression_fat
+com.ibm.ws.transport.http.remoteip_fat
+com.ibm.ws.transport.http2_fat
+com.ibm.ws.transport.iiop.open_fat

--- a/.github/test-categories/WEBCONTAINER_2
+++ b/.github/test-categories/WEBCONTAINER_2
@@ -1,0 +1,5 @@
+com.ibm.ws.webcontainer.security.jacc.1.5_fat
+com.ibm.ws.webcontainer.servlet.3.1_fat
+com.ibm.ws.webcontainer.servlet.4.0_fat
+com.ibm.ws.webserver.plugin.utility_fat
+io.openliberty.wsoc.internal_fat

--- a/.github/test-categories/WSAT_1
+++ b/.github/test-categories/WSAT_1
@@ -1,0 +1,7 @@
+com.ibm.ws.wsat.common_fat
+com.ibm.ws.wsat.concurrent_fat
+com.ibm.ws.wsat.migration_fat.1
+com.ibm.ws.wsat.migration_fat.2
+com.ibm.ws.wsat.migration_fat.3
+com.ibm.ws.wsat.migration_fat.4
+com.ibm.ws.wsat.migration_fat.5

--- a/.github/test-categories/WSAT_2
+++ b/.github/test-categories/WSAT_2
@@ -1,0 +1,10 @@
+com.ibm.ws.wsat.recovery_fat.1
+com.ibm.ws.wsat.recovery_fat.2
+com.ibm.ws.wsat.recovery_fat.3
+com.ibm.ws.wsat_fat.1
+com.ibm.ws.wsat_fat.2
+com.ibm.ws.wsat_fat.3
+com.ibm.ws.wsat_fat.4
+com.ibm.ws.wsat_fat.5
+com.ibm.ws.wsat_fat.6
+com.ibm.ws.wsat_fat.7

--- a/.github/test-categories/Z_APPCLIENT
+++ b/.github/test-categories/Z_APPCLIENT
@@ -1,0 +1,5 @@
+com.ibm.ws.clientcontainer.8.0_fat
+com.ibm.ws.clientcontainer.beanvalidation_fat
+com.ibm.ws.clientcontainer.cdi_fat
+com.ibm.ws.clientcontainer.javamail_fat
+com.ibm.ws.clientcontainer.json_fat

--- a/.github/workflow-scripts/check-fat-failures.sh
+++ b/.github/workflow-scripts/check-fat-failures.sh
@@ -13,6 +13,13 @@ if [[ $CATEGORY =~ MODIFIED_.*_MODE ]]; then
     echo "No FATs were directly modfied. Skipping this job."
     exit 0
   fi
+else
+  # This is a regular category defined in .github/test-categories/
+  if [[ ! -f .github/test-categories/$CATEGORY ]]; then
+    echo "::error::Test category $CATEGORY does not exist. A file containing a list of FAT buckets was not found at .github/test-categories/$CATEGORY";
+    exit 1;
+  fi
+  FAT_BUCKETS=$(cat .github/test-categories/$CATEGORY)
 fi
 
 cd dev

--- a/.github/workflows/openliberty-ci.yml
+++ b/.github/workflows/openliberty-ci.yml
@@ -22,6 +22,10 @@ jobs:
   build:
     name: Build Open Liberty
     runs-on: ubuntu-latest
+    outputs:
+      test-matrix: ${{ steps.gen-params.outputs.test-matrix }}
+      test-os: ${{ steps.gen-params.outputs.test-os }}
+      test-java: ${{ steps.gen-params.outputs.test-java }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Java
@@ -29,6 +33,21 @@ jobs:
       with:
         java-version: 11
         openjdk_impl: openj9
+    - name: Generate output
+      id: gen-params
+      run: |
+        cat > .github/pull_request_body.txt << END_OF_PR_BODY
+        ${{ github.event.pull_request.body }}
+        END_OF_PR_BODY
+        echo "PR Summary is:"
+        cat .github/pull_request_body.txt
+
+        echo "::set-output name=test-os::ubuntu-latest"
+        echo "::set-output name=test-java::11"
+
+        MATRIX_RESULT=$(java .github/GenerateCategories.java .github/pull_request_body.txt)
+        echo "MATRIX_RESULT is $MATRIX_RESULT"
+        echo "::set-output name=test-matrix::$MATRIX_RESULT"
     - name: Apply repository caches
       uses: actions/cache@v2
       with:
@@ -101,457 +120,11 @@ jobs:
   fat_tests:
     name: FAT Tests - ${{matrix.category}}
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ${{ needs.build.outputs.test-os }}
     strategy:
       fail-fast: false
       max-parallel: 19
-      matrix:
-        # All categories will be included even if they are not listed here. This array is only used to control the ordering the jobs run. 
-        # If a category is not specified here, it runs in the order it is listed in the following 'include' section
-        category: [ MODIFIED_LITE_MODE, MODIFIED_FULL_MODE, GENERAL, CDI_1, CONCURRENT_1, EJB_1, JAXRS_1, JCA, JDBC, JPA_1, KERNEL_1,
-                    MP_CONFIG, MP_GRAPHQL, MP_METRICS_1, MP_REACTIVE, MP_REST_CLIENT_1, SECURITY_3, TRANSACTION_1, WEBCONTAINER_1 ]
-        include:
-          # These are special categories that run directly modfied FATs in LITE/FULL mode
-          - category: MODIFIED_LITE_MODE
-          - category: MODIFIED_FULL_MODE
-          - category: GENERAL
-            fat-buckets: >
-              build.example_fat
-              com.ibm.ws.java11_fat
-              build.featureStart_fat
-          - category: CDI_1
-            fat-buckets: >
-              com.ibm.ws.cdi.2.0_fat
-              com.ibm.ws.cdi.annotations_fat
-              com.ibm.ws.cdi.api_fat
-              com.ibm.ws.cdi.beansxml.implicit_fat
-              com.ibm.ws.cdi.beansxml_fat
-              com.ibm.ws.cdi.ejb_fat
-          - category: CDI_2
-            fat-buckets: >
-              com.ibm.ws.cdi.extension_fat
-              com.ibm.ws.cdi.jee_fat
-              com.ibm.ws.cdi.jndi_fat
-              com.ibm.ws.cdi.lifecycle_fat
-              com.ibm.ws.cdi.noncontextual_fat
-              com.ibm.ws.cdi.third.party_fat
-              com.ibm.ws.cdi.visibility_fat
-          - category: CONCURRENT_1
-            fat-buckets: >
-              com.ibm.ws.concurrent.mp.1.1_fat_tck
-              com.ibm.ws.concurrent.mp_fat
-              com.ibm.ws.concurrent.mp_fat_tck
-              com.ibm.ws.concurrent.persistent_fat
-              com.ibm.ws.concurrent.persistent_fat_auto_pollinterval
-              com.ibm.ws.concurrent.persistent_fat_compat
-              com.ibm.ws.concurrent.persistent_fat_compatibility
-              com.ibm.ws.concurrent.persistent_fat_configupdate
-              com.ibm.ws.concurrent.persistent_fat_configupdate_databasetaskstore
-              com.ibm.ws.concurrent.persistent_fat_delayexec
-              com.ibm.ws.concurrent.persistent_fat_demo
-              com.ibm.ws.concurrent.persistent_fat_demo_timers
-              com.ibm.ws.concurrent.persistent_fat_errorpaths
-          - category: CONCURRENT_2
-            fat-buckets: >
-              com.ibm.ws.concurrent.persistent_fat_execdisabled
-              com.ibm.ws.concurrent.persistent_fat_failover1serv
-              com.ibm.ws.concurrent.persistent_fat_failovertimers
-              com.ibm.ws.concurrent.persistent_fat_feature
-              com.ibm.ws.concurrent.persistent_fat_initial_polling
-              com.ibm.ws.concurrent.persistent_fat_jca
-              com.ibm.ws.concurrent.persistent_fat_locking
-              com.ibm.ws.concurrent.persistent_fat_mbean
-              com.ibm.ws.concurrent.persistent_fat_multiple
-              com.ibm.ws.concurrent.persistent_fat_multiserver
-              com.ibm.ws.concurrent.persistent_fat_oneexec
-          - category: CONCURRENT_3
-            fat-buckets: >
-              com.ibm.ws.concurrent.persistent_fat_retry
-              com.ibm.ws.concurrent.persistent_fat_simctrl
-              com.ibm.ws.concurrent.persistent_fat_timers
-              com.ibm.ws.concurrent_fat
-              com.ibm.ws.concurrent_fat_cdi
-              com.ibm.ws.concurrent_fat_config
-              com.ibm.ws.concurrent_fat_db
-              com.ibm.ws.concurrent_fat_demo
-              com.ibm.ws.concurrent_fat_ejb
-              com.ibm.ws.concurrent_fat_policy
-              com.ibm.ws.context_fat
-              com.ibm.ws.context_fat_customproviders
-              com.ibm.ws.context_fat_serialization
-          - category: EJB_1
-            fat-buckets: >
-              com.ibm.ws.ejbcontainer.async_fat
-              com.ibm.ws.ejbcontainer.bindings_fat
-              com.ibm.ws.ejbcontainer.cdi_fat
-              com.ibm.ws.ejbcontainer.exception_fat
-              com.ibm.ws.ejbcontainer.injection_fat
-              com.ibm.ws.ejbcontainer.interceptor.v32_fat
-              com.ibm.ws.ejbcontainer.interceptor_fat
-              com.ibm.ws.ejbcontainer.legacy_fat
-              com.ibm.ws.ejbcontainer.mdb.ra_fat
-          - category: EJB_2
-            fat-buckets: >
-              com.ibm.ws.ejbcontainer.remote.client_fat
-              com.ibm.ws.ejbcontainer.remote_fat
-              com.ibm.ws.ejbcontainer.security.jacc_fat
-              com.ibm.ws.ejbcontainer.security.jacc_fat.2
-              com.ibm.ws.ejbcontainer.session.async_fat
-              com.ibm.ws.ejbcontainer.session.passivation_fat
-              com.ibm.ws.ejbcontainer.timer.persistent_fat
-              com.ibm.ws.ejbcontainer.tx_fat
-              com.ibm.ws.injection_fat
-              com.ibm.ws.managedbeans_fat
-          - category: WEBCONTAINER_1
-            fat-buckets: >
-              com.ibm.ws.grpc_fat
-              com.ibm.ws.transport.http.compression_fat
-              com.ibm.ws.transport.http.remoteip_fat
-              com.ibm.ws.transport.http2_fat
-              com.ibm.ws.transport.iiop.open_fat
-          - category: WEBCONTAINER_2
-            fat-buckets: >
-              com.ibm.ws.webcontainer.security.jacc.1.5_fat
-              com.ibm.ws.webcontainer.servlet.3.1_fat
-              com.ibm.ws.webcontainer.servlet.4.0_fat
-              com.ibm.ws.webserver.plugin.utility_fat
-              io.openliberty.wsoc.internal_fat
-          - category: JAXRS_1
-            fat-buckets: >
-              com.ibm.ws.jaxrs.2.1_fat_extended
-              com.ibm.ws.jaxrs.2.x.webcontainer_fat
-              com.ibm.ws.jaxrs.2.x_fat_clientProps
-              io.openliberty.jakarta.restfulWS.3.0.api_fat
-              io.openliberty.restfulWS.3.0.client_fat
-              io.openliberty.restfulWS.3.0_fat
-          - category: JAXRS_2
-            fat-buckets: >
-              com.ibm.ws.jaxrs.2.1.client_fat
-              com.ibm.ws.jaxrs.2.1.sse_fat
-              com.ibm.ws.jaxrs.2.1_fat
-              com.ibm.ws.jaxrs.2.1_fat_executor
-          - category: JAXRS_3
-            fat-buckets: >
-              com.ibm.ws.jaxrs.2.0.cdi.1.2_fat
-              com.ibm.ws.jaxrs.2.0.client_fat
-              com.ibm.ws.jaxrs.2.0_fat
-              com.ibm.ws.jaxrs.2.1.cdi.2.0_fat
-          - category: JCA
-            fat-buckets: >
-              com.ibm.ws.jca_fat
-              com.ibm.ws.jca_fat_bval
-              com.ibm.ws.jca_fat_classloading
-              com.ibm.ws.jca_fat_configprops
-              com.ibm.ws.jca_fat_derbyra
-              com.ibm.ws.jca_fat_duplicates
-              com.ibm.ws.jca_fat_dynamicConfig
-              com.ibm.ws.jca_fat_enterpriseApp
-              com.ibm.ws.jca_fat_errorpaths
-              com.ibm.ws.jca_fat_example_anno
-          - category: JDBC
-            fat-buckets: >
-              com.ibm.ws.jdbc_fat
-              com.ibm.ws.jdbc_fat_db2
-              com.ibm.ws.jdbc_fat_derby
-              com.ibm.ws.jdbc_fat_driver
-              com.ibm.ws.jdbc_fat_krb5
-              com.ibm.ws.jdbc_fat_loadfromapp
-              com.ibm.ws.jdbc_fat_oracle
-              com.ibm.ws.jdbc_fat_postgresql
-              com.ibm.ws.jdbc_fat_sqlserver
-              com.ibm.ws.jdbc_fat_v41
-              com.ibm.ws.jdbc_fat_v43
-          - category: JPA_1
-            fat-buckets: >
-              com.ibm.ws.jpa.container.ormdiagnostics_fat
-              com.ibm.ws.jpa_22_fat
-              com.ibm.ws.jpa_eclipselink_fat
-              com.ibm.ws.jpa_ol_fat
-              com.ibm.ws.jpa_spec10_injection_fat
-              com.ibm.ws.jpa_spec10_part01_fat
-          - category: JPA_2
-            fat-buckets: >
-              com.ibm.ws.jpa_spec10_part02_fat
-              com.ibm.ws.jpa_spec10_query_fat
-              com.ibm.ws.jpa_spec20_fat
-              com.ibm.ws.jpa_spec21_fat
-              com.ibm.ws.persistence_fat
-          - category: MP_MISC
-            fat-buckets: >
-              com.ibm.ws.microprofile.1.0_fat
-              com.ibm.ws.microprofile.1.2_fat
-              io.openliberty.microprofile.lra.1.0.internal_fat_tck
-          - category: MP_CONFIG
-            fat-buckets: >
-              com.ibm.ws.microprofile.config.1.1_fat
-              com.ibm.ws.microprofile.config.1.1_fat_tck
-              com.ibm.ws.microprofile.config.1.2_fat
-              com.ibm.ws.microprofile.config.1.2_fat_tck
-              com.ibm.ws.microprofile.config.1.3_fat
-              com.ibm.ws.microprofile.config.1.3_fat_tck
-              com.ibm.ws.microprofile.config.1.4_fat
-              com.ibm.ws.microprofile.config.1.4_fat_tck
-              com.ibm.ws.microprofile.config_git_fat_tck
-              io.openliberty.microprofile.config.2.0.internal_fat
-              io.openliberty.microprofile.config.2.0.internal_fat_tck
-          - category: MP_FAULT_TOLERANCE
-            fat-buckets: >
-              com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck
-              com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck
-              com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck
-              com.ibm.ws.microprofile.faulttolerance.cdi_fat
-              com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics
-              com.ibm.ws.microprofile.faulttolerance_fat_tck
-              com.ibm.ws.microprofile.faulttolerance_git_fat_tck
-              io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck
-          - category: MP_GRAPHQL
-            fat-buckets: >
-              com.ibm.ws.microprofile.graphql.1.0_fat
-              com.ibm.ws.microprofile.graphql_fat_tck
-          - category: MP_HEALTH
-            fat-buckets: >
-              com.ibm.ws.microprofile.health.1.0_fat_tck
-              com.ibm.ws.microprofile.health.2.0_fat
-              com.ibm.ws.microprofile.health.2.0_fat_tck
-              com.ibm.ws.microprofile.health.2.1_fat_tck
-              com.ibm.ws.microprofile.health.2.2_fat_tck
-              com.ibm.ws.microprofile.health_fat
-              io.openliberty.microprofile.health.3.0.internal_fat
-              io.openliberty.microprofile.health.3.0.internal_fat_tck
-          - category: MP_METRICS_1
-            fat-buckets: >
-              com.ibm.ws.microprofile.metrics.1.1.noAuth_fat_tck
-              com.ibm.ws.microprofile.metrics.1.1_fat_tck
-              com.ibm.ws.microprofile.metrics.2.0_fat_tck
-              com.ibm.ws.microprofile.metrics.2.2_fat_tck
-              com.ibm.ws.microprofile.metrics.2.3_fat_tck
-          - category: MP_METRICS_2
-            fat-buckets: >
-              com.ibm.ws.microprofile.metrics.2.x.monitor_fat
-              com.ibm.ws.microprofile.metrics.monitor_fat
-              com.ibm.ws.microprofile.metrics_fat
-              com.ibm.ws.microprofile.metrics_fat_tck
-              com.ibm.ws.microprofile.mpjwt.1.1_fat_tck
-              io.openliberty.microprofile.metrics.internal.3.0_fat_tck
-              io.openliberty.microprofile.metrics.internal.3.x.monitor_fat
-          - category: MP_OPENAPI
-            fat-buckets: >
-              com.ibm.ws.microprofile.openapi.1.1_fat_tck
-              com.ibm.ws.microprofile.openapi_fat
-              com.ibm.ws.microprofile.openapi_fat_tck
-              com.ibm.ws.microprofile.opentracing.1.1_fat_tck
-              com.ibm.ws.microprofile.opentracing.1.2_fat_tck
-              com.ibm.ws.microprofile.opentracing.1.3_fat_tck
-              com.ibm.ws.microprofile.opentracing.jaeger_fat
-              com.ibm.ws.microprofile.opentracing_fat_tck
-              io.openliberty.microprofile.openapi.2.0.internal_fat
-              io.openliberty.microprofile.openapi.2.0.internal_fat_tck
-          - category: OPENTRACING
-            fat-buckets: >
-              com.ibm.ws.opentracing.1.x_fat
-              com.ibm.ws.opentracing_fat
-              io.openliberty.microprofile.opentracing.2.0.internal.jaeger_fat
-              io.openliberty.microprofile.opentracing.2.0.internal_fat_tck
-              io.openliberty.opentracing.2.x_fat
-          - category: MP_REACTIVE
-            fat-buckets: >
-              com.ibm.ws.microprofile.reactive.messaging_fat
-              com.ibm.ws.microprofile.reactive.messaging_fat_tck
-              com.ibm.ws.microprofile.reactive.messaging_git_fat_tck
-              com.ibm.ws.microprofile.reactive.streams.operators_fat
-              com.ibm.ws.microprofile.reactive.streams.operators_fat_tck
-          - category: MP_REST_CLIENT_1
-            fat-buckets: >
-              com.ibm.ws.microprofile.rest.client.FT_fat
-              com.ibm.ws.microprofile.rest.client11_fat_tck
-              com.ibm.ws.microprofile.rest.client12_fat_tck
-              com.ibm.ws.microprofile.rest.client13_fat_tck
-          - category: MP_REST_CLIENT_2
-            fat-buckets: >
-              com.ibm.ws.microprofile.rest.client14_fat_tck
-              com.ibm.ws.microprofile.rest.client_fat
-              com.ibm.ws.microprofile.rest.client_fat_tck
-          - category: MP_JWT_1
-            fat-buckets: >
-              com.ibm.ws.security.jwt_fat.builder
-              com.ibm.ws.security.jwt_fat.consumer
-          - category: MP_JWT_2
-            # TODO: this bucket hangs: com.ibm.ws.security.mp.jwt.1.1_fat
-            fat-buckets: >
-              com.ibm.ws.security.jwtsso_fat
-              com.ibm.ws.security.mp.jwt_fat_tck
-          - category: SECURITY_1
-            fat-buckets: >
-              com.ibm.ws.security.acme_fat
-              com.ibm.ws.security.jaspic_fat
-          - category: SECURITY_2
-            fat-buckets: >
-              com.ibm.ws.security.javaeesec_fat
-              com.ibm.ws.security.javaeesec_fat.2
-              com.ibm.ws.security.javaeesec_fat.3
-          - category: SECURITY_3
-            # TODO: bucket 'com.ibm.ws.security.social_fat.oidcCertification' is disabled currently
-            fat-buckets: >
-              com.ibm.ws.security.registry.basic_fat
-              com.ibm.ws.security.social_fat
-              com.ibm.ws.security.wim.adapter.file_fat
-          - category: SECURITY_4
-            fat-buckets: >
-              com.ibm.ws.security.wim.adapter.ldap_fat
-              com.ibm.ws.security.wim.core_fat
-              com.ibm.ws.security.wim.registry_fat
-              com.ibm.ws.security.wim.scim.2.0_fat
-              com.ibm.ws.ssl_fat_keystoreGen
-              com.ibm.ws.ssl_fat_pkcs12
-          - category: MISC
-            # com.ibm.ws.mongo_fat // disabled: requires Consul
-            fat-buckets: >
-              com.ibm.ws.cloudant_fat
-              com.ibm.ws.couchdb_fat
-              com.ibm.ws.jmx_fat
-              com.ibm.ws.springboot.support_fat
-          - category: KERNEL_1
-            fat-buckets: >
-              com.ibm.ws.anno_fat
-              com.ibm.ws.app.manager.wab.installer_fat
-              com.ibm.ws.app.manager_fat
-              com.ibm.ws.artifact_fat
-              com.ibm.ws.artifact_fat_bvt
-          - category: KERNEL_2
-            fat-buckets: >
-              com.ibm.ws.config_fat
-              com.ibm.ws.kernel.boot_fat
-              com.ibm.ws.kernel.feature_fat
-          - category: KERNEL_3
-            fat-buckets: >
-              com.ibm.ws.kernel.filemonitor_fat
-              com.ibm.ws.osgi.console_fat
-              com.ibm.ws.rest.handler.config_fat
-              com.ibm.ws.rest.handler.validator.cloudant_fat
-              com.ibm.ws.rest.handler.validator_fat
-              com.ibm.ws.runtime.update_fat
-              com.ibm.ws.threading_policy_fat
-          - category: SESSIONS
-            fat-buckets: >
-              com.ibm.ws.jcache_fat
-              com.ibm.ws.session.cache_fat
-              com.ibm.ws.session.cache_fat_config
-              com.ibm.ws.session.cache_fat_config_infinispan
-              com.ibm.ws.session.cache_fat_infinispan
-              com.ibm.ws.session.cache_fat_infinispan_container
-          - category: JAVAEE
-            fat-buckets: >
-              com.ibm.ws.beanvalidation.v11_fat
-              com.ibm.ws.beanvalidation.v20_fat
-              com.ibm.ws.el.3.0_fat
-              com.ibm.ws.javaee.7.0_fat
-              com.ibm.ws.javaee.8.0_fat
-              com.ibm.ws.javamail.1.6_fat
-              com.ibm.ws.jaxb_fat
-          - category: TRANSACTION_1
-            fat-buckets: >
-              com.ibm.ws.jta_fat
-              com.ibm.ws.transaction.HADB_fat
-              com.ibm.ws.transaction.cloud_fat.1
-              com.ibm.ws.transaction.cloud_fat.2
-              com.ibm.ws.transaction.cloud_fat.3
-              com.ibm.ws.transaction.cloud_fat.4
-              com.ibm.ws.transaction.cloud_fat.5
-              com.ibm.ws.transaction.cloud_fat.6
-              com.ibm.ws.transaction.cloud_fat.7
-          - category: TRANSACTION_2
-            fat-buckets: >
-              com.ibm.ws.transaction.core_fat.1
-              com.ibm.ws.transaction.core_fat.2
-              com.ibm.ws.transaction.core_fat.3
-              com.ibm.ws.transaction.core_fat.4
-              com.ibm.ws.transaction.core_fat.5
-              com.ibm.ws.transaction.core_fat.6
-              com.ibm.ws.transaction.core_fat.7
-              com.ibm.ws.transaction.core_fat.8
-              com.ibm.ws.transaction.core_fat.9
-          - category: TRANSACTION_3
-            fat-buckets: >
-              com.ibm.ws.transaction.db_fat
-              com.ibm.ws.transaction.recovery_fat.1
-              com.ibm.ws.transaction.recovery_fat.2
-              com.ibm.ws.transaction.recovery_fat.3
-              com.ibm.ws.tx.jta_fat
-              com.ibm.ws.tx.jta_fat_hibernate
-          - category: MESSAGING
-            fat-buckets: >
-              com.ibm.ws.messaging.open_clientcontainer_fat
-              com.ibm.ws.messaging.open_comms_fat
-              com.ibm.ws.messaging.open_fat
-              com.ibm.ws.messaging.open_jms20_fat
-          - category: LOGGING_1
-            fat-buckets: >
-              com.ibm.ws.event.logging_fat
-              com.ibm.ws.logging.hpel_fat
-              com.ibm.ws.logging.json_fat
-              com.ibm.ws.logging_fat
-              com.ibm.ws.logstash.collector_fat
-          - category: LOGGING_2
-            fat-buckets: >
-              com.ibm.ws.request.probe.jdbc_fat
-              com.ibm.ws.request.probe.servlet_fat
-              com.ibm.ws.request.probes_fat
-              com.ibm.ws.request.timing_fat
-          - category: INSTALL
-            fat-buckets: >
-              com.ibm.ws.install.featureUtility_fat
-              com.ibm.ws.install.packaging_fat
-              com.ibm.ws.os.packaging_fat
-              com.ibm.ws.repository_fat
-              wlp.lib.extract_fat
-          - category: JAXWS
-            fat-buckets: >
-              com.ibm.ws.jaxws.2.2.webcontainer_fat
-              com.ibm.ws.jaxws.cdi_fat
-              com.ibm.ws.jaxws.clientcontainer_fat
-              com.ibm.ws.jaxws.ejb_fat
-              com.ibm.ws.jbatch.cdi_fat
-              com.ibm.ws.jbatch.misc_fat
-          - category: JSF_JSP
-            fat-buckets: >
-              com.ibm.ws.jsf.2.2_fat
-              com.ibm.ws.jsf.2.3_fat
-              com.ibm.ws.jsfContainer_fat_2.2
-              com.ibm.ws.jsfContainer_fat_2.3
-              com.ibm.ws.jsp.2.3_fat
-          - category: JSON
-            fat-buckets: >
-              com.ibm.ws.jsonb_fat
-              com.ibm.ws.jsonp.1.1_fat
-              com.ibm.ws.jsonp_fat
-          - category: APPCLIENT
-            fat-buckets: >
-              com.ibm.ws.clientcontainer.8.0_fat
-              com.ibm.ws.clientcontainer.beanvalidation_fat
-              com.ibm.ws.clientcontainer.cdi_fat
-              com.ibm.ws.clientcontainer.javamail_fat
-              com.ibm.ws.clientcontainer.json_fat
-          - category: WSAT_1
-            fat-buckets: >
-              com.ibm.ws.wsat.common_fat
-              com.ibm.ws.wsat.concurrent_fat
-              com.ibm.ws.wsat.migration_fat.1
-              com.ibm.ws.wsat.migration_fat.2
-              com.ibm.ws.wsat.migration_fat.3
-              com.ibm.ws.wsat.migration_fat.4
-              com.ibm.ws.wsat.migration_fat.5
-          - category: WSAT_2
-            fat-buckets: >
-              com.ibm.ws.wsat.recovery_fat.1
-              com.ibm.ws.wsat.recovery_fat.2
-              com.ibm.ws.wsat.recovery_fat.3
-              com.ibm.ws.wsat_fat.1
-              com.ibm.ws.wsat_fat.2
-              com.ibm.ws.wsat_fat.3
-              com.ibm.ws.wsat_fat.4
-              com.ibm.ws.wsat_fat.5
-              com.ibm.ws.wsat_fat.6
-              com.ibm.ws.wsat_fat.7
+      matrix: ${{fromJson(needs.build.outputs.test-matrix)}}
     steps:
     - uses: actions/checkout@v2
       with:
@@ -564,7 +137,7 @@ jobs:
     - name: Set up Java
       uses: joschi/setup-jdk@v2
       with:
-        java-version: 11
+        java-version: ${{ needs.build.outputs.test-java }}
         openjdk_impl: openj9
     - name: Apply repository caches
       uses: actions/cache@v2
@@ -589,7 +162,6 @@ jobs:
       timeout-minutes: 150
       shell: bash
       env:
-        FAT_BUCKETS: ${{matrix.fat-buckets}}
         CATEGORY: ${{matrix.category}}
         GH_EVENT_NAME: ${{github.event_name}}
       run: .github/workflow-scripts/run-fat-build.sh
@@ -597,7 +169,6 @@ jobs:
       shell: bash
       if: always()
       env:
-        FAT_BUCKETS: ${{matrix.fat-buckets}}
         CATEGORY: ${{matrix.category}}
       run: .github/workflow-scripts/check-fat-failures.sh
     - name: Upload failing FAT artifacts

--- a/dev/build.changeDetector/src/com/ibm/ws/infra/depchain/ChangeDetector2.java
+++ b/dev/build.changeDetector/src/com/ibm/ws/infra/depchain/ChangeDetector2.java
@@ -413,7 +413,8 @@ public class ChangeDetector2 {
         if (fPath == null)
             return FileType.UNKNOWN;
 
-        if (fPath.contains("dependabot"))
+        if (fPath.contains("dependabot") ||
+            fPath.startsWith(".github/test-categories/"))
             return FileType.UNIT_BVT_TEST;
 
         if (!fPath.startsWith("dev/"))


### PR DESCRIPTION
This allows reading the PR summary (i.e. this section of text) to be read in as input by the GH Actions workflow.

Currently there is only one keyword which is supported, which is if any FAT categories are explicitly mentioned, they will be prioritized to run first in the PR. For example, since I mention JDBC and JCA (which are FAT categories), they will run first.

If categories are not explicitly mentioned, then they are run in alphabetical order.