### PR TITLE
Override `doTrace` to avoid automatic TRACE request rejection

### DIFF
--- a/dev/io.openliberty.org.jboss.resteasy.server/src/com/ibm/websphere/jaxrs/server/IBMRestServlet.java
+++ b/dev/io.openliberty.org.jboss.resteasy.server/src/com/ibm/websphere/jaxrs/server/IBMRestServlet.java
@@ -10,6 +10,12 @@
  *******************************************************************************/
 package com.ibm.websphere.jaxrs.server;
 
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.jboss.resteasy.plugins.server.servlet.HttpServlet30Dispatcher;
 
 import com.ibm.websphere.ras.annotation.Trivial;
@@ -18,4 +24,8 @@ import com.ibm.websphere.ras.annotation.Trivial;
 public class IBMRestServlet extends HttpServlet30Dispatcher {
     private static final long serialVersionUID = -7916305366621576524L;
 
+    @Override
+    protected void doTrace(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        service("TRACE", request, response);
+    }
 }


### PR DESCRIPTION
The web container rejects TRACE requests by default - with or without the security features enabled.  When security is disabled, this can be worked around by setting `<webContainer enableTraceRequests="true"/>` in the server.xml, but that will not work when security is enabled.  To ensure that TRACE requests are not rejected when security is enabled, we must override the `doTrace` method in IBMRestServlet.