### PR TITLE
Update Jakarta Persistence API (JPA) to final release version 3.0.0.

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -754,7 +754,7 @@
     <dependency>
       <groupId>jakarta.persistence</groupId>
       <artifactId>jakarta.persistence-api</artifactId>
-      <version>3.0.0-RC2</version>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>jakarta.resource</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -146,7 +146,7 @@ jakarta.json.bind:jakarta.json.bind-api:2.0.0-RC2
 jakarta.json:jakarta.json-api:2.0.0-RC3
 jakarta.jws:jakarta.jws-api:3.0.0-RC2
 jakarta.mail:jakarta.mail-api:2.0.0-RC6
-jakarta.persistence:jakarta.persistence-api:3.0.0-RC2
+jakarta.persistence:jakarta.persistence-api:3.0.0
 jakarta.resource:jakarta.resource-api:2.0.0-RC2
 jakarta.security.auth.message:jakarta.security.auth.message-api:2.0.0-RC1
 jakarta.security.enterprise:jakarta.security.enterprise-api:2.0.0-RC2

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.persistence-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakarta.persistence-3.0.feature
@@ -5,7 +5,7 @@ IBM-Process-Types: server, \
  client
 -features=io.openliberty.jakarta.persistence.base-3.0
 -bundles=io.openliberty.jakarta.persistence.api.3.0
--jars=io.openliberty.jakarta.persistence.3.0; location:=dev/api/spec/; mavenCoordinates="jakarta.persistence:jakarta.persistence-api:3.0-RC2"
+-jars=io.openliberty.jakarta.persistence.3.0; location:=dev/api/spec/; mavenCoordinates="jakarta.persistence:jakarta.persistence-api:3.0.0"
 kind=beta
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/io.openliberty.jakarta.persistence.3.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.persistence.3.0/bnd.bnd
@@ -33,7 +33,7 @@ Private-Package: io.openliberty.jakarta.persistence.internal, \
    org.apache.geronimo.specs.jpa
 
 #Include-Resource: \
-#   @${repo;jakarta.persistence:jakarta.persistence-api;3.0.0-RC2}!/about.html
+#   @${repo;jakarta.persistence:jakarta.persistence-api;3.0.0}!/about.html
 
 instrument.disabled: true
 


### PR DESCRIPTION
For #14882 , updating Jakarta Persistence API to final 3.0.0 version, since it is now posted to maven central.