### PR TITLE
Do not create a Java SCC with tools

### DIFF
--- a/dev/cnf/resources/bin/tool
+++ b/dev/cnf/resources/bin/tool
@@ -250,6 +250,15 @@ fi
 # Setting on all platforms to avoid cross platform bugs
 JVM_ARGS="-Djava.awt.headless=true ${JVM_ARGS}"
 
+# Do not create a SCC
+if [ -n "${IBM_JAVA_OPTIONS}" ]; then
+  IBM_JAVA_OPTIONS="${IBM_JAVA_OPTIONS} -Xshareclasses:none"
+fi
+
+if [ -n "${OPENJ9_JAVA_OPTIONS}" ]; then
+  OPENJ9_JAVA_OPTIONS="${OPENJ9_JAVA_OPTIONS} -Xshareclasses:none"
+fi
+
 # Execute the tool script or JAR.
 if [ -f "${WLP_INSTALL_DIR}"/lib/tools-internal/@TOOL_SCRIPT@ ]; then
   . "${WLP_INSTALL_DIR}"/lib/tools-internal/@TOOL_SCRIPT@ "$@"

--- a/dev/cnf/resources/bin/tool.bat
+++ b/dev/cnf/resources/bin/tool.bat
@@ -59,6 +59,15 @@ if exist "%JAVA_HOME%\lib\modules" set JVM_ARGS=--add-opens java.base/java.lang=
 set JVM_ARGS=-Djava.awt.headless=true !JVM_ARGS!
 set TOOL_JAVA_CMD_QUOTED=!JAVA_CMD_QUOTED! !JVM_ARGS! -jar "!WLP_INSTALL_DIR!\bin\@TOOL_JAR@"
 
+@REM Do not create a SCC
+if defined IBM_JAVA_OPTIONS (
+  set IBM_JAVA_OPTIONS=!IBM_JAVA_OPTIONS! -Xshareclasses:none
+)
+
+if defined OPENJ9_JAVA_OPTIONS (
+  set OPENJ9_JAVA_OPTIONS=!OPENJ9_JAVA_OPTIONS! -Xshareclasses:none
+)
+
 @REM Execute the tool script or JAR.
 if exist "!WLP_INSTALL_DIR!\lib\tools-internal/@TOOL_SCRIPT@.bat" goto:script
 !TOOL_JAVA_CMD_QUOTED! %*


### PR DESCRIPTION
If a SCC option exists on IBM_JAVA_OPTIONS or OPENJ9_JAVA_OPTIONS, the tools will create a SCC or add to an existing SCC, which we don't want. Adding -Xshareclasses:none.



