### PR TITLE
Add step to validate copyright headers

### DIFF
--- a/.github/workflow-scripts/validate-copyright-headers.sh
+++ b/.github/workflow-scripts/validate-copyright-headers.sh
@@ -1,0 +1,34 @@
+set +e
+
+# Strings indicating IBM-specific copyright notice.
+# We don't want any of these tokens to be in Open Liberty.
+IBM_COPYRT_STR1="IBM Confidential"
+IBM_COPYRT_STR2="Property of IBM"
+IBM_COPYRT_STR3="Restricted Materials of IBM"
+
+rm copyright_modified_files.diff &> /dev/null
+git diff --name-only HEAD^...HEAD^2 >> copyright_modified_files.diff
+
+# Ensure files modified in this PR have valid copyright headers
+BAD_FILES=""
+while read MODIFIED_FILE; do
+  # Allow this file to contain the bad tokens
+  if [[ $MODIFIED_FILE == '.github/workflow-scripts/validate-copyright-headers.sh' ]]; then
+    continue
+  fi
+  echo "Checking file $MODIFIED_FILE"
+  if grep -q -e "$IBM_COPYRT_STR1" -e "$IBM_COPYRT_STR2" -e "$IBM_COPYRT_STR3" "$MODIFIED_FILE"; then
+    BAD_LINES=$(grep -n -e "$IBM_COPYRT_STR1" -e "$IBM_COPYRT_STR2" -e "$IBM_COPYRT_STR3" "$MODIFIED_FILE")
+    echo "::error::The modified file $MODIFIED_FILE has an invalid copyright header. Problem lines are: $BAD_LINES";
+    BAD_FILES="$BAD_FILES $MODIFIED_FILE"
+  fi
+done < copyright_modified_files.diff
+
+# If any files with invalid copyright headers were found, report them and fail
+echo "BAD_FILES is $BAD_FILES"
+if [[ $BAD_FILES != "" ]]; then
+  echo "::error::The following modified files had invalid copyright headers: $BAD_FILES"
+  exit 1;
+else
+  echo "The copyright header check completed normally."
+fi

--- a/.github/workflows/openliberty-ci.yml
+++ b/.github/workflows/openliberty-ci.yml
@@ -28,6 +28,11 @@ jobs:
       test-java: ${{ steps.gen-params.outputs.test-java }}
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 50
+    - name: Validate copyright headers
+      if: "github.event_name == 'pull_request'"
+      run: .github/workflow-scripts/validate-copyright-headers.sh
     - name: Set up Java
       uses: joschi/setup-jdk@v2
       with:


### PR DESCRIPTION
Ensure that no modified files contain any of the following tokens:

- `IBM Confidential`
- `Property of IBM`
- `Restricted Materials of IBM`

A new check should now run at the beginning of the `build` job and fail the check if invalid tokens are found.

If invalid copyright headers are found, then the build step fails (in the first minute of execution) and no FAT jobs launch:
![image](https://user-images.githubusercontent.com/5427967/97639724-23a75d00-1a0d-11eb-9880-0997c6c8c04c.png)


If a user clicks into the failing check detail, the problem files/lines will be highlighted:
![image](https://user-images.githubusercontent.com/5427967/97639772-3f126800-1a0d-11eb-84a0-639831f68b17.png)
