### PR TITLE
Update mpConfig-2.0 to use released versions of MicroProfile and SmallRye Config

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -624,17 +624,17 @@
     <dependency>
       <groupId>io.smallrye.config</groupId>
       <artifactId>smallrye-config-common</artifactId>
-      <version>2.0.0-RC4</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.smallrye.config</groupId>
       <artifactId>smallrye-config-core</artifactId>
-      <version>2.0.0-RC4</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.smallrye.config</groupId>
       <artifactId>smallrye-config</artifactId>
-      <version>2.0.0-RC4</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.smallrye</groupId>

--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -624,12 +624,17 @@
     <dependency>
       <groupId>io.smallrye.config</groupId>
       <artifactId>smallrye-config-common</artifactId>
-      <version>2.0.0-RC1</version>
+      <version>2.0.0-RC4</version>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye.config</groupId>
+      <artifactId>smallrye-config-core</artifactId>
+      <version>2.0.0-RC4</version>
     </dependency>
     <dependency>
       <groupId>io.smallrye.config</groupId>
       <artifactId>smallrye-config</artifactId>
-      <version>2.0.0-RC1</version>
+      <version>2.0.0-RC4</version>
     </dependency>
     <dependency>
       <groupId>io.smallrye</groupId>
@@ -1724,7 +1729,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.config</groupId>
       <artifactId>microprofile-config-api</artifactId>
-      <version>2.0-RC15</version>
+      <version>2.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.context-propagation</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -120,9 +120,9 @@ io.smallrye.common:smallrye-common-classloader:1.5.0
 io.smallrye.common:smallrye-common-constraint:1.5.0
 io.smallrye.common:smallrye-common-expression:1.5.0
 io.smallrye.common:smallrye-common-function:1.5.0
-io.smallrye.config:smallrye-config-common:2.0.0-RC4
-io.smallrye.config:smallrye-config-core:2.0.0-RC4
-io.smallrye.config:smallrye-config:2.0.0-RC4
+io.smallrye.config:smallrye-config-common:2.0.0
+io.smallrye.config:smallrye-config-core:2.0.0
+io.smallrye.config:smallrye-config:2.0.0
 io.smallrye:smallrye-graphql-client-api:1.0.9
 io.smallrye:smallrye-graphql-client:1.0.9
 io.smallrye:smallrye-graphql-schema-model:1.0.9

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -121,6 +121,7 @@ io.smallrye.common:smallrye-common-constraint:1.5.0
 io.smallrye.common:smallrye-common-expression:1.5.0
 io.smallrye.common:smallrye-common-function:1.5.0
 io.smallrye.config:smallrye-config-common:2.0.0-RC4
+io.smallrye.config:smallrye-config-core:2.0.0-RC4
 io.smallrye.config:smallrye-config:2.0.0-RC4
 io.smallrye:smallrye-graphql-client-api:1.0.9
 io.smallrye:smallrye-graphql-client:1.0.9

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -120,8 +120,8 @@ io.smallrye.common:smallrye-common-classloader:1.5.0
 io.smallrye.common:smallrye-common-constraint:1.5.0
 io.smallrye.common:smallrye-common-expression:1.5.0
 io.smallrye.common:smallrye-common-function:1.5.0
-io.smallrye.config:smallrye-config-common:2.0.0-RC1
-io.smallrye.config:smallrye-config:2.0.0-RC1
+io.smallrye.config:smallrye-config-common:2.0.0-RC4
+io.smallrye.config:smallrye-config:2.0.0-RC4
 io.smallrye:smallrye-graphql-client-api:1.0.9
 io.smallrye:smallrye-graphql-client:1.0.9
 io.smallrye:smallrye-graphql-schema-model:1.0.9

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -341,7 +341,7 @@ org.eclipse.microprofile.config:microprofile-config-api:1.1
 org.eclipse.microprofile.config:microprofile-config-api:1.2.1
 org.eclipse.microprofile.config:microprofile-config-api:1.3
 org.eclipse.microprofile.config:microprofile-config-api:1.4
-org.eclipse.microprofile.config:microprofile-config-api:2.0-RC15
+org.eclipse.microprofile.config:microprofile-config-api:2.0
 org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.0
 org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.1
 org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:1.0

--- a/dev/io.openliberty.io.smallrye.config/bnd.bnd
+++ b/dev/io.openliberty.io.smallrye.config/bnd.bnd
@@ -30,7 +30,8 @@ Service-Component: \
       packages=io.smallrye.config\
         |io.smallrye.config.inject\
         |io.smallrye.config.common\
-        |io.smallrye.config.common.utils"
+        |io.smallrye.config.common.utils\
+        |io.smallrye.config.core"
 
 Include-Resource: \
   META-INF=resources/META-INF
@@ -45,6 +46,7 @@ Export-Package: \
   io.openliberty.io.smallrye.common;version=latest, \
   io.smallrye.config:smallrye-config;version=latest, \
   io.smallrye.config:smallrye-config-common;version=latest, \
+  io.smallrye.config:smallrye-config-core;version=latest, \
   com.ibm.websphere.javaee.cdi.2.0;version=latest, \
   com.ibm.websphere.javaee.annotation.1.3;version=latest, \
   io.openliberty.org.eclipse.microprofile.config.2.0;version=latest, \

--- a/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-tck</artifactId>
-            <version>2.0-RC15</version> 
+            <version>2.0</version> 
         </dependency>
 
         <dependency>


### PR DESCRIPTION
#build
#fat.buckets.to.run=io.openliberty.microprofile.config.2.0.internal_fat_tck,io.openliberty.microprofile.config.2.0.internal_fat

^^ This build command didn't work. See comment below.




