### PR TITLE
Cache the generated OpenAPI model

### DIFF
--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/ApplicationManagerElement.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/ApplicationManagerElement.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.simplicity.config;
+
+import javax.xml.bind.annotation.XmlAttribute;
+
+/**
+ *
+ */
+public class ApplicationManagerElement extends ConfigElement {
+
+    private Boolean autoExpand;
+    private String startTimeout;
+    private String stopTimeout;
+    private Boolean useJandex;
+
+    public Boolean getAutoExpand() {
+        return autoExpand;
+    }
+
+    @XmlAttribute
+    public void setAutoExpand(Boolean autoExpand) {
+        this.autoExpand = autoExpand;
+    }
+
+    public String getStartTimeout() {
+        return startTimeout;
+    }
+
+    @XmlAttribute
+    public void setStartTimeout(String startTimeout) {
+        this.startTimeout = startTimeout;
+    }
+
+    public String getStopTimeout() {
+        return stopTimeout;
+    }
+
+    @XmlAttribute
+    public void setStopTimeout(String stopTimeout) {
+        this.stopTimeout = stopTimeout;
+    }
+
+    public Boolean getUseJandex() {
+        return useJandex;
+    }
+
+    @XmlAttribute
+    public void setUseJandex(Boolean useJandex) {
+        this.useJandex = useJandex;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("ApplicationManagerElement [");
+        if (autoExpand != null) {
+            builder.append("autoExpand=");
+            builder.append(autoExpand);
+            builder.append(", ");
+        }
+        if (startTimeout != null) {
+            builder.append("startTimeout=");
+            builder.append(startTimeout);
+            builder.append(", ");
+        }
+        if (stopTimeout != null) {
+            builder.append("stopTimeout=");
+            builder.append(stopTimeout);
+            builder.append(", ");
+        }
+        if (useJandex != null) {
+            builder.append("useJandex=");
+            builder.append(useJandex);
+        }
+        builder.append("]");
+        return builder.toString();
+    }
+
+}

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/ServerConfiguration.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/ServerConfiguration.java
@@ -171,6 +171,9 @@ public class ServerConfiguration implements Cloneable {
     @XmlElement(name = "applicationMonitor")
     private ApplicationMonitorElement applicationMonitor;
 
+    @XmlElement(name = "applicationManager")
+    private ApplicationManagerElement applicationManager;
+
     @XmlElement(name = "executor")
     private ExecutorElement executor;
 
@@ -714,6 +717,16 @@ public class ServerConfiguration implements Cloneable {
             this.classLoading = new ClassloadingElement();
 
         return this.classLoading;
+    }
+
+    /**
+     * @return the applicationManager
+     */
+    public ApplicationManagerElement getApplicationManager() {
+        if (this.applicationManager == null)
+            this.applicationManager = new ApplicationManagerElement();
+
+        return this.applicationManager;
     }
 
     /**

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/bnd.bnd
@@ -32,6 +32,7 @@ Export-Package: \
     io.openliberty.microprofile.openapi20.validation
 
 Private-Package: \
+    io.openliberty.microprofile.openapi20.cache,\
     io.openliberty.microprofile.openapi20.resources,\
     io.openliberty.microprofile.openapi20.validation.resources
 

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/ApplicationProcessor.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/ApplicationProcessor.java
@@ -10,7 +10,14 @@
  *******************************************************************************/
 package io.openliberty.microprofile.openapi20;
 
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -24,6 +31,7 @@ import com.ibm.wsspi.adaptable.module.Entry;
 import com.ibm.wsspi.adaptable.module.NonPersistentCache;
 import com.ibm.wsspi.adaptable.module.UnableToAdaptException;
 
+import io.openliberty.microprofile.openapi20.cache.CacheEntry;
 import io.openliberty.microprofile.openapi20.utils.Constants;
 import io.openliberty.microprofile.openapi20.utils.IndexUtils;
 import io.openliberty.microprofile.openapi20.utils.LoggingUtils;
@@ -39,42 +47,41 @@ import io.smallrye.openapi.runtime.io.Format;
 
 /**
  * The ApplicationProcessor class processes an application that has been deployed to the OpenLiberty instance in order
- * to generate an OpenAPI model. 
+ * to generate an OpenAPI model.
  */
 public class ApplicationProcessor {
 
     private static final TraceComponent tc = Tr.register(ApplicationProcessor.class);
 
     /**
-     * The processApplication method processes applications that are added to the OpenLiberty instance. 
+     * The processApplication method processes applications that are added to the OpenLiberty instance.
      * 
      * @param appInfo
      *            The ApplicationInfo for the application to be processed.
      * @return OpenAPIProvider
-     *            The OpenAPIProvider for the application, or null if the application is not an OAS applciation.
+     *         The OpenAPIProvider for the application, or null if the application is not an OAS applciation.
      */
     @FFDCIgnore(UnableToAdaptException.class)
     public static OpenAPIProvider processApplication(final ApplicationInfo appInfo) {
-        
+
         // Create the variable to return
         OpenAPIProvider openAPIProvider = null;
 
         if (LoggingUtils.isEventEnabled(tc)) {
             Tr.event(tc, "Application Processor: Processing application started: appInfo=" + appInfo);
         }
-            
+
         // Make sure that we have valid application info
         if (appInfo != null) {
-            
+
             // Get the container for the application
             Container appContainer = appInfo.getContainer();
             if (appContainer != null) {
-                
+
                 // Check for app classes, if it is not there then the app manager is not in control of this app
                 try {
                     NonPersistentCache cache = appContainer.adapt(NonPersistentCache.class);
-                    ApplicationClassesContainerInfo applicationClassesContainerInfo =
-                        (ApplicationClassesContainerInfo) cache.getFromCache(ApplicationClassesContainerInfo.class);
+                    ApplicationClassesContainerInfo applicationClassesContainerInfo = (ApplicationClassesContainerInfo) cache.getFromCache(ApplicationClassesContainerInfo.class);
                     if (applicationClassesContainerInfo != null) {
 
                         // Check to see if the deployed application is an EAR/EBA
@@ -92,11 +99,11 @@ public class ApplicationProcessor {
                                     // Attempt to adapt the entry to a container
                                     Container container = entry.adapt(Container.class);
                                     if (container != null) {
-                                        
+
                                         // Attempt to retrieve WebModuleInfo for the container
                                         WebModuleInfo webModuleInfo = ModuleUtils.getWebModuleInfo(container);
                                         if (webModuleInfo != null) {
-                                            
+
                                             // Process the web module
                                             openAPIProvider = processWebModule(container, webModuleInfo);
                                             if (openAPIProvider != null) {
@@ -115,14 +122,14 @@ public class ApplicationProcessor {
                         } else {
                             // Not an Enterprise Application... attempt to get the WebModuleInfo
                             WebModuleInfo webModuleInfo = ModuleUtils.getWebModuleInfo(appContainer);
-                            
+
                             // Make sure that we have a valid web module.  If we do, process it.
                             if (webModuleInfo != null) {
                                 openAPIProvider = processWebModule(appContainer, webModuleInfo);
                                 if (openAPIProvider != null) {
                                     Tr.info(tc, MessageConstants.OPENAPI_APPLICATION_PROCESSED, webModuleInfo.getApplicationInfo().getDeploymentName());
                                 }
-                                
+
                                 if (LoggingUtils.isEventEnabled(tc)) {
                                     Tr.event(tc, "Application Processor: Processing application ended: appInfo=" + appInfo);
                                 }
@@ -153,7 +160,7 @@ public class ApplicationProcessor {
                 Tr.event(tc, "Application Processor: Processing application ended: appInfo=null");
             }
         }
-        
+
         return openAPIProvider;
     }
 
@@ -166,92 +173,96 @@ public class ApplicationProcessor {
      * @param moduleInfo
      *            The WebModuleInfo object for the web module
      * @return OpenAPIProvider
-     *            The OpenAPIProvider for the web module, or null if the web module is not an OAS applciation.
+     *         The OpenAPIProvider for the web module, or null if the web module is not an OAS applciation.
      */
     private static OpenAPIProvider processWebModule(final Container appContainer, final WebModuleInfo moduleInfo) {
-        
+
         // Create the variable to return
         OpenAPIProvider openAPIProvider = null;
-        
+
         if (LoggingUtils.isEventEnabled(tc)) {
             Tr.event(tc, "WebModule: Processing started : deploymentName=" + moduleInfo.getApplicationInfo().getDeploymentName() + " : contextRoot=" + moduleInfo.getContextRoot());
         }
         ClassLoader appClassloader = moduleInfo.getClassLoader();
         OpenAPI openAPIModel = null;
-        
+
         // Read and process the MicroProfile config. Try with resources will close the ConfigProcessor when done.
         try (ConfigProcessor configProcessor = new ConfigProcessor(appClassloader)) {
             if (LoggingUtils.isEventEnabled(tc)) {
                 Tr.event(tc, "Retrieved configuration values : " + configProcessor);
             }
-            
-            try {
-                OpenApiConfig config = configProcessor.getOpenAPIConfig();
-                OpenApiDocument.INSTANCE.reset();
-                OpenApiDocument.INSTANCE.config(config);
-                OpenApiStaticFile staticFile = StaticFileProcessor.getOpenAPIFile(appContainer);
-                OpenApiDocument.INSTANCE.modelFromStaticFile(OpenApiProcessor.modelFromStaticFile(staticFile));
-                OpenApiDocument.INSTANCE.modelFromAnnotations(OpenApiProcessor.modelFromAnnotations(config, IndexUtils.getIndexView(moduleInfo, config)));
-                OpenApiDocument.INSTANCE.modelFromReader(OpenApiProcessor.modelFromReader(config, appClassloader));
-                OpenApiDocument.INSTANCE.filter(OpenApiProcessor.getFilter(config, appClassloader));
-                OpenApiDocument.INSTANCE.initialize();
-                
-                openAPIModel =  OpenApiDocument.INSTANCE.get();
-                
-                /*
-                 * We need to determine whether the scanned application is an OAS application at all. In order to do
-                 * this we can check two things:
-                 * 
-                 *     1) Whether a static file was found in the application.
-                 *     2) Whether the generated OpenAPI model object is a just the default generated by the SmallRye
-                 *        implementation.
-                 */
-                if (staticFile == null && OpenAPIUtils.isDefaultOpenApiModel(openAPIModel)) {
-                    if (LoggingUtils.isEventEnabled(tc)) {
-                        Tr.event(tc, "Default Open API document generated");
+            CacheEntry newCacheEntry = null;
+            OpenApiConfig config = configProcessor.getOpenAPIConfig();
+            String modulePathString = appContainer.getPhysicalPath();
+            Path modulePath = modulePathString == null ? null : Paths.get(modulePathString);
+            Path cacheDir = getCacheDir();
+
+            if (modulePath != null && isWar(modulePath) && cacheDir != null) {
+                // The web module is a single file. We should use the cache if possible.
+                newCacheEntry = CacheEntry.createNew(moduleInfo.getApplicationInfo().getDeploymentName(), cacheDir);
+                newCacheEntry.setConfig(config);
+                newCacheEntry.addDependentFile(modulePath);
+
+                CacheEntry loadedCacheEntry = CacheEntry.read(moduleInfo.getApplicationInfo().getDeploymentName(), cacheDir);
+                if (loadedCacheEntry != null && loadedCacheEntry.isUpToDateWith(newCacheEntry)) {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "Using OpenAPI model loaded from cache");
                     }
-                    openAPIModel = null;
+
+                    openAPIModel = loadedCacheEntry.getModel();
+                }
+            }
+
+            if (openAPIModel == null) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Generating OpenAPI model");
                 }
 
-                if (openAPIModel != null) {
-                    // Add default info to the doc if none is present
-                    if (openAPIModel.getInfo() == null) {
-                        openAPIModel.setInfo(new InfoImpl().title(Constants.DEFAULT_OPENAPI_DOC_TITLE)
-                                .version(Constants.DEFAULT_OPENAPI_DOC_VERSION));
-                    }
+                openAPIModel = generateModel(config, appContainer, moduleInfo, appClassloader);
+                if (openAPIModel != null && newCacheEntry != null) {
+                    newCacheEntry.setModel(openAPIModel);
+                    newCacheEntry.write();
+                }
+            }
 
-                    if (LoggingUtils.isEventEnabled(tc)) {
-                        Tr.event(tc, "Generated document: " + OpenAPIUtils.getOpenAPIDocument(openAPIModel, Format.JSON));
-                    }
-                    
-                    // Create the OpenAPIProvider to return
-                    openAPIProvider = new WebModuleOpenAPIProvider(moduleInfo, openAPIModel, OpenAPIUtils.containsServersDefinition(openAPIModel));
+            if (openAPIModel != null) {
+                // Add default info to the doc if none is present
+                if (openAPIModel.getInfo() == null) {
+                    openAPIModel.setInfo(new InfoImpl().title(Constants.DEFAULT_OPENAPI_DOC_TITLE).version(Constants.DEFAULT_OPENAPI_DOC_VERSION));
+                }
 
-                    // Validate the document if the validation property has been enabled.
-                    if (configProcessor.isValidating()) {
-                        try {
-                            if (LoggingUtils.isEventEnabled(tc)) {
-                                Tr.event(tc, "Validate document");
-                            }
-                            OpenAPIUtils.validateDocument(openAPIModel);
-                        } catch (Throwable e) {
-                            if (LoggingUtils.isEventEnabled(tc)) {
-                                Tr.event(tc, "Failed to call OASValidator: " + e.getMessage());
-                            }
+                if (LoggingUtils.isEventEnabled(tc)) {
+                    Tr.event(tc, "Generated document: " + OpenAPIUtils.getOpenAPIDocument(openAPIModel, Format.JSON));
+                }
+
+                // Create the OpenAPIProvider to return
+                openAPIProvider = new WebModuleOpenAPIProvider(moduleInfo, openAPIModel, OpenAPIUtils.containsServersDefinition(openAPIModel));
+
+                // Validate the document if the validation property has been enabled.
+                if (configProcessor.isValidating()) {
+                    try {
+                        if (LoggingUtils.isEventEnabled(tc)) {
+                            Tr.event(tc, "Validate document");
+                        }
+                        OpenAPIUtils.validateDocument(openAPIModel);
+                    } catch (Throwable e) {
+                        if (LoggingUtils.isEventEnabled(tc)) {
+                            Tr.event(tc, "Failed to call OASValidator: " + e.getMessage());
                         }
                     }
-                } else {
-                    if (LoggingUtils.isEventEnabled(tc)) {
-                        Tr.event(tc, "WebModule: Processing ended : Not an OAS application : deploymentName=" + moduleInfo.getApplicationInfo().getDeploymentName() + " : contextRoot=" + moduleInfo.getContextRoot());
-                    }
                 }
-            } catch (Exception e) {
+            } else {
                 if (LoggingUtils.isEventEnabled(tc)) {
-                    final String message = String.format("Failed to process application %s: %s", moduleInfo.getApplicationInfo().getDeploymentName(), e.getMessage());
-                    Tr.event(tc, "Failed to process application: " + message);
+                    Tr.event(tc, "WebModule: Processing ended : Not an OAS application : deploymentName=" + moduleInfo.getApplicationInfo().getDeploymentName() + " : contextRoot="
+                                 + moduleInfo.getContextRoot());
                 }
-                Tr.error(tc, MessageConstants.OPENAPI_APPLICATION_PROCESSING_ERROR, moduleInfo.getApplicationInfo().getDeploymentName());
             }
+        } catch (Exception e) {
+            if (LoggingUtils.isEventEnabled(tc)) {
+                final String message = String.format("Failed to process application %s: %s", moduleInfo.getApplicationInfo().getDeploymentName(), e.getMessage());
+                Tr.event(tc, "Failed to process application: " + message);
+            }
+            Tr.error(tc, MessageConstants.OPENAPI_APPLICATION_PROCESSING_ERROR, moduleInfo.getApplicationInfo().getDeploymentName());
         }
 
         if (LoggingUtils.isEventEnabled(tc)) {
@@ -260,7 +271,57 @@ public class ApplicationProcessor {
         return openAPIProvider;
     }
 
-    private ApplicationProcessor() {
-        // This class is not meant to be instantiated.
+    private static OpenAPI generateModel(OpenApiConfig config, Container appContainer, WebModuleInfo moduleInfo, ClassLoader appClassloader) {
+        OpenAPI openAPIModel;
+        OpenApiDocument.INSTANCE.reset();
+        OpenApiDocument.INSTANCE.config(config);
+        OpenApiStaticFile staticFile = StaticFileProcessor.getOpenAPIFile(appContainer);
+        OpenApiDocument.INSTANCE.modelFromStaticFile(OpenApiProcessor.modelFromStaticFile(staticFile));
+        OpenApiDocument.INSTANCE.modelFromAnnotations(OpenApiProcessor.modelFromAnnotations(config, IndexUtils.getIndexView(moduleInfo, config)));
+        OpenApiDocument.INSTANCE.modelFromReader(OpenApiProcessor.modelFromReader(config, appClassloader));
+        OpenApiDocument.INSTANCE.filter(OpenApiProcessor.getFilter(config, appClassloader));
+        OpenApiDocument.INSTANCE.initialize();
+
+        openAPIModel = OpenApiDocument.INSTANCE.get();
+
+        /*
+         * We need to determine whether the scanned application is an OAS application at all. In order to do
+         * this we can check two things:
+         * 
+         * 1) Whether a static file was found in the application.
+         * 2) Whether the generated OpenAPI model object is a just the default generated by the SmallRye
+         * implementation.
+         */
+        if (staticFile == null && OpenAPIUtils.isDefaultOpenApiModel(openAPIModel)) {
+            if (LoggingUtils.isEventEnabled(tc)) {
+                Tr.event(tc, "Default Open API document generated");
+            }
+            openAPIModel = null;
+        }
+        return openAPIModel;
     }
+
+    private static boolean isWar(Path path) {
+        return path.getFileName().toString().endsWith(".war") && Files.isRegularFile(path);
+    }
+
+    private static Path getCacheDir() {
+        Bundle bundle = FrameworkUtil.getBundle(ApplicationProcessor.class);
+        if (bundle == null) {
+            // Not in OSGi, shouldn't happen at runtime
+            return null;
+        }
+
+        File cacheFile = bundle.getDataFile("");
+        if (cacheFile == null) {
+            // Shouldn't happen
+            if (LoggingUtils.isEventEnabled(tc)) {
+                Tr.event(tc, "No support from OSGi for caching");
+            }
+            return null;
+        }
+
+        return cacheFile.toPath();
+    }
+
 }

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/cache/CacheEntry.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/cache/CacheEntry.java
@@ -1,0 +1,347 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.openapi20.cache;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
+
+import io.openliberty.microprofile.openapi20.utils.LoggingUtils;
+import io.smallrye.openapi.api.OpenApiConfig;
+import io.smallrye.openapi.runtime.OpenApiProcessor;
+import io.smallrye.openapi.runtime.OpenApiStaticFile;
+import io.smallrye.openapi.runtime.io.Format;
+import io.smallrye.openapi.runtime.io.OpenApiSerializer;
+
+/**
+ * Responsible for collecting and writing an OpenAPI cache entry
+ * <p>
+ * The cache key comprises of:
+ * <ul>
+ * <li>the application name</li>
+ * <li>the files scanned for annotations</li>
+ * <li>the OpenAPI configuration</li>
+ * </ul>
+ * The cached value is the OpenAPI model constructed from the application.
+ */
+public class CacheEntry {
+
+    private static final TraceComponent tc = Tr.register(CacheEntry.class);
+
+    private static final String CACHE_DIR = "cache";
+    private static final String MODEL_FILE = "model";
+    private static final String CONFIG_FILE = "config";
+    private static final String FILES_LIST_FILE = "files";
+
+    private String appName;
+    private Path cacheDir;
+    private OpenAPI model;
+    private OpenApiConfig config;
+    private Properties configProperties;
+    private List<String> fileEntries = new ArrayList<>();
+
+    /**
+     * Create a new empty cache entry
+     * <p>
+     * This entry can then be populated with {@link #setModel(OpenAPI)}, {@link #setConfig(OpenApiConfig)} and {@link #addDependentFile(Path)} and stored with {@link #write()}.
+     * 
+     * @param applicationName the name of the application
+     * @param baseDir the cache directory
+     * @return the new CacheEntry
+     */
+    public static CacheEntry createNew(String applicationName, Path baseDir) {
+        return new CacheEntry(applicationName, baseDir);
+    }
+
+    /**
+     * Load a cache entry for an application, if it exists.
+     * <p>
+     * This entry can then be compared with an entry for the current application using {@link #isUpToDateWith(CacheEntry)} and if it is up to date, the cached model can be
+     * retrieved with {@link #getModel()}.
+     * 
+     * @param applicationName the application name
+     * @param baseDir the cache directory
+     * @return the loaded cache entry, or {@code null} if a valid cache entry does not exist for this application name
+     */
+    public static CacheEntry read(String applicationName, Path baseDir) {
+        CacheEntry cacheEntry = new CacheEntry(applicationName, baseDir);
+        if (!Files.isDirectory(cacheEntry.cacheDir)) {
+            return null;
+        }
+
+        try {
+            if (!cacheEntry.read()) {
+                return null;
+            }
+        } catch (IOException e) {
+            Tr.warning(tc, "Unexpected error attempting to read cache for the {0} application. The error is {1}", applicationName, e.toString());
+            return null;
+        }
+
+        return cacheEntry;
+    }
+
+    private CacheEntry(String applicationName, Path baseDir) {
+        try {
+            this.appName = URLEncoder.encode(applicationName, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            // Won't happen
+            throw new RuntimeException("Unable to use UTF-8 encoding", e);
+        }
+        this.cacheDir = baseDir.resolve(CACHE_DIR).resolve(this.appName);
+    }
+
+    /**
+     * Add a file which was used to generate the OpenAPI model
+     * <p>
+     * This method must be called for every <i>on-disk</i> file used to generate the OpenAPI model.
+     * <p>
+     * Where files within archives are used to generate the model (e.g. library jars within a war file, or a war file within an ear file), only the enclosing archive needs to added
+     * using this method.
+     * 
+     * @param file the file
+     * @throws IOException if the file's size or last modified time can't be read
+     */
+    public void addDependentFile(Path file) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        sb.append(file.toAbsolutePath().toString());
+        sb.append(",");
+        sb.append(Files.size(file));
+        sb.append(",");
+        sb.append(Files.getLastModifiedTime(file).toMillis());
+        fileEntries.add(sb.toString());
+    }
+
+    /**
+     * Set the config for the cache key
+     * 
+     * @param config the config
+     */
+    public void setConfig(OpenApiConfig config) {
+        this.config = config;
+        this.configProperties = null;
+    }
+
+    /**
+     * Set the model to be cached
+     * 
+     * @param model the model
+     */
+    public void setModel(OpenAPI model) {
+        this.model = model;
+    }
+
+    /**
+     * Get the model stored in this CacheEntry
+     * 
+     * @return the model
+     */
+    public OpenAPI getModel() {
+        return model;
+    }
+
+    /**
+     * Check whether this cache entry is up to date with the current state of the application and config.
+     * <p>
+     * This method may only be called on a cache entry read from disk with {@link #read(String, Path)}.
+     * 
+     * @param current a CacheEntry representing the current state. It must have the config set and all dependent files added before this method is called.
+     * @return {@code true} if this cache entry is up to date, {@code false} otherwise
+     */
+    @Trivial // method has sufficient tracing
+    public boolean isUpToDateWith(CacheEntry current) {
+        if (model == null || configProperties == null) {
+            throw new IllegalStateException("isUpToDateWith called on CacheEntry not read from disk");
+        }
+        Objects.requireNonNull(current, "cache entry for current state must be given");
+
+        // sanity check the app name
+        if (!Objects.equals(appName, current.appName)) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(this, tc, "Cache out of date because app name is not the same?!", appName, current.appName);
+            }
+            return false;
+        }
+
+        // compare config
+        // Note: old cached model is used here to provide a list of paths and operations
+        // which is needed to get the full list of config properties for the current environment
+        Properties currentConfigProperties = current.getConfigProperties(model);
+        if (!Objects.equals(configProperties, currentConfigProperties)) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(this, tc, "Cache out of date because config is not the same", configProperties, currentConfigProperties);
+            }
+            return false;
+        }
+
+        // compare scanned files
+        if (!Objects.equals(fileEntries, current.fileEntries)) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(this, tc, "Cache out of date because files have changed", fileEntries, current.fileEntries);
+            }
+            return false;
+        }
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(this, tc, "Cache is up to date");
+        }
+
+        return true;
+    }
+
+    private Properties getConfigProperties(OpenAPI model) {
+        if (configProperties != null) {
+            return configProperties;
+        } else if (config != null) {
+            return ConfigSerializer.serializeConfig(config, model);
+        } else {
+            return null;
+        }
+    }
+
+    public void write() throws IOException {
+        // check that everything required for a cache entry has been provided
+        if (appName == null || model == null || (configProperties == null && config == null) || fileEntries.isEmpty()) {
+            if (LoggingUtils.isDebugEnabled(tc)) {
+                if (appName == null)
+                    Tr.debug(this, tc, "Not writing cache entry, AppName is null");
+                if (model == null)
+                    Tr.debug(this, tc, "Not writing cache entry, model is null");
+                if (configProperties == null && config == null)
+                    Tr.debug(this, tc, "Not writing cache entry, config is null");
+                if (fileEntries.isEmpty())
+                    Tr.debug(this, tc, "Not writing cache entry, fileEntries is empty");
+            }
+            return;
+        }
+
+        if (LoggingUtils.isDebugEnabled(tc)) {
+            Tr.debug(this, tc, "Writing cache entry");
+        }
+
+        try {
+            // delete cache directory if present
+            if (Files.exists(cacheDir)) {
+                if (Files.isDirectory(cacheDir)) {
+                    Files.walkFileTree(cacheDir, RECURSIVE_DELETER);
+                } else {
+                    throw new IOException("Non-directory found in cache location: " + cacheDir.toAbsolutePath());
+                }
+            }
+
+            // create cache directory
+            Files.createDirectories(cacheDir);
+
+            // write list of dependent file data
+            writeFileList(cacheDir.resolve(FILES_LIST_FILE));
+
+            // serialize config
+            writeConfig(cacheDir.resolve(CONFIG_FILE));
+
+            // serialize model
+            writeModel(cacheDir.resolve(MODEL_FILE));
+
+            if (LoggingUtils.isDebugEnabled(tc)) {
+                Tr.debug(this, tc, "Cache entry written");
+            }
+        } catch (Exception e) {
+            // warn upon unexpected failure
+            Tr.warning(tc, "An unexpected error occurred while writing the cache for application {0}. The error is {1}", appName, e.toString());
+        }
+    }
+
+    private boolean read() throws IOException {
+        Path modelFile = cacheDir.resolve(MODEL_FILE);
+        Path configFile = cacheDir.resolve(CONFIG_FILE);
+        Path filesListFile = cacheDir.resolve(FILES_LIST_FILE);
+
+        if (!Files.exists(modelFile) || !Files.exists(configFile) || !Files.exists(filesListFile)) {
+            return false;
+        }
+
+        readModel(modelFile);
+        readConfig(configFile);
+        readFileList(filesListFile);
+
+        return true;
+    }
+
+    private void readModel(Path input) throws IOException {
+        try (InputStream is = new FileInputStream(input.toFile())) {
+            OpenApiStaticFile openApiFile = new OpenApiStaticFile(is, Format.JSON);
+            model = OpenApiProcessor.modelFromStaticFile(openApiFile);
+        }
+    }
+
+    private void writeModel(Path output) throws IOException {
+        String jsonModel = OpenApiSerializer.serialize(model, Format.JSON);
+        Files.write(output, jsonModel.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private void readConfig(Path input) throws IOException {
+        Properties result = new Properties();
+        try (InputStream is = Files.newInputStream(input)) {
+            result.load(is);
+        }
+        configProperties = result;
+    }
+
+    private void writeConfig(Path output) throws IOException {
+        try (OutputStream os = Files.newOutputStream(output)) {
+            getConfigProperties(model).store(os, "");
+        }
+    }
+
+    private void readFileList(Path input) throws IOException {
+        fileEntries = Files.readAllLines(input, StandardCharsets.UTF_8);
+    }
+
+    private void writeFileList(Path output) throws IOException {
+        Files.write(output, fileEntries, StandardCharsets.UTF_8);
+    }
+
+    private static final FileVisitor<Path> RECURSIVE_DELETER = new SimpleFileVisitor<Path>() {
+
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+            Files.delete(file);
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+            Files.delete(dir);
+            return FileVisitResult.CONTINUE;
+        }
+
+    };
+
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/cache/ConfigSerializer.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/cache/ConfigSerializer.java
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.openapi20.cache;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+
+import io.smallrye.openapi.api.OpenApiConfig;
+import io.smallrye.openapi.api.OpenApiConfig.OperationIdStrategy;
+
+public class ConfigSerializer {
+
+    // Package protected for unit testing
+    enum ConfigField {
+        MODEL_READER("modelReader", OpenApiConfig::modelReader),
+        FILTER("filter", OpenApiConfig::filter),
+        SCAN_DISABLE("scanDisable", c -> Boolean.toString(c.scanDisable())),
+        SCAN_PACKAGES("scanPackages", OpenApiConfig::scanPackages, Pattern::pattern),
+        SCAN_CLASSES("scanClasses", OpenApiConfig::scanClasses, Pattern::pattern),
+        SCAN_EXCLUDE_PACKAGES("scanExcludePackages", OpenApiConfig::scanExcludePackages, Pattern::pattern),
+        SCAN_EXCLUDE_CLASSES("scanExcludeClasses", OpenApiConfig::scanExcludeClasses, Pattern::pattern),
+        SERVERS("servers", c -> serializeSet(c.servers())),
+        // pathServers handled in writeConfig
+        // operationServers handled in writeConfig
+        SCAN_DEPENDENCIES_DISABLE("scanDependenciesDisable", c -> Boolean.toString(c.scanDependenciesDisable())),
+        SCAN_DEPENDENCIES_JARS("scanDependenciesJars", c -> serializeSet(c.scanDependenciesJars())),
+        CUSTOM_SCHEMA_REGISTRY_CLASS("customSchemaRegistryClass", OpenApiConfig::customSchemaRegistryClass),
+        APPLICATION_PATH_DISABLE("applicationPathDisable", c -> Boolean.toString(c.applicationPathDisable())),
+        SCHEMAS("getSchemas", c -> serializeMap(c.getSchemas())),
+        OPEN_API_VERSION("getOpenApiVersion", OpenApiConfig::getOpenApiVersion),
+        INFO_TITLE("getInfoTitle", OpenApiConfig::getInfoTitle),
+        INFO_VERSION("getInfoVersion", OpenApiConfig::getInfoVersion),
+        INFO_DESCRIPTION("getInfoDescription", OpenApiConfig::getInfoDescription),
+        INFO_TERMS_OF_SERVICE("getInfoTermsOfService", OpenApiConfig::getInfoTermsOfService),
+        INFO_CONTACT_EMAIL("getInfoContactEmail", OpenApiConfig::getInfoContactEmail),
+        INFO_CONTACT_NAME("getInfoContactName", OpenApiConfig::getInfoContactName),
+        INFO_CONTACT_URL("getInfoContactUrl", OpenApiConfig::getInfoContactUrl),
+        INFO_LICENSE_NAME("getInfoLicenseName", OpenApiConfig::getInfoLicenseName),
+        INFO_LICENSE_URL("getInfoLicenseUrl", OpenApiConfig::getInfoLicenseName),
+        OPERATION_ID_STRATEGY("getOperationIdStrategy", OpenApiConfig::getOperationIdStrategy, OperationIdStrategy::name),
+        ;
+
+        Function<OpenApiConfig, String> function;
+        String name;
+
+        private ConfigField(String name, Function<OpenApiConfig, String> function) {
+            this.name = name;
+            this.function = function;
+        }
+
+        private <V> ConfigField(String name, Function<OpenApiConfig, V> valueGetter, Function<V, String> stringConverter) {
+            this.name = name;
+            this.function = c -> {
+                V value = valueGetter.apply(c);
+                return value == null ? null : stringConverter.apply(value);
+            };
+        }
+    }
+
+    /**
+     * Convert an OpenApiConfig into a Properties object so that it can be easily stored.
+     * 
+     * @param config the config
+     * @param model the model used to retrieve paths and operation ids
+     * @return a Properties object containing the relevant keys and values from the config
+     */
+    public static Properties serializeConfig(OpenApiConfig config, OpenAPI model) {
+        Properties result = new Properties();
+        for (ConfigField field : ConfigField.values()) {
+            String value = field.function.apply(config);
+            if (value != null) {
+                result.put(field.name, value);
+            }
+        }
+        for (String pathName : getPathNames(model)) {
+            Set<String> value = config.pathServers(pathName);
+            if (value != null && !value.isEmpty()) {
+                result.put("pathServer." + pathName, serializeSet(value));
+            }
+        }
+        for (String operationId : getOperationIds(model)) {
+            Set<String> value = config.operationServers(operationId);
+            if (value != null && !value.isEmpty()) {
+                result.put("operationServer." + operationId, serializeSet(value));
+            }
+        }
+        return result;
+    }
+
+    private static String serializeSet(Set<String> set) {
+        // Sort to ensure repeatability
+        ArrayList<String> list = new ArrayList<>(set);
+        Collections.sort(list);
+        return String.join(",", list);
+    }
+
+    private static String serializeMap(Map<String, String> map) {
+        // Sort to ensure repeatability
+        List<Entry<String, String>> entryList = new ArrayList<>(map.entrySet());
+        Collections.sort(entryList, Map.Entry.comparingByKey());
+
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (Entry<String, String> e : map.entrySet()) {
+            if (!first) {
+                sb.append(",");
+            }
+            first = false;
+            sb.append(e.getKey());
+            sb.append("=");
+            sb.append(e.getValue());
+        }
+        return sb.toString();
+    }
+
+    private static Set<String> getPathNames(OpenAPI model) {
+        return model.getPaths().getPathItems().keySet();
+    }
+
+    private static Set<String> getOperationIds(OpenAPI model) {
+        return model.getPaths().getPathItems().values().stream() // Get the paths
+                    .flatMap(i -> i.getOperations().values().stream()) // Get all the operations from all the paths
+                    .filter(o -> o.getOperationId() != null) // Filter out the ones without an id
+                    .map(o -> o.getOperationId()) // Extract just the operation id
+                    .collect(Collectors.toSet()); // Collect the IDs into a set
+    }
+
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/cache/package-info.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/cache/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+@com.ibm.websphere.ras.annotation.TraceOptions(traceGroup = Constants.TRACE_GROUP, messageBundle = Constants.TRACE_OPENAPI)
+package io.openliberty.microprofile.openapi20.cache;
+
+import io.openliberty.microprofile.openapi20.utils.Constants;

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/cache/ConfigSerializerTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/test/io/openliberty/microprofile/openapi20/cache/ConfigSerializerTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.openapi20.cache;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+
+import org.junit.Test;
+
+import io.openliberty.microprofile.openapi20.cache.ConfigSerializer.ConfigField;
+import io.smallrye.openapi.api.OpenApiConfig;
+
+public class ConfigSerializerTest {
+
+    /**
+     * Methods in OpenApiConfig which should not have a corresponding entry in the ConfigField enum
+     */
+    public static final Collection<String> METHODS_TO_IGNORE = Arrays.asList("pathServers",
+                                                                             "operationServers",
+                                                                             "patternOf",
+                                                                             "asCsvSet");
+
+    /**
+     * Test that the ConfigSerializer covers all methods of OpenApiConfig
+     * <p>
+     * This should only fail if the version of smallrye-open-api is updated and ConfigSerializer is not updated to match.
+     */
+    @Test
+    public void testCoverage() {
+        HashSet<String> configFieldNames = new HashSet<>();
+        for (ConfigField field : ConfigSerializer.ConfigField.values()) {
+            configFieldNames.add(field.name);
+        }
+
+        HashSet<String> missingFields = new HashSet<>();
+        for (Method m : OpenApiConfig.class.getMethods()) {
+            if (!METHODS_TO_IGNORE.contains(m.getName()) && !configFieldNames.remove(m.getName())) {
+                missingFields.add(m.getName());
+            }
+        }
+
+        assertThat("OpenApiConfig methods missing from ConfigField enum", missingFields, is(empty()));
+        assertThat("ConfigField entries which don't have a matching method in OpenApiConfig", configFieldNames, is(empty()));
+    }
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/FATSuite.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/FATSuite.java
@@ -15,11 +15,13 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import io.openliberty.microprofile.openapi20.fat.cache.CacheTest;
+import io.openliberty.microprofile.openapi20.fat.deployments.DeploymentTest;
 
 @RunWith(Suite.class)
 @SuiteClasses({
     ApplicationProcessorTest.class,
-    CacheTest.class
+    CacheTest.class,
+    DeploymentTest.class
 })
 public class FATSuite {
 }

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/cache/CacheTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/cache/CacheTest.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.openapi20.fat.cache;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.OVERWRITE;
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.util.Collections;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+
+@Mode(TestMode.FULL)
+@RunWith(FATRunner.class)
+public class CacheTest {
+
+    @Server("ApplicationProcessorServer")
+    public static LibertyServer server;
+
+    @Test
+    public void testCacheHit() throws Exception {
+        // Deploy app
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "cacheTest.war").addPackage(CacheTest.class.getPackage());
+        ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
+
+        // start server
+        server.startServer();
+
+        // check that document is generated and cache written
+        assertThat(server.findStringsInTrace("Generating OpenAPI model"), not(empty()));
+        assertThat(server.findStringsInTrace("Cache entry written"), not(empty()));
+
+        // stop server without archiving it
+        server.stopServer(false);
+
+        // start server without clean (since that would clear the cache)
+        server.startServer(false);
+
+        // check that cache is used and document is not generated
+        assertThat(server.findStringsInTrace("Using OpenAPI model loaded from cache"), not(empty()));
+        assertThat(server.findStringsInTrace("Generating OpenAPI model"), is(empty()));
+    }
+
+    @Test
+    public void testCacheMissAppUpdate() throws Exception {
+        // Deploy app
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "cacheTest.war").addPackage(CacheTest.class.getPackage());
+        ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
+
+        // start server
+        server.startServer();
+
+        // check that document is generated and cache written
+        assertThat(server.findStringsInTrace("Generating OpenAPI model"), not(empty()));
+        assertThat(server.findStringsInTrace("Cache entry written"), not(empty()));
+
+        // stop server without archiving it
+        server.stopServer(false);
+
+        // Redeploy app
+        ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY, OVERWRITE);
+
+        // start server without clean (since that would clear the cache)
+        server.startServer(false);
+
+        // check that cache is not used
+        assertThat(server.findStringsInTrace("Cache out of date because files have changed"), not(empty()));
+        assertThat(server.findStringsInTrace("Generating OpenAPI model"), not(empty()));
+        assertThat(server.findStringsInTrace("Cache entry written"), not(empty()));
+    }
+
+    @Test
+    public void testCacheMissConfig() throws Exception {
+        // Deploy app
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "cacheTest.war").addPackage(CacheTest.class.getPackage());
+        ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
+
+        // start server
+        server.startServer();
+
+        // check that document is generated and cache written
+        assertThat(server.findStringsInTrace("Generating OpenAPI model"), not(empty()));
+        assertThat(server.findStringsInTrace("Cache entry written"), not(empty()));
+
+        // stop server without archiving it
+        server.stopServer(false);
+
+        // Update server config
+        server.setAdditionalSystemProperties(Collections.singletonMap("MP_OPENAPI_SCAN_DISABLE", "true"));
+
+        // start server without clean (since that would clear the cache)
+        server.startServer(false);
+
+        // check that cache is not used
+        assertThat(server.findStringsInTrace("Cache out of date because config is not the same"), not(empty()));
+        assertThat(server.findStringsInTrace("Generating OpenAPI model"), not(empty()));
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        try {
+            server.stopServer();
+        } finally {
+            server.setAdditionalSystemProperties(null);
+        }
+    }
+
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/cache/CacheTestApp.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/cache/CacheTestApp.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,18 +8,12 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package io.openliberty.microprofile.openapi20.fat;
+package io.openliberty.microprofile.openapi20.fat.cache;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
 
-import io.openliberty.microprofile.openapi20.fat.cache.CacheTest;
+@ApplicationPath("/")
+public class CacheTestApp extends Application {
 
-@RunWith(Suite.class)
-@SuiteClasses({
-    ApplicationProcessorTest.class,
-    CacheTest.class
-})
-public class FATSuite {
 }

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/cache/CacheTestResource.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/cache/CacheTestResource.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.openapi20.fat.cache;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+
+@Path("/")
+public class CacheTestResource {
+    
+    @GET
+    @Path("/test")
+    @Operation(summary = "test method")
+    @APIResponse(responseCode = "200", description = "constant \"OK\" response")
+    @Produces(value = MediaType.TEXT_PLAIN)
+    public String test() {
+        return "OK";
+    }
+
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/DeploymentTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/DeploymentTest.java
@@ -1,0 +1,266 @@
+package io.openliberty.microprofile.openapi20.fat.deployments;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.DISABLE_VALIDATION;
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.util.Collections;
+import java.util.function.Consumer;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.ibm.websphere.simplicity.RemoteFile;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.Application;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyFileManager;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.HttpRequest;
+import io.openliberty.microprofile.openapi20.fat.utils.OpenAPIConnection;
+import io.openliberty.microprofile.openapi20.fat.utils.OpenAPITestUtil;
+
+/**
+ * Test that OpenAPI works correctly when the application is deployed in different ways (ear, war, etc.)
+ */
+@RunWith(FATRunner.class)
+public class DeploymentTest {
+
+    @Server("OpenAPITestServer")
+    public static LibertyServer server;
+
+    private ServerConfiguration initialConfig;
+
+    @BeforeClass
+    public static void setupServer() throws Exception {
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void shutdownServer() throws Exception {
+        server.stopServer();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        initialConfig = server.getServerConfiguration();
+        RemoteFile testLibsDir = LibertyFileManager.createRemoteFile(server.getMachine(), server.getServerRoot() + "/testLibs");
+        testLibsDir.mkdirs();
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        server.setMarkToEndOfLog();
+        server.updateServerConfiguration(initialConfig);
+        server.waitForConfigUpdateInLogUsingMark(Collections.emptySet());
+
+        RemoteFile appsDir = server.getFileFromLibertyServerRoot("apps");
+        for (RemoteFile app : appsDir.list(false)) {
+            app.delete();
+        }
+
+        RemoteFile testLibsDir = LibertyFileManager.createRemoteFile(server.getMachine(), server.getServerRoot() + "/testLibs");
+        for (RemoteFile lib : testLibsDir.list(false)) {
+            lib.delete();
+        }
+    }
+
+    @Test
+    public void testEar() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "testWar.war")
+                                   .addClasses(DeploymentTestApp.class, DeploymentTestResource.class);
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "testEar.ear")
+                                          .addAsModule(war);
+
+        deployApp(ear);
+
+        assertRest();
+        assertOpenApiDoc();
+        // Slightly odd behaviour - the app manager expands the .ear so the .war file is available on disk
+        // However, when the .ear is redeployed, the .ear is re-expanded and the location is different
+        assertCache(ear, CacheUsed.CACHE_NOT_USED, CacheWritten.CACHE_WRITTEN);
+    }
+
+    @Test
+    public void testExpandedEar() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "testWar.war")
+                                   .addClasses(DeploymentTestApp.class, DeploymentTestResource.class);
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "testEar.ear")
+                                          .addAsModule(war);
+
+        deployApp(ear, c -> c.getApplicationManager().setAutoExpand(true));
+
+        assertRest();
+        assertOpenApiDoc();
+        assertCache(ear, CacheUsed.CACHE_NOT_USED, CacheWritten.CACHE_NOT_WRITTEN);
+    }
+
+    @Test
+    public void testWar() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "testWar.war")
+                                   .addClasses(DeploymentTestApp.class, DeploymentTestResource.class);
+
+        deployApp(war);
+
+        assertRest();
+        assertOpenApiDoc();
+        assertCache(war, CacheUsed.CACHE_USED, CacheWritten.CACHE_NOT_WRITTEN);
+    }
+
+    @Test
+    public void testExpandedWar() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "testWar.war")
+                                   .addClasses(DeploymentTestApp.class, DeploymentTestResource.class);
+
+        deployApp(war, c -> c.getApplicationManager().setAutoExpand(true));
+
+        assertRest();
+        assertOpenApiDoc();
+        assertCache(war, CacheUsed.CACHE_NOT_USED, CacheWritten.CACHE_NOT_WRITTEN);
+    }
+
+    @Test
+    public void testWarLib() throws Exception {
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "testJar.jar")
+                                    .addClasses(DeploymentTestApp.class, DeploymentTestResource.class);
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "testWar.war")
+                                   .addAsLibrary(jar);
+
+        deployApp(war);
+
+        assertRest();
+        assertOpenApiDoc();
+        assertCache(war, CacheUsed.CACHE_USED, CacheWritten.CACHE_NOT_WRITTEN);
+    }
+
+    @Test
+    @Ignore // Known bug
+    public void testExpandedWarLib() throws Exception {
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "testJar.jar")
+                                    .addClasses(DeploymentTestApp.class, DeploymentTestResource.class);
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "testWar.war")
+                                   .addAsLibrary(jar);
+
+        deployApp(war, c -> c.getApplicationManager().setAutoExpand(true));
+
+        assertRest();
+        assertOpenApiDoc();
+        assertCache(war, CacheUsed.CACHE_NOT_USED, CacheWritten.CACHE_NOT_WRITTEN);
+    }
+
+    private Application getConfig(Archive<?> archive) {
+        Application appConfig = new Application();
+        appConfig.setId("testApp");
+        appConfig.setLocation(archive.getName());
+        if (archive instanceof WebArchive) {
+            appConfig.setType("war");
+        } else if (archive instanceof EnterpriseArchive) {
+            appConfig.setType("ear");
+        }
+
+        return appConfig;
+    }
+
+    private void assertRest() throws Exception {
+        String response = new HttpRequest(server, "/testWar/test").run(String.class);
+        assertEquals("Failed to call test resource", "OK", response);
+    }
+
+    private void assertOpenApiDoc() throws Exception {
+        String doc = OpenAPIConnection.openAPIDocsConnection(server, false).download();
+        JsonNode openapiNode = OpenAPITestUtil.readYamlTree(doc);
+        OpenAPITestUtil.checkPaths(openapiNode, 1, "/test");
+    }
+
+    /**
+     * Remove and reload the application and assert whether the cache is used or not
+     * 
+     * @param archive the application archive
+     * @param cacheUsed whether the model is loaded from the cache
+     * @param cacheWritten whether the generated model is written to the cache
+     * @throws Exception
+     */
+    private void assertCache(Archive<?> archive, CacheUsed cacheUsed, CacheWritten cacheWritten) throws Exception {
+
+        // Remove app from server.xml
+        ServerConfiguration deployedConfig = server.getServerConfiguration();
+        server.setMarkToEndOfLog();
+        server.updateServerConfiguration(initialConfig);
+        server.waitForConfigUpdateInLogUsingMark(Collections.emptySet());
+        server.waitForStringInLogUsingMark("CWWKZ0009I.*" + getName(archive)); // App stopped
+
+        // Add app to server.xml
+        server.setMarkToEndOfLog();
+        server.setTraceMarkToEndOfDefaultTrace();
+        server.updateServerConfiguration(deployedConfig);
+        server.waitForConfigUpdateInLogUsingMark(Collections.singleton(getName(archive)));
+
+        // Check for appropriate cache messages in trace
+        if (cacheUsed == CacheUsed.CACHE_USED) {
+            assertThat(server.findStringsInLogsAndTraceUsingMark("Using OpenAPI model loaded from cache"), not(empty()));
+            assertThat(server.findStringsInLogsAndTraceUsingMark("Generating OpenAPI model"), is(empty()));
+        } else {
+            assertThat(server.findStringsInLogsAndTraceUsingMark("Using OpenAPI model loaded from cache"), is(empty()));
+            assertThat(server.findStringsInLogsAndTraceUsingMark("Generating OpenAPI model"), not(empty()));
+        }
+
+        if (cacheWritten == CacheWritten.CACHE_WRITTEN) {
+            assertThat(server.findStringsInLogsAndTraceUsingMark("Cache entry written"), not(empty()));
+        } else {
+            assertThat(server.findStringsInLogsAndTraceUsingMark("Cache entry written"), is(empty()));
+        }
+    }
+
+    private enum CacheUsed {
+        CACHE_USED,
+        CACHE_NOT_USED
+    }
+
+    private enum CacheWritten {
+        CACHE_WRITTEN,
+        CACHE_NOT_WRITTEN
+    }
+
+    private void deployApp(Archive<?> archive) throws Exception {
+        deployApp(archive, c -> {
+        });
+    }
+
+    private void deployApp(Archive<?> archive, Consumer<ServerConfiguration> configModifier) throws Exception {
+        ShrinkHelper.exportAppToServer(server, archive, SERVER_ONLY, DISABLE_VALIDATION);
+
+        server.setMarkToEndOfLog();
+        ServerConfiguration config = server.getServerConfiguration();
+        config.getApplications().add(getConfig(archive));
+        configModifier.accept(config);
+        server.updateServerConfiguration(config);
+        server.waitForConfigUpdateInLogUsingMark(Collections.singleton(getName(archive)));
+    }
+
+    private String getName(Archive<?> archive) {
+        String name = archive.getName();
+        int lastDot = name.lastIndexOf('.');
+        if (lastDot != -1) {
+            name = name.substring(0, lastDot);
+        }
+        return name;
+    }
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/DeploymentTestApp.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/DeploymentTestApp.java
@@ -1,0 +1,7 @@
+package io.openliberty.microprofile.openapi20.fat.deployments;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class DeploymentTestApp extends Application {}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/DeploymentTestResource.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/DeploymentTestResource.java
@@ -1,0 +1,23 @@
+package io.openliberty.microprofile.openapi20.fat.deployments;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+
+@Path("/")
+public class DeploymentTestResource {
+
+    @GET
+    @Path("/test")
+    @Operation(summary = "test method")
+    @APIResponse(responseCode = "200", description = "constant \"OK\" response")
+    @Produces(value = MediaType.TEXT_PLAIN)
+    public String test() {
+        return "OK";
+    }
+
+}

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/publish/servers/ApplicationProcessorServer/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/publish/servers/ApplicationProcessorServer/bootstrap.properties
@@ -9,4 +9,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all=enabled:mpOpenAPI=debug=enabled
+com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=info=enabled:mpOpenAPI=all=enabled

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/publish/servers/OpenAPITestServer/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/publish/servers/OpenAPITestServer/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2018 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info=enabled:mpOpenAPI=all=enabled

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/publish/servers/OpenAPITestServer/server.xml
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/publish/servers/OpenAPITestServer/server.xml
@@ -1,0 +1,23 @@
+<!--
+    Copyright (c) 2018 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+  <include location="../fatTestPorts.xml" />
+
+  <featureManager>
+    <feature>componenttest-1.0</feature>
+    <feature>ssl-1.0</feature>
+    <feature>mpOpenAPI-2.0</feature>
+  </featureManager>
+
+  <keyStore id="defaultKeyStore" password="password" />
+
+</server>


### PR DESCRIPTION
Add the ability to cache the OpenAPI model when a web module is deployed as a single file.

Invalidate the cache if the app file or any relevant config changes.

Note that we don't do anything to delete the cached model file if the app is undeployed (though it will be deleted if the server is started with `--clean`). This is consistent with the way liberty handles the annotation scanning cache.

Relates to #14752 