### PR TITLE
Issue 14734: Fix for empty or null OAuth client name

### DIFF
--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/websphere/security/oauth20/store/OAuthClient.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/websphere/security/oauth20/store/OAuthClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,7 +29,7 @@ public class OAuthClient {
         this.providerId = providerId;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
-        this.displayName = displayName;
+        this.displayName = (displayName == null || displayName.isEmpty()) ? clientId : displayName;
         this.enabled = enabled;
         this.clientMetadata = clientMetadata;
     }

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/BaseClient.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/BaseClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2014 IBM Corporation and others.
+ * Copyright (c) 1997, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -63,7 +63,7 @@ public class BaseClient implements OAuth20Client, Serializable {
         _componentId = componentId;
         _clientId = clientId;
         _clientSecret = clientSecret;
-        _clientName = clientName;
+        _clientName = (clientName == null || clientName.isEmpty()) ? clientId : clientName;
         _redirectURIs = redirectURIs;
         _isEnabled = isEnabled;
         _allowRegexpRedirects = Boolean.valueOf(false);
@@ -112,6 +112,9 @@ public class BaseClient implements OAuth20Client, Serializable {
     }
 
     public void setClientName(String clientName) {
+        if (clientName == null || clientName.isEmpty()) {
+            clientName = getClientId();
+        }
         this._clientName = clientName;
     }
 

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/OidcBaseClientDBModel.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/OidcBaseClientDBModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -49,7 +49,7 @@ public class OidcBaseClientDBModel {
         this.componentId = componentId;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
-        this.displayName = displayName;
+        this.displayName = (displayName == null || displayName.isEmpty()) ? clientId : displayName;
         this.redirectUri = redirectUri;
         this.enabled = enabled;
         this.clientMetadata = clientMetadata;
@@ -108,6 +108,9 @@ public class OidcBaseClientDBModel {
      * @param displayName the displayName to set
      */
     public void setDisplayName(String displayName) {
+        if (displayName == null || displayName.isEmpty()) {
+            displayName = getClientId();
+        }
         this.displayName = displayName;
     }
 


### PR DESCRIPTION
Resolves #14734

Addresses a potential problem on DB2 when the display/client name of an OAuth client is null or an empty string. This should ensure that the name is set to the client ID in those cases.