### PR TITLE
SSL auto feature should work with restfulWSClient-3.0 (not just server)

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.restfulWSClient3.0-ssl1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.restfulWSClient3.0-ssl1.0.feature
@@ -1,7 +1,7 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
- symbolicName=io.openliberty.restfulWS3.0-ssl1.0
+ symbolicName=io.openliberty.restfulWSClient3.0-ssl1.0
  visibility=private
- IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.restfulWS-3.0))", \
+ IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.restfulWSClient-3.0))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.ssl-1.0))"
  -bundles=io.openliberty.restfulWS.internal.ssl.jakarta
  IBM-Install-Policy: when-satisfied


### PR DESCRIPTION
Users should only need `restfulWSClient-3.0` and SSL to be able to use Liberty-configured SSL settings.

This is not yet released function.