### PR TITLE
Update mpConfig 2.0 to use latest artifacts from Maven Central

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -649,27 +649,37 @@
     <dependency>
       <groupId>io.smallrye.common</groupId>
       <artifactId>smallrye-common-annotation</artifactId>
-      <version>1.4.0</version>
+      <version>1.5.0</version>
     </dependency>
     <dependency>
       <groupId>io.smallrye.common</groupId>
       <artifactId>smallrye-common-classloader</artifactId>
-      <version>1.4.0</version>
+      <version>1.5.0</version>
     </dependency>
     <dependency>
       <groupId>io.smallrye.common</groupId>
       <artifactId>smallrye-common-constraint</artifactId>
-      <version>1.4.0</version>
+      <version>1.5.0</version>
     </dependency>
     <dependency>
       <groupId>io.smallrye.common</groupId>
       <artifactId>smallrye-common-expression</artifactId>
-      <version>1.4.0</version>
+      <version>1.5.0</version>
     </dependency>
     <dependency>
       <groupId>io.smallrye.common</groupId>
       <artifactId>smallrye-common-function</artifactId>
-      <version>1.4.0</version>
+      <version>1.5.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye.config</groupId>
+      <artifactId>smallrye-config-common</artifactId>
+      <version>2.0.0-RC1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye.config</groupId>
+      <artifactId>smallrye-config</artifactId>
+      <version>2.0.0-RC1</version>
     </dependency>
     <dependency>
       <groupId>io.smallrye</groupId>
@@ -1705,6 +1715,11 @@
       <groupId>org.eclipse.microprofile.config</groupId>
       <artifactId>microprofile-config-api</artifactId>
       <version>1.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.microprofile.config</groupId>
+      <artifactId>microprofile-config-api</artifactId>
+      <version>2.0-RC15</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.context-propagation</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -125,11 +125,13 @@ io.perfmark:perfmark-api:0.22.0
 io.projectreactor:reactor-core:3.1.8.RELEASE
 io.reactivex.rxjava2:rxjava:2.2.19
 io.reactivex:rxjava:1.3.8
-io.smallrye.common:smallrye-common-annotation:1.4.0
-io.smallrye.common:smallrye-common-classloader:1.4.0
-io.smallrye.common:smallrye-common-constraint:1.4.0
-io.smallrye.common:smallrye-common-expression:1.4.0
-io.smallrye.common:smallrye-common-function:1.4.0
+io.smallrye.common:smallrye-common-annotation:1.5.0
+io.smallrye.common:smallrye-common-classloader:1.5.0
+io.smallrye.common:smallrye-common-constraint:1.5.0
+io.smallrye.common:smallrye-common-expression:1.5.0
+io.smallrye.common:smallrye-common-function:1.5.0
+io.smallrye.config:smallrye-config-common:2.0.0-RC1
+io.smallrye.config:smallrye-config:2.0.0-RC1
 io.smallrye:smallrye-graphql-client-api:1.0.9
 io.smallrye:smallrye-graphql-client:1.0.9
 io.smallrye:smallrye-graphql-schema-model:1.0.9
@@ -337,6 +339,7 @@ org.eclipse.microprofile.config:microprofile-config-api:1.1
 org.eclipse.microprofile.config:microprofile-config-api:1.2.1
 org.eclipse.microprofile.config:microprofile-config-api:1.3
 org.eclipse.microprofile.config:microprofile-config-api:1.4
+org.eclipse.microprofile.config:microprofile-config-api:2.0-RC15
 org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.0
 org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.1
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:1.0

--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -86,8 +86,6 @@ com.ibm.ws.org.eclipse.platform:org.eclipse.osgi:3.15.200.v20200214-1600
 com.ibm.ws.org.objenesis:objenesis:1.0
 com.ibm.ws:geronimo-validation:1.1
 com.ibm.ws:nekohtml:1.9.18
-io.smallrye.config:smallrye-config-common:2.0.0-ibm20201020
-io.smallrye.config:smallrye-config:2.0.0-ibm20201020
 io.smallrye:smallrye-open-api-core:2.1.0-SNAPSHOT-20200917
 io.smallrye:smallrye-open-api-jaxrs:2.1.0-SNAPSHOT-20200917
 net.sf.jtidy:jtidy:9.3.8
@@ -102,8 +100,6 @@ org.apache.cxf:cxf-rt-ws-security:2.6.2-ibm-s20180529-1900
 org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0
 org.apache.santuario:xmlsec:1.5.2-ibm
 org.apache.ws.security:wss4j:1.6.7-ibm-s20130913-2015
-org.eclipse.microprofile.config:microprofile-config-api:2.0-ibm20201020
-org.eclipse.microprofile.config:microprofile-config-tck:2.0-ibm20201020
 org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.0-20191203
 org.eclipse.microprofile.graphql:microprofile-graphql-tck:1.0.0-20191203
 org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.7-69f2c2b

--- a/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -45,15 +45,17 @@
         </dependencies>
     </dependencyManagement> 
     
+    <!-- Whilst using an artifact that is in Maven (microprofile-config-tck:2.0-RC15) we shouldn't need this.
 	<repositories>
-		<!-- This TCK is currently using a custom built artifact- microprofile-config-tck:2.0-ibm20201020.
-		If Artifactory is unavailable, the following DHE repository will be searched for the artifact -->
+		<! If the TCK is using a custom built artifact, e.g.- microprofile-config-tck:2.0-ibm20201020.
+		And Artifactory is unavailable, the following DHE repository should be searched for the artifact >
 		<repository>
 			<name>IBM DHE Maven repository</name>
 			<id>DHE</id>
 			<url>http://public.dhe.ibm.com/ibmdl/export/pub/software/olrepo</url>
 		</repository>
 	</repositories>
+	-->
 
     <dependencies>
 
@@ -68,7 +70,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-tck</artifactId>
-            <version>2.0-ibm20201020</version> 
+            <version>2.0-RC15</version> 
         </dependency>
 
         <dependency>

--- a/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -11,15 +11,6 @@
 <suite name="microprofile-config-2.0-tck" verbose="2"
     configfailurepolicy="continue">
     <test name="tck-package-org.eclipse.microprofile.config20.tck">
-        <method-selectors>
-            <method-selector>
-                <script language="beanshell">
-                     <![CDATA[
-                     !method.getName().equals("testInjectedConfigSerializable")
-                ]]>
-                </script>    
-            </method-selector>
-        </method-selectors>
         <packages>
             <package name="org.eclipse.microprofile.config.tck.*"></package>
         </packages>


### PR DESCRIPTION
Update mpConfig to use:

* org.eclipse.microprofile.config:microprofile-config-api:2.0-RC15
* org.eclipse.microprofile.config:microprofile-config-tck:2.0-RC15
* io.smallrye.config:smallrye-config-common:2.0.0-RC1
* io.smallrye.config:smallrye-config:2.0.0-RC1
* io.smallrye.common:smallrye-common-annotation:1.5.0
* io.smallrye.common:smallrye-common-classloader:1.5.0
* io.smallrye.common:smallrye-common-constraint:1.5.0
* io.smallrye.common:smallrye-common-expression:1.5.0
* io.smallrye.common:smallrye-common-function:1.5.0

Note: `org.eclipse.microprofile.config:microprofile-config-tck:2.0-RC15` doesn't need to be added to `oss_dependecies.maven` since it's only used for the TCK tests and isn't packaged/released.
