### PR TITLE
11278 Update Jakarta JSON 2.0 APIs to final

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -734,12 +734,12 @@
     <dependency>
       <groupId>jakarta.json.bind</groupId>
       <artifactId>jakarta.json.bind-api</artifactId>
-      <version>2.0.0-RC2</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>jakarta.json</groupId>
       <artifactId>jakarta.json-api</artifactId>
-      <version>2.0.0-RC3</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>jakarta.jws</groupId>
@@ -1899,7 +1899,7 @@
     <dependency>
       <groupId>org.eclipse</groupId>
       <artifactId>yasson</artifactId>
-      <version>2.0.0-M2</version>
+      <version>2.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.ektorp</groupId>
@@ -2039,7 +2039,7 @@
     <dependency>
       <groupId>org.glassfish</groupId>
       <artifactId>jakarta.json</artifactId>
-      <version>2.0.0-RC3</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -142,8 +142,8 @@ jakarta.enterprise:jakarta.enterprise.cdi-api:3.0.0-M4
 jakarta.inject:jakarta.inject-api:2.0.0-RC4
 jakarta.interceptor:jakarta.interceptor-api:2.0.0-RC2
 jakarta.jms:jakarta.jms-api:3.0.0-RC1
-jakarta.json.bind:jakarta.json.bind-api:2.0.0-RC2
-jakarta.json:jakarta.json-api:2.0.0-RC3
+jakarta.json.bind:jakarta.json.bind-api:2.0.0
+jakarta.json:jakarta.json-api:2.0.0
 jakarta.jws:jakarta.jws-api:3.0.0-RC2
 jakarta.mail:jakarta.mail-api:2.0.0-RC6
 jakarta.persistence:jakarta.persistence-api:3.0.0-RC2
@@ -375,7 +375,7 @@ org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.4.0
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:2.0-RC2
 org.eclipse.transformer:org.eclipse.transformer.cli:0.2.0-SNAPSHOT
 org.eclipse.transformer:org.eclipse.transformer:0.2.0-SNAPSHOT
-org.eclipse:yasson:2.0.0-M2
+org.eclipse:yasson:2.0.1
 org.ektorp:org.ektorp:1.4.1
 org.fusesource.jansi:jansi:1.18
 org.glassfish.hk2.external:aopalliance-repackaged:2.3.0-b10
@@ -403,7 +403,7 @@ org.glassfish.jersey.ext.rx:jersey-rx-client-rxjava2:2.30.1
 org.glassfish.jersey.ext.rx:jersey-rx-client-rxjava:2.30.1
 org.glassfish.jersey.inject:jersey-hk2:2.26
 org.glassfish:jakarta.faces:3.0.0-RC1
-org.glassfish:jakarta.json:2.0.0-RC3
+org.glassfish:jakarta.json:2.0.0
 org.glassfish:javax.faces:2.3.3
 org.glassfish:javax.json:1.0.4
 org.glassfish:javax.json:1.1.4

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonpImpl-2.0.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonpImpl-2.0.0.feature
@@ -4,7 +4,7 @@ symbolicName=io.openliberty.jsonpImpl-2.0.0
 singleton=true
 visibility=private
 -features=com.ibm.websphere.appserver.eeCompatible-9.0
--bundles=io.openliberty.jakarta.jsonp.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.json:jakarta.json-api:2.0.0-RC2", \
+-bundles=io.openliberty.jakarta.jsonp.2.0; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.json:jakarta.json-api:2.0.0", \
  com.ibm.ws.org.glassfish.json.1.1.jakarta
 kind=beta
 edition=core

--- a/dev/com.ibm.ws.org.eclipse.yasson.2.0/bnd.bnd
+++ b/dev/com.ibm.ws.org.eclipse.yasson.2.0/bnd.bnd
@@ -8,13 +8,13 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
--include= jar:${fileuri;${repo;org.eclipse:yasson;2.0.0.M2;EXACT}}!/META-INF/MANIFEST.MF,bnd.overrides
+-include= jar:${fileuri;${repo;org.eclipse:yasson;2.0.1;EXACT}}!/META-INF/MANIFEST.MF,bnd.overrides
 
 instrument.disabled: true
 
 -includeresource: \
-   @${repo;org.eclipse:yasson;2.0.0.M2;EXACT}!/org/eclipse/yasson/*,\
-   @${repo;org.eclipse:yasson;2.0.0.M2;EXACT}!/META-INF/services/jakarta.json.bind.spi.JsonbProvider,\
+   @${repo;org.eclipse:yasson;2.0.1;EXACT}!/org/eclipse/yasson/*,\
+   @${repo;org.eclipse:yasson;2.0.1;EXACT}!/META-INF/services/jakarta.json.bind.spi.JsonbProvider,\
    yasson-messages.properties=resources/yasson-messages.properties
 
 -buildpath: \

--- a/dev/com.ibm.ws.org.glassfish.json.2.0/bnd.bnd
+++ b/dev/com.ibm.ws.org.glassfish.json.2.0/bnd.bnd
@@ -8,10 +8,10 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
--include= jar:${fileuri;${repo;org.glassfish:jakarta.json;2.0.0.RC3;EXACT}}!/META-INF/MANIFEST.MF,bnd.overrides
+-include= jar:${fileuri;${repo;org.glassfish:jakarta.json;2.0.0;EXACT}}!/META-INF/MANIFEST.MF,bnd.overrides
 
 -includeresource: \
-   @${repo;org.glassfish:jakarta.json;2.0.0.RC3;EXACT}!/org/glassfish/json/*
+   @${repo;org.glassfish:jakarta.json;2.0.0;EXACT}!/org/glassfish/json/*
 
 -buildpath: \
 	org.glassfish:jakarta.json;version=2.0.0

--- a/dev/io.openliberty.jakarta.jsonb.2.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.jsonb.2.0/bnd.bnd
@@ -22,7 +22,7 @@ Export-Package: \
    jakarta.json.bind.spi;version="2.0"
 
 Include-Resource: \
-  @${repo; jakarta.json.bind:jakarta.json.bind-api;2.0.0.RC2;EXACT}!/META-INF/NOTICE
+  @${repo; jakarta.json.bind:jakarta.json.bind-api;2.0.0;EXACT}!/META-INF/NOTICE
 
 instrument.disabled: true
 

--- a/dev/io.openliberty.jakarta.jsonp.2.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.jsonp.2.0/bnd.bnd
@@ -24,7 +24,7 @@ Export-Package: \
    jakarta.json.stream;version=2.0
  
 Include-Resource: \
-  @${repo;jakarta.json:jakarta.json-api;2.0.0.RC3;EXACT}!/!module-info.class
+  @${repo;jakarta.json:jakarta.json-api;2.0.0;EXACT}!/!module-info.class
 
 instrument.disabled: true
 


### PR DESCRIPTION
Ref: #11278

Update the jakarta jsonp/b APIs and the corresponding glassfish/yasson implementations to the final releases.  Notice the yasson release bumped to 2.0.1.