### PR TITLE
Wait indefinitely for the variable registry service

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/SystemConfiguration.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/SystemConfiguration.java
@@ -78,7 +78,13 @@ class SystemConfiguration {
         metatypeRegistryTracker.open();
 
         WsLocationAdmin locationService = locationTracker.getService();
-        VariableRegistry variableRegistryService = variableRegistryTracker.getService();
+        VariableRegistry variableRegistryService = null;
+        try {
+            // Wait indefinitely for the variable registry service to be available
+            variableRegistryService = variableRegistryTracker.waitForService(0);
+        } catch (InterruptedException e) {
+            // Auto FFDC
+        }
 
         OnError onError = getOnError();
         if (onError != OnError.WARN) {


### PR DESCRIPTION
A timing issue has appeared recently where the variable registry service is not available when it is first use. The WSConfigXMLActivator needs to wait for it to be available to avoid problems. 