### PR TITLE
Manually zip/unzip liberty image for upload/download

### DIFF
--- a/.github/workflow-scripts/run-fat-build.sh
+++ b/.github/workflow-scripts/run-fat-build.sh
@@ -54,6 +54,7 @@ ant -version
 echo "\n## Java version:"
 java -version
 
+unzip -q openliberty-image.zip
 cd dev
 chmod +x gradlew
 chmod 777 build.image/wlp/bin/*

--- a/.github/workflows/openliberty-ci.yml
+++ b/.github/workflows/openliberty-ci.yml
@@ -80,13 +80,13 @@ jobs:
         cd dev
         chmod +x gradlew
         ./gradlew cnf:initialize assemble
+        cd .. && zip -rq openliberty-image.zip dev/build.image/wlp/
     - name: Upload liberty image
       uses: actions/upload-artifact@v2
       with:
-        name: liberty-image
+        name: openliberty-image
         if-no-files-found: error
-        path: |
-          dev/build.image/wlp/
+        path: openliberty-image.zip
   unit_tests:
     name: Unit Tests
     runs-on: ubuntu-latest
@@ -183,8 +183,7 @@ jobs:
     - name: Download liberty image
       uses: actions/download-artifact@v2
       with:
-        name: liberty-image
-        path: dev/build.image/wlp/
+        name: openliberty-image
     - name: Run FAT buckets
       timeout-minutes: 150
       shell: bash


### PR DESCRIPTION
Significantly improves the performance of upload/download of the Liberty image by doing a zip/unzip of the necessary files instead of uploading the exploded directory.

New upload time: 4m --> 1m
New download time: 1m30s --> 15s