### PR TITLE
Wait for configuration update in testEventLoggingLogModeUpdate2

### DIFF
--- a/dev/com.ibm.ws.event.logging_fat/fat/src/com/ibm/ws/event/logging/FATTest.java
+++ b/dev/com.ibm.ws.event.logging_fat/fat/src/com/ibm/ws/event/logging/FATTest.java
@@ -681,7 +681,7 @@ public class FATTest {
     @Test
     public void testEventLoggingLogModeUpdate2() throws Exception {
         server.setServerConfigurationFile("server_logModeExit.xml");
-        assertNotNull(server.waitForStringInLog("CWWKG0017I", 90000));
+        assertNotNull(server.waitForStringInLog("CWWKG0017I|CWWKG0018I", 90000));
         Log.info(c, "testEventLoggingLogModeUpdate2", "--------> Started server with logMode = Exit");
 
         Log.info(c, "testEventLoggingLogModeUpdate2", "Calling jdbcTestPrj_1 Application with URL=" + url.toString());

--- a/dev/com.ibm.ws.event.logging_fat/fat/src/com/ibm/ws/event/logging/FATTest.java
+++ b/dev/com.ibm.ws.event.logging_fat/fat/src/com/ibm/ws/event/logging/FATTest.java
@@ -12,6 +12,7 @@
 package com.ibm.ws.event.logging;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -680,6 +681,7 @@ public class FATTest {
     @Test
     public void testEventLoggingLogModeUpdate2() throws Exception {
         server.setServerConfigurationFile("server_logModeExit.xml");
+        assertNotNull(server.waitForStringInLog("CWWKG0017I", 90000));
         Log.info(c, "testEventLoggingLogModeUpdate2", "--------> Started server with logMode = Exit");
 
         Log.info(c, "testEventLoggingLogModeUpdate2", "Calling jdbcTestPrj_1 Application with URL=" + url.toString());


### PR DESCRIPTION
Fixes #14784 
Test fails when ran in different order. BEGIN logs are read from log before server configuration is updated.