### PR TITLE
test leaked JMS connection handles

### DIFF
--- a/dev/com.ibm.ws.container.service.compat/src/com/ibm/ws/jca/cm/handle/HandleList.java
+++ b/dev/com.ibm.ws.container.service.compat/src/com/ibm/ws/jca/cm/handle/HandleList.java
@@ -18,13 +18,13 @@ import java.util.ArrayList;
  * was a quick way of mocking up, in an oversimplified way for experimentation
  * purposes, what the real handle list does.
  */
-public class HandleList extends ArrayList<HandleListInterface.Handle> implements HandleListInterface {
+public class HandleList extends ArrayList<HandleListInterface.HandleDetails> implements HandleListInterface {
     private static final long serialVersionUID = -4425328702653290017L;
 
     private boolean destroyed;
 
     @Override
-    public synchronized HandleList addHandle(HandleListInterface.Handle a) {
+    public synchronized HandleList addHandle(HandleListInterface.HandleDetails a) {
         super.add(a);
         return this;
     }
@@ -43,9 +43,12 @@ public class HandleList extends ArrayList<HandleListInterface.Handle> implements
     }
 
     @Override
-    public synchronized void removeHandle(Object r) {
+    public synchronized HandleDetails removeHandle(Object h) {
         if (!destroyed)
-            super.remove(r);
+            for (int i = super.size(); i > 0;)
+                if (get(--i).forHandle(h))
+                    return super.remove(i);
+        return null;
     }
 
     @Override

--- a/dev/com.ibm.ws.container.service.compat/src/com/ibm/ws/jca/cm/handle/HandleListInterface.java
+++ b/dev/com.ibm.ws.container.service.compat/src/com/ibm/ws/jca/cm/handle/HandleListInterface.java
@@ -16,8 +16,11 @@ package com.ibm.ws.jca.cm.handle;
  * connection management bundle, which isn't always available.
  */
 public interface HandleListInterface {
-    interface Handle {
+    interface HandleDetails {
         void close();
+
+        // used by removeHandle to determine if this handle details instance pertains to the specified handle
+        boolean forHandle(Object h);
 
         void park();
 
@@ -29,12 +32,15 @@ public interface HandleListInterface {
      * HandleList or the underlying HandleList if this interface is implemented
      * as a proxy.
      */
-    HandleList addHandle(Handle a);
+    HandleList addHandle(HandleDetails a);
 
     /**
      * Remove the specified handle from the list.
+     *
+     * @param h connection handle that might be found in the handle list.
+     * @return handle details instance that was removed from this list. Otherwise null.
      */
-    void removeHandle(Object r);
+    HandleDetails removeHandle(Object h);
 
     /**
      * Reassociate the managed connection for all handles in the list.

--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/HandleListProxy.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/HandleListProxy.java
@@ -13,22 +13,77 @@ package com.ibm.ejs.container;
 import com.ibm.ejs.j2c.HandleListInterface;
 import com.ibm.ws.jca.cm.handle.HandleList;
 
-// TODO still need to port the implementation to Liberty
+/**
+ * This is a HandleList proxy that is pushed onto the
+ * {@link com.ibm.ws.threadContext.ConnectionHandleAccessorImpl} thread context
+ * for beans that don't yet have an associated HandleList. This class uses
+ * {@link EJBThreadData#getCallbackBeanO()} to determine the current bean, so
+ * the callback bean must always be current before pushing this proxy.
+ *
+ * <p>This proxy is used to avoid the per-bean memory overhead of a HandleList
+ * until a handle needs to be tracked. Since HandleList is only used for
+ * non-smart handles and all Liberty connection factories support smart handles,
+ * the majority of beans will never need a HandleList.
+ */
 class HandleListProxy implements HandleListInterface {
-    public static final HandleListInterface INSTANCE = null;
+    public static final HandleListInterface INSTANCE = new HandleListProxy();
 
-    @Override
-    public HandleList addHandle(Handle handle) {
-        return null;
+    private HandleListProxy() {
     }
 
     @Override
-    public void parkHandle() {}
+    public String toString() {
+        BeanO beanO = EJSContainer.getCallbackBeanO();
+        return super.toString() + '[' + beanO.getHandleList(false) + ", " + beanO + ']';
+    }
+
+    /**
+     * Gets or optionally creates a handle list for the current callback bean.
+     * If the current callback bean does not have a HandleList and
+     * {@code create} is {@code false}, then {@code null} is returned.
+     *
+     * @param create {@code true} if a HandleList must be created
+     * @return the HandleList or {@code null}
+     */
+    private HandleList getHandleList(boolean create) {
+        BeanO beanO = EJSContainer.getCallbackBeanO();
+        return beanO.getHandleList(create);
+    }
 
     @Override
-    public void reAssociate() {}
+    public HandleList addHandle(HandleDetails a) {
+        HandleList hl = getHandleList(true);
+
+        hl.addHandle(a);
+        return hl;
+    }
 
     @Override
-    public void removeHandle(Object handle) {
+    public HandleDetails removeHandle(Object handle) {
+        HandleList hl = getHandleList(false);
+
+        if (hl != null) {
+            return hl.removeHandle(handle);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void reAssociate() {
+        HandleList hl = getHandleList(false);
+
+        if (hl != null) {
+            hl.reAssociate();
+        }
+    }
+
+    @Override
+    public void parkHandle() {
+        HandleList hl = getHandleList(false);
+
+        if (hl != null) {
+            hl.parkHandle();
+        }
     }
 }

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/HCMDetails.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/HCMDetails.java
@@ -22,7 +22,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.jca.cm.handle.HandleListInterface;
 
-public class HCMDetails implements HandleListInterface.Handle {
+public class HCMDetails implements HandleListInterface.HandleDetails {
     private static final TraceComponent tc = Tr.register(HCMDetails.class, J2CConstants.traceSpec, J2CConstants.NLS_FILE);
 
     public final ConnectionManager _cm;
@@ -69,6 +69,14 @@ public class HCMDetails implements HandleListInterface.Handle {
             if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
                 Tr.exit(this, tc, "close", e);
         }
+    }
+
+    @Override
+    public boolean forHandle(Object h) {
+        boolean isMyHandle = _handle.equals(h);
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "forHandle " + h + "? " + isMyHandle);
+        return isMyHandle;
     }
 
     @Override

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/MCWrapper.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/MCWrapper.java
@@ -2109,7 +2109,7 @@ public final class MCWrapper implements com.ibm.ws.j2c.MCWrapper, JCAPMIHelper {
             }
             Tr.error(tc, "FAILED_CONNECTION_J2CA0021", new Object[] { e, cfName });
             ResourceException re = new ResourceException("associateConnection: Failed to associate connection. Exception caught.");
-            re.initCause(re);
+            re.initCause(e);
             throw re;
 
         }

--- a/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/JCATest.java
+++ b/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/app/JCATest.java
@@ -26,13 +26,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
-import com.ibm.ws.jca.fat.FATSuite;
-
 import com.ibm.websphere.simplicity.config.JavaPermission;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.ws.jca.fat.FATSuite;
 
 import componenttest.annotation.AllowedFFDC;
-import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.JakartaEE9Action;
@@ -169,4 +167,24 @@ public class JCATest extends FATServletClient {
         runTest();
     }
 
+    /**
+     * Save an unsharable JMS connection handle from one servlet method for use in another.
+     * With HandleList disabled, this should be possible.
+     */
+    @Test
+    public void testSaveUnsharableConnectionForLater_HandleListDisabled() throws Exception {
+        runTest("testSaveUnsharableConnectionForLater_HandleListDisabled");
+        runTest("testUseUnsharableConnectionFromPreviousRequest_HandleListDisabled");
+    }
+
+    /**
+     * Save an unsharable JMS connection handle from one servlet method for use in another.
+     * With HandleList enabled, the connection should be closed automatically by the container,
+     * preventing usage within the second servlet request.
+     */
+    @Test
+    public void testSaveUnsharableConnectionForLater_HandleListEnabled() throws Exception {
+        runTest("testSaveUnsharableConnectionForLater_HandleListEnabled");
+        runTest("testUseUnsharableConnectionFromPreviousRequest_HandleListEnabled");
+    }
 }

--- a/dev/com.ibm.ws.jca_fat/publish/servers/com.ibm.ws.jca.fat.jakarta/server.xml
+++ b/dev/com.ibm.ws.jca_fat/publish/servers/com.ibm.ws.jca.fat.jakarta/server.xml
@@ -24,11 +24,12 @@
     <variable name="onError" value="FAIL"/>
 
     <jmsConnectionFactory id="cf1" jndiName="jms/cf1">
-      <connectionManager maxPoolSize="2" connectionTimeout="0"/>
+      <connectionManager maxPoolSize="2" connectionTimeout="0" enableHandleList="true"/> <!-- TODO use correct property name (or default to it) -->
       <properties.FAT1 tableName="cf1tbl" userName="CF1USER"/>
     </jmsConnectionFactory>
+
     <jmsConnectionFactory id="cf6" jndiName="jms/cf6">
-      <connectionManager maxPoolSize="6" connectionTimeout="0" enableSharingForDirectLookups="false"/>
+      <connectionManager maxPoolSize="6" connectionTimeout="0" enableSharingForDirectLookups="false" enableHandleList="false"/> <!-- TODO use correct property name -->
       <properties.FAT1 tableName="cf6tbl" userName="CF6USER"/>
     </jmsConnectionFactory>
     

--- a/dev/com.ibm.ws.jca_fat/publish/servers/com.ibm.ws.jca.fat/server.xml
+++ b/dev/com.ibm.ws.jca_fat/publish/servers/com.ibm.ws.jca.fat/server.xml
@@ -24,11 +24,12 @@
     <variable name="onError" value="FAIL"/>
 
     <jmsConnectionFactory id="cf1" jndiName="jms/cf1">
-      <connectionManager maxPoolSize="2" connectionTimeout="0"/>
+      <connectionManager maxPoolSize="2" connectionTimeout="0" enableHandleList="true"/> <!-- TODO use correct property name (or default to it) -->
       <properties.FAT1 tableName="cf1tbl" userName="CF1USER"/>
     </jmsConnectionFactory>
+
     <jmsConnectionFactory id="cf6" jndiName="jms/cf6">
-      <connectionManager maxPoolSize="6" connectionTimeout="0" enableSharingForDirectLookups="false"/>
+      <connectionManager maxPoolSize="6" connectionTimeout="0" enableSharingForDirectLookups="false" enableHandleList="false"/> <!-- TODO use correct property name -->
       <properties.FAT1 tableName="cf6tbl" userName="CF6USER"/>
     </jmsConnectionFactory>
     

--- a/dev/com.ibm.ws.jca_fat/test-applications/fvtweb/src/web/JCAFVTServlet.java
+++ b/dev/com.ibm.ws.jca_fat/test-applications/fvtweb/src/web/JCAFVTServlet.java
@@ -10,9 +10,17 @@
  *******************************************************************************/
 package web;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
 import java.lang.management.ManagementFactory;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
@@ -48,6 +56,12 @@ public class JCAFVTServlet extends FATServlet {
      * and thus the application as a whole, survives a config update.
      */
     private String state = "NEW";
+
+    /**
+     * This is a place for test methods to attempt to stash JMS connections across servlet requests
+     * in order to test whether the HandleList closes them.
+     */
+    private final static Map<String, CompletableFuture<Connection>> unfinishedWork = new HashMap<>();
 
     public void requireNewServletInstance(HttpServletRequest request, HttpServletResponse response) throws Throwable {
         if (!"NEW".equals(state))
@@ -787,6 +801,65 @@ public class JCAFVTServlet extends FATServlet {
         }
         conn1.close();
 
+    }
+
+    /**
+     * Attempt to leave a JMS connection open across a servlet request so that it can be used later.
+     * Obtain the connection from a JMS connection factory whose connection manager has the HandleList disabled.
+     */
+    public void testSaveUnsharableConnectionForLater_HandleListDisabled(HttpServletRequest request, HttpServletResponse response) throws Throwable {
+        ConnectionFactory cf = (ConnectionFactory) new InitialContext().lookup("jms/cf6");
+        Connection con = cf.createConnection();
+        Object previous = unfinishedWork.put("testSaveUnsharableConnectionForLater_HandleListDisabled", CompletableFuture.completedFuture(con));
+        assertNull(previous); // only permit this method to be invoked once
+    }
+
+    /**
+     * Attempt to leave a JMS connection open across a servlet request so that it can be used later.
+     * Obtain the connection from a JMS connection factory whose connection manager has the HandleList enabled.
+     */
+    public void testSaveUnsharableConnectionForLater_HandleListEnabled(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        ConnectionFactory cf = (ConnectionFactory) new InitialContext().lookup("java:comp/env/jms/cf1-unshareable");
+        Connection con = cf.createConnection();
+        Object previous = unfinishedWork.put("testSaveUnsharableConnectionForLater_HandleListEnabled", CompletableFuture.completedFuture(con));
+        assertNull(previous); // only permit this method to be invoked once
+    }
+
+    /**
+     * Attempt to use a JMS connection that was left open across a previous servlet request.
+     * With the HandleList disabled, this should be possible.
+     */
+    public void testUseUnsharableConnectionFromPreviousRequest_HandleListDisabled(HttpServletRequest request, HttpServletResponse response) throws Throwable {
+        CompletableFuture<Connection> stage1 = unfinishedWork.get("testSaveUnsharableConnectionForLater_HandleListDisabled");
+        CompletableFuture<String> stage2 = stage1.thenApply(con -> {
+            try {
+                String clientId = con.getClientID();
+                Session session = con.createSession(true, Session.AUTO_ACKNOWLEDGE);
+                session.close();
+                con.close();
+                return clientId;
+            } catch (JMSException x) {
+                throw new CompletionException(x);
+            }
+        });
+        assertEquals("defaultClientID", stage2.join());
+    }
+
+    /**
+     * Attempt to use a JMS connection that was left open across a previous servlet request.
+     * With the HandleList enabled, this shouldn't be possible.
+     */
+    public void testUseUnsharableConnectionFromPreviousRequest_HandleListEnabled(HttpServletRequest request, HttpServletResponse response) throws Throwable {
+        CompletableFuture<Connection> stage = unfinishedWork.get("testSaveUnsharableConnectionForLater_HandleListEnabled");
+        Connection con = stage.join();
+        try {
+            Session session = con.createSession(true, Session.AUTO_ACKNOWLEDGE);
+            fail("HandleList should have closed the connection handle. Instead, we got a session: " + session);
+        } catch (javax.jms.IllegalStateException x) {
+            // pass, connection is closed
+        } finally {
+            con.close();
+        }
     }
 
     private ObjectInstance getMBeanObjectInstance(String jndiName) throws Exception {

--- a/dev/com.ibm.ws.jca_fat/test-resourceadapters/fvt-resourceadapter/src/fat/jca/resourceadapter/FVTConnection.java
+++ b/dev/com.ibm.ws.jca_fat/test-resourceadapters/fvt-resourceadapter/src/fat/jca/resourceadapter/FVTConnection.java
@@ -54,6 +54,8 @@ public class FVTConnection implements Connection {
 
     @Override
     public Session createSession(boolean transacted, int acknowledgeMode) throws JMSException {
+        if (mc == null)
+            throw new javax.jms.IllegalStateException("JMS connection is closed.");
         return new FVTSession(this);
     }
 
@@ -84,6 +86,8 @@ public class FVTConnection implements Connection {
 
     @Override
     public void start() throws JMSException {
+        if (mc == null)
+            throw new javax.jms.IllegalStateException("JMS connection is closed.");
     }
 
     @Override


### PR DESCRIPTION
Write tests that attempts to keep JMS connection handles open across servlet requests.  One test runs with HandleList enabled, and the other with it disabled.  Verify that the HandleList, when enabled, causes the leaked JMS connection to be automatically closed.  Verify that, when HandleList is disabled, the JMS connection remains usable in a second servlet request.