### PR TITLE
Register CDI extensions from SPI against all deployments not just the…

### DIFF
--- a/dev/com.ibm.ws.cdi.internal/src/com/ibm/ws/cdi/internal/archive/liberty/ExtensionArchiveImpl.java
+++ b/dev/com.ibm.ws.cdi.internal/src/com/ibm/ws/cdi/internal/archive/liberty/ExtensionArchiveImpl.java
@@ -52,6 +52,7 @@ public class ExtensionArchiveImpl extends CDIArchiveImpl implements ExtensionArc
         return extensionContainerInfo.isExtClassesOnly();
     }
 
+    //This uses Strings rather than class because we want to load the classes as late as possible.
     @Override
     public Set<String> getExtensionClasses() {
         Set<String> extensionClasses = super.getExtensionClasses();

--- a/dev/com.ibm.ws.cdi.internal/src/com/ibm/ws/cdi/internal/interfaces/WebSphereCDIDeployment.java
+++ b/dev/com.ibm.ws.cdi.internal/src/com/ibm/ws/cdi/internal/interfaces/WebSphereCDIDeployment.java
@@ -180,6 +180,6 @@ public interface WebSphereCDIDeployment extends CDI11Deployment {
      *
      * @param extensions a set of additional CDI extension classes.
      */
-    void registerSPIExtension(Set<Extension> extensions);
+    void registerSPIExtensions(Set<Extension> extensions);
 
 }

--- a/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/weld/WebSphereCDIDeploymentImpl.java
+++ b/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/weld/WebSphereCDIDeploymentImpl.java
@@ -698,7 +698,7 @@ public class WebSphereCDIDeploymentImpl implements WebSphereCDIDeployment {
     }
 
     @Override
-    public void registerSPIExtension(Set<Extension> extensions) {
+    public void registerSPIExtensions(Set<Extension> extensions) {
         spiExtensions.addAll(extensions);
     }
 


### PR DESCRIPTION
fixes #14883 by calling `applicationContext.registerSPIExtensions` even when not creating a BDA