### PR TITLE
11793 - return HTTP 415 when JAX-RS request Content-Type header contains an invalid charset

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
@@ -188,7 +188,8 @@ instrument.classesExcludes: com/ibm/ws/jaxrs20/internal/resources/*.class, \
 	com.ibm.websphere.appserver.spi.threading, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
 	com.ibm.ws.jaxrs.2.x.config;version=latest,\
-	javax.activation:activation;version=1.1
+	javax.activation:activation;version=1.1, \
+	com.ibm.ws.webcontainer;version=latest
 
 -testpath: \
 	org.hamcrest:hamcrest-all;version=1.3, \

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/endpoint/AbstractJaxRsWebEndpoint.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/endpoint/AbstractJaxRsWebEndpoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,11 +18,9 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.BadRequestException;
 
 import org.apache.cxf.jaxrs.utils.HttpUtils;
 import org.apache.cxf.transport.http.AbstractHTTPDestination;
-import org.apache.cxf.transport.http.InvalidCharsetException;
 import org.apache.cxf.transport.servlet.BaseUrlHelper;
 
 import com.ibm.websphere.ras.Tr;
@@ -135,9 +133,6 @@ public abstract class AbstractJaxRsWebEndpoint implements JaxRsWebEndpoint {
             updateDestination(request);
             destination.invoke(servletConfig, servletConfig.getServletContext(), request, response);
         } catch (IOException e) {
-            if (e instanceof InvalidCharsetException) {
-                throw new BadRequestException(e);
-            }
             throw new ServletException(e);
         } catch (JaxRsRuntimeException ex) {
             throw new ServletException(ex.getCause());

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
@@ -82,6 +82,7 @@ import org.apache.cxf.ws.addressing.EndpointReferenceUtils;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.webcontainer.exception.InvalidMediaTypeException;
 
 /**
  * Common base for HTTP Destination implementations.
@@ -464,9 +465,9 @@ public abstract class AbstractHTTPDestination
             String normalizedEncoding = HttpHeaderHelper.mapCharset(enc);
             if (normalizedEncoding == null) {
                 // Liberty Change Start
-                String m = "Invalid encoding: " + enc;
+                String m = "Invalid MediaType encoding: " + enc;
                 Tr.warning(tc, m);
-                throw new InvalidCharsetException(m);
+                throw new InvalidMediaTypeException(m); // throw so webcontainer returns a 415
                 // Liberty Change End
             }
             inMessage.put(Message.ENCODING, normalizedEncoding);

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/helloworld/HelloWorldTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/helloworld/HelloWorldTest.java
@@ -27,7 +27,9 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
+import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
@@ -55,7 +57,7 @@ public class HelloWorldTest {
     @AfterClass
     public static void tearDown() throws Exception {
         if (server != null) {
-            server.stopServer();
+            server.stopServer("SRVE0315E", "SRVE0777E");
         }
     }
 
@@ -94,10 +96,11 @@ public class HelloWorldTest {
         runGetMethod(200, "/helloworld/apppathrest%21/helloworld", "Hello World");
     }
 
-    // disable this test until webcontainer fixes on their end as well
-//    @Test
+    @Test
+    @SkipForRepeat("EE9_FEATURES")
+    @ExpectedFFDC("com.ibm.ws.webcontainer.exception.InvalidMediaTypeException")
     public void testInvalidCharset() throws Exception {
-        assertEquals(400, runGetMethodInvalidCharset("/helloworld/rest/helloworld"));
+        assertEquals(415, runGetMethodInvalidCharset("/helloworld/rest/helloworld"));
     }
 
     private StringBuilder runGetMethod(int exprc, String requestUri, String testOut)

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/json/UTF8Test.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/json/UTF8Test.java
@@ -78,4 +78,9 @@ public class UTF8Test extends AbstractTest {
     public void testCountriesLowerCase() throws Exception {
         this.runTestOnServer(target, "testCountriesLowerCase", null, "OK");
     }
+
+    @Test
+    public void testInvalidBody() throws Exception {
+        this.runTestOnServer(target, "testInvalidBody", null, "400");
+    }
 }

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.json/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.json/server.xml
@@ -6,4 +6,5 @@
     
   	<include location="../fatTestPorts.xml"/>
   	<javaPermission className="java.io.FilePermission" name="ALL FILES" actions="read"/>
+  	<javaPermission className="java.security.AllPermission"/> <!-- TODO replace with URLPermission once it permits wildcards-->
 </server>

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/json/src/com/ibm/ws/jaxrs/fat/json/ClientTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/json/src/com/ibm/ws/jaxrs/fat/json/ClientTestServlet.java
@@ -12,10 +12,17 @@ package com.ibm.ws.jaxrs.fat.json;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.ProtocolException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -110,5 +117,36 @@ public class ClientTestServlet extends HttpServlet {
         assertEquals("danmark", countries[0].getName());
         assertEquals("ægypten", countries[1].getName());
         ret.append("OK");
+    }
+
+    public void testInvalidBody(Map<String, String> param, StringBuilder ret) throws ProtocolException, MalformedURLException, IOException {
+        ret.append(sendInvalidJson("rest/country/returnCapital"));
+    }
+
+    protected int sendInvalidJson(String path) throws ProtocolException, MalformedURLException, IOException {
+        URL url = new URL(getAddress(path));
+        HttpURLConnection con = (HttpURLConnection)url.openConnection();
+        con.setRequestMethod("POST");
+        con.setRequestProperty("Content-Type", "application/json");
+        con.setRequestProperty("Accept", "application/json");
+        con.setDoOutput(true);
+
+        String jsonInputString = "invalid json";
+
+        try(OutputStream os = con.getOutputStream()) {
+            byte[] input = jsonInputString.getBytes("utf-8");
+            os.write(input, 0, input.length);
+        }
+
+        try(BufferedReader br = new BufferedReader(
+                                                   new InputStreamReader(con.getInputStream(), "utf-8"))) {
+                                                     StringBuilder response = new StringBuilder();
+                                                     String responseLine = null;
+                                                     while ((responseLine = br.readLine()) != null) {
+                                                         response.append(responseLine.trim());
+                                                     }
+                                                     System.out.println(response.toString());
+                                                 }
+        return con.getResponseCode();
     }
 }

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/json/src/com/ibm/ws/jaxrs/fat/json/CountryInfo.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/json/src/com/ibm/ws/jaxrs/fat/json/CountryInfo.java
@@ -8,16 +8,9 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package org.apache.cxf.transport.http;
+package com.ibm.ws.jaxrs.fat.json;
 
-import java.io.IOException;
-
-public class InvalidCharsetException extends IOException {
-
-    public InvalidCharsetException(String m) {
-        super(m);
-    }
-
-    private static final long serialVersionUID = 1676878985438910205L;
-
+public class CountryInfo {
+    public String name;
+    public String capital;
 }

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/json/src/com/ibm/ws/jaxrs/fat/json/UTF8Resource.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/json/src/com/ibm/ws/jaxrs/fat/json/UTF8Resource.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
@@ -39,5 +40,13 @@ public class UTF8Resource {
         countries.add(new Country("DK", "danmark"));
         countries.add(new Country("EG", "ægypten"));
         return countries.toArray(new Country[countries.size()]);
+    }
+
+    @POST
+    @Path("/returnCapital")
+    @Produces(MediaType.APPLICATION_JSON)
+    public String returnCapital(CountryInfo countryInfo) {
+        // should blow up trying to read invalid json from client
+        return countryInfo.capital;
     }
 }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs20/endpoint/AbstractJaxRsWebEndpoint.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs20/endpoint/AbstractJaxRsWebEndpoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,11 +18,9 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.BadRequestException;
 
 import org.apache.cxf.jaxrs.utils.HttpUtils;
 import org.apache.cxf.transport.http.AbstractHTTPDestination;
-import org.apache.cxf.transport.http.InvalidCharsetException;
 import org.apache.cxf.transport.servlet.BaseUrlHelper;
 
 import com.ibm.websphere.ras.Tr;
@@ -135,9 +133,6 @@ public abstract class AbstractJaxRsWebEndpoint implements JaxRsWebEndpoint {
             updateDestination(request);
             destination.invoke(servletConfig, servletConfig.getServletContext(), request, response);
         } catch (IOException e) {
-            if (e instanceof InvalidCharsetException) {
-                throw new BadRequestException(e);
-            }
             throw new ServletException(e);
         } catch (JaxRsRuntimeException ex) {
             throw new ServletException(ex.getCause());

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/bnd.bnd
@@ -24,6 +24,7 @@
   com.ibm.ws.logging.core,\
   com.ibm.ws.org.apache.cxf.cxf.core.3.2;version=latest,\
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-  com.ibm.wsspi.org.osgi.core
+  com.ibm.wsspi.org.osgi.core, \
+  com.ibm.ws.webcontainer;version=latest
 
 jakartaeeMe: true

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
@@ -81,6 +81,7 @@ import org.apache.cxf.ws.addressing.EndpointReferenceUtils;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.webcontainer.exception.InvalidMediaTypeException;
 
 /**
  * Common base for HTTP Destination implementations.
@@ -466,9 +467,9 @@ public abstract class AbstractHTTPDestination
             String normalizedEncoding = HttpHeaderHelper.mapCharset(enc);
             if (normalizedEncoding == null) {
                 // Liberty Change Start
-                String m = "Invalid encoding: " + enc;
+                String m = "Invalid MediaType encoding: " + enc;
                 Tr.warning(tc, m);
-                throw new InvalidCharsetException(m);
+                throw new InvalidMediaTypeException(m); // throw so webcontainer returns a 415
                 // Liberty Change End
             }
             inMessage.put(Message.ENCODING, normalizedEncoding);

--- a/dev/com.ibm.ws.webcontainer/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer/bnd.bnd
@@ -97,7 +97,8 @@ Export-Package: !*.internal.*, \
     com.ibm.ws.webcontainer.webapp;provide:=true, \
     com.ibm.ws.webcontainer.servlet, \
     com.ibm.ws.webcontainer.spiadapter.collaborator, \
-    com.ibm.ws.container
+    com.ibm.ws.container, \
+    com.ibm.ws.webcontainer.exception;provide=true
     
 Private-Package: \
 	com.ibm.websphere.csi, \

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/exception/InvalidMediaTypeException.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/exception/InvalidMediaTypeException.java
@@ -8,16 +8,12 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package org.apache.cxf.transport.http;
+package com.ibm.ws.webcontainer.exception;
 
-import java.io.IOException;
-
-public class InvalidCharsetException extends IOException {
-
-    public InvalidCharsetException(String m) {
-        super(m);
+@SuppressWarnings("serial")
+public class InvalidMediaTypeException extends RuntimeException {
+    
+    public InvalidMediaTypeException(String message) {
+        super(message);
     }
-
-    private static final long serialVersionUID = 1676878985438910205L;
-
 }

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebAppErrorReport.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebAppErrorReport.java
@@ -24,6 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.ibm.websphere.servlet.error.ServletErrorReport;
 import com.ibm.ws.webcontainer.exception.IncludeFileNotFoundException;
+import com.ibm.ws.webcontainer.exception.InvalidMediaTypeException;
 import com.ibm.ws.webcontainer.servlet.DefaultErrorReporter;
 import com.ibm.wsspi.webcontainer.RequestProcessor;
 import com.ibm.wsspi.webcontainer.WCCustomProperties;
@@ -161,6 +162,7 @@ public class WebAppErrorReport extends ServletErrorReport     // 96236
         while (rootCause.getCause() != null) {
             rootCause = rootCause.getCause();
         }
+
         if (WCCustomProperties.SERVLET_30_FNF_BEHAVIOR&&rootCause instanceof IncludeFileNotFoundException) {
             r.setErrorCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         }
@@ -174,6 +176,9 @@ public class WebAppErrorReport extends ServletErrorReport     // 96236
             } else {
                 r.setErrorCode(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
             }
+        }
+        else if (rootCause instanceof InvalidMediaTypeException) {
+            r.setErrorCode(HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE);
         }
         else {
             r.setErrorCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
The error occurs while we are setting up the CXF Message for processing by the PhaseInterceptorChain. The exception is thrown back to Webcontainer before we can process it ourselves. Since JAX-RS can't process the exception, Webcontainer has to process it, however, webcontainer doesn't know what to do, so it sets the error code to HTTP 500 in `WebAppErrorReport.constructErrorReport()`

I added the new Webcontainer Exception: `InvalidMediaTypeException` so that I could throw it from an exception from JAX-RS  that webcontainer would understand and map it to a 415 response code in `WebAppErrorReport.constructErrorReport()`.
By adding `InvalidMediaTypeException` to Webcontainer, I avoid any JAX-RS dependencies in Webcontainer and can send back a better response code than HTTP 500.

I also created 2 tests:
- One tests that a Content-Type with and invalid charset properly returns HTTP 415
- One tests that an invalid json payload returns an HTTP 400

I had previously gotten the invalid payload scenario to work, but wanted a test to compare why the JAX-RS exceptions were being mapped for an invalid payload and not in the case of an invalid Content-Type header.
The difference is that the invalid payload gets processed in the PhaseInterceptorChain, which handles sending the response, whereas invalid Content-Type throws an exception back to Webcontainer during setup and relies on Webcontainer to return the response.

