### PR TITLE
Update to no longer synchronize on Integer objects

### DIFF
--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipCachingServiceImpl.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipCachingServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012,2019 IBM Corporation and others.
+ * Copyright (c) 2012,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -135,8 +135,6 @@ public class ZipCachingServiceImpl implements ZipCachingService {
     // Note that computeIfAbsent has limitations: Only the single
     // key/value pair may be updated.  The lambda which provides
     // the value must be "quick".
-
-    private static final Integer zipFileHandlesLock = new Integer(0);
     private static final LinkedHashMap<String, ZipFileHandle> zipFileHandles;
 
     static {
@@ -186,7 +184,7 @@ public class ZipCachingServiceImpl implements ZipCachingService {
      *     zip file handle.  Not currently thrown.
      */
     private static ZipFileHandle getZipFileHandle(String path) throws IOException {
-        synchronized ( zipFileHandlesLock ) {
+        synchronized ( zipFileHandles ) {
             ZipFileHandle handle = zipFileHandles.get(path);
             if ( handle == null ) {
                 handle = new ZipFileHandleImpl(path);
@@ -321,11 +319,11 @@ public class ZipCachingServiceImpl implements ZipCachingService {
         output.println();
         output.println("Active and Cached ZipFile Handles:");
 
-        synchronized ( ZipCachingServiceImpl.zipFileHandlesLock ) {
-            if ( ZipCachingServiceImpl.zipFileHandles.isEmpty() ) {
+        synchronized ( zipFileHandles ) {
+            if ( zipFileHandles.isEmpty() ) {
                 output.println("  ** NONE **");
             } else {
-                for ( Map.Entry<String, ZipFileHandle> handleEntry : ZipCachingServiceImpl.zipFileHandles.entrySet() ) {
+                for ( Map.Entry<String, ZipFileHandle> handleEntry : zipFileHandles.entrySet() ) {
                     ZipFileHandle handle = handleEntry.getValue();
                     if ( handle instanceof ZipFileHandleImpl ) {
                         ZipFileHandleImpl handleImpl = (ZipFileHandleImpl) handle;

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipFileHandleImpl.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipFileHandleImpl.java
@@ -88,7 +88,10 @@ public class ZipFileHandleImpl implements ZipFileHandle {
 
     //
 
-    private final Integer zipFileLock = new Integer(0);
+    private static class ZipFileLock {
+        // EMPTY
+    }
+    private final ZipFileLock zipFileLock = new ZipFileLock();
     private ZipFile zipFile;
     private int openCount;
 
@@ -216,9 +219,6 @@ public class ZipFileHandleImpl implements ZipFileHandle {
         }
     }
 
-    //
-
-    private final Integer zipEntriesLock = new Integer(1);
     private final Map<String, byte[]> zipEntries;
 
     {
@@ -352,7 +352,7 @@ public class ZipFileHandleImpl implements ZipFileHandle {
         // reads could create large delays.
 
         byte[] entryBytes;
-        synchronized( zipEntriesLock ) {
+        synchronized( zipEntries ) {
             entryBytes = zipEntries.get(entryCacheKey);
         }
 
@@ -364,7 +364,7 @@ public class ZipFileHandleImpl implements ZipFileHandle {
                 inputStream.close(); // throws IOException
             }
 
-            synchronized( zipEntriesLock ) {
+            synchronized( zipEntries ) {
                 zipEntries.put(entryCacheKey, entryBytes);
             }
         }

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipFileReaper.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipFileReaper.java
@@ -896,7 +896,10 @@ public class ZipFileReaper {
 
     private final ZipFileDataStore pendingQuickStorage;
     private final ZipFileDataStore pendingSlowStorage;
-    private final Object pendingStorageLock = new Integer(0);
+    private static class PendingStorageLock {
+        // EMPTY
+    }
+    private final PendingStorageLock pendingStorageLock = new PendingStorageLock();
 
     private final ZipFileDataStore completedStorage;
 

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainer.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainer.java
@@ -185,7 +185,10 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
         EXTRACT_TIME;
     }
 
-    private static final Integer timingsLock = ( COLLECT_TIMINGS ? new Integer(0) : null );
+    public static class TimingsLock {
+        // EMPTY
+    }
+    private static final TimingsLock timingsLock = ( COLLECT_TIMINGS ? new TimingsLock() : null );
 
     private static int[] timingCounts = ( COLLECT_TIMINGS ? new int[ Timings.values().length ] : null );
     private static long[] timingTotals= ( COLLECT_TIMINGS ? new long[ Timings.values().length ] : null );
@@ -261,8 +264,10 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
     }
 
     // Assign 'isMultiRelease' using double locking ...
-
-    private final Integer multiReleaseLock = new Integer(0);
+    private static class MultiReleaseLock {
+        // EMPTY
+    }
+    private final MultiReleaseLock multiReleaseLock = new MultiReleaseLock();
     private volatile Boolean isMultiRelease = null;
 
     /**
@@ -358,7 +363,7 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
             this.zipFileNotifier = new ZipFileArtifactNotifier(this, useArchivePath);
             this.archiveName = archiveFile.getName();
         } else {
-            this.archiveFileLock = new Integer(1);
+            this.archiveFileLock = new ArchiveFileLock();
             this.zipFileNotifier = new ZipFileArtifactNotifier(this, entryInEnclosingContainer);
             this.archiveName = entryInEnclosingContainer.getName();
         }
@@ -583,8 +588,11 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
     // failure is handled by issuing an error, then processing with the archive
     // being empty.
 
+    private static class ArchiveFileLock {
+        // EMPTY
+    }
     // Null if the container started with an archive file.
-    private final Integer archiveFileLock;
+    private final ArchiveFileLock archiveFileLock;
 
     private boolean archiveFileFailed;
     private File archiveFile;
@@ -688,7 +696,10 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
 
     //
 
-    private final Integer zipFileHandleLock = new Integer(2);
+    private static class ZipFileHandleLock {
+        // Empty
+    }
+    private final ZipFileHandleLock zipFileHandleLock = new ZipFileHandleLock();
     private boolean zipFileHandleFailed;
     private ZipFileHandle zipFileHandle;
 
@@ -799,7 +810,10 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
 
     //
 
-    private final Integer fastModeLock = new Integer(3);
+    private static class FastModeLock {
+        // EMPTY
+    }
+    private final FastModeLock fastModeLock = new FastModeLock();
     private int fastModeCount;
 
     @Override
@@ -835,7 +849,10 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
 
     //
 
-    private final Integer zipEntryDataLock = new Integer(4);
+    private static class ZipEntryDataLock {
+        // EMPTY
+    }
+    private final ZipEntryDataLock zipEntryDataLock = new ZipEntryDataLock();
     private volatile ZipEntryData[] zipEntryData;
     private Map<String, ZipEntryData> zipEntryDataMap;
 
@@ -1093,8 +1110,10 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
         }
     }
 
-    private final Integer iteratorDataLock = new Integer(5);
-
+    private static class IteratorDataLock {
+        // EMPTY
+    }
+    private final IteratorDataLock iteratorDataLock = new IteratorDataLock();
     private volatile Map<String, ZipFileContainerUtils.IteratorData> iteratorData;
 
     @Trivial
@@ -1118,7 +1137,11 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
 
     //
 
-    private final Integer nestedContainerEntriesLock = new Integer(6);
+    private static class NestedContainerEntriesLock {
+        // EMPTY
+    }
+    private final NestedContainerEntriesLock nestedContainerEntriesLock =
+        new NestedContainerEntriesLock();
     private Map<String, ZipFileEntry> nestedContainerEntries;
 
     @Trivial
@@ -1431,8 +1454,6 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
 
     // Extraction utility ...
 
-    private static final Integer extractionsLock = new Integer(7);
-
     private static final Map<String, CountDownLatch> extractionLocks =
         new HashMap<String, CountDownLatch>();
 
@@ -1457,7 +1478,7 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
         boolean isPrimary;
         CountDownLatch completionLatch;
 
-        synchronized( extractionsLock ) {
+        synchronized( extractionLocks ) {
             completionLatch = extractionLocks.get(path);
 
             if ( completionLatch != null ) {
@@ -1478,13 +1499,13 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
     //       unblocking secondary extractions.
 
     private void releaseExtractionGuard(ExtractionGuard extractionLatch) {
-        synchronized( extractionsLock ) {
+        synchronized( extractionLocks ) {
             extractionLocks.remove( extractionLatch.path );
         }
         extractionLatch.completionLatch.countDown();
     }
 
-    private class ExtractionGuard {
+    private static class ExtractionGuard {
         public final String path;
         public final boolean isPrimary;
         public final CountDownLatch completionLatch;

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/bytebuffer/internal/WsByteBufferPoolManagerImpl.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/bytebuffer/internal/WsByteBufferPoolManagerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2006 IBM Corporation and others.
+ * Copyright (c) 2005, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -92,7 +92,8 @@ public class WsByteBufferPoolManagerImpl implements WsByteBufferPoolManager {
     private long lastTimeCheck = 0L;
     private int leakDetectionInterval = -1;
     private String leakDetectionOutput = null;
-    private final Integer leakDetectionSyncObject = new Integer(1);
+    private final Object leakDetectionSyncObject = new Object() {
+    };
 
     /**
      * Create the one WsByteBufferPool Manager that is to be used.

--- a/dev/com.ibm.ws.jaxrs.2.0.server/src/com/ibm/ws/jaxrs20/server/LibertyJaxRsServerFactoryBean.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.server/src/com/ibm/ws/jaxrs20/server/LibertyJaxRsServerFactoryBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2017 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -76,7 +76,7 @@ public class LibertyJaxRsServerFactoryBean extends JAXRSServerFactoryBean {
     private ServletConfig servletConfig;
     private JaxRsProviderFactoryService providerFactoryService;
 
-    private final static Integer lockObject = new Integer(0);
+    private final static Object lockObject = new Object() {};
 
     /**
      * @param jaxRsModuleMetaData

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/FreePool.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/FreePool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2016 IBM Corporation and others.
+ * Copyright (c) 1997, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -47,7 +47,8 @@ public final class FreePool implements JCAPMIHelper {
 
     protected final MCWrapperList mcWrapperList;
     private final String nl = CommonFunction.nl;
-    protected final Integer freeConnectionLockObject = new Integer(0);
+    protected final Object freeConnectionLockObject = new Object() {
+    };
     private PoolManager pm = null;
     protected int numberOfConnectionsInFreePool = 0;
     protected int numberOfConnectionsAssignedToThisFreePool = 0;
@@ -379,9 +380,9 @@ public final class FreePool implements JCAPMIHelper {
      * - If removeFromFreePool is false, the mcWrapper do not exist in the free pool
      *
      * @param Managed connection wrapper
-     * @param Remove  from free pool
-     * @param Are     we already synchronized on the freeLockObject
-     * @param Skip    waiter notify
+     * @param Remove from free pool
+     * @param Are we already synchronized on the freeLockObject
+     * @param Skip waiter notify
      * @param Cleanup and Destroy MCWrapper
      * @pre mcWrapper != null
      * @throws ClassCastException

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/J2CGlobalConfigProperties.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/J2CGlobalConfigProperties.java
@@ -95,9 +95,14 @@ public final class J2CGlobalConfigProperties implements PropertyChangeListener, 
     private String transactionResourceRegistration;
 
     protected boolean checkManagedConnectionInstanceof = true;
+
+    private static class J2CLock {
+        // EMPTY
+    }
+
     //The following lock is NOT a config prop but I'm putting
     //it here for convience.
-    protected final transient Integer checkManagedConnectionInstanceofLock = new Integer(0);
+    protected final transient Object checkManagedConnectionInstanceofLock = new J2CLock();
     protected boolean checkManagedConnectionInstanceofInitialized = false;
 
     protected boolean embeddedRa = false;
@@ -350,9 +355,9 @@ public final class J2CGlobalConfigProperties implements PropertyChangeListener, 
     protected Properties dsMetaDataProps = null;
     public boolean callResourceAdapterStatMethods = false;
     public int numberOfInuseConnections = 0;
-    public transient Integer numberOfInuseConnectionsLockObject = new Integer(0);
+    public transient Object numberOfInuseConnectionsLockObject = new J2CLock();
     public int numberOfFreeConnections = 0;
-    public transient Integer numberOfFreeConnectionsLockObject = new Integer(0);
+    public transient Object numberOfFreeConnectionsLockObject = new J2CLock();
     protected transient Integer maxNumberOfMCsAllowableInThread = null;
     private transient boolean parkIfDissociateUnavailable;
     protected transient Boolean throwExceptionOnMCThreadCheck = null;

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/PoolManager.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/PoolManager.java
@@ -77,8 +77,12 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
     final ConnectorServiceImpl connectorSvc;
     protected J2CGlobalConfigProperties gConfigProps;
 
+    private static class PoolManagerLock {
+        // EMPTY
+    }
+
     protected boolean reaperThreadStarted = false;
-    private final Integer taskTimerLockObject = new Integer(0);
+    private final Object taskTimerLockObject = new PoolManagerLock();
     protected int waitSkip = 0;
     protected boolean displayInfiniteWaitMessage;
 
@@ -95,15 +99,15 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
 
     private ClassLoader raClassLoader;
 
-    protected final Integer pmCounterLock = new Integer(0);
-    protected final Integer destroyMCWrapperListLock = new Integer(0);
+    protected final Object pmCounterLock = new PoolManagerLock();
+    protected final Object destroyMCWrapperListLock = new PoolManagerLock();
     protected final AtomicInteger totalConnectionCount = new AtomicInteger(0);
-    protected final Integer poolManagerBalancePoolLock = new Integer(0);
-    protected final Integer waiterFreePoolLock = new Integer(0);
+    protected final Object poolManagerBalancePoolLock = new PoolManagerLock();
+    protected final Object waiterFreePoolLock = new PoolManagerLock();
     protected int waiterCount = 0;
     protected boolean allowConnectionRequests = true;
     private boolean connectionPoolShutDown = false;
-    protected final Integer poolManagerTestConnectionLock = new Integer(0);
+    protected final Object poolManagerTestConnectionLock = new PoolManagerLock();
 
     private int collectorCount = 0;
     private final ArrayList<MCWrapper> mcWrappersToDestroy = new ArrayList<MCWrapper>(50);
@@ -133,17 +137,17 @@ public final class PoolManager implements Runnable, PropertyChangeListener, Veto
 
     protected MCWrapper parkedMCWrapper = null;
     protected boolean createParkedConnection;
-    protected final Integer parkedConnectionLockObject = new Integer(0);
+    protected final Object parkedConnectionLockObject = new PoolManagerLock();
     protected int totalPoolConnectionRequests = 0;
     protected ScheduledFuture<?> am = null;
-    protected final Integer amLockObject = new Integer(0);
+    protected final Object amLockObject = new PoolManagerLock();
     private boolean pmQuiesced = false;
     protected final AtomicInteger activeRequest = new AtomicInteger(0);
-    protected final Integer updateToPoolInProgressLockObject = new Integer(0);
+    protected final Object updateToPoolInProgressLockObject = new PoolManagerLock();
     protected boolean updateToPoolInProgress = false;
     protected int updateToPoolInProgressSleepTime = 250;
     protected final AtomicInteger activeTLSRequest = new AtomicInteger(0);
-    protected final Integer updateToTLSPoolInProgressLockObject = new Integer(0);
+    protected final Object updateToTLSPoolInProgressLockObject = new PoolManagerLock();
     protected final AtomicBoolean updateToTLSPoolInProgress = new AtomicBoolean(false);
     protected int updateToTLSPoolInProgressSleepTime = 250;
     protected Writer writer = null;

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/SharedPool.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/SharedPool.java
@@ -42,7 +42,8 @@ public final class SharedPool {
     /*
      * SharedLockObject to synchronize access to the mcWrapperList
      */
-    protected Integer sharedLockObject = new Integer(0);
+    protected Object sharedLockObject = new Object() {
+    };
     /*
      * mcWrapperList - contains shared mcWrappers
      * mcWrapperListTemp - used for changing the mcWrapperList

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -76,7 +76,11 @@ public class PolicyExecutorImpl implements PolicyExecutor {
      * Use this lock to make a consistent update to both expedite and expeditesAvailable,
      * maxConcurrency and maxConcurrencyConstraint, and to maxQueueSize and maxQueueSizeConstraint.
      */
-    private final Integer configLock = new Integer(0); // new instance required to avoid sharing
+    private static class ConfigLock {
+        // EMPTY
+    }
+
+    private final ConfigLock configLock = new ConfigLock(); // new instance required to avoid sharing
 
     private int expedite;
 

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/srt/SRTInputStream31.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1/src/com/ibm/ws/webcontainer31/srt/SRTInputStream31.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -41,8 +41,8 @@ public class SRTInputStream31 extends SRTInputStream
     private InterChannelCallback callback;
     //The request we use to find out if Async has been started
     private SRTServletRequest31 request;
-    private final Object lockObj = new Integer(0);
-    private final Object completeLockObj = new Integer(1);  
+    private final Object lockObj = new Object() {};
+    private final Object completeLockObj = new Object() {};  
     private boolean asyncReadOutstanding = false;
     private boolean readLineCall = false;
     private boolean isClosed = false;


### PR DESCRIPTION
- With Java 16, JEP 390 changes Integer primitive wrappers so that they should not be synchronized on any longer.

The changes in this PR undo many previous PRs that introduced synchronizing on Integer in order to remove having so many inner classes used for synchronization.  This change re-introduces many of those inner classes again.  This will have a small impact on footprint and probably CPU since we will be loading more classes.

Fixes #16299 