### PR TITLE
Issue #14931: Fix EJB Handle in App Client

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.enterpriseBeansRemoteClient-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.enterpriseBeansRemoteClient-2.0.feature
@@ -1,7 +1,8 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.enterpriseBeansRemoteClient-2.0
 visibility=private
-IBM-API-Package: com.ibm.websphere.ejbcontainer; type="internal"
+IBM-API-Package: com.ibm.websphere.ejbcontainer; type="internal", \
+ com.ibm.ws.ejb.portable; type="internal"
 -features=io.openliberty.jakartaeePlatform-9.0, \
  io.openliberty.ejbCore-2.0, \
  io.openliberty.jakarta.ejb-4.0, \

--- a/dev/com.ibm.ws.ejbcontainer.remote.client_fat/fat/src/com/ibm/ws/ejbcontainer/remote/client/fat/tests/EjbLinkTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote.client_fat/fat/src/com/ibm/ws/ejbcontainer/remote/client/fat/tests/EjbLinkTest.java
@@ -121,7 +121,9 @@ public class EjbLinkTest extends FATServletClient {
         // then allow the @Startup InitTxRecoveryLog bean to start.
         ShrinkHelper.exportDropinAppToServer(server, InitTxRecoveryLogApp, DeployOptions.SERVER_ONLY);
 
-        client.addIgnoreErrors("CWWKC0105W");
+        // CWNEN1001E - testStyle1BeanInJarAndWarFromClient; ambiguous, cannot lookup
+        // CWNEN0030E - testStyle1BeanInJarAndWarFromClient; ambiguous, cannot lookup
+        client.addIgnoreErrors("CWWKC0105W", "CWNEN1001E", "CWNEN0030E");
         client.startClient();
     }
 
@@ -426,6 +428,86 @@ public class EjbLinkTest extends FATServletClient {
 
     @Test
     public void findBeanFromWar2Jar() throws Exception {
+        check();
+    }
+
+    @Test
+    public void testStyle1OtherJarXMLFromClient() throws Exception {
+        check();
+    }
+
+    @Test
+    public void testStyle2OtherJarXMLFromClient() throws Exception {
+        check();
+    }
+
+    @Test
+    public void testStyle3OtherJarXMLFromClient() throws Exception {
+        check();
+    }
+
+    @Test
+    public void testStyle1OtherJarAnnFromClient() throws Exception {
+        check();
+    }
+
+    @Test
+    public void testStyle2OtherJarAnnFromClient() throws Exception {
+        check();
+    }
+
+    @Test
+    public void testStyle3OtherJarAnnFromClient() throws Exception {
+        check();
+    }
+
+    @Test
+    public void testStyle1OtherWarXMLFromClient() throws Exception {
+        check();
+    }
+
+    @Test
+    public void testStyle2OtherWarXMLFromClient() throws Exception {
+        check();
+    }
+
+    @Test
+    public void testStyle3OtherWarXMLFromClient() throws Exception {
+        check();
+    }
+
+    @Test
+    public void testStyle1OtherWarAnnFromClient() throws Exception {
+        check();
+    }
+
+    @Test
+    public void testStyle2OtherWarAnnFromClient() throws Exception {
+        check();
+    }
+
+    @Test
+    public void testStyle3OtherWarAnnFromClient() throws Exception {
+        check();
+    }
+
+    @Test
+    public void testStyle1BeanInJarAndWarFromClient() throws Exception {
+        check();
+    }
+
+    @Test
+    public void findBeanFromClientInJar() throws Exception {
+        check();
+    }
+
+    @Test
+    public void findBeanFromClientInWar() throws Exception {
+        check();
+    }
+
+    @Test
+    public void find2xBeanFromClientInJar() throws Exception {
         check();
     }
 

--- a/dev/com.ibm.ws.ejbcontainer.remote.client_fat/test-applications/EjbLinkBean.jar/src/com/ibm/ws/ejbcontainer/ejblink/ejb/ComponentBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote.client_fat/test-applications/EjbLinkBean.jar/src/com/ibm/ws/ejbcontainer/ejblink/ejb/ComponentBean.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.ejblink.ejb;
+
+import javax.ejb.RemoteHome;
+import javax.ejb.Stateless;
+
+@Stateless
+@RemoteHome(ComponentRemoteHome.class)
+public class ComponentBean {
+    private static final String CLASS_NAME = ComponentBean.class.getName();
+
+    /**
+     * Verify AutoLinked EJB is the expected bean
+     **/
+    public String getBeanName() {
+        return CLASS_NAME;
+    }
+}

--- a/dev/com.ibm.ws.ejbcontainer.remote.client_fat/test-applications/EjbLinkBean.jar/src/com/ibm/ws/ejbcontainer/ejblink/ejb/ComponentRemote.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote.client_fat/test-applications/EjbLinkBean.jar/src/com/ibm/ws/ejbcontainer/ejblink/ejb/ComponentRemote.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.ejblink.ejb;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.EJBObject;
+
+public interface ComponentRemote extends EJBObject {
+    /**
+     * Verify AutoLinked EJB is the expected bean
+     **/
+    public String getBeanName() throws RemoteException;
+}

--- a/dev/com.ibm.ws.ejbcontainer.remote.client_fat/test-applications/EjbLinkBean.jar/src/com/ibm/ws/ejbcontainer/ejblink/ejb/ComponentRemoteHome.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote.client_fat/test-applications/EjbLinkBean.jar/src/com/ibm/ws/ejbcontainer/ejblink/ejb/ComponentRemoteHome.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.ejblink.ejb;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.CreateException;
+import javax.ejb.EJBHome;
+
+public interface ComponentRemoteHome extends EJBHome {
+    ComponentRemote create() throws CreateException, RemoteException;
+}

--- a/dev/com.ibm.ws.ejbcontainer.remote.client_fat/test-applications/EjbLinkClient.jar/resources/META-INF/application-client.xml
+++ b/dev/com.ibm.ws.ejbcontainer.remote.client_fat/test-applications/EjbLinkClient.jar/resources/META-INF/application-client.xml
@@ -1,6 +1,84 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE application-client PUBLIC "-//Sun Microsystems, Inc.//DTD J2EE Application Client 1.2//EN"  "http://java.sun.com/j2ee/dtds/application-client_1_2.dtd">
-   <application-client id="Application-client_ID">
-      <display-name>EjbLinkClient</display-name>
-     
-   </application-client>
+<application-client id="Application-client_ID">
+   <display-name>EjbLinkClient</display-name>
+
+   <ejb-ref>
+      <ejb-ref-name>ejb/OtherJarStyle1</ejb-ref-name>
+      <ejb-ref-type>Session</ejb-ref-type>
+      <remote>com.ibm.ws.ejbcontainer.ejblink.ejb.EjbLinkRemote</remote>
+      <ejb-link>OtherJarBean</ejb-link>
+   </ejb-ref>
+
+   <ejb-ref>
+      <ejb-ref-name>ejb/OtherJarStyle2</ejb-ref-name>
+      <ejb-ref-type>Session</ejb-ref-type>
+      <remote>com.ibm.ws.ejbcontainer.ejblink.ejb.EjbLinkRemote</remote>
+      <ejb-link>../EjbLinkOtherBean.jar#OtherJarBean</ejb-link>
+   </ejb-ref>
+
+   <ejb-ref>
+      <ejb-ref-name>ejb/OtherJarStyle3</ejb-ref-name>
+      <ejb-ref-type>Session</ejb-ref-type>
+      <remote>com.ibm.ws.ejbcontainer.ejblink.ejb.EjbLinkRemote</remote>
+      <ejb-link>logicalOther/OtherJarBean</ejb-link>
+   </ejb-ref>
+
+   <ejb-ref>
+      <ejb-ref-name>ejb/WarStyle1</ejb-ref-name>
+      <remote>com.ibm.ws.ejbcontainer.ejblink.ejb.EjbLinkRemote</remote>
+      <ejb-link>OtherWarBean</ejb-link>
+   </ejb-ref>
+
+   <ejb-ref>
+      <ejb-ref-name>ejb/WarStyle2</ejb-ref-name>
+      <remote>com.ibm.ws.ejbcontainer.ejblink.ejb.EjbLinkRemote</remote>
+      <ejb-link>../EjbLinkInOtherWar.war#OtherWarBean</ejb-link>
+   </ejb-ref>
+
+   <ejb-ref>
+      <ejb-ref-name>ejb/WarStyle3</ejb-ref-name>
+      <remote>com.ibm.ws.ejbcontainer.ejblink.ejb.EjbLinkRemote</remote>
+      <ejb-link>logicalOtherWar/OtherWarBean</ejb-link>
+   </ejb-ref>
+
+   <ejb-ref>
+      <ejb-ref-name>ejb/OtherWarStyle1</ejb-ref-name>
+      <ejb-ref-type>Session</ejb-ref-type>
+      <remote>com.ibm.ws.ejbcontainer.ejblink.ejb.EjbLinkRemote</remote>
+      <ejb-link>OtherWarBean</ejb-link>
+   </ejb-ref>
+
+   <ejb-ref>
+      <ejb-ref-name>ejb/OtherWarStyle2</ejb-ref-name>
+      <ejb-ref-type>Session</ejb-ref-type>
+      <remote>com.ibm.ws.ejbcontainer.ejblink.ejb.EjbLinkRemote</remote>
+      <ejb-link>../EjbLinkInOtherWar.war#OtherWarBean</ejb-link>
+   </ejb-ref>
+
+   <ejb-ref>
+      <ejb-ref-name>ejb/OtherWarStyle3</ejb-ref-name>
+      <ejb-ref-type>Session</ejb-ref-type>
+      <remote>com.ibm.ws.ejbcontainer.ejblink.ejb.EjbLinkRemote</remote>
+      <ejb-link>logicalOtherWar/OtherWarBean</ejb-link>
+   </ejb-ref>
+
+   <ejb-ref>
+      <ejb-ref-name>ejb/JarStyle1</ejb-ref-name>
+      <remote>com.ibm.ws.ejbcontainer.ejblink.ejb.EjbLinkRemote</remote>
+      <ejb-link>OtherJarBean</ejb-link>
+   </ejb-ref>
+
+   <ejb-ref>
+      <ejb-ref-name>ejb/JarStyle2</ejb-ref-name>
+      <remote>com.ibm.ws.ejbcontainer.ejblink.ejb.EjbLinkRemote</remote>
+      <ejb-link>../EjbLinkOtherBean.jar#OtherJarBean</ejb-link>
+   </ejb-ref>
+
+   <ejb-ref>
+      <ejb-ref-name>ejb/JarStyle3</ejb-ref-name>
+      <remote>com.ibm.ws.ejbcontainer.ejblink.ejb.EjbLinkRemote</remote>
+      <ejb-link>logicalOther/OtherJarBean</ejb-link>
+   </ejb-ref>
+
+</application-client>


### PR DESCRIPTION
Jakarta EE 9 App Client is currently failing if an EJB Handle
is returned to the client with a class not found for
com.ibm.ws.ejb.portable.HandleImpl, the liberty implementation.

Fixed by exposing as internal API like it was for Java EE Clients,
but did that in ejbRemoteClient feature instead of Jakarta EE Client
as was done for older levels.

Also, added FAT tests that covered this scenario, as well as other
scenarios that test ejb-ref resolution in the application client
using ejb-link/beanName and auto-link.

fixes #14931 