### PR TITLE
port web container code for HandleList

### DIFF
--- a/dev/com.ibm.ws.webcontainer/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer/bnd.bnd
@@ -50,6 +50,10 @@ Service-Component: \
      optional:="webAppConnectionCollaborator,webAppSecurityCollaborator,webAppTransactionCollaborator,webAppInvocationCollaborator,webAppInitializationCollaborator"; \
      multiple:="webAppSecurityCollaborator,webAppInvocationCollaborator,webAppInitializationCollaborator"; \
 	 dynamic:="webAppConnectionCollaborator,webAppSecurityCollaborator,webAppTransactionCollaborator,webAppInvocationCollaborator,webAppInitializationCollaborator", \
+   com.ibm.ws.webcontainer.collaborator.ConnectionHandleCollaborator;\
+     implementation:=com.ibm.ws.webcontainer.collaborator.ConnectionHandleCollaborator;\
+     provide:=com.ibm.wsspi.webcontainer.collaborator.IConnectionCollaborator;\
+     configuration-policy:=ignore,\
    com.ibm.ws.generatePluginConfig;\
      implementation:=com.ibm.ws.webcontainer.osgi.mbeans.GeneratePluginConfigMBean;\
      provide:='javax.management.DynamicMBean,com.ibm.wsspi.webcontainer.osgi.mbeans.GeneratePluginConfig,com.ibm.ws.webserver.plugin.runtime.interfaces.PluginUtilityConfigGenerator,com.ibm.wsspi.kernel.service.utils.ServerQuiesceListener';\
@@ -124,6 +128,7 @@ Import-Package: \
    	com.ibm.ws.javaee.dd.jsp; version=1.0, \
    	com.ibm.ws.javaee.dd.web; version=1.0, \
    	com.ibm.ws.javaee.dd.web.common; version=1.0, \
+	com.ibm.ws.jca.cm.handle, \
 	com.ibm.ws.util, \
 	com.ibm.wsspi.injectionengine, \
 	com.ibm.ws.runtime.metadata, \
@@ -138,6 +143,7 @@ Import-Package: \
      !com.ibm.wsspi.buffermgmt, \
      !com.ibm.ejs.sm.client.ui, \
      !com.ibm.websphere.monitor.jmx, \
+     !com.ibm.ws.jca.cm, \
     *
     
  

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/collaborator/ConnectionHandleCollaborator.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/collaborator/ConnectionHandleCollaborator.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2005,2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.webcontainer.collaborator;
+
+import org.osgi.framework.ServiceReference;
+
+import com.ibm.ejs.j2c.HandleList;
+import com.ibm.websphere.csi.CSIException;
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.ffdc.FFDCFilter;
+import com.ibm.ws.jca.cm.handle.HandleListInterface;
+import com.ibm.ws.threadContext.ConnectionHandleAccessorImpl;
+import com.ibm.ws.threadContext.ThreadContext;
+import com.ibm.wsspi.webcontainer.WCCustomProperties;
+import com.ibm.wsspi.webcontainer.collaborator.IConnectionCollaborator;
+
+/**
+ * Connection Handle Collaborator
+ */
+public class ConnectionHandleCollaborator implements IConnectionCollaborator{
+    TraceComponent tc = Tr.register(ConnectionHandleCollaborator.class);
+
+    private final ThreadContext<HandleListInterface> threadContext;
+
+    @SuppressWarnings("unchecked")
+    public ConnectionHandleCollaborator() {
+        // get the thread context
+        ThreadContext<?> thctx = ConnectionHandleAccessorImpl.getConnectionHandleAccessor().getThreadContext();
+        threadContext = (ThreadContext<HandleListInterface>) thctx;
+    }
+
+    /*
+     * preinvoke
+     *
+     */
+    public void preInvoke(HandleList hl, boolean singleThread) throws CSIException
+    {
+        // if it's a single thread servlet, then we can reuse handles
+        if (singleThread || WCCustomProperties.DISABLE_MULTI_THREAD_CONN_MGMT)
+            hl.reAssociate();
+
+        threadContext.beginContext(hl);
+    }
+
+
+    /*
+     * postinvoke
+     *
+     */
+    public void postInvoke(HandleList hl, boolean singleThread) throws CSIException
+    {
+        // take the handle list off the thread context
+        HandleList threadHandleList = (HandleList)threadContext.endContext();
+
+        // make sure our handle lists match
+        if (threadHandleList != hl)
+        {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                Tr.debug(this, tc, "postInvoke", "unexpected - web app request dispatcher handleList context doesn't match thread handleList context " + hl);
+        }
+        else
+        {
+            // if it's a single thread servlet, then we can reuse handles
+            if (singleThread || WCCustomProperties.DISABLE_MULTI_THREAD_CONN_MGMT)
+            {
+                // process handle list
+                try
+                {
+                    threadHandleList.parkHandle();
+                }
+                catch (RuntimeException e)
+                {
+                    throw e;
+                }
+                catch (Exception e)
+                {
+                    FFDCFilter.processException(e, getClass().getName(), "95", this);
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                    {
+                        Tr.debug(this, tc, "postInvoke", "unexpected - error manipulating connection handles. See any previous errors related to Managed Connection.");
+                    }
+
+                    // Eat exception. ConnectionManager will log an Error Message. Re-Throwing
+                    //at this point may cause container to "rollback". Client will probably get
+                    //exception later when trying to re-use handle - possibly in the pre-invoke
+                }
+            }
+            else
+            {
+                // multi thread...force a drop of the handles
+                threadHandleList.close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Some of the HandleList code (needed for the feature to track and close connection handles that were left open) is absent from Open Liberty and needs to be ported over, which will be done under this pull.