### PR TITLE
Issue 14908: Wait on features for ConfigManager modify

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_RealmPropertyMappingTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_RealmPropertyMappingTest.java
@@ -127,8 +127,7 @@ public class URAPIs_RealmPropertyMappingTest {
          */
         try {
             if (libertyServer != null) {
-                Log.info(c, "teardown", "Temporarily ignore CWIMK0004E");
-                libertyServer.stopServer("CWIMK0004E");
+                libertyServer.stopServer();
             }
         } finally {
             try {
@@ -350,7 +349,7 @@ public class URAPIs_RealmPropertyMappingTest {
      * Add userSecurityNameMapping configuration.
      *
      * @param serverConfig The {@link ServerConfiguration} instance to update.
-     * @param mapping      An array of size 2 that contains the input and output user security name mapping properties.
+     * @param mapping An array of size 2 that contains the input and output user security name mapping properties.
      */
     private void addUserSecurityNameMapping(ServerConfiguration serverConfig, String[] mapping) {
         FederatedRepository federatedRepository = serverConfig.getFederatedRepository();
@@ -363,7 +362,7 @@ public class URAPIs_RealmPropertyMappingTest {
      * Add userDisplayNameMapping configuration.
      *
      * @param serverConfig The {@link ServerConfiguration} instance to update.
-     * @param mapping      An array of size 2 that contains the input and output user display name mapping properties.
+     * @param mapping An array of size 2 that contains the input and output user display name mapping properties.
      */
     private void addUserDisplayNameMapping(ServerConfiguration serverConfig, String[] mapping) {
         FederatedRepository federatedRepository = serverConfig.getFederatedRepository();
@@ -376,7 +375,7 @@ public class URAPIs_RealmPropertyMappingTest {
      * Add uniqueUserIdMapping configuration.
      *
      * @param serverConfig The {@link ServerConfiguration} instance to update.
-     * @param mapping      An array of size 2 that contains the input and output unique user ID mapping properties.
+     * @param mapping An array of size 2 that contains the input and output unique user ID mapping properties.
      */
     private void addUniqueUserIdMapping(ServerConfiguration serverConfig, String[] mapping) {
         FederatedRepository federatedRepository = serverConfig.getFederatedRepository();
@@ -389,7 +388,7 @@ public class URAPIs_RealmPropertyMappingTest {
      * Add groupSecurityNameMapping configuration.
      *
      * @param serverConfig The {@link ServerConfiguration} instance to update.
-     * @param mapping      An array of size 2 that contains the input and output group security name mapping properties.
+     * @param mapping An array of size 2 that contains the input and output group security name mapping properties.
      */
     private void addGroupSecurityNameMapping(ServerConfiguration serverConfig, String[] mapping) {
         FederatedRepository federatedRepository = serverConfig.getFederatedRepository();
@@ -402,7 +401,7 @@ public class URAPIs_RealmPropertyMappingTest {
      * Add groupDisplayNameMapping configuration.
      *
      * @param serverConfig The {@link ServerConfiguration} instance to update.
-     * @param mapping      An array of size 2 that contains the input and output group display name mapping properties.
+     * @param mapping An array of size 2 that contains the input and output group display name mapping properties.
      */
     private void addGroupDisplayNameMapping(ServerConfiguration serverConfig, String[] mapping) {
         FederatedRepository federatedRepository = serverConfig.getFederatedRepository();
@@ -415,7 +414,7 @@ public class URAPIs_RealmPropertyMappingTest {
      * Add uniqueGroupIdMapping configuration.
      *
      * @param serverConfig The {@link ServerConfiguration} instance to update.
-     * @param mapping      An array of size 2 that contains the input and output unique group ID mapping properties.
+     * @param mapping An array of size 2 that contains the input and output unique group ID mapping properties.
      */
     private void addUniqueGroupIdMapping(ServerConfiguration serverConfig, String[] mapping) {
         FederatedRepository federatedRepository = serverConfig.getFederatedRepository();

--- a/dev/com.ibm.ws.security.wim.core_fat/bnd.bnd
+++ b/dev/com.ibm.ws.security.wim.core_fat/bnd.bnd
@@ -29,4 +29,5 @@ fat.project: true
 	com.ibm.ws.security.wim.core;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.com.unboundid;version=latest,\
-	com.unboundid:unboundid-ldapsdk;version=latest
+	com.unboundid:unboundid-ldapsdk;version=latest,\
+	com.ibm.ws.security.wim.repository_test.custom;version=latest

--- a/dev/com.ibm.ws.security.wim.core_fat/build.gradle
+++ b/dev/com.ibm.ws.security.wim.core_fat/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     project(':com.ibm.ws.com.unboundid')
 }
 autoFVT.dependsOn ':com.ibm.ws.security.registry_test.servlet:assemble'
+autoFVT.dependsOn ':com.ibm.ws.security.wim.repository_test.custom:assemble'
 autoFVT.doLast {
   /*
    * Copy the local ApacheDS LDAP instances. 
@@ -25,6 +26,19 @@ autoFVT.doLast {
     from project(':com.ibm.ws.org.apache.directory.server').projectDir
     into autoFvtDir
     include 'apacheds-2.0.0-M15/**'
+  }
+  
+    /*
+   * Copy sample CustomRepository user feature to this test bucket.
+   */
+  copy { 
+    from project(':com.ibm.ws.security.wim.repository_test.custom').file('publish/usr/extension/lib/features/customRepositorySample-1.0.mf')
+    into new File(autoFvtDir, 'publish/features')
+  }
+  copy {
+    from new File(project(':com.ibm.ws.security.wim.repository_test.custom').buildDir, 'com.ibm.ws.security.wim.repository_test.custom.jar')
+    into new File(autoFvtDir, 'publish/bundles')
+    rename 'com.ibm.ws.security.wim.repository_test.custom.jar', 'com.ibm.ws.security.wim.repository_test.custom_1.0.jar'
   }
 
   /*

--- a/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/ConfigManagerFeatureTest.java
+++ b/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/ConfigManagerFeatureTest.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.security.wim.core.fat;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.impl.LibertyServerFactory;
+
+/**
+ * Test that we aren't printing out missing participatingBaseEntries messages at the incorrect times (CWIMK0004E)
+ * when there are custom registries or repositories to load as features.
+ *
+ */
+@RunWith(FATRunner.class)
+@Mode(TestMode.LITE)
+public class ConfigManagerFeatureTest {
+
+    private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.security.wim.core.fat.mod");
+    private static final Class<?> c = ConfigManagerFeatureTest.class;
+
+    private static final String ADD_REG = "dynamicUpdate/userRegistry.xml";
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        Log.info(c, "setUp", "Starting the server...");
+
+        server.installUserBundle("com.ibm.ws.security.wim.repository_test.custom_1.0");
+        server.installUserFeature("customRepositorySample-1.0");
+
+        server.startServer(c.getName() + ".log");
+        assertNotNull("Server did not came up",
+                      server.waitForStringInLog("CWWKF0011I"));
+
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        Log.info(c, "tearDown", "Stopping the server...");
+
+        server.stopServer();
+
+        server.uninstallUserBundle("com.ibm.ws.security.wim.repository_test.custom_1.0");
+        server.uninstallUserFeature("customRepositorySample-1.0");
+
+    }
+
+    /**
+     * This is an internal method used to set the server.xml
+     */
+    private static void setServerConfiguration(String serverXML) throws Exception {
+
+        // Update server.xml
+        Log.info(c, "setServerConfiguration", "setServerConfigurationFile to : " + serverXML);
+
+        // set a new mark
+        server.setMarkToEndOfLog(server.getDefaultLogFile());
+
+        // Update the server xml
+        server.setServerConfigurationFile("/" + serverXML);
+
+        // Wait for CWWKG0017I and CWWKF0008I to appear in logs after we started the config update
+        Log.info(c, "setServerConfiguration",
+                 "waitForStringInLogUsingMark: CWWKG0017I: The server configuration was successfully updated.");
+        server.waitForStringInLogUsingMark("CWWKG0017I"); //CWWKG0017I: The server configuration was successfully updated in 0.2 seconds.
+
+    }
+
+    /**
+     * Add a custom registry and update the participating base entries, we should not print a CWIMK0004E message indicating we're missing
+     * base entries.
+     */
+    @Test
+    public void testParticipatingBaseEntriesVerification() throws Exception {
+        Log.info(c, "testParticipatingBaseEntriesVerification", "Entering test testParticipatingBaseEntriesVerification");
+
+        /*
+         * Update to a config with Custom Repository and update the participatingBaseEntries to cause a modify to ConfigManager
+         */
+        Log.info(c, "testParticipatingBaseEntriesVerification", "Adding Custom User Repository with updated participatingBaseEntries");
+        setServerConfiguration(ADD_REG);
+
+        List<String> msg = server.findStringsInLogs("CWIMK0004E");
+        assertTrue("Should not find CWIMK0004E in the logs: " + msg, msg.isEmpty());
+
+    }
+
+}

--- a/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.wim.core_fat/fat/src/com/ibm/ws/security/wim/core/fat/FATSuite.java
@@ -21,7 +21,8 @@ import org.junit.runners.Suite.SuiteClasses;
                 DynamicUpdateTest.class,
                 NoRegistryConfiguredTest.class,
                 WimCoreRegressionTest.class,
-                ConfigManagerInitModifyTest.class
+                ConfigManagerInitModifyTest.class,
+                ConfigManagerFeatureTest.class
 })
 /**
  * Purpose: This suite collects and runs all known good test suites.

--- a/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/userRegistry.xml
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/userRegistry.xml
@@ -1,0 +1,17 @@
+<server description="new server">
+
+	<include location="../fatTestPorts.xml" />
+	<!-- Enable features -->
+<featureManager>
+	<feature>appSecurity-2.0</feature>
+	<feature>usr:customRepositorySample-1.0</feature>
+</featureManager>
+
+	<federatedRepository>
+		<primaryRealm name="FederatedRealm">
+			<participatingBaseEntry name="o=ibm,c=us" />
+		</primaryRealm>
+	</federatedRepository>
+
+
+</server>


### PR DESCRIPTION
Fixes #14908 

Wait on any feature updates to complete before ConfigManager notifies `RealmConfigChangeListener` listeners.

Added a new test that does a modify/update with a custom repository.

Remove the ignore on `URAPIs_RealmPropertyMappingTest` changed introduced by #15007 for a temp workaround.