### PR TITLE
Ensure app path is decoded when matching resources.

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/helloworld/HelloWorldTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/helloworld/HelloWorldTest.java
@@ -28,12 +28,10 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class HelloWorldTest {
 
     @Server("com.ibm.ws.jaxrs.fat.helloworld")

--- a/dev/io.openliberty.org.jboss.resteasy.common/src/org/jboss/resteasy/plugins/server/servlet/ServletUtil.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/org/jboss/resteasy/plugins/server/servlet/ServletUtil.java
@@ -1,0 +1,151 @@
+package org.jboss.resteasy.plugins.server.servlet;
+
+import org.jboss.resteasy.core.Headers;
+import org.jboss.resteasy.specimpl.ResteasyHttpHeaders;
+import org.jboss.resteasy.specimpl.ResteasyUriInfo;
+import org.jboss.resteasy.util.HttpHeaderNames;
+import org.jboss.resteasy.util.MediaTypeHelper;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class ServletUtil
+{
+   public static ResteasyUriInfo extractUriInfo(HttpServletRequest request, String servletPrefix)
+   {
+      String contextPath = request.getContextPath();
+      if (servletPrefix != null && servletPrefix.length() > 0 && !servletPrefix.equals("/"))
+      {
+         if (!contextPath.endsWith("/") && !servletPrefix.startsWith("/"))
+            contextPath += "/";
+         contextPath += servletPrefix;
+      }
+      String queryString = request.getQueryString();
+      String absolute;
+      if (queryString != null && queryString.length() > 0)
+      {
+         absolute = request.getRequestURL().append('?').append(queryString).toString();
+      }
+      else
+      {
+         absolute = request.getRequestURL().toString();
+      }
+      if (!absolute.contains(contextPath))
+      {
+         String encodedContextPath = Arrays.stream(contextPath.substring(1).split("/"))
+                                           .map(s -> {
+                                              try {
+                                                 return URLEncoder.encode(s, "UTF-8");
+                                                } catch (UnsupportedEncodingException ex) {
+                                                 return s;
+                                              }
+                                             })
+                                           .collect(Collectors.joining("/", "/", ""));
+         if (absolute.contains(encodedContextPath))
+         {
+            absolute = absolute.replace(encodedContextPath, contextPath);
+         }
+      }
+      return new ResteasyUriInfo(absolute, contextPath);
+   }
+
+   public static ResteasyHttpHeaders extractHttpHeaders(HttpServletRequest request)
+   {
+
+      MultivaluedMap<String, String> requestHeaders = extractRequestHeaders(request);
+      ResteasyHttpHeaders headers = new ResteasyHttpHeaders(requestHeaders);
+
+      String contentType = request.getContentType();
+      if (contentType != null)
+         headers.getMutableHeaders().putSingle(HttpHeaders.CONTENT_TYPE, contentType);
+
+      Map<String, Cookie> cookies = extractCookies(request);
+      headers.setCookies(cookies);
+
+      // test parsing should throw an exception on error
+      headers.testParsing();
+
+      return headers;
+
+   }
+
+   static Map<String, Cookie> extractCookies(HttpServletRequest request)
+   {
+      Map<String, Cookie> cookies = new HashMap<String, Cookie>();
+      if (request.getCookies() != null)
+      {
+         for (javax.servlet.http.Cookie cookie : request.getCookies())
+         {
+            cookies.put(cookie.getName(), new Cookie(cookie.getName(), cookie.getValue(), cookie.getPath(),
+                  cookie.getDomain(), cookie.getVersion()));
+
+         }
+      }
+      return cookies;
+   }
+
+   public static List<MediaType> extractAccepts(MultivaluedMap<String, String> requestHeaders)
+   {
+      List<MediaType> acceptableMediaTypes = new ArrayList<MediaType>();
+      List<String> accepts = requestHeaders.get(HttpHeaderNames.ACCEPT);
+      if (accepts == null)
+         return acceptableMediaTypes;
+
+      for (String accept : accepts)
+      {
+         acceptableMediaTypes.addAll(MediaTypeHelper.parseHeader(accept));
+      }
+      return acceptableMediaTypes;
+   }
+
+   public static List<String> extractLanguages(MultivaluedMap<String, String> requestHeaders)
+   {
+      List<String> acceptable = new ArrayList<String>();
+      List<String> accepts = requestHeaders.get(HttpHeaderNames.ACCEPT_LANGUAGE);
+      if (accepts == null)
+         return acceptable;
+
+      for (String accept : accepts)
+      {
+         String[] splits = accept.split(",");
+         for (String split : splits)
+            acceptable.add(split.trim());
+      }
+      return acceptable;
+   }
+
+   public static MultivaluedMap<String, String> extractRequestHeaders(HttpServletRequest request)
+   {
+      Headers<String> requestHeaders = new Headers<String>();
+
+      Enumeration<String> headerNames = request.getHeaderNames();
+      while (headerNames.hasMoreElements())
+      {
+         String headerName = headerNames.nextElement();
+         Enumeration<String> headerValues = request.getHeaders(headerName);
+         while (headerValues.hasMoreElements())
+         {
+            String headerValue = headerValues.nextElement();
+            requestHeaders.add(headerName, headerValue);
+         }
+      }
+      return requestHeaders;
+   }
+}

--- a/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/component/RESTfulServletContainerInitializer.java
+++ b/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/component/RESTfulServletContainerInitializer.java
@@ -37,6 +37,7 @@ import org.jboss.resteasy.microprofile.config.ResteasyConfigProvider;
 import org.jboss.resteasy.plugins.server.servlet.HttpServlet30Dispatcher;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
 import org.jboss.resteasy.plugins.servlet.ResteasyServletInitializer;
+import org.jboss.resteasy.util.Encode;
 
 @Trivial
 @HandlesTypes({Application.class, Path.class, Provider.class})
@@ -134,7 +135,7 @@ public class RESTfulServletContainerInitializer extends ResteasyServletInitializ
             return;
         }
         ServletRegistration.Dynamic reg;
-        String mapping = path.value();
+        String mapping = Encode.decode(path.value());
         String prefix;
 
         if (!mapping.startsWith("/")) mapping = "/" + mapping;


### PR DESCRIPTION
This resolves an issue with restfulWS-3.0 regarding the encoding/decoding of the application path. Both `@ApplicationPath("app%21")` and `@ApplicationPath("app!")` are legit according to the spec/TCK and either one should be able to be accessed from requests `GET http://localhost:9080/context-root/app%21/...` and `GET http://localhost:9080/context-root/app!/...`.

When storing resource paths in RESTEasy, the decoded path is used (i.e. `/app!`). But when the HTTP request arrives, the app path portion of the URL may not always be decoded, preventing RESTEasy from matching the request to the proper resource (resulting in a 404).  This change resolves this by ensuring that the app portion of the URL is decoded prior to resource matching.