### PR TITLE
Clean up usage of temporary variables

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/variables/ConfigVariableRegistry.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/variables/ConfigVariableRegistry.java
@@ -232,6 +232,11 @@ public class ConfigVariableRegistry implements VariableRegistry, ConfigVariables
         }
     }
 
+    @Sensitive
+    public Map<String, LibertyVariable> getConfigVariables() {
+        return this.configVariables;
+    }
+
     /*
      * Override system variables.
      */


### PR DESCRIPTION
The internal state of config variables can get a bit confused if we encounter an 'include' element that contains a variable and have to temporarily add variables to the registry. 