### PR TITLE
test that handlelist closes leaked autocommit false connection

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_v43/fat/src/com/ibm/ws/jdbc/fat/v43/JDBC43Test.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/fat/src/com/ibm/ws/jdbc/fat/v43/JDBC43Test.java
@@ -83,7 +83,7 @@ public class JDBC43Test extends FATServletClient {
                           "J2CA0081E", // TODO why does Derby think a transaction is still active?
                           "WLTC0018E", // TODO remove once transactions bug is fixed
                           "WLTC0032W", // local tran rolled back, expected when trying to keep unshared connection open across servlet boundary
-                          "WLTC0033W.*poolOf1"); // same reason as above
+                          "WLTC0033W.*poolOf2"); // same reason as above
     }
 
     /**


### PR DESCRIPTION
Connection with autocommit false and a database local transaction is kept open across LTC boundaries.  There is already code in place that detects crossing the LTC boundary and rolls back the transaction.  However, with the HandleList in place, the connection handle is also automatically closed, preventing further use.  Update a test case that was written for this scenario to use a data source with HandleList enabled and cover the expected behavior.