### PR TITLE
add file option to tlsprofiler

### DIFF
--- a/dev/com.ibm.ws.security.utility/resources/com/ibm/ws/security/utility/resources/UtilityOptions.nlsprops
+++ b/dev/com.ibm.ws.security.utility/resources/com/ibm/ws/security/utility/resources/UtilityOptions.nlsprops
@@ -258,6 +258,11 @@ tlsProfiler.required-key.host=\
 \ \ \ \ --host
 tlsProfiler.required-desc.host=\
 \tSpecify the host.
+tlsProfiler.option-key.file=\
+\ \ \ \ --file
+tlsProfiler.option-desc.file=\
+\tOptional. The result will be written to the file specified \n\
+\tinstead of the console screen.
 tlsProfiler.option-key.verbose=\
 \ \ \ \ --verbose
 tlsProfiler.option-desc.verbose=\

--- a/dev/com.ibm.ws.security.utility/src/com/ibm/ws/security/utility/SecurityUtility.java
+++ b/dev/com.ibm.ws.security.utility/src/com/ibm/ws/security/utility/SecurityUtility.java
@@ -163,7 +163,7 @@ public class SecurityUtility extends UtilityTemplate {
         util.registerTask(new EncodeTask(SCRIPT_NAME));
         util.registerTask(new CreateSSLCertificateTask(certCreator, fileUtil, SCRIPT_NAME));
         util.registerTask(new CreateLTPAKeysTask(ltpaKeyFileCreator, fileUtil, SCRIPT_NAME));
-        util.registerTask(new TLSProfilerTask(SCRIPT_NAME));
+        util.registerTask(new TLSProfilerTask(fileUtil, SCRIPT_NAME));
 
         // Kick everything off
         int rc = util.runProgram(args).getReturnCode();

--- a/dev/com.ibm.ws.security.utility/test/com/ibm/ws/security/utility/tasks/TLSProfilerTaskTest.java
+++ b/dev/com.ibm.ws.security.utility/test/com/ibm/ws/security/utility/tasks/TLSProfilerTaskTest.java
@@ -24,6 +24,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.ibm.ws.security.utility.IFileUtility;
 import com.ibm.ws.security.utility.utils.ConsoleWrapper;
 import com.ibm.ws.security.utility.utils.StringStartsWithMatcher;
 
@@ -43,10 +44,11 @@ public class TLSProfilerTaskTest {
     private final String host = "--host=ibm.com";
     private final String port = "--port=443";
     private final String verbose = "--verbose";
+    private final IFileUtility fileUtil = mock.mock(IFileUtility.class);
 
     @Before
     public void setUp() {
-        tlsprofiler = new TLSProfilerTask("myScript");
+        tlsprofiler = new TLSProfilerTask(fileUtil, "myScript");
     }
 
     @After
@@ -73,6 +75,8 @@ public class TLSProfilerTaskTest {
     public void handleTask_HostAndPortArgs() {
         mock.checking(new Expectations() {
             {
+                allowing(fileUtil).getServersDirectory();
+                will(returnValue("/tmp/servers/"));
                 one(stdout).println(with(aStringStartsWith("Successful handshakes to the target host and port")));
                 allowing(stdout).println(with(aStringStartsWith("TLS")));
             }


### PR DESCRIPTION
Adding --file option for the tlsProfiler securityUtility command.
If no file is specified, the output will go to console as before.
If full path is specified, output will be written to specified location. If no file name is specified, filename will be created in the form of tlsProfiler-date.txt. If only filename is specified, file will be created in liberty's server directory.
console output will include file location, eg. Writing file to: /Users/bob/test1/test2/output.txt