### PR TITLE
Handle apps with no Application but web.xmls specifying "Application"

### DIFF
--- a/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/component/RESTfulServletContainerInitializer.java
+++ b/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/component/RESTfulServletContainerInitializer.java
@@ -84,7 +84,7 @@ public class RESTfulServletContainerInitializer extends ResteasyServletInitializ
         }
 
         if (appClasses.size() == 0) {
-            return;
+            appClasses.add(Application.class);
         }
 
         for (Class<?> app : appClasses) {
@@ -228,7 +228,8 @@ public class RESTfulServletContainerInitializer extends ResteasyServletInitializ
             String servletClassName = reg.getClassName();
             if (IBM_REST_SERVLET_NAME.equals(servletClassName) ||
                 RESTEASY_DISPATCHER_NAME.equals(servletClassName) ||
-                RESTEASY_DISPATCHER_30_NAME.equals(servletClassName)) {
+                RESTEASY_DISPATCHER_30_NAME.equals(servletClassName) ||
+                Application.class.getName().equals(reg.getName())) {
                 if (mapped) {
                     Tr.warning(tc, "MULTIPLE_REST_SERVLETS_CWWKW1300W", ctx.getServletContextName());
                 }

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/WebXmlNoAppTest.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/WebXmlNoAppTest.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS30.fat;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.restfulWS30.fat.webXmlNoApp.WebXmlNoAppTestServlet;
+
+/**
+ * Tests whether a class can be both an <code>Application</code> subclass
+ * <em>and<em> a resource class.
+ */
+@RunWith(FATRunner.class)
+public class WebXmlNoAppTest extends FATServletClient {
+
+    public static final String APP_NAME = "webXmlNoApp";
+    public static final String SERVER_NAME = APP_NAME;
+    private static final String WEB_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                    + "<web-app version=\"5.0\" xmlns=\"https://jakarta.ee/xml/ns/jakartaee\"\n"
+                    + "   xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+                    + "   xsi:schemaLocation=\"https://jakarta.ee/xml/ns/jakartaee \n"
+                    + "   https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd\">\n"
+                    + "\n"
+                    + "    <servlet>\n"
+                    + "        <servlet-name>jakarta.ws.rs.core.Application</servlet-name>\n"
+                    + "    </servlet>\n"
+                    + "    <servlet-mapping>\n"
+                    + "        <servlet-name>jakarta.ws.rs.core.Application</servlet-name>\n"
+                    + "        <url-pattern>/pathFromWebXml/*</url-pattern>\n"
+                    + "    </servlet-mapping>\n"
+                    + "</web-app>" ;
+
+    @Server(SERVER_NAME)
+    @TestServlet(servlet = WebXmlNoAppTestServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addAsWebInfResource(new StringAsset(WEB_XML), "web.xml")
+                        .addPackages(true, WebXmlNoAppTestServlet.class.getPackage());
+
+        ShrinkHelper.exportDropinAppToServer(server, war, DeployOptions.SERVER_ONLY);
+
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/webXmlNoApp/BarResource.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/webXmlNoApp/BarResource.java
@@ -8,21 +8,13 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package io.openliberty.restfulWS30.fat;
+package io.openliberty.restfulWS30.fat.webXmlNoApp;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Produces;
 
-@RunWith(Suite.class)
-@SuiteClasses({
-                AppAndResourceTest.class,
-                JsonbTest.class,
-                ValidatorTest.class,
-                WebXmlNoAppTest.class,
-                XmlWithJaxbTest.class,
-                XmlWithoutJaxbTest.class
-})
-public class FATSuite {
-
+public interface BarResource {
+    @GET
+    @Produces("application/json")
+    String bar();
 }

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/webXmlNoApp/BarResourceImpl.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/webXmlNoApp/BarResourceImpl.java
@@ -8,21 +8,20 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package io.openliberty.restfulWS30.fat;
+package io.openliberty.restfulWS30.fat.webXmlNoApp;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
 
-@RunWith(Suite.class)
-@SuiteClasses({
-                AppAndResourceTest.class,
-                JsonbTest.class,
-                ValidatorTest.class,
-                WebXmlNoAppTest.class,
-                XmlWithJaxbTest.class,
-                XmlWithoutJaxbTest.class
-})
-public class FATSuite {
+@Path("bar")
+public class BarResourceImpl implements BarResource {
+
+    @GET
+    @Produces({"text/html"})
+    @Override
+    public String bar() {
+        return "<html><head><title>Bar</title></head><body>Bar</body></html>";
+    }
 
 }

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/webXmlNoApp/FooResource.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/webXmlNoApp/FooResource.java
@@ -8,21 +8,13 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package io.openliberty.restfulWS30.fat;
+package io.openliberty.restfulWS30.fat.webXmlNoApp;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Produces;
 
-@RunWith(Suite.class)
-@SuiteClasses({
-                AppAndResourceTest.class,
-                JsonbTest.class,
-                ValidatorTest.class,
-                WebXmlNoAppTest.class,
-                XmlWithJaxbTest.class,
-                XmlWithoutJaxbTest.class
-})
-public class FATSuite {
-
+public interface FooResource {
+    @GET
+    @Produces("text/plain")
+    String foo();
 }

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/webXmlNoApp/FooResourceImpl.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/webXmlNoApp/FooResourceImpl.java
@@ -8,21 +8,16 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package io.openliberty.restfulWS30.fat;
+package io.openliberty.restfulWS30.fat.webXmlNoApp;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import jakarta.ws.rs.Path;
 
-@RunWith(Suite.class)
-@SuiteClasses({
-                AppAndResourceTest.class,
-                JsonbTest.class,
-                ValidatorTest.class,
-                WebXmlNoAppTest.class,
-                XmlWithJaxbTest.class,
-                XmlWithoutJaxbTest.class
-})
-public class FATSuite {
+@Path("foo")
+public class FooResourceImpl implements FooResource {
+
+    @Override
+    public String foo() {
+        return "foo";
+    }
 
 }

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/webXmlNoApp/WebXmlNoAppTestServlet.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/webXmlNoApp/WebXmlNoAppTestServlet.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS30.fat.webXmlNoApp;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+
+import jakarta.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet("/WebXmlNoAppTestServlet")
+public class WebXmlNoAppTestServlet extends FATServlet {
+
+    @Test
+    public void testCanInvokeResourceClassWithMethodAnnotationsInheritedFromInterface() throws Exception {
+        URI uri = URI.create("http://localhost:" + System.getProperty("bvt.prop.HTTP_default") + "/webXmlNoApp/pathFromWebXml/foo");
+        HttpURLConnection conn = (HttpURLConnection) uri.toURL().openConnection();
+        assertEquals(200, conn.getResponseCode());
+        assertEquals("foo", readEntity(conn.getInputStream()));
+    }
+
+    @Test
+    public void testCanInvokeResourceClassWithMethodAnnotationsOverridingInterface() throws Exception {
+        URI uri = URI.create("http://localhost:" + System.getProperty("bvt.prop.HTTP_default") + "/webXmlNoApp/pathFromWebXml/bar");
+        HttpURLConnection conn = (HttpURLConnection) uri.toURL().openConnection();
+        assertEquals(200, conn.getResponseCode());
+        assertEquals("<html><head><title>Bar</title></head><body>Bar</body></html>", readEntity(conn.getInputStream()));
+    }
+
+    private String readEntity(InputStream is) throws Exception {
+        StringBuilder sb = new StringBuilder();
+        byte[] b = new byte[256];
+        int i = is.read(b);
+        while (i > 0) {
+            sb.append(new String(b, 0, i));
+            i = is.read(b);
+        }
+        return sb.toString().trim();
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/webXmlNoApp/bootstrap.properties
+++ b/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/webXmlNoApp/bootstrap.properties
@@ -1,0 +1,3 @@
+bootstrap.include=../testports.properties
+#com.ibm.ws.logging.max.files=1
+#com.ibm.ws.logging.trace.specification=LogService=all:RESTfulWS=all

--- a/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/webXmlNoApp/server.xml
+++ b/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/webXmlNoApp/server.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<server>
+    <featureManager>
+        <feature>componenttest-2.0</feature>
+        <feature>restfulWS-3.0</feature>
+    </featureManager>
+    <include location="../fatTestPorts.xml"/>
+    
+    <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
+    <javaPermission className="java.net.URLPermission" name="http://localhost:8010/webXmlNoApp/-" actions="GET:"/>
+</server>


### PR DESCRIPTION
Resolves a TCK issue where the app contains only resource classes (no Application subclass), but web.xml specifies `jakarta.ws.rs.core.Application` as the servlet name.