### PR TITLE
Ignore ambiguous binding warning in tests

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/BadApplicationTests.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/BadApplicationTests.java
@@ -149,8 +149,9 @@ public class BadApplicationTests extends AbstractTest {
         // CWNEN0064E - testE4xEnvEntryExistingNonEnumNonClass, testE4aEnvEntryExistingNonEnumNonClass
         // CWWKZ0002E - testApplicationExceptionExtendsThrowable, testApplicationExceptionExtendsThrowableEE8
         // CWWKZ0106E - testApplicationExceptionExtendsThrowable, testApplicationExceptionExtendsThrowableEE8
+        // CNTR0338W - Ambiguous binding warning
         server.stopServer("CNTR0075E", "CNTR0190E", "CNTR4002E", "CNTR4006E", "CNTR5107E", "CWNEN0009E", "CWNEN0011E", "CWNEN0021W", "CWNEN0063E", "CWNEN0064E", "CWWKZ0002E",
-                          "CWWKZ0106E");
+                          "CWWKZ0106E", "CNTR0338W");
     }
 
     // For C2, constant for the bogus class name, which should appear somewhere in the error message:

--- a/dev/com.ibm.ws.ejbcontainer.security.jacc_fat/fat/src/com/ibm/ws/ejbcontainer/security/jacc_fat/EJBAnnTestBase.java
+++ b/dev/com.ibm.ws.ejbcontainer.security.jacc_fat/fat/src/com/ibm/ws/ejbcontainer/security/jacc_fat/EJBAnnTestBase.java
@@ -99,7 +99,8 @@ public class EJBAnnTestBase {
             try {
                 server.stopServer("SRVE9967W", // Quite a few
                                   "CWWKS9112W", // PureAnnServletToEJBRunAsTest, EJBJarMixM07ExtTest, EJBJarMixM08ExtTest, EJBJarMixM09ExtTest
-                                  "CWWKS9405E" // EJBJarMixM07ExtTest, EJBJarMixM08ExtTest, EJBJarMixM09ExtTest
+                                  "CWWKS9405E", // EJBJarMixM07ExtTest, EJBJarMixM08ExtTest, EJBJarMixM09ExtTest
+                                  "CNTR0338W" // Quite a few - Ambiguous EJB Binding
                 );
             } finally {
                 JACCFatUtils.uninstallJaccUserFeature(server);


### PR DESCRIPTION
Some Full tests missed ignoring the warning.