### PR TITLE
Improve GenerateCategories for handling FAT-only and no-FAT PRs

### DIFF
--- a/.github/workflow-scripts/GenerateCategories.java
+++ b/.github/workflow-scripts/GenerateCategories.java
@@ -1,11 +1,15 @@
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -28,6 +32,9 @@ public class GenerateCategories {
 
     static final boolean DEBUG = false;
 
+    static final String TEST_CATEGORY_DIR = ".github/test-categories";
+    static final String MODIFIED_FILES_DIFF = ".github/modified_files.diff";
+
     public static void main(String args[]) throws Exception {
 
         debug("Starting");
@@ -49,31 +56,57 @@ public class GenerateCategories {
 
         // Discover all categories by checking for files under .github/test-categories/
         SortedSet<String> allCategories = new TreeSet<>();
-        for (File categoryFile : Paths.get(".github/test-categories").toFile().listFiles()) {
+        for (File categoryFile : Paths.get(TEST_CATEGORY_DIR).toFile().listFiles()) {
             allCategories.add(categoryFile.getName().toUpperCase());
         }
         debug("All discovered categories are: " + allCategories);
 
         // Any categories that were mentioned in the PR summary should run first
-        TreeMap<Integer, String> menteiondCategories = new TreeMap<>();
+        TreeMap<Integer, String> mentionedCategories = new TreeMap<>();
         for (String category : allCategories) {
             int categoryIndex = prSummary.indexOf(category);
             if (categoryIndex >= 0) {
                 debug("PR summary mentioned category: " + category + " at index " + categoryIndex);
-                menteiondCategories.put(categoryIndex, category);
+                mentionedCategories.put(categoryIndex, category);
             }
         }
-        debug("Explicitly mentioned categories were: " + menteiondCategories.values());
+        debug("Explicitly mentioned categories were: " + mentionedCategories.values());
+
+        SortedSet<String> unmentionedCategories = new TreeSet<>(allCategories);
+        unmentionedCategories.removeAll(mentionedCategories.values());
+
+        Set<String> modifiedProjects = getModifiedProjects();
+        if (isFATOnlyChange()) {
+            SortedSet<String> modifiedCategories = new TreeSet<>();
+            debug("This is a FAT-only change. Will remove unrelated and unmentioned categories.");
+            for (String category : unmentionedCategories) {
+                List<String> categoryBuckets = getBuckets(category);
+                for (String bucket : categoryBuckets) {
+                    if (modifiedProjects.contains(bucket)) {
+                        debug("Will run category " + category + " because it contains modified FAT bucket: " + bucket);
+                        modifiedCategories.add(category);
+                        break;
+                    }
+                }
+            }
+
+            unmentionedCategories = modifiedCategories;
+            debug("Modified but unmentioned categories were: " + unmentionedCategories);
+        } else {
+            debug("Unmentioned categories were: " + unmentionedCategories);
+        }
 
         List<String> finalCategories = new ArrayList<>();
-        // special categories that run directly modified buckets
-        finalCategories.add("MODIFIED_LITE_MODE");
-        finalCategories.add("MODIFIED_FULL_MODE");
+        // If any FATs were modified at all, add special categories
+        // that run directly modified buckets
+        if (getModifiedProjects().stream().anyMatch(proj -> proj.contains("_fat"))) {
+            debug("At least 1 FAT was modified in this PR.");
+            finalCategories.add("MODIFIED_LITE_MODE");
+            finalCategories.add("MODIFIED_FULL_MODE");
+        }
         // now add mentioned categories in order
-        finalCategories.addAll(menteiondCategories.values());
+        finalCategories.addAll(mentionedCategories.values());
         // finally add all remaining categories
-        SortedSet<String> unmentionedCategories = new TreeSet<>(allCategories);
-        unmentionedCategories.removeAll(menteiondCategories.values());
         finalCategories.addAll(unmentionedCategories);
 
         debug("Final categories are:");
@@ -96,6 +129,72 @@ public class GenerateCategories {
         System.out.println(result);
         debug("Done");
 
+    }
+
+    private static List<String> getBuckets(String category) throws IOException {
+        Path categoryFile = Paths.get(TEST_CATEGORY_DIR + '/' + category);
+        if (!categoryFile.toFile().exists()) {
+            throw new FileNotFoundException(categoryFile.toAbsolutePath().toString());
+        }
+
+        return Files.readAllLines(categoryFile);
+    }
+
+    private static List<String> moddedFiles = null;
+
+    private static List<String> getModifiedFiles() throws IOException {
+        if (moddedFiles != null)
+            return moddedFiles;
+        Path modifiedFilesPath = Paths.get(MODIFIED_FILES_DIFF);
+        if (!modifiedFilesPath.toFile().exists()) {
+            debug("Did not find any modified files.");
+            return Collections.emptyList();
+        }
+
+        return moddedFiles = Files.readAllLines(modifiedFilesPath).stream()//
+                .filter(f -> !f.isEmpty())//
+                .map(f -> {
+                    debug("Found modified file: " + f);
+                    return f;
+                }).collect(Collectors.toList());
+    }
+
+    private static Set<String> getModifiedProjects() throws IOException {
+        Set<String> modifiedProjects = new HashSet<>();
+
+        for (String modifiedFile : getModifiedFiles()) {
+            if (modifiedFile.startsWith(TEST_CATEGORY_DIR))
+                continue;
+            if (!modifiedFile.startsWith("dev/")) {
+                debug("WARN: Found modified file outside of 'dev/' tree.");
+                modifiedProjects.add("INFRA_OR_UNKNOWN");
+            }
+            String projectName = modifiedFile.substring(4);
+            projectName = projectName.substring(0, projectName.indexOf('/'));
+            modifiedProjects.add(projectName);
+        }
+
+        return modifiedProjects;
+    }
+
+    private static boolean isFATOnlyChange() throws IOException {
+        Set<String> modifiedProjects = getModifiedProjects();
+
+        if (modifiedProjects.isEmpty()) {
+            debug("No modified projects found. Falling back to assuming NOT a FAT-only change.");
+            return false;
+        }
+
+        debug("Found modified projects: " + modifiedProjects);
+
+        for (String modifiedProject : modifiedProjects) {
+            if (!modifiedProject.contains("_fat")) {
+                debug("Found modified non-FAT project: " + modifiedProject);
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static void debug(Object msg) {

--- a/.github/workflows/cleanup-duplicate-runs.yml
+++ b/.github/workflows/cleanup-duplicate-runs.yml
@@ -3,7 +3,7 @@ name: Cleanup Duplicate Builds
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '*/5 * * * *'
+    - cron:  '*/15 * * * *'
 
 jobs:
   cleanup-prs:
@@ -15,3 +15,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           workflow: openliberty-ci.yml
+

--- a/.github/workflows/openliberty-ci.yml
+++ b/.github/workflows/openliberty-ci.yml
@@ -47,6 +47,9 @@ jobs:
         END_OF_PR_BODY
         echo "PR Summary is:"
         cat .github/pull_request_body.txt
+        git diff --name-only HEAD^...HEAD^2 >> .github/modified_files.diff
+        echo "Modified files in this PR are:"
+        cat .github/modified_files.diff
 
         echo "::set-output name=test-os::ubuntu-latest"
         echo "::set-output name=test-java::11"


### PR DESCRIPTION
Currently the change detector will no-op buckets that aren't related to the code being modified, but this still takes a non-negligable amount of time to no-op an entire category.

There are 3 categories of PRs:
1. FAT-only changes
2. FAT + other changes
3. no FAT changes

Previously we were only optimized for (2), and this PR will allow us to heavily optimize for (1), as well as slightly optimizing for (3)