### PR TITLE
translatable message for autoCloseConnections

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentTxTestServer/server.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentTxTestServer/server.xml
@@ -25,13 +25,13 @@
     <application location="MPConcurrentTxApp.war"/>
 
     <dataSource id="DefaultDataSource">
-        <connectionManager enableHandleList="true" autoCloseConnections="true"/> <!-- TODO remove enableHandleList once 15181 is merged -->
+        <connectionManager autoCloseConnections="true"/>
         <jdbcDriver libraryRef="DerbyLib"/>
         <properties.derby.embedded createDatabase="create" databaseName="memory:txdb"/>
     </dataSource>
 
     <dataSource id="OnePhaseDataSource" jndiName="jdbc/ds1phase" type="javax.sql.ConnectionPoolDataSource">
-        <connectionManager enableHandleList="false" autoCloseConnections="false"/> <!-- TODO remove enableHandleList once 15181 is merged -->
+        <connectionManager autoCloseConnections="false"/>
         <jdbcDriver libraryRef="DerbyLib"/>
         <properties.derby.embedded createDatabase="create" databaseName="memory:txdb"/>
     </dataSource>

--- a/dev/com.ibm.ws.jca.cm/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.jca.cm/resources/OSGI-INF/l10n/metatype.properties
@@ -52,7 +52,7 @@ reapTime.desc=Amount of time between runs of the pool maintenance thread. A valu
 # Connection Manager advanced properties
 
 autoCloseCon=Automatically close connections
-autoCloseCon.desc=Attempts to clean up after applications that leave connections open across the end of a servlet request, enterprise bean instance, managed executor task, contextual task, or managed completion stage. When an unsharable connection is obtained within one of these application artifacts and remains open when it ends, the container attempts to close the connection handle. The container may also close sharable connections that do not support DissociatableManagedConnection. It is recommended that applications always close connections rather than relying on the container, even when this option is enabled.
+autoCloseCon.desc=Attempts to clean up after applications that leave connections open after the end of a servlet request, enterprise bean instance, managed executor task, contextual task, or managed completion stage. When an unsharable connection is obtained within one of these application artifacts and remains open when it ends, the container attempts to close the connection handle. The container may also close sharable connections that do not support DissociatableManagedConnection. Applications should always follow the programming model defined by the specification and close connections at the appropriate times rather than relying on the container, even when this option is enabled.
 
 maxConPerThd=Maximum open connections per thread
 maxConPerThd.desc=Limits the number of open connections on each thread.

--- a/dev/com.ibm.ws.jca.cm/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.jca.cm/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2019 IBM Corporation and others.
+# Copyright (c) 2011, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -50,6 +50,9 @@ reapTime=Reap time
 reapTime.desc=Amount of time between runs of the pool maintenance thread. A value of -1 disables pool maintenance.
 
 # Connection Manager advanced properties
+
+autoCloseCon=Automatically close connections
+autoCloseCon.desc=Attempts to clean up after applications that leave connections open across the end of a servlet request, enterprise bean instance, managed executor task, contextual task, or managed completion stage. When an unsharable connection is obtained within one of these application artifacts and remains open when it ends, the container attempts to close the connection handle. The container may also close sharable connections that do not support DissociatableManagedConnection. It is recommended that applications always close connections rather than relying on the container, even when this option is enabled.
 
 maxConPerThd=Maximum open connections per thread
 maxConPerThd.desc=Limits the number of open connections on each thread.


### PR DESCRIPTION
Add translatable message for autoCloseConnections that we will be able to use once the capability is put into beta.