### PR TITLE
Update loginProperty syntax in LDAP FATs

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec_fat/publish/files/globalClientCertFailOverToAppDefined.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/publish/files/globalClientCertFailOverToAppDefined.xml
@@ -13,7 +13,6 @@
     <ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore" trustStoreRef="defaultTrustStore" clientAuthenticationSupported="true" />
 
     <ldapRegistry id="LDAP" realm="MyLdapRealm" host="localhost" port="${ldap.1.port}" ignoreCase="true"
-        loginProperty="uid"
         bindDN="uid=admin,ou=users,o=ibm,c=us"
         bindPassword="s3cur1ty"
         baseDN="o=ibm,c=us"

--- a/dev/com.ibm.ws.security.javaeesec_fat/publish/files/globalClientCertFailOverToBA.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/publish/files/globalClientCertFailOverToBA.xml
@@ -13,7 +13,6 @@
     <ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore" trustStoreRef="defaultTrustStore" clientAuthenticationSupported="true" />
 
     <ldapRegistry id="LDAP" realm="MyLdapRealm" host="localhost" port="${ldap.1.port}" ignoreCase="true"
-        loginProperty="uid"
         bindDN="uid=admin,ou=users,o=ibm,c=us"
         bindPassword="s3cur1ty"
         baseDN="o=ibm,c=us"

--- a/dev/com.ibm.ws.security.javaeesec_fat/publish/files/globalClientCertFailOverToForm.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/publish/files/globalClientCertFailOverToForm.xml
@@ -13,7 +13,6 @@
     <ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore" trustStoreRef="defaultTrustStore" clientAuthenticationSupported="true" />
 
     <ldapRegistry id="LDAP" realm="MyLdapRealm" host="localhost" port="${ldap.1.port}" ignoreCase="true"
-        loginProperty="uid"
         bindDN="uid=admin,ou=users,o=ibm,c=us"
         bindPassword="s3cur1ty"
         baseDN="o=ibm,c=us"

--- a/dev/com.ibm.ws.security.javaeesec_fat/publish/files/globalClientCertNoFailOver.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/publish/files/globalClientCertNoFailOver.xml
@@ -13,7 +13,6 @@
     <ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore" trustStoreRef="defaultTrustStore" clientAuthentication="true" />
 
     <ldapRegistry id="LDAP" realm="MyLdapRealm" host="localhost" port="${ldap.1.port}" ignoreCase="true"
-        loginProperty="uid"
         bindDN="uid=admin,ou=users,o=ibm,c=us"
         bindPassword="s3cur1ty"
         baseDN="o=ibm,c=us"

--- a/dev/com.ibm.ws.security.javaeesec_fat/publish/files/globalClientCertNoFailOverSupport.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/publish/files/globalClientCertNoFailOverSupport.xml
@@ -13,7 +13,6 @@
     <ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore" trustStoreRef="defaultTrustStore" clientAuthenticationSupported="true" />
 
     <ldapRegistry id="LDAP" realm="MyLdapRealm" host="localhost" port="${ldap.1.port}" ignoreCase="true"
-        loginProperty="uid"
         bindDN="uid=admin,ou=users,o=ibm,c=us"
         bindPassword="s3cur1ty"
         baseDN="o=ibm,c=us"

--- a/dev/com.ibm.ws.security.javaeesec_fat/publish/servers/com.ibm.ws.security.javaeesec.clientcert.fat/server.xml
+++ b/dev/com.ibm.ws.security.javaeesec_fat/publish/servers/com.ibm.ws.security.javaeesec.clientcert.fat/server.xml
@@ -13,7 +13,6 @@
     <ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore" trustStoreRef="defaultTrustStore" clientAuthentication="true" />
 
     <ldapRegistry id="LDAP" realm="MyLdapRealm" host="localhost" port="${ldap.1.port}" ignoreCase="true"
-        loginProperty="uid"
         bindDN="uid=admin,ou=users,o=ibm,c=us"
         bindPassword="s3cur1ty"
         baseDN="o=ibm,c=us"

--- a/dev/com.ibm.ws.security.wim.adapter.file_fat/publish/files/dyanamicUpdate/ldap_and_custom_registry.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.file_fat/publish/files/dyanamicUpdate/ldap_and_custom_registry.xml
@@ -14,8 +14,8 @@
 	<ldapRegistry id="TDS_LDAP" realm="SampleLdapIDSRealm" host="${ldap.server.4.name}" port="${ldap.server.4.port}" ignoreCase="true"
 		baseDN="o=ibm,c=us"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m"
-		loginProperty="cn" >
+		searchTimeout="8m">
+		<loginProperty name = "cn"/>
 		<ldapEntityType name="PersonAccount">
 			<objectClass>inetOrgPerson</objectClass>
 			<rdnProperty name="cn" objectClass="inetOrgPerson"/>

--- a/dev/com.ibm.ws.security.wim.adapter.file_fat/publish/files/dyanamicUpdate/ldap_basic_custom_registry.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.file_fat/publish/files/dyanamicUpdate/ldap_basic_custom_registry.xml
@@ -32,8 +32,8 @@
 	<ldapRegistry id="TDS_LDAP" realm="SampleLdapIDSRealm" host="${ldap.server.4.name}" port="${ldap.server.4.port}" ignoreCase="true"
 		baseDN="o=ibm,c=us"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m"
-		loginProperty="cn" >
+		searchTimeout="8m">
+		<loginProperty name = "cn"/>
 		<ldapEntityType name="PersonAccount">
 			<objectClass>inetOrgPerson</objectClass>
 			<rdnProperty name="cn" objectClass="inetOrgPerson"/>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertComplexFilter.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertComplexFilter.xml
@@ -32,8 +32,8 @@
 		certificateMapMode="CERTIFICATE_FILTER"
 		certificateFilter="(&amp;(uid=${SubjectCN})(initials=${SubjectCN})(cn=${IssuerCN}))"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m"
-		loginProperty="cn">
+		searchTimeout="8m">
+		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertComplexFilter1.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertComplexFilter1.xml
@@ -32,8 +32,8 @@
 		certificateMapMode="CERTIFICATE_FILTER"
 		certificateFilter="(&amp;(uid=$[SubjectCN])(initials=$[SubjectCN])(cn=$[IssuerCN]))"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m"
-		loginProperty="cn">
+		searchTimeout="8m">
+		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertExactDN.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertExactDN.xml
@@ -31,8 +31,8 @@
 		baseDN="o=ibm,c=us"
 		certificateMapMode="EXACT_DN"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m"
-		loginProperty="cn">
+		searchTimeout="8m">
+		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertInvalidFilter.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertInvalidFilter.xml
@@ -32,8 +32,8 @@
 		certificateMapMode="CERTIFICATE_FILTER"
 		certificateFilter="cn=${invalid}"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m"
-		loginProperty="cn">
+		searchTimeout="8m">
+		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertInvalidFilter1.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertInvalidFilter1.xml
@@ -32,8 +32,8 @@
 		certificateMapMode="CERTIFICATE_FILTER"
 		certificateFilter="cn=${invalid]"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m"
-		loginProperty="cn">
+		searchTimeout="8m">
+		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertInvalidFilter2.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertInvalidFilter2.xml
@@ -32,8 +32,8 @@
 		certificateMapMode="CERTIFICATE_FILTER"
 		certificateFilter="cn=$[invalid}"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m"
-		loginProperty="cn">
+		searchTimeout="8m">
+		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertMultipleLDAP.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertMultipleLDAP.xml
@@ -32,8 +32,8 @@
 		certificateMapMode="CERTIFICATE_FILTER"
 		certificateFilter="uid=${SubjectCN}"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m"
-		loginProperty="cn">
+		searchTimeout="8m">
+		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
@@ -46,9 +46,9 @@
 		bindPassword="testuserpwd"
 		certificateMapMode="CERTIFICATE_FILTER"
 		certificateFilter="cn=${SubjectCN}"		
-		ldapType="Microsoft Active Directory"		
-		searchTimeout="8m"
-		loginProperty="cn">
+		ldapType="Microsoft Active Directory"
+		searchTimeout="8m">
+		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.6.name}" port="${ldap.server.6.port}"/>
         </failoverServers>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertNonMatchingFilter.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertNonMatchingFilter.xml
@@ -32,8 +32,8 @@
 		certificateMapMode="CERTIFICATE_FILTER"
 		certificateFilter="cn=${SubjectO}"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m"
-		loginProperty="cn">
+		searchTimeout="8m">
+		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientcert.server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientcert.server.xml
@@ -33,8 +33,8 @@
 		certificateMapMode="CERTIFICATE_FILTER"
 		certificateFilter="cn=${SubjectCN}"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m"
-		loginProperty="cn">
+		searchTimeout="8m">
+		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/dynamicUpdate/server_invalidSearchBase.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/dynamicUpdate/server_invalidSearchBase.xml
@@ -52,7 +52,6 @@
         <propertiesNotSupported name="homeAddress"/>
         <propertiesNotSupported name="businessAddress"/>
       </attributeConfiguration>
-      <loginProperty name="uid"/>
       <contextPool enabled="true" initialSize="1" maxSize="0" timeout="0ms"
           waitTime="3000ms" preferredSize="3"/>
       <ldapCache>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/dynamicUpdate/server_multipleSearchBase.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/dynamicUpdate/server_multipleSearchBase.xml
@@ -52,7 +52,6 @@
         <propertiesNotSupported name="homeAddress"/>
         <propertiesNotSupported name="businessAddress"/>
       </attributeConfiguration>
-      <loginProperty name="uid"/>
       <contextPool enabled="true" initialSize="1" maxSize="0" timeout="0ms"
           waitTime="3000ms" preferredSize="3"/>
       <ldapCache>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/dynamicUpdate/server_validSearchBase.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/dynamicUpdate/server_validSearchBase.xml
@@ -52,7 +52,6 @@
         <propertiesNotSupported name="homeAddress"/>
         <propertiesNotSupported name="businessAddress"/>
       </attributeConfiguration>
-      <loginProperty name="uid"/>
       <contextPool enabled="true" initialSize="1" maxSize="0" timeout="0ms"
           waitTime="3000ms" preferredSize="3"/>
       <ldapCache>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/fedclientCertComplexFilter.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/fedclientCertComplexFilter.xml
@@ -33,8 +33,8 @@
 		certificateMapMode="CERTIFICATE_FILTER"
 		certificateFilter="(&amp;(uid=${SubjectCN})(initials=${SubjectCN})(cn=${IssuerCN}))"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m"
-		loginProperty="cn">
+		searchTimeout="8m">
+		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/fedclientCertExactDN.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/fedclientCertExactDN.xml
@@ -32,8 +32,8 @@
 		baseDN="o=ibm,c=us"
 		certificateMapMode="EXACT_DN"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m"
-		loginProperty="cn">
+		searchTimeout="8m">
+		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/fedclientCertInvalidFilter.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/fedclientCertInvalidFilter.xml
@@ -33,8 +33,8 @@
 		certificateMapMode="CERTIFICATE_FILTER"
 		certificateFilter="cn=${invalid}"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m"
-		loginProperty="cn">
+		searchTimeout="8m">
+		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/fedclientCertNonMatchingFilter.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/fedclientCertNonMatchingFilter.xml
@@ -33,8 +33,8 @@
 		certificateMapMode="CERTIFICATE_FILTER"
 		certificateFilter="cn=${SubjectO}"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m"
-		loginProperty="cn">
+		searchTimeout="8m">
+		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/fedclientcert.server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/fedclientcert.server.xml
@@ -34,8 +34,8 @@
 		certificateMapMode="CERTIFICATE_FILTER"
 		certificateFilter="cn=${SubjectCN}"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m"
-		loginProperty="cn">
+		searchTimeout="8m">
+		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.certlogin/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.certlogin/server.xml
@@ -32,8 +32,8 @@
 		certificateMapMode="CERTIFICATE_FILTER"
 		certificateFilter="cn=${SubjectCN}"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m"
-		loginProperty="cn">
+		searchTimeout="8m">
+		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
         </failoverServers>	

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.certlogin_SBInFilter/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.certlogin_SBInFilter/server.xml
@@ -32,8 +32,8 @@
 		certificateMapMode="CERTIFICATE_FILTER"
 		certificateFilter="cn=$[SubjectCN]"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m"
-		loginProperty="cn">
+		searchTimeout="8m">
+		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
         </failoverServers>	

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.fedcertlogin/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.fedcertlogin/server.xml
@@ -32,8 +32,8 @@
 		certificateMapMode="CERTIFICATE_FILTER"
 		certificateFilter="cn=${SubjectCN}"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m"
-		loginProperty="cn">
+		searchTimeout="8m">
+		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
         </failoverServers>	

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.propertynotsupported/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.propertynotsupported/server.xml
@@ -21,8 +21,7 @@
 	<ldapRegistry id="LDAP" realm="SampleLdapIDSRealm" host="${ldap.server.1.name}" port="${ldap.server.1.port}" ignoreCase="true"
 		baseDN="o=ibm,c=us"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m"
-		loginProperty="uid">
+		searchTimeout="8m">
       <attributeConfiguration>
         <propertiesNotSupported name="cn"/>
       </attributeConfiguration>


### PR DESCRIPTION
Update LDAP FATs to use the new loginProperty syntax. Remove loginProperty if uid (default) to keep config minimal.