### PR TITLE
Issue #14800: Ignore CWWKC1501 in EJB Timer FAT

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/PersistentTimerTestHelper.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/PersistentTimerTestHelper.java
@@ -68,6 +68,14 @@ public class PersistentTimerTestHelper {
         // but transaction service has already been shutdown.
         ignoreList.add("J2CA0027E");
 
+        // CWWKC1501W: Persistent executor [EJBPersistentTimerExecutor] rolled back task [task id]
+        //             (!EJBTimerP![j2eename]) due to failure javax.ejb.EJBException: Timeout method
+        //             [method name] will not be invoked because server is stopping
+        //
+        // persistent.internal.InvokerTask run starts for a persistent timer during server shutdown,
+        // but EJB timer service throws exception due to server stopping.
+        ignoreList.add("CWWKC1501W.*server is stopping");
+
         // CWWKC1503W: Persistent executor [EJBPersistentTimerExecutor] rolled back task [task id]
         //             (!EJBTimerP![j2eename]) due to failure javax.ejb.EJBException: Timeout method
         //             [method name] will not be invoked because server is stopping


### PR DESCRIPTION
CWWKC1501 indicates a persistent EJB timer is rolledback,
and this is normal when shutting down a server while timers
are actively running.

Test is verifying the behavior of how a timer recovers
after server restart, so it is safe to ignore this
message in the logs; expected.

fixes #14800 