### PR TITLE
Fix modified FAT bucket detection for paths containing a second '_fat' token

### DIFF
--- a/.github/workflow-scripts/check-fat-failures.sh
+++ b/.github/workflow-scripts/check-fat-failures.sh
@@ -8,7 +8,7 @@ if [[ $CATEGORY =~ MODIFIED_.*_MODE ]]; then
   git diff --name-only HEAD^...HEAD^2 >> modified_files.diff
   echo "Modified files are:"
   cat modified_files.diff
-  FAT_BUCKETS=$(sed -n "s/^dev\/\(.*_fat[^\/]*\)\/.*$/\1/p" modified_files.diff | uniq)
+  FAT_BUCKETS=$(sed -n "s/^dev\/\([^\/]*_fat[^\/]*\)\/.*$/\1/p" modified_files.diff | uniq)
   if [[ -z $FAT_BUCKETS ]]; then
     echo "No FATs were directly modfied. Skipping this job."
     exit 0

--- a/.github/workflow-scripts/run-fat-build.sh
+++ b/.github/workflow-scripts/run-fat-build.sh
@@ -18,7 +18,7 @@ if [[ $CATEGORY =~ MODIFIED_.*_MODE ]]; then
   git diff --name-only HEAD^...HEAD^2 >> modified_files.diff
   echo "Modified files are:"
   cat modified_files.diff
-  FAT_BUCKETS=$(sed -n "s/^dev\/\(.*_fat[^\/]*\)\/.*$/\1/p" modified_files.diff | uniq)
+  FAT_BUCKETS=$(sed -n "s/^dev\/\([^\/]*_fat[^\/]*\)\/.*$/\1/p" modified_files.diff | uniq)
   if [[ -z $FAT_BUCKETS ]]; then
     echo "No FATs were directly modfied. Skipping this job."
     exit 0

--- a/dev/io.openliberty.microprofile.config.2.0.internal_fat/fat/src/io/openliberty/microprofile/config/internal_fat/apps/badobserver/TestObserver.java
+++ b/dev/io.openliberty.microprofile.config.2.0.internal_fat/fat/src/io/openliberty/microprofile/config/internal_fat/apps/badobserver/TestObserver.java
@@ -19,7 +19,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @ApplicationScoped
 public class TestObserver {
 
-    // Should throw a deployment exception
+    //  Should throw a deployment exception
     private static final void observerMethod(@Observes @Initialized(ApplicationScoped.class) final Object obj,
                                              @ConfigProperty(name = "DOESNOTEXIST") final String doesnotexist) {
         throw new RuntimeException("This method should not have been called");


### PR DESCRIPTION
Fixes an issue in the GH Actions build where we would incorrectly detect the modified FATs for the MODIFIED_LITE_MODE and MODIFIED_FULL_MODE categories:

```
Modified files are:
dev/io.openliberty.microprofile.config.2.0.internal_fat/fat/src/io/openliberty/microprofile/config/internal_fat/apps/defaultSources/DefaultSourcesTestServlet.java
Will be running buckets io.openliberty.microprofile.config.2.0.internal_fat/fat/src/io/openliberty/microprofile/config/internal_fat
```

Run this category first: MP_CONFIG