### PR TITLE
initialize InstallKernelMap before capturing SharedOutput

### DIFF
--- a/dev/com.ibm.ws.install/test/com/ibm/ws/install/InstallKernelMapTest.java
+++ b/dev/com.ibm.ws.install/test/com/ibm/ws/install/InstallKernelMapTest.java
@@ -36,6 +36,7 @@ public class InstallKernelMapTest {
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
+        InstallKernelMap ikm = new InstallKernelMap();
         outputMgr.captureStreams();
     }
 


### PR DESCRIPTION
This should fix the issue with Install Unit Tests printing 1 character per line on windows and some other systems.
