### PR TITLE
test automatic close of nondissociatable sharable connection

### DIFF
--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
@@ -175,6 +175,12 @@ public class DerbyResourceAdapterTest extends FATServletClient {
     }
 
     @Test
+    public void testNonDissociatableSharableHandleIsClosedAcrossServletMethods() throws Exception {
+        runTest(server, DerbyRAServlet, "testNonDissociatableSharableHandleLeftOpenAfterServletMethod");
+        runTest(server, DerbyRAServlet, "testNonDissociatableSharableHandleIsClosed");
+    }
+
+    @Test
     public void testRecursiveTimer() throws Exception {
         runTest(DerbyRAAnnoServlet);
     }


### PR DESCRIPTION
Write a test that leaves a nondissociatable sharable connection handle open across the end of a servlet request. Verify in a separate servlet request that the connection handle has been automatically closed by the HandleList.