### PR TITLE
Remove comment with link to Narayana code

### DIFF
--- a/dev/com.ibm.ws.io.smallrye.graphql/src/io/smallrye/graphql/servlet/IndexInitializer.java
+++ b/dev/com.ibm.ws.io.smallrye.graphql/src/io/smallrye/graphql/servlet/IndexInitializer.java
@@ -30,8 +30,6 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 /**
  * This creates an index from the classpath.
- * Based on similar class in LRA
- * (https://github.com/jbosstm/narayana/blob/master/rts/lra/lra-proxy/api/src/main/java/io/narayana/lra/client/internal/proxy/nonjaxrs/ClassPathIndexer.java)
  * 
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */


### PR DESCRIPTION
Removing a confusing comment with a link to Narayana code.

Since this is only removing a comment, I don't want to waste build machine cycles on a personal build, so I plan to merge as soon as this has been reviewed/approved.