### PR TITLE
Fix anno feature to be a singleton

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/SymbolicNameTest.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/SymbolicNameTest.java
@@ -12,8 +12,10 @@
 package com.ibm.ws.feature.tests;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -43,5 +45,62 @@ public class SymbolicNameTest {
             }
             Assert.assertEquals("symbolicName doesn't match the name of the file", fileName, symbolicName);
 	    }
+	}
+
+	/**
+	 * Validates that if multiple features start with the same prefix that they are appropriately
+	 * marked as singletons so that they can't both load in the same server.
+	 */
+	@Test
+	public void testSingleton() {
+	    Map<String, Map<String, List<FeatureInfo>>> featureMap = new HashMap<>();
+        for (File featureFile : featureFileList) {
+            FeatureInfo featureInfo = new FeatureInfo(featureFile);
+            if (featureInfo.isAutoFeature()) {
+                continue;
+            }
+            String symbolicName = featureInfo.getName();
+            // javaeePlatform and appSecurity are special because they have dependencies on each other.
+            if (symbolicName.startsWith("com.ibm.websphere.appserver.javaeePlatform") ||
+                    symbolicName.startsWith("com.ibm.websphere.appserver.appSecurity")) {
+                continue;
+            }
+
+            int versionIndex = symbolicName.lastIndexOf('-');
+            String nameWithoutVersion;
+            if (versionIndex != -1) {
+                nameWithoutVersion = symbolicName.substring(0, versionIndex);
+            } else {
+                nameWithoutVersion = symbolicName;
+            }
+            Map<String, List<FeatureInfo>> featureListMap = featureMap.get(nameWithoutVersion);
+            if (featureListMap == null) {
+                featureListMap = new HashMap<>();
+                featureMap.put(nameWithoutVersion, featureListMap);
+            }
+            String visibility = featureInfo.getVisibility();
+            List<FeatureInfo> featureList = featureListMap.get(visibility);
+            if (featureList == null) {
+                featureList = new ArrayList<>();
+                featureListMap.put(visibility, featureList);
+            }
+            featureList.add(featureInfo);
+        }
+        StringBuilder errorMessage = new StringBuilder();
+        for (Map<String, List<FeatureInfo>> featureListMap : featureMap.values()) {
+            for (List<FeatureInfo> featureList : featureListMap.values()) {
+                if (featureList.size() > 1) {
+                    for (FeatureInfo featureInfo : featureList) {
+                        if (!featureInfo.isSingleton()) {
+                            errorMessage.append("Found issues with " + featureInfo.getName() + '\n');
+                            errorMessage.append("     There are other versions with the same name and it isn't marked as a singleton: " + '\n');
+                        }
+                    }
+                }
+            }
+        }
+        if (errorMessage.length() != 0) {
+            Assert.fail("Found features that aren't correctly marked as singletons: " + '\n' + errorMessage.toString());
+        }
 	}
 }

--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureInfo.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureInfo.java
@@ -43,7 +43,8 @@ public class FeatureInfo {
 	private boolean isAutoFeature = false;
 	private boolean isParallelActivationEnabled = false;
 	private boolean isDisableOnConflictEnabled = true;
-
+	private boolean isSingleton = false;
+    private String visibility = "private";
 
 	public FeatureInfo(File feature) {
 		this.feature = feature;
@@ -84,7 +85,21 @@ public class FeatureInfo {
         return this.isDisableOnConflictEnabled;
     }
 
-	//Activating autofeature just means "I'm an autofeature, and i *might* activate this other feature
+    public boolean isSingleton() {
+        if (!isInit)
+            populateInfo();
+
+        return this.isSingleton;
+    }
+
+    public String getVisibility() {
+        if (!isInit)
+            populateInfo();
+
+        return this.visibility;
+    }
+
+    //Activating autofeature just means "I'm an autofeature, and i *might* activate this other feature
 	//So it's like a "Sometimes" dependency, but is potentially useful for figuring out a superset of
 	//potential provisioned features.
 	protected void addActivatingAutoFeature(String featureName) {
@@ -153,6 +168,12 @@ public class FeatureInfo {
             this.isParallelActivationEnabled = activationType != null && "parallel".equals(activationType.trim());
             String disableOnConflict = builder.getProperty("WLP-DisableAllFeatures-OnConflict");
             this.isDisableOnConflictEnabled = disableOnConflict == null || "true".equals(disableOnConflict);
+            String singleton = builder.getProperty("singleton");
+            this.isSingleton = singleton != null && "true".equals(singleton.trim());
+            String vis = builder.getProperty("visibility");
+            if (vis != null) {
+                visibility = vis.trim();
+            }
 
             this.edition = edition;
             this.kind = kind;

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.anno-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.anno-1.0.feature
@@ -1,5 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.anno-1.0
+singleton=true
 WLP-DisableAllFeatures-OnConflict: false
 IBM-API-Package: javax.annotation; type="spec", \
  javax.annotation.security; type="spec", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.anno-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.anno-2.0.feature
@@ -1,5 +1,6 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.anno-2.0
+singleton=true
 IBM-API-Package: jakarta.annotation; type="spec", \
  jakarta.annotation.security; type="spec", \
  jakarta.annotation.sql; type="spec"

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.0.feature
@@ -2,6 +2,7 @@
 symbolicName=com.ibm.websphere.appserver.jaxrs.common-2.0
 WLP-DisableAllFeatures-OnConflict: false
 visibility=private
+singleton=true
 IBM-App-ForceRestart: uninstall, \
  install
 IBM-API-Package: \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.jaxrs.common-2.1.feature
@@ -2,6 +2,7 @@
 symbolicName=com.ibm.websphere.appserver.jaxrs.common-2.1
 WLP-DisableAllFeatures-OnConflict: false
 visibility=private
+singleton=true
 IBM-App-ForceRestart: uninstall, \
  install
 -features=\

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/persistentExecutor-1.0/com.ibm.websphere.appserver.persistentExecutor-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/persistentExecutor-1.0/com.ibm.websphere.appserver.persistentExecutor-1.0.feature
@@ -3,6 +3,7 @@ IBM-ShortName: persistentExecutor-1.0
 Subsystem-Name: Persistent Scheduled Executor 1.0
 symbolicName=com.ibm.websphere.appserver.persistentExecutor-1.0
 visibility=public
+singleton=true
 IBM-API-Package: \
   com.ibm.websphere.concurrent.persistent; type="ibm-api", \
   com.ibm.websphere.concurrent.persistent.mbean; type="ibm-api"

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/persistentExecutor-2.0/com.ibm.websphere.appserver.persistentExecutor-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/persistentExecutor-2.0/com.ibm.websphere.appserver.persistentExecutor-2.0.feature
@@ -3,13 +3,14 @@ IBM-ShortName: persistentExecutor-2.0
 Subsystem-Name: Persistent Scheduled Executor 2.0
 symbolicName=com.ibm.websphere.appserver.persistentExecutor-2.0
 visibility=public
+singleton=true
 IBM-API-Package: \
   com.ibm.websphere.concurrent.persistent; type="ibm-api", \
   com.ibm.websphere.concurrent.persistent.mbean; type="ibm-api"
 -features=\
   com.ibm.websphere.appserver.appmanager-1.0, \
   com.ibm.websphere.appserver.concurrent-2.0, \
-  com.ibm.websphere.appserver.jdbc-4.3; ibm.tolerates:="4.2, 4.1", \
+  com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:="4.3, 4.1", \
   com.ibm.websphere.appserver.transaction-2.0, \
   io.openliberty.persistentExecutorSubset-2.0
 kind=noship


### PR DESCRIPTION
- Update all features including anno to be marked singleton if there is more than one feature with the name
- Update persistentExecutor-2.0 to depend on jdbc 4.2 and tolerate 4.3 just like the other features do for jdbc dependencies.
- Add a test case so that this problem is detected in the future so it causes the build to break.

This change was initiated as part of the work that @tjwatson is doing where he saw that both anno 1.0 and 2.0 were loaded.  In fixing it, I created a test case to have this not happen again in the future.