### PR TITLE
Fix mpConfig-2.0 FAT TCKs

### DIFF
--- a/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -43,7 +43,17 @@
                 <scope>import</scope>
             </dependency>
         </dependencies>
-    </dependencyManagement>
+    </dependencyManagement> 
+    
+	<repositories>
+		<!-- This TCK is currently using a custom built artifact- microprofile-config-tck:2.0-ibm20201020.
+		If Artifactory is unavailable, the following DHE repository will be searched for the artifact -->
+		<repository>
+			<name>IBM DHE Maven repository</name>
+			<id>DHE</id>
+			<url>http://public.dhe.ibm.com/ibmdl/export/pub/software/olrepo</url>
+		</repository>
+	</repositories>
 
     <dependencies>
 
@@ -58,7 +68,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-tck</artifactId>
-            <version>2.0-ibm20201020</version> <!--2.0-SNAPSHOT-->
+            <version>2.0-ibm20201020</version> 
         </dependency>
 
         <dependency>

--- a/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -11,43 +11,11 @@
 <suite name="microprofile-config-2.0-tck" verbose="2"
     configfailurepolicy="continue">
     <test name="tck-package-org.eclipse.microprofile.config20.tck">
-        <!-- <classes>
-            <class name="org.eclipse.microprofile.config.tck.PropertyExpressionsTest"/>
-        </classes>-->
         <method-selectors>
             <method-selector>
                 <script language="beanshell">
                      <![CDATA[
-                     !method.getName().equals("escape")
-                     !method.getName().equals("noExpressionComposed")
-                     !method.getName().equals("multipleExpansions")
-                     !method.getName().equals("infiniteExpansion")
-                     !method.getName().equals("composedExpressions")
-                     !method.getName().equals("defaultExpressionEmpty")
-                     !method.getName().equals("defaultExpressionComposedEmpty")
-                     !method.getName().equals("simpleExpression")
-                     !method.getName().equals("expressionMissing")
-                     !method.getName().equals("arrayEscapes")
-                     !method.getName().equals("defaultExpressionComposed")
-                     !method.getName().equals("noExpression")
-                     !method.getName().equals("escapeBraces")
-                     !method.getName().equals("multipleExpressions")
-                     !method.getName().equals("defaultExpression")
                      !method.getName().equals("testInjectedConfigSerializable")
-                     !method.getName().equals("testConfigProfileWithDev")
-                     !method.getName().equals("testConfigPropertiesDefaultOnBean")
-                     !method.getName().equals("testConfigPropertiesNoPrefixOnBean")
-                     !method.getName().equals("testConfigPropertiesWithPrefix")
-                     !method.getName().equals("testNoConfigPropertiesAnnotationInjection")
-                     !method.getName().equals("testConfigPropertiesWithoutPrefix")
-                     !method.getName().equals("testConfigPropertiesPlainInjection")
-                     !method.getName().equals("testConfigPropertiesNoPrefixOnBeanThenSupplyPrefix")
-                     !method.getName().equals("expression")
-                     !method.getName().equals("expressionNoDefault")
-                     !method.getName().equals("configValueInjection")
-                     !method.getName().equals("configValue")
-                     !method.getName().equals("configValueEmpty")
-                     !method.getName().equals("test")
                 ]]>
                 </script>    
             </method-selector>


### PR DESCRIPTION
Should resolve #14915 

We need to observe the #build to see if `microprofile-config-tck:2.0-ibm20201020` downloads from DHE or Artifactory. Hopefully the latter.

This PR also includes a fix to ensure all appropriate TCKs run.
