### PR TITLE
HandleList test for Singleton EJB

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/resources/WEB-INF/ibm-ejb-jar-bnd.xml
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/resources/WEB-INF/ibm-ejb-jar-bnd.xml
@@ -15,7 +15,7 @@
         xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-ejb-jar-bnd_1_1.xsd"
         version="1.1">
 
-  <session name="BeanInWebApp">
+  <session name="StatefulBeanInWebApp">
     <resource-ref name="jdbc/dsref">
       <custom-login-configuration name="webapplogin">
         <property name="shape" value="heptagon"/>

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/src/web/derby/SingletonBeanInWebApp.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/src/web/derby/SingletonBeanInWebApp.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package web.derby;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionException;
+
+import javax.ejb.Lock;
+import javax.ejb.LockType;
+import javax.ejb.Singleton;
+
+@Singleton
+public class SingletonBeanInWebApp {
+    @Lock(LockType.READ)
+    public <T> T invoke(Callable<T> action) {
+        try {
+            return action.call();
+        } catch (RuntimeException x) {
+            throw x;
+        } catch (Exception x) {
+            throw new CompletionException(x);
+        }
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/src/web/derby/StatefulBeanInWebApp.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/test-applications/derbyapp/src/web/derby/StatefulBeanInWebApp.java
@@ -18,7 +18,7 @@ import javax.ejb.Stateful;
 import javax.sql.DataSource;
 
 @Stateful
-public class BeanInWebApp implements CloseableExecutorBean, Executor {
+public class StatefulBeanInWebApp implements CloseableExecutorBean, Executor {
     @Resource(name = "java:comp/env/jdbc/dsref", lookup = "jdbc/sharedLibDataSource")
     DataSource ds;
 


### PR DESCRIPTION
Write a test of HandleList where a singleton EJB method that leaks a connection handle is invoked concurrently.  Verify that when the method invocation completes, the respective connection handle is automatically closed, while the connection handles from other method invocations remain open until those method invocations end.  This is possible because a separate HandleList is used per method for singleton EJBs.