### PR TITLE
autoCloseConnections in ConnectionFactoryDefinition

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManagerServiceImpl.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManagerServiceImpl.java
@@ -466,7 +466,7 @@ public class ConnectionManagerServiceImpl extends ConnectionManagerService {
                 Tr.debug(this, tc, "Setting disableLibertyConnectionManager to " + disableLibertyConnectionPool);
         }
 
-        Object value = map.remove("autoCloseConnections");
+        Object value = map.remove(AUTO_CLOSE_CONNECTIONS);
         boolean autoCloseConnections = value instanceof Boolean ? (Boolean) value : Boolean.parseBoolean((String) value);
 
         if (disableLibertyConnectionPool) {

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/ConnectionManagerService.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/ConnectionManagerService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 IBM Corporation and others.
+ * Copyright (c) 2011, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,6 +27,13 @@ import com.ibm.wsspi.resource.ResourceInfo;
  * Connection manager service.
  */
 public abstract class ConnectionManagerService extends Observable {
+
+    /**
+     * Name of property that determines whether or not to automatically close unshared connections
+     * that remain open when a HandleList goes out of scope. Also applies to non-dissociatable
+     * shared connections.
+     */
+    protected static final String AUTO_CLOSE_CONNECTIONS = "autoCloseConnections";
 
     /**
      * Name of element used for data source configuration.
@@ -74,6 +81,7 @@ public abstract class ConnectionManagerService extends Observable {
      */
     public static final List<String> CONNECTION_MANAGER_PROPS = Collections.unmodifiableList(Arrays.asList(
                                                                                                            J2CConstants.POOL_AgedTimeout,
+                                                                                                           AUTO_CLOSE_CONNECTIONS,
                                                                                                            J2CConstants.POOL_ConnectionTimeout,
                                                                                                            "enableSharingForDirectLookups",
                                                                                                            MAX_IDLE_TIME,

--- a/dev/com.ibm.ws.jca_fat_derbyra/bnd.bnd
+++ b/dev/com.ibm.ws.jca_fat_derbyra/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -27,8 +27,8 @@ tested.features:\
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
-	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
-	com.ibm.websphere.javaee.connector.1.6;version=latest,\
+	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
+	com.ibm.websphere.javaee.connector.1.7;version=latest,\
 	com.ibm.websphere.javaee.ejb.3.2;version=latest,\
 	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
 	com.ibm.ws.security.jaas.common;version=latest,\

--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
@@ -38,6 +38,7 @@ public class DerbyResourceAdapterTest extends FATServletClient {
 
     private static final String derbyRAAppName = "derbyRAAppName";
     private static final String DerbyRAAnnoServlet = "fvtweb/DerbyRAAnnoServlet";
+    private static final String DerbyRACFDServlet = "fvtweb/DerbyRACFDServlet";
     private static final String DerbyRAServlet = "fvtweb/DerbyRAServlet";
 
     @Server("com.ibm.ws.jca.fat.derbyra")
@@ -48,6 +49,7 @@ public class DerbyResourceAdapterTest extends FATServletClient {
 
         WebArchive war = ShrinkWrap.create(WebArchive.class, WAR_NAME + ".war");
         war.addPackage("web");
+        war.addPackage("web.cfd");
         war.addPackage("web.mdb");
         war.addAsWebInfResource(new File("test-applications/fvtweb/resources/WEB-INF/ibm-web-bnd.xml"));
         war.addAsWebInfResource(new File("test-applications/fvtweb/resources/WEB-INF/web.xml"));
@@ -131,14 +133,14 @@ public class DerbyResourceAdapterTest extends FATServletClient {
 
     @Test
     public void testConnectionFactoryDefinitionLeakedConnectionWithAutoCloseEnabled() throws Exception {
-        runTest(server, DerbyRAAnnoServlet, "testConnectionFactoryDefinitionLeakConnectionWithAutoCloseEnabled");
-        runTest(server, DerbyRAAnnoServlet, "testConnectionFactoryDefinitionLeakedConnectionWithAutoCloseEnabledClosed");
+        runTest(server, DerbyRACFDServlet, "testConnectionFactoryDefinitionLeakConnectionWithAutoCloseEnabled");
+        runTest(server, DerbyRACFDServlet, "testConnectionFactoryDefinitionLeakedConnectionWithAutoCloseEnabledClosed");
     }
 
     @Test
     public void testConnectionFactoryDefinitionLeakedConnectionWithAutoCloseDisabled() throws Exception {
-        runTest(server, DerbyRAAnnoServlet, "testConnectionFactoryDefinitionLeakConnectionWithAutoCloseDisabled");
-        runTest(server, DerbyRAAnnoServlet, "testConnectionFactoryDefinitionLeakedConnectionWithAutoCloseDisabledNotClosed");
+        runTest(server, DerbyRACFDServlet, "testConnectionFactoryDefinitionLeakConnectionWithAutoCloseDisabled");
+        runTest(server, DerbyRACFDServlet, "testConnectionFactoryDefinitionLeakedConnectionWithAutoCloseDisabledNotClosed");
     }
 
     @Test

--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
@@ -130,6 +130,18 @@ public class DerbyResourceAdapterTest extends FATServletClient {
     }
 
     @Test
+    public void testConnectionFactoryDefinitionLeakedConnectionWithAutoCloseEnabled() throws Exception {
+        runTest(server, DerbyRAAnnoServlet, "testConnectionFactoryDefinitionLeakConnectionWithAutoCloseEnabled");
+        runTest(server, DerbyRAAnnoServlet, "testConnectionFactoryDefinitionLeakedConnectionWithAutoCloseEnabledClosed");
+    }
+
+    @Test
+    public void testConnectionFactoryDefinitionLeakedConnectionWithAutoCloseDisabled() throws Exception {
+        runTest(server, DerbyRAAnnoServlet, "testConnectionFactoryDefinitionLeakConnectionWithAutoCloseDisabled");
+        runTest(server, DerbyRAAnnoServlet, "testConnectionFactoryDefinitionLeakedConnectionWithAutoCloseDisabledNotClosed");
+    }
+
+    @Test
     public void testExecutionContext() throws Exception {
         runTest(DerbyRAServlet);
     }

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/DerbyRAAnnoServlet.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/DerbyRAAnnoServlet.java
@@ -33,6 +33,8 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import javax.annotation.Resource;
 import javax.naming.InitialContext;
+import javax.resource.ConnectionFactoryDefinition;
+import javax.resource.ConnectionFactoryDefinitions;
 import javax.resource.spi.BootstrapContext;
 import javax.resource.spi.XATerminator;
 import javax.resource.spi.work.ExecutionContext;
@@ -51,6 +53,18 @@ import javax.transaction.xa.Xid;
 
 import componenttest.app.FATServlet;
 
+@ConnectionFactoryDefinitions({
+                                @ConnectionFactoryDefinition(
+                                                             name = "java:module/env/eis/ds6-auto-close-true",
+                                                             interfaceName = "javax.sql.DataSource",
+                                                             resourceAdapter = "DerbyRA",
+                                                             properties = "autoCloseConnections=true"),
+                                @ConnectionFactoryDefinition(
+                                                             name = "java:module/env/eis/ds7-auto-close-false",
+                                                             interfaceName = "javax.sql.DataSource",
+                                                             resourceAdapter = "DerbyRA",
+                                                             properties = "autoCloseConnections=false")
+})
 public class DerbyRAAnnoServlet extends FATServlet {
 
     private static final long serialVersionUID = 7440572626782340872L;
@@ -58,11 +72,20 @@ public class DerbyRAAnnoServlet extends FATServlet {
     @Resource(name = "java:global/env/eis/bootstrapContext", lookup = "eis/bootstrapContext")
     private BootstrapContext bootstrapContext;
 
+    // Intentionally left open by test after servlet method ends. Never do this in a real application.
+    private static Connection cachedConnection;
+
     @Resource(lookup = "eis/ds1")
     private CommonDataSource cds1;
 
     @Resource(name = "java:module/env/eis/ds1ref", lookup = "eis/ds1")
     private DataSource ds1;
+
+    @Resource(lookup = "java:module/env/eis/ds6-auto-close-true", shareable = false)
+    private DataSource ds6;
+
+    @Resource(lookup = "java:module/env/eis/ds7-auto-close-false", shareable = false)
+    private DataSource ds7;
 
     @Resource(name = "java:app/env/eis/map1ref", lookup = "eis/map1")
     private Map<String, String> map1;
@@ -176,6 +199,55 @@ public class DerbyRAAnnoServlet extends FATServlet {
             assertEquals("mdbtestRecovery: valueA --> valueB", oldValueFromDB);
         } finally {
             map1.clear();
+        }
+    }
+
+    /**
+     * First part of a test that leaves a connection handle open across the end of a servlet request
+     * and expects the container to automatically close it.
+     */
+    public void testConnectionFactoryDefinitionLeakConnectionWithAutoCloseEnabled() throws Throwable {
+        cachedConnection = ds6.getConnection();
+    }
+
+    /**
+     * First part of a test that leaves a connection handle open across the end of a servlet request
+     * and expects the container to leave it open.
+     */
+    public void testConnectionFactoryDefinitionLeakConnectionWithAutoCloseDisabled() throws Throwable {
+        cachedConnection = ds7.getConnection();
+    }
+
+    /**
+     * Second part of a test that leaves a connection handle open across the end of a servlet request
+     * and expects the container to automatically close it.
+     */
+    public void testConnectionFactoryDefinitionLeakedConnectionWithAutoCloseEnabledClosed() throws Throwable {
+        Connection con = cachedConnection;
+        try {
+            cachedConnection = null;
+            assertTrue(con.isClosed());
+        } finally {
+            con.close();
+        }
+    }
+
+    /**
+     * Second part of a test that leaves a connection handle open across the end of a servlet request
+     * and expects the container to leave it open. The connection must still be usable.
+     */
+    public void testConnectionFactoryDefinitionLeakedConnectionWithAutoCloseDisabledNotClosed() throws Throwable {
+        Connection con = cachedConnection;
+        try {
+            ResultSet result = con.createStatement().executeQuery("VALUES(7)");
+            assertTrue(result.next());
+            assertEquals(7, result.getInt(1));
+            Statement st = result.getStatement();
+            result.close();
+            st.close();
+        } finally {
+            cachedConnection = null;
+            con.close();
         }
     }
 

--- a/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/cfd/DerbyRAConnectionFactoryDefinitionServlet.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/cfd/DerbyRAConnectionFactoryDefinitionServlet.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package web.cfd;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import javax.annotation.Resource;
+import javax.resource.ConnectionFactoryDefinition;
+import javax.resource.ConnectionFactoryDefinitions;
+import javax.servlet.annotation.WebServlet;
+import javax.sql.DataSource;
+
+import componenttest.app.FATServlet;
+
+@ConnectionFactoryDefinitions({
+                                @ConnectionFactoryDefinition(
+                                                             name = "java:module/env/eis/ds6-auto-close-true",
+                                                             interfaceName = "javax.sql.DataSource",
+                                                             resourceAdapter = "DerbyRA",
+                                                             properties = "autoCloseConnections=true"),
+                                @ConnectionFactoryDefinition(
+                                                             name = "java:module/env/eis/ds7-auto-close-false",
+                                                             interfaceName = "javax.sql.DataSource",
+                                                             resourceAdapter = "DerbyRA",
+                                                             properties = "autoCloseConnections=false")
+})
+@WebServlet(urlPatterns = "/DerbyRACFDServlet")
+public class DerbyRAConnectionFactoryDefinitionServlet extends FATServlet {
+    private static final long serialVersionUID = 1L;
+
+    // Intentionally left open by test after servlet method ends. Never do this in a real application.
+    private static Connection cachedConnection;
+
+    @Resource(lookup = "java:module/env/eis/ds6-auto-close-true", shareable = false)
+    private DataSource ds6;
+
+    @Resource(lookup = "java:module/env/eis/ds7-auto-close-false", shareable = false)
+    private DataSource ds7;
+
+    /**
+     * First part of a test that leaves a connection handle open across the end of a servlet request
+     * and expects the container to automatically close it.
+     */
+    public void testConnectionFactoryDefinitionLeakConnectionWithAutoCloseEnabled() throws Throwable {
+        cachedConnection = ds6.getConnection();
+    }
+
+    /**
+     * First part of a test that leaves a connection handle open across the end of a servlet request
+     * and expects the container to leave it open.
+     */
+    public void testConnectionFactoryDefinitionLeakConnectionWithAutoCloseDisabled() throws Throwable {
+        cachedConnection = ds7.getConnection();
+    }
+
+    /**
+     * Second part of a test that leaves a connection handle open across the end of a servlet request
+     * and expects the container to automatically close it.
+     */
+    public void testConnectionFactoryDefinitionLeakedConnectionWithAutoCloseEnabledClosed() throws Throwable {
+        Connection con = cachedConnection;
+        try {
+            cachedConnection = null;
+            assertTrue(con.isClosed());
+        } finally {
+            con.close();
+        }
+    }
+
+    /**
+     * Second part of a test that leaves a connection handle open across the end of a servlet request
+     * and expects the container to leave it open. The connection must still be usable.
+     */
+    public void testConnectionFactoryDefinitionLeakedConnectionWithAutoCloseDisabledNotClosed() throws Throwable {
+        Connection con = cachedConnection;
+        try {
+            ResultSet result = con.createStatement().executeQuery("VALUES(7)");
+            assertTrue(result.next());
+            assertEquals(7, result.getInt(1));
+            Statement st = result.getStatement();
+            result.close();
+            st.close();
+        } finally {
+            cachedConnection = null;
+            con.close();
+        }
+    }
+}


### PR DESCRIPTION
When the connectionManager property autoCloseConnections is specified via ConnectionFactoryDefinition, the value should be honored.  Update the implementation and add tests.