### PR TITLE
more detailed logging for adding ejb descriptors

### DIFF
--- a/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/weld/BeanDeploymentArchiveImpl.java
+++ b/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/weld/BeanDeploymentArchiveImpl.java
@@ -786,6 +786,8 @@ public class BeanDeploymentArchiveImpl implements WebSphereBeanDeploymentArchive
      */
     @Override
     public void addEjbDescriptor(EjbDescriptor<?> ejbDescriptor) {
+        Tr.entry(tc, "addEjbDescriptor. Adding EjbDescriptor: " + ejbDescriptor + " with ejbName: " + ejbDescriptor.getEjbName() + " to bda: " + getHumanReadableName());
+
         if (getBeanDiscoveryMode() != BeanDiscoveryMode.NONE) {
             this.ejbDescriptors.add(ejbDescriptor);
             Class<?> beanClass = ejbDescriptor.getBeanClass();


### PR DESCRIPTION
Adds a bit more useful logging for figuring out why we can't find an EJB later down the line. 