### PR TITLE
Always remove useKeyTab property when running on IBM JDK

### DIFF
--- a/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/Krb5LoginModuleWrapper.java
+++ b/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/Krb5LoginModuleWrapper.java
@@ -83,8 +83,11 @@ public class Krb5LoginModuleWrapper implements LoginModule {
         this.sharedState = (Map<String, Object>) sharedState;
         this.options = new HashMap<>(opts);
 
+        final String IBM_JDK_USE_KEYTAB = "useKeytab"; // URL
+        final String OPENJDK_USE_KEYTAB = "useKeyTab"; // boolean
+
         if (!isIBMJdk8)
-            useKeytabValue = options.get("useKeyTab");
+            useKeytabValue = options.get(OPENJDK_USE_KEYTAB);
 
         if (isIBMJdk8) {
             // Sanitize any OpenJDK-only config options
@@ -96,10 +99,11 @@ public class Krb5LoginModuleWrapper implements LoginModule {
             }
             options.remove("doNotPrompt");
             options.remove("refreshKrb5Config");
+
+            options.remove(OPENJDK_USE_KEYTAB);
             if (options.containsKey("keyTab")) {
                 String keytab = (String) options.remove("keyTab");
-                options.remove("useKeyTab");
-                options.put("useKeytab", keytab);
+                options.put(IBM_JDK_USE_KEYTAB, keytab);
             }
             options.remove("clearPass");
             boolean useTicketCache = Boolean.valueOf((String) options.remove("useTicketCache"));


### PR DESCRIPTION
When using a Kerberos datasource configuration on IBM JDK 8 without a keyTab configuration, the following error occurs:
```
Caused by: javax.resource.ResourceException: javax.security.auth.login.LoginException: Bad JAAS configuration: unrecognized option: useKeyTab
	at com.ibm.ejs.j2c.ConnectionManager.getFinalSubject(ConnectionManager.java:1666)
	at com.ibm.ejs.j2c.ConnectionManager.allocateConnection(ConnectionManager.java:304)
	at com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource.getConnection(WSJdbcDataSource.java:137)
	... 34 more
Caused by: javax.security.auth.login.LoginException: Bad JAAS configuration: unrecognized option: useKeyTab
	at com.ibm.security.jgss.i18n.I18NException.throwLoginException(Unknown Source)
	at com.ibm.security.auth.module.Krb5LoginModule.d(Unknown Source)
	at com.ibm.security.auth.module.Krb5LoginModule.a(Unknown Source)
	at com.ibm.security.auth.module.Krb5LoginModule.login(Unknown Source)
	at com.ibm.ws.security.kerberos.auth.Krb5LoginModuleWrapper.login(Krb5LoginModuleWrapper.java:128)
	at com.ibm.ws.security.kerberos.auth.KerberosService.doKerberosLogin(KerberosService.java:191)
	at com.ibm.ws.security.kerberos.auth.KerberosService.getOrCreateSubject(KerberosService.java:153)
	at com.ibm.ws.security.jca.internal.AuthDataServiceImpl.obtainSubject(AuthDataServiceImpl.java:164)
	at com.ibm.ws.security.jca.internal.AuthDataServiceImpl.createSubjectUsingAuthData(AuthDataServiceImpl.java:144)
	at com.ibm.ws.security.jca.internal.AuthDataServiceImpl.getSubject(AuthDataServiceImpl.java:127)
	at com.ibm.ejs.j2c.ConnectionManager$1.run(ConnectionManager.java:1661)
	at com.ibm.ejs.j2c.ConnectionManager$1.run(ConnectionManager.java:1658)
	at java.security.AccessController.doPrivileged(AccessController.java:703)
	at com.ibm.ejs.j2c.ConnectionManager.getFinalSubject(ConnectionManager.java:1658)
	... 36 more
```

Here is an example of the configuration involved:
```xml
  <library id="pglib">
    <fileset dir="${server.config.dir}/postgresql"/>
  </library>
  
  <kerberos configFile="${KRB5_CONF}"/>

  <dataSource jndiName="jdbc/krb/DataSource" type="javax.sql.DataSource">
    <jdbcDriver libraryRef="pglib" />
    <properties.postgresql user="${KRB5_USER}" databaseName="${PG_DBNAME}" serverName="${PG_HOSTNAME}" portNumber="${PG_PORT}"/>
    <containerAuthData krb5Principal="${KRB5_USER}" password="${KRB5_PASS}"/>
  </dataSource>
```