### PR TITLE
Use uniq token with Logout test

### DIFF
--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/MPJwtBasicTests.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/MPJwtBasicTests.java
@@ -231,6 +231,9 @@ public class MPJwtBasicTests extends CommonMpJwtFat {
 
         // now try it again and we should get a 401
         response = actions.invokeUrlWithAuthorizationHeaderToken(_testName, webClient, testUrl, FATSuite.authHeaderPrefix, token, HttpMethod.GET, null);
+        // sleep so that any test that follows will get a uniq token - if tokens are created too quickly, we'll create identical tokens - the cache cleanup for
+        // this logout will end up deleting the token actually created for the next test
+        Thread.sleep(1 * 1000);
         int rc = response.getWebResponse().getStatusCode();
         Assert.assertTrue("expected 401 but got " + rc, rc == 401);
         expectations = new Expectations();


### PR DESCRIPTION
Update the the testLogoutReuseCache test to wait 1 second before completing.  The current time is part of what makes a token unique.  Our tests use the same user, client, ... so when we the a token is created for the logout test, we may end up creating the same token in the next test if the tests run too fast.  When cache cleanup runs, it ends up cleaning up the token created for the next test causing that test to fail.