### PR TITLE
Skip testEnvironmentConfigSource() on Windows machines

### DIFF
--- a/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -17,6 +17,7 @@
 					<!-- ConfigProviderTest.testEnvironmentConfigSource() looks for a Config Property called "path". -->
 					<!-- On some Windows machines, the Property can be called "Path", and hence the value isn't found. -->
 					<!-- Therefore this test is skipped on Windows machines. -->
+					<!-- Relates to: https://github.com/eclipse/microprofile-config/issues/664 -->
 					<![CDATA[
 					String os = System.getProperty("os.name");
 					if (os.contains("Windows")){

--- a/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -11,6 +11,24 @@
 <suite name="microprofile-config-2.0-tck" verbose="2"
     configfailurepolicy="continue">
     <test name="tck-package-org.eclipse.microprofile.config20.tck">
+		<method-selectors>
+			<method-selector>
+				<script language="beanshell">
+					<!-- ConfigProviderTest.testEnvironmentConfigSource() looks for a Config Property called "path". -->
+					<!-- On some Windows machines, the Property can be called "Path", and hence the value isn't found. -->
+					<!-- Therefore this test is skipped on Windows machines. -->
+					<![CDATA[
+					String os = System.getProperty("os.name");
+					if (os.contains("Windows")){
+					    return !method.getName().startsWith("testEnvironmentConfigSource");
+					}else{
+					    return true;
+					}
+					]]>
+				</script>
+			</method-selector>
+		</method-selectors>
+		
         <packages>
             <package name="org.eclipse.microprofile.config.tck.*"></package>
         </packages>


### PR DESCRIPTION
#build

