### PR TITLE
Issue 14925: OAuth subject lookup fix

### DIFF
--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/common/claims/UserClaimsRetriever.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/common/claims/UserClaimsRetriever.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -48,14 +48,17 @@ public class UserClaimsRetriever {
     /**
      * @param username
      * @param groupIdentifier
+     * @param cacheKey
      * @return a Map containing the user's claims
      * @throws WSSecurityException
      */
-    public UserClaims getUserClaims(String username, String groupIdentifier) throws WSSecurityException {
+    public UserClaims getUserClaims(String username, String groupIdentifier, String cacheKey) throws WSSecurityException {
         UserClaims userClaims = new UserClaims(username, groupIdentifier);
         String realmName = userRegistry.getRealm();
 
-        String cacheKey = getCacheKey(realmName, username);
+        if (cacheKey == null) {
+            cacheKey = getCacheKey(realmName, username);
+        }
         Subject subject = authCacheService.getSubject(cacheKey);
         if (subject == null) { // If we can not find the user from cache, we get it from RunAsSubject
             subject = WSSubject.getRunAsSubject();

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/common/claims/UserClaimsRetrieverService.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/common/claims/UserClaimsRetrieverService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -71,11 +71,15 @@ public class UserClaimsRetrieverService {
         ConfigUtils.setUserClaimsRetrieverService(null);
     }
 
-    @FFDCIgnore(Exception.class)
     public UserClaims getUserClaims(String username, String groupIdentifier) {
+        return getUserClaims(username, groupIdentifier, null);
+    }
+
+    @FFDCIgnore(Exception.class)
+    public UserClaims getUserClaims(String username, String groupIdentifier, String cacheKey) {
         try {
             UserClaimsRetriever userClaimsRetriever = getUserClaimsRetriever();
-            return userClaimsRetriever.getUserClaims(username, groupIdentifier);
+            return userClaimsRetriever.getUserClaims(username, groupIdentifier, cacheKey);
         } catch (Exception e) {
             // TODO: Use static empty user claims
             return new UserClaims((String) null, groupIdentifier);

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/internal/OAuth20AuthenticatorImpl.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/internal/OAuth20AuthenticatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -209,7 +209,7 @@ public class OAuth20AuthenticatorImpl implements OAuth20Authenticator {
         String user_name = token.getUser();
         UserClaimsRetrieverService ucrService = ConfigUtils.getUserClaimsRetrieverService();
         if (ucrService != null) {
-            UserClaims userClaims = ucrService.getUserClaims(user_name, DEFAULT_GROUP_IDENTIFIER);
+            UserClaims userClaims = ucrService.getUserClaims(user_name, DEFAULT_GROUP_IDENTIFIER, cacheKey);
             if (userClaims != null) {
                 Map<String, Object> claimsMap = userClaims.asMap();
                 List<String> groups = (List<String>) claimsMap.get(DEFAULT_GROUP_IDENTIFIER);

--- a/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/common/claims/UserClaimsRetrieverTest.java
+++ b/dev/com.ibm.ws.security.oauth/test/com/ibm/ws/security/common/claims/UserClaimsRetrieverTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2019 IBM Corporation and others.
+ * Copyright (c) 2013, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -70,7 +70,7 @@ public class UserClaimsRetrieverTest {
         setExpecationsForCachedSubjectPath(user1Realm, user1, "group1", "group2");
         UserClaimsRetriever userClaimsRetriever = new UserClaimsRetriever(authCache, userRegistry);
 
-        UserClaims userClaims = userClaimsRetriever.getUserClaims(user1, groupIdentifier);
+        UserClaims userClaims = userClaimsRetriever.getUserClaims(user1, groupIdentifier, null);
 
         assertUser1Claims(userClaims);
         assertUserClaimsInMap(userClaims.asMap(), user1Realm, user1, expectedGroupsForUser1);
@@ -97,7 +97,7 @@ public class UserClaimsRetrieverTest {
         setExpecationsForCachedSubjectPath(user2Realm, user2, "group3");
         UserClaimsRetriever userClaimsRetriever = new UserClaimsRetriever(authCache, userRegistry);
 
-        UserClaims userClaims = userClaimsRetriever.getUserClaims(user2, groupIdentifier);
+        UserClaims userClaims = userClaimsRetriever.getUserClaims(user2, groupIdentifier, null);
 
         assertUserClaims(userClaims, user2Realm, user2, expectedGroupsForUser2);
     }
@@ -107,7 +107,7 @@ public class UserClaimsRetrieverTest {
         setExpecationsForCachedSubjectPath(user1Realm, user1);
         UserClaimsRetriever userClaimsRetriever = new UserClaimsRetriever(authCache, userRegistry);
 
-        UserClaims userClaims = userClaimsRetriever.getUserClaims(user1, groupIdentifier);
+        UserClaims userClaims = userClaimsRetriever.getUserClaims(user1, groupIdentifier, null);
 
         assertNull("There must not be groups for the user.", userClaims.getGroups());
     }
@@ -119,7 +119,7 @@ public class UserClaimsRetrieverTest {
         noAuthCacheSubjectExpected();
         UserClaimsRetriever userClaimsRetriever = new UserClaimsRetriever(authCache, userRegistry);
 
-        UserClaims userClaims = userClaimsRetriever.getUserClaims(user1, groupIdentifier);
+        UserClaims userClaims = userClaimsRetriever.getUserClaims(user1, groupIdentifier, null);
 
         assertUser1Claims(userClaims);
     }


### PR DESCRIPTION
Resolves #14925

Updates the user claims retrieval logic for when an OAuth access token is provided in a request. The cache key for the provided token is used to look up Subject information from the authentication cache.