### PR TITLE
Change JSP Version String with Transformation, Update JSP 2.3 FAT

### DIFF
--- a/dev/com.ibm.ws.jsp.2.3/src/com/ibm/ws/jsp23/translator/visitor/generator/GeneratorUtilsExtImpl.java
+++ b/dev/com.ibm.ws.jsp.2.3/src/com/ibm/ws/jsp23/translator/visitor/generator/GeneratorUtilsExtImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -91,7 +91,9 @@ public class GeneratorUtilsExtImpl implements GeneratorUtilsExt {
 
     @Override
     public String getClassFileVersion() {
-        return "2.3";
+         // See OL #12387
+         // Transformation Required Here for Pages 3.0
+         return "JSPVersion2.3".substring(10,13);
     }
 
     //PI59436 start

--- a/dev/com.ibm.ws.jsp.2.3/src/com/ibm/ws/jsp23/webcontainerext/JspVersionImpl.java
+++ b/dev/com.ibm.ws.jsp.2.3/src/com/ibm/ws/jsp23/webcontainerext/JspVersionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,8 @@ public class JspVersionImpl implements JspVersion {
 
     @Override
     public String getJspVersionString() {
-        return "2.3";
+         // See OL #12387
+         // Transformation Required Here for Pages 3.0
+         return "JSPVersion2.3".substring(10,13);
     }
 }

--- a/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSP23JSP22ServerTest.java
+++ b/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSP23JSP22ServerTest.java
@@ -82,8 +82,9 @@ public class JSP23JSP22ServerTest {
      *
      * @throws Exception
      */
+    @SkipForRepeat(SkipForRepeat.EE9_FEATURES) // Only Regular Run
     @Test
-    public void testJspFeatureChange() throws Exception {
+    public void testJsp23to22FeatureChange() throws Exception {
         WebConversation wc = new WebConversation();
         wc.setExceptionsThrownOnErrorStatus(false);
 
@@ -110,6 +111,37 @@ public class JSP23JSP22ServerTest {
         LOG.info("Response from a 2.2 compilation: " + response.getText());
 
         assertTrue("The response did not contain: JSP version: 2.2", response.getText().contains("JSP version: 2.2"));
+
+    }
+    @SkipForRepeat(SkipForRepeat.NO_MODIFICATION) // Only for EE9 Run 
+    @Test
+    public void testPages30to23FeatureChange() throws Exception {
+        WebConversation wc = new WebConversation();
+        wc.setExceptionsThrownOnErrorStatus(false);
+
+        LOG.info("Requesting JSP with pages-3.0 feature enabled");
+
+        String url = JSPUtils.createHttpUrlString(server, APP_NAME, "testJspFeatureChange.jsp");
+        LOG.info("url: " + url);
+
+        WebRequest request = new GetMethodWebRequest(url);
+        WebResponse response = wc.getResponse(request);
+        LOG.info("Response from a 3.0 compilation: " + response.getText());
+
+        assertTrue("The response did not contain: Pages version: 3.0", response.getText().contains("JSP version: 3.0"));
+
+        List<String> jsp22Feature = new ArrayList<String>();
+        jsp22Feature.add("jsp-2.3");
+        server.changeFeatures(jsp22Feature);
+        server.waitForConfigUpdateInLogUsingMark(Collections.singleton("TestJspFeatureChange"), true, new String[0]);
+
+        LOG.info("Requesting JSP with jsp-2.3 feature enabled");
+
+        response = wc.getResponse(request);
+
+        LOG.info("Response from a 2.3 compilation: " + response.getText());
+
+        assertTrue("The response did not contain: JSP version: 2.3", response.getText().contains("JSP version: 2.3"));
 
     }
 }

--- a/dev/wlp-jakartaee-transform/rules/jakarta-direct.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-direct.properties
@@ -63,7 +63,7 @@ javax.servlet.jsp.jstl.sql.userName=jakarta.servlet.jsp.jstl.sql.userName
 # Jakarta Server Faces
 javax.faces.validator.beanValidator.ValidatorFactory=jakarta.faces.validator.beanValidator.ValidatorFactory
 
-# Jakarta Server Pages TLD Locations
+# Jakarta Server Pages
 /javax/servlet/jsp/resources/web-jsptaglibrary_1_1.dtd=/jakarta/servlet/jsp/resources/web-jsptaglibrary_1_1.dtd
 /javax/servlet/jsp/resources/web-jsptaglibrary_1_2.dtd=/jakarta/servlet/jsp/resources/web-jsptaglibrary_1_2.dtd
 /javax/servlet/jsp/resources/web-jsptaglibrary_2_0.xsd=/jakarta/servlet/jsp/resources/web-jsptaglibrary_2_0.xsd
@@ -72,6 +72,7 @@ javax.faces.validator.beanValidator.ValidatorFactory=jakarta.faces.validator.bea
 /javax/servlet/resources/j2ee_1_4.xsd=/jakarta/servlet/resources/j2ee_1_4.xsd
 /javax/servlet/resources/j2ee_web_services_client_1_1.xsd=/jakarta/servlet/resources/j2ee_web_services_client_1_1.xsd
 /javax/servlet/resources/xml.xsd=/jakarta/servlet/resources/xml.xsd
+JSPVersion2.3=JSPVersion3.0
 
 # Batch 
 # CDI types


### PR DESCRIPTION
Potential fix for #12387 that uses the transformer

Instead of 2.3=3.0, we have a rule for JSPVersion2.3=JSPVersion3.0 since "2.3" and "3.0" are too general.
