### PR TITLE
Disable osgi.checkConfiguration by default

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkConfigurator.java
+++ b/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkConfigurator.java
@@ -95,11 +95,10 @@ public class FrameworkConfigurator {
         // equinox to do that.
         config.put("osgi.framework.activeThreadType", "none");
 
-        // Use an equinox property to ensure that equinox checks whether or not
-        // the jar files we're installing (for file:// URLs) have changed if
-        // osgi is not starting clean. If the bundle jar has changed, associated
-        // cached data is tossed.
-        config.putIfAbsent("osgi.checkConfiguration", "true");
+        // No longer check timestamps of JARs from Equinox
+        // on restart.  It is assumed any new Liberty bundles
+        // will use a different location on disk
+        config.putIfAbsent("osgi.checkConfiguration", "false");
 
         // We do not want Bundle-ActivationPolicy: lazy to cause bundle
         // resolution to automatically start bundles.


### PR DESCRIPTION
When enabled this setting cause Equinox
to check the timestamp of every bundle JAR
installed and it uninstall anything that
has changed since last start.

The framework then causes a refresh of the
uninstalled bundles.  In some cases this
will cause other bundles to re-resolve
which ends up resolving before the
region digraph has been registered with
the framework.  This means the bundles
will be resolved without the issolation
which the Feature Manager establishes.

It appears in some cloud environments and
container images false timestamp reporting
is happening which incorrectly causes some
kernel bundles to be tossed.  To avoid
this the osgi.checkConfiguration option
is disabled.

