### PR TITLE
 run custom login module test bucket with Jakarta EE

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/bnd.bnd
@@ -22,6 +22,8 @@ src: \
 
 fat.project: true
 
+tested.features: connectors-2.0, enterprisebeanslite-4.0, servlet-5.0, xmlbinding-3.0
+
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)
 -buildpath: \

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
@@ -43,7 +43,7 @@ public class JDBCLoadFromAppTest extends FATServletClient {
     @ClassRule
     public static RepeatTests r = RepeatTests
                     .withoutModification()
-                    ;//.andWith(new JakartaEE9Action()); TODO uncomment once JCA (and possibly other) features are ready for Jakarta
+                    .andWith(new JakartaEE9Action());
 
     @Server("com.ibm.ws.jdbc.fat.loadfromapp")
     @TestServlets(value = {

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/publish/servers/com.ibm.ws.jdbc.fat.loadfromapp/server.xml
@@ -137,10 +137,12 @@
     <!-- permissions for login modules -->
     <javaPermission codebase="${server.config.dir}/apps/derbyApp.war" className="javax.security.auth.AuthPermission" name="createLoginContext.system.WEB_INBOUND"/>
     <javaPermission codebase="${server.config.dir}/apps/derbyApp.war" className="javax.security.auth.AuthPermission" name="modifyPrivateCredentials"/>
+    <javaPermission codebase="${server.config.dir}/apps/derbyApp.war" className="javax.security.auth.PrivateCredentialPermission" name='jakarta.resource.spi.security.PasswordCredential org.test.NoPrincipalClass "*"' actions="read"/>
     <javaPermission codebase="${server.config.dir}/apps/derbyApp.war" className="javax.security.auth.PrivateCredentialPermission" name='javax.resource.spi.security.PasswordCredential org.test.NoPrincipalClass "*"' actions="read"/>
 
     <javaPermission codebase="${server.config.dir}/apps/otherApp.ear" className="javax.security.auth.AuthPermission" name="createLoginContext.system.WEB_INBOUND"/>
     <javaPermission codebase="${server.config.dir}/apps/otherApp.ear" className="javax.security.auth.AuthPermission" name="modifyPrivateCredentials"/>
+    <javaPermission codebase="${server.config.dir}/apps/otherApp.ear" className="javax.security.auth.PrivateCredentialPermission" name='jakarta.resource.spi.security.PasswordCredential org.test.NoPrincipalClass "*"' actions="read"/>
     <javaPermission codebase="${server.config.dir}/apps/otherApp.ear" className="javax.security.auth.PrivateCredentialPermission" name='javax.resource.spi.security.PasswordCredential org.test.NoPrincipalClass "*"' actions="read"/>
 
     <variable name="onError" value="FAIL"/>


### PR DESCRIPTION
Enable the test bucket that covers custom login modules for JDBC to run with Jakarta EE.  It was waiting on the Jakarta Connector feature, which is available now.