### PR TITLE
Re-enable MP Concurrent tests and add a Repeat Action for 1.1

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -804,7 +804,7 @@
     <dependency>
       <groupId>jakarta.ws.rs</groupId>
       <artifactId>jakarta.ws.rs-api</artifactId>
-      <version>3.0.0-M1</version>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>jakarta.xml.bind</groupId>

--- a/dev/com.ibm.ws.concurrent.mp_fat/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp_fat/bnd.bnd
@@ -24,7 +24,7 @@ src: \
 
 fat.project: true
 
-tested.features:cdi-3.0
+tested.features: mpConfig-2.0
 
 -buildpath: \
 	com.ibm.tx.core;version=latest,\
@@ -41,7 +41,4 @@ tested.features:cdi-3.0
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.concurrent;version=latest,\
     com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-    io.openliberty.jakarta.annotation.2.0;version=latest,\
-	io.openliberty.jakarta.concurrency.2.0;version=latest,\
-	io.openliberty.jakarta.servlet.5.0;version=latest,\
-	io.openliberty.jakarta.transaction.2.0;version=latest
+

--- a/dev/com.ibm.ws.concurrent.mp_fat/build.gradle
+++ b/dev/com.ibm.ws.concurrent.mp_fat/build.gradle
@@ -10,7 +10,6 @@
  *******************************************************************************/
 
 addRequiredLibraries.dependsOn addDerby
-addRequiredLibraries.dependsOn addJakartaTransformer
 
 dependencies {
   requiredLibs project(':com.ibm.ws.concurrent')

--- a/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/FATSuite.java
@@ -19,8 +19,8 @@ import org.junit.runners.Suite.SuiteClasses;
                 MPConcurrentTest.class,
                 MPConcurrentConfigTest.class,
                 MPConcurrentJAXRSTest.class,
-                //MPConcurrentTxTest.class, //Relies on Jakarta EE 9 but MicroProfile does not yet support EE9
-                //MPContextProp1_1_Test.class, //Relies on Jakarta EE 9 but MicroProfile does not yet support EE9
+                MPConcurrentTxTest.class,
+                MPContextProp1_1_Test.class,
                 MPConcurrentCDITest.class // moved last because @RepeatTests, when added to this class, interferes with test classes that run after it // TODO
 })
 public class FATSuite {

--- a/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentCDITest.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentCDITest.java
@@ -15,15 +15,18 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.test.context.location.CityContextProvider;
 import org.test.context.location.StateContextProvider;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import concurrent.mp.fat.cdi.web.MPConcurrentCDITestServlet;
@@ -32,6 +35,11 @@ import concurrent.mp.fat.cdi.web.MPConcurrentCDITestServlet;
 public class MPConcurrentCDITest extends FATServletClient {
 
     private static final String CDI_APP = "MPConcurrentCDIApp";
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests
+                    .withoutModification()
+                    .andWith(new MPContextProp11RepeatAction("MPConcurrentCDITestServer"));
 
     @Server("MPConcurrentCDITestServer")
     @TestServlet(servlet = MPConcurrentCDITestServlet.class, contextRoot = CDI_APP)
@@ -44,7 +52,7 @@ public class MPConcurrentCDITest extends FATServletClient {
         JavaArchive customContextProviders = ShrinkWrap.create(JavaArchive.class, "customContextProviders.jar")
                         .addPackage("org.test.context.location")
                         .addAsServiceProvider(ThreadContextProvider.class, CityContextProvider.class, StateContextProvider.class);
-        ShrinkHelper.exportToServer(server, "lib", customContextProviders);
+        ShrinkHelper.exportToServer(server, "lib", customContextProviders, DeployOptions.SERVER_ONLY);
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentConfigTest.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentConfigTest.java
@@ -25,17 +25,20 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.test.context.location.CityContextProvider;
 import org.test.context.location.StateContextProvider;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet;
@@ -44,6 +47,11 @@ import concurrent.mp.fat.config.web.MPConcurrentConfigTestServlet;
 public class MPConcurrentConfigTest extends FATServletClient {
 
     private static final String APP_NAME = "MPConcurrentConfigApp";
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests
+                    .withoutModification()
+                    .andWith(new MPContextProp11RepeatAction("MPConcurrentConfigTestServer"));
 
     @Server("MPConcurrentConfigTestServer")
     @TestServlet(servlet = MPConcurrentConfigTestServlet.class, contextRoot = APP_NAME)
@@ -94,7 +102,7 @@ public class MPConcurrentConfigTest extends FATServletClient {
         JavaArchive customContextProviders = ShrinkWrap.create(JavaArchive.class, "customContextProviders.jar")
                         .addPackage("org.test.context.location")
                         .addAsServiceProvider(ThreadContextProvider.class, CityContextProvider.class, StateContextProvider.class);
-        ShrinkHelper.exportToServer(server, "lib", customContextProviders);
+        ShrinkHelper.exportToServer(server, "lib", customContextProviders, DeployOptions.SERVER_ONLY);
 
         server.startServer();
 

--- a/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentJAXRSTest.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentJAXRSTest.java
@@ -27,19 +27,28 @@ import javax.json.JsonStructure;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import componenttest.topology.utils.HttpUtils;
 
 @RunWith(FATRunner.class)
 public class MPConcurrentJAXRSTest extends FATServletClient {
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests
+                    .withoutModification()
+                    .andWith(new MPContextProp11RepeatAction("MPConcurrentJAXRSTestServer"));
+
     private static final String APP_NAME = "MPConcurrentJAXRSApp";
 
     /**
@@ -54,7 +63,7 @@ public class MPConcurrentJAXRSTest extends FATServletClient {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        ShrinkHelper.defaultApp(server, APP_NAME, "concurrent.mp.fat.jaxrs.web");
+        ShrinkHelper.defaultApp(server, APP_NAME, new DeployOptions[] { DeployOptions.SERVER_ONLY }, "concurrent.mp.fat.jaxrs.web");
         server.startServer();
         testThreads = Executors.newFixedThreadPool(5);
     }

--- a/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentTest.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentTest.java
@@ -15,21 +15,29 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.test.context.location.CityContextProvider;
 import org.test.context.location.StateContextProvider;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import concurrent.mp.fat.web.MPConcurrentTestServlet;
 
 @RunWith(FATRunner.class)
 public class MPConcurrentTest extends FATServletClient {
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests
+                    .withoutModification()
+                    .andWith(new MPContextProp11RepeatAction("MPConcurrentTestServer"));
 
     private static final String APP_NAME = "MPConcurrentApp";
 
@@ -44,7 +52,7 @@ public class MPConcurrentTest extends FATServletClient {
         JavaArchive customContextProviders = ShrinkWrap.create(JavaArchive.class, "customContextProviders.jar")
                         .addPackage("org.test.context.location")
                         .addAsServiceProvider(ThreadContextProvider.class, CityContextProvider.class, StateContextProvider.class);
-        ShrinkHelper.exportToServer(server, "lib", customContextProviders);
+        ShrinkHelper.exportToServer(server, "lib", customContextProviders, DeployOptions.SERVER_ONLY);
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentTxTest.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPConcurrentTxTest.java
@@ -12,21 +12,30 @@ package com.ibm.ws.concurrent.mp.fat;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import concurrent.mp.fat.tx.web.MPConcurrentTxTestServlet;
 
 @RunWith(FATRunner.class)
 public class MPConcurrentTxTest extends FATServletClient {
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests
+                    .withoutModification()
+                    .andWith(new MPContextProp11RepeatAction("MPConcurrentTxTestServer"));
 
     private static final String APP_NAME = "MPConcurrentTxApp";
 
@@ -36,7 +45,7 @@ public class MPConcurrentTxTest extends FATServletClient {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        ShrinkHelper.defaultApp(server, APP_NAME, "concurrent.mp.fat.tx.web");
+        ShrinkHelper.defaultApp(server, APP_NAME, new DeployOptions[] { DeployOptions.SERVER_ONLY }, "concurrent.mp.fat.tx.web");
         server.startServer();
     }
 
@@ -53,7 +62,9 @@ public class MPConcurrentTxTest extends FATServletClient {
                    "java.lang.IllegalStateException", // attempt to use same transaction on 2 threads at once
                    "javax.transaction.xa.XAException" // transaction marked rollback-only due to intentionally caused error
     })
+
     @Test
+    @SkipForRepeat(MPContextProp11RepeatAction.ID)
     public void testTransactionTimesOutAndReleasesLocks() throws Exception {
         server.setMarkToEndOfLog();
 

--- a/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPContextProp11RepeatAction.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/fat/src/com/ibm/ws/concurrent/mp/fat/MPContextProp11RepeatAction.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.concurrent.mp.fat;
+
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.FeatureReplacementAction;
+
+public class MPContextProp11RepeatAction extends FeatureReplacementAction {
+
+    public static final String ID = "MP_CONTEXT_PROP_11";
+
+    public MPContextProp11RepeatAction(String server) {
+        super();
+        addFeature("mpContextPropagation-1.1");
+        addFeature("mpConfig-2.0");
+        removeFeature("mpContextPropagation-1.0");
+        removeFeature("mpConfig-1.3");
+        removeFeature("mpConfig-1.4");
+        withID(ID);
+        withTestMode(TestMode.FULL);
+        forServers(server);
+    }
+
+}

--- a/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentTxTestServer/server.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentTxTestServer/server.xml
@@ -12,11 +12,11 @@
 
     <featureManager>
         <feature>componenttest-1.0</feature>
-        <feature>concurrent-2.0</feature>
+        <feature>concurrent-1.0</feature>
         <feature>jdbc-4.2</feature>
         <feature>jndi-1.0</feature>
         <feature>mpContextPropagation-1.0</feature>
-        <feature>servlet-5.0</feature>
+        <feature>servlet-4.0</feature>
     </featureManager>
     
     <include location="../fatTestPorts.xml"/>

--- a/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPContextProp1_1_Server/server.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPContextProp1_1_Server/server.xml
@@ -11,11 +11,11 @@
 <server>
 
     <featureManager>
-        <feature>componenttest-2.0</feature>
+        <feature>componenttest-1.0</feature>
         <feature>jdbc-4.2</feature>
         <feature>jndi-1.0</feature>
         <feature>mpContextPropagation-1.1</feature>
-        <feature>servlet-5.0</feature>
+        <feature>servlet-4.0</feature>
     </featureManager>
     
     <include location="../fatTestPorts.xml"/>

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentApp/src/concurrent/mp/fat/web/MPConcurrentTestServlet.java
@@ -73,8 +73,11 @@ import org.junit.Test;
 import org.test.context.location.CurrentLocation;
 import org.test.context.location.TestContextTypes;
 
+import com.ibm.ws.concurrent.mp.fat.MPContextProp11RepeatAction;
+
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.MinimumJavaLevel;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 @SuppressWarnings("serial")
@@ -5311,6 +5314,7 @@ public class MPConcurrentTestServlet extends FATServlet {
      * than a managed executor.
      */
     @Test
+    @SkipForRepeat(MPContextProp11RepeatAction.ID)
     public void testWithContextCapture_CompletableFuture_builder() throws Exception {
         String servletThreadName = Thread.currentThread().getName();
 
@@ -5391,6 +5395,7 @@ public class MPConcurrentTestServlet extends FATServlet {
      * CompletionStage that is backed by a ThreadContext rather than a managed executor.
      */
     @Test
+    @SkipForRepeat(MPContextProp11RepeatAction.ID)
     public void testWithContextCapture_CompletableFuture_serverConfig() throws Exception {
         String servletThreadName = Thread.currentThread().getName();
 
@@ -5464,6 +5469,7 @@ public class MPConcurrentTestServlet extends FATServlet {
      * than a managed executor.
      */
     @Test
+    @SkipForRepeat(MPContextProp11RepeatAction.ID)
     public void testWithContextCapture_CompletionStage_builder() throws Exception {
         String servletThreadName = Thread.currentThread().getName();
 
@@ -5567,6 +5573,7 @@ public class MPConcurrentTestServlet extends FATServlet {
      * CompletionStage that is backed by a ThreadContext rather than a managed executor.
      */
     @Test
+    @SkipForRepeat(MPContextProp11RepeatAction.ID)
     public void testWithContextCapture_CompletionStage_serverConfig() throws Exception {
         String servletThreadName = Thread.currentThread().getName();
 

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentTxApp/src/concurrent/mp/fat/tx/web/MPConcurrentTxTestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPConcurrentTxApp/src/concurrent/mp/fat/tx/web/MPConcurrentTxTestServlet.java
@@ -36,29 +36,28 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import jakarta.annotation.Resource;
-import jakarta.enterprise.concurrent.ContextService;
-import jakarta.enterprise.concurrent.ManagedExecutorService;
-import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
-import jakarta.servlet.ServletConfig;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.annotation.WebServlet;
-import jakarta.servlet.http.HttpServlet;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.transaction.Status;
-import jakarta.transaction.SystemException;
-import jakarta.transaction.TransactionManager;
-import jakarta.transaction.UserTransaction;
-
+import javax.annotation.Resource;
+import javax.enterprise.concurrent.ContextService;
+import javax.enterprise.concurrent.ManagedExecutorService;
+import javax.enterprise.concurrent.ManagedScheduledExecutorService;
 import javax.naming.InitialContext;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
+import javax.transaction.Status;
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+import javax.transaction.UserTransaction;
 
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.context.ThreadContext;
 import org.junit.Test;
 
-import com.ibm.tx.jta.ExtendedTransactionManager;
 import com.ibm.tx.jta.TransactionManagerFactory;
 
 import componenttest.annotation.AllowedFFDC;
@@ -245,7 +244,7 @@ public class MPConcurrentTxTestServlet extends HttpServlet {
         // scenario with successful commit
         tx.begin();
         try {
-            jakarta.transaction.Transaction tranToPropagate = tm.getTransaction();
+            Transaction tranToPropagate = tm.getTransaction();
 
             Connection con = defaultDataSource.getConnection();
             Statement st = con.createStatement();
@@ -253,7 +252,7 @@ public class MPConcurrentTxTestServlet extends HttpServlet {
 
             CompletableFuture<Integer> stage = CompletableFuture.supplyAsync(() -> {
                 try {
-                    jakarta.transaction.Transaction tranToRestore = tm.suspend();
+                    Transaction tranToRestore = tm.suspend();
                     tm.resume(tranToPropagate);
                     try (Connection con2 = defaultDataSource.getConnection(); Statement st2 = con2.createStatement()) {
                         return st2.executeUpdate("INSERT INTO IACOUNTIES VALUES ('Dubuque', 96571)");
@@ -289,7 +288,7 @@ public class MPConcurrentTxTestServlet extends HttpServlet {
         // scenario with rollback
         tx.begin();
         try {
-            jakarta.transaction.Transaction tranToPropagate = tm.getTransaction();
+            Transaction tranToPropagate = tm.getTransaction();
 
             Connection con = defaultDataSource.getConnection();
             Statement st = con.createStatement();
@@ -297,7 +296,7 @@ public class MPConcurrentTxTestServlet extends HttpServlet {
 
             CompletableFuture<Integer> stage = CompletableFuture.supplyAsync(() -> {
                 try {
-                    jakarta.transaction.Transaction tranToRestore = tm.suspend();
+                    Transaction tranToRestore = tm.suspend();
                     tm.resume(tranToPropagate);
                     try (Connection con2 = defaultDataSource.getConnection(); Statement st2 = con2.createStatement()) {
                         return st2.executeUpdate("INSERT INTO IACOUNTIES VALUES ('Story', 95888)");

--- a/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPContextProp1_1_App/src/concurrent/mp/fat/v11/web/MPContextProp1_1_TestServlet.java
+++ b/dev/com.ibm.ws.concurrent.mp_fat/test-applications/MPContextProp1_1_App/src/concurrent/mp/fat/v11/web/MPContextProp1_1_TestServlet.java
@@ -24,7 +24,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
@@ -41,24 +40,21 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-import jakarta.annotation.Resource;
-import jakarta.servlet.ServletConfig;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.annotation.WebServlet;
-import jakarta.servlet.http.HttpServlet;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
+import javax.annotation.Resource;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.context.ThreadContext;
 import org.junit.Test;
 import org.test.context.location.CurrentLocation;
 import org.test.context.location.TestContextTypes;
-
-import componenttest.annotation.AllowedFFDC;
 
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = "/MPContextProp1_1_TestServlet")
@@ -388,7 +384,7 @@ public class MPContextProp1_1_TestServlet extends HttpServlet {
         assertNotNull("Neither stage was rejected, despite queue capacity configured to 1: " + dependentStage1 + ", " + dependentStage2, abortedTaskException);
 
         blocker.countDown();
- 
+
         if (dependentStage1.isCompletedExceptionally())
             assertEquals("Location is Iowa", dependentStage2.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
 


### PR DESCRIPTION
fixes #14941

Re-enable the tests to work with EE 8 only, not EE 9.
Added a Repeat Action to run all tests against mpContextPropagation-1.1 as well in FULL mode