### PR TITLE
Update settings to get things building in eclipse

### DIFF
--- a/dev/com.ibm.ws.jbatch.common_fat/.classpath
+++ b/dev/com.ibm.ws.jbatch.common_fat/.classpath
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
     <classpathentry kind="src" output="bin" path="src"/>
-    <classpathentry kind="src" output="bin" path="fat/src"/>
-    <classpathentry kind="src" output="bin_test" path="test"/>
-    <classpathentry kind="src" path="test-applications/testmarker/src"/>
-    <classpathentry kind="src" path="test-applications/formlogin/src"/>
+    <classpathentry kind="src" path="test-applications/BonusPayout.war/src"/>
+    <classpathentry kind="src" path="test-applications/DbServletApp.war/src"/>
     <classpathentry kind="con" path="aQute.bnd.classpath.container"/>
     <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
     <classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jbatch.common_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jbatch.common_fat/bnd.bnd
@@ -21,7 +21,6 @@ Bundle-Description: Common code for Batch FAT projects; version=${bVersion}
 
 src: \
     src,\
-    fat/src,\
     test-applications/BonusPayout.war/src,\
     test-applications/DbServletApp.war/src
 

--- a/dev/com.ibm.ws.jbatch.open_fat/.classpath
+++ b/dev/com.ibm.ws.jbatch.open_fat/.classpath
@@ -3,21 +3,9 @@
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/batchSecurity.war/src"/>
 	<classpathentry kind="src" path="test-applications/batchFAT.war/src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.ws.org.osgi.annotation.versioning"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/fattest.simplicity"/>
-	<classpathentry kind="lib" path="/ant_build/lib/junit.jar"/>
-	<classpathentry kind="src" path="/com.ibm.websphere.javaee.servlet.3.0"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.websphere.javaee.batch.1.0"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.websphere.javaee.cdi.1.0"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.websphere.security"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.ws.jbatch.test.dbservlet"/>
-	<classpathentry kind="src" path="/com.ibm.ws.common.encoder"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.ws.org.apache.commons.io"/>
-	<classpathentry kind="src" path="/com.ibm.ws.security.jaas.common"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.websphere.javaee.transaction.1.2"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.websphere.javaee.jsonp.1.0"/>
-	<classpathentry kind="src" path="/com.ibm.jbatch.container"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
-	<classpathentry kind="output" path="build/classes"/>
+	<classpathentry kind="src" path="com.ibm.ws.jbatch.common_fat-BonusPayout"/>
+	<classpathentry kind="src" path="com.ibm.ws.jbatch.common_fat-DbServletApp"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.jbatch.open_fat/.project
+++ b/dev/com.ibm.ws.jbatch.open_fat/.project
@@ -10,8 +10,26 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
 	</natures>
+	<linkedResources>
+		<link>
+			<name>com.ibm.ws.jbatch.common_fat-BonusPayout</name>
+			<type>2</type>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.jbatch.common_fat/test-applications/BonusPayout.war/src</locationURI>
+		</link>
+		<link>
+			<name>com.ibm.ws.jbatch.common_fat-DbServletApp</name>
+			<type>2</type>
+			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.jbatch.common_fat/test-applications/DbServletApp.war/src</locationURI>
+		</link>
+	</linkedResources>
 </projectDescription>

--- a/dev/com.ibm.ws.jbatch.open_fat/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.jbatch.open_fat/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.sipcontainer.servlet.3.1/bnd.bnd
+++ b/dev/com.ibm.ws.sipcontainer.servlet.3.1/bnd.bnd
@@ -37,4 +37,5 @@ Import-Package: \
 	com.ibm.ws.sipcontainer;version=latest,\
 	com.ibm.ws.webcontainer.servlet.3.1;version=latest,\
 	com.ibm.ws.webcontainer;version=latest,\
+	com.ibm.ws.transport.http;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest


### PR DESCRIPTION
- Update classpath to use bnd for classpath and not project dependencies.
- Fix source directory lists in .classpath and bnd files to be correct
- Add to buildpath for sipcontainer.servlet so that indirect reference is found
- Add missing bnd settings in .project file and add bndtools.core.prefs file.