### PR TITLE
11851 Enable jakarta jms features for appClient and ee9 beta

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.cdi3.0-messaging3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.cdi3.0-messaging3.0.feature
@@ -7,6 +7,6 @@ IBM-Provision-Capability:\
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.jakarta.messaging-3.0))"
 -bundles=com.ibm.ws.messaging.jms.2.0.cdi.jakarta
 IBM-Install-Policy: when-satisfied
-kind=noship
-edition=full
+kind=beta
+edition=base
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.messaging-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.messaging-3.0.feature
@@ -2,6 +2,6 @@
 symbolicName=io.openliberty.jakarta.messaging-3.0
 singleton=true
 -bundles=io.openliberty.jakarta.messaging.3.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.jms:jakarta.jms-api:3.0"
-kind=noship
-edition=full
+kind=beta
+edition=base
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.messaging-3.0.internal.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.messaging-3.0.internal.feature
@@ -9,6 +9,6 @@ IBM-API-Package: jakarta.jms; version="3.0"; type="spec"
  io.openliberty.jakartaeePlatform-9.0, \
  com.ibm.websphere.appserver.transaction-2.0
 -bundles=com.ibm.ws.messaging.jmsspec.common.jakarta
-kind=noship
-edition=full
+kind=beta
+edition=base
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaee-9.0/io.openliberty.jakartaee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaee-9.0/io.openliberty.jakartaee-9.0.feature
@@ -19,6 +19,10 @@ Subsystem-Name: Jakarta EE Platform 9.0
  io.openliberty.jacc-2.0,\
  io.openliberty.jaxb-3.0,\
  io.openliberty.mail-2.0,\
+ io.openliberty.messaging-3.0,\
+ io.openliberty.messagingClient-3.0,\
+ io.openliberty.messagingSecurity-3.0,\
+ io.openliberty.messagingServer-3.0,\
  io.openliberty.webProfile-9.0
 kind=beta
 edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaeeClient-9.0/io.openliberty.jakartaeeClient-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaeeClient-9.0/io.openliberty.jakartaeeClient-9.0.feature
@@ -18,6 +18,7 @@ Subsystem-Name: Jakarta EE Application Client
   io.openliberty.jsonb-2.0, \
   io.openliberty.jsonp-2.0, \
   io.openliberty.mail-2.0, \
-  io.openliberty.managedBeans-2.0 
+  io.openliberty.managedBeans-2.0, \
+  io.openliberty.messagingClient-3.0 
 kind=beta
 edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/messaging-3.0/io.openliberty.messaging-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/messaging-3.0/io.openliberty.messaging-3.0.feature
@@ -12,6 +12,6 @@ Subsystem-Name: Jakarta Message Service 3.0
  io.openliberty.connectors-2.0, \
  com.ibm.websphere.appserver.eeCompatible-9.0
 -bundles=com.ibm.ws.jms20.feature
-kind=noship
-edition=full
+kind=beta
+edition=base
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/messagingClient-3.0/io.openliberty.messagingClient-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/messagingClient-3.0/io.openliberty.messagingClient-3.0.feature
@@ -17,6 +17,6 @@ Subsystem-Name: Jakarta Messaging 3.0 Client for Message Server
  com.ibm.ws.messaging.jms.common.jakarta, \
  com.ibm.ws.messaging.jms.2.0.jakarta, \
  com.ibm.ws.messaging.comms.client
-kind=noship
-edition=full
+kind=beta
+edition=base
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/messagingSecurity-3.0/io.openliberty.messagingSecurity-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/messagingSecurity-3.0/io.openliberty.messagingSecurity-3.0.feature
@@ -11,6 +11,6 @@ Subsystem-Name: Message Server Security 3.0
 -bundles=com.ibm.ws.messaging.utils, \
  com.ibm.ws.messaging.security, \
  com.ibm.ws.messaging.security.common
-kind=noship
-edition=full
+kind=beta
+edition=base
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/messagingServer-3.0/io.openliberty.messagingServer-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/messagingServer-3.0/io.openliberty.messagingServer-3.0.feature
@@ -18,6 +18,6 @@ Subsystem-Name: Message Server 3.0
  com.ibm.websphere.security
 -jars=com.ibm.websphere.appserver.api.messaging; location:=dev/api/ibm/
 -files=dev/api/ibm/javadoc/com.ibm.websphere.appserver.api.messaging_1.0-javadoc.zip
-kind=noship
-edition=full
+kind=beta
+edition=base
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.ws.kernel.feature_fat/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.feature_fat/bnd.bnd
@@ -43,8 +43,9 @@ tested.features: needsNewEe-1.0, newEe-1.0, \
 	wasJmsClient-2.0, wasJmsSecurity-1.0, wasJmsServer-1.0, webProfile-8.0, websocket-1.1, \
 	featuref-1.0, productauto:pfeaturen-1.0, productauto:pfeaturem-1.0, featuree-1.0, productauto:pfeaturel-1.0, featureg-1.0, productauto:pfeaturef-1.0, productauto:pfeatureg-1.0, productauto:pfeaturee-1.0, capabilityc-1.0, badpathtool-1.0, emptyiconheader-1.0, goldenpathtool-1.0, icondirectivestool-1.0, noheadertool-1.0, missingiconstool-1.0, jwt-1.0, servlet-3.1, \
 	appclientsupport-2.0, appsecurity-4.0, enterprisebeansremote-4.0, jakartaee-9.0, enterprisebeanshome-4.0, cdi-3.0, enterprisebeanslite-4.0, jacc-2.0, \
-    falseb-1.0, falsea-1.0, falsec-1.0, falsed-1.0, falsee-1.0, \
-    trueA-1.0, trueB-1.0, trueC-1.0, trueConflict-1.0
+	falseb-1.0, falsea-1.0, falsec-1.0, falsed-1.0, falsee-1.0, \
+	trueA-1.0, trueB-1.0, trueC-1.0, trueConflict-1.0, \
+	messaging-3.0, messagingClient-3.0, messagingSecurity-3.0, messagingServer-3.0
 
 -buildpath: \
 	org.eclipse.osgi;version=latest,\

--- a/dev/com.ibm.ws.messaging.open_clientcontainer_fat/bnd.bnd
+++ b/dev/com.ibm.ws.messaging.open_clientcontainer_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018 IBM Corporation and others.
+# Copyright (c) 2018, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -23,8 +23,14 @@ src: \
 
 fat.project: true
 
+tested.features: \
+        messagingClient-3.0,\
+        messagingServer-3.0,\
+        messaging-3.0,\
+        jakartaeeClient-9.0
+
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
-#      or binaries from Artifactory (e.g. commons-logging:commons-logging)
+# or binaries from Artifactory (e.g. commons-logging:commons-logging)
 -buildpath: \
         com.ibm.websphere.javaee.annotation.1.1;version=latest,\
         com.ibm.websphere.javaee.jms.2.0;version=latest,\

--- a/dev/com.ibm.ws.messaging.open_clientcontainer_fat/build.gradle
+++ b/dev/com.ibm.ws.messaging.open_clientcontainer_fat/build.gradle
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+addRequiredLibraries {
+  dependsOn addJakartaTransformer
+}

--- a/dev/com.ibm.ws.messaging.open_clientcontainer_fat/common/src/com/ibm/ws/messaging/open_clientcontainer/fat/FATBase.java
+++ b/dev/com.ibm.ws.messaging.open_clientcontainer_fat/common/src/com/ibm/ws/messaging/open_clientcontainer/fat/FATBase.java
@@ -123,6 +123,15 @@ public class FATBase {
       Util.TRACE_EXIT();
     }
   }
+  
+  protected static void undeployApplication(String appName) throws Exception {
+    try {
+      Util.TRACE_ENTRY();
+      client_.deleteFileFromLibertyClientRoot("apps/" + appName + ".ear" );
+    } finally {
+      Util.TRACE_EXIT();
+    }
+  }
 
   protected static void start() throws Exception {
     try {

--- a/dev/com.ibm.ws.messaging.open_clientcontainer_fat/fat/src/com/ibm/ws/messaging/open_clientcontainer/fat/ClientIDTest.java
+++ b/dev/com.ibm.ws.messaging.open_clientcontainer_fat/fat/src/com/ibm/ws/messaging/open_clientcontainer/fat/ClientIDTest.java
@@ -1,5 +1,5 @@
 /* ============================================================================
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,14 +30,16 @@ import componenttest.custom.junit.runner.FATRunner;
 @AllowedFFDC({ "com.ibm.ws.sib.jfapchannel.JFapConnectionBrokenException" })
 public class ClientIDTest extends FATBase {
   static {
-    client_ = LibertyClientFactory.getLibertyClient("com.ibm.ws.open_clientcontainer.fat.ClientIDContainer");
-    server_ = LibertyServerFactory.getLibertyServer("com.ibm.ws.open_clientcontainer.fat.Server");
+    client_ = null;
+    server_ = null;
   }
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     try {
       Util.TRACE_ENTRY();
+      client_ = LibertyClientFactory.getLibertyClient("com.ibm.ws.open_clientcontainer.fat.ClientIDContainer");
+      server_ = LibertyServerFactory.getLibertyServer("com.ibm.ws.open_clientcontainer.fat.Server");
       deployApplication("ClientID");
       start();
     } finally {
@@ -51,6 +53,7 @@ public class ClientIDTest extends FATBase {
       Util.TRACE_ENTRY();
       server_.stopServer();
     } finally {
+      undeployApplication("ClientID");
       Util.TRACE_EXIT();
     }
   }

--- a/dev/com.ibm.ws.messaging.open_clientcontainer_fat/fat/src/com/ibm/ws/messaging/open_clientcontainer/fat/FATSuite.java
+++ b/dev/com.ibm.ws.messaging.open_clientcontainer_fat/fat/src/com/ibm/ws/messaging/open_clientcontainer/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /* ============================================================================
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,9 +11,14 @@
  */
 package com.ibm.ws.messaging.open_clientcontainer.fat;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+
+import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.RepeatTests;
+
 @RunWith(Suite.class)
 @SuiteClasses({
 	JMS2AsyncSendTest.class,
@@ -21,4 +26,8 @@ import org.junit.runners.Suite.SuiteClasses;
 	MessageListenerTest.class,
 	ClientIDTest.class
 })
-public class FATSuite { }
+public class FATSuite { 
+	
+	@ClassRule
+	public static RepeatTests repeater = RepeatTests.withoutModification().andWith(new JakartaEE9Action().removeFeature("jaxws-2.2"));
+}

--- a/dev/com.ibm.ws.messaging.open_clientcontainer_fat/fat/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS1AsyncSendTest.java
+++ b/dev/com.ibm.ws.messaging.open_clientcontainer_fat/fat/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS1AsyncSendTest.java
@@ -1,5 +1,5 @@
 /* ============================================================================
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,14 +34,16 @@ import componenttest.custom.junit.runner.FATRunner;
              })
 public class JMS1AsyncSendTest extends FATBase {
   static {
-    client_ = LibertyClientFactory.getLibertyClient("com.ibm.ws.open_clientcontainer.fat.JMS1Container");
-    server_ = LibertyServerFactory.getLibertyServer("com.ibm.ws.open_clientcontainer.fat.Server");
+    client_ = null;
+    server_ = null;
   }
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     try {
       Util.TRACE_ENTRY();
+      client_ = LibertyClientFactory.getLibertyClient("com.ibm.ws.open_clientcontainer.fat.JMS1Container");
+      server_ = LibertyServerFactory.getLibertyServer("com.ibm.ws.open_clientcontainer.fat.Server");
       deployApplication("JMS1AsyncSend");
       // CWSIA0281E - expected invalid destination
       // CWSIC2008E - FFDC for commit/rollback error in testJMS1TransactedListener
@@ -63,6 +65,7 @@ public class JMS1AsyncSendTest extends FATBase {
       // CWSIK0025E - Queue full; expected from several operations
       server_.stopServer("CWSIC2018E","CWSIJ0047E","CWSIC2009E","CWSIK0025E");
     } finally {
+      undeployApplication("JMS1AsyncSend");
       Util.TRACE_EXIT();
     }
   }

--- a/dev/com.ibm.ws.messaging.open_clientcontainer_fat/fat/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS2AsyncSendTest.java
+++ b/dev/com.ibm.ws.messaging.open_clientcontainer_fat/fat/src/com/ibm/ws/messaging/open_clientcontainer/fat/JMS2AsyncSendTest.java
@@ -1,5 +1,5 @@
 /* ============================================================================
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -32,14 +32,16 @@ import componenttest.custom.junit.runner.FATRunner;
             })
 public class JMS2AsyncSendTest extends FATBase {
   static {
-    client_ = LibertyClientFactory.getLibertyClient("com.ibm.ws.open_clientcontainer.fat.JMS2Container");
-    server_ = LibertyServerFactory.getLibertyServer("com.ibm.ws.open_clientcontainer.fat.Server");
+    client_ = null;
+    server_ = null;
   }
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     try {
       Util.TRACE_ENTRY();
+      client_ = LibertyClientFactory.getLibertyClient("com.ibm.ws.open_clientcontainer.fat.JMS2Container");
+      server_ = LibertyServerFactory.getLibertyServer("com.ibm.ws.open_clientcontainer.fat.Server");
       deployApplication("JMS2AsyncSend");
       // CWSIC2008E -  FFDC for commit/rollback error in testJMS2ContextInListener
       client_.addIgnoreErrors("CWSIC2008E");
@@ -59,7 +61,8 @@ public class JMS2AsyncSendTest extends FATBase {
       // CWSIK0025E - Queue full; expected.
       server_.stopServer("CWSIJ0051E","CWSIK0015E","CWSIC2009E","CWSIK0025E");
     } finally {
-      Util.TRACE_EXIT();
+        undeployApplication("JMS2AsyncSend");
+        Util.TRACE_EXIT();
     }
   }
 

--- a/dev/com.ibm.ws.messaging.open_clientcontainer_fat/fat/src/com/ibm/ws/messaging/open_clientcontainer/fat/MessageListenerTest.java
+++ b/dev/com.ibm.ws.messaging.open_clientcontainer_fat/fat/src/com/ibm/ws/messaging/open_clientcontainer/fat/MessageListenerTest.java
@@ -1,5 +1,5 @@
 /* ============================================================================
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,14 +30,16 @@ import componenttest.custom.junit.runner.FATRunner;
 @AllowedFFDC({ "com.ibm.ws.sib.jfapchannel.JFapConnectionBrokenException" })
 public class MessageListenerTest extends FATBase {
   static {
-    client_ = LibertyClientFactory.getLibertyClient("com.ibm.ws.open_clientcontainer.fat.MessageListenerContainer");
-    server_ = LibertyServerFactory.getLibertyServer("com.ibm.ws.open_clientcontainer.fat.Server");
+    client_ = null;
+    server_ = null;
   }
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     try {
       Util.TRACE_ENTRY();
+      client_ = LibertyClientFactory.getLibertyClient("com.ibm.ws.open_clientcontainer.fat.MessageListenerContainer");
+      server_ = LibertyServerFactory.getLibertyServer("com.ibm.ws.open_clientcontainer.fat.Server");
       deployApplication("MessageListener");
       start();
     } finally {
@@ -50,6 +52,7 @@ public class MessageListenerTest extends FATBase {
     try {
       Util.TRACE_ENTRY();
       server_.stopServer();
+      undeployApplication("MessageListener");
     } finally {
       Util.TRACE_EXIT();
     }


### PR DESCRIPTION
Ref: #11851 

1. Enable jakarta jms within the jakarta ee9 app client by adding feature messagingClient-3.0 to jakartaeeClient-9.0.
2. Repeat the messaging.open_clientcontainer_fat for ee9, which verifies messaging scenarios over jakartaeeClient-9.0.
3. Enable the jakarta jms feature set for the 21001 ee9 beta by adding all messagingXXX-3.0 features to feature jakartaee-9.0.
 