### PR TITLE
Enable FATs in GH Actions build

### DIFF
--- a/.github/workflows/openliberty-ci.yml
+++ b/.github/workflows/openliberty-ci.yml
@@ -125,8 +125,6 @@ jobs:
       run: .github/workflow-scripts/upload-unit-tests.sh
   fat_tests:
     name: FAT Tests - ${{matrix.category}}
-    # temporarily disable FATs
-    if: "false"
     needs: build
     runs-on: ${{ needs.build.outputs.test-os }}
     strategy:

--- a/.github/workflows/openliberty-ci.yml
+++ b/.github/workflows/openliberty-ci.yml
@@ -54,7 +54,7 @@ jobs:
         MATRIX_RESULT=$(java .github/workflow-scripts/GenerateCategories.java .github/pull_request_body.txt)
         echo "MATRIX_RESULT is $MATRIX_RESULT"
         echo "::set-output name=test-matrix::$MATRIX_RESULT"
-    - name: Apply repository caches
+    - name: Apply Gradle cache
       uses: actions/cache@v2
       with:
         path: |
@@ -62,12 +62,19 @@ jobs:
           !~/.gradle/caches/modules-2/io.openliberty*
           !~/.gradle/caches/modules-2/com.ibm.w*
           ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+    - name: Apply Maven cache
+      uses: actions/cache@v2
+      with:
+        path: |
           ~/.m2/repository/
           !~/.m2/repository/io/openliberty
           !~/.m2/repository/com/ibm/w*
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/*.maven') }}
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/*.maven') }}
         restore-keys: |
-          ${{ runner.os }}-gradle-
+          ${{ runner.os }}-maven-
     - name: Build with Gradle
       run: |
         cd dev
@@ -94,7 +101,7 @@ jobs:
       with:
         java-version: 11
         openjdk_impl: openj9
-    - name: Apply repository caches
+    - name: Apply Gradle cache
       uses: actions/cache@v2
       with:
         path: |
@@ -102,12 +109,19 @@ jobs:
           !~/.gradle/caches/modules-2/io.openliberty*
           !~/.gradle/caches/modules-2/com.ibm.w*
           ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+    - name: Apply Maven cache
+      uses: actions/cache@v2
+      with:
+        path: |
           ~/.m2/repository/
           !~/.m2/repository/io/openliberty
           !~/.m2/repository/com/ibm/w*
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/*.maven') }}
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/*.maven') }}
         restore-keys: |
-          ${{ runner.os }}-gradle-
+          ${{ runner.os }}-maven-
     - name: Run unit tests
       run: |
         cd dev
@@ -145,7 +159,7 @@ jobs:
       with:
         java-version: ${{ needs.build.outputs.test-java }}
         openjdk_impl: openj9
-    - name: Apply repository caches
+    - name: Apply Gradle cache
       uses: actions/cache@v2
       with:
         path: |
@@ -153,12 +167,19 @@ jobs:
           !~/.gradle/caches/modules-2/io.openliberty*
           !~/.gradle/caches/modules-2/com.ibm.w*
           ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+    - name: Apply Maven cache
+      uses: actions/cache@v2
+      with:
+        path: |
           ~/.m2/repository/
           !~/.m2/repository/io/openliberty
           !~/.m2/repository/com/ibm/w*
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/*.maven') }}
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/*.maven') }}
         restore-keys: |
-          ${{ runner.os }}-gradle-
+          ${{ runner.os }}-maven-
     - name: Download liberty image
       uses: actions/download-artifact@v2
       with:

--- a/dev/build.example_fat/fat/src/com/ibm/ws/example/FATSuite.java
+++ b/dev/build.example_fat/fat/src/com/ibm/ws/example/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/wlp.lib.extract_fat/bnd.bnd
+++ b/dev/wlp.lib.extract_fat/bnd.bnd
@@ -18,6 +18,7 @@ src: \
 fat.project: true
 
 -dependson: \
+    build.changeDetector
 	com.ibm.ws.kernel.feature
 
 -buildpath: \


### PR DESCRIPTION
Explicitly mentioned categories will be ordered first. Directly modified FATs will also be run first.

Run these categories first: JCA, SECURITY_1