### PR TITLE
Encapsulated variable reset as an explicit function for cdi tests

### DIFF
--- a/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/Cdi12Test.java
+++ b/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/Cdi12Test.java
@@ -124,6 +124,8 @@ public class Cdi12Test extends LoggingTest {
 
     @AfterClass
     public static void tearDown() throws Exception {
+        // Reset Variables for tests
+        CdiTest.resetTests();
         if (SS.getLibertyServer() != null && SS.getLibertyServer().isStarted()) {
             SS.getLibertyServer().stopServer(null);
         }

--- a/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/Cdi20Test.java
+++ b/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/Cdi20Test.java
@@ -120,6 +120,8 @@ public class Cdi20Test extends LoggingTest {
 
     @AfterClass
     public static void tearDown() throws Exception {
+        // Reset Variables for tests after tests have finished
+        CdiTest.resetTests();
         if (SS.getLibertyServer() != null && SS.getLibertyServer().isStarted()) {
             SS.getLibertyServer().stopServer(null);
         }

--- a/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/all/CdiTest.java
+++ b/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/all/CdiTest.java
@@ -44,6 +44,12 @@ public class CdiTest {
         this.wsocTest = test;
     }
 
+    public static void resetTests() {
+        sequenceCounter = 0;
+        sequenceCounter12 = 0;
+        sequenceCounter20 = 0;
+    }
+
     /*
      * ServerEndpoint - @see AnnotatedEndpointCDI1
      */
@@ -172,11 +178,6 @@ public class CdiTest {
      */
     public void testCdiProgrammaticEndpointCDI12() throws Exception {
 
-        // Reset counter to 0 for the second FAT run since a new application is deployed
-        if (sequenceCounter12 == 2) {
-            sequenceCounter12 = 0;
-        }
-
         String s1 = "Message1FromClient";
         String e1 = "Dependent Scoped Counter: 2 ApplicationScopedCounter: 3";
 
@@ -198,11 +199,6 @@ public class CdiTest {
      * ServerEndpoint - @see ProgrammaticExtendEndpointCDI12
      */
     public void testCdiProgrammaticEndpointMultipleOnMessageCDI12() throws Exception {
-
-        // Reset counter to 0 for the second FAT run since a new application is deployed
-        if (sequenceCounter12 == 2) {
-            sequenceCounter12 = 0;
-        }
 
         String s1 = "Message1FromClient";
         String s2 = "Message2FromClient";
@@ -249,11 +245,6 @@ public class CdiTest {
      */
     public void testCdiProgrammaticEndpointCDI20() throws Exception {
 
-        // Reset counter to 0 for the second FAT run since a new application is deployed
-        if (sequenceCounter20 == 2) {
-            sequenceCounter20 = 0;
-        }
-
         String s1 = "Message1FromClient";
         String e1 = "Dependent Scoped Counter: 2 ApplicationScopedCounter: 3";
 
@@ -275,11 +266,6 @@ public class CdiTest {
      * ServerEndpoint - @see ProgrammaticExtendEndpointCDI20
      */
     public void testCdiProgrammaticEndpointMultipleOnMessageCDI20() throws Exception {
-
-        // Reset counter to 0 for the second FAT run since a new application is deployed
-        if (sequenceCounter20 == 2) {
-            sequenceCounter20 = 0;
-        }
 
         String s1 = "Message1FromClient";
         String s2 = "Message2FromClient";


### PR DESCRIPTION
fixes #14290 

Added a reset function to the CDI tests in order to make it explicit when the variables are reset. This function is now called at the end of the tests