### PR TITLE
Fixes for JDBC kerberos support on IBM JDK 8.

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/FATSuite.java
@@ -40,6 +40,11 @@ public class FATSuite {
 
     public static final boolean REUSE_CONTAINERS = FATRunner.FAT_TEST_LOCALRUN && !ExternalTestServiceDockerClientStrategy.useRemoteDocker();
 
+    static {
+        // Needed for IBM JDK 8 support.
+        java.lang.System.setProperty("com.ibm.jsse2.overrideDefaultTLS", "true");
+    }
+
     @BeforeClass
     public static void startKerberos() throws Exception {
         if (!KerberosPlatformRule.shouldRun(null)) {

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/containers/DB2KerberosContainer.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/containers/DB2KerberosContainer.java
@@ -57,7 +57,7 @@ public class DB2KerberosContainer extends Db2Container {
         withEnv("DB2_KRB5_PRINCIPAL", "db2srvc@EXAMPLE.COM");
         waitingFor(new LogMessageWaitStrategy()
                         .withRegEx("^.*SETUP SCRIPT COMPLETE.*$")
-                        .withStartupTimeout(Duration.ofMinutes(FATRunner.FAT_TEST_LOCALRUN ? 3 : 25)));
+                        .withStartupTimeout(Duration.ofMinutes(FATRunner.FAT_TEST_LOCALRUN ? 10 : 25)));
         withLogConsumer(DB2KerberosContainer::log);
         withReuse(true);
     }

--- a/dev/com.ibm.ws.security.jca/src/com/ibm/ws/security/jca/internal/AuthDataServiceImpl.java
+++ b/dev/com.ibm.ws.security.jca/src/com/ibm/ws/security/jca/internal/AuthDataServiceImpl.java
@@ -160,7 +160,8 @@ public class AuthDataServiceImpl implements AuthDataService {
 
     private Subject obtainSubject(ManagedConnectionFactory managedConnectionFactory, AuthData authData) throws LoginException {
         if (authData.getKrb5Principal() != null) {
-            SerializableProtectedString pass = authData.getPassword() == null ? null : new SerializableProtectedString(authData.getPassword());
+            // When no password is provided authData.getPassword() returns an empty String.
+            SerializableProtectedString pass = String.valueOf(authData.getPassword()).equals("") ? null : new SerializableProtectedString(authData.getPassword());
             return krb5Service.getOrCreateSubject(authData.getKrb5Principal(), pass, authData.getKrb5TicketCache());
         } else {
             Subject subject = createSubject(managedConnectionFactory, authData);


### PR DESCRIPTION
Fixed needing to use a file:/ URL pattern for keytab and ccache files.
Fixed incorrectly identifying when a password is set.
Fixed various problem related to interactive vs non-interactive modes.
Fixed `Received fatal alert: protocol_version` error by adding the system property `com.ibm.jsse2.overrideDefaultTLS=true`

