### PR TITLE
grpc_fat: expand trace for HelloWorldCDITests

### DIFF
--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.cdi.interceptor.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.cdi.interceptor.xml
@@ -18,7 +18,17 @@
     <include location="../fatTestPorts.xml"/>
 
     <grpc target="helloworld.Greeter" serverInterceptors="com.ibm.ws.grpc.fat.helloworld.service.HelloWorldServerCDIInterceptor"/>
-    
-    
+
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
+
+        <logging
+        traceSpecification="*=info=enabled:
+            GRPC=all:
+            com.ibm.ws.webcontainer*=all:
+            com.ibm.wsspi.webcontainer*=all:
+            HTTPChannel=all:
+            HTTPTransport=all:
+            GenericBNF=all"
+        maxFileSize="40" maxFiles="1" traceFormat="BASIC" />
+
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.cdi.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.server.cdi.xml
@@ -18,4 +18,15 @@
     <include location="../fatTestPorts.xml"/>
     
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
+
+    <logging
+        traceSpecification="*=info=enabled:
+            GRPC=all:
+            com.ibm.ws.webcontainer*=all:
+            com.ibm.wsspi.webcontainer*=all:
+            HTTPChannel=all:
+            HTTPTransport=all:
+            GenericBNF=all"
+        maxFileSize="40" maxFiles="1" traceFormat="BASIC" />
+
 </server>


### PR DESCRIPTION
Add webcontainer trace for the servers used in `HelloWorldCDITests` to help diagnose an intermittent build break