### PR TITLE
Wait for server stop process to end

### DIFF
--- a/dev/wlp.lib.extract/src/wlp/lib/extract/SelfExtractRun.java
+++ b/dev/wlp.lib.extract/src/wlp/lib/extract/SelfExtractRun.java
@@ -120,7 +120,7 @@ public class SelfExtractRun extends SelfExtract {
      * @return unique dir name
      */
     private static String createTempDirectory(String baseDir, String fileStem) {
-        Long nano = new Long(System.nanoTime());
+        Long nano = Long.valueOf(System.nanoTime());
         return baseDir + File.separator + fileStem + nano;
     }
 
@@ -271,7 +271,7 @@ public class SelfExtractRun extends SelfExtract {
         outputReader.start();
 
         // now setup the shutdown hook
-        Runtime.getRuntime().addShutdownHook(new Thread(new ShutdownHook(platformType, extractDirectory, serverName, outputReader, errorReader, extractDirPredefined)));
+        Runtime.getRuntime().addShutdownHook(new Thread(new ShutdownHook(platformType, extractDirectory, serverName, extractDirPredefined)));
         // wait on server start process to complete, capture and pass on return code
         rc = proc.waitFor();
 
@@ -349,7 +349,7 @@ public class SelfExtractRun extends SelfExtract {
         props.setProperty("LOG_DIR",
                           extractDirectory + File.separator + "wlp" + File.separator + "usr" + File.separator + "servers" + File.separator + serverName + File.separator + "logs");
 
-        Class clazz = cl.loadClass(className);
+        Class<?> clazz = cl.loadClass(className);
         List<String> argList = new ArrayList<String>(args.length + 2);
         argList.add(serverName);
         if (args.length > 0) {
@@ -359,7 +359,7 @@ public class SelfExtractRun extends SelfExtract {
         Method m = clazz.getDeclaredMethod("main", new Class[] { String[].class });
 
         // Add the shutdown hook to clean up
-        Runtime.getRuntime().addShutdownHook(new Thread(new ShutdownHook(platformType, extractDirectory, serverName, null, null, extractDirPredefined)));
+        Runtime.getRuntime().addShutdownHook(new Thread(new ShutdownHook(platformType, extractDirectory, serverName, extractDirPredefined)));
 
         attachJavaAgent(extractDirectory);
 
@@ -388,10 +388,11 @@ public class SelfExtractRun extends SelfExtract {
                 URL thisJar = SelfExtractRun.class.getProtectionDomain().getCodeSource().getLocation();
                 try {
                     URL toolsJar = new URL("file:" + f.getCanonicalPath());
+                    @SuppressWarnings("resource")
                     URLClassLoader cl = new URLClassLoader(new URL[] { thisJar, toolsJar }, null);
                     Class<?> clazz = cl.loadClass("wlp.lib.extract.AgentAttach");
                     Method m = clazz.getDeclaredMethod("attach", new Class[] { String.class });
-                    Object result = m.invoke(null, new String[] { javaAgent.getAbsolutePath() });
+                    Object result = m.invoke(null, javaAgent.getAbsolutePath());
                     if (result != null) {
                         err("UNABLE_TO_ATTACH_AGENT", result);
                     }

--- a/dev/wlp.lib.extract/src/wlp/lib/extract/ShutdownHook.java
+++ b/dev/wlp.lib.extract/src/wlp/lib/extract/ShutdownHook.java
@@ -30,39 +30,24 @@ public class ShutdownHook implements Runnable {
 
     private static final ResourceBundle resourceBundle = ResourceBundle.getBundle(SelfExtract.class.getName() + "Messages");
 
-    int platformType;
-    String dir;
-    String serverName;
-    Thread out;
-    Thread err;
-    boolean extractDirPredefined = false;
-
-    // no parm ctor not public
-    private ShutdownHook() {
-
-    }
+    final int platformType;
+    final String dir;
+    final String serverName;
+    final boolean extractDirPredefined;
 
     /**
      * The only constructor.
      *
-     * @param platformType - platform type: unix(1), windows(2), cygwin(3)
-     * @param dir - extraction directory
-     * @param serverName - name of server from jar (in extraction directory)
-     * @param out - output stream reader thread of parent process.
-     * @param err - error stream reader thread of parent process.
+     * @param platformType         - platform type: unix(1), windows(2), cygwin(3)
+     * @param dir                  - extraction directory
+     * @param serverName           - name of server from jar (in extraction directory)
      * @param extractDirPredefined - flag which indicates if WLP_JAR_EXTRACT_DIR was predefined by user
      */
     public ShutdownHook(int platformType,
                         String dir,
                         String serverName,
-                        StreamReader out,
-                        StreamReader err,
                         boolean extractDirPredefined) {
-
-        this();
         this.serverName = serverName;
-        this.out = out;
-        this.err = err;
         this.dir = dir;
         this.platformType = platformType;
         this.extractDirPredefined = extractDirPredefined;
@@ -155,7 +140,7 @@ public class ShutdownHook implements Runnable {
      * Write logic for windows cleanup script
      *
      * @param file - script File object
-     * @param bw - bufferedWriter to write into script file
+     * @param bw   - bufferedWriter to write into script file
      * @throws IOException
      */
     private void writeWindowsCleanup(File file, BufferedWriter bw) throws IOException {
@@ -191,7 +176,7 @@ public class ShutdownHook implements Runnable {
      * Write logic for Unix cleanup script
      *
      * @param file - script File object
-     * @param bw - bufferedWriter to write into script file
+     * @param bw   - bufferedWriter to write into script file
      * @throws IOException
      */
     private void writeUnixCleanup(File file, BufferedWriter bw) throws IOException {
@@ -224,7 +209,7 @@ public class ShutdownHook implements Runnable {
      * Write logic for Cygwin cleanup script
      *
      * @param file - script File object
-     * @param bw - bufferedWriter to write into script file
+     * @param bw   - bufferedWriter to write into script file
      * @throws IOException
      */
     private void writeCygwinCleanup(File file, BufferedWriter bw) throws IOException {
@@ -298,18 +283,6 @@ public class ShutdownHook implements Runnable {
         try {
 
             stopServer(); // first, stop server
-
-            // wait on error/output stream threads to complete
-            // note on Windows the streams never close, so wait with brief timeout
-            if (out != null && err != null) {
-                if (!System.getProperty("os.name").startsWith("Win")) {
-                    out.join();
-                    err.join();
-                } else { // windows, so use timeout
-                    out.join(500);
-                    err.join(500);
-                }
-            }
 
             // When the server is launched with java -jar, delete the server on exit minus
             // the /logs folder, unless WLP_JAR_EXTRACT_DIR is set at which point don't delete

--- a/dev/wlp.lib.extract/src/wlp/lib/extract/ShutdownHook.java
+++ b/dev/wlp.lib.extract/src/wlp/lib/extract/ShutdownHook.java
@@ -117,8 +117,12 @@ public class ShutdownHook implements Runnable {
             cmd = "bash -c  " + '"' + cmd.replace('\\', '/') + '"';
         }
 
-        Runtime.getRuntime().exec(cmd, SelfExtractUtils.runEnv(dir), null); // stop server
-
+        Process stopProcess = Runtime.getRuntime().exec(cmd, SelfExtractUtils.runEnv(dir), null); // stop server
+        try {
+            stopProcess.waitFor();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     /**


### PR DESCRIPTION
Need to be sure the server stop process ends before
deleting the wlp extract folder.  A timeout is not used because we need to still support Java 7 for the wlp.lib.extract project

Fixes #15280