### PR TITLE
OpenAPI-2.0: write cache entries asynchronously

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/bnd.bnd
@@ -42,6 +42,8 @@ Include-Resource: \
 
 -dsannotations-inherit: true
 -dsannotations: io.openliberty.microprofile.openapi20.ApplicationListener,\
+    io.openliberty.microprofile.openapi20.ApplicationProcessor,\
+    io.openliberty.microprofile.openapi20.ApplicationRegistry,\
     io.openliberty.microprofile.openapi20.OLOASFactoryResolverImpl,\
     io.openliberty.microprofile.openapi20.css.CustomCSSProcessor,\
     io.openliberty.microprofile.openapi20.DefaultHostListener

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/resources/io/openliberty/microprofile/openapi20/resources/OpenAPI.nlsprops
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/resources/io/openliberty/microprofile/openapi20/resources/OpenAPI.nlsprops
@@ -64,4 +64,7 @@ OPENAPI_APPLICATION_PROCESSED.useraction=No action is required.
 OPENAPI_APPLICATION_PROCESSING_ERROR=CWWKO1661E: An error occured when processing application {0} and an OpenAPI document was not produced.
 OPENAPI_APPLICATION_PROCESSING_ERROR.explanation=A runtime error occured when processing the application.
 OPENAPI_APPLICATION_PROCESSING_ERROR.useraction=Gather logs and contact IBM service.
-  
+
+OPENAPI_CACHE_WRITE_ERROR=CWWKO1662W: An unexpected error occurred while writing the OpenAPI cache for application {0}. The error is {1}
+OPENAPI_CACHE_WRITE_ERROR.explanation=A runtime error occurred while caching the OpenAPI model for the application.
+OPENAPI_CACHE_WRITE_ERROR.useraction=Review the FFDC logs and exception text to identify the problem.

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/resources/io/openliberty/microprofile/openapi20/resources/OpenAPI.nlsprops
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/resources/io/openliberty/microprofile/openapi20/resources/OpenAPI.nlsprops
@@ -65,6 +65,6 @@ OPENAPI_APPLICATION_PROCESSING_ERROR=CWWKO1661E: An error occured when processin
 OPENAPI_APPLICATION_PROCESSING_ERROR.explanation=A runtime error occured when processing the application.
 OPENAPI_APPLICATION_PROCESSING_ERROR.useraction=Gather logs and contact IBM service.
 
-OPENAPI_CACHE_WRITE_ERROR=CWWKO1662W: An unexpected error occurred while writing the OpenAPI cache for application {0}. The error is {1}
-OPENAPI_CACHE_WRITE_ERROR.explanation=A runtime error occurred while caching the OpenAPI model for the application.
+OPENAPI_CACHE_WRITE_ERROR=CWWKO1662W: An unexpected error occurred when the OpenAPI cache was written for the {0} application. The error is {1}
+OPENAPI_CACHE_WRITE_ERROR.explanation=A runtime error occurred when the OpenAPI model was cached for the application.
 OPENAPI_CACHE_WRITE_ERROR.useraction=Review the FFDC logs and exception text to identify the problem.

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/ApplicationListener.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/ApplicationListener.java
@@ -12,6 +12,7 @@ package io.openliberty.microprofile.openapi20;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -29,6 +30,9 @@ import io.openliberty.microprofile.openapi20.utils.LoggingUtils;
 public class ApplicationListener implements ApplicationStateListener {
 
     private static final TraceComponent tc = Tr.register(ApplicationListener.class);
+    
+    @Reference
+    private ApplicationRegistry applicationRegistry;
 
     /** {@inheritDoc} */
     @Override
@@ -38,7 +42,7 @@ public class ApplicationListener implements ApplicationStateListener {
                 Tr.event(tc, "Application starting process started: " + appInfo);
             }
             
-            ApplicationRegistry.getInstance().addApplication(appInfo);
+            applicationRegistry.addApplication(appInfo);
             
             if (LoggingUtils.isEventEnabled(tc)) {
                 Tr.event(tc, "Application starting process ended: " + appInfo);
@@ -58,7 +62,7 @@ public class ApplicationListener implements ApplicationStateListener {
     @Override
     public void applicationStopping(ApplicationInfo appInfo) {
         try {
-            ApplicationRegistry.getInstance().removeApplication(appInfo);
+            applicationRegistry.removeApplication(appInfo);
         } catch (Throwable e) {
             if (LoggingUtils.isEventEnabled(tc)) {
                 Tr.event(tc, "Failed to remove application: " + e.getMessage());

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/OpenAPIProvider.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/OpenAPIProvider.java
@@ -69,4 +69,11 @@ public interface OpenAPIProvider {
      *          The true iff the OpenAPI model contains server definitions.
      */
     public boolean getServersDefined();
+    
+    /**
+     * Wait for any background tasks to complete (e.g. writing the cached model)
+     * <p>
+     * This method will block until any outstanding background tasks for this model are complete.
+     */
+    public void waitForBackgroundTasks();
 }

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/cache/ConfigSerializer.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/cache/ConfigSerializer.java
@@ -22,6 +22,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.PathItem;
+import org.eclipse.microprofile.openapi.models.Paths;
 
 import io.smallrye.openapi.api.OpenApiConfig;
 import io.smallrye.openapi.api.OpenApiConfig.OperationIdStrategy;
@@ -132,15 +134,35 @@ public class ConfigSerializer {
     }
 
     private static Set<String> getPathNames(OpenAPI model) {
-        return model.getPaths().getPathItems().keySet();
+        Paths paths = model.getPaths();
+        if (paths == null) {
+            return Collections.emptySet();
+        }
+        
+        Map<String, PathItem> pathItems = paths.getPathItems();
+        if (pathItems == null) {
+            return Collections.emptySet();
+        }
+        
+        return pathItems.keySet();
     }
 
     private static Set<String> getOperationIds(OpenAPI model) {
-        return model.getPaths().getPathItems().values().stream() // Get the paths
-                    .flatMap(i -> i.getOperations().values().stream()) // Get all the operations from all the paths
-                    .filter(o -> o.getOperationId() != null) // Filter out the ones without an id
-                    .map(o -> o.getOperationId()) // Extract just the operation id
-                    .collect(Collectors.toSet()); // Collect the IDs into a set
+        Paths paths = model.getPaths();
+        if (paths == null) {
+            return Collections.emptySet();
+        }
+        
+        Map<String, PathItem> pathItems = paths.getPathItems();
+        if (pathItems == null) {
+            return Collections.emptySet();
+        }
+        
+        return pathItems.values().stream() // Get the paths
+                        .flatMap(i -> i.getOperations().values().stream()) // Get all the operations from all the paths
+                        .filter(o -> o.getOperationId() != null) // Filter out the ones without an id
+                        .map(o -> o.getOperationId()) // Extract just the operation id
+                        .collect(Collectors.toSet()); // Collect the IDs into a set
     }
 
 }

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/utils/MessageConstants.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/utils/MessageConstants.java
@@ -12,17 +12,69 @@ package io.openliberty.microprofile.openapi20.utils;
 
 public class MessageConstants {
 
+    /**
+     * CWWKO1652W: The server cannot read the specified CSS document {0} due to {1} : {2}.
+     */
     public static final String CSS_NOT_PROCESSED                    = "CSS_NOT_PROCESSED"; //$NON-NLS-1$
+    
+    /**
+     * CWWKO1656W: The server read the specified CSS document {0}, but was unable to find <.swagger-ui .headerbar >.
+     */
     public static final String CSS_SECTION_NOT_FOUND                = "CSS_SECTION_NOT_FOUND"; //$NON-NLS-1$
+    
+    /**
+     * CWWKO1655W: The custom CSS file {0} that was specified for the OpenAPI UI was not processed. The server will restore the default values for the OpenAPI UI. Reason={1} : {2}.
+     */
     public static final String CUSTOM_CSS_NOT_PROCESSED             = "CUSTOM_CSS_NOT_PROCESSED"; //$NON-NLS-1$
+    
+    /**
+     * CWWKO1654W: The background image that was specified at {0} either does not exist or is invalid.
+     */
     public static final String INVALID_CSS_BACKGROUND_IMAGE         = "INVALID_CSS_BACKGROUND_IMAGE"; //$NON-NLS-1$
+    
+    /**
+     * CWWKO1660I: The application {0} was processed and an OpenAPI document was produced.
+     */
     public static final String OPENAPI_APPLICATION_PROCESSED        = "OPENAPI_APPLICATION_PROCESSED"; //$NON-NLS-1$
+    
+    /**
+     * CWWKO1661E: An error occured when processing application {0} and an OpenAPI document was not produced.
+     */
     public static final String OPENAPI_APPLICATION_PROCESSING_ERROR = "OPENAPI_APPLICATION_PROCESSING_ERROR"; //$NON-NLS-1$
+    
+    /**
+     * CWWKO1662W: An unexpected error occurred while writing the OpenAPI cache for application {0}. The error is {1}
+     */
+    public static final String OPENAPI_CACHE_WRITE_ERROR            = "OPENAPI_CACHE_WRITE_ERROR"; //$NON-NLS-1$
+    
+    /**
+     * CWWKO1650E: Validation of the OpenAPI document produced the following error(s):
+     */
     public static final String OPENAPI_DOCUMENT_VALIDATION_ERROR    = "OPENAPI_DOCUMENT_VALIDATION_ERROR"; //$NON-NLS-1$
+    
+    /**
+     * CWWKO1651W: Validation of the OpenAPI document produced the following warning(s):
+     */
     public static final String OPENAPI_DOCUMENT_VALIDATION_WARNING  = "OPENAPI_DOCUMENT_VALIDATION_WARNING"; //$NON-NLS-1$
+    
+    /**
+     * CWWKO1659E: Failed to parse the OpenAPI document for application: {0}.
+     */
     public static final String OPENAPI_FILE_PARSE_ERROR             = "OPENAPI_FILE_PARSE_ERROR"; //$NON-NLS-1$
+    
+    /**
+     * CWWKO1657E: Failed to load the OpenAPI filter class: {0}.
+     */
     public static final String OPENAPI_FILTER_LOAD_ERROR            = "OPENAPI_FILTER_LOAD_ERROR"; //$NON-NLS-1$
+    
+    /**
+     * CWWKO1658E: Failed to load the OpenAPI model reader class: {0}.
+     */
     public static final String OPENAPI_MODEL_READER_LOAD_ERROR      = "OPENAPI_MODEL_READER_LOAD_ERROR"; //$NON-NLS-1$
+    
+    /**
+     * CWWKO1653W: The value that was specified for the {0} property is not supported. The value must be {1}.
+     */
     public static final String UNSUPPORTED_CSS_VALUE                = "UNSUPPORTED_CSS_VALUE"; //$NON-NLS-1$
     
     private MessageConstants() {


### PR DESCRIPTION
Part of the startup process is to write the generated OpenAPI model to
the cache so that it can be used next time the application starts.

However, since the cache entry isn't needed for the current run of the
application, we can write it in the background to allow the app to start
faster.

For #14678 