### PR TITLE
default binding for concurrency extension, and other tests

### DIFF
--- a/dev/com.ibm.ws.concurrent/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.concurrent/resources/OSGI-INF/metatype/metatype.xml
@@ -46,6 +46,7 @@
   <AD id="ConcurrencyPolicy.target"              type="String"  ibm:final="true" default="(service.pid=${concurrencyPolicyRef})" name="internal" description="internal use only"/>
   <AD id="contextServiceRef"                     type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.context.service" default="DefaultContextService" cardinality="1" name="%contextServiceRef" description="%contextServiceRef.desc"/>
   <AD id="ContextService.target"                 type="String"  ibm:final="true" default="(service.pid=${contextServiceRef})" name="internal" description="internal use only"/>
+  <AD id="creates.objectClass"                   type="String"  ibm:final="true" ibm:variable="io.openliberty.concurrency.mes.objectClasses" default="java.util.concurrent.ExecutorService, javax.enterprise.concurrent.ManagedExecutorService, org.eclipse.microprofile.context.ManagedExecutor" cardinality="10" name="internal" description="internal use only"/>
   <AD id="javaCompDefaultName"                   type="String"  required="false" name="internal" description="internal use only" />
   <AD id="jndiName"                              type="String"  required="false" ibm:unique="jndiName" name="%jndiName" description="%jndiName.desc"/>
   <AD id="longRunningPolicyRef"                  type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.concurrency.policy.concurrencyPolicy" required="false" cardinality="1" name="%longRunningPolicy" description="%longRunningPolicy.desc"/>
@@ -65,6 +66,7 @@
   <AD id="ConcurrencyPolicy.target"              type="String"  ibm:final="true" default="(service.pid=${concurrencyPolicyRef})" name="internal" description="internal use only"/>
   <AD id="contextServiceRef"                     type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.context.service" default="DefaultContextService" cardinality="1" name="%contextServiceRef" description="%contextServiceRef.desc"/>
   <AD id="ContextService.target"                 type="String"  ibm:final="true" default="(service.pid=${contextServiceRef})" name="internal" description="internal use only"/>
+  <AD id="creates.objectClass"                   type="String"  ibm:final="true" ibm:variable="io.openliberty.concurrency.mses.objectClasses" default="java.util.concurrent.ExecutorService, java.util.concurrent.ScheduledExecutorService, javax.enterprise.concurrent.ManagedExecutorService, javax.enterprise.concurrent.ManagedScheduledExecutorService" cardinality="10" name="internal" description="internal use only"/>
   <AD id="javaCompDefaultName"                   type="String"  required="false" name="internal" description="internal use only" />
   <AD id="jndiName"                              type="String"  required="false" ibm:unique="jndiName" name="%jndiName" description="%jndiName.desc"/>
   <AD id="longRunningPolicyRef"                  type="String"  ibm:type="pid" ibm:reference="com.ibm.ws.concurrency.policy.concurrencyPolicy" required="false" cardinality="1" name="%longRunningPolicy" description="%longRunningPolicy.desc"/>

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
@@ -80,10 +80,7 @@ import com.ibm.wsspi.threadcontext.WSContextService;
 @Component(configurationPid = "com.ibm.ws.concurrent.managedExecutorService", configurationPolicy = ConfigurationPolicy.REQUIRE,
            service = { ExecutorService.class, ManagedExecutor.class, ManagedExecutorService.class, //
                        ResourceFactory.class, ApplicationRecycleComponent.class },
-           reference = @Reference(name = "ApplicationRecycleCoordinator", service = ApplicationRecycleCoordinator.class),
-           property = { "creates.objectClass=java.util.concurrent.ExecutorService",
-                        "creates.objectClass=javax.enterprise.concurrent.ManagedExecutorService",
-                        "creates.objectClass=org.eclipse.microprofile.context.ManagedExecutor" })
+           reference = @Reference(name = "ApplicationRecycleCoordinator", service = ApplicationRecycleCoordinator.class))
 public class ManagedExecutorServiceImpl implements ExecutorService, //
                 ManagedExecutor, ManagedExecutorService, CompletionStageExecutor, //
                 ResourceFactory, ApplicationRecycleComponent, WSManagedExecutorService {

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedScheduledExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedScheduledExecutorServiceImpl.java
@@ -40,11 +40,7 @@ import com.ibm.wsspi.resource.ResourceFactory;
            service = { ExecutorService.class, ManagedExecutorService.class, //
                        ResourceFactory.class, ApplicationRecycleComponent.class, //
                        ScheduledExecutorService.class, ManagedScheduledExecutorService.class },
-           reference = @Reference(name = "ApplicationRecycleCoordinator", service = ApplicationRecycleCoordinator.class),
-           property = { "creates.objectClass=java.util.concurrent.ExecutorService",
-                        "creates.objectClass=java.util.concurrent.ScheduledExecutorService",
-                        "creates.objectClass=javax.enterprise.concurrent.ManagedExecutorService",
-                        "creates.objectClass=javax.enterprise.concurrent.ManagedScheduledExecutorService" })
+           reference = @Reference(name = "ApplicationRecycleCoordinator", service = ApplicationRecycleCoordinator.class))
 public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceImpl implements ManagedScheduledExecutorService {
 
     private static final TraceComponent tc = Tr.register(ManagedScheduledExecutorServiceImpl.class);

--- a/dev/com.ibm.ws.concurrent_fat_work/test-applications/WorkTestApp/resources/WEB-INF/ibm-web-bnd.xml
+++ b/dev/com.ibm.ws.concurrent_fat_work/test-applications/WorkTestApp/resources/WEB-INF/ibm-web-bnd.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-bnd xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-bnd_1_0.xsd" version="1.0">
+    
+  	<resource-ref name="java:module/env/wm/executorRef" binding-name="wm/executor"/>
+
+</web-bnd>

--- a/dev/com.ibm.ws.concurrent_fat_work/test-applications/WorkTestApp/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.concurrent_fat_work/test-applications/WorkTestApp/resources/WEB-INF/web.xml
@@ -9,5 +9,16 @@
     <res-type>test.concurrent.work.WorkManager</res-type>
     <lookup-name>wm/scheduledExecutor</lookup-name>
   </resource-ref>
-  
+
+  <resource-ref>
+    <res-ref-name>java:module/env/wm/executorRef</res-ref-name>
+    <res-type>test.concurrent.work.WorkManager</res-type>
+    <!-- see ibm-web-bnd.xml file for binding -->
+  </resource-ref>
+
+  <resource-ref>
+    <res-ref-name>wm/executor</res-ref-name>
+    <res-type>test.concurrent.work.WorkManager</res-type>
+    <!-- uses default binding -->
+  </resource-ref>
 </web-app>

--- a/dev/com.ibm.ws.concurrent_fat_work/test-bundles/workMgrProvider/resources/OSGI-INF/wlp/defaultInstances.xml
+++ b/dev/com.ibm.ws.concurrent_fat_work/test-bundles/workMgrProvider/resources/OSGI-INF/wlp/defaultInstances.xml
@@ -10,4 +10,10 @@
  -->
 <server>
   <concurrencyService extensionProvider.component.name="test.concurrent.work.wm.WorkManagerProvider"/>
+
+  <variable name="io.openliberty.concurrency.mes.objectClasses"
+            value="java.util.concurrent.ExecutorService, javax.enterprise.concurrent.ManagedExecutorService, org.eclipse.microprofile.context.ManagedExecutor, test.concurrent.work.WorkManager"/>
+
+  <variable name="io.openliberty.concurrency.mses.objectClasses"
+            value="java.util.concurrent.ExecutorService, java.util.concurrent.ScheduledExecutorService, javax.enterprise.concurrent.ManagedExecutorService, javax.enterprise.concurrent.ManagedScheduledExecutorService, test.concurrent.work.WorkManager"/>
 </server>

--- a/dev/com.ibm.ws.concurrent_fat_work/test-bundles/workMgrProvider/src/test/concurrent/work/wm/SchedulingWorkManagerImpl.java
+++ b/dev/com.ibm.ws.concurrent_fat_work/test-bundles/workMgrProvider/src/test/concurrent/work/wm/SchedulingWorkManagerImpl.java
@@ -36,12 +36,25 @@ import test.concurrent.work.WorkRejectedException;
  */
 public class SchedulingWorkManagerImpl extends ManagedScheduledExecutorExtension implements WorkManager {
     private final WSManagedExecutorService executor;
+    private final String toString;
 
     SchedulingWorkManagerImpl(WSManagedExecutorService executor, ResourceInfo resourceInfo) {
         super(executor, resourceInfo);
         this.executor = executor;
+
+        // Generate toString output from which tests can check that the proper managed executor was used:
+        // WorkManager@12345678 java:module/env/wm/executorRef of ManagedExecutor@9abcdef0 wm/executor
+        // or
+        // direct lookup @87654321 of ManagedExecutor@9abcdef0 wm/executor
+        String type = resourceInfo == null ? "direct lookup " : resourceInfo.getType().substring(resourceInfo.getType().lastIndexOf('.'));
+        StringBuilder s = new StringBuilder(type).append('@').append(Integer.toHexString(System.identityHashCode(this)));
+        if (resourceInfo != null)
+            s.append(' ').append(resourceInfo.getName());
+        s.append(" of ").append(executor.toString());
+        toString = s.toString();
     }
 
+    @Override
     public WorkItem schedule(Work work) throws WorkRejectedException {
         try {
             Future<Work> future = ((ExecutorService) executor).submit(() -> {
@@ -52,5 +65,10 @@ public class SchedulingWorkManagerImpl extends ManagedScheduledExecutorExtension
         } catch (RejectedExecutionException x) {
             throw new WorkRejectedException(x);
         }
+    }
+
+    @Override
+    public final String toString() {
+        return toString;
     }
 }

--- a/dev/com.ibm.ws.concurrent_fat_work/test-bundles/workMgrProvider/src/test/concurrent/work/wm/WorkManagerImpl.java
+++ b/dev/com.ibm.ws.concurrent_fat_work/test-bundles/workMgrProvider/src/test/concurrent/work/wm/WorkManagerImpl.java
@@ -36,12 +36,25 @@ import test.concurrent.work.WorkRejectedException;
  */
 public class WorkManagerImpl extends ManagedExecutorExtension implements WorkManager {
     private final WSManagedExecutorService executor;
+    private final String toString;
 
     WorkManagerImpl(WSManagedExecutorService executor, ResourceInfo resourceInfo) {
         super(executor, resourceInfo);
         this.executor = executor;
+
+        // Generate toString output from which tests can check that the proper managed executor was used:
+        // WorkManager@12345678 java:module/env/wm/executorRef of ManagedExecutor@9abcdef0 wm/executor
+        // or
+        // direct lookup @87654321 of ManagedExecutor@9abcdef0 wm/executor
+        String type = resourceInfo == null ? "direct lookup " : resourceInfo.getType().substring(resourceInfo.getType().lastIndexOf('.'));
+        StringBuilder s = new StringBuilder(type).append('@').append(Integer.toHexString(System.identityHashCode(this)));
+        if (resourceInfo != null)
+            s.append(' ').append(resourceInfo.getName());
+        s.append(" of ").append(executor.toString());
+        toString = s.toString();
     }
 
+    @Override
     public WorkItem schedule(Work work) throws WorkRejectedException {
         try {
             Future<Work> future = ((ExecutorService) executor).submit(() -> {
@@ -52,5 +65,10 @@ public class WorkManagerImpl extends ManagedExecutorExtension implements WorkMan
         } catch (RejectedExecutionException x) {
             throw new WorkRejectedException(x);
         }
+    }
+
+    @Override
+    public final String toString() {
+        return toString;
     }
 }

--- a/dev/wlp-jakartaee-transform/rules/jakarta-metatype.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-metatype.properties
@@ -1,3 +1,6 @@
+# For com.ibm.ws.concurrent/resources/OSGI-INF/metatype/metatype.xml
+javax.enterprise.concurrent.ManagedExecutorService=jakarta.enterprise.concurrent.ManagedExecutorService
+javax.enterprise.concurrent.ManagedScheduledExecutorService=jakarta.enterprise.concurrent.ManagedScheduledExecutorService
 # For com.ibm.ws.messaging.jms.common/OSGI-INF/metatype/metatype.xml
 # and test server configurations
 "javax.jms.ConnectionFactory"="jakarta.jms.ConnectionFactory"

--- a/dev/wlp-jakartaee-transform/rules/jakarta-xml-master.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-xml-master.properties
@@ -48,9 +48,10 @@ io.openliberty.org.jboss.resteasy.jaxb.provider.ResourceProvider.xml=jakarta-res
 # Messaging
 com.ibm.ws.jca.processor.jms.service.JMSDestinationResourceFactoryBuilder.xml=jakarta-messaging.properties
 com.ibm.ws.jca.processor.jms.service.JMSConnectionFactoryResourceBuilder.xml=jakarta-messaging.properties
-metatype.xml=jakarta-messaging-metatype.properties
-SharedSubscriptionDurClient.xml=jakarta-messaging-metatype.properties
-SharedSubscriptionNonDurClient.xml=jakarta-messaging-metatype.properties
+SharedSubscriptionDurClient.xml=jakarta-metatype.properties
+SharedSubscriptionNonDurClient.xml=jakarta-metatype.properties
+# Metatype (needed by Concurrency and Messaging)
+metatype.xml=jakarta-metatype.properties
 # Connectors
 com.ibm.ws.jca.activationSpec.supertype.xml=jakarta-resource.properties
 com.ibm.ws.jca.adminObject.supertype.xml=jakarta-resource.properties


### PR DESCRIPTION
Get default bindings working when using the managed executor/managed scheduled executor extension.  Add tests for it, and include some other tests for explicitly specified bindings and so forth.