### PR TITLE
Ensure all FAT tests run against FT 3.0

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/multimodule/tests/TestMultiModuleClassLoading.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/multimodule/tests/TestMultiModuleClassLoading.java
@@ -48,7 +48,8 @@ public class TestMultiModuleClassLoading extends FATServletClient {
 
     //run against both EE8 and EE7 features
     @ClassRule
-    public static RepeatTests r = RepeatFaultTolerance.repeat(SERVER_NAME, TestMode.LITE, MicroProfileActions.MP13, RepeatFaultTolerance.MP21_METRICS20);
+    public static RepeatTests r = RepeatFaultTolerance.repeat(SERVER_NAME, TestMode.LITE, MicroProfileActions.LATEST, MicroProfileActions.MP13,
+                                                              RepeatFaultTolerance.MP21_METRICS20);
 
     @BeforeClass
     public static void setupApp() throws Exception {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/multimodule/tests/TestMultiModuleConfigLoad.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/multimodule/tests/TestMultiModuleConfigLoad.java
@@ -59,7 +59,8 @@ public class TestMultiModuleConfigLoad extends FATServletClient {
 
     //run against both EE8 and EE7 features
     @ClassRule
-    public static RepeatTests r = RepeatFaultTolerance.repeat(SERVER_NAME, TestMode.LITE, MicroProfileActions.MP13, RepeatFaultTolerance.MP21_METRICS20);
+    public static RepeatTests r = RepeatFaultTolerance.repeat(SERVER_NAME, TestMode.LITE, MicroProfileActions.LATEST, MicroProfileActions.MP13,
+                                                              RepeatFaultTolerance.MP21_METRICS20);
 
     @BeforeClass
     public static void appSetup() throws Exception {

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/FallbackMethodTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/FallbackMethodTest.java
@@ -28,7 +28,6 @@ import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -43,7 +42,7 @@ import componenttest.topology.utils.FATServletClient;
 public class FallbackMethodTest extends FATServletClient {
 
     @ClassRule
-    public static RepeatTests r = RepeatFaultTolerance.repeat("FaultToleranceMultiModule", TestMode.LITE, MicroProfileActions.MP22);
+    public static RepeatTests r = RepeatFaultTolerance.repeatDefault("FaultToleranceMultiModule");
 
     @Server(value = "FaultToleranceMultiModule")
     @TestServlet(servlet = FallbackMethodServlet.class, contextRoot = "ftFallbackMethod")

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/completionstage/CDICompletionStageTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/completionstage/CDICompletionStageTest.java
@@ -35,7 +35,7 @@ import componenttest.topology.utils.FATServletClient;
 public class CDICompletionStageTest extends FATServletClient {
 
     @ClassRule
-    public static RepeatTests r = RepeatFaultTolerance.repeat("FaultToleranceMultiModule", TestMode.LITE, MicroProfileActions.MP22);
+    public static RepeatTests r = RepeatFaultTolerance.repeat("FaultToleranceMultiModule", TestMode.FULL, MicroProfileActions.LATEST, MicroProfileActions.MP22);
 
     private static final String SERVER_NAME = "FaultToleranceMultiModule";
     private static final String APP_NAME = "ftCompletionStage";

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/interceptors/InterceptorTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/interceptors/InterceptorTest.java
@@ -40,7 +40,7 @@ import componenttest.topology.utils.FATServletClient;
 public class InterceptorTest extends FATServletClient {
 
     @ClassRule
-    public static RepeatTests r = RepeatFaultTolerance.repeat("FaultToleranceMultiModule", TestMode.LITE, MicroProfileActions.MP22);
+    public static RepeatTests r = RepeatFaultTolerance.repeat("FaultToleranceMultiModule", TestMode.FULL, MicroProfileActions.LATEST, MicroProfileActions.MP22);
 
     private static final String APP_NAME = "ftInterceptors";
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/jaxrs/JaxRsTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/jaxrs/JaxRsTest.java
@@ -38,7 +38,7 @@ import componenttest.topology.utils.HttpUtils;
 public class JaxRsTest extends FATServletClient {
 
     @ClassRule
-    public static RepeatTests r = RepeatFaultTolerance.repeat("JaxRsFaultTolerance", TestMode.LITE, MicroProfileActions.MP22);
+    public static RepeatTests r = RepeatFaultTolerance.repeat("JaxRsFaultTolerance", TestMode.FULL, MicroProfileActions.LATEST, MicroProfileActions.MP22);
 
     private static final String APP_NAME = "ftJaxRs";
 


### PR DESCRIPTION
Ensure that all the fault tolerance FAT tests run against FT 3.0 (as
well as whatever other versions are appropriate).

I checked through the tests in `com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics` and `com.ibm.ws.microprofile.faulttolerance.cdi_fat` to ensure that all tests had a `RepeatTests` class rule which specified either `LATEST` or `MP40`