### PR TITLE
DO NOT MERGE: Update SmallRye Config 2.0 RC version

### DIFF
--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -131,8 +131,8 @@ io.smallrye.common:smallrye-common-classloader:1.5.0
 io.smallrye.common:smallrye-common-constraint:1.5.0
 io.smallrye.common:smallrye-common-expression:1.5.0
 io.smallrye.common:smallrye-common-function:1.5.0
-io.smallrye.config:smallrye-config-common:2.0.0-RC1
-io.smallrye.config:smallrye-config:2.0.0-RC1
+io.smallrye.config:smallrye-config-common:2.0.0-RC2
+io.smallrye.config:smallrye-config:2.0.0-RC2
 io.smallrye:smallrye-graphql-client-api:1.0.9
 io.smallrye:smallrye-graphql-client:1.0.9
 io.smallrye:smallrye-graphql-schema-model:1.0.9
@@ -340,7 +340,7 @@ org.eclipse.microprofile.config:microprofile-config-api:1.1
 org.eclipse.microprofile.config:microprofile-config-api:1.2.1
 org.eclipse.microprofile.config:microprofile-config-api:1.3
 org.eclipse.microprofile.config:microprofile-config-api:1.4
-org.eclipse.microprofile.config:microprofile-config-api:2.0-RC15
+org.eclipse.microprofile.config:microprofile-config-api:2.0-ibm20201127
 org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.0
 org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.1
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:1.0


### PR DESCRIPTION
This is simply a test build to generate a build for performance testing.

`org.eclipse.microprofile.config:microprofile-config-api:2.0-ibm20201127` is only in Artifactory.

#build

