### PR TITLE
fix HTTP/2 connection shutdown test problems

### DIFF
--- a/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/utils.java
+++ b/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/utils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,7 @@ import com.ibm.wsspi.bytebuffer.WsByteBuffer;
 
 public class utils {
 
-    public static final int IO_DEFAULT_TIMEOUT = 10000;
+    public static final int IO_DEFAULT_TIMEOUT = 28000;
     public static final int IO_DEFAULT_BUFFER_SIZE = 4090;
 
     public static final byte FRAME_TYPE_DATA = 0x00;

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/outbound/HttpOutputStreamImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/outbound/HttpOutputStreamImpl.java
@@ -234,8 +234,7 @@ public class HttpOutputStreamImpl extends HttpOutputStreamConnectWeb {
                 Tr.debug(tc, "validate response is cleaned up hc: " + this.hashCode() + " details: " + this);
             }
 
-            // Return to clean up the rest of the request/response
-            return;
+            throw new IOException("H2 Response already destroyed on error condition");
 
         }
 

--- a/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/ContinuationFrameTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/ContinuationFrameTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.ibm.ws.http.channel.h2internal.frames.FrameData;
 import com.ibm.ws.http.channel.h2internal.frames.FrameGoAway;
-import com.ibm.ws.http.channel.h2internal.frames.FrameHeaders;
 import com.ibm.ws.http.channel.h2internal.hpack.H2HeaderField;
 import com.ibm.ws.http.channel.h2internal.hpack.HpackConstants;
 import com.ibm.ws.http2.test.Http2Client;
@@ -50,8 +49,7 @@ public class ContinuationFrameTests extends H2FATDriverServlet {
         FrameGoAway errorFrame = new FrameGoAway(0, debugData, PROTOCOL_ERROR, 1, false);
         h2Client.addExpectedFrame(errorFrame);
 
-        FrameHeaders headers = setupDefaultPreface(h2Client);
-        h2Client.addExpectedFrame(headers);
+        setupDefaultUpgradedConnection(h2Client);
 
         // create headers to send over to the server; note that the end headers flag IS set
         List<HeaderEntry> firstHeadersToSend = new ArrayList<HeaderEntry>();
@@ -69,7 +67,6 @@ public class ContinuationFrameTests extends H2FATDriverServlet {
 
         // send over the header frames followed by the continuation frames
         h2Client.sendFrame(frameHeadersToSend);
-        h2Client.waitFor(headers);
         h2Client.sendFrame(continuationHeaders);
 
         blockUntilConnectionIsDone.await();
@@ -90,8 +87,7 @@ public class ContinuationFrameTests extends H2FATDriverServlet {
         FrameGoAway errorFrame = new FrameGoAway(0, debugData, PROTOCOL_ERROR, 1, false);
         h2Client.addExpectedFrame(errorFrame);
 
-        FrameHeaders headers = setupDefaultPreface(h2Client);
-        h2Client.addExpectedFrame(headers);
+        setupDefaultUpgradedConnection(h2Client);
 
         // create headers to send over to the server; note that the end headers flag IS NOT set
         List<HeaderEntry> firstHeadersToSend = new ArrayList<HeaderEntry>();
@@ -116,7 +112,6 @@ public class ContinuationFrameTests extends H2FATDriverServlet {
         // send over the header frames followed by the continuation frames
         h2Client.sendFrame(frameHeadersToSend);
         h2Client.sendFrame(firstContinuationHeaders);
-        h2Client.waitFor(headers);
         h2Client.sendFrame(lastContinuationHeaders);
 
         blockUntilConnectionIsDone.await();
@@ -137,8 +132,7 @@ public class ContinuationFrameTests extends H2FATDriverServlet {
         FrameGoAway errorFrame = new FrameGoAway(0, debugData, PROTOCOL_ERROR, 1, false);
         h2Client.addExpectedFrame(errorFrame);
 
-        FrameHeaders headers = setupDefaultPreface(h2Client);
-        h2Client.addExpectedFrame(headers);
+        setupDefaultUpgradedConnection(h2Client);
 
         // create headers to send over to the server; note that end_headers IS set
         List<HeaderEntry> firstHeadersToSend = new ArrayList<HeaderEntry>();
@@ -157,7 +151,6 @@ public class ContinuationFrameTests extends H2FATDriverServlet {
         // send over the header frames followed by the data and continuation frames
         h2Client.sendFrame(frameHeadersToSend);
         h2Client.sendFrame(new FrameData(3, "derp".getBytes(), false));
-        h2Client.waitFor(headers);
         h2Client.sendFrame(firstContinuationHeaders);
 
         blockUntilConnectionIsDone.await();

--- a/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/HttpMethodTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/HttpMethodTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -55,7 +55,7 @@ public class HttpMethodTests extends H2FATDriverServlet {
         pingFrame.setAckFlag();
         h2Client.addExpectedFrame(pingFrame);
 
-        setupDefaultPreface(h2Client);
+        setupDefaultUpgradedConnection(h2Client);
 
         List<HeaderEntry> firstHeadersToSend = new ArrayList<HeaderEntry>();
         firstHeadersToSend.add(new HeaderEntry(new H2HeaderField(":method", "CONNECT"), HpackConstants.LiteralIndexType.NEVERINDEX, false));
@@ -106,7 +106,7 @@ public class HttpMethodTests extends H2FATDriverServlet {
         pingFrame.setAckFlag();
         h2Client.addExpectedFrame(pingFrame);
 
-        setupDefaultPreface(h2Client);
+        setupDefaultUpgradedConnection(h2Client);
 
         List<HeaderEntry> firstHeadersToSend = new ArrayList<HeaderEntry>();
         firstHeadersToSend.add(new HeaderEntry(new H2HeaderField(":method", "CONNECT"), HpackConstants.LiteralIndexType.NEVERINDEX, false));
@@ -155,7 +155,7 @@ public class HttpMethodTests extends H2FATDriverServlet {
         secondFrameHeaders.setHeaderFields(secondHeadersReceived);
         h2Client.addExpectedFrame(secondFrameHeaders);
 
-        setupDefaultPreface(h2Client);
+        setupDefaultUpgradedConnection(h2Client);
 
         List<HeaderEntry> firstHeadersToSend = new ArrayList<HeaderEntry>();
         firstHeadersToSend.add(new HeaderEntry(new H2HeaderField(":method", "HEAD"), HpackConstants.LiteralIndexType.NEVERINDEX, false));
@@ -187,7 +187,7 @@ public class HttpMethodTests extends H2FATDriverServlet {
         secondFrameHeaders.setHeaderFields(secondHeadersReceived);
         h2Client.addExpectedFrame(secondFrameHeaders);
 
-        setupDefaultPreface(h2Client);
+        setupDefaultUpgradedConnection(h2Client);
 
         List<HeaderEntry> firstHeadersToSend = new ArrayList<HeaderEntry>();
         firstHeadersToSend.add(new HeaderEntry(new H2HeaderField(":method", "OPTIONS"), HpackConstants.LiteralIndexType.NEVERINDEX, false));
@@ -218,7 +218,7 @@ public class HttpMethodTests extends H2FATDriverServlet {
         secondFrameHeaders.setHeaderFields(secondHeadersReceived);
         h2Client.addExpectedFrame(secondFrameHeaders);
 
-        setupDefaultPreface(h2Client);
+        setupDefaultUpgradedConnection(h2Client);
 
         // set up the first headers to send out
         List<HeaderEntry> firstHeadersToSend = new ArrayList<HeaderEntry>();
@@ -250,7 +250,7 @@ public class HttpMethodTests extends H2FATDriverServlet {
         secondFrameHeaders.setHeaderFields(secondHeadersReceived);
         h2Client.addExpectedFrame(secondFrameHeaders);
 
-        setupDefaultPreface(h2Client);
+        setupDefaultUpgradedConnection(h2Client);
 
         // set up the first headers to send out
         List<HeaderEntry> firstHeadersToSend = new ArrayList<HeaderEntry>();


### PR DESCRIPTION
For #15219 and #15220

* add back an IOException for case where response resources are cleaned up earlier than expected due to an error condition
* update most tests which rely on the h2c upgrade to wait for the first stream to complete before sending frames on new (often error-inducing) frames
* increase the http2 client first read timeout