### PR TITLE
Issue 13577: Expanding support for JWE consumption

### DIFF
--- a/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JwKRetriever.java
+++ b/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JwKRetriever.java
@@ -224,7 +224,10 @@ public class JwKRetriever {
         if (keyText != null) {
             return jwkSet.getKeyBySetIdAndKeyText(setId, keyText, keyType);
         }
-        return jwkSet.getKeyBySetId(setId, keyType);
+        if (kid == null) {
+            return jwkSet.getKeyBySetId(setId, keyType);
+        }
+        return key;
     }
 
     protected boolean remoteHttpCall(String jwksUri, @Sensitive String keyText, @Sensitive String keyLocation) {

--- a/dev/com.ibm.ws.security.fat.common.jwt/fat/src/com/ibm/ws/security/fat/common/jwt/sharedTests/ConsumeMangledJWTTests.java
+++ b/dev/com.ibm.ws.security.fat.common.jwt/fat/src/com/ibm/ws/security/fat/common/jwt/sharedTests/ConsumeMangledJWTTests.java
@@ -18,6 +18,7 @@ import com.gargoylesoftware.htmlunit.Page;
 import com.ibm.ws.security.fat.common.CommonSecurityFat;
 import com.ibm.ws.security.fat.common.expectations.Expectations;
 import com.ibm.ws.security.fat.common.jwt.JWTTokenBuilder;
+import com.ibm.ws.security.fat.common.jwt.JwtMessageConstants;
 import com.ibm.ws.security.fat.common.jwt.PayloadConstants;
 import com.ibm.ws.security.fat.common.jwt.utils.JwtTokenBuilderUtils;
 import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
@@ -841,7 +842,7 @@ public abstract class ConsumeMangledJWTTests extends CommonSecurityFat {
         String[] parts = jwtToken.split("\\.");
         String badToken = parts[1] + "." + parts[2];
 
-        Expectations expectations = buildNegativeAttributeExpectations(".+JoseException.+was 2");
+        Expectations expectations = buildNegativeAttributeExpectations(JwtMessageConstants.CWWKS6063E_JWS_REQUIRED_BUT_TOKEN_NOT_JWS);
 
         Page response = consumeToken(badToken);
         validationUtils.validateResult(response, currentAction, expectations);
@@ -861,7 +862,7 @@ public abstract class ConsumeMangledJWTTests extends CommonSecurityFat {
         String[] parts = jwtToken.split("\\.");
         String badToken = parts[0] + "." + parts[2];
 
-        Expectations expectations = buildNegativeAttributeExpectations(".+JoseException.+was 2");
+        Expectations expectations = buildNegativeAttributeExpectations(JwtMessageConstants.CWWKS6063E_JWS_REQUIRED_BUT_TOKEN_NOT_JWS);
 
         Page response = consumeToken(badToken);
         validationUtils.validateResult(response, currentAction, expectations);
@@ -881,7 +882,7 @@ public abstract class ConsumeMangledJWTTests extends CommonSecurityFat {
         String[] parts = jwtToken.split("\\.");
         String badToken = parts[0] + "." + parts[1];
 
-        Expectations expectations = buildNegativeAttributeExpectations(".+JoseException.+was 2");
+        Expectations expectations = buildNegativeAttributeExpectations(JwtMessageConstants.CWWKS6063E_JWS_REQUIRED_BUT_TOKEN_NOT_JWS);
 
         Page response = consumeToken(badToken);
         validationUtils.validateResult(response, currentAction, expectations);

--- a/dev/com.ibm.ws.security.fat.common.jwt/src/com/ibm/ws/security/fat/common/jwt/JwtMessageConstants.java
+++ b/dev/com.ibm.ws.security.fat.common.jwt/src/com/ibm/ws/security/fat/common/jwt/JwtMessageConstants.java
@@ -58,6 +58,9 @@ public class JwtMessageConstants extends com.ibm.ws.security.fat.common.MessageC
     public static final String CWWKS6055W_BETA_SIGNATURE_ALGORITHM_USED = "CWWKS6055W";
     public static final String CWWKS6058W_KEY_MGMT_KEY_MISSING = "CWWKS6058W";
 
+    public static final String CWWKS6063E_JWS_REQUIRED_BUT_TOKEN_NOT_JWS = "CWWKS6063E";
+    public static final String CWWKS6064E_JWE_REQUIRED_BUT_TOKEN_NOT_JWE = "CWWKS6064E";
+
     public static final String CWPKI0812E_CANT_FIND_KEY = "CWPKI0812E";
 
 }

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/ConsumerUtil.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/internal/ConsumerUtil.java
@@ -345,12 +345,24 @@ public class ConsumerUtil {
             String errorMsg = Tr.formatMessage(tc, "JWT_CONSUMER_NULL_OR_EMPTY_STRING", new Object[] { config.getId(), jwtString });
             throw new InvalidTokenException(errorMsg);
         }
+        checkJwtFormatAgainstConfigRequirements(jwtString, config);
         if (JweHelper.isJwe(jwtString)) {
             jwtString = JweHelper.extractJwsFromJweToken(jwtString, config, mpConfigProps);
         }
         JwtConsumerBuilder builder = initializeJwtConsumerBuilderWithoutValidation(config);
         JwtConsumer firstPassJwtConsumer = builder.build();
         return firstPassJwtConsumer.process(jwtString);
+    }
+
+    void checkJwtFormatAgainstConfigRequirements(String jwtString, JwtConsumerConfig config) throws InvalidTokenException {
+        if (JweHelper.isJwsRequired(config, mpConfigProps) && !JweHelper.isJws(jwtString)) {
+            String errorMsg = Tr.formatMessage(tc, "JWS_REQUIRED_BUT_TOKEN_NOT_JWS", new Object[] { config.getId() });
+            throw new InvalidTokenException(errorMsg);
+        }
+        if (JweHelper.isJweRequired(config, mpConfigProps) && !JweHelper.isJwe(jwtString)) {
+            String errorMsg = Tr.formatMessage(tc, "JWE_REQUIRED_BUT_TOKEN_NOT_JWE", new Object[] { config.getId() });
+            throw new InvalidTokenException(errorMsg);
+        }
     }
 
     protected JwtContext parseJwtWithValidation(String jwtString, JwtContext jwtContext, JwtConsumerConfig config,

--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JweHelper.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JweHelper.java
@@ -16,14 +16,17 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.CertificateException;
 
+import org.jose4j.base64url.Base64;
 import org.jose4j.jwe.ContentEncryptionAlgorithmIdentifiers;
 import org.jose4j.jwe.JsonWebEncryption;
 import org.jose4j.jwe.KeyManagementAlgorithmIdentifiers;
+import org.jose4j.lang.JoseException;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.websphere.security.jwt.InvalidTokenException;
+import com.ibm.websphere.security.jwt.KeyException;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.common.jwk.impl.JwKRetriever;
 import com.ibm.ws.security.common.jwk.impl.JwkKidBuilder;
@@ -54,6 +57,14 @@ public class JweHelper {
         }
     }
 
+    public static boolean isJws(String jwtString) {
+        if (jwtString == null || jwtString.isEmpty()) {
+            return false;
+        }
+        String notPeriod = "[^\\.]";
+        return jwtString.matches("^(" + notPeriod + "*\\.){2}" + notPeriod + "*$");
+    }
+
     public static boolean isJwe(String jwtString) {
         if (jwtString == null || jwtString.isEmpty()) {
             return false;
@@ -62,23 +73,60 @@ public class JweHelper {
         return jwtString.matches("^(" + notPeriod + "*\\.){4}" + notPeriod + "*$");
     }
 
+    /**
+     * Returns whether the current request must only accept JWS tokens, per the MP JWT 1.2 specification. Per the spec, if the
+     * {@value MpConfigProperties.DECRYPT_KEY_LOCATION} MP Config property (or, in our case, the keyManagementKeyAlias config
+     * attribute) is NOT set, then we must only accept JWS tokens; tokens in JWE format should be rejected.
+     *
+     * For more information, see
+     * {@link https://github.com/eclipse/microprofile-jwt-auth/blob/master/spec/src/main/asciidoc/configuration.asciidoc#requirements-for-accepting-signed-and-encrypted-tokens}
+     */
+    public static boolean isJwsRequired(JwtConsumerConfig config, MpConfigProperties mpConfigProps) {
+        return !isJweRequired(config, mpConfigProps);
+    }
+
+    /**
+     * Returns whether the current request must only accept JWE tokens, per the MP JWT 1.2 specification. Per the spec, if the
+     * {@value MpConfigProperties.DECRYPT_KEY_LOCATION} MP Config property (or, in our case, the keyManagementKeyAlias config
+     * attribute) is set, then we must only accept JWE tokens; tokens in JWS format should be rejected.
+     *
+     * For more information, see
+     * {@link https://github.com/eclipse/microprofile-jwt-auth/blob/master/spec/src/main/asciidoc/configuration.asciidoc#requirements-for-accepting-signed-and-encrypted-tokens}
+     */
+    public static boolean isJweRequired(JwtConsumerConfig config, MpConfigProperties mpConfigProps) {
+        String keyAlias = config.getKeyManagementKeyAlias();
+        String keyLocation = mpConfigProps.get(MpConfigProperties.DECRYPT_KEY_LOCATION);
+        return (keyAlias != null || keyLocation != null);
+    }
+
     @FFDCIgnore({ Exception.class })
     public static String extractJwsFromJweToken(String jweString, JwtConsumerConfig config, MpConfigProperties mpConfigProps) throws InvalidTokenException {
         JweHelper helper = new JweHelper();
-        String jws = null;
+        String payload = null;
         try {
-            JsonWebEncryption jwe = new JsonWebEncryption();
-            jwe.setCompactSerialization(jweString);
-            helper.verifyContentType(jwe);
-            // TODO - Extract kid from JWE string, if present, and pass to getJweDecryptionKey()
-            Key decryptionKey = helper.getJweDecryptionKey(config, mpConfigProps);
-            jwe.setKey(decryptionKey);
-            jws = jwe.getPayload();
+            payload = helper.getJwePayload(jweString, config, mpConfigProps);
         } catch (Exception e) {
             String errorMsg = Tr.formatMessage(tc, "ERROR_EXTRACTING_JWS_PAYLOAD_FROM_JWE", new Object[] { config.getId(), e });
             throw new InvalidTokenException(errorMsg, e);
         }
-        return jws;
+        if (!isJws(payload)) {
+            String errorMsg = Tr.formatMessage(tc, "NESTED_JWS_REQUIRED_BUT_NOT_FOUND");
+            throw new InvalidTokenException(errorMsg);
+        }
+        return payload;
+    }
+
+    String getJwePayload(String jweString, JwtConsumerConfig config, MpConfigProperties mpConfigProps) throws JoseException, Exception, InvalidTokenException {
+        JweHelper helper = new JweHelper();
+        JsonWebEncryption jwe = new JsonWebEncryption();
+        jwe.setCompactSerialization(jweString);
+        Key decryptionKey = helper.getJweDecryptionKey(config, mpConfigProps, helper.getKidFromJweString(jweString));
+        jwe.setKey(decryptionKey);
+        String payload = jwe.getPayload();
+        if (isJws(payload)) {
+            helper.verifyContentType(jwe);
+        }
+        return payload;
     }
 
     void verifyContentType(JsonWebEncryption jwe) throws InvalidTokenException {
@@ -88,6 +136,21 @@ public class JweHelper {
             String errorMsg = Tr.formatMessage(tc, "CTY_NOT_JWT_FOR_NESTED_JWS", new Object[] { "\"cty\"", cty, "\"" + requiredContentType + "\"" });
             throw new InvalidTokenException(errorMsg);
         }
+    }
+
+    @FFDCIgnore(Exception.class)
+    String getKidFromJweString(String jweString) {
+        String kid = null;
+        try {
+            String headerString = jweString.substring(0, jweString.indexOf("."));
+            headerString = new String(Base64.decode(headerString));
+            kid = (String) JwtUtils.claimFromJsonObject(headerString, "kid");
+        } catch (Exception e) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Caught exception getting kid from JWE string: " + e);
+            }
+        }
+        return kid;
     }
 
     void setJweKeyData(JsonWebEncryption jwe, BuilderImpl builder, JwtConfig jwtConfig) throws KeyStoreException, CertificateException, InvalidTokenException {
@@ -115,23 +178,34 @@ public class JweHelper {
     }
 
     @Sensitive
-    PrivateKey getJweDecryptionKey(JwtConsumerConfig config, MpConfigProperties mpConfigProps) throws Exception {
+    PrivateKey getJweDecryptionKey(JwtConsumerConfig config, MpConfigProperties mpConfigProps, String kid) throws Exception {
         String keyAlias = config.getKeyManagementKeyAlias();
         if (keyAlias != null) {
             // Server configuration takes precedence over MP Config property values
             String keyStoreRef = config.getKeyStoreRef();
             return JwtUtils.getPrivateKey(keyAlias, keyStoreRef);
         }
-        return getJweDecryptionKeyFromMpConfigProps(config, mpConfigProps);
+        return getJweDecryptionKeyFromMpConfigProps(config, mpConfigProps, kid);
     }
 
     @Sensitive
-    private PrivateKey getJweDecryptionKeyFromMpConfigProps(JwtConsumerConfig config, MpConfigProperties mpConfigProps) throws Exception {
+    private PrivateKey getJweDecryptionKeyFromMpConfigProps(JwtConsumerConfig config, MpConfigProperties mpConfigProps, String kid) throws Exception {
         String keyLocation = mpConfigProps.get(MpConfigProperties.DECRYPT_KEY_LOCATION);
+        checkDecryptKeyLocationForInlineKey(keyLocation);
         JwKRetriever jwkRetriever = new JwKRetriever(config.getJwkSet());
         jwkRetriever.setSignatureAlgorithm(mpConfigProps.getConfiguredSignatureAlgorithm(config));
         jwkRetriever.setKeyLocation(keyLocation);
-        return jwkRetriever.getPrivateKeyFromJwk(null, config.getUseSystemPropertiesForHttpClientConnections());
+        return jwkRetriever.getPrivateKeyFromJwk(kid, config.getUseSystemPropertiesForHttpClientConnections());
+    }
+
+    void checkDecryptKeyLocationForInlineKey(@Sensitive String location) throws KeyException {
+        if (location == null || location.isEmpty()) {
+            return;
+        }
+        if (location.contains("BEGIN ")) {
+            String errorMsg = Tr.formatMessage(tc, "DECRYPT_KEY_LOCATION_INLINE_KEY", new Object[] { MpConfigProperties.DECRYPT_KEY_LOCATION });
+            throw new KeyException(errorMsg);
+        }
     }
 
     void setJweKidHeader(JsonWebEncryption jwe, Key keyManagementKey) {

--- a/dev/com.ibm.ws.security.jwt/test/com/ibm/ws/security/jwt/internal/ConsumerUtilTest.java
+++ b/dev/com.ibm.ws.security.jwt/test/com/ibm/ws/security/jwt/internal/ConsumerUtilTest.java
@@ -98,6 +98,7 @@ public class ConsumerUtilTest {
     private static final String MSG_JWT_CONSUMER_MALFORMED_CLAIM = "CWWKS6043E";
     private static final String MSG_JWT_IAT_AFTER_CURRENT_TIME = "CWWKS6044E";
     private static final String MSG_JWT_TRUSTED_ISSUERS_NULL = "CWWKS6052E";
+    private static final String MSG_JWS_REQUIRED_BUT_TOKEN_NOT_JWS = "CWWKS6063E";
 
     private static final String JOSE_EXCEPTION = "org.jose4j.lang.JoseException";
     private static final String PARSE_EXCEPTION = "org.jose4j.json.internal.json_simple.parser.ParseException";
@@ -576,18 +577,20 @@ public class ConsumerUtilTest {
     public void testParseJwtWithoutValidation_singlePartTokenString() {
         try {
             final String tokenString = "test";
+            final String configId = testName.getMethodName();
             try {
                 mockery.checking(new Expectations() {
                     {
-                        one(jwtConfig).getClockSkew();
-                        will(returnValue(0L));
+                        allowing(jwtConfig).getKeyManagementKeyAlias();
+                        will(returnValue(null));
+                        one(jwtConfig).getId();
+                        will(returnValue(configId));
                     }
                 });
                 JwtContext context = consumerUtil.parseJwtWithoutValidation(tokenString, jwtConfig);
                 fail("Should have thrown Exception but did not. Got context: " + context);
             } catch (Exception e) {
-                // TODO - anything we can wrap this open source exception with?
-                validateException(e, JOSE_EXCEPTION + ".+" + INVALID_COMPACT_SERIALIZATION + ".+" + tokenString);
+                validateException(e, MSG_JWS_REQUIRED_BUT_TOKEN_NOT_JWS + ".+" + configId);
             }
         } catch (Throwable t) {
             outputMgr.failWithThrowable(testName.getMethodName(), t);
@@ -601,18 +604,20 @@ public class ConsumerUtilTest {
     public void testParseJwtWithoutValidation_twoPartTokenString() {
         try {
             final String tokenString = "test.test";
+            final String configId = testName.getMethodName();
             try {
                 mockery.checking(new Expectations() {
                     {
-                        one(jwtConfig).getClockSkew();
-                        will(returnValue(0L));
+                        allowing(jwtConfig).getKeyManagementKeyAlias();
+                        will(returnValue(null));
+                        one(jwtConfig).getId();
+                        will(returnValue(configId));
                     }
                 });
                 JwtContext context = consumerUtil.parseJwtWithoutValidation(tokenString, jwtConfig);
                 fail("Should have thrown Exception but did not. Got context: " + context);
             } catch (Exception e) {
-                // TODO - anything we can wrap this open source exception with?
-                validateException(e, JOSE_EXCEPTION + ".+" + INVALID_COMPACT_SERIALIZATION + ".+" + tokenString);
+                validateException(e, MSG_JWS_REQUIRED_BUT_TOKEN_NOT_JWS + ".+" + configId);
             }
         } catch (Throwable t) {
             outputMgr.failWithThrowable(testName.getMethodName(), t);
@@ -629,6 +634,8 @@ public class ConsumerUtilTest {
             try {
                 mockery.checking(new Expectations() {
                     {
+                        allowing(jwtConfig).getKeyManagementKeyAlias();
+                        will(returnValue(null));
                         one(jwtConfig).getClockSkew();
                         will(returnValue(0L));
                     }

--- a/dev/com.ibm.ws.security.jwt/test/com/ibm/ws/security/jwt/utils/JweHelperTest.java
+++ b/dev/com.ibm.ws.security.jwt/test/com/ibm/ws/security/jwt/utils/JweHelperTest.java
@@ -1,0 +1,197 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.jwt.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import org.jmock.Expectations;
+import org.jose4j.base64url.Base64;
+import org.jose4j.jwe.JsonWebEncryption;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.websphere.security.jwt.InvalidTokenException;
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import test.common.SharedOutputManager;
+
+public class JweHelperTest extends CommonTestClass {
+
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("com.ibm.ws.security.jwt.*=all:com.ibm.ws.security.common.*=all");
+
+    static final String MSG_CTY_NOT_JWT_FOR_NESTED_JWS = "CWWKS6057E";
+
+    private JweHelper helper = null;
+
+    private final JsonWebEncryption jwe = mockery.mock(JsonWebEncryption.class);
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    @Before
+    public void beforeTest() {
+        System.out.println("Entering test: " + testName.getMethodName());
+        helper = new JweHelper();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.out.println("Exiting test: " + testName.getMethodName());
+        mockery.assertIsSatisfied();
+    }
+
+    @Test
+    public void test_verifyContentType_ctyNull() {
+        final String cty = null;
+        mockery.checking(new Expectations() {
+            {
+                one(jwe).getContentTypeHeaderValue();
+                will(returnValue(cty));
+            }
+        });
+        try {
+            helper.verifyContentType(jwe);
+            fail("Should have thrown an InvalidTokenException but did not.");
+        } catch (InvalidTokenException e) {
+            verifyException(e, MSG_CTY_NOT_JWT_FOR_NESTED_JWS);
+        }
+    }
+
+    @Test
+    public void test_verifyContentType_ctyEmpty() {
+        final String cty = "";
+        mockery.checking(new Expectations() {
+            {
+                one(jwe).getContentTypeHeaderValue();
+                will(returnValue(cty));
+            }
+        });
+        try {
+            helper.verifyContentType(jwe);
+            fail("Should have thrown an InvalidTokenException but did not.");
+        } catch (InvalidTokenException e) {
+            verifyException(e, MSG_CTY_NOT_JWT_FOR_NESTED_JWS);
+        }
+    }
+
+    @Test
+    public void test_verifyContentType_ctyNotJwt() {
+        final String cty = "nope";
+        mockery.checking(new Expectations() {
+            {
+                one(jwe).getContentTypeHeaderValue();
+                will(returnValue(cty));
+            }
+        });
+        try {
+            helper.verifyContentType(jwe);
+            fail("Should have thrown an InvalidTokenException but did not.");
+        } catch (InvalidTokenException e) {
+            verifyException(e, MSG_CTY_NOT_JWT_FOR_NESTED_JWS);
+        }
+    }
+
+    @Test
+    public void test_verifyContentType_ctyIsJwt() throws InvalidTokenException {
+        final String cty = "jwt";
+        mockery.checking(new Expectations() {
+            {
+                one(jwe).getContentTypeHeaderValue();
+                will(returnValue(cty));
+            }
+        });
+        helper.verifyContentType(jwe);
+    }
+
+    @Test
+    public void test_getKidFromJweString_justFourPeriods() {
+        final String jwe = "....";
+        String result = helper.getKidFromJweString(jwe);
+        assertNull("Returned kid value should have been null, but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_getKidFromJweString_onePeriod() {
+        final String jwe = ".";
+        String result = helper.getKidFromJweString(jwe);
+        assertNull("Returned kid value should have been null, but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_getKidFromJweString_notBase64Encoded() {
+        final String jwe = "this should be the header....";
+        String result = helper.getKidFromJweString(jwe);
+        assertNull("Returned kid value should have been null, but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_getKidFromJweString_notBase64EncodedJson() {
+        final String jwe = "{\"kid\":\"some_id\"}....";
+        String result = helper.getKidFromJweString(jwe);
+        assertNull("Returned kid value should have been null, but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_getKidFromJweString_notJson() {
+        String encoded = Base64.encode("not json".getBytes());
+        final String jwe = encoded + "....";
+        String result = helper.getKidFromJweString(jwe);
+        assertNull("Returned kid value should have been null, but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_getKidFromJweString_emptyJson() {
+        String encoded = Base64.encode("{}".getBytes());
+        final String jwe = encoded + "....";
+        String result = helper.getKidFromJweString(jwe);
+        assertNull("Returned kid value should have been null, but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_getKidFromJweString_missingKidEntry() {
+        String encoded = Base64.encode("{\"alg\":\"RS256\"}".getBytes());
+        final String jwe = encoded + "....";
+        String result = helper.getKidFromJweString(jwe);
+        assertNull("Returned kid value should have been null, but was [" + result + "].", result);
+    }
+
+    @Test
+    public void test_getKidFromJweString_emptyKidEntry() {
+        String kid = "";
+        String encoded = Base64.encode(("{\"kid\":\"" + kid + "\"}").getBytes());
+        final String jwe = encoded + "....";
+        String result = helper.getKidFromJweString(jwe);
+        assertEquals("Returned kid value did not match expected value.", kid, result);
+    }
+
+    @Test
+    public void test_getKidFromJweString_nonEmptyKidEntry() {
+        String kid = "this is the kid value";
+        String encoded = Base64.encode(("{\"kid\":\"" + kid + "\"}").getBytes());
+        final String jwe = encoded + "....";
+        String result = helper.getKidFromJweString(jwe);
+        assertEquals("Returned kid value did not match expected value.", kid, result);
+    }
+
+}

--- a/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/JwtConsumerApiConfigTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/JwtConsumerApiConfigTests.java
@@ -1874,17 +1874,19 @@ public class JwtConsumerApiConfigTests extends CommonSecurityFat {
     }
 
     /**
-     * server.xml has a config that does not specify a keyManagementKeyAlias - this test ensures that after building a jwt
-     * that is encrypted, we can not decrypt the token because there is not keyManagementKeyAlg
-     *
-     * @throws Exception
+     * server.xml has a config that does not specify a keyManagementKeyAlias - this test ensures that we do not accept encrypted
+     * tokens when there is no keyManagementKeyAlias.
+     * 
+     * See
+     * https://github.com/eclipse/microprofile-jwt-auth/blob/master/spec/src/main/asciidoc/configuration.asciidoc#requirements-for-accepting-signed-and-encrypted-tokens
      */
     @Test
     public void JwtConsumerApiConfigTests_encryptedToken_consumerDoesNotDecrypt() throws Exception {
 
         String jwtToken = actions.getJwtTokenUsingBuilder(_testName, consumerServer, "key_encrypt_good_RS256", null);
 
-        Expectations expectations = consumerHelpers.buildNegativeAttributeExpectations(JwtConsumerMessageConstants.CWWKS6056E_CAN_NOT_EXTRACT_JWS_FROM_JWE + ".+InvalidKeyException", currentAction, consumerServer, JwtConsumerConstants.SIGALG_RS256);
+        String serverLogMsg = JwtConsumerMessageConstants.CWWKS6063E_JWS_REQUIRED_BUT_TOKEN_NOT_JWS;
+        Expectations expectations = consumerHelpers.buildNegativeAttributeExpectations(serverLogMsg, currentAction, consumerServer, JwtConsumerConstants.SIGALG_RS256);
 
         Page response = actions.invokeJwtConsumer(_testName, consumerServer, JwtConsumerConstants.SIGALG_RS256, jwtToken);
         validationUtils.validateResult(response, currentAction, expectations);
@@ -1892,18 +1894,19 @@ public class JwtConsumerApiConfigTests extends CommonSecurityFat {
     }
 
     /**
-     * server.xml has a config that specifies a key management key alias - this test ensures that
-     * after building a jwt that is not encrypted can be parsed by a consumer that can handle
-     * encryption (but should NOT require an encrypted token)
-     *
-     * @throws Exception
+     * server.xml has a config that specifies a key management key alias - this test ensures that we do not accept unencrypted
+     * tokens when keyManagementKeyAlias is configured.
+     * 
+     * See
+     * https://github.com/eclipse/microprofile-jwt-auth/blob/master/spec/src/main/asciidoc/configuration.asciidoc#requirements-for-accepting-signed-and-encrypted-tokens
      */
     @Test
     public void JwtConsumerApiConfigTests_tokenNotEncrypted_consumerDecrypts() throws Exception { // this test would be the same as null keyManagementKeyAlias
 
         String jwtToken = actions.getJwtTokenUsingBuilder(_testName, consumerServer, "sigAlg_RS256", null);
 
-        Expectations expectations = consumerHelpers.addGoodConsumerAlgExpectations(currentAction, consumerServer, JwtConsumerConstants.SIGALG_RS256);
+        String serverLogMsg = JwtConsumerMessageConstants.CWWKS6064E_JWE_REQUIRED_BUT_TOKEN_NOT_JWE;
+        Expectations expectations = consumerHelpers.buildNegativeAttributeExpectations(serverLogMsg, currentAction, consumerServer, JwtConsumerConstants.SIGALG_RS256);
 
         Page response = actions.invokeJwtConsumer(_testName, consumerServer, "good_decrypt_RS256", jwtToken);
         validationUtils.validateResult(response, currentAction, expectations);

--- a/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/ReplayCookieTests.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/ReplayCookieTests.java
@@ -281,7 +281,7 @@ public class ReplayCookieTests extends CommonSecurityFat {
         expectations.addExpectation(new ServerMessageExpectation(currentAction, server, MessageConstants.CWWKS5524E_ERROR_CREATING_JWT));
         expectations.addExpectation(new ServerMessageExpectation(currentAction, server, MessageConstants.CWWKS5523E_ERROR_CREATING_JWT_USING_TOKEN_IN_REQ));
         expectations.addExpectation(new ServerMessageExpectation(currentAction, server, MessageConstants.CWWKS6031E_JWT_ERROR_PROCESSING_JWT + ".+"
-                                                                                        + "Invalid JOSE Compact Serialization"));
+                                                                                        + MessageConstants.CWWKS6063E_JWS_REQUIRED_BUT_TOKEN_NOT_JWS));
 
         Page response = actions.invokeUrlWithCookie(_testName, protectedUrl, cookieWithoutSignature);
         validationUtils.validateResult(response, currentAction, expectations);

--- a/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/utils/MessageConstants.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat/fat/src/com/ibm/ws/security/jwtsso/fat/utils/MessageConstants.java
@@ -18,6 +18,7 @@ public class MessageConstants extends com.ibm.ws.security.fat.common.MessageCons
 
     public static final String CWWKS6031E_JWT_ERROR_PROCESSING_JWT = "CWWKS6031E";
     public static final String CWWKS6041E_JWT_INVALID_SIGNATURE = "CWWKS6041E";
+    public static final String CWWKS6063E_JWS_REQUIRED_BUT_TOKEN_NOT_JWS = "CWWKS6063E";
 
     public static final String CWWKS5506E_USERNAME_NOT_FOUND = "CWWKS5506E";
     public static final String CWWKS5508E_ERROR_CREATING_RESULT = "CWWKS5508E";

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/tck_suite_aud_env.xml
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/tck_suite_aud_env.xml
@@ -28,7 +28,6 @@
              
               <!-- MP JWT 1.1 that need audiences set. They contain a key but do not define mp.jwt.verify.publickey.location or issuer. 
                    Passes if key and issuer are overridden with server.env.  -->  
-              
               <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest" />
 	          <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest" />            
 	          <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest" />
@@ -39,13 +38,10 @@
  			  <!-- MP JWT 1.2 JAXRS tests   --> 
               <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrincipalInjectionTest" /> 
               <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.ApplicationScopedInjectionTest" />
-             
-              
-              <!--  MP JWT 1.2 JAXRS JWE tests  - Need to enable when JWE support is delivered
-              <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedEncryptTest" />
+
+              <!--  MP JWT 1.2 JAXRS JWE tests -->
               <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" />
-              -->
-             
+
         </classes>
     </test>
 

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/tck_suite_aud_noenv.xml
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/tck_suite_aud_noenv.xml
@@ -59,11 +59,9 @@
             -->
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" />
        
-            <!-- MP JWT 1.2 - need to enable when JWE support is delivered 
             <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKClasspathTest" />
             <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKSClasspathTest" />
             <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsPEMClasspathTest" />
-            -->
 
 
 		</classes>

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/tck_suite_aud_noenv.xml
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/tck_suite_aud_noenv.xml
@@ -58,11 +58,12 @@
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest" />
             -->
             <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.CookieTokenTest" />
-       
+
+            <!-- Waiting on updates to TCK 
             <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKClasspathTest" />
             <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsJWKSClasspathTest" />
             <class name="org.eclipse.microprofile.jwt.tck.config.jwe.PrivateKeyAsPEMClasspathTest" />
-
+            -->
 
 		</classes>
     </test>


### PR DESCRIPTION
For issue #13577

Changes included:
- New failure (`CWWKS6062E`) for when the decrypt key location appears to be an inlined private key
- New failure (`CWWKS6063E`) for when a JWE is sent but the decrypt key location info is not configured (either in MP Config props or the `keyManagementKeyAlias` config attribute)
- New failure (`CWWKS6064E`) for when a JWS is sent but the decrypt key location info is configured
- New failure (`CWWKS6065E`) for when a JWE is sent but its payload is not a JWS token
- Adds support for looking up JWE decryption key based on the `"kid"` value in the JWE header
- FAT updates to look for new messages
- Enables the `RolesAllowedSignEncryptTest` TCK test - all tests in that class now passing