### PR TITLE
test parked handles across EJB methods

### DIFF
--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
@@ -68,6 +68,8 @@ public class DerbyResourceAdapterTest extends FATServletClient {
 
         server.addInstalledAppForValidation(derbyRAAppName);
         server.startServer();
+
+        FATServletClient.runTest(server, DerbyRAServlet, "initDatabaseTables");
     }
 
     @AfterClass
@@ -159,6 +161,16 @@ public class DerbyResourceAdapterTest extends FATServletClient {
 
     @Test
     public void testJCADataSourceResourceRef() throws Exception {
+        runTest(DerbyRAServlet);
+    }
+
+    @Test
+    public void testNonDissociatableHandlesCannotBeParkedAcrossTransactionScopes() throws Exception {
+        runTest(DerbyRAServlet);
+    }
+
+    @Test
+    public void testNonDissociatableHandlesParkedAcrossEJBMethods() throws Exception {
         runTest(DerbyRAServlet);
     }
 

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/DerbyConnectionCachingBean.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/DerbyConnectionCachingBean.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package web;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import javax.ejb.EJBException;
+import javax.ejb.Remove;
+import javax.ejb.Stateful;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.sql.DataSource;
+
+/**
+ * This EJB caches a connection handle across method invocations (which are to be performed within a
+ * the same transaction by the caller). The EJB remove method intentionally leaks the connection handle
+ * so that we can verify that the HandleList cleans it up.
+ */
+@Stateful
+public class DerbyConnectionCachingBean {
+    private Connection con;
+
+    public void connect() {
+        try {
+            DataSource ds = (DataSource) InitialContext.doLookup("eis/ds5"); // shareable
+            con = ds.getConnection();
+        } catch (NamingException | SQLException x) {
+            throw new EJBException(x);
+        }
+    }
+
+    public Integer find(String name) {
+        try (Statement s = con.createStatement()) {
+            ResultSet result = s.executeQuery("SELECT VAL FROM TESTTBL WHERE NAME='" + name + "'");
+            return result.next() ? result.getInt(1) : null;
+        } catch (SQLException x) {
+            throw new EJBException(x);
+        }
+    }
+
+    public Connection getCachedConnection() {
+        return con;
+    }
+
+    public void insert(String name, int value) {
+        try (Statement s = con.createStatement()) {
+            s.executeUpdate("INSERT INTO TESTTBL VALUES('" + name + "', " + value + ")");
+        } catch (SQLException x) {
+            throw new EJBException(x);
+        }
+    }
+
+    @Remove
+    public void removeEJB() {
+        System.out.println("EJB remove not closing connection handle: " + con);
+    }
+}

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/DerbyRAServlet.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/DerbyRAServlet.java
@@ -10,6 +10,10 @@
  *******************************************************************************/
 package web;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -33,11 +37,13 @@ import javax.management.MBeanServer;
 import javax.management.ObjectInstance;
 import javax.management.ObjectName;
 import javax.naming.InitialContext;
+import javax.naming.NamingException;
 import javax.resource.spi.BootstrapContext;
 import javax.resource.spi.XATerminator;
 import javax.resource.spi.work.ExecutionContext;
 import javax.resource.spi.work.TransactionContext;
 import javax.resource.spi.work.WorkManager;
+import javax.servlet.ServletException;
 import javax.sql.DataSource;
 import javax.transaction.UserTransaction;
 import javax.transaction.xa.XAResource;
@@ -54,6 +60,17 @@ public class DerbyRAServlet extends FATServlet {
      * Maximum number of milliseconds a test should wait for something to happen
      */
     private static final long TIMEOUT = 5000;
+
+    public void initDatabaseTables() throws ServletException {
+        try {
+            DataSource ds = (DataSource) InitialContext.doLookup("java:module/env/eis/ds5ref-unshareable");
+            try (Connection con = ds.getConnection()) {
+                con.createStatement().execute("CREATE TABLE TESTTBL(NAME VARCHAR(80) NOT NULL PRIMARY KEY, VAL INT NOT NULL)");
+            }
+        } catch (NamingException | SQLException x) {
+            throw new ServletException(x);
+        }
+    }
 
     /**
      * Verify that an admin object can be looked up directly as java.util.Map.
@@ -339,6 +356,71 @@ public class DerbyRAServlet extends FATServlet {
             }
         } finally {
             con.close();
+        }
+    }
+
+    /**
+     * When HandleList is enabled, it automatically closes shareable parked connection handles that are
+     * leaked across transaction scopes.
+     */
+    public void testNonDissociatableHandlesCannotBeParkedAcrossTransactionScopes() throws Exception {
+        DerbyRABean bean = InitialContext.doLookup("java:global/derbyRAApp/fvtweb/DerbyRABean!web.DerbyRABean");
+
+        Connection con = bean.runInNewGlobalTran(() -> {
+            DataSource ds = (DataSource) InitialContext.doLookup("eis/ds5"); // shareable
+            Connection c = ds.getConnection();
+            Statement st = c.createStatement();
+            st.executeUpdate("INSERT INTO TESTTBL VALUES('park-handle-across-transaction', 3000)");
+            st.close();
+            return c;
+        });
+
+        assertTrue(con.isClosed());
+    }
+
+    /**
+     * When HandleList is enabled, shareable connection handles are parked across EJB methods within a transaction
+     * if the resource adapter does not support DissociatableManagedConnection. The connection handle continues to be
+     * usable in subsequent EJB methods within the transaction, remaining open until the EJB is destroyed, at which
+     * point the HandleList closes connection handles that remain open and would otherwise be leaked.
+     */
+    public void testNonDissociatableHandlesParkedAcrossEJBMethods() throws Exception {
+        DerbyConnectionCachingBean bean = InitialContext.doLookup("java:global/derbyRAApp/fvtweb/DerbyConnectionCachingBean!web.DerbyConnectionCachingBean");
+        UserTransaction tx = InitialContext.doLookup("java:comp/UserTransaction");
+        tx.begin();
+        try {
+            bean.connect();
+
+            bean.insert("park-handle-across-EJB-methods-1", 1000);
+            bean.insert("park-handle-across-EJB-methods-2", 2000);
+            assertEquals(Integer.valueOf(1000), bean.find("park-handle-across-EJB-methods-1"));
+            assertEquals(Integer.valueOf(2000), bean.find("park-handle-across-EJB-methods-2"));
+
+            Connection cachedConnection = bean.getCachedConnection();
+            assertFalse(cachedConnection.isClosed());
+
+            bean.removeEJB();
+            assertTrue(cachedConnection.isClosed());
+        } finally {
+            tx.commit();
+        }
+
+        // access the same data from another transaction:
+
+        bean = InitialContext.doLookup("java:global/derbyRAApp/fvtweb/DerbyConnectionCachingBean!web.DerbyConnectionCachingBean");
+        tx.begin();
+        try {
+            bean.connect();
+            assertEquals(Integer.valueOf(1000), bean.find("park-handle-across-EJB-methods-1"));
+            assertEquals(Integer.valueOf(2000), bean.find("park-handle-across-EJB-methods-2"));
+
+            Connection cachedConnection = bean.getCachedConnection();
+            assertFalse(cachedConnection.isClosed());
+
+            bean.removeEJB();
+            assertTrue(cachedConnection.isClosed());
+        } finally {
+            tx.commit();
         }
     }
 


### PR DESCRIPTION
Write a test case that relies on non-dissociatable connection handles being parked across EJB methods within a transaction, but being closed upon EJB remove.
Write another test case that verifies these handles cannot be parked across a transaction.