### PR TITLE
Update to use 0.2.0 instead of 0.2.0-SNAPSHOT for org.eclipse.transformer deps

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1929,12 +1929,12 @@
     <dependency>
       <groupId>org.eclipse.transformer</groupId>
       <artifactId>org.eclipse.transformer.cli</artifactId>
-      <version>0.2.0-SNAPSHOT</version>
+      <version>0.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.transformer</groupId>
       <artifactId>org.eclipse.transformer</artifactId>
-      <version>0.2.0-SNAPSHOT</version>
+      <version>0.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -381,8 +381,8 @@ org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.2.0
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.3.1
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.4.0
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:2.0-RC2
-org.eclipse.transformer:org.eclipse.transformer.cli:0.2.0-SNAPSHOT
-org.eclipse.transformer:org.eclipse.transformer:0.2.0-SNAPSHOT
+org.eclipse.transformer:org.eclipse.transformer.cli:0.2.0
+org.eclipse.transformer:org.eclipse.transformer:0.2.0
 org.eclipse:yasson:2.0.1
 org.ektorp:org.ektorp:1.4.1
 org.fusesource.jansi:jansi:1.18

--- a/dev/fattest.simplicity/bnd.bnd
+++ b/dev/fattest.simplicity/bnd.bnd
@@ -60,12 +60,12 @@ test.project: true
 	com.ibm.websphere.javaee.jsonp.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
 	io.openliberty.jakarta.servlet.5.0;version=latest,\
-	org.eclipse.transformer:org.eclipse.transformer.cli;version=0.2.0.SNAPSHOT,\
+	org.eclipse.transformer:org.eclipse.transformer.cli;version=0.2.0,\
 	biz.aQute.bnd:biz.aQute.bnd.transform;version=5.1.1,\
     commons-cli:commons-cli;version=1.4,\
     org.slf4j:slf4j-simple;version=1.7.30,\
     org.slf4j:slf4j-api;version=1.7.26,\
-    org.eclipse.transformer:org.eclipse.transformer;version=0.2.0.SNAPSHOT,\
+    org.eclipse.transformer:org.eclipse.transformer;version=0.2.0,\
 	com.ibm.ws.common.encoder;version=latest,\
 	com.ibm.ws.componenttest;version=latest,\
 	com.ibm.ws.componenttest:com.ibm.componenttest.common;version=1.0.0,\

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -73,8 +73,8 @@ dependencies {
                           'commons-cli:commons-cli:1.4',
                           'org.slf4j:slf4j-simple:1.7.30',
                           'org.slf4j:slf4j-api:1.7.26',
-                          'org.eclipse.transformer:org.eclipse.transformer:0.2.0-SNAPSHOT',
-                          'org.eclipse.transformer:org.eclipse.transformer.cli:0.2.0-SNAPSHOT'
+                          'org.eclipse.transformer:org.eclipse.transformer:0.2.0',
+                          'org.eclipse.transformer:org.eclipse.transformer.cli:0.2.0'
 }
 
 task addRequiredLibraries(type: Copy) {

--- a/dev/wlp-gradle/subprojects/tasks.gradle
+++ b/dev/wlp-gradle/subprojects/tasks.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -155,8 +155,8 @@ dependencies {
                           'commons-cli:commons-cli:1.4',
                           'org.slf4j:slf4j-simple:1.7.30',
                           'org.slf4j:slf4j-api:1.7.26',
-                          'org.eclipse.transformer:org.eclipse.transformer:0.2.0-SNAPSHOT',
-                          'org.eclipse.transformer:org.eclipse.transformer.cli:0.2.0-SNAPSHOT'
+                          'org.eclipse.transformer:org.eclipse.transformer:0.2.0',
+                          'org.eclipse.transformer:org.eclipse.transformer.cli:0.2.0'
 }
 
 task jakartaeeTransform {

--- a/dev/wlp-jakartaee-transform/bnd.bnd
+++ b/dev/wlp-jakartaee-transform/bnd.bnd
@@ -9,15 +9,15 @@
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
 
--include= jar:${fileuri;${repo;org.eclipse.transformer:org.eclipse.transformer.cli;0.2.0.SNAPSHOT}}!/META-INF/MANIFEST.MF,bnd.overrides
+-include= jar:${fileuri;${repo;org.eclipse.transformer:org.eclipse.transformer.cli;0.2.0}}!/META-INF/MANIFEST.MF,bnd.overrides
 
 -includeresource: \
-    @${repo;org.eclipse.transformer:org.eclipse.transformer.cli;0.2.0.SNAPSHOT}!/!META-INF/maven/*
+    @${repo;org.eclipse.transformer:org.eclipse.transformer.cli;0.2.0}!/!META-INF/maven/*
 
 -buildpath: \
-    org.eclipse.transformer:org.eclipse.transformer.cli;version=0.2.0.SNAPSHOT,\
+    org.eclipse.transformer:org.eclipse.transformer.cli;version=0.2.0,\
     biz.aQute.bnd:biz.aQute.bnd.transform;version=5.1.1,\
     org.slf4j:slf4j-api;version=1.7.26,\
-    org.eclipse.transformer:org.eclipse.transformer;version=0.2.0.SNAPSHOT,\
+    org.eclipse.transformer:org.eclipse.transformer;version=0.2.0,\
     commons-cli:commons-cli;version=1.4,\
     org.slf4j:slf4j-simple;version=1.7.30


### PR DESCRIPTION
#build 
fix #15124
From Issue:
```
OpenLiberty was using 0.2.0-SNAPSHOT versions of org.eclipse.transformer.cli and org.eclipse.transformer.
A 0.2.0 version was released October 5th, 2020.

For external builds, it appears OL was sourcing the 0.2.0-SNAPSHOT artifacts from https://oss.sonatype.org/content/repositories/snapshots/org/eclipse/transformer/

However, on Nov 29th, somebody uploaded a 0.3.0-SNAPSHOT and deleted the 0.2.0-SNAPSHOT artifacts.
But OL should be using the released 0.2.0 regardless.
```