### PR TITLE
EL Permission investigate

### DIFF
--- a/dev/com.ibm.ws.el.3.0_fat/test-applications/TestEL3.0.war/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.el.3.0_fat/test-applications/TestEL3.0.war/resources/META-INF/permissions.xml
@@ -20,9 +20,4 @@
         <name>getClassLoader</name>  
     </permission>
 
-    <permission>  
-        <class-name>java.lang.RuntimePermission</class-name>
-        <name>accessClassInPackage.com.sun.beans.editors</name>  
-    </permission>
-
 </permissions>


### PR DESCRIPTION
fixes #12284 
Removed previously added j2sec permission to verify Build Break doesn't occur and the failure was just locally. Ran two custom j2sec builds last week with the EL-3, Servlet-4 and Wsoc FAT buckets which  passed without the permission so can confirm this was a false positive and the permission should be removed.