### PR TITLE
Beta ee9 auto features for sessionCache, webBundle, and JMS defaultre…

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.app.manager.wab.jakarta-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.app.manager.wab.jakarta-1.0.feature
@@ -10,6 +10,6 @@ IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature
 
 IBM-Install-Policy: when-satisfied
 
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.messaging.defaultresource-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.messaging.defaultresource-3.0.feature
@@ -7,5 +7,5 @@ IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.messagingServer-3.0))"
 -bundles=com.ibm.ws.messaging.jms.defaultresource
 IBM-Install-Policy: when-satisfied
-kind=noship
-edition=full
+kind=beta
+edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.sessionCache1.0.jakarta.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.sessionCache1.0.jakarta.feature
@@ -13,6 +13,5 @@ IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature
 
 IBM-Install-Policy: when-satisfied
 
-kind=noship
-edition=full
-
+kind=beta
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.sessionDatabase1.0.jakarta.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.sessionDatabase1.0.jakarta.feature
@@ -12,6 +12,6 @@ IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature
 
 IBM-Install-Policy: when-satisfied
 
-kind=noship
-edition=full
+kind=beta
+edition=core
 

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.webBundleSecurity1.0.jakarta.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.webBundleSecurity1.0.jakarta.feature
@@ -13,6 +13,6 @@ IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature
 
 IBM-Install-Policy: when-satisfied
 
-edition=full
-kind=noship
+edition=core
+kind=beta
 WLP-Activation-Type: parallel


### PR DESCRIPTION
Enable for beta the auto features which support jakarta function for features sessionCache, sessionDatabase, webBundle, and webBundleSecurity.  Also, enable the jakarta jms auto feature that provides the default jms resource types.
