### PR TITLE
Ignore server quiesce timeouts in MP Rest Client FATs

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/AsyncMethodTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/AsyncMethodTest.java
@@ -70,7 +70,8 @@ public class AsyncMethodTest extends FATServletClient {
             assertTrue("Found JsonBProvider errors in log file", 
                        jsonbProviderErrors == null || jsonbProviderErrors.isEmpty());
         } finally {
-            server.stopServer("CWWKF0033E"); //ignore this error for mismatch with jsonb-1.0 and Java EE 7
+            server.stopServer("CWWKE1102W",  //ignore server quiesce timeouts due to slow test machines
+                              "CWWKF0033E"); //ignore this error for mismatch with jsonb-1.0 and Java EE 7
         }
     }
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicCdiInEE8Test.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicCdiInEE8Test.java
@@ -68,6 +68,6 @@ public class BasicCdiInEE8Test extends FATServletClient {
     @AfterClass
     public static void afterClass() throws Exception {
         server.stopServer();
-        remoteAppServer.stopServer();
+        remoteAppServer.stopServer("CWWKE1102W");  //ignore server quiesce timeouts due to slow test machines);
     }
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicCdiTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicCdiTest.java
@@ -67,7 +67,7 @@ public class BasicCdiTest extends FATServletClient {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        server.stopServer();
-        remoteAppServer.stopServer();
+        server.stopServer("CWWKE1102W");  //ignore server quiesce timeouts due to slow test machines
+        remoteAppServer.stopServer("CWWKE1102W");
     }
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicEJBTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicEJBTest.java
@@ -67,7 +67,7 @@ public class BasicEJBTest extends FATServletClient {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        server.stopServer();
-        remoteAppServer.stopServer();
+        server.stopServer("CWWKE1102W");  //ignore server quiesce timeouts due to slow test machines
+        remoteAppServer.stopServer("CWWKE1102W");
     }
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicTest.java
@@ -67,7 +67,7 @@ public class BasicTest extends FATServletClient {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        server.stopServer();
-        remoteAppServer.stopServer("CWWKO0801E");
+        server.stopServer("CWWKE1102W");  //ignore server quiesce timeouts due to slow test machines
+        remoteAppServer.stopServer("CWWKE1102W", "CWWKO0801E");
     }
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/CdiPropsAndProvidersTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/CdiPropsAndProvidersTest.java
@@ -74,8 +74,8 @@ public class CdiPropsAndProvidersTest extends FATServletClient {
             assertTrue("Did not find expected @Dependent interface injected into @RequestScoped bean in CWWKW0750I message: " + requestScopedIntfMsg,
                        requestScopedIntfMsg.contains(UnusedClient.class.getName() + "(" + UnusedBeanWithMPRestClient.class.getName() + ")"));
         } finally {
-            server.stopServer();
-            remoteAppServer.stopServer();
+            server.stopServer("CWWKE1102W");  //ignore server quiesce timeouts due to slow test machines
+            remoteAppServer.stopServer("CWWKE1102W");
         }
     }
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/CollectionsTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/CollectionsTest.java
@@ -77,10 +77,10 @@ public class CollectionsTest extends FATServletClient {
     @AfterClass
     public static void afterClass() throws Exception {
         if (server != null) {
-            server.stopServer();
+            server.stopServer("CWWKE1102W");  //ignore server quiesce timeouts due to slow test machines
         }
         if (remoteAppServer != null) {
-            remoteAppServer.stopServer();
+            remoteAppServer.stopServer("CWWKE1102W");
         }
     }
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HandleResponsesTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HandleResponsesTest.java
@@ -68,7 +68,7 @@ public class HandleResponsesTest extends FATServletClient {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        server.stopServer();
-        remoteAppServer.stopServer();
+        server.stopServer("CWWKE1102W");  //ignore server quiesce timeouts due to slow test machines
+        remoteAppServer.stopServer("CWWKE1102W");
     }
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HeaderPropagation12Test.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HeaderPropagation12Test.java
@@ -52,6 +52,6 @@ public class HeaderPropagation12Test extends FATServletClient {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        server.stopServer();
+        server.stopServer("CWWKE1102W");  //ignore server quiesce timeouts due to slow test machines
     }
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HeaderPropagationTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HeaderPropagationTest.java
@@ -56,6 +56,6 @@ public class HeaderPropagationTest extends FATServletClient {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        server.stopServer();
+        server.stopServer("CWWKE1102W");  //ignore server quiesce timeouts due to slow test machines
     }
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HostnameVerifierTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HostnameVerifierTest.java
@@ -62,7 +62,7 @@ public class HostnameVerifierTest extends FATServletClient {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        server.stopServer();
+        server.stopServer("CWWKE1102W");  //ignore server quiesce timeouts due to slow test machines
 
     }
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/JsonbContextTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/JsonbContextTest.java
@@ -57,7 +57,7 @@ public class JsonbContextTest extends FATServletClient {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        server.stopServer();
-        remoteAppServer.stopServer();
+        server.stopServer("CWWKE1102W");  //ignore server quiesce timeouts due to slow test machines
+        remoteAppServer.stopServer("CWWKE1102W");
     }
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/MultiClientCdiTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/MultiClientCdiTest.java
@@ -55,7 +55,7 @@ public class MultiClientCdiTest extends FATServletClient {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        server.stopServer();
+        server.stopServer("CWWKE1102W");  //ignore server quiesce timeouts due to slow test machines
     }
 
     // The following tests verify that the second app can do the same as the first app.

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/ProduceConsumeTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/ProduceConsumeTest.java
@@ -55,6 +55,6 @@ public class ProduceConsumeTest extends FATServletClient {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        server.stopServer(/*"CWWKF0033E"*/); //ignore this error for mismatch with jsonb-1.0 and Java EE 7
+        server.stopServer("CWWKE1102W");  //ignore server quiesce timeouts due to slow test machines
     }
 }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/PropsTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/PropsTest.java
@@ -53,6 +53,6 @@ public class PropsTest extends FATServletClient {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        server.stopServer();
+        server.stopServer("CWWKE1102W");  //ignore server quiesce timeouts due to slow test machines
     }
 }


### PR DESCRIPTION
Resolves intermittent timeouts on slow test machines.