### PR TITLE
 info message with leaked connection stack

### DIFF
--- a/dev/com.ibm.ws.container.service.compat/src/com/ibm/ws/jca/cm/handle/HandleList.java
+++ b/dev/com.ibm.ws.container.service.compat/src/com/ibm/ws/jca/cm/handle/HandleList.java
@@ -42,7 +42,7 @@ public class HandleList implements HandleListInterface {
             for (int i = numToClose; i > 0;) {
                 HandleDetails r = list[--i];
                 list[i] = null;
-                r.close();
+                r.close(true);
             }
         }
     }

--- a/dev/com.ibm.ws.container.service.compat/src/com/ibm/ws/jca/cm/handle/HandleListInterface.java
+++ b/dev/com.ibm.ws.container.service.compat/src/com/ibm/ws/jca/cm/handle/HandleListInterface.java
@@ -17,7 +17,7 @@ package com.ibm.ws.jca.cm.handle;
  */
 public interface HandleListInterface {
     interface HandleDetails {
-        void close();
+        void close(boolean leaked);
 
         // used by removeHandle to determine if this handle details instance pertains to the specified handle
         boolean forHandle(Object h);

--- a/dev/com.ibm.ws.jca.cm/resources/com/ibm/ws/jca/cm/internal/resources/J2CAMessages.nlsprops
+++ b/dev/com.ibm.ws.jca.cm/resources/com/ibm/ws/jca/cm/internal/resources/J2CAMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011 IBM Corporation and others.
+# Copyright (c) 2011,2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -73,3 +73,7 @@ INVALID_MBEAN_INVOKE_ACTION_J2CA8061.useraction=Change the action being invoked 
 MBEAN_ATTRIBUTE_NOT_FOUND_J2CA8062=J2CA8062E: The {0} attribute is not valid for the {1} MBean.
 MBEAN_ATTRIBUTE_NOT_FOUND_J2CA8062.explanation=An attempt was made to get or set an attribute that was not available for the specified MBean.
 MBEAN_ATTRIBUTE_NOT_FOUND_J2CA8062.useraction=Change the attribute specified to one of the available attributes for this MBean.
+
+CONNECTION_LEAK_DETECTED_J2CA8070=J2CA8070I: A connection that was obtained from {0} was not closed. The following stack identifies the code that obtained the connection: {1}
+CONNECTION_LEAK_DETECTED_J2CA8070.explanation=A connection was not closed by the code that obtained it. The stack identifies one area of the code where this is occurring, but there might also be others. In order to avoid cluttering the logs and minimize the impact of collecting stacks, only one occurrence is reported per server start.
+CONNECTION_LEAK_DETECTED_J2CA8070.useraction=Using the stack as a guide, locate the code that requests the connection and update it to close the connection.

--- a/dev/com.ibm.ws.jca.cm/resources/com/ibm/ws/jca/cm/internal/resources/J2CAMessages.nlsprops
+++ b/dev/com.ibm.ws.jca.cm/resources/com/ibm/ws/jca/cm/internal/resources/J2CAMessages.nlsprops
@@ -75,5 +75,5 @@ MBEAN_ATTRIBUTE_NOT_FOUND_J2CA8062.explanation=An attempt was made to get or set
 MBEAN_ATTRIBUTE_NOT_FOUND_J2CA8062.useraction=Change the attribute specified to one of the available attributes for this MBean.
 
 CONNECTION_LEAK_DETECTED_J2CA8070=J2CA8070I: A connection that was obtained from {0} was not closed. The following stack identifies the code that obtained the connection: {1}
-CONNECTION_LEAK_DETECTED_J2CA8070.explanation=A connection was not closed by the code that obtained it. The stack identifies one area of the code where this is occurring, but there might also be others. In order to avoid cluttering the logs and minimize the impact of collecting stacks, only one occurrence is reported per server start.
+CONNECTION_LEAK_DETECTED_J2CA8070.explanation=A connection was not closed by the code that obtained it. The stack identifies one area of the code where an unclosed connection occurs, but other instances might exist elsewhere. To avoid cluttering the logs and minimize the impact of collecting stacks, only one occurrence is reported per server start.
 CONNECTION_LEAK_DETECTED_J2CA8070.useraction=Using the stack as a guide, locate the code that requests the connection and update it to close the connection.

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/HCMDetails.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/HCMDetails.java
@@ -12,7 +12,9 @@ package com.ibm.ejs.j2c;
 
 import java.lang.reflect.Method;
 import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.security.PrivilegedExceptionAction;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.resource.spi.ConnectionRequestInfo;
 import javax.security.auth.Subject;
@@ -22,14 +24,25 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.jca.cm.handle.HandleListInterface;
 
-public class HCMDetails implements HandleListInterface.HandleDetails {
+public class HCMDetails implements HandleListInterface.HandleDetails, PrivilegedAction<StackTraceElement[]> {
     private static final TraceComponent tc = Tr.register(HCMDetails.class, J2CConstants.traceSpec, J2CConstants.NLS_FILE);
+
+    /**
+     * Indicates if a connection leak has ever been observed.
+     */
+    private static final AtomicBoolean connectionLeakOccurred = new AtomicBoolean();
+
+    /**
+     * Indicates if the stack of a connection leak has been reported to the user.
+     */
+    private static final AtomicBoolean connectionLeakStackReported = new AtomicBoolean();
 
     public final ConnectionManager _cm;
     public final Object _handle;
     public MCWrapper _mcWrapper;
     public final Subject _subject;
     public final ConnectionRequestInfo _cRequestInfo;
+    private StackTraceElement[] stackOfAllocateConnection;
 
     HCMDetails(ConnectionManager cm,
                java.lang.Object handle,
@@ -41,14 +54,32 @@ public class HCMDetails implements HandleListInterface.HandleDetails {
         _mcWrapper = mcWrapper;
         _subject = subject;
         _cRequestInfo = cRequestInfo;
+
+        // Capture thread stacks after the first connection leak is observed, up until a connection leak stack gets reported.
+        if (connectionLeakOccurred.get() && !connectionLeakStackReported.get()) {
+            stackOfAllocateConnection = AccessController.doPrivileged(this);
+        }
     }
 
     @Override
-    public void close() {
+    public void close(boolean leaked) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
-            Tr.entry(this, tc, "close", _handle);
+            Tr.entry(this, tc, "close", leaked ? ("leaked " + _handle) : _handle);
 
         try {
+            if (leaked
+                && !connectionLeakOccurred.compareAndSet(false, true) // it's not the first time a connection leak occurred
+                && stackOfAllocateConnection != null) { // and we have the stack for it
+
+                // Report the first captured connection leak stack to the user, and any others to trace
+                if (connectionLeakStackReported.compareAndSet(false, true)) {
+                    Tr.info(tc, "CONNECTION_LEAK_DETECTED_J2CA8070", _cm.gConfigProps.cfName, printableStackOfAllocate());
+                } else if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
+                    Tr.event(this, tc, "Connection leak detected for " + _cm.gConfigProps.cfName + ". Stack of allocate:",
+                             printableStackOfAllocate());
+                }
+            }
+
             if (_handle instanceof java.sql.Connection)
                 ((java.sql.Connection) _handle).close();
             else if (_handle instanceof javax.resource.cci.Connection)
@@ -112,6 +143,23 @@ public class HCMDetails implements HandleListInterface.HandleDetails {
             Tr.exit(this, tc, "park");
     }
 
+    /**
+     * Format the connection allocation stack trace with one StackTraceElement on each line and some indentation.
+     *
+     * @return stack trace formatted as printable text.
+     */
+    private String printableStackOfAllocate() {
+        final String EOLN = String.format("%n");
+        StringBuilder s = new StringBuilder();
+        boolean include = false;
+        for (StackTraceElement line : stackOfAllocateConnection)
+            if (include)
+                s.append(EOLN).append("    ").append(line);
+            else // skip the portion of the stack above the constructor of this class
+                include = "<init>".equals(line.getMethodName());
+        return s.toString();
+    }
+
     @Override
     public void reassociate() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
@@ -145,5 +193,15 @@ public class HCMDetails implements HandleListInterface.HandleDetails {
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
             Tr.exit(this, tc, "reassociate");
+    }
+
+    /**
+     * Privileged action to obtain the current stack.
+     *
+     * @return the current thread stack.
+     */
+    @Override
+    public StackTraceElement[] run() {
+        return Thread.currentThread().getStackTrace();
     }
 }

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/MCWrapper.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/MCWrapper.java
@@ -3212,7 +3212,7 @@ public final class MCWrapper implements com.ibm.ws.j2c.MCWrapper, JCAPMIHelper {
         // of close sends another connectionClosed event, the inline processing of which would otherwise
         // interfere with the iterator.
         for (HandleDetails h : handlesToClose)
-            h.close();
+            h.close(false);
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/JDBCLoadFromAppTest.java
@@ -10,7 +10,10 @@
  *******************************************************************************/
 package com.ibm.ws.jdbc.fat.loadfromapp;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.File;
+import java.util.List;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -97,9 +100,15 @@ public class JDBCLoadFromAppTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer("CWWKS1148E(?=.*LoadFromAppLoginModule)(?=.*derbyApp)", // Intentional error: loginmod.LoadFromAppLoginModule not found in derbyApp
-                          "CWWKS1148E(?=.*LoadFromWebAppLoginModule)(?=.*otherApp)", // Intentional error: web.derby.LoadFromWebAppLoginModule not found in otherApp
-                          "SRVE9967W.*derbyLocale" // ignore missing Derby locales
-        );
+        try {
+            // Must find exactly 1 warning for connection leaks after running tests:
+            List<String> connectionLeakWarnings = server.findStringsInLogs("J2CA8070I");
+            assertEquals(connectionLeakWarnings.toString(), 1, connectionLeakWarnings.size());
+        } finally {
+            server.stopServer("CWWKS1148E(?=.*LoadFromAppLoginModule)(?=.*derbyApp)", // Intentional error: loginmod.LoadFromAppLoginModule not found in derbyApp
+                              "CWWKS1148E(?=.*LoadFromWebAppLoginModule)(?=.*otherApp)", // Intentional error: web.derby.LoadFromWebAppLoginModule not found in otherApp
+                              "SRVE9967W.*derbyLocale" // ignore missing Derby locales
+            );
+        }
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_v43/fat/src/com/ibm/ws/jdbc/fat/v43/JDBC43Test.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/fat/src/com/ibm/ws/jdbc/fat/v43/JDBC43Test.java
@@ -10,7 +10,10 @@
  *******************************************************************************/
 package com.ibm.ws.jdbc.fat.v43;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.File;
+import java.util.List;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.importer.ZipImporter;
@@ -75,15 +78,21 @@ public class JDBC43Test extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer("DSRA0302E.*XA_RBOTHER", // raised by mock JDBC driver for XA operations after abort
-                          "DSRA0302E.*XA_RBROLLBACK", // expected when invoking end on JDBC driver during an abort
-                          "DSRA0304E", // expected when invoking end on JDBC driver during an abort
-                          "DSRA8790W", // expected for begin/endRequest invoked by application being ignored
-                          "J2CA0045E.*poolOf1", // expected when testing that no more connections are available
-                          "J2CA0081E", // TODO why does Derby think a transaction is still active?
-                          "WLTC0018E", // TODO remove once transactions bug is fixed
-                          "WLTC0032W", // local tran rolled back, expected when trying to keep unshared connection open across servlet boundary
-                          "WLTC0033W.*poolOf2"); // same reason as above
+        try {
+            // Must find exactly 1 warning for connection leaks after running tests:
+            List<String> connectionLeakWarnings = server.findStringsInLogs("J2CA8070I");
+            assertEquals(connectionLeakWarnings.toString(), 1, connectionLeakWarnings.size());
+        } finally {
+            server.stopServer("DSRA0302E.*XA_RBOTHER", // raised by mock JDBC driver for XA operations after abort
+                              "DSRA0302E.*XA_RBROLLBACK", // expected when invoking end on JDBC driver during an abort
+                              "DSRA0304E", // expected when invoking end on JDBC driver during an abort
+                              "DSRA8790W", // expected for begin/endRequest invoked by application being ignored
+                              "J2CA0045E.*poolOf1", // expected when testing that no more connections are available
+                              "J2CA0081E", // TODO why does Derby think a transaction is still active?
+                              "WLTC0018E", // TODO remove once transactions bug is fixed
+                              "WLTC0032W", // local tran rolled back, expected when trying to keep unshared connection open across servlet boundary
+                              "WLTC0033W.*poolOf2"); // same reason as above
+        }
     }
 
     /**


### PR DESCRIPTION
After the first connection leak, capture stacks of subsequent getConnection requests to log a message to the user upon the occurrence of the next connection leak.  Additional connection leak stacks that were recorded but which we do not report the user can be logged to trace.