### PR TITLE
Use correct ArtifactId for jtidy dependency

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -927,6 +927,11 @@
       <version>1.6.2</version>
     </dependency>
     <dependency>
+      <groupId>jtidy</groupId>
+      <artifactId>jtidy</artifactId>
+      <version>4aug2000r7-dev</version>
+    </dependency>
+    <dependency>
       <groupId>net.minidev</groupId>
       <artifactId>json-smart</artifactId>
       <version>1.3.1</version>
@@ -935,11 +940,6 @@
       <groupId>net.sf.ehcache</groupId>
       <artifactId>ehcache-core</artifactId>
       <version>2.5.2</version>
-    </dependency>
-    <dependency>
-      <groupId>net.sf.jtidy</groupId>
-      <artifactId>jtidy</artifactId>
-      <version>4aug2000r7-dev</version>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.cssparser</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -181,9 +181,9 @@ javax.xml.bind:jaxb-api:2.3.0
 javax.xml.ws:jaxws-api:2.3.0
 javax:javaee-api:7.0
 joda-time:joda-time:1.6.2
+jtidy:jtidy:4aug2000r7-dev
 net.minidev:json-smart:1.3.1
 net.sf.ehcache:ehcache-core:2.5.2
-net.sf.jtidy:jtidy:4aug2000r7-dev
 net.sourceforge.cssparser:cssparser:0.9.23
 net.sourceforge.htmlunit:htmlunit-core-js:2.15
 net.sourceforge.htmlunit:htmlunit-core-js:2.27

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/build.gradle
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/build.gradle
@@ -27,7 +27,7 @@ dependencies {
       'commons-codec:commons-codec:1.6',
       'commons-logging:commons-logging:1.1.3',
       'xml-apis:xml-apis:1.4.01',
-      'net.sf.jtidy:jtidy:4aug2000r7-dev',
+      'jtidy:jtidy:4aug2000r7-dev',
       'httpunit:httpunit:1.5.4',
       project(':com.ibm.ws.webcontainer.security_test.servlets')
     }


### PR DESCRIPTION
Running the webcontainer.servlet.3.1_fat bucket using maven central fails due to a nonexistent dependency:
```
> Task :com.ibm.ws.webcontainer.servlet.3.1_fat:addRequiredLibraries FAILED


FAILURE: Build failed with an exception.
Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.

Use '--warning-mode all' to show the individual deprecation warnings.
* What went wrong:
See https://docs.gradle.org/6.4/userguide/command_line_interface.html#sec:command_line_warnings
Execution failed for task ':com.ibm.ws.webcontainer.servlet.3.1_fat:addRequiredLibraries'.
271 actionable tasks: 35 executed, 236 up-to-date
> Could not resolve all files for configuration ':com.ibm.ws.webcontainer.servlet.3.1_fat:requiredLibs'.
   > Could not find net.sf.jtidy:jtidy:4aug2000r7-dev.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/net/sf/jtidy/jtidy/4aug2000r7-dev/jtidy-4aug2000r7-dev.pom
       - https://oss.sonatype.org/content/repositories/snapshots/net/sf/jtidy/jtidy/4aug2000r7-dev/jtidy-4aug2000r7-dev.pom
       - https://oss.sonatype.org/content/repositories/snapshots/net/sf/jtidy/jtidy/4aug2000r7-dev/jtidy-4aug2000r7-dev.jar
       - http://public.dhe.ibm.com/ibmdl/export/pub/software/olrepo/net/sf/jtidy/jtidy/4aug2000r7-dev/jtidy-4aug2000r7-dev.pom
       - http://public.dhe.ibm.com/ibmdl/export/pub/software/olrepo/net/sf/jtidy/jtidy/4aug2000r7-dev/jtidy-4aug2000r7-dev.jar
     Required by:
         project :com.ibm.ws.webcontainer.servlet.3.1_fat
```

#build 

WEBCONTAINER_1