### PR TITLE
message not ported to OpenLiberty

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/HCMDetails.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/HCMDetails.java
@@ -92,14 +92,12 @@ public class HCMDetails implements HandleListInterface.HandleDetails {
             // The RRA throws this exception for the above case.  Other RA's may throw different exceptions
             //  which will fall into the follow on catch clauses which will rethrow the exception.
 
-            Object[] parms = new Object[] { "parkHandle", "parkHandle", _handle, e };
-            Tr.warning(tc, "PARK_OR_REASSOCIATE_FAILED_W_J2CA0083", parms); // TODO message not added to Liberty
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                Tr.debug(this, tc, "error is expected if it follows a transaction timeout", e);
         } catch (Exception e) {
             // This could be caused by Transaction timeout having forced a mc.cleanup
             //  which invalidated the handle for this parkHandle call.
 
-            Object[] parms = new Object[] { "parkHandle", "parkHandle", _handle, e };
-            Tr.warning(tc, "PARK_OR_REASSOCIATE_FAILED_W_J2CA0083", parms); // TODO message not added to Liberty
             FFDCFilter.processException(e, getClass().getName(), "373", this);
 
             if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
@@ -127,16 +125,14 @@ public class HCMDetails implements HandleListInterface.HandleDetails {
             // The RRA throws this exception for the above case.  Other RA's may throw different exceptions
             //  which will fall into the followon catch clauses which will rethrow the exception.
 
-            Object[] parms = new Object[] { "reAssociate", "reAssociate", _handle, e };
-            Tr.warning(tc, "PARK_OR_REASSOCIATE_FAILED_W_J2CA0083", parms); // TODO message not added to Liberty
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                Tr.debug(this, tc, "error is expected if it follows a transaction timeout", e);
         } catch (Exception e) {
             // This could be caused by Transaction timeout having forced a mc.cleanup
             // which invalidated the handle for this parkHandle call.
 
             // reAssociate failed for some unknown reason
 
-            Object[] parms = new Object[] { "reAssociate", "reAssociate", _handle, e };
-            Tr.warning(tc, "PARK_OR_REASSOCIATE_FAILED_W_J2CA0083", parms); // TODO message not added to Liberty
             FFDCFilter.processException(e, getClass().getName(), "297", this);
 
             if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())


### PR DESCRIPTION
The key for a translatable message, PARK_OR_REASSOCIATE_FAILED_W_J2CA0083, is used within ported code within HCMDetails. However, the message itself was not yet ported to OpenLiberty.  When I looked over the message to port it, it appeared to refer to internals useful for the support team rather than something meaningful to the end user.  Under this pull, I'm replacing it with debug trace rather than porting the message over.