### PR TITLE
11851 Add doPriv to jms runtime for subscriber mbean service registra…

### DIFF
--- a/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/fat/src/com/ibm/ws/messaging/jms20/deliverydelay/fat/DelayFullTest.java
+++ b/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/fat/src/com/ibm/ws/messaging/jms20/deliverydelay/fat/DelayFullTest.java
@@ -246,8 +246,6 @@ public class DelayFullTest {
 
     @Test
     public void testPersistentMessageStore_B() throws Exception {
-        // dz restartServers(DEFAULT_CLIENT);
-
         runInServlet("testPersistentMessage");
 
         restartServers();
@@ -258,8 +256,6 @@ public class DelayFullTest {
 
     @Test
     public void testPersistentMessageStore_Tcp() throws Exception {
-        // dz restartServers(DEFAULT_CLIENT);
-
         runInServlet("testPersistentMessage_Tcp");
 
         restartServers();
@@ -267,15 +263,6 @@ public class DelayFullTest {
         boolean testResult = runInServlet("testPersistentMessageReceive_Tcp");
         assertTrue("testPersistentMessageStore_Tcp failed", testResult);
     }
-
-    // TODO: SIB runtime is missing a doPriv.  Test fails without this permission 
-    // in the client xml:
-    //
-    // <javaPermission className="org.osgi.framework.ServicePermission" name="*" actions="register"/>
-    //
-    // See DelayClient_MDB.xml
-    //
-    // This will be resolved in a subsequent issue/pull-request.
 
     @Test
     public void testPersistentMessageStoreTopic_B() throws Exception {

--- a/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/publish/files/DelayClient_MDB.xml
+++ b/dev/com.ibm.ws.messaging.open_jms20deliverydelay_fat/publish/files/DelayClient_MDB.xml
@@ -46,10 +46,6 @@
     <fileStore id="com.ibm.ws.sib.fileStore" logFileSize="10"/>
   </messagingEngine>
 
-  <!-- THIS LOOKS LIKE A BUG -->
-  <!-- See DelayFullTest.testPersistentMessageStoreTopic_B -->
-  <javaPermission className="org.osgi.framework.ServicePermission" name="*" actions="register"/>
-
   <jmsQueueConnectionFactory jndiName="jndi_JMS_BASE_QCF" connectionManagerRef="ConMgr6">
     <properties.wasJms userName="CF1USER" password="junkpassword"/> 
   </jmsQueueConnectionFactory>

--- a/dev/com.ibm.ws.messaging.runtime/src/com/ibm/ws/sib/admin/internal/MessagingMBeanFactoryImpl.java
+++ b/dev/com.ibm.ws.messaging.runtime/src/com/ibm/ws/sib/admin/internal/MessagingMBeanFactoryImpl.java
@@ -11,6 +11,8 @@
 
 package com.ibm.ws.sib.admin.internal;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -349,7 +351,8 @@ public final class MessagingMBeanFactoryImpl implements ControllableRegistration
             properties.put("service.vendor", "IBM");
             String cName = c.getName();
             properties.put("jmx.objectname", "WebSphere:feature=wasJmsServer,type=Subscriber,name=" + cName);
-            ServiceRegistration<SubscriberMBean> subscriberMbean = (ServiceRegistration<SubscriberMBean>) bcontext.registerService(SubscriberMBean.class.getName(), sp, properties);
+            ServiceRegistration<SubscriberMBean> subscriberMbean = AccessController.doPrivileged((
+                    PrivilegedAction<ServiceRegistration<SubscriberMBean>>) () -> (ServiceRegistration<SubscriberMBean>)bcontext.registerService(SubscriberMBean.class.getName(), sp, properties));
             serviceObjects.put(cName, subscriberMbean);
         } catch (Exception e) {
             SibTr.exception(tc, e);


### PR DESCRIPTION
Ref: #11851 

Fix lacking doPriv exposed by jms20deliverydelay fat.