### PR TITLE
MicroProfile specs should not beta yet

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.1.feature
@@ -2,6 +2,6 @@
 symbolicName=com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.1
 singleton=true
 -bundles=io.openliberty.org.eclipse.microprofile.contextpropagation.1.1; location:="dev/api/stable/,lib/"; mavenCoordinates="com.ibm.ws.org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.1"
-kind=beta
-edition=core
+kind=noship
+edition=full
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation-1.1/com.ibm.websphere.appserver.mpContextPropagation-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpContextPropagation-1.1/com.ibm.websphere.appserver.mpContextPropagation-1.1.feature
@@ -14,5 +14,5 @@ IBM-API-Package: \
   com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.1
 -bundles=\
   com.ibm.ws.microprofile.contextpropagation.1.0
-kind=beta
-edition=core
+kind=noship
+edition=full


### PR DESCRIPTION
Per discussion with Emily, we shouldn't beta MicroProfile specs yet and should wait to align with the others.  This pull takes MP Context Propagation 1.1 out of beta.