### PR TITLE
Add new tests for features

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tasks/FeatureBnd.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tasks/FeatureBnd.java
@@ -20,7 +20,7 @@ public class FeatureBnd {
     /** */
     public static final String IBM_PROVISION_CAPABILITY = "IBM-Provision-Capability";
     /**  */
-    private static final String IBM_SHORT_NAME = "IBM-ShortName";
+    public static final String IBM_SHORT_NAME = "IBM-ShortName";
 
     private static final String IBM_LICENSE_INFORMATION = "IBM-License-Information";
 

--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tasks/FeatureBuilder.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tasks/FeatureBuilder.java
@@ -68,7 +68,7 @@ public class FeatureBuilder extends Builder {
     	String filterString = rawString.toString();
 		String[] messyAutoFeatures = filterString.split(OSGI_PREFIX);
 		for (String messyAutoFeature : messyAutoFeatures) {
-			if (!messyAutoFeature.startsWith("com"))
+			if (!messyAutoFeature.startsWith("com") && !messyAutoFeature.startsWith("io.openliberty"))
 				continue;
 
 			processedAutoFeatures.add(trimAutofeatureString(messyAutoFeature));

--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureInfo.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/utils/FeatureInfo.java
@@ -13,7 +13,6 @@ package com.ibm.ws.feature.utils;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -45,6 +44,7 @@ public class FeatureInfo {
 	private boolean isDisableOnConflictEnabled = true;
 	private boolean isSingleton = false;
     private String visibility = "private";
+    private String shortName;
 
 	public FeatureInfo(File feature) {
 		this.feature = feature;
@@ -154,6 +154,12 @@ public class FeatureInfo {
 		return this.kind;
 	}
 
+	public String getShortName() {
+	    if (!isInit)
+	        populateInfo();
+
+	    return this.shortName;
+	}
 
 	private synchronized void populateInfo() {
 		if (isInit)
@@ -178,6 +184,7 @@ public class FeatureInfo {
             if (vis != null) {
                 visibility = vis.trim();
             }
+            this.shortName = builder.getProperty(FeatureBnd.IBM_SHORT_NAME);
 
             this.edition = edition;
             this.kind = kind;

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.ejbComponentMetadataDecorator-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.ejbComponentMetadataDecorator-1.0.feature
@@ -2,7 +2,7 @@
 symbolicName=com.ibm.websphere.appserver.ejbComponentMetadataDecorator-1.0
 visibility=private
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.ejbCore-1.0)(osgi.identity=io.openliberty.ejbCore-2.0)))", \
- osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.jeeMetadataContext-1.0))"
+ osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.contextService-1.0))"
 IBM-Install-Policy: when-satisfied
 -bundles=com.ibm.ws.javaee.metadata.context.ejb
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jeeMetadataContext-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jeeMetadataContext-1.0.feature
@@ -1,9 +1,0 @@
--include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.jeeMetadataContext-1.0
-visibility=private
-IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.contextService-1.0))"
-IBM-Install-Policy: when-satisfied
--bundles=com.ibm.ws.javaee.metadata.context
-kind=ga
-edition=core
-WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.contextService-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.contextService-1.0.feature
@@ -6,7 +6,8 @@ IBM-API-Package: com.ibm.ws.context.service.serializable; type="internal"
 -features=com.ibm.websphere.appserver.appLifecycle-1.0
 -bundles=com.ibm.ws.resource, \
  com.ibm.ws.javaee.version, \
- com.ibm.ws.context
+ com.ibm.ws.context, \
+ com.ibm.ws.javaee.metadata.context
 kind=ga
 edition=core
 WLP-Activation-Type: parallel


### PR DESCRIPTION
- Update test to make sure that public features are in a directory that matches their short name
- Add test to make sure that auto features depend on more than one feature and fix auto feature that did not pass this test.
- Add test to make sure that l10n properties files have the same package name as the feature name.
- Add io.openliberty prefix to feature name filter.