### PR TITLE
Update to make grpc fat project build in eclipse.

### DIFF
--- a/dev/com.ibm.ws.grpc_fat/bnd.bnd
+++ b/dev/com.ibm.ws.grpc_fat/bnd.bnd
@@ -46,6 +46,7 @@ tested.features:\
 	io.grpc:grpc-census;version=1.31.1,\
 	io.grpc:grpc-context;version=1.31.1,\
 	io.grpc:grpc-core;version=1.31.1,\
+	io.grpc:grpc-netty;version=1.31.1,\
 	io.grpc:grpc-protobuf;version=1.31.1,\
 	io.grpc:grpc-protobuf-lite;version=1.31.1,\
 	io.grpc:grpc-stub;version=1.31.1,\


### PR DESCRIPTION
This change is needed due to changes made in PR #14663