### PR TITLE
Make OpenAPI 2.0 fully scan module directories

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/utils/IndexUtils.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/utils/IndexUtils.java
@@ -63,13 +63,11 @@ public class IndexUtils {
         Indexer indexer = new Indexer();
         FilteredIndexView filter = new FilteredIndexView(null, config);
 
-        // Get the URL to the /WEB-INF/classes directory in the web module
         String containerPhysicalPath = webModuleInfo.getContainer().getPhysicalPath();
         Path containerPath = Paths.get(containerPhysicalPath);
-        Path webinfClassesPath = containerPath.resolve(Constants.DIR_WEB_INF).resolve(Constants.DIR_CLASSES);
-        if (Files.exists(webinfClassesPath) && Files.isDirectory(webinfClassesPath)) {
-            // The /WEB-INF/classes directrory exists.  This is probably an expanded/loose app. Process the files in the directory.
-            try (Stream<Path> walk = Files.walk(webinfClassesPath)) {
+        if (Files.exists(containerPath) && Files.isDirectory(containerPath)) {
+            // Container path is a directory, this is probably an expanded/loose app. Process the files in the directory.
+            try (Stream<Path> walk = Files.walk(containerPath)) {
                 List<Path> files = walk
                     .filter(Files::isRegularFile)
                     .collect(Collectors.toList());
@@ -85,7 +83,7 @@ public class IndexUtils {
                 } // FOR
             } catch (IOException e) {
                 if (LoggingUtils.isEventEnabled(tc)) {
-                    Tr.event(tc, String.format("Error occurred when attempting to walk files for directory %s: %s", webinfClassesPath, e.getMessage()));
+                    Tr.event(tc, String.format("Error occurred when attempting to walk files for directory %s: %s", containerPath, e.getMessage()));
                 }
             }
         } else if (  Files.isRegularFile(containerPath)
@@ -94,7 +92,7 @@ public class IndexUtils {
                      )
                   ) {
             try {
-                // The /WEB-INF/classes directrory does not exist.  This is a JAR/WAR.
+                // Container path is a .jar or .war file.
                 if (LoggingUtils.isEventEnabled(tc)) {
                     Tr.event(tc, "Processing archive: " + containerPath);
                 }

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/DeploymentTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/DeploymentTest.java
@@ -20,7 +20,6 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -152,7 +151,6 @@ public class DeploymentTest {
     }
 
     @Test
-    @Ignore // Known bug
     public void testExpandedWarLib() throws Exception {
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "testJar.jar")
                                     .addClasses(DeploymentTestApp.class, DeploymentTestResource.class);


### PR DESCRIPTION
When a web module corresponds to a directory on disk, scan the whole
directory, not just the WEB-INF/classes directory, so we don't miss the
contents of WEB-INF/lib.

This makes the behaviour consistent whether the module is an archive or
a directory. However, in both cases we're potentially scanning more than
we should.

Fixes #15033 