### PR TITLE
Fix issue with possible NPE from FATTestFramework properties

### DIFF
--- a/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
+++ b/dev/com.ibm.ws.jpa_22_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
@@ -112,11 +112,11 @@ public class JPAFATServletClient extends FATServletClient {
             dbProps.load(con.getInputStream());
             System.out.println("Acquired Database Metadata: " + dbProps);
 
-            dbProductName = dbProps.getProperty("dbproduct_name");
-            dbProductVersion = dbProps.getProperty("dbproduct_version");
-            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version");
-            jdbcURL = dbProps.getProperty("jdbc_url");
-            jdbcUsername = dbProps.getProperty("jdbc_username");
+            dbProductName = dbProps.getProperty("dbproduct_name", "UNKNOWN");
+            dbProductVersion = dbProps.getProperty("dbproduct_version", "UNKNOWN");
+            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version", "UNKNOWN");
+            jdbcURL = dbProps.getProperty("jdbc_url", "UNKNOWN");
+            jdbcUsername = dbProps.getProperty("jdbc_username", "UNKNOWN");
 
             dbVendor = DatabaseVendor.resolveDBProduct(dbProductName);
         } else {

--- a/dev/com.ibm.ws.jpa_30_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
+++ b/dev/com.ibm.ws.jpa_30_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
@@ -112,11 +112,11 @@ public class JPAFATServletClient extends FATServletClient {
             dbProps.load(con.getInputStream());
             System.out.println("Acquired Database Metadata: " + dbProps);
 
-            dbProductName = dbProps.getProperty("dbproduct_name");
-            dbProductVersion = dbProps.getProperty("dbproduct_version");
-            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version");
-            jdbcURL = dbProps.getProperty("jdbc_url");
-            jdbcUsername = dbProps.getProperty("jdbc_username");
+            dbProductName = dbProps.getProperty("dbproduct_name", "UNKNOWN");
+            dbProductVersion = dbProps.getProperty("dbproduct_version", "UNKNOWN");
+            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version", "UNKNOWN");
+            jdbcURL = dbProps.getProperty("jdbc_url", "UNKNOWN");
+            jdbcUsername = dbProps.getProperty("jdbc_username", "UNKNOWN");
 
             dbVendor = DatabaseVendor.resolveDBProduct(dbProductName);
         } else {

--- a/dev/com.ibm.ws.jpa_eclipselink_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
+++ b/dev/com.ibm.ws.jpa_eclipselink_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
@@ -138,13 +138,13 @@ public class JPAFATServletClient extends FATServletClient {
                 System.out.println("   " + key + " = " + dbProps.getProperty((String) key));
             }
 
-            dbMajorVersion = dbProps.getProperty("dbmajor_version");
-            dbMinorVersion = dbProps.getProperty("dbminor_version");
-            dbProductName = dbProps.getProperty("dbproduct_name");
-            dbProductVersion = dbProps.getProperty("dbproduct_version");
-            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version");
-            jdbcURL = dbProps.getProperty("jdbc_url");
-            jdbcUsername = dbProps.getProperty("jdbc_username");
+            dbMajorVersion = dbProps.getProperty("dbmajor_version", "UNKNOWN");
+            dbMinorVersion = dbProps.getProperty("dbminor_version", "UNKNOWN");
+            dbProductName = dbProps.getProperty("dbproduct_name", "UNKNOWN");
+            dbProductVersion = dbProps.getProperty("dbproduct_version", "UNKNOWN");
+            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version", "UNKNOWN");
+            jdbcURL = dbProps.getProperty("jdbc_url", "UNKNOWN");
+            jdbcUsername = dbProps.getProperty("jdbc_username", "UNKNOWN");
 
             dbVendor = DatabaseVendor.resolveDBProduct(dbProductName);
         } else {

--- a/dev/com.ibm.ws.jpa_locking_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
+++ b/dev/com.ibm.ws.jpa_locking_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
@@ -136,22 +136,12 @@ public class JPAFATServletClient extends FATServletClient {
                 System.out.println("   " + key + " = " + dbProps.getProperty((String) key));
             }
 
-            dbProductName = dbProps.getProperty("dbproduct_name");
-            dbProductVersion = dbProps.getProperty("dbproduct_version");
-            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version");
-            jdbcURL = dbProps.getProperty("jdbc_url");
-            jdbcUsername = dbProps.getProperty("jdbc_username");
+            dbProductName = dbProps.getProperty("dbproduct_name", "UNKNOWN");
+            dbProductVersion = dbProps.getProperty("dbproduct_version", "UNKNOWN");
+            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version", "UNKNOWN");
+            jdbcURL = dbProps.getProperty("jdbc_url", "UNKNOWN");
+            jdbcUsername = dbProps.getProperty("jdbc_username", "UNKNOWN");
 
-//            Properties dbProps = new Properties();
-//            dbProps.load(con.getInputStream());
-//            System.out.println("Acquired Database Metadata: " + dbProps);
-//
-//            dbProductName = dbProps.getProperty("dbproduct_name");
-//            dbProductVersion = dbProps.getProperty("dbproduct_version");
-//            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version");
-//            jdbcURL = dbProps.getProperty("jdbc_url");
-//            jdbcUsername = dbProps.getProperty("jdbc_username");
-//
             dbVendor = DatabaseVendor.resolveDBProduct(dbProductName);
         } else {
             System.out.println("Failed to acquire Database Metadata.");

--- a/dev/com.ibm.ws.jpa_ol_fat/fat/src/io/openliberty/jpa/JPAFATServletClient.java
+++ b/dev/com.ibm.ws.jpa_ol_fat/fat/src/io/openliberty/jpa/JPAFATServletClient.java
@@ -136,11 +136,11 @@ public class JPAFATServletClient extends FATServletClient {
                 System.out.println("   " + key + " = " + dbProps.getProperty((String) key));
             }
 
-            dbProductName = dbProps.getProperty("dbproduct_name");
-            dbProductVersion = dbProps.getProperty("dbproduct_version");
-            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version");
-            jdbcURL = dbProps.getProperty("jdbc_url");
-            jdbcUsername = dbProps.getProperty("jdbc_username");
+            dbProductName = dbProps.getProperty("dbproduct_name", "UNKNOWN");
+            dbProductVersion = dbProps.getProperty("dbproduct_version", "UNKNOWN");
+            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version", "UNKNOWN");
+            jdbcURL = dbProps.getProperty("jdbc_url", "UNKNOWN");
+            jdbcUsername = dbProps.getProperty("jdbc_username", "UNKNOWN");
 
             dbVendor = DatabaseVendor.resolveDBProduct(dbProductName);
         } else {

--- a/dev/com.ibm.ws.jpa_spec10_injection_ejbinwar_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
+++ b/dev/com.ibm.ws.jpa_spec10_injection_ejbinwar_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
@@ -136,22 +136,12 @@ public class JPAFATServletClient extends FATServletClient {
                 System.out.println("   " + key + " = " + dbProps.getProperty((String) key));
             }
 
-            dbProductName = dbProps.getProperty("dbproduct_name");
-            dbProductVersion = dbProps.getProperty("dbproduct_version");
-            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version");
-            jdbcURL = dbProps.getProperty("jdbc_url");
-            jdbcUsername = dbProps.getProperty("jdbc_username");
+            dbProductName = dbProps.getProperty("dbproduct_name", "UNKNOWN");
+            dbProductVersion = dbProps.getProperty("dbproduct_version", "UNKNOWN");
+            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version", "UNKNOWN");
+            jdbcURL = dbProps.getProperty("jdbc_url", "UNKNOWN");
+            jdbcUsername = dbProps.getProperty("jdbc_username", "UNKNOWN");
 
-//            Properties dbProps = new Properties();
-//            dbProps.load(con.getInputStream());
-//            System.out.println("Acquired Database Metadata: " + dbProps);
-//
-//            dbProductName = dbProps.getProperty("dbproduct_name");
-//            dbProductVersion = dbProps.getProperty("dbproduct_version");
-//            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version");
-//            jdbcURL = dbProps.getProperty("jdbc_url");
-//            jdbcUsername = dbProps.getProperty("jdbc_username");
-//
             dbVendor = DatabaseVendor.resolveDBProduct(dbProductName);
         } else {
             System.out.println("Failed to acquire Database Metadata.");

--- a/dev/com.ibm.ws.jpa_spec10_injection_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
+++ b/dev/com.ibm.ws.jpa_spec10_injection_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
@@ -136,22 +136,12 @@ public class JPAFATServletClient extends FATServletClient {
                 System.out.println("   " + key + " = " + dbProps.getProperty((String) key));
             }
 
-            dbProductName = dbProps.getProperty("dbproduct_name");
-            dbProductVersion = dbProps.getProperty("dbproduct_version");
-            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version");
-            jdbcURL = dbProps.getProperty("jdbc_url");
-            jdbcUsername = dbProps.getProperty("jdbc_username");
+            dbProductName = dbProps.getProperty("dbproduct_name", "UNKNOWN");
+            dbProductVersion = dbProps.getProperty("dbproduct_version", "UNKNOWN");
+            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version", "UNKNOWN");
+            jdbcURL = dbProps.getProperty("jdbc_url", "UNKNOWN");
+            jdbcUsername = dbProps.getProperty("jdbc_username", "UNKNOWN");
 
-//            Properties dbProps = new Properties();
-//            dbProps.load(con.getInputStream());
-//            System.out.println("Acquired Database Metadata: " + dbProps);
-//
-//            dbProductName = dbProps.getProperty("dbproduct_name");
-//            dbProductVersion = dbProps.getProperty("dbproduct_version");
-//            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version");
-//            jdbcURL = dbProps.getProperty("jdbc_url");
-//            jdbcUsername = dbProps.getProperty("jdbc_username");
-//
             dbVendor = DatabaseVendor.resolveDBProduct(dbProductName);
         } else {
             System.out.println("Failed to acquire Database Metadata.");

--- a/dev/com.ibm.ws.jpa_spec10_part01_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
+++ b/dev/com.ibm.ws.jpa_spec10_part01_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
@@ -136,22 +136,12 @@ public class JPAFATServletClient extends FATServletClient {
                 System.out.println("   " + key + " = " + dbProps.getProperty((String) key));
             }
 
-            dbProductName = dbProps.getProperty("dbproduct_name");
-            dbProductVersion = dbProps.getProperty("dbproduct_version");
-            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version");
-            jdbcURL = dbProps.getProperty("jdbc_url");
-            jdbcUsername = dbProps.getProperty("jdbc_username");
+            dbProductName = dbProps.getProperty("dbproduct_name", "UNKNOWN");
+            dbProductVersion = dbProps.getProperty("dbproduct_version", "UNKNOWN");
+            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version", "UNKNOWN");
+            jdbcURL = dbProps.getProperty("jdbc_url", "UNKNOWN");
+            jdbcUsername = dbProps.getProperty("jdbc_username", "UNKNOWN");
 
-//            Properties dbProps = new Properties();
-//            dbProps.load(con.getInputStream());
-//            System.out.println("Acquired Database Metadata: " + dbProps);
-//
-//            dbProductName = dbProps.getProperty("dbproduct_name");
-//            dbProductVersion = dbProps.getProperty("dbproduct_version");
-//            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version");
-//            jdbcURL = dbProps.getProperty("jdbc_url");
-//            jdbcUsername = dbProps.getProperty("jdbc_username");
-//
             dbVendor = DatabaseVendor.resolveDBProduct(dbProductName);
         } else {
             System.out.println("Failed to acquire Database Metadata.");

--- a/dev/com.ibm.ws.jpa_spec10_part02_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
+++ b/dev/com.ibm.ws.jpa_spec10_part02_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
@@ -136,22 +136,12 @@ public class JPAFATServletClient extends FATServletClient {
                 System.out.println("   " + key + " = " + dbProps.getProperty((String) key));
             }
 
-            dbProductName = dbProps.getProperty("dbproduct_name");
-            dbProductVersion = dbProps.getProperty("dbproduct_version");
-            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version");
-            jdbcURL = dbProps.getProperty("jdbc_url");
-            jdbcUsername = dbProps.getProperty("jdbc_username");
+            dbProductName = dbProps.getProperty("dbproduct_name", "UNKNOWN");
+            dbProductVersion = dbProps.getProperty("dbproduct_version", "UNKNOWN");
+            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version", "UNKNOWN");
+            jdbcURL = dbProps.getProperty("jdbc_url", "UNKNOWN");
+            jdbcUsername = dbProps.getProperty("jdbc_username", "UNKNOWN");
 
-//            Properties dbProps = new Properties();
-//            dbProps.load(con.getInputStream());
-//            System.out.println("Acquired Database Metadata: " + dbProps);
-//
-//            dbProductName = dbProps.getProperty("dbproduct_name");
-//            dbProductVersion = dbProps.getProperty("dbproduct_version");
-//            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version");
-//            jdbcURL = dbProps.getProperty("jdbc_url");
-//            jdbcUsername = dbProps.getProperty("jdbc_username");
-//
             dbVendor = DatabaseVendor.resolveDBProduct(dbProductName);
         } else {
             System.out.println("Failed to acquire Database Metadata.");

--- a/dev/com.ibm.ws.jpa_spec10_query_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
+++ b/dev/com.ibm.ws.jpa_spec10_query_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
@@ -136,22 +136,12 @@ public class JPAFATServletClient extends FATServletClient {
                 System.out.println("   " + key + " = " + dbProps.getProperty((String) key));
             }
 
-            dbProductName = dbProps.getProperty("dbproduct_name");
-            dbProductVersion = dbProps.getProperty("dbproduct_version");
-            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version");
-            jdbcURL = dbProps.getProperty("jdbc_url");
-            jdbcUsername = dbProps.getProperty("jdbc_username");
+            dbProductName = dbProps.getProperty("dbproduct_name", "UNKNOWN");
+            dbProductVersion = dbProps.getProperty("dbproduct_version", "UNKNOWN");
+            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version", "UNKNOWN");
+            jdbcURL = dbProps.getProperty("jdbc_url", "UNKNOWN");
+            jdbcUsername = dbProps.getProperty("jdbc_username", "UNKNOWN");
 
-//            Properties dbProps = new Properties();
-//            dbProps.load(con.getInputStream());
-//            System.out.println("Acquired Database Metadata: " + dbProps);
-//
-//            dbProductName = dbProps.getProperty("dbproduct_name");
-//            dbProductVersion = dbProps.getProperty("dbproduct_version");
-//            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version");
-//            jdbcURL = dbProps.getProperty("jdbc_url");
-//            jdbcUsername = dbProps.getProperty("jdbc_username");
-//
             dbVendor = DatabaseVendor.resolveDBProduct(dbProductName);
         } else {
             System.out.println("Failed to acquire Database Metadata.");

--- a/dev/com.ibm.ws.jpa_spec20_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
+++ b/dev/com.ibm.ws.jpa_spec20_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
@@ -136,11 +136,11 @@ public class JPAFATServletClient extends FATServletClient {
                 System.out.println("   " + key + " = " + dbProps.getProperty((String) key));
             }
 
-            dbProductName = dbProps.getProperty("dbproduct_name");
-            dbProductVersion = dbProps.getProperty("dbproduct_version");
-            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version");
-            jdbcURL = dbProps.getProperty("jdbc_url");
-            jdbcUsername = dbProps.getProperty("jdbc_username");
+            dbProductName = dbProps.getProperty("dbproduct_name", "UNKNOWN");
+            dbProductVersion = dbProps.getProperty("dbproduct_version", "UNKNOWN");
+            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version", "UNKNOWN");
+            jdbcURL = dbProps.getProperty("jdbc_url", "UNKNOWN");
+            jdbcUsername = dbProps.getProperty("jdbc_username", "UNKNOWN");
 
             dbVendor = DatabaseVendor.resolveDBProduct(dbProductName);
         } else {

--- a/dev/com.ibm.ws.jpa_spec21_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
+++ b/dev/com.ibm.ws.jpa_spec21_fat/fat/src/com/ibm/ws/jpa/JPAFATServletClient.java
@@ -136,11 +136,11 @@ public class JPAFATServletClient extends FATServletClient {
                 System.out.println("   " + key + " = " + dbProps.getProperty((String) key));
             }
 
-            dbProductName = dbProps.getProperty("dbproduct_name");
-            dbProductVersion = dbProps.getProperty("dbproduct_version");
-            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version");
-            jdbcURL = dbProps.getProperty("jdbc_url");
-            jdbcUsername = dbProps.getProperty("jdbc_username");
+            dbProductName = dbProps.getProperty("dbproduct_name", "UNKNOWN");
+            dbProductVersion = dbProps.getProperty("dbproduct_version", "UNKNOWN");
+            jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version", "UNKNOWN");
+            jdbcURL = dbProps.getProperty("jdbc_url", "UNKNOWN");
+            jdbcUsername = dbProps.getProperty("jdbc_username", "UNKNOWN");
 
             dbVendor = DatabaseVendor.resolveDBProduct(dbProductName);
         } else {

--- a/dev/com.ibm.ws.jpa_testframework/src/com/ibm/ws/testtooling/vehicle/web/JPATestServlet.java
+++ b/dev/com.ibm.ws.jpa_testframework/src/com/ibm/ws/testtooling/vehicle/web/JPATestServlet.java
@@ -246,13 +246,13 @@ public abstract class JPATestServlet extends FATServlet {
             System.out.println("   " + key + " = " + dbProps.getProperty((String) key));
         }
 
-        dbMajorVersion = dbProps.getProperty("dbmajor_version");
-        dbMinorVersion = dbProps.getProperty("dbminor_version");
-        dbProductName = dbProps.getProperty("dbproduct_name");
-        dbProductVersion = dbProps.getProperty("dbproduct_version");
-        jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version");
-        jdbcURL = dbProps.getProperty("jdbc_url");
-        jdbcUsername = dbProps.getProperty("jdbc_username");
+        dbMajorVersion = dbProps.getProperty("dbmajor_version", "UNKNOWN");
+        dbMinorVersion = dbProps.getProperty("dbminor_version", "UNKNOWN");
+        dbProductName = dbProps.getProperty("dbproduct_name", "UNKNOWN");
+        dbProductVersion = dbProps.getProperty("dbproduct_version", "UNKNOWN");
+        jdbcDriverVersion = dbProps.getProperty("jdbcdriver_version", "UNKNOWN");
+        jdbcURL = dbProps.getProperty("jdbc_url", "UNKNOWN");
+        jdbcUsername = dbProps.getProperty("jdbc_username", "UNKNOWN");
 
         dbMetaAcquired = true;
     }


### PR DESCRIPTION
There exists a bug in the JPA testframework where Null values can be passed into the test properties. This causes a NPE from the testframework when the properties are copied into a HashMap.

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>