### PR TITLE
Issue #15150: EJB Fat Permissions for Jakarta EE 9

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.async_fat/publish/servers/com.ibm.ws.ejbcontainer.async.fat.AsyncConfigServer/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.async_fat/publish/servers/com.ibm.ws.ejbcontainer.async.fat.AsyncConfigServer/server.xml
@@ -42,4 +42,5 @@
     </ejbContainer>
 
     <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="javax.security.auth.AuthPermission" name="createLoginContext.WSLogin"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="javax.security.auth.AuthPermission" name="createLoginContext.WSLogin"/>
 </server>

--- a/dev/com.ibm.ws.ejbcontainer.async_fat/publish/servers/com.ibm.ws.ejbcontainer.async.fat.AsyncRemoteServer/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.async_fat/publish/servers/com.ibm.ws.ejbcontainer.async.fat.AsyncRemoteServer/server.xml
@@ -9,4 +9,5 @@
 
     <!-- Yoko ORB bug; org.apache.yoko.rmispec.util.UtilLoader.loadServiceClass needs doPriv around getClassLoader + others -->	
     <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
 </server>

--- a/dev/com.ibm.ws.ejbcontainer.async_fat/publish/servers/com.ibm.ws.ejbcontainer.async.fat.AsyncSecureServer/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.async_fat/publish/servers/com.ibm.ws.ejbcontainer.async.fat.AsyncSecureServer/server.xml
@@ -31,4 +31,5 @@
     <include location="../fatTestPorts.xml"/>
 
     <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="javax.security.auth.AuthPermission" name="createLoginContext.WSLogin"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="javax.security.auth.AuthPermission" name="createLoginContext.WSLogin"/>
 </server>


### PR DESCRIPTION
Update there server.xml for EJB FAT that will repeat for Jakarta EE 9
to include permissions for Java 2 Security for the Jakarta version of
the EJBContainer fat tools jar.

fixes #15150 