### PR TITLE
11851 Fix jakarta messaging connection metadata

### DIFF
--- a/dev/com.ibm.ws.messaging.jms.2.0/src/com/ibm/ws/sib/api/jms/impl/JmsMetaDataImpl.java
+++ b/dev/com.ibm.ws.messaging.jms.2.0/src/com/ibm/ws/sib/api/jms/impl/JmsMetaDataImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -36,7 +36,7 @@ public class JmsMetaDataImpl implements ConnectionMetaData
     private static TraceComponent tc = SibTr.register(JmsMetaDataImpl.class, ApiJmsConstants.MSG_GROUP_INT, ApiJmsConstants.MSG_BUNDLE_INT);
 
     // ***************************** STATE VARIABLES ****************************
-    private static final int jmsMajorVersion = 2;
+    private static final int jmsMajorVersion = (isJakartaMessaging30()) ? 3 : 2;
     private static final int jmsMinorVersion = 0;
 
     // Initialize this information (which will be dynamically read from the
@@ -173,6 +173,23 @@ public class JmsMetaDataImpl implements ConnectionMetaData
     }
 
     // ******************* IMPLEMENTATION METHODS ***********************
+
+    // This method exists to support the jms20 SIB RA, transformed for jakarta 
+    // messaging 3.0, for use within jakarta ee9 server and client processes.
+    /**
+     * Determine whether the user configured jakarta messaging features.
+     * @return true whenever the jakarta.jms API is accessible to the SIB runtime
+     *  and applications.
+     */
+    private static boolean isJakartaMessaging30() {
+        Class<?> clazz = null;
+        try {
+            clazz = Class.forName("jakarta.jms.JMSContext");
+        } catch (Throwable t) {
+            // Expect ClassNotFoundException
+        }
+        return clazz != null;
+    };
 
     /**
      * This method retrieves the information stored in the jar manifest and uses

--- a/dev/com.ibm.ws.messaging.open_jms20context_fat/fat/src/com/ibm/ws/messaging/JMS20/fat/JMSContextTest_118058.java
+++ b/dev/com.ibm.ws.messaging.open_jms20context_fat/fat/src/com/ibm/ws/messaging/JMS20/fat/JMSContextTest_118058.java
@@ -230,7 +230,7 @@ public class JMSContextTest_118058 {
         assertTrue("Test testsetClientID_createContextUser_TCP_SecOff failed", testResult);
     }
 
-    // / 118058_3_2 : Check if CLIENT_ACKNOWLEDGE session mode is used , then it
+    // 118058_3_2 : Check if CLIENT_ACKNOWLEDGE session mode is used , then it
     // is ignored and AUTO_ACKNOWLEDGE is set
     // Bindings an Security Off
 

--- a/dev/com.ibm.ws.messaging.open_jms20context_fat/test-applications/JMSContext/src/jmscontext/web/JMSContextServlet.java
+++ b/dev/com.ibm.ws.messaging.open_jms20context_fat/test-applications/JMSContext/src/jmscontext/web/JMSContextServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2020 IBM Corporation and others.
+v * Copyright (c) 2013, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -289,15 +289,27 @@ public class JMSContextServlet extends HttpServlet {
     }
 
     private boolean verifyMetadata(ConnectionMetaData metadata) throws JMSException {
-        return ( metadata.getJMSVersion().equals("2.0") &&
-                 (metadata.getJMSMajorVersion() == 2) &&
+        String targetJmsVersion = (isJakartaMessaging30()) ? "3.0" : "2.0";
+        int targetJmsMajorVersion = (isJakartaMessaging30()) ? 3 : 2;
+        return ( metadata.getJMSVersion().equals(targetJmsVersion) &&
+                 (metadata.getJMSMajorVersion() == targetJmsMajorVersion) &&
                  (metadata.getJMSMinorVersion() == 0) &&
                  metadata.getJMSProviderName().equals("IBM") &&
                  metadata.getProviderVersion().equals("1.0") &&
                  (metadata.getProviderMajorVersion() == 1) &&
                  (metadata.getProviderMinorVersion() == 0) );
     }
-        
+
+    private static boolean isJakartaMessaging30() {
+        Class clazz = null;
+        try {
+            clazz = Class.forName("jakarta.jms.JMSContext");
+        } catch (Throwable t) {
+            // Expect CNFE, but could be linkage error.
+        }
+        return clazz != null;
+    }
+
     public void testGetMetadata_B_SecOff(
         HttpServletRequest request, HttpServletResponse response) throws Exception {
 


### PR DESCRIPTION
Modify the SIB RA runtime to provide the correct major version, "3", in queue/topic connection metadata when jakarta messaging is enabled.