### PR TITLE
Add capability to map sqlCodes and sqlStates to stale connections

### DIFF
--- a/.github/workflows/openliberty-ci.yml
+++ b/.github/workflows/openliberty-ci.yml
@@ -22,6 +22,7 @@ env:
 jobs:
   build:
     name: Build Open Liberty
+    if: "github.event.pull_request.draft == false"
     runs-on: ubuntu-latest
     outputs:
       test-matrix: ${{ steps.gen-params.outputs.test-matrix }}
@@ -92,6 +93,7 @@ jobs:
         path: openliberty-image.zip
   unit_tests:
     name: Unit Tests
+    if: "github.event.pull_request.draft == false"
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/l10n/metatype.properties
@@ -106,6 +106,17 @@ isoLevel.SERIALIZABLE.desc=Dirty reads, non-repeatable reads and phantom reads a
 isoLevel.SNAPSHOT.desc=Snapshot isolation for Microsoft SQL Server JDBC Driver and DataDirect Connect for JDBC driver.
 isoLevel.NONE.desc=Indicates that the JDBC driver does not support transactions.
 
+# Map Error
+mapError=Map error
+mapError.desc=Map a specific sqlCode or sqlState to an action such as a stale connection.
+
+mapError.sqlState=SQL State
+mapError.sqlState.desc=A string that follows either the XOPEN SQLstate conventions or the SQL:2003 conventions. Mutually exclusive with the sqlCode attribute.
+mapError.sqlCode=SQL Code
+mapError.sqlCode.desc=An integer error code specific to the backend database. Normally this will be the actual error code returned by the underlying database. Mutually exclusive with the sqlState attribute.
+mapError.to=Map error to
+mapError.to.desc=The target mapping for the sqlCode or sqlState. Allowed values are: NONE (removes a mapping), or STALE_CONNECTION (connections that are determined to be stale will be evicted from the connection pool once closed)
+
 onConnect=On connect
 onConnect.desc=SQL command to execute once on each new connection that is established to the database. The SQL statement applies only to newly created connections, not to existing connections that are reused from the connection pool. If updated while the server is running, existing connections are destroyed.
 

--- a/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/metatype/metatype.xml
@@ -43,7 +43,7 @@
   <AD id="connectionManagerRef"               name="%conMgrRef"    description="%conMgrRef.desc"    required="false" type="String"  cardinality="1" ibm:type="pid" ibm:reference="com.ibm.ws.jca.connectionManager"/>
   <AD id="connectionManager.target"           name="internal"      description="internal use only"  required="false" type="String"  ibm:final="true" default="(service.pid=${connectionManagerRef})"/>
   <AD id="connectionManager.cardinality.minimum" name="internal"   description="internal use only"  type="String" ibm:final="true" default="${count(connectionManagerRef)}"/>
-  <AD id="properties"                      name="internal"      description="internal use only"  required="false" type="String"  cardinality="1" ibm:type="pid" ibm:reference="com.ibm.ws.jdbc.dataSource.properties.supertype" ibm:flat="true"/>
+  <AD id="properties"                      name="internal"      description="internal use only"  required="false" type="String"  cardinality="1"    ibm:type="pid" ibm:reference="com.ibm.ws.jdbc.dataSource.properties.supertype" ibm:flat="true"/>
   <AD id="type"                               name="%type"         description="%type.desc"         required="false" type="String">
    <Option value="javax.sql.XADataSource"             label="javax.sql.XADataSource"/>
    <Option value="javax.sql.ConnectionPoolDataSource" label="javax.sql.ConnectionPoolDataSource"/>
@@ -80,6 +80,7 @@
   </AD>
   <AD id="enableBeginEndRequest"                  name="internal"      description="internal use only"  ibmui:group="Advanced" required="false" type="Boolean"/>
   <AD id="enableConnectionCasting"                name="%enblConCast"  description="%enblConCast.desc"  ibmui:group="Advanced" type="Boolean" default="false"/>
+  <AD id="mapError"                               name="internal"      description="internal use only"  ibmui:group="Advanced" required="false" type="String"  cardinality="1000" ibm:type="pid" ibm:reference="com.ibm.ws.jdbc.dataSource.mapError" ibm:flat="true"/>
   <AD id="onConnect"                              name="%onConnect"    description="%onConnect.desc"    ibmui:group="Advanced" required="false" type="String"  cardinality="1000"/>
   <AD id="queryTimeout"                           name="%qryTimeout"   description="%qryTimeout.desc"   ibmui:group="Advanced" required="false" type="String"  ibm:type="duration(s)"/>
   <AD id="recoveryAuthDataRef"                    name="%recoveryAuth" description="%recoveryAuth.desc" ibmui:group="Advanced" required="false" type="String"  cardinality="1" ibm:type="pid" ibm:reference="com.ibm.ws.security.jca.internal.authdata.config"/>
@@ -91,6 +92,16 @@
   <AD id="validationTimeout"                      name="%valTimeout"   description="%valTimeout.desc"   ibmui:group="Advanced" required="false" type="String"  ibm:type="duration(s)"/>  
  </OCD>
 
+ <Designate factoryPid="com.ibm.ws.jdbc.dataSource.mapError">
+  <Object ocdref="com.ibm.ws.jdbc.dataSource.mapError"/>
+ </Designate>
+
+ <OCD id="com.ibm.ws.jdbc.dataSource.mapError" ibm:alias="mapError" name="%mapError" description="%mapError.desc" ibmui:localization="OSGI-INF/l10n/metatype">
+  <AD id="sqlState"  required="false" type="String"  name="%mapError.sqlState" description="%mapError.sqlState.desc"/>
+  <AD id="sqlCode"   required="false" type="Integer" name="%mapError.sqlCode"  description="%mapError.sqlCode.desc"/>
+  <AD id="to"        required="true"  type="String"  name="%mapError.to"       description="%mapError.to.desc"/>
+ </OCD>
+ 
  <!-- Super type for all vendor properties lists -->
  <Designate factoryPid="com.ibm.ws.jdbc.dataSource.properties.supertype">
   <Object ocdref="com.ibm.ws.jdbc.dataSource.properties.supertype"/>

--- a/dev/com.ibm.ws.jdbc/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc/bnd.bnd
@@ -111,6 +111,7 @@ instrument.disabled: true
 	com.ibm.ws.tx.embeddable;version=latest,\
 	com.ibm.tx.jta;version=latest,\
 	com.ibm.ws.jca.cm;version=latest,\
+	com.ibm.ws.jdbc.metatype;version=latest,\
 	com.ibm.ws.resource;version=latest,\
 	com.ibm.ws.classloading;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\

--- a/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
+++ b/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
@@ -366,6 +366,20 @@ PROP_SET_ERROR.useraction=Verify that the value that is specified is valid for t
 # 8060 deleted
 # 8065 deleted
 
+# 8066E
+# {0}         The invalid attribute value
+# {1}         The allowed attribute values
+# Do not translate: mapError
+8066E_MAP_ERROR_INVALID_TARGET=DSRA8066E: Invalid value ''{0}'' specified for the mapError ''to'' attribute. Allowed values are: {1}
+8066E_MAP_ERROR_INVALID_TARGET.explanation=An unknown value was specified for the mapError configuration element.
+8066E_MAP_ERROR_INVALID_TARGET.useraction=Update the configuration to specify one of the allowed values.
+
+# 8067E
+# Do not translate: sqlCode, sqlState, mapError
+8067E_MAP_ERROR_SQLCODE_SQLSTATE=DSRA8067E: Must specify exactly one of the ''sqlCode'' or ''sqlState'' attributes on the mapError element.
+8067E_MAP_ERROR_SQLCODE_SQLSTATE.explanation=The sqlCode and sqlState attributes are mutually exclusive, and one of the attributes must be specified.
+8067E_MAP_ERROR_SQLCODE_SQLSTATE.useraction=Update the configuration to specify exactly one of the sqlCode or sqlState attributes.
+
 # 8100E      JAVAX_CONN_ERR
 # 
 # {0}        Type of Connection: XAConnection or PooledConnection.

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/DSConfig.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/DSConfig.java
@@ -12,6 +12,7 @@ package com.ibm.ws.rsadapter;
 
 import java.sql.SQLException; 
 import java.sql.SQLNonTransientException;
+import java.util.ArrayList;
 import java.util.Arrays; 
 import java.util.Collections;
 import java.util.List; 
@@ -20,9 +21,12 @@ import java.util.NavigableMap;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
+import javax.resource.spi.IllegalStateException;
+
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.ffdc.FFDCSelfIntrospectable; 
+import com.ibm.ws.ffdc.FFDCSelfIntrospectable;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.jca.cm.ConnectorService;
 import com.ibm.ws.jdbc.internal.DataSourceDef;
 import com.ibm.ws.jdbc.internal.PropertyService;
@@ -35,6 +39,52 @@ import com.ibm.wsspi.resource.ResourceFactory;
  */
 public class DSConfig implements FFDCSelfIntrospectable {
     private static final TraceComponent tc = Tr.register(DSConfig.class, AdapterUtil.TRACE_GROUP, AdapterUtil.NLS_FILE);
+    
+    public static class MapError {
+        
+        public static enum Target {
+            NONE,
+            STALE_CONNECTION
+        }
+        
+        public Integer sqlCode;
+        public String sqlState;
+        public Target to;
+        
+        @FFDCIgnore(IllegalArgumentException.class)
+        public void setProperty(String name, Object value) {
+            if ("sqlCode".equals(name)) {
+                sqlCode = (Integer) value;
+            } else if ("sqlState".equals(name)) {
+                sqlState = (String) value;
+            } else if ("to".equals(name)) {
+                try {
+                    to = Target.valueOf((String) value);
+                } catch (IllegalArgumentException e) {
+                    Tr.error(tc, "8066E_MAP_ERROR_INVALID_TARGET", value, Arrays.toString(Target.values()));
+                    throw e;
+                }
+            }
+        }
+        
+        public void validate() {
+            if ((sqlCode != null && sqlState != null) ||
+                (sqlCode == null && sqlState == null)) {
+                Tr.error(tc, "8067E_MAP_ERROR_SQLCODE_SQLSTATE");
+                throw new IllegalArgumentException(AdapterUtil.getNLSMessage("8067E_MAP_ERROR_SQLCODE_SQLSTATE"));
+            }
+            // do not need to validate the 'to' attribute because it is marked required in metatype so it will be enforced in config layer
+        }
+        
+        @Override
+        public String toString() {
+            return new StringBuilder(super.toString())
+                            .append("{ sqlCode=").append(sqlCode)
+                            .append(", sqlState=").append(sqlState)
+                            .append(", to=" + to).append(" }")
+                            .toString();
+        }
+    }
 
     // WebSphere data source property names and values
     public static final String
@@ -48,6 +98,7 @@ public class DSConfig implements FFDCSelfIntrospectable {
                     ENABLE_CONNECTION_CASTING = "enableConnectionCasting",
                     ENABLE_MULTITHREADED_ACCESS_DETECTION = "enableMultithreadedAccessDetection", // currently disabled in liberty profile
                     JDBC_DRIVER_REF = "jdbcDriverRef",
+                    MAP_ERROR = "mapError",
                     ON_CONNECT = "onConnect",
                     QUERY_TIMEOUT = "queryTimeout",
                     RECOVERY_AUTH_DATA_REF = "recoveryAuthDataRef",
@@ -72,6 +123,7 @@ public class DSConfig implements FFDCSelfIntrospectable {
                                                                ENABLE_BEGIN_END_REQUEST, // Not a supported property. Only for internal testing/experimentation.
                                                                ENABLE_CONNECTION_CASTING,
                                                                JDBC_DRIVER_REF,
+                                                               MAP_ERROR,
                                                                ON_CONNECT,
                                                                QUERY_TIMEOUT,
                                                                RECOVERY_AUTH_DATA_REF,
@@ -194,6 +246,12 @@ public class DSConfig implements FFDCSelfIntrospectable {
      * JNDI name.
      */
     public final String jndiName;
+    
+    /**
+     * List of error mappings to check if certain sqlCode or sqlState values should map to specific actions.
+     * May be null if none are configured
+     */
+    public final List<MapError> errorMappings;
 
     /**
      * List of SQL commands to execute once per newly established connection. Can be null if none are configured.
@@ -260,21 +318,22 @@ public class DSConfig implements FFDCSelfIntrospectable {
      * @param connectorSvc connector service instance
      * @throws Exception if an error occurs
      */
+    @SuppressWarnings("unchecked")
     public DSConfig(String id, String jndi,
                     NavigableMap<String, Object> wProps, Properties vProps,
                     ConnectorService connectorSvc) throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
             Tr.entry(tc, getClass().getSimpleName(), new Object[] { jndi, wProps });
-
+        
         this.connectorSvc = connectorSvc;
         this.id = id;
         jndiName = jndi;
         vendorProps = vProps;
-
+        
         entries = wProps;
         entry = entries.pollFirstEntry();
-
+        
         beginTranForResultSetScrollingAPIs = remove(BEGIN_TRAN_FOR_SCROLLING_APIS, true);
         beginTranForVendorAPIs = remove(BEGIN_TRAN_FOR_VENDOR_APIS, true);
         CommitOrRollbackOnCleanup commitOrRollback = remove(COMMIT_OR_ROLLBACK_ON_CLEANUP, null, CommitOrRollbackOnCleanup.class);
@@ -283,6 +342,7 @@ public class DSConfig implements FFDCSelfIntrospectable {
         enableConnectionCasting = remove(ENABLE_CONNECTION_CASTING, false);
         enableMultithreadedAccessDetection = false;
         isolationLevel = remove(DataSourceDef.isolationLevel.name(), -1, -1, null, -1, 0, 1, 2, 4, 8, 16, 4096);
+        errorMappings = new ArrayList<>(remove(MAP_ERROR, Collections.emptyMap()).values());
         onConnect = remove(ON_CONNECT, (String[]) null);
         queryTimeout = remove(QUERY_TIMEOUT, (Integer) null, 0, TimeUnit.SECONDS);
         statementCacheSize = remove(STATEMENT_CACHE_SIZE, 10, 0, null);
@@ -294,6 +354,9 @@ public class DSConfig implements FFDCSelfIntrospectable {
         commitOrRollbackOnCleanup = commitOrRollback == null
                         ? (transactional ? null : CommitOrRollbackOnCleanup.rollback)
                                         : commitOrRollback;
+                        
+        for (MapError errorMapping : errorMappings)
+            errorMapping.validate();
 
         if (trace && tc.isDebugEnabled() && entry != null)
             Tr.debug(this, tc, "unknown attributes: " + entries);
@@ -466,6 +529,33 @@ public class DSConfig implements FFDCSelfIntrospectable {
         for (int diff; value == null && entry != null && (diff = entry.getKey().compareTo(name)) <= 0; entry = entries.pollFirstEntry()) {
             if (diff == 0) // matched
                 value = entry.getValue() instanceof String[] ? (String[]) entry.getValue() : new String[] { (String) entry.getValue() };
+            else {
+                // TODO: when we have a stricter variant of onError, apply it to unrecognized attributes
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                    Tr.debug(this, tc, "unrecognized attribute: " + entry.getKey());
+                //SQLException ex = AdapterUtil.ignoreWarnOrFail(tc, null, SQLException.class, "PROP_NOT_FOUND", jndiName == null ? id : jndiName, entry.getKey());
+                //if (ex != null)
+                //    throw ex;
+            }
+        }
+
+        return value == null ? defaultValue : value;
+    }
+    
+    /**
+     * Remove properties up to and including the specified property. Return the property if found.
+     * 
+     * @param name name of the property.
+     * @param defaultValue default value to use if not found.
+     * @return value of the property if found. Otherwise the default value.
+     */
+    @SuppressWarnings("rawtypes")
+    private Map remove(String name, Map defaultValue) throws SQLException {
+        Map value = null;
+
+        for (int diff; value == null && entry != null && (diff = entry.getKey().compareTo(name)) <= 0; entry = entries.pollFirstEntry()) {
+            if (diff == 0) // matched
+                value = (Map) entry.getValue();
             else {
                 // TODO: when we have a stricter variant of onError, apply it to unrecognized attributes
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2Helper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2Helper.java
@@ -86,7 +86,12 @@ public class DB2Helper extends DatabaseHelper {
             threadIdentitySupport = AbstractConnectionFactoryService.THREAD_IDENTITY_ALLOWED;
             threadSecurity = true;
         }
-
+    }
+    
+    @Override
+    void customizeStaleStates() {
+        super.customizeStaleStates();
+        
         Collections.addAll(staleErrorCodes,
                            -30108,
                            -30081

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2JCCHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2JCCHelper.java
@@ -124,11 +124,6 @@ public class DB2JCCHelper extends DB2Helper {
 
         configuredTraceLevel = 0; // value of DB2BaseDataSource.TRACE_NONE
 
-        Collections.addAll(staleErrorCodes,
-                           -4499,
-                           -4498,
-                           -1776);
-
         isRRSTransaction = false;
         threadIdentitySupport = AbstractConnectionFactoryService.THREAD_IDENTITY_NOT_ALLOWED;
         threadSecurity = false;
@@ -233,6 +228,16 @@ public class DB2JCCHelper extends DB2Helper {
         } else { // means need to integrate
             db2UPw = new PrintWriter(new TraceWriter(db2Tc), true);
         }
+    }
+    
+    @Override
+    void customizeStaleStates() {
+        super.customizeStaleStates();
+        
+        Collections.addAll(staleErrorCodes,
+                           -4499,
+                           -4498,
+                           -1776);
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iNativeHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iNativeHelper.java
@@ -75,7 +75,12 @@ public class DB2iNativeHelper extends DB2Helper {
 
             switchingSupportDetermined = true;
         }
-
+    }
+    
+    @Override
+    void customizeStaleStates() {
+        super.customizeStaleStates();
+        
         // --- The Native driver will return this CLI SQLState (HY017) whenever a connection is no longer available.
         //     This covers the case when an underlying iSeries QSQSRVR prestart job on the iSeries that represents
         //     the jdbc connection in the WAS connection pool is killed and the connection is later used.

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iToolboxHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iToolboxHelper.java
@@ -78,7 +78,12 @@ public class DB2iToolboxHelper extends DB2Helper {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(this, tc, "isolationSwitchingSupported property not set for this datasource");
         }
-
+    }
+    
+    @Override
+    void customizeStaleStates() {
+        super.customizeStaleStates();
+        
         // --- The Native driver will return this CLI SQLState (HY017) whenever a connection is no longer available.
         //     This covers the case when an underlying iSeries QSQSRVR prestart job on the iSeries that represents
         //     the jdbc connection in the WAS connection pool is killed and the connection is later used.

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DataDirectConnectSQLServerHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DataDirectConnectSQLServerHelper.java
@@ -101,6 +101,28 @@ public class DataDirectConnectSQLServerHelper extends DatabaseHelper {
     DataDirectConnectSQLServerHelper(WSManagedConnectionFactoryImpl mcf) {
         super(mcf);
 
+        // Default values for the statement properties LongDataCacheSize and QueryTimeout are
+        // configurable as data source properties. These data source properties are supplied to
+        // the data store helper so that we can reset the statement properties to these default
+        // values when caching statements.
+        Properties props = mcf.dsConfig.get().vendorProps;
+        Object value = props.get(LONG_DATA_CACHE_SIZE);
+        try {
+            longDataCacheSize = value instanceof Number ? ((Number) value).intValue()
+                              : value instanceof String ? Integer.parseInt((String) value)
+                              : longDataCacheSize;
+        } catch (NumberFormatException x) {
+            // error paths already covered by data source properties processing code 
+        }
+
+        if (TraceComponent.isAnyTracingEnabled() &&  tc.isDebugEnabled()) 
+            Tr.debug(this, tc, "Default longDataCacheSize = " + longDataCacheSize);
+    }
+    
+    @Override
+    void customizeStaleStates() {
+        super.customizeStaleStates();
+        
         Collections.addAll(staleDDErrorCodes,
                            2217,
                            2251,
@@ -128,23 +150,6 @@ public class DataDirectConnectSQLServerHelper extends DatabaseHelper {
                            6002,
                            6005,
                            6006);
-
-        // Default values for the statement properties LongDataCacheSize and QueryTimeout are
-        // configurable as data source properties. These data source properties are supplied to
-        // the data store helper so that we can reset the statement properties to these default
-        // values when caching statements.
-        Properties props = mcf.dsConfig.get().vendorProps;
-        Object value = props.get(LONG_DATA_CACHE_SIZE);
-        try {
-            longDataCacheSize = value instanceof Number ? ((Number) value).intValue()
-                              : value instanceof String ? Integer.parseInt((String) value)
-                              : longDataCacheSize;
-        } catch (NumberFormatException x) {
-            // error paths already covered by data source properties processing code 
-        }
-
-        if (TraceComponent.isAnyTracingEnabled() &&  tc.isDebugEnabled()) 
-            Tr.debug(this, tc, "Default longDataCacheSize = " + longDataCacheSize);
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DerbyHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DerbyHelper.java
@@ -45,7 +45,12 @@ public class DerbyHelper extends DatabaseHelper {
         super(mcf);
 
         mcf.supportsGetTypeMap = false;
-
+    }
+    
+    @Override
+    void customizeStaleStates() {
+        super.customizeStaleStates();
+        
         Collections.addAll(staleErrorCodes,
                            40000,
                            45000,

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DerbyNetworkClientHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DerbyNetworkClientHelper.java
@@ -55,9 +55,6 @@ public class DerbyNetworkClientHelper extends DerbyHelper {
     DerbyNetworkClientHelper(WSManagedConnectionFactoryImpl mcf) {
         super(mcf);
 
-        Collections.addAll(staleErrorCodes,
-                           -4499);
-
         Properties props = mcf.dsConfig.get().vendorProps;
         // we are not reading the tracelevel since we don't set the trace on the connection as we do with dB2, 
         // with Derby, we set the trace on the DS level only.  NO API from Derby to set per connection.
@@ -111,6 +108,14 @@ public class DerbyNetworkClientHelper extends DerbyHelper {
         else { // means need to integrate
             derbyNSPw = new PrintWriter(new TraceWriter(derbyTc), true);
         }
+    }
+    
+    @Override
+    void customizeStaleStates() {
+        super.customizeStaleStates();
+        
+        Collections.addAll(staleErrorCodes,
+                           -4499);
     }
 
     public boolean doesStatementCacheIsoLevel() {

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/InformixHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/InformixHelper.java
@@ -44,7 +44,12 @@ public class InformixHelper extends DatabaseHelper {
      */
     InformixHelper(WSManagedConnectionFactoryImpl mcf) {
         super(mcf);
-
+    }
+    
+    @Override
+    void customizeStaleStates() {
+        super.customizeStaleStates();
+        
         Collections.addAll(staleErrorCodes,
                            -79735,
                            -79716,

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/InformixJCCHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/InformixJCCHelper.java
@@ -65,7 +65,12 @@ public class InformixJCCHelper extends InformixHelper {
         mcf.supportsGetTypeMap = false;
 
         configuredTraceLevel = 0; // value of DB2BaseDataSource.TRACE_NONE
-
+    }
+    
+    @Override
+    void customizeStaleStates() {
+        super.customizeStaleStates();
+        
         Collections.addAll(staleErrorCodes,
                            -4499);
     }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/MicrosoftSQLServerHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/MicrosoftSQLServerHelper.java
@@ -63,13 +63,6 @@ public class MicrosoftSQLServerHelper extends DatabaseHelper {
         mcf.supportsGetTypeMap = false;
         mcf.supportsIsReadOnly = false;
 
-        Collections.addAll(staleErrorCodes,
-                           230,
-                           6001,
-                           6002,
-                           6005,
-                           6006);
-
         // Default value for the statement property ResponseBuffering is
         // configurable as a data source property. This data source property is supplied to
         // the data store helper so that we can reset the statement properties to the default
@@ -81,6 +74,18 @@ public class MicrosoftSQLServerHelper extends DatabaseHelper {
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(this, tc, "Default responseBuffering = " + responseBuffering);
+    }
+    
+    @Override
+    void customizeStaleStates() {
+        super.customizeStaleStates();
+        
+        Collections.addAll(staleErrorCodes,
+                           230,
+                           6001,
+                           6002,
+                           6005,
+                           6006);
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
@@ -133,33 +133,6 @@ public class OracleHelper extends DatabaseHelper {
 
         matrix = new String[4]; // OracleConnection.END_TO_END_STATE_INDEX_MAX
 
-        Collections.addAll(staleErrorCodes,
-                           20,
-                           28,
-                           1012,
-                           1014,
-                           1033,
-                           1034,
-                           1035,
-                           1089,
-                           1090,
-                           1092,
-                           3113,
-                           3114,
-                           12505,
-                           12541,
-                           12560,
-                           12571,
-                           17002,
-                           17008,
-                           17009,
-                           17401,
-                           17410,
-                           17430,
-                           17447,
-                           24794,
-                           25408);
-
         int limit = 0; // unlimited
         int count = 1; // only one file to rotate through
         String _oracleLogFileName = null;
@@ -255,6 +228,38 @@ public class OracleHelper extends DatabaseHelper {
                     Tr.debug(oraTc, "Oracle trace file is not set, Oracle logging/tracing will be mergned with WAS logging based on WAS logging settings");
             }
         }
+    }
+    
+    @Override
+    void customizeStaleStates() {
+        super.customizeStaleStates();
+        
+        Collections.addAll(staleErrorCodes,
+                           20,
+                           28,
+                           1012,
+                           1014,
+                           1033,
+                           1034,
+                           1035,
+                           1089,
+                           1090,
+                           1092,
+                           3113,
+                           3114,
+                           12505,
+                           12541,
+                           12560,
+                           12571,
+                           17002,
+                           17008,
+                           17009,
+                           17401,
+                           17410,
+                           17430,
+                           17447,
+                           24794,
+                           25408);
     }
     
     @Override

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/SybaseHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/SybaseHelper.java
@@ -47,7 +47,12 @@ public class SybaseHelper extends DatabaseHelper
         super(mcf);
 
         mcf.supportsGetTypeMap = false;
-
+    }
+    
+    @Override
+    void customizeStaleStates() {
+        super.customizeStaleStates();
+        
         Collections.addAll(staleSQLStates,
                            "JZ0C0",
                            "JZ0C1");

--- a/dev/com.ibm.ws.jdbc_fat_v41/.classpath
+++ b/dev/com.ibm.ws.jdbc_fat_v41/.classpath
@@ -2,6 +2,8 @@
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/basicfat/src"/>
+	<classpathentry kind="src" path="test-applications/errorMappingApp/src"/>
+	<classpathentry kind="src" path="test-applications/errorMappingDriver/src"/>
 	<classpathentry kind="src" path="test-applications/slowdriver/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>

--- a/dev/com.ibm.ws.jdbc_fat_v41/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_v41/bnd.bnd
@@ -14,6 +14,8 @@ bVersion=1.0
 src: \
 	fat/src,\
 	test-applications/basicfat/src,\
+	test-applications/errorMappingApp/src,\
+	test-applications/errorMappingDriver/src,\
 	test-applications/slowdriver/src
 
 fat.project: true

--- a/dev/com.ibm.ws.jdbc_fat_v41/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_v41/build.gradle
@@ -8,7 +8,6 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-
 configurations {
   derby40
 }
@@ -20,6 +19,12 @@ dependencies {
 }
 
 File serverDir = new File(autoFvtDir, 'publish/servers/com.ibm.ws.jdbc.fat.v41')
+
+task addDerbyToErrorMapServer(type: Copy) {
+  from configurations.derby
+  into file("$autoFvtDir/publish/servers/com.ibm.ws.jdbc.fat.v41.errorMap/derby")
+  rename 'derby-.*.jar', 'derby.jar'
+}
 
 task addDerbyToServerDir(type: Copy) {
   from configurations.derby
@@ -36,5 +41,6 @@ task addDerby40ToServerDir(type: Copy) {
 addRequiredLibraries {
   dependsOn addDerbyToServerDir
   dependsOn addDerby40ToServerDir
+  dependsOn addDerbyToErrorMapServer
   dependsOn addJakartaTransformer
 }

--- a/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/ErrorMappingTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/ErrorMappingTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jdbc.fat.v41;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import jdbc.fat.v41.errormap.web.ErrorMappingTestServlet;
+
+@RunWith(FATRunner.class)
+@AllowedFFDC // allow all FFDCs because this test forces a lot of different error paths
+@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
+public class ErrorMappingTest extends FATServletClient {
+
+    static final String APP_NAME = "errorMappingApp";
+
+    @Server("com.ibm.ws.jdbc.fat.v41.errorMap")
+    @TestServlet(servlet = ErrorMappingTestServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        JavaArchive errorDriver = ShrinkHelper.buildJavaArchive("errorMappingDriver.jar", "jdbc.fat.v41.errormap.driver");
+        ShrinkHelper.exportToServer(server, "derby", errorDriver);
+
+        ShrinkHelper.defaultApp(server, APP_NAME, "jdbc.fat.v41.errormap.web");
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer("CWWKG0058E.*mapError", // expected by 'jdbc/invalid/noTarget'
+                          "DSRA8066E.*BOGUS", // expected by testInvalidConfig_bogusTarget
+                          "DSRA8067E", // expected by testInvalidConfig_noStateOrCode / testInvalidConfig_stateAndCode
+                          "com\\.ibm\\.ws\\.jdbc.*CWWKE0701E" // expected by invalid datasource configs
+        );
+    }
+
+    @Test
+    public void testInvalidConfig_noTarget() throws Exception {
+        runTest(server, APP_NAME + "/ErrorMappingTestServlet", testName);
+        assertNotNull("Should find CWWKG0058E error message in logs indicating that the 'to' attribute is required on the <mapError> element",
+                      server.waitForStringInLog("CWWKG0058E.*mapError.*to"));
+    }
+
+}

--- a/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/FATSuite.java
@@ -10,9 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.jdbc.fat.v41;
 
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -28,8 +26,9 @@ import componenttest.topology.impl.LibertyServerFactory;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                JDBC41UpgradeTest.class,
-                JDBC41Test.class
+//                JDBC41UpgradeTest.class,
+//                JDBC41Test.class,
+                ErrorMappingTest.class
 })
 public class FATSuite {
     public static final String appName = "basicfat";
@@ -38,16 +37,16 @@ public class FATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests
                     .withoutModification()
-                    .andWith(new JakartaEE9Action());
+                    .andWith(new JakartaEE9Action().fullFATOnly());
 
     @BeforeClass
     public static void setup() throws Exception {
-        WebArchive app = ShrinkWrap.create(WebArchive.class, appName + ".war")
-                        .addPackage("jdbc.fat.v41.web");
-        ShrinkHelper.exportAppToServer(server, app);
+        ShrinkHelper.defaultApp(server, appName, "jdbc.fat.v41.web");
+        exportCustomDriver(server, "derby");
+    }
 
-        JavaArchive slowdriver = ShrinkWrap.create(JavaArchive.class, "slowdriver.jar")
-                        .addPackage("jdbc.fat.v41.slowdriver");
-        ShrinkHelper.exportToServer(server, "derby", slowdriver);
+    public static void exportCustomDriver(LibertyServer server, String dir) throws Exception {
+        JavaArchive slowdriver = ShrinkHelper.buildJavaArchive("slowdriver.jar", "jdbc.fat.v41.slowdriver");
+        ShrinkHelper.exportToServer(server, dir, slowdriver);
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_v41/publish/servers/com.ibm.ws.jdbc.fat.v41.errorMap/bootstrap.properties
+++ b/dev/com.ibm.ws.jdbc_fat_v41/publish/servers/com.ibm.ws.jdbc.fat.v41.errorMap/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+com.ibm.ws.logging.trace.specification=*=info=enabled:com.ibm.ws.jdbc.*=all=enabled:com.ibm.ws.rsadapter.*=all=enabled:com.ibm.ejs.j2c.*=all=enabled
+com.ibm.ws.logging.max.file.size=0
+osgi.console=5678
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jdbc_fat_v41/publish/servers/com.ibm.ws.jdbc.fat.v41.errorMap/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v41/publish/servers/com.ibm.ws.jdbc.fat.v41.errorMap/server.xml
@@ -1,0 +1,85 @@
+<server>
+    <featureManager>
+        <feature>componenttest-1.0</feature>
+        <feature>servlet-3.1</feature>
+        <feature>jdbc-4.1</feature>
+        <feature>jndi-1.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+
+    <application location="errorMappingApp.war" >
+        <classloader commonLibraryRef="CustomDriverLib"/>
+    </application>
+    
+    <library id="CustomDriverLib">
+        <fileset dir="${server.config.dir}/derby" includes="derby.jar,errorMappingDriver.jar"/>
+    </library>
+    
+    <jdbcDriver id="CustomDriver" libraryRef="CustomDriverLib" javax.sql.DataSource="jdbc.fat.v41.errormap.driver.ErrorMapDataSourceImpl"/>
+    
+    <dataSource jndiName="jdbc/errorMap" type="javax.sql.DataSource" jdbcDriverRef="CustomDriver">
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create"/>
+        <mapError sqlCode="1234" to="STALE_CONNECTION"/>
+    </dataSource>
+    
+    <dataSource jndiName="jdbc/noMappings" type="javax.sql.DataSource" jdbcDriverRef="CustomDriver">
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create"/>
+    </dataSource>
+    
+    <dataSource jndiName="jdbc/removeMapping" type="javax.sql.DataSource" jdbcDriverRef="CustomDriver">
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create"/>
+        <mapError sqlState="08001" to="NONE"/>
+    </dataSource>
+    
+    <dataSource jndiName="jdbc/manyMappings" type="javax.sql.DataSource" jdbcDriverRef="CustomDriver">
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create"/>
+        <mapError sqlCode="0001" to="STALE_CONNECTION"/>
+        <mapError sqlCode="2" to="STALE_CONNECTION"/>
+        <mapError sqlCode="1003" to="STALE_CONNECTION"/>
+        <mapError sqlState="E1004" to="STALE_CONNECTION"/>
+        <mapError sqlState="5" to="STALE_CONNECTION"/>
+        <mapError sqlCode="6" to="STALE_CONNECTION"/>
+        <mapError sqlCode="7" to="STALE_CONNECTION"/>
+        <mapError sqlCode="-008" to="STALE_CONNECTION"/>
+        <mapError sqlCode="-10009" to="STALE_CONNECTION"/>
+        <mapError sqlCode="1010" to="NONE"/>
+        <mapError sqlState="E1111" to="STALE_CONNECTION"/>
+    </dataSource>
+    
+    <dataSource jndiName="jdbc/invalid/noTarget" type="javax.sql.DataSource" jdbcDriverRef="CustomDriver">
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create"/>
+        <!-- invalid configuration: the 'to' attribute is not defined-->
+        <mapError sqlCode="1234"/>
+    </dataSource>
+    
+    <dataSource jndiName="jdbc/invalid/bogusTarget" type="javax.sql.DataSource" jdbcDriverRef="CustomDriver">
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create"/>
+        <!-- invalid configuration: the value "BOGUS" is not an allowed value for the 'to' attribute -->
+        <mapError sqlCode="1234" to="BOGUS"/>
+    </dataSource>
+    
+    <dataSource jndiName="jdbc/invalid/noStateOrCode" type="javax.sql.DataSource" jdbcDriverRef="CustomDriver">
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create"/>
+        <!-- invalid configuration: either sqlCode or sqlState must be defined -->
+        <mapError to="STALE_CONNECTION"/>
+    </dataSource>
+    
+    <dataSource jndiName="jdbc/invalid/stateAndCode" type="javax.sql.DataSource" jdbcDriverRef="CustomDriver">
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create"/>
+        <!-- invalid configuration: sqlCode and sqlState are mutually exclusive -->
+        <mapError sqlCode="1234" sqlState="E1234" to="STALE_CONNECTION"/>
+    </dataSource>
+    
+    <javaPermission codebase="${server.config.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${server.config.dir}/apps/errorMappingApp.war" className="java.sql.SQLPermission" name="callAbort"/>
+    <javaPermission codebase="${server.config.dir}/apps/errorMappingApp.war" className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+    <javaPermission codebase="${server.config.dir}/apps/errorMappingApp.war" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codebase="${server.config.dir}/apps/errorMappingApp.war" className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
+
+    <!--  Permissions for application to access mbeans -->
+    <javaPermission codebase="${server.config.dir}/apps/errorMappingApp.war" className="javax.management.MBeanPermission" actions="queryNames"/>
+    <javaPermission codebase="${server.config.dir}/apps/errorMappingApp.war" className="javax.management.MBeanServerPermission" name="createMBeanServer"/>
+    
+    <variable name="onError" value="FAIL"/>
+</server>

--- a/dev/com.ibm.ws.jdbc_fat_v41/test-applications/errorMappingApp/src/jdbc/fat/v41/errormap/web/ErrorMappingTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_v41/test-applications/errorMappingApp/src/jdbc/fat/v41/errormap/web/ErrorMappingTestServlet.java
@@ -1,0 +1,300 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jdbc.fat.v41.errormap.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.lang.management.ManagementFactory;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Set;
+
+import javax.annotation.Resource;
+import javax.management.JMX;
+import javax.management.MBeanServer;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.servlet.annotation.WebServlet;
+import javax.sql.DataSource;
+import javax.transaction.UserTransaction;
+
+import org.junit.Test;
+
+import com.ibm.ws.jca.cm.mbean.ConnectionManagerMBean;
+
+import componenttest.app.FATServlet;
+import jdbc.fat.v41.errormap.driver.ErrorMapConnection;
+
+@SuppressWarnings("serial")
+@WebServlet(urlPatterns = "/ErrorMappingTestServlet")
+public class ErrorMappingTestServlet extends FATServlet {
+
+    @Resource
+    UserTransaction tx;
+
+    @Resource(lookup = "jdbc/errorMap")
+    DataSource ds;
+
+    @Resource(lookup = "jdbc/removeMapping")
+    DataSource removeMapping;
+
+    @Resource(lookup = "jdbc/noMappings")
+    DataSource noMappings;
+
+    @Resource(lookup = "jdbc/manyMappings")
+    DataSource manyMappings;
+
+    /**
+     * Verify that once a connection goes stale (as indicated by server.xml config)
+     * it is removed from the connection pool.
+     */
+    @Test
+    public void testStaleConnection() throws Exception {
+
+        tx.begin();
+        try (Connection con = ds.getConnection()) {
+            System.out.println("Got an initial connection");
+        } finally {
+            tx.commit();
+        }
+        assertPoolSize("jdbc/errorMap", 1);
+
+        // Force a stale connection. The connection should be purged from the pool.
+        tx.begin();
+        try (Connection con = ds.getConnection()) {
+            ErrorMapConnection customCon = con.unwrap(ErrorMapConnection.class);
+            customCon.setNextSqlCode(1234);
+
+            System.out.println("Triggering sqlCode 1234 on connection");
+            customCon.createStatement();
+        } catch (SQLException expected) {
+            assertEquals("Did not get expected exception. Message was: " + expected.getMessage(), 1234, expected.getErrorCode());
+        } finally {
+            tx.commit();
+        }
+
+        // The sqlcode should be mapped to "stale connection" which should evict the connection from the pool
+        assertPoolSize("jdbc/errorMap", 0);
+    }
+
+    @Test
+    public void testUnmappedError() throws Exception {
+        tx.begin();
+        try (Connection con = ds.getConnection()) {
+            System.out.println("Got an initial connection");
+        } finally {
+            tx.commit();
+        }
+        assertPoolSize("jdbc/errorMap", 1);
+
+        // Force a connection error. It will not be purged from the pool because it is not mapped to a stale connection
+        tx.begin();
+        try (Connection con = ds.getConnection()) {
+            ErrorMapConnection customCon = con.unwrap(ErrorMapConnection.class);
+            customCon.setNextSqlCode(5555);
+
+            System.out.println("Triggering sqlCode 5555 on connection");
+            customCon.createStatement();
+        } catch (SQLException expected) {
+            assertEquals("Did not get expected exception. Message was: " + expected.getMessage(), 5555, expected.getErrorCode());
+        } finally {
+            tx.commit();
+        }
+
+        // Since sqlCode 5555 is not mapped to a stale connection, it should still be in the pool
+        assertPoolSize("jdbc/errorMap", 1);
+    }
+
+    @Test
+    public void testRemovedMapping() throws Exception {
+        tx.begin();
+        try (Connection con = removeMapping.getConnection()) {
+            System.out.println("Got an initial connection");
+        } finally {
+            tx.commit();
+        }
+        assertPoolSize("jdbc/removeMapping", 1);
+
+        // Force a connection error for sqlState '08001'. Normally it would map to a connection error according to the built-in
+        // mappings we have, but since the mapping has been removed it will not be purged from the pool
+        tx.begin();
+        try (Connection con = removeMapping.getConnection()) {
+            ErrorMapConnection customCon = con.unwrap(ErrorMapConnection.class);
+            customCon.setNextSqlState("08001");
+
+            System.out.println("Triggering sqlState '08001' on connection");
+            customCon.createStatement();
+        } catch (SQLException expected) {
+            assertEquals("Did not get expected exception. Message was: " + expected.getMessage(), "08001", expected.getSQLState());
+        } finally {
+            tx.commit();
+        }
+
+        // Since the error mapping for sqlState '08001' was removed, the connection should still be in the pool
+        assertPoolSize("jdbc/removeMapping", 1);
+    }
+
+    @Test
+    public void testNoMappings() throws Exception {
+        tx.begin();
+        try (Connection con = noMappings.getConnection()) {
+            System.out.println("Got an initial connection");
+        } finally {
+            tx.commit();
+        }
+        assertPoolSize("jdbc/noMappings", 1);
+
+        // Force a connection error for sqlState '08001'. This should map to a stale connection and be removed from the pool
+        tx.begin();
+        try (Connection con = noMappings.getConnection()) {
+            ErrorMapConnection customCon = con.unwrap(ErrorMapConnection.class);
+            customCon.setNextSqlState("08001");
+
+            System.out.println("Triggering sqlState '08001' on connection");
+            customCon.createStatement();
+        } catch (SQLException expected) {
+            assertEquals("Did not get expected exception. Message was: " + expected.getMessage(), "08001", expected.getSQLState());
+        } finally {
+            tx.commit();
+        }
+        assertPoolSize("jdbc/noMappings", 0);
+
+        // Force a connection error for sqlState '08002'. This should NOT map to a stale connection and remain in the pool
+        tx.begin();
+        try (Connection con = noMappings.getConnection()) {
+            ErrorMapConnection customCon = con.unwrap(ErrorMapConnection.class);
+            customCon.setNextSqlState("08002");
+
+            System.out.println("Triggering sqlState '08002' on connection");
+            customCon.createStatement();
+        } catch (SQLException expected) {
+            assertEquals("Did not get expected exception. Message was: " + expected.getMessage(), "08002", expected.getSQLState());
+        } finally {
+            tx.commit();
+        }
+        assertPoolSize("jdbc/noMappings", 1);
+    }
+
+    @Test
+    public void testManyMappings() throws Exception {
+        tx.begin();
+        try (Connection con = manyMappings.getConnection()) {
+            System.out.println("Got an initial connection");
+        } finally {
+            tx.commit();
+        }
+        assertPoolSize("jdbc/manyMappings", 1);
+
+        // Force a connection error for sqlCode -8. This should map to a stale connection and be removed from the pool
+        tx.begin();
+        try (Connection con = manyMappings.getConnection()) {
+            ErrorMapConnection customCon = con.unwrap(ErrorMapConnection.class);
+            customCon.setNextSqlCode(-8);
+
+            System.out.println("Triggering sqlCode '-8' on connection");
+            customCon.createStatement();
+        } catch (SQLException expected) {
+            assertEquals("Did not get expected exception. Message was: " + expected.getMessage(), -8, expected.getErrorCode());
+        } finally {
+            tx.commit();
+        }
+        assertPoolSize("jdbc/manyMappings", 0);
+
+        // Force a connection error for sqlState '1010'. This should NOT map to a stale connection and remain in the pool
+        tx.begin();
+        try (Connection con = manyMappings.getConnection()) {
+            ErrorMapConnection customCon = con.unwrap(ErrorMapConnection.class);
+            customCon.setNextSqlCode(1010);
+
+            System.out.println("Triggering sqlCode '1010' on connection");
+            customCon.createStatement();
+        } catch (SQLException expected) {
+            assertEquals("Did not get expected exception. Message was: " + expected.getMessage(), 1010, expected.getErrorCode());
+        } finally {
+            tx.commit();
+        }
+        assertPoolSize("jdbc/manyMappings", 1);
+
+        // Force a connection error for sqlState 'E1111'. This should map to a stale connection and be removed from the pool
+        tx.begin();
+        try (Connection con = manyMappings.getConnection()) {
+            ErrorMapConnection customCon = con.unwrap(ErrorMapConnection.class);
+            customCon.setNextSqlState("E1111");
+
+            System.out.println("Triggering sqlCode 'E1111' on connection");
+            customCon.createStatement();
+        } catch (SQLException expected) {
+            assertEquals("Did not get expected exception. Message was: " + expected.getMessage(), "E1111", expected.getSQLState());
+        } finally {
+            tx.commit();
+        }
+        assertPoolSize("jdbc/manyMappings", 0);
+    }
+
+    public void testInvalidConfig_noTarget() throws Exception {
+        // Due to the way required config attributes work in Liberty, the invalid element will be ignored but an error message will be in logs
+        InitialContext.doLookup("jdbc/invalid/noTarget");
+    }
+
+    @Test
+    public void testInvalidConfig_bogusTarget() throws Exception {
+        try {
+            InitialContext.doLookup("jdbc/invalid/bogusTarget");
+            fail("Should not be able to lookup a datasource with <mapError> with an invalid 'to' attribute");
+        } catch (NamingException expected) {
+            System.out.println("Caught expected exception: " + expected.getMessage());
+        }
+    }
+
+    @Test
+    public void testInvalidConfig_noStateOrCode() throws Exception {
+        try {
+            InitialContext.doLookup("jdbc/invalid/noStateOrCode");
+            fail("Should not be able to lookup a datasource with <mapError> with no 'sqlState' or 'sqlCode' defined");
+        } catch (NamingException expected) {
+            System.out.println("Caught expected exception: " + expected.getMessage());
+        }
+    }
+
+    @Test
+    public void testInvalidConfig_stateAndCode() throws Exception {
+        try {
+            InitialContext.doLookup("jdbc/invalid/stateAndCode");
+            fail("Should not be able to lookup a datasource with <mapError> with a 'sqlState' and 'sqlCode' defined");
+        } catch (NamingException expected) {
+            System.out.println("Caught expected exception: " + expected.getMessage());
+        }
+    }
+
+    private static void assertPoolSize(String jndiName, int expectedSize) throws Exception {
+        ConnectionManagerMBean mbean = getConnectionManagerBean(jndiName);
+        assertEquals("Connection pool did not contain the expected number of connections: " + mbean.showPoolContents(),
+                     expectedSize, mbean.getSize());
+    }
+
+    private static ConnectionManagerMBean getConnectionManagerBean(String jndiName) throws Exception {
+        final String MBEAN_TYPE = "com.ibm.ws.jca.cm.mbean.ConnectionManagerMBean";
+        MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+        ObjectName obn = new ObjectName("WebSphere:type=" + MBEAN_TYPE + ",jndiName=" + jndiName + ",*");
+        Set<ObjectInstance> s = mbs.queryMBeans(obn, null);
+        if (s.size() != 1) {
+            System.out.println("ERROR: Found incorrect number of MBeans (" + s.size() + ")");
+            for (ObjectInstance i : s)
+                System.out.println("  Found MBean: " + i.getObjectName());
+            throw new Exception("Expected to find exactly 1 MBean, instead found " + s.size());
+        }
+        return JMX.newMBeanProxy(mbs, s.iterator().next().getObjectName(), ConnectionManagerMBean.class);
+    }
+
+}

--- a/dev/com.ibm.ws.jdbc_fat_v41/test-applications/errorMappingDriver/src/jdbc/fat/v41/errormap/driver/ErrorMapConnection.java
+++ b/dev/com.ibm.ws.jdbc_fat_v41/test-applications/errorMappingDriver/src/jdbc/fat/v41/errormap/driver/ErrorMapConnection.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jdbc.fat.v41.errormap.driver;
+
+import java.sql.Connection;
+
+public interface ErrorMapConnection extends Connection {
+
+    public void setNextSqlCode(int sqlCode);
+
+    public void setNextSqlState(String sqlState);
+
+}

--- a/dev/com.ibm.ws.jdbc_fat_v41/test-applications/errorMappingDriver/src/jdbc/fat/v41/errormap/driver/ErrorMapConnectionImpl.java
+++ b/dev/com.ibm.ws.jdbc_fat_v41/test-applications/errorMappingDriver/src/jdbc/fat/v41/errormap/driver/ErrorMapConnectionImpl.java
@@ -1,0 +1,399 @@
+/*******************************************************************************
+ * Copyright (c) 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jdbc.fat.v41.errormap.driver;
+
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.NClob;
+import java.sql.PreparedStatement;
+import java.sql.SQLClientInfoException;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Savepoint;
+import java.sql.Statement;
+import java.sql.Struct;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.Executor;
+
+public class ErrorMapConnectionImpl implements Connection, ErrorMapConnection {
+    private final Connection impl;
+    private final ErrorMapDataSourceImpl datasource;
+    private final Set<Statement> stmtSet = new HashSet<Statement>();
+
+    private Integer sqlCode = null;
+    private String sqlState = null;
+
+    public ErrorMapConnectionImpl(ErrorMapDataSourceImpl ds, Connection conn) {
+        datasource = ds;
+        impl = conn;
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> arg0) throws SQLException {
+        return ErrorMapConnection.class.equals(arg0) || impl.isWrapperFor(arg0);
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> arg0) throws SQLException {
+        if (ErrorMapConnection.class.equals(ErrorMapConnection.class))
+            return (T) this;
+        return impl.unwrap(arg0);
+    }
+
+    @Override
+    public void abort(Executor arg0) throws SQLException {
+        blowupIfRequested();
+        impl.abort(arg0);
+    }
+
+    @Override
+    public void clearWarnings() throws SQLException {
+        impl.clearWarnings();
+    }
+
+    @Override
+    public void close() throws SQLException {
+        impl.close();
+    }
+
+    @Override
+    public void commit() throws SQLException {
+        blowupIfRequested();
+        impl.commit();
+    }
+
+    @Override
+    public Array createArrayOf(String arg0, Object[] arg1) throws SQLException {
+        return impl.createArrayOf(arg0, arg1);
+    }
+
+    @Override
+    public Blob createBlob() throws SQLException {
+        return impl.createBlob();
+    }
+
+    @Override
+    public Clob createClob() throws SQLException {
+        return impl.createClob();
+    }
+
+    @Override
+    public NClob createNClob() throws SQLException {
+        return impl.createNClob();
+    }
+
+    @Override
+    public SQLXML createSQLXML() throws SQLException {
+        return impl.createSQLXML();
+    }
+
+    @Override
+    public Statement createStatement() throws SQLException {
+        blowupIfRequested();
+        Statement s = impl.createStatement();
+        stmtSet.add(s);
+        return s;
+    }
+
+    @Override
+    public Statement createStatement(int arg0, int arg1) throws SQLException {
+        blowupIfRequested();
+        Statement s = impl.createStatement(arg0, arg1);
+        stmtSet.add(s);
+        return s;
+    }
+
+    @Override
+    public Statement createStatement(int arg0, int arg1, int arg2) throws SQLException {
+        blowupIfRequested();
+        Statement s = impl.createStatement(arg0, arg1, arg2);
+        stmtSet.add(s);
+        return s;
+    }
+
+    @Override
+    public Struct createStruct(String arg0, Object[] arg1) throws SQLException {
+        return impl.createStruct(arg0, arg1);
+    }
+
+    @Override
+    public boolean getAutoCommit() throws SQLException {
+        blowupIfRequested();
+        return impl.getAutoCommit();
+    }
+
+    @Override
+    public String getCatalog() throws SQLException {
+        blowupIfRequested();
+        return impl.getCatalog();
+    }
+
+    @Override
+    public Properties getClientInfo() throws SQLException {
+        blowupIfRequested();
+        return impl.getClientInfo();
+    }
+
+    @Override
+    public String getClientInfo(String arg0) throws SQLException {
+        blowupIfRequested();
+        return impl.getClientInfo(arg0);
+    }
+
+    @Override
+    public int getHoldability() throws SQLException {
+        blowupIfRequested();
+        return impl.getHoldability();
+    }
+
+    @Override
+    public DatabaseMetaData getMetaData() throws SQLException {
+        return impl.getMetaData();
+    }
+
+    @Override
+    public int getNetworkTimeout() throws SQLException {
+        blowupIfRequested();
+        return impl.getNetworkTimeout();
+    }
+
+    @Override
+    public String getSchema() throws SQLException {
+        blowupIfRequested();
+        return impl.getSchema();
+    }
+
+    @Override
+    public int getTransactionIsolation() throws SQLException {
+        blowupIfRequested();
+        return impl.getTransactionIsolation();
+    }
+
+    @Override
+    public Map<String, Class<?>> getTypeMap() throws SQLException {
+        // Simulate a JDBC 3.0 driver which throws a SQLException with the SQLState indicating not supported
+        throw new SQLException("Not Supported.", "0A000");
+    }
+
+    @Override
+    public SQLWarning getWarnings() throws SQLException {
+        return impl.getWarnings();
+    }
+
+    @Override
+    public boolean isClosed() throws SQLException {
+        return impl.isClosed();
+    }
+
+    @Override
+    public boolean isReadOnly() throws SQLException {
+        return impl.isReadOnly();
+    }
+
+    @Override
+    public boolean isValid(int arg0) throws SQLException {
+        return impl.isValid(arg0);
+    }
+
+    @Override
+    public String nativeSQL(String arg0) throws SQLException {
+        blowupIfRequested();
+        return impl.nativeSQL(arg0);
+    }
+
+    @Override
+    public CallableStatement prepareCall(String arg0) throws SQLException {
+        blowupIfRequested();
+        CallableStatement s = impl.prepareCall(arg0);
+        stmtSet.add(s);
+        return s;
+    }
+
+    @Override
+    public CallableStatement prepareCall(String arg0, int arg1, int arg2) throws SQLException {
+        blowupIfRequested();
+        CallableStatement s = impl.prepareCall(arg0, arg1, arg2);
+        stmtSet.add(s);
+        return s;
+    }
+
+    @Override
+    public CallableStatement prepareCall(String arg0, int arg1, int arg2, int arg3) throws SQLException {
+        blowupIfRequested();
+        CallableStatement s = impl.prepareCall(arg0, arg1, arg2, arg3);
+        stmtSet.add(s);
+        return s;
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String arg0) throws SQLException {
+        blowupIfRequested();
+        PreparedStatement s = impl.prepareStatement(arg0);
+        stmtSet.add(s);
+        return s;
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String arg0, int arg1) throws SQLException {
+        blowupIfRequested();
+        PreparedStatement s = impl.prepareStatement(arg0, arg1);
+        stmtSet.add(s);
+        return s;
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String arg0, int[] arg1) throws SQLException {
+        blowupIfRequested();
+        PreparedStatement s = impl.prepareStatement(arg0, arg1);
+        stmtSet.add(s);
+        return s;
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String arg0, String[] arg1) throws SQLException {
+        blowupIfRequested();
+        PreparedStatement s = impl.prepareStatement(arg0, arg1);
+        stmtSet.add(s);
+        return s;
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String arg0, int arg1, int arg2) throws SQLException {
+        blowupIfRequested();
+        PreparedStatement s = impl.prepareStatement(arg0, arg1, arg2);
+        stmtSet.add(s);
+        return s;
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String arg0, int arg1, int arg2, int arg3) throws SQLException {
+        blowupIfRequested();
+        PreparedStatement s = impl.prepareStatement(arg0, arg1, arg2, arg3);
+        stmtSet.add(s);
+        return s;
+    }
+
+    @Override
+    public void releaseSavepoint(Savepoint arg0) throws SQLException {
+        impl.releaseSavepoint(arg0);
+    }
+
+    @Override
+    public void rollback() throws SQLException {
+        blowupIfRequested();
+        impl.rollback();
+    }
+
+    @Override
+    public void rollback(Savepoint arg0) throws SQLException {
+        blowupIfRequested();
+        impl.rollback(arg0);
+    }
+
+    @Override
+    public void setAutoCommit(boolean arg0) throws SQLException {
+        blowupIfRequested();
+        impl.setAutoCommit(arg0);
+    }
+
+    @Override
+    public void setCatalog(String arg0) throws SQLException {
+        impl.setCatalog(arg0);
+    }
+
+    @Override
+    public void setClientInfo(Properties arg0) throws SQLClientInfoException {
+        impl.setClientInfo(arg0);
+    }
+
+    @Override
+    public void setClientInfo(String arg0, String arg1) throws SQLClientInfoException {
+        impl.setClientInfo(arg0, arg1);
+    }
+
+    @Override
+    public void setHoldability(int arg0) throws SQLException {
+        impl.setHoldability(arg0);
+    }
+
+    @Override
+    public void setNetworkTimeout(Executor arg0, int arg1) throws SQLException {
+        impl.setNetworkTimeout(arg0, arg1);
+    }
+
+    @Override
+    public void setReadOnly(boolean arg0) throws SQLException {
+        impl.setReadOnly(arg0);
+    }
+
+    @Override
+    public Savepoint setSavepoint() throws SQLException {
+        return impl.setSavepoint();
+    }
+
+    @Override
+    public Savepoint setSavepoint(String arg0) throws SQLException {
+        return impl.setSavepoint(arg0);
+    }
+
+    @Override
+    public void setSchema(String arg0) throws SQLException {
+        impl.setSchema(arg0);
+    }
+
+    @Override
+    public void setTransactionIsolation(int arg0) throws SQLException {
+        impl.setTransactionIsolation(arg0);
+    }
+
+    @Override
+    public void setTypeMap(Map<String, Class<?>> arg0) throws SQLException {
+        // Simulate a JDBC 3.0 driver which throws a SQLException with the SQLState indicating not supported
+        throw new SQLException("Not Supported.", "0A000");
+    }
+
+    private void log(String msg) {
+        System.out.println("[" + getClass().getSimpleName() + "]:     " + msg);
+    }
+
+    @Override
+    public void setNextSqlCode(int sqlCode) {
+        this.sqlCode = sqlCode;
+    }
+
+    @Override
+    public void setNextSqlState(String sqlState) {
+        this.sqlState = sqlState;
+    }
+
+    private void blowupIfRequested() throws SQLException {
+        if (sqlCode == null && sqlState == null)
+            return;
+
+        // need to blow up with requeted sqlstate or sqlcode
+        String msg = "Throwing an exception requsted by the test application. sqlCode=" + sqlCode + " sqlState=" + sqlState;
+        SQLException ex = sqlCode != null ? //
+                        new SQLException(msg, sqlState, sqlCode) : //
+                        new SQLException(msg, sqlState);
+        log(msg);
+        sqlState = null;
+        sqlCode = null;
+        throw ex;
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_v41/test-applications/errorMappingDriver/src/jdbc/fat/v41/errormap/driver/ErrorMapDataSource.java
+++ b/dev/com.ibm.ws.jdbc_fat_v41/test-applications/errorMappingDriver/src/jdbc/fat/v41/errormap/driver/ErrorMapDataSource.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jdbc.fat.v41.errormap.driver;
+
+import javax.sql.DataSource;
+
+public interface ErrorMapDataSource extends DataSource {
+
+    public void mockNextSqlCode(int sqlCode);
+
+    public void mockNextSqlState(String sqlState);
+
+}

--- a/dev/com.ibm.ws.jdbc_fat_v41/test-applications/errorMappingDriver/src/jdbc/fat/v41/errormap/driver/ErrorMapDataSourceImpl.java
+++ b/dev/com.ibm.ws.jdbc_fat_v41/test-applications/errorMappingDriver/src/jdbc/fat/v41/errormap/driver/ErrorMapDataSourceImpl.java
@@ -1,0 +1,132 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package jdbc.fat.v41.errormap.driver;
+
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.logging.Logger;
+
+import org.apache.derby.jdbc.EmbeddedDataSource40;
+
+/**
+ * This class is a wrapper around the EmbeddedDataSource40.
+ * It allows the unit tests to override the implementation of methods.
+ */
+public class ErrorMapDataSourceImpl implements ErrorMapDataSource, Serializable {
+    private static final long serialVersionUID = -8721843807690710887L;
+    private final EmbeddedDataSource40 impl;
+
+    private Integer sqlCode = null;
+    private String sqlState = null;
+
+    public ErrorMapDataSourceImpl() {
+        impl = new EmbeddedDataSource40();
+    }
+
+    /* Methods for wrapping Derby Embedded */
+    public void setCreateDatabase(String create) {
+        impl.setCreateDatabase(create);
+    }
+
+    public String getCreateDatabase() {
+        return impl.getCreateDatabase();
+    }
+
+    public void setDatabaseName(String name) {
+        impl.setDatabaseName(name);
+    }
+
+    public String getDatabaseName() {
+        return impl.getDatabaseName();
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Logger getParentLogger() throws UnsupportedOperationException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter arg0) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setLoginTimeout(int arg0) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> arg0) throws SQLException {
+        return ErrorMapDataSource.class.equals(arg0) || impl.isWrapperFor(arg0);
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> arg0) throws SQLException {
+        if (ErrorMapDataSource.class.equals(arg0))
+            return (T) this;
+        return impl.unwrap(arg0);
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        log("Getting a connection with no user/pass");
+        blowupIfRequested();
+        return new ErrorMapConnectionImpl(this, impl.getConnection());
+    }
+
+    @Override
+    public Connection getConnection(String user, String pass) throws SQLException {
+        log("Getting a connection with user=" + user + " pass=" + pass);
+        blowupIfRequested();
+        return new ErrorMapConnectionImpl(this, impl.getConnection(user, pass));
+    }
+
+    private void log(String msg) {
+        System.out.println("[ErrorMapDataSourceImpl]: " + msg);
+    }
+
+    @Override
+    public void mockNextSqlCode(int sqlCode) {
+        this.sqlCode = sqlCode;
+    }
+
+    @Override
+    public void mockNextSqlState(String sqlState) {
+        this.sqlState = sqlState;
+    }
+
+    private void blowupIfRequested() throws SQLException {
+        if (sqlCode == null && sqlState == null)
+            return;
+
+        // need to blow up with requeted sqlstate or sqlcode
+        String msg = "Throwing an exception requsted by the test application. sqlCode=" + sqlCode + " sqlState=" + sqlState;
+        SQLException ex = sqlCode != null ? //
+                        new SQLException(msg, sqlState, sqlCode) : //
+                        new SQLException(msg, sqlState);
+        log(msg);
+        sqlState = null;
+        sqlCode = null;
+        throw ex;
+    }
+}


### PR DESCRIPTION
Add a new `<mapError>` configuration element under `<dataSource>` which can be used to map specific sqlCode and sqlState values to stale connections.

The `<mapError>` config element has 3 attributes:
 - sqlCode: (Integer) the SQL code that should be mapped. Mutually exclusive with sqlState
 - sqlState: (String) the SQL state that should be mapped. Mutually exclusive with sqlCode
 - to: (String, required) the target action that exceptions of the specified sqlCode or sqlState should be mapped to. Current allowed values are: 
      - NONE: removes mapping
      - STALE_CONNECTION: maps to a stale connection. Connections that are determined to be stale will be evicted from the connection pool

Example usage:
```xml
    <dataSource jndiName="jdbc/myDb">
        <jdbcDriver ... />
        <properties ... />
        <mapError sqlCode="1234" to="STALE_CONNECTION"/>
    </dataSource>
```

Build settings: prioritize JDBC and JCA