### PR TITLE
Update Mojarra 3.0.0-RC3 to 3.0.1 for facesContainer tests  

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2239,7 +2239,7 @@
     <dependency>
       <groupId>org.glassfish</groupId>
       <artifactId>jakarta.faces</artifactId>
-      <version>3.0.0-RC3</version>
+      <version>3.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -443,7 +443,7 @@ org.glassfish.jersey.ext.rx:jersey-rx-client-rxjava2:2.30.1
 org.glassfish.jersey.ext.rx:jersey-rx-client-rxjava:2.30.1
 org.glassfish.jersey.inject:jersey-hk2:2.26
 org.glassfish.web:jakarta.servlet.jsp.jstl:2.0.0
-org.glassfish:jakarta.faces:3.0.0-RC3
+org.glassfish:jakarta.faces:3.0.1
 org.glassfish:jakarta.json:2.0.0
 org.glassfish:javax.faces:2.3.3
 org.glassfish:javax.json:1.0.4

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/build.gradle
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/build.gradle
@@ -49,7 +49,7 @@ dependencies {
       'commons-beanutils:commons-beanutils:1.9.4',
       project(':io.openliberty.org.apache.commons.codec'),
       'javax.xml.bind:jaxb-api:2.3.0'
-    mojarra30 'org.glassfish:jakarta.faces:3.0.0-RC3'
+    mojarra30 'org.glassfish:jakarta.faces:3.0.1'
     myfaces30 'org.apache.myfaces.core:myfaces-api:3.0.0',
       'org.apache.myfaces.core:myfaces-impl:3.0.0'
     }


### PR DESCRIPTION
fixes #14533
The 3.0.0 version was buggy, so I'm using 3.0.1 instead.

FacesContainer FAT will now use the latest Mojarra libraries. 
