### PR TITLE
config updates to autoCloseConnections

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/ConfigTest.java
+++ b/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/ConfigTest.java
@@ -294,6 +294,59 @@ public class ConfigTest extends FATServletClient {
     }
 
     /**
+     * Update the autoCloseConnections attribute of a connectionManager element while the server is running.
+     * Verify that the updated value is honored.
+     */
+    @Test
+    public void testConfigChangeAutoCloseConnections() throws Throwable {
+        String method = "testConfigChangeAutoCloseConnections";
+        Log.info(c, method, "Executing " + method);
+
+        // Locate the connectionManager that we will be reconfiguring
+        ServerConfiguration config = server.getServerConfiguration();
+        ConnectionManager conMgr1 = null;
+        for (ConnectionManager connectionManager : config.getConnectionManagers())
+            if ("conMgr1".equals(connectionManager.getId()))
+                conMgr1 = connectionManager;
+        // Fail if we cannot find it
+        if (conMgr1 == null) {
+            System.out.println("Failure during " + method + " with the following config:");
+            System.out.println(config);
+            fail("Did not find connectionManager with id=conMgr1");
+        }
+
+        // First verify the default behavior
+        runTest(basicfat, "testConfigChangeAutoCloseConnectionsLeakConnection");
+        runTest(basicfat, "testConfigChangeAutoCloseConnectionsConnectionNotClosed"); // TODO update when the default switches
+
+        // TODO after the change to the default, swap the order of the next two blocks:
+
+        conMgr1.setAutoCloseConnections("true");
+        try {
+            updateServerConfig(config, EMPTY_EXPR_LIST);
+            runTest(basicfat, "testConfigChangeAutoCloseConnectionsLeakConnection");
+            runTest(basicfat, "testConfigChangeAutoCloseConnectionsConnectionClosed");
+        } catch (Throwable x) {
+            System.out.println("Failure during " + method + " with the following config:");
+            System.out.println(config);
+            throw x;
+        }
+
+        conMgr1.setAutoCloseConnections("false");
+        try {
+            updateServerConfig(config, EMPTY_EXPR_LIST);
+            runTest(basicfat, "testConfigChangeAutoCloseConnectionsLeakConnection");
+            runTest(basicfat, "testConfigChangeAutoCloseConnectionsConnectionNotClosed");
+        } catch (Throwable x) {
+            System.out.println("Failure during " + method + " with the following config:");
+            System.out.println(config);
+            throw x;
+        }
+
+        cleanUpExprs = EMPTY_EXPR_LIST;
+    }
+
+    /**
      * Update the data source configuration
      * from commitOrRollbackOnCleanup unspecified,
      * to commitOrRollbackOnCleanup=commit

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/ConnectionManager.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/ConnectionManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,9 @@ import javax.xml.bind.annotation.XmlAttribute;
  */
 public class ConnectionManager extends ConfigElement {
     private String agedTimeout;
+    private String autoCloseConnections;
     private String connectionTimeout;
+    private String enableSharingForDirectLookups;
     private String maxIdleTime;
     private String maxPoolSize;
     private String minPoolSize;
@@ -121,12 +123,30 @@ public class ConnectionManager extends ConfigElement {
     }
 
     @XmlAttribute
+    public void setAutoCloseConnections(String value) {
+        autoCloseConnections = value;
+    }
+
+    public String getAutoCloseConnections() {
+        return autoCloseConnections;
+    }
+
+    @XmlAttribute
     public void setConnectionTimeout(String connectionTimeout) {
         this.connectionTimeout = connectionTimeout;
     }
 
     public String getConnectionTimeout() {
         return connectionTimeout;
+    }
+
+    @XmlAttribute
+    public void setEnableSharingForDirectLookups(String value) {
+        enableSharingForDirectLookups = value;
+    }
+
+    public String getEnableSharingForDirectLookups() {
+        return enableSharingForDirectLookups;
     }
 
     @XmlAttribute
@@ -198,8 +218,12 @@ public class ConnectionManager extends ConfigElement {
         buf.append("id=\"" + (getId() == null ? "" : getId()) + "\" ");
         if (agedTimeout != null)
             buf.append("agedTimeout=\"" + agedTimeout + "\" ");
+        if (autoCloseConnections != null)
+            buf.append("autoCloseConnections=\"" + autoCloseConnections + "\" ");
         if (connectionTimeout != null)
             buf.append("connectionTimeout=\"" + connectionTimeout + "\" ");
+        if (enableSharingForDirectLookups != null)
+            buf.append("enableSharingForDirectLookups=\"" + enableSharingForDirectLookups + "\" ");
         if (maxIdleTime != null)
             buf.append("maxIdleTime=\"" + maxIdleTime + "\" ");
         if (maxPoolSize != null)


### PR DESCRIPTION
Add autoCloseConnections to the test infrastructure for updating a Liberty server while running.
Then add tests of updates to autoCloseConnections while the server is running.