### PR TITLE
Remove EJB from CDI description

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-3.0/resources/l10n/io.openliberty.cdi-3.0.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-3.0/resources/l10n/io.openliberty.cdi-3.0.properties
@@ -16,4 +16,4 @@
 
 description=The Jakarta Contexts and Dependency Injection 3.0 specification makes it easier to integrate \
  Jakarta EE components of different types. It provides a common mechanism to inject components \
- such as EJBs or managed beans into other components such as JSPs or other EJBs.
+ such as enterprise beans or managed beans into other components such as JSPs or other enterprise beans.


### PR DESCRIPTION
Remove the EJB trademark from CDI 3.0 feature description
and replaced with enterprise beans.

