### PR TITLE
test that handles parked when left open by message driven bean are closed when transaction ends

### DIFF
--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
@@ -132,8 +132,8 @@ public class DerbyResourceAdapterTest extends FATServletClient {
         runTest(DerbyRAServlet);
     }
 
-    //@Test TODO enable once HandleList is working for message driven beans
-    public void testHandleListClosesConnectionLeakedFromMDB() throws Exception {
+    @Test
+    public void testHandleListClosesParkedHandleWhenMDBTransactionEnds() throws Exception {
         runTest(DerbyRAAnnoServlet);
     }
 

--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
@@ -132,6 +132,11 @@ public class DerbyResourceAdapterTest extends FATServletClient {
         runTest(DerbyRAServlet);
     }
 
+    //@Test TODO enable once HandleList is working for message driven beans
+    public void testHandleListClosesConnectionLeakedFromMDB() throws Exception {
+        runTest(DerbyRAAnnoServlet);
+    }
+
     @Test
     public void testJCADataSourceDirectLookup() throws Exception {
         runTest(DerbyRAServlet);

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/server.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/server.xml
@@ -1,3 +1,13 @@
+<!--
+    Copyright (c) 2017,2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
 <server>
     <featureManager>
       <feature>componenttest-1.0</feature>
@@ -17,7 +27,7 @@
     <resourceAdapter location="${server.config.dir}/connectors/DerbyRA.rar" contextServiceRef="DefaultContextService"/>
 
     <connectionFactory jndiName="eis/ds1">
-      <connectionManager maxPoolSize="2" connectionTimeout="0"/>
+      <connectionManager maxPoolSize="2" connectionTimeout="0" enableHandleList="true"/> <!-- rely on default behavior or use correct config property once added -->
       <containerAuthData user="DS1USER" password="{xor}GwxuDwgb"/>
       <properties.DerbyRA/>
     </connectionFactory>

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/server.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/server.xml
@@ -27,7 +27,7 @@
     <resourceAdapter location="${server.config.dir}/connectors/DerbyRA.rar" contextServiceRef="DefaultContextService"/>
 
     <connectionFactory jndiName="eis/ds1">
-      <connectionManager maxPoolSize="2" connectionTimeout="0" enableHandleList="true"/> <!-- rely on default behavior or use correct config property once added -->
+      <connectionManager maxPoolSize="2" connectionTimeout="0"/>
       <containerAuthData user="DS1USER" password="{xor}GwxuDwgb"/>
       <properties.DerbyRA/>
     </connectionFactory>
@@ -49,7 +49,7 @@
     </connectionFactory>
 
     <connectionFactory jndiName="eis/ds5">
-      <connectionManager maxPoolSize="1" connectionTimeout="0"/>
+      <connectionManager maxPoolSize="1" connectionTimeout="0" enableHandleList="true"/> <!-- TODO rely on default behavior or use correct config property once added -->
       <properties.DerbyRA dissociatable="false" lazyEnlistable="true" userName="DS1USER" password="{xor}GwxuDwgb"/>
     </connectionFactory>
 

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/mdb/DerbyRAMessageDrivenBean.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/mdb/DerbyRAMessageDrivenBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,8 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.sql.Statement;
+import java.util.Map;
+import java.util.TreeMap;
 
 import javax.annotation.Resource;
 import javax.ejb.MessageDriven;
@@ -25,8 +27,11 @@ import javax.sql.DataSource;
 
 @MessageDriven
 public class DerbyRAMessageDrivenBean implements MessageListener {
-    @Resource(lookup = "eis/ds1")
+    @Resource(lookup = "eis/ds1", shareable = false)
     private DataSource ds1;
+
+    // Map of test case name to a connection that it intentionally left open
+    private static final Map<String, Connection> leakedConnections = new TreeMap<String, Connection>();
 
     @Override
     public Record onMessage(Record record) throws ResourceException {
@@ -36,6 +41,24 @@ public class DerbyRAMessageDrivenBean implements MessageListener {
         Object key = m.get("key");
         Object newValue = m.get("newValue");
         Object oldValue = m.get("previousValue");
+
+        String testNameForConnectionLeak = null;
+        // look for special instructions from individual tests
+        if ("mdbtestHandleListClosesConnectionLeakedFromMDB".equals(key)) {
+            if ("LeakConnection".equals(newValue))
+                testNameForConnectionLeak = (String) key;
+            else if ("ExpectConnectionClosed".equals(newValue)) {
+                Connection leakedCon = leakedConnections.get(key);
+                try {
+                    oldValue = leakedCon.isClosed();
+                    System.out.println("Expecting connection to be closed by the HandleList. Did we find it closed? " + oldValue);
+                } catch (SQLException x) {
+                    throw new ResourceException(x);
+                }
+            } else
+                System.out.println("Setting new value to " + newValue);
+        }
+
         // Write the previous value to a database table
         try {
             Connection con = ds1.getConnection();
@@ -48,7 +71,12 @@ public class DerbyRAMessageDrivenBean implements MessageListener {
                 }
                 stmt.close();
             } finally {
-                con.close();
+                if (testNameForConnectionLeak == null)
+                    con.close();
+                else {
+                    System.out.println("MDB intentionally avoids closing connection " + con);
+                    leakedConnections.put(testNameForConnectionLeak, con);
+                }
             }
         } catch (SQLException x) {
             throw new ResourceException(x);

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/mdb/DerbyRAMessageDrivenBean.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/mdb/DerbyRAMessageDrivenBean.java
@@ -44,10 +44,17 @@ public class DerbyRAMessageDrivenBean implements MessageListener {
         // Write the previous value to a database table
         try {
             Connection con;
-            if ("UseCachedConnection".equals(newValue) || "UseCachedConnectionAndClose".equals(newValue))
+            if ("UseCachedConnection".equals(newValue)) {
                 con = cachedConnectionRef.get();
-            else
+                if (con.isClosed()) {
+                    oldValue = "CachedConnectionIsClosed";
+                    con = ds5.getConnection();
+                } else {
+                    oldValue = "CachedConnectionIsNotClosed";
+                }
+            } else {
                 con = ds5.getConnection();
+            }
             try {
                 Statement stmt = con.createStatement();
                 try {
@@ -60,11 +67,8 @@ public class DerbyRAMessageDrivenBean implements MessageListener {
                 if ("CacheConnection".equals(newValue)) {
                     System.out.println("MDB intentionally caches connection " + con);
                     cachedConnectionRef.set(con);
-                } else if ("UseCachedConnection".equals(newValue)) {
-                    // Connection is already cached. Don't close it.
                 } else {
-                    if ("UseCachedConnectionAndClose".equals(newValue))
-                        cachedConnectionRef.set(null);
+                    cachedConnectionRef.set(null);
                     con.close();
                 }
             }

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/resources/META-INF/ra.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/resources/META-INF/ra.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    Copyright (c) 2017,2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
 <connector xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/connector_1_6.xsd" version="1.6" metadata-complete="true">
   <description>This is the ra.xml for DerbyRA</description> 
   <display-name>Derby Resource Adapter</display-name> 
@@ -102,7 +112,7 @@
         <description>Data Type of Key</description>
         <config-property-name>keyType</config-property-name> 
         <config-property-type>java.lang.String</config-property-type>
-        <config-property-value>varchar(20)</config-property-value> 
+        <config-property-value>varchar(60)</config-property-value>
       </config-property>
       <config-property>
         <description>Table Name</description>

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyConnection.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-resourceadapters/fvt-resourceadapter/src/fat/derbyra/resourceadapter/DerbyConnection.java
@@ -203,6 +203,8 @@ public class DerbyConnection implements Connection {
 
     @Override
     public boolean isClosed() throws SQLException {
+        if (isClosed)
+            return true;
         lazyInit();
         return mc == null || mc.con.isClosed();
     }


### PR DESCRIPTION
Write a test of HandleList for message driven beans, where the message driven bean caches a connection handle.  The connection handle is initially parked when DissociatableManagedConnection is not supported by the resource adapter, but the server must automatically close the connection handle when the transaction ends.