### PR TITLE
Update mpMetrics to use the MP Metrics 3.0 artifacts from sonatype - via artifactory and DHE - v2

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1797,21 +1797,6 @@
       <version>2.3</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.microprofile.metrics</groupId>
-      <artifactId>microprofile-metrics-api</artifactId>
-      <version>3.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.microprofile.metrics</groupId>
-      <artifactId>microprofile-metrics-api</artifactId>
-      <version>3.0-RC1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.microprofile.metrics</groupId>
-      <artifactId>microprofile-metrics-api</artifactId>
-      <version>3.0-RC3</version>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.microprofile.openapi</groupId>
       <artifactId>microprofile-openapi-api</artifactId>
       <version>1.0.1</version>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -355,9 +355,6 @@ org.eclipse.microprofile.metrics:microprofile-metrics-api:1.1.1
 org.eclipse.microprofile.metrics:microprofile-metrics-api:2.0.0
 org.eclipse.microprofile.metrics:microprofile-metrics-api:2.2
 org.eclipse.microprofile.metrics:microprofile-metrics-api:2.3
-org.eclipse.microprofile.metrics:microprofile-metrics-api:3.0
-org.eclipse.microprofile.metrics:microprofile-metrics-api:3.0-RC1
-org.eclipse.microprofile.metrics:microprofile-metrics-api:3.0-RC3
 org.eclipse.microprofile.openapi:microprofile-openapi-api:1.0.1
 org.eclipse.microprofile.openapi:microprofile-openapi-api:1.1.1
 org.eclipse.microprofile.openapi:microprofile-openapi-api:2.0-RC3

--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -107,6 +107,7 @@ org.eclipse.microprofile.config:microprofile-config-tck:2.0-ibm20201020
 org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.0-20191203
 org.eclipse.microprofile.graphql:microprofile-graphql-tck:1.0.0-20191203
 org.eclipse.microprofile.metrics:microprofile-metrics-api:3.0
+org.eclipse.microprofile.metrics:microprofile-metrics-api:3.0.0
 org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.7-69f2c2b
 org.eclipse.persistence:org.eclipse.persistence.asm:2.7.7-69f2c2b
 org.eclipse.persistence:org.eclipse.persistence.core:2.7.7-69f2c2b

--- a/dev/io.openliberty.org.eclipse.microprofile/metrics.3.0.bnd
+++ b/dev/io.openliberty.org.eclipse.microprofile/metrics.3.0.bnd
@@ -21,6 +21,6 @@ Export-Package: \
   org.eclipse.microprofile.metrics.annotation;version=3.0
 
 Include-Resource: \
-  @${repo;org.eclipse.microprofile.metrics:microprofile-metrics-api;3.0}
+  @${repo;org.eclipse.microprofile.metrics:microprofile-metrics-api;3.0.0;EXACT}
 
 WS-TraceGroup: METRICS


### PR DESCRIPTION
#build
Old PR  at #15090 was improperly pulling artifacts from maven central instead and was using older versions (i.e not  3.0.0) with the absence of the  `EXACT` designation in the bundle reference.

If retrieving artifacts from `DHE`, the dependency should only be included in the `oss_ibm.maven` file.
Including it in `oss_dependencies.maven` will force it to look up the affected artifacts on maven and skip DHE lookup when artifactory credentials are not presented. Even if the DHE artifact has already been downloaded to the local `.ibmdhe` repository from a `cnf:initialize` call the build will ignore it.
