### PR TITLE
fix gRPC stream completion race condition

### DIFF
--- a/dev/com.ibm.ws.grpc_fat/publish/servers/ConsumerServer/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/ConsumerServer/server.xml
@@ -77,10 +77,19 @@
 	</application>
 
 	<logging
-		traceSpecification="*=info=enabled:io.openliberty.grpc*=all:com.ibm.testapp.g3store*=all:com.ibm.ws.webcontainer*=all:com.ibm.wsspi.webcontainer*=all:HTTPChannel=all:TCPChannel=all:com.ibm.ws.http*=all"
-		maxFileSize="200" maxFiles="4" traceFormat="BASIC" />
-		
-		
+		traceSpecification="*=info:
+			com.ibm.ws.webcontainer*=all:
+			com.ibm.wsspi.webcontainer*=all:
+			HTTPChannel=all:
+			HTTPTransport=all:
+			TCPChannel=all:
+			GenericBNF=all:
+			GRPC=all:
+			io.grpc*=all:
+			io.netty*=all:
+			com.ibm.testapp.g3store*=all"
+		maxFileSize="100" maxFiles="1" traceFormat="BASIC" />
+
 	<jwtBuilder
 		id="defaultJWT" 
 		issuer="testIssuer"

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/ProducerServer/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/ProducerServer/server.xml
@@ -33,7 +33,17 @@
 	<ssl id="defaultSSLConfig" trustDefaultCerts="true" />
 
 	<logging
-		traceSpecification="*=info=enabled:io.openliberty.grpc*=all:com.ibm.testapp.g3store*=all:TCPChannel=fine:com.ibm.ws.http*=all:com.ibm.ws.webcontainer.async*=all"
-		maxFileSize="400" maxFiles="20" traceFormat="BASIC" />
+		traceSpecification="*=info:
+			com.ibm.ws.webcontainer*=all:
+			com.ibm.wsspi.webcontainer*=all:
+			HTTPChannel=all:
+			HTTPTransport=all:
+			TCPChannel=all:
+			GenericBNF=all:
+			GRPC=all:
+			io.grpc*=all:
+			io.netty*=all:
+			com.ibm.testapp.g3store*=all"
+		maxFileSize="200" maxFiles="1" traceFormat="BASIC" />
 
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/StoreServer/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/StoreServer/server.xml
@@ -131,10 +131,19 @@ and that access id must then exist in the role map -->
 			</security-role>
 		</application-bnd>
 	</application>
-		
+
 	<logging
-		traceSpecification="*=info=enabled:io.openliberty.grpc*=all:com.ibm.testapp.g3store*=all:TCPChannel=fine:com.ibm.ws.http*=all:com.ibm.ws.webcontainer.async*=all"
-		maxFileSize="400" maxFiles="20" traceFormat="BASIC" />
-		
+		traceSpecification="*=info:
+			com.ibm.ws.webcontainer*=all:
+			com.ibm.wsspi.webcontainer*=all:
+			HTTPChannel=all:
+			HTTPTransport=all:
+			TCPChannel=all:
+			GenericBNF=all:
+			GRPC=all:
+			io.grpc*=all:
+			io.netty*=all:
+			com.ibm.testapp.g3store*=all"
+		maxFileSize="200" maxFiles="1" traceFormat="BASIC" />
 
 </server>

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/H2StreamProcessor.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/H2StreamProcessor.java
@@ -1124,10 +1124,6 @@ public class H2StreamProcessor {
                         }
 
                         getBodyFromFrame();
-                        if (currentFrame.flagEndStreamSet()) {
-                            endStream = true;
-                            updateStreamState(StreamState.HALF_CLOSED_REMOTE);
-                        }
 
                         WsByteBuffer buf = processCompleteData(false);
 
@@ -1135,8 +1131,13 @@ public class H2StreamProcessor {
                             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                                 Tr.debug(tc, "calling setNewBodyBuffer with: " + buf);
                             }
-                            // store the buffer and call async complete()
+                            // store the buffer, set the end of stream if necessary, and call async complete().
+                            // setting the end of steam flag earlier can result in a race condition.
                             h2HttpInboundLinkWrap.setAndStoreNewBodyBuffer(buf);
+                            if (currentFrame.flagEndStreamSet()) {
+                                endStream = true;
+                                updateStreamState(StreamState.HALF_CLOSED_REMOTE);
+                            }
                             h2HttpInboundLinkWrap.invokeAppComplete();
                         } else {
                             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/H2StreamProcessor.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/H2StreamProcessor.java
@@ -1143,6 +1143,10 @@ public class H2StreamProcessor {
                             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                                 Tr.debug(tc, "did not call setNewBodyBuffer. buf was null");
                             }
+                            if (currentFrame.flagEndStreamSet()) {
+                                endStream = true;
+                                updateStreamState(StreamState.HALF_CLOSED_REMOTE);
+                            }
                         }
 
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {


### PR DESCRIPTION
for #15012

In rare cases, a ```java.lang.IllegalStateException: Past end of stream``` can be thrown when gRPC data is read in by Liberty.