### PR TITLE
Enable EE9 testing for Batch FATs

### DIFF
--- a/dev/com.ibm.ws.jbatch.cdi_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jbatch.cdi_fat/bnd.bnd
@@ -22,7 +22,19 @@ fat.project: true
 # Not 100% sure what this means, just put it in to have the test pass.
 tested.features: \
     cdi-2.0,\
-    servlet-4.0
+    servlet-4.0,\
+    connectors-2.0,\
+    enterprisebeans-4.0,\
+    jaxb-3.0,\
+    mdb-4.0,\
+    batch-2.0,\
+    persistencecontainer-3.0,\
+    enterprisebeansremote-4.0,\
+    jdbc-4.2,\
+    enterprisebeanshome-4.0,\
+    enterprisebeanslite-4.0,\
+    enterprisebeanspersistenttimer-4.0,\
+    persistence-3.0
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.jbatch.cdi_fat/build.gradle
+++ b/dev/com.ibm.ws.jbatch.cdi_fat/build.gradle
@@ -9,4 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-addRequiredLibraries.dependsOn addDerby
+addRequiredLibraries {
+	dependsOn addDerby
+	dependsOn addJakartaTransformer
+}

--- a/dev/com.ibm.ws.jbatch.cdi_fat/fat/src/fat/junit/BatchInjectionTest.java
+++ b/dev/com.ibm.ws.jbatch.cdi_fat/fat/src/fat/junit/BatchInjectionTest.java
@@ -27,6 +27,7 @@ import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -56,7 +57,8 @@ public class BatchInjectionTest extends FATServletClient {
     //
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE8_FEATURES().forServers("BatchInjection"));
+                    .andWith(FeatureReplacementAction.EE8_FEATURES().forServers("BatchInjection"))
+                    .andWith(new JakartaEE9Action().forServers("BatchInjection"));
 
     @Server("BatchInjection")
     @TestServlet(servlet = BatchInjectionServlet.class, path = "implicit/BatchInjectionServlet")

--- a/dev/com.ibm.ws.jbatch.cdi_fat/fat/src/fat/junit/FATSuite.java
+++ b/dev/com.ibm.ws.jbatch.cdi_fat/fat/src/fat/junit/FATSuite.java
@@ -20,5 +20,4 @@ import org.junit.runners.Suite.SuiteClasses;
                 TranTimeoutCleanupTest.class,
 })
 public class FATSuite {
-
 }

--- a/dev/com.ibm.ws.jbatch.cdi_fat/fat/src/fat/junit/TranTimeoutCleanupTest.java
+++ b/dev/com.ibm.ws.jbatch.cdi_fat/fat/src/fat/junit/TranTimeoutCleanupTest.java
@@ -16,6 +16,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -27,6 +28,8 @@ import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
@@ -48,6 +51,10 @@ import componenttest.topology.utils.FATServletClient;
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class TranTimeoutCleanupTest extends FATServletClient {
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.withoutModification()
+                    .andWith(new JakartaEE9Action().forServers("TranTimeoutCleanup"));
 
     @Server("TranTimeoutCleanup")
     @TestServlet(servlet = TranTimeoutCleanupServlet.class, path = "implicit/TranTimeoutCleanupServlet")

--- a/dev/com.ibm.ws.jbatch.misc_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jbatch.misc_fat/bnd.bnd
@@ -22,7 +22,19 @@ fat.project: true
 # Not 100% sure what this means, just put it in to have the test pass.
 tested.features: \
     cdi-2.0,\
-    servlet-4.0
+    servlet-4.0,\
+    connectors-2.0,\
+    enterprisebeans-4.0,\
+    jaxb-3.0,\
+    mdb-4.0,\
+    batch-2.0,\
+    persistencecontainer-3.0,\
+    enterprisebeansremote-4.0,\
+    jdbc-4.2,\
+    enterprisebeanshome-4.0,\
+    enterprisebeanslite-4.0,\
+    enterprisebeanspersistenttimer-4.0,\
+    persistence-3.0
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.jbatch.misc_fat/build.gradle
+++ b/dev/com.ibm.ws.jbatch.misc_fat/build.gradle
@@ -9,4 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-addRequiredLibraries.dependsOn addDerby
+addRequiredLibraries {
+	dependsOn addDerby
+	dependsOn addJakartaTransformer
+}

--- a/dev/com.ibm.ws.jbatch.misc_fat/fat/src/fat/junit/FATTest.java
+++ b/dev/com.ibm.ws.jbatch.misc_fat/fat/src/fat/junit/FATTest.java
@@ -26,6 +26,7 @@ import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -56,7 +57,8 @@ public class FATTest extends FATServletClient {
     //
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE8_FEATURES().forServers("BatchDeserialize"));
+                    .andWith(FeatureReplacementAction.EE8_FEATURES().forServers("BatchDeserialize"))
+                    .andWith(new JakartaEE9Action().forServers("BatchDeserialize"));
 
     @Server("BatchDeserialize")
     @TestServlet(servlet = BatchFATServlet.class, path = "implicit/FATServlet")

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EE7FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EE7FeatureReplacementAction.java
@@ -30,6 +30,8 @@ public class EE7FeatureReplacementAction extends FeatureReplacementAction {
                                                  "jcaInboundSecurity-1.0",
                                                  "jpa-2.1",
                                                  "jpaContainer-2.1",
+                                                 "batch-1.0",
+                                                 "batchManagement-1.0",
                                                  "beanValidation-1.1",
                                                  "jaxrs-2.0",
                                                  "jaxrsClient-2.0",

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EE8FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EE8FeatureReplacementAction.java
@@ -30,6 +30,8 @@ public class EE8FeatureReplacementAction extends FeatureReplacementAction {
                                                  "jcaInboundSecurity-1.0",
                                                  "jpa-2.2",
                                                  "jpaContainer-2.2",
+                                                 "batch-1.0",
+                                                 "batchManagement-1.0",
                                                  "beanValidation-2.0",
                                                  "jaxrs-2.1",
                                                  "jaxrsClient-2.1",

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE9Action.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE9Action.java
@@ -64,6 +64,8 @@ public class JakartaEE9Action extends FeatureReplacementAction {
                                                  "appAuthentication-2.0",
                                                  "appAuthorization-2.0",
                                                  "appSecurity-4.0",
+                                                 "batch-2.0",
+                                                 "batchManagement-2.0",
                                                  "beanValidation-3.0",
                                                  "cdi-3.0",
                                                  "concurrent-2.0",


### PR DESCRIPTION
Now that batch-2.0 and related features are available, update the Batch FATs in OL to run with the EE9 repeat rule.