### PR TITLE
test that HandleList closes handles on EJB destroy

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/server.xml
@@ -27,6 +27,7 @@
     <application id="otherApp" location="otherApp.ear"/>
 
     <dataSource id="DefaultDataSource" ibm.internal.nonship.function="true">
+      <connectionManager enableHandleList="true"/> <!-- TODO remove once this becomes default behavior -->
       <jdbcDriver javax.sql.DataSource="jdbc.driver.proxy.ProxyDataSource" libraryRef="ibm.internal.simulate.no.library.do.not.ship" ibm.internal.nonship.function="true"/> <!-- TODO remove libraryRef -->
       <properties databaseName="memory:ds1"/>
     </dataSource>
@@ -37,6 +38,7 @@
     </dataSource>
 
     <dataSource id="sharedLibDataSource" jndiName="jdbc/sharedLibDataSource">
+      <connectionManager enableHandleList="false"/> <!-- TODO use correct property name, once added -->
       <!-- loads its JDBC driver from a shared library, NOT from the app like the other data sources in this server -->
       <jdbcDriver>
         <library>

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/src/web/derby/CloseableExecutorBean.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/src/web/derby/CloseableExecutorBean.java
@@ -10,26 +10,8 @@
  *******************************************************************************/
 package web.derby;
 
+import java.io.Closeable;
 import java.util.concurrent.Executor;
 
-import javax.annotation.Resource;
-import javax.ejb.Remove;
-import javax.ejb.Stateful;
-import javax.sql.DataSource;
-
-@Stateful
-public class BeanInWebApp implements CloseableExecutorBean, Executor {
-    @Resource(name = "java:comp/env/jdbc/dsref", lookup = "jdbc/sharedLibDataSource")
-    DataSource ds;
-
-    @Override
-    @Remove
-    public void close() {
-        System.out.println("EJB remove method (close) invoked");
-    }
-
-    @Override
-    public void execute(Runnable runnable) {
-        runnable.run();
-    }
+public interface CloseableExecutorBean extends Closeable, Executor {
 }


### PR DESCRIPTION
Write a test to confirm that when HandleList is enabled, Liberty automatically closes connection handles that are leaked beyond EJB destroy.
Also, write a test to confirm that when HandleList is disabled, the connection handle is not closed and can still be used.