### PR TITLE
HTTP/2 channel needs to check for gRPC request earlier

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/H2StreamProcessor.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/H2StreamProcessor.java
@@ -1076,7 +1076,7 @@ public class H2StreamProcessor {
 
         if (direction == Constants.Direction.READ_IN) {
             if (frameType == FrameTypes.DATA) {
-                if (!h2HttpInboundLinkWrap.getIsGrpc()) {
+                if (!h2HttpInboundLinkWrap.setAndGetIsGrpc()) {
                     getBodyFromFrame();
                     if (currentFrame.flagEndStreamSet()) {
                         endStream = true;


### PR DESCRIPTION
In some cases, we need to check to see if a request is for a gRPC service earlier than we currently do.  We need to perform that check earlier in the processing of new HTTP/2 requests.