### PR TITLE
Remove references to sonatype OSS snapshots repo

### DIFF
--- a/dev/cnf/resources/bnd/repos.bnd
+++ b/dev/cnf/resources/bnd/repos.bnd
@@ -46,8 +46,8 @@ fetch.oss.repository: \
   aQute.bnd.repository.maven.provider.MavenBndRepository; \
     name              = RemotePublic; \
     releaseUrl        = https://repo.maven.apache.org/maven2/; \
-    snapshotUrl       = https://oss.sonatype.org/content/repositories/snapshots/; \
     index             = ${build}/oss_dependencies.maven
+    # Note: no snapshotUrl because we must not rely on public snapshots
 
 fetch.oss.ibm.repository: \
   aQute.bnd.repository.maven.provider.MavenBndRepository; \

--- a/dev/settings.gradle
+++ b/dev/settings.gradle
@@ -58,11 +58,11 @@ pluginManagement {
   props.setProperty('fetch.oss.source.repository', fetchRepoSource)
 
   // Bnd configuration for where to download open source software binaries from.
+  // Note: no non-artifactory snapshotUrl because we must not rely on public snapshots
   String fetchRepoPublic = !isUsingArtifactory ?
           ('aQute.bnd.repository.maven.provider.MavenBndRepository;'
                   +'name = RemotePublic;'
                   +'releaseUrl=https://repo.maven.apache.org/maven2/'
-                  +';snapshotUrl=https://oss.sonatype.org/content/repositories/snapshots/'
                   +';index=${build}/oss_dependencies.maven') :
 
           ('aQute.bnd.repository.maven.provider.MavenBndRepository'

--- a/dev/wlp-gradle/subprojects/maven-central-mirror.gradle
+++ b/dev/wlp-gradle/subprojects/maven-central-mirror.gradle
@@ -33,17 +33,4 @@ repositories {
       }
     }
   }
-  
-  // Always include sonatype snapshot repo for ONLY the transformer snapshot dependency
-  maven {
-    url ("https://oss.sonatype.org/content/repositories/snapshots/")
-    metadataSources {
-      mavenPom()
-      artifact()
-    }
-    content {
-      includeGroup "org.eclipse.transformer"
-      includeGroup "org.eclipse.transformer.cli"
-    }
-  }
 }

--- a/dev/wlp-gradle/subprojects/repos.gradle
+++ b/dev/wlp-gradle/subprojects/repos.gradle
@@ -31,13 +31,6 @@ repositories {
         }
     } else {
         mavenCentral()
-         maven {
-            url ("https://oss.sonatype.org/content/repositories/snapshots/")
-            metadataSources {
-                mavenPom()
-                artifact()
-            }
-        }
         maven {
             url ("http://public.dhe.ibm.com/ibmdl/export/pub/software/olrepo/")
             metadataSources {


### PR DESCRIPTION
Snapshots in the sonatype OSS repo can be removed or changed at any
time. We must not rely on snapshot artifacts to build the product.

Fixes #15127