### PR TITLE
Re-enable osgi.checkConfiguration setting

### DIFF
--- a/dev/com.ibm.ws.appclient.boot/test/com/ibm/ws/kernel/boot/internal/commands/FrameworkManagerTest.java
+++ b/dev/com.ibm.ws.appclient.boot/test/com/ibm/ws/kernel/boot/internal/commands/FrameworkManagerTest.java
@@ -162,7 +162,7 @@ public class FrameworkManagerTest {
     public void testClientStartFrameworkException() throws Throwable {
         TestFrameworkManager fm = new TestFrameworkManager() {
             @Override
-            protected Framework startFramework(BootstrapConfig config) {
+            protected Framework initFramework(BootstrapConfig config) {
                 throw new TestException();
             }
         };
@@ -191,7 +191,8 @@ public class FrameworkManagerTest {
     }
 
     @SuppressWarnings("serial")
-    private static class TestException extends RuntimeException {}
+    private static class TestException extends RuntimeException {
+    }
 
     private class TestFrameworkManager extends FrameworkManager {
         private final CountDownLatch frameworkStoppedLatch = new CountDownLatch(1);
@@ -201,7 +202,7 @@ public class FrameworkManagerTest {
         }
 
         @Override
-        protected Framework startFramework(BootstrapConfig config) throws BundleException {
+        protected Framework initFramework(BootstrapConfig config) throws BundleException {
             frameworkStarted = true;
             return FrameworkManagerTest.this.framework;
         }
@@ -222,10 +223,12 @@ public class FrameworkManagerTest {
         }
 
         @Override
-        protected void innerLaunchFramework(boolean isClient) {}
+        protected void innerLaunchFramework(boolean isClient) {
+        }
 
         @Override
-        protected void startServerCommandListener() {}
+        protected void startServerCommandListener() {
+        }
 
         @Override
         public boolean waitForReady() throws InterruptedException {

--- a/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkConfigurator.java
+++ b/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkConfigurator.java
@@ -95,10 +95,11 @@ public class FrameworkConfigurator {
         // equinox to do that.
         config.put("osgi.framework.activeThreadType", "none");
 
-        // No longer check timestamps of JARs from Equinox
-        // on restart.  It is assumed any new Liberty bundles
-        // will use a different location on disk
-        config.putIfAbsent("osgi.checkConfiguration", "false");
+        // Use an equinox property to ensure that equinox checks whether or not
+        // the jar files we're installing (for file:// URLs) have changed if
+        // osgi is not starting clean. If the bundle jar has changed, associated
+        // cached data is tossed.
+        config.putIfAbsent("osgi.checkConfiguration", "true");
 
         // We do not want Bundle-ActivationPolicy: lazy to cause bundle
         // resolution to automatically start bundles.

--- a/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkManager.java
+++ b/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkManager.java
@@ -187,11 +187,11 @@ public class FrameworkManager {
      * Create and launch the OSGi framework
      *
      * @param config
-     *            BootstrapConfig object encapsulating active initial framework
-     *            properties
+     *                        BootstrapConfig object encapsulating active initial framework
+     *                        properties
      * @param logProvider
-     *            The initialized/active log provider that must be included in
-     *            framework management activities (start/stop/.. ), or null
+     *                        The initialized/active log provider that must be included in
+     *                        framework management activities (start/stop/.. ), or null
      * @param callback
      */
     public void launchFramework(BootstrapConfig config, LogProvider logProvider) {
@@ -259,8 +259,8 @@ public class FrameworkManager {
 
             }
 
-            // Start the framework.
-            Framework fwk = startFramework(config);
+            // Init the framework.
+            Framework fwk = initFramework(config);
 
             if (fwk == null) {
                 Tr.error(tc, "error.unableToLaunch");
@@ -465,9 +465,9 @@ public class FrameworkManager {
      * launch the platform/runtime.
      *
      * @param systemBundleCtx
-     *            The framework system bundle context
+     *                            The framework system bundle context
      * @param config
-     *            The active bootstrap config
+     *                            The active bootstrap config
      */
     private void registerLibertyProcessService(BundleContext systemBundleCtx, BootstrapConfig config) {
         List<String> cmds = config.getCmdArgs();
@@ -482,7 +482,7 @@ public class FrameworkManager {
      * Register the instrumentation class as a service in the OSGi registry
      *
      * @param systemBundleCtx
-     *            The framework system bundle context
+     *                            The framework system bundle context
      */
     protected void registerInstrumentationService(BundleContext systemContext) {
         Instrumentation inst = config.getInstrumentation();
@@ -500,7 +500,7 @@ public class FrameworkManager {
      * Register the PauseableComponentController class as a service in the OSGi registry
      *
      * @param systemBundleCtx
-     *            The framework system bundle context
+     *                            The framework system bundle context
      */
     protected void registerPauseableComponentController(BundleContext systemContext) {
         PauseableComponentControllerImpl pauseableComponentController = new PauseableComponentControllerImpl(systemContext);
@@ -541,7 +541,7 @@ public class FrameworkManager {
      * Create and start a new instance of an OSGi framework using the provided
      * properties as framework properties.
      */
-    protected Framework startFramework(BootstrapConfig config) throws BundleException {
+    protected Framework initFramework(BootstrapConfig config) throws BundleException {
         // Set the default startlevel of the framework. We want the framework to
         // start at our bootstrap level (i.e. Framework bundle itself will start, and
         // it will pre-load and re-start any previously known bundles in the
@@ -560,7 +560,7 @@ public class FrameworkManager {
             Framework fwk = fwkFactory.newFramework(config.getFrameworkProperties());
             if (fwk == null)
                 return null;
-            fwk.start();
+            fwk.init();
             return fwk;
         } catch (BundleException ex) {
             throw ex;
@@ -883,11 +883,11 @@ public class FrameworkManager {
      * the elapsed time, in milliseconds, to format
      *
      * @param factor
-     *            If true, the elapsed time will be factored into more detailed
-     *            units: days/hours/minutes/seconds
-     *            The decimal format of the seconds is #.### or #.## or #.# or # or 0
-     *            If false it will be returned as the total of seconds
-     *            The decimal format of the seconds is #.### or #.## or #.# or # or 0
+     *                   If true, the elapsed time will be factored into more detailed
+     *                   units: days/hours/minutes/seconds
+     *                   The decimal format of the seconds is #.### or #.## or #.# or # or 0
+     *                   If false it will be returned as the total of seconds
+     *                   The decimal format of the seconds is #.### or #.## or #.# or # or 0
      *
      * @return A String containing the formatted elapsed time.
      *         Examples when the English language 'en' is the 'Locale':
@@ -1064,9 +1064,9 @@ public class FrameworkManager {
      * server status from them.
      *
      * @param timestamp
-     *            Create a unique dump folder based on the time stamp string.
+     *                            Create a unique dump folder based on the time stamp string.
      * @param javaDumpActions
-     *            The java dumps to create, or null for the default set.
+     *                            The java dumps to create, or null for the default set.
      */
     public void introspectFramework(String timestamp, Set<JavaDumpAction> javaDumpActions) {
         Tr.audit(tc, "info.introspect.request.received");

--- a/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/boot/internal/FrameworkManagerTest.java
+++ b/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/boot/internal/FrameworkManagerTest.java
@@ -162,7 +162,7 @@ public class FrameworkManagerTest {
     public void testStartFrameworkException() throws Throwable {
         TestFrameworkManager fm = new TestFrameworkManager() {
             @Override
-            protected Framework startFramework(BootstrapConfig config) {
+            protected Framework initFramework(BootstrapConfig config) {
                 throw new TestException();
             }
         };
@@ -225,7 +225,8 @@ public class FrameworkManagerTest {
     }
 
     @SuppressWarnings("serial")
-    private static class TestException extends RuntimeException {}
+    private static class TestException extends RuntimeException {
+    }
 
     private class TestFrameworkManager extends FrameworkManager {
         private final CountDownLatch frameworkStoppedLatch = new CountDownLatch(1);
@@ -235,7 +236,7 @@ public class FrameworkManagerTest {
         }
 
         @Override
-        protected Framework startFramework(BootstrapConfig config) throws BundleException {
+        protected Framework initFramework(BootstrapConfig config) throws BundleException {
             frameworkStarted = true;
             return FrameworkManagerTest.this.framework;
         }
@@ -256,10 +257,12 @@ public class FrameworkManagerTest {
         }
 
         @Override
-        protected void innerLaunchFramework(boolean isClient) {}
+        protected void innerLaunchFramework(boolean isClient) {
+        }
 
         @Override
-        protected void startServerCommandListener() {}
+        protected void startServerCommandListener() {
+        }
 
         @Override
         public boolean waitForReady() throws InterruptedException {

--- a/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/launch/internal/ProvisionerTest.java
+++ b/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/launch/internal/ProvisionerTest.java
@@ -263,6 +263,9 @@ public class ProvisionerTest {
                 one(mockBundle).adapt(Module.class);
                 will(returnValue(testModule));
 
+                one(mockBundle).getSymbolicName();
+                will(returnValue("mock.bundle"));
+
                 one(mockBundleRevision).getTypes();
                 will(returnValue(0));
 
@@ -292,7 +295,7 @@ public class ProvisionerTest {
         recordExceptions(iStatus); // print any unexpected exceptions for
         // debug
 
-        assertFalse(m + " C: There should not be an install exception", iStatus.installExceptions());
+        assertFalse(m + " C: There should not be an install exception: " + iStatus.getInstallExceptions(), iStatus.installExceptions());
         assertNull(m + " C: There should not be an exception to trace", iStatus.traceInstallExceptions());
 
         if (iStatus.bundlesToStart())
@@ -328,6 +331,9 @@ public class ProvisionerTest {
                 one(mockBundle).adapt(Module.class);
                 will(returnValue(testModule));
 
+                one(mockBundle).getSymbolicName();
+                will(returnValue("mock.bundle"));
+
                 one(mockBundle).adapt(BundleStartLevel.class);
                 will(returnValue(mockBundleStartLevel));
 
@@ -353,7 +359,7 @@ public class ProvisionerTest {
         recordExceptions(iStatus); // print any unexpected exceptions for
         // debug
 
-        assertFalse(m + " C: There should not be an install exception", iStatus.installExceptions());
+        assertFalse(m + " C: There should not be an install exception: " + iStatus.getInstallExceptions(), iStatus.installExceptions());
         assertNull(m + " C: There should not be an exception to trace", iStatus.traceInstallExceptions());
 
         if (iStatus.bundlesToStart())
@@ -427,6 +433,9 @@ public class ProvisionerTest {
                 will(returnValue(BundleRevision.TYPE_FRAGMENT));
                 one(mockBundle).adapt(Module.class);
                 will(returnValue(testModule));
+
+                one(mockBundle).getSymbolicName();
+                will(returnValue("mock.bundle"));
 
                 never(mockBundle).adapt(BundleStartLevel.class);
                 never(mockBundleStartLevel).getStartLevel();

--- a/dev/com.ibm.ws.kernel.feature_fat/.classpath
+++ b/dev/com.ibm.ws.kernel.feature_fat/.classpath
@@ -10,8 +10,14 @@
 	<classpathentry kind="src" path="test-applications/test.feature.api.client.war/src"/>
 	<classpathentry kind="src" path="test-applications/ServletTest/src"/>
 	<classpathentry kind="src" path="test-applications/IgnoreAPI.ear/IgnoreAPIEJB.jar/src"/>
+	<classpathentry kind="src" path="test-bundles/test.override.requires.javax.swing.plaf/src"/>
+	<classpathentry kind="src" path="test-bundles/test.override.provides.javax.swing.plaf/src"/>
 	<classpathentry kind="src" output="bin" path="fat/src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry exported="true" kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.kernel.feature_fat/bnd.bnd
+++ b/dev/com.ibm.ws.kernel.feature_fat/bnd.bnd
@@ -24,7 +24,9 @@ src: \
 	test-bundles/test.service.provider/src, \
 	test-bundles/test.activation.type/src, \
 	test-bundles/test.origin.bundle/src, \
-	test-bundles/test.compatibility/src
+	test-bundles/test.compatibility/src, \
+	test-bundles/test.override.provides.javax.swing.plaf/src, \
+	test-bundles/test.override.requires.javax.swing.plaf/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/SystemBundleOverrideTest.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/fat/src/com/ibm/ws/kernel/feature/fat/SystemBundleOverrideTest.java
@@ -12,25 +12,33 @@
 package com.ibm.ws.kernel.feature.fat;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.ibm.websphere.simplicity.RemoteFile;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
 @RunWith(FATRunner.class)
 public class SystemBundleOverrideTest {
 
-    private final static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.kernel.feature.override");
-    private final String bundleActivatorEyecatcher = "override.systemFeature.requiresJavaxRMI.Activator.start: javax.rmi.PortableRemoteObject loaded from";
+    private static final String SYSTEM_PROVIDES_API_FEATURE = "override.systemFeature.providesSwing";
+    private static final String SYSTEM_REQUIRES_API_FEATURE = "override.systemFeature.requiresSwing";
+    private static final String USER_PROVIDES_API_FEATURE = "override.userFeature.providesSwing";
+    private static final List<String> ALLTEST_FEATURES = Arrays.asList(SYSTEM_PROVIDES_API_FEATURE, SYSTEM_REQUIRES_API_FEATURE, USER_PROVIDES_API_FEATURE);
 
+    private final static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.kernel.feature.override");
     private final long timeout = 30000;
 
     private static final Class<?> TEST_CLASS = SystemBundleOverrideTest.class;
@@ -46,34 +54,24 @@ public class SystemBundleOverrideTest {
         if (server.isStarted()) {
             server.stopServer();
         }
-        if (server.fileExistsInLibertyInstallRoot(SYS_FEATURES_SUBDIR + "override.systemFeature.requiresJavaxRMI.mf")) {
-            server.deleteFileFromLibertyInstallRoot(SYS_FEATURES_SUBDIR + "override.systemFeature.requiresJavaxRMI.mf");
-        }
-        if (server.fileExistsInLibertyInstallRoot(SYS_FEATURES_SUBDIR + "override.systemFeature.providesJavaxRMI.mf")) {
-            server.deleteFileFromLibertyInstallRoot(SYS_FEATURES_SUBDIR + "override.systemFeature.providesJavaxRMI.mf");
-        }
-        if (server.fileExistsInLibertyInstallRoot(SYS_FEATURES_SUBDIR + "override.userFeature.providesJavaxRMI.mf")) {
-            server.deleteFileFromLibertyInstallRoot(SYS_FEATURES_SUBDIR + "override.userFeature.providesJavaxRMI.mf");
-        }
-        if (server.fileExistsInLibertyInstallRoot(USR_FEATURES_SUBDIR + "override.systemFeature.requiresJavaxRMI.mf")) {
-            server.deleteFileFromLibertyInstallRoot(USR_FEATURES_SUBDIR + "override.systemFeature.requiresJavaxRMI.mf");
-        }
-        if (server.fileExistsInLibertyInstallRoot(USR_FEATURES_SUBDIR + "override.systemFeature.providesJavaxRMI.mf")) {
-            server.deleteFileFromLibertyInstallRoot(USR_FEATURES_SUBDIR + "override.systemFeature.providesJavaxRMI.mf");
-        }
-        if (server.fileExistsInLibertyInstallRoot(USR_FEATURES_SUBDIR + "override.userFeature.providesJavaxRMI.mf")) {
-            server.deleteFileFromLibertyInstallRoot(USR_FEATURES_SUBDIR + "override.userFeature.providesJavaxRMI.mf");
+        for (String f : ALLTEST_FEATURES) {
+            if (server.fileExistsInLibertyInstallRoot(SYS_FEATURES_SUBDIR + f + ".mf")) {
+                server.deleteFileFromLibertyInstallRoot(SYS_FEATURES_SUBDIR + f + ".mf");
+            }
+            if (server.fileExistsInLibertyInstallRoot(USR_FEATURES_SUBDIR + f + ".mf")) {
+                server.deleteFileFromLibertyInstallRoot(USR_FEATURES_SUBDIR + f + ".mf");
+            }
         }
 
         // Install test features
-        server.installSystemFeature("override.systemFeature.requiresJavaxRMI");
-        server.installSystemBundle("override.systemFeature.requiresJavaxRMI_1.0.0");
+        server.installSystemFeature(SYSTEM_PROVIDES_API_FEATURE);
+        server.installSystemBundle(SYSTEM_PROVIDES_API_FEATURE);
 
-        server.installSystemFeature("override.systemFeature.providesJavaxRMI");
-        server.installSystemBundle("override.systemFeature.providesJavaxRMI_1.0.0");
+        server.installSystemFeature(SYSTEM_REQUIRES_API_FEATURE);
+        server.installSystemBundle(SYSTEM_REQUIRES_API_FEATURE);
 
-        server.installUserFeature("override.userFeature.providesJavaxRMI");
-        server.installUserBundle("override.userFeature.providesJavaxRMI_1.0.0");
+        server.installUserFeature(USER_PROVIDES_API_FEATURE);
+        server.installUserBundle(USER_PROVIDES_API_FEATURE);
 
         server.setServerConfigurationFile("override.server.xml");
 
@@ -89,16 +87,29 @@ public class SystemBundleOverrideTest {
 
         server.stopServer();
 
-        server.uninstallSystemFeature("override.systemFeature.requiresJavaxRMI");
-        server.uninstallSystemBundle("override.systemFeature.requiresJavaxRMI_1.0.0");
+        server.uninstallSystemFeature(SYSTEM_PROVIDES_API_FEATURE);
+        server.uninstallSystemBundle(SYSTEM_PROVIDES_API_FEATURE);
 
-        server.uninstallSystemFeature("override.systemFeature.providesJavaxRMI");
-        server.uninstallSystemBundle("override.systemFeature.providesJavaxRMI_1.0.0");
+        server.uninstallSystemFeature(SYSTEM_REQUIRES_API_FEATURE);
+        server.uninstallSystemBundle(SYSTEM_REQUIRES_API_FEATURE);
 
-        server.uninstallUserFeature("override.userFeature.providesJavaxRMI");
-        server.uninstallUserBundle("override.userFeature.providesJavaxRMI_1.0.0");
+        server.uninstallUserFeature(USER_PROVIDES_API_FEATURE);
+        server.uninstallUserBundle(USER_PROVIDES_API_FEATURE);
 
         Log.exiting(TEST_CLASS, "teardown");
+    }
+
+    private final static String ACTIVATION_START_MESSAGE = "SUCCESS: wire found to -> .*";
+    static final String BSN_SYSTEM = "org.eclipse.osgi";
+    static final String BSN_FEATURE = "override.systemFeature.providesSwing";
+
+    private void checkActivationStartMessage(String expectedProvider) {
+        // The test Bundle activator start method looks for its own wiring for the javax.swing.plaf package
+        // and prints out this:
+        // SUCCESS: wire found to -> <provider BSN>
+        String startMessage = server.waitForStringInLogUsingMark(ACTIVATION_START_MESSAGE, timeout);
+        assertNotNull("No activation start message.", startMessage);
+        assertTrue("Wrong provider: " + startMessage, startMessage.endsWith(expectedProvider));
     }
 
     /**
@@ -109,56 +120,39 @@ public class SystemBundleOverrideTest {
     public void testSystemBundlePackagesOverrides() throws Exception {
         Log.entering(TEST_CLASS, "testSystemBundlePackagesOverrides");
 
-        if (JavaInfo.forServer(server).majorVersion() >= 11) {
-            // javax.rmi is no longer available in JDK 11
-            Log.info(TEST_CLASS, "testSystemBundlePackagesOverrides", "Skipping test on Java >= 11");
-            return;
-        }
-
         try {
-            // The override.systemFeature.requiresJavaxRMI_1.0.0 Bundle activator start method looks like this:
-
-            // Class clazz = PortableRemoteObject.class;
-            // URL location = clazz.getResource('/' + clazz.getName().replace('.', '/') + ".class");
-            // System.out.println("override.systemFeature.requiresJavaxRMI.Activator.start: javax.rmi.PortableRemoteObject loaded from: " + location.getPath());
-
-            // This will give the URL to the location where the PortableRemoteObject.class  was loaded from. I felt it was a better test
-            // to avoid using osgi/equinox interfaces to verify where the class was loading from
-
-            String JAVA_RUNTIME_ID = JavaInfo.forServer(server).majorVersion() >= 9 ? ".*jrt.*" : ".*rt.jar.*";
-
             // Case 1
-            // A system feature requires javax.rmi, which is provided by base java.
-            // Check activator message to make sure it was loaded from the rt.jar
+            // A system feature requires javax.swing.plaf, which is provided by base java.
+            // Check activator message to make sure it was loaded from the system bundle
             TestUtils.makeConfigUpdateSetMark(server, "override.case1.server.xml");
-            assertNotNull(server.waitForStringInLogUsingMark(bundleActivatorEyecatcher + JAVA_RUNTIME_ID, timeout));
+            checkActivationStartMessage(BSN_SYSTEM);
 
             // Case 2
-            // A system feature requires javax.rmi, which is now provided from a newly installed system feature
-            // Check activator message to make sure it was loaded from a bundleresource and not rt.jar
+            // A system feature requires javax.swing.plaf, which is now provided from a newly installed system feature
+            // Check activator message to make sure it was loaded from the feature bundle
             TestUtils.makeConfigUpdateSetMark(server, "override.case2.server.xml");
-            assertNotNull(server.waitForStringInLogUsingMark(bundleActivatorEyecatcher + ".*bundleresource.*", timeout));
+            checkActivationStartMessage(BSN_FEATURE);
 
             // Case 3
-            // A system feature requires javax.rmi, but the new system feature added in case 2 is removed, so
+            // A system feature requires javax.swing.plaf, but the new system feature added in case 2 is removed, so
             // it is again provide by base java.
-            // Check activator message to make sure it was loaded from rt.jar once again
+            // Check activator message to make sure it was loaded from the system bundle once again
             TestUtils.makeConfigUpdateSetMark(server, "override.case1.server.xml");
-            assertNotNull(server.waitForStringInLogUsingMark(bundleActivatorEyecatcher + JAVA_RUNTIME_ID, timeout));
+            checkActivationStartMessage(BSN_SYSTEM);
 
             // Case 4
             // Switch back to Case 2 such that on the following case, the bundle will refresh and reactivate and
             // display the activator eyecatcher again.
             TestUtils.makeConfigUpdateSetMark(server, "override.case2.server.xml");
-            assertNotNull(server.waitForStringInLogUsingMark(bundleActivatorEyecatcher + ".*bundleresource.*", timeout));
+            checkActivationStartMessage(BSN_FEATURE);
 
             // Case 5
-            // A system feature requires javax.rmi, which is provided by base java.
-            // A user feature is installed that exports/provides javax.rmi, however, this should not
+            // A system feature requires javax.swing.plaf, which is provided by base java.
+            // A user feature is installed that exports/provides javax.swing.plaf, however, this should not
             // override the system bundle export. We don't want user features to be able to override
             // system packages and alter the behavior of the core Liberty features
             TestUtils.makeConfigUpdateSetMark(server, "override.case3.server.xml");
-            assertNotNull(server.waitForStringInLogUsingMark(bundleActivatorEyecatcher + JAVA_RUNTIME_ID, timeout));
+            checkActivationStartMessage(BSN_SYSTEM);
         } catch (Exception e) {
             Log.error(TEST_CLASS, "testSystemBundlePackagesOverrides", e);
             throw e;
@@ -178,41 +172,33 @@ public class SystemBundleOverrideTest {
     public void testSystemBundlePackagesOverridesWarmStarts() throws Exception {
         Log.entering(TEST_CLASS, "testSystemBundlePackagesOverridesWarmStarts");
 
-        if (JavaInfo.forServer(server).majorVersion() >= 11) {
-            // javax.rmi is no longer available in JDK 11
-            Log.info(TEST_CLASS, "testSystemBundlePackagesOverridesWarmStarts", "Skipping test on Java >= 11");
-            return;
-        }
-
         try {
-            // The override.systemFeature.requiresJavaxRMI_1.0.0 Bundle activator start method looks like this:
-
-            // Class clazz = PortableRemoteObject.class;
-            // URL location = clazz.getResource('/' + clazz.getName().replace('.', '/') + ".class");
-            // System.out.println("override.systemFeature.requiresJavaxRMI.Activator.start: javax.rmi.PortableRemoteObject loaded from: " + location.getPath());
-
-            // This will give the URL to the location where the PortableRemoteObject.class  was loaded from. I felt it was a better test
-            // to avoid using osgi/equinox interfaces to verify where the class was loading from
-
-            String JAVA_RUNTIME_ID = JavaInfo.forServer(server).majorVersion() >= 9 ? ".*jrt.*" : ".*rt.jar.*";
-
-            // Case 1
-            // A system feature requires javax.rmi, which is provided by base java.
-            // Check activator message to make sure it was loaded from the rt.jar
-            TestUtils.makeConfigUpdateSetMark(server, "override.case1.server.xml");
-            assertNotNull(server.waitForStringInLogUsingMark(bundleActivatorEyecatcher + JAVA_RUNTIME_ID, timeout));
-
             // Case 2
-            // A system feature requires javax.rmi, which is now provided from a newly installed system feature
-            // Check activator message to make sure it was loaded from a bundleresource and not rt.jar
+            // A system feature requires javax.swing.plaf, which is now provided from a newly installed system feature
+            // Check activator message to make sure it was loaded from the feature bundle
             TestUtils.makeConfigUpdateSetMark(server, "override.case2.server.xml");
-            assertNotNull(server.waitForStringInLogUsingMark(bundleActivatorEyecatcher + ".*bundleresource.*", timeout));
+            checkActivationStartMessage(BSN_FEATURE);
 
             // Case 3
             // Make sure that Case 2 still works on a warm start and that no exceptions occur
             server.stopServer();
-            server.startServer("SystemOverrideTest2.log");
-            assertNotNull(server.waitForStringInLogUsingMark(bundleActivatorEyecatcher + ".*bundleresource.*", timeout));
+            server.startServer("SystemOverrideTest2.log", false);
+            checkActivationStartMessage(BSN_FEATURE);
+
+            // Case 4
+            // Touch the timestamp of the equinox region bundle to force it to be re-installed
+            // Make sure we still are wired to the feature bundle
+            server.stopServer();
+            RemoteFile libDir = server.getFileFromLibertyInstallRoot("lib");
+            RemoteFile[] libs = libDir.list(false);
+            for (RemoteFile lib : libs) {
+                if (lib.getName().contains("equinox.region")) {
+                    File libFile = new File(lib.getAbsolutePath());
+                    libFile.setLastModified(libFile.lastModified() + 100);
+                }
+            }
+            server.startServer("SystemOverrideTest3.log", false);
+            checkActivationStartMessage(BSN_FEATURE);
         } catch (Exception e) {
             Log.error(TEST_CLASS, "testSystemBundlePackagesOverridesWarmStarts", e);
             throw e;

--- a/dev/com.ibm.ws.kernel.feature_fat/override.systemFeature.providesSwing.bnd
+++ b/dev/com.ibm.ws.kernel.feature_fat/override.systemFeature.providesSwing.bnd
@@ -1,0 +1,16 @@
+#*******************************************************************************
+# Copyright (c) 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0.0
+
+Bundle-SymbolicName: override.systemFeature.providesSwing
+
+Export-Package: javax.swing.plaf;version='1.0.0'

--- a/dev/com.ibm.ws.kernel.feature_fat/override.systemFeature.requiresSwing.bnd
+++ b/dev/com.ibm.ws.kernel.feature_fat/override.systemFeature.requiresSwing.bnd
@@ -1,0 +1,22 @@
+#*******************************************************************************
+# Copyright (c) 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0.0
+
+Bundle-SymbolicName: override.systemFeature.requiresSwing
+
+Private-Package: test.override.requires.javax.swing.plat
+
+Bundle-Activator: test.override.requires.javax.swing.plat.Activator
+
+Import-Package: \
+	javax.swing.plaf,\
+	*

--- a/dev/com.ibm.ws.kernel.feature_fat/override.userFeature.providesSwing.bnd
+++ b/dev/com.ibm.ws.kernel.feature_fat/override.userFeature.providesSwing.bnd
@@ -1,0 +1,16 @@
+#*******************************************************************************
+# Copyright (c) 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0.0
+
+Bundle-SymbolicName: override.userFeature.providesSwing
+
+Export-Package: javax.swing.plaf;version='1.0.0'

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/override.systemFeature.providesJavaxRMI.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/override.systemFeature.providesJavaxRMI.mf
@@ -1,7 +1,0 @@
-Subsystem-ManifestVersion: 1
-Subsystem-SymbolicName: override.systemFeature.providesJavaxRMI-1.0; visibility:=public
-Subsystem-Version: 1.0.0
-Subsystem-Type: osgi.subsystem.feature
-Subsystem-Content: override.systemFeature.providesJavaxRMI; version="[1,1.0.100)"
-IBM-API-Package: javax.rmi; type="spec"
-IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/override.systemFeature.providesSwing.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/override.systemFeature.providesSwing.mf
@@ -1,0 +1,7 @@
+Subsystem-ManifestVersion: 1
+Subsystem-SymbolicName: override.systemFeature.providesSwing-1.0; visibility:=public
+Subsystem-Version: 1.0.0
+Subsystem-Type: osgi.subsystem.feature
+Subsystem-Content: override.systemFeature.providesSwing; version="[1,1.0.100)"
+IBM-API-Package: javax.swing.plaf; type="spec"
+IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/override.systemFeature.requiresJavaxRMI.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/override.systemFeature.requiresJavaxRMI.mf
@@ -1,6 +1,0 @@
-Subsystem-ManifestVersion: 1
-Subsystem-SymbolicName: override.systemFeature.requiresJavaxRMI-1.0; visibility:=public; singleton:=true
-Subsystem-Version: 1.0.0
-Subsystem-Type: osgi.subsystem.feature
-Subsystem-Content: override.systemFeature.requiresJavaxRMI; version="[1,1.0.100)"
-IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/override.systemFeature.requiresSwing.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/override.systemFeature.requiresSwing.mf
@@ -1,0 +1,6 @@
+Subsystem-ManifestVersion: 1
+Subsystem-SymbolicName: override.systemFeature.requiresSwing-1.0; visibility:=public; singleton:=true
+Subsystem-Version: 1.0.0
+Subsystem-Type: osgi.subsystem.feature
+Subsystem-Content: override.systemFeature.requiresSwing; version="[1,1.0.100)"
+IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/override.userFeature.providesJavaxRMI.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/override.userFeature.providesJavaxRMI.mf
@@ -1,7 +1,0 @@
-Subsystem-ManifestVersion: 1
-Subsystem-SymbolicName: override.userFeature.providesJavaxRMI-1.0; visibility:=public
-Subsystem-Version: 1.0.0
-Subsystem-Type: osgi.subsystem.feature
-Subsystem-Content: override.userFeature.providesJavaxRMI; version="[1,1.0.100)"
-IBM-API-Package: javax.rmi; type="spec"
-IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/features/override.userFeature.providesSwing.mf
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/features/override.userFeature.providesSwing.mf
@@ -1,0 +1,7 @@
+Subsystem-ManifestVersion: 1
+Subsystem-SymbolicName: override.userFeature.providesSwing-1.0; visibility:=public
+Subsystem-Version: 1.0.0
+Subsystem-Type: osgi.subsystem.feature
+Subsystem-Content: override.userFeature.providesSwing; version="[1,1.0.100)"
+IBM-API-Package: javax.swing.plaf; type="spec"
+IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/files/override.case1.server.xml
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/files/override.case1.server.xml
@@ -4,7 +4,7 @@
     
        <!-- Enable features -->
     <featureManager>
-        <feature>override.systemFeature.requiresJavaxRMI-1.0</feature>
+        <feature>override.systemFeature.requiresSwing-1.0</feature>
     </featureManager>
     
 </server>

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/files/override.case2.server.xml
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/files/override.case2.server.xml
@@ -4,8 +4,8 @@
     
        <!-- Enable features -->
     <featureManager>
-        <feature>override.systemFeature.requiresJavaxRMI-1.0</feature>
-        <feature>override.systemFeature.providesJavaxRMI-1.0</feature>
+        <feature>override.systemFeature.requiresSwing-1.0</feature>
+        <feature>override.systemFeature.providesSwing-1.0</feature>
     </featureManager>
     
 </server>

--- a/dev/com.ibm.ws.kernel.feature_fat/publish/files/override.case3.server.xml
+++ b/dev/com.ibm.ws.kernel.feature_fat/publish/files/override.case3.server.xml
@@ -4,8 +4,8 @@
     
        <!-- Enable features -->
     <featureManager>
-        <feature>override.systemFeature.requiresJavaxRMI-1.0</feature>
-        <feature>usr:override.userFeature.providesJavaxRMI-1.0</feature>
+        <feature>override.systemFeature.requiresSwing-1.0</feature>
+        <feature>usr:override.userFeature.providesSwing-1.0</feature>
     </featureManager>
     
 </server>

--- a/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.override.provides.javax.swing.plaf/src/javax/swing/plaf/ProvidedAPI.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.override.provides.javax.swing.plaf/src/javax/swing/plaf/ProvidedAPI.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package javax.swing.plaf;
+
+/**
+ *
+ */
+public class ProvidedAPI {
+
+}

--- a/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.override.requires.javax.swing.plaf/src/test/override/requires/javax/swing/plat/Activator.java
+++ b/dev/com.ibm.ws.kernel.feature_fat/test-bundles/test.override.requires.javax.swing.plaf/src/test/override/requires/javax/swing/plat/Activator.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.override.requires.javax.swing.plat;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.namespace.PackageNamespace;
+import org.osgi.framework.wiring.BundleWiring;
+
+public class Activator implements BundleActivator {
+
+    @Override
+    public void start(BundleContext context) throws Exception {
+        BundleWiring wiring = context.getBundle().adapt(BundleWiring.class);
+
+        wiring.getRequiredWires(PackageNamespace.PACKAGE_NAMESPACE).stream() //
+                        .filter((w) -> "javax.swing.plaf".equals(w.getCapability().getAttributes().get(PackageNamespace.PACKAGE_NAMESPACE))) //
+                        .filter((w) -> {
+                            System.out.println("SUCCESS: wire found to -> " + w.getProvider().getSymbolicName());
+                            return true;
+                        }) //
+                        .findFirst() //
+                        .orElseThrow(NoSuchFieldException::new);
+    }
+
+    @Override
+    public void stop(BundleContext context) throws Exception {
+
+    }
+
+}


### PR DESCRIPTION
In order to recover when the equinox.region bundle is
discarded by the framework the kernel boot provisioner
has changed to do the following:

1) initialize the framework
2) make sure all kernel bundles are installed
3) if the equinox region bundle needs installed then
force it to resolve without allow any other bundles
to resolve.
4) finally start the framework as usual

This will enable region digraph hooks before allowing
other bundles to resolve to ensure they are following
the rules setout from a previous run.  The equinox
region persists in the system bundle data area.  Even
when it is uninstalled the persistent digraph remains
and is discovered when equinox region is reinstalled.

