### PR TITLE
Update to use ClassRule on the FATSuite

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/bnd.bnd
@@ -51,7 +51,15 @@ fat.project: true
 # These features get added programmatically
 tested.features: jaxws-2.3, \
   jaxb-2.3, \
-  servlet-4.0
+  jsp-2.3, \
+  servlet-4.0, \
+  cdi-2.0, \
+  appSecurity-3.0
+#  pages-3.0, \
+#  servlet-5.0, \
+#  appSecurity-4.0, \
+#  xmlBinding-3.0, \
+#  xmlWS-3.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.2,\

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/build.gradle
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/build.gradle
@@ -96,3 +96,5 @@ task addRestConnector(type: Copy) {
 addRequiredLibraries {
   dependsOn addCXF, addSpring, addPureCXF, addRestConnector
 }
+
+addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/BindingTypeWsdlMismatchTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/BindingTypeWsdlMismatchTest.java
@@ -14,7 +14,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -22,17 +21,12 @@ import com.ibm.ws.jaxws.fat.util.TestUtils;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
 
 /**
  * Test the binding type is align with the wsdl file if specified.
  */
 @RunWith(FATRunner.class)
 public class BindingTypeWsdlMismatchTest extends BindingTypeWsdlMismatchTest_Lite {
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction().forServers("BindingTypeWsdlMismatchTestServer").addFeature("jaxws-2.3").removeFeature("jaxws-2.2").removeFeature("jsp-2.2").removeFeature("servlet-3.1").withID("jaxws-2.3"));
 
     /**
      * TestDescription:

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/CXFJMXSupportTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/CXFJMXSupportTest.java
@@ -42,7 +42,6 @@ import javax.net.ssl.X509TrustManager;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -51,16 +50,11 @@ import com.ibm.ws.jaxws.jmx.test.fat.util.ClientConnector;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
 @RunWith(FATRunner.class)
 public class CXFJMXSupportTest {
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction().forServers("CXFJMXSupportTestServer").addFeature("jaxws-2.3").removeFeature("jaxws-2.2").removeFeature("jsp-2.2").removeFeature("servlet-3.1").withID("jaxws-2.3"));
 
     @Server("CXFJMXSupportTestServer")
     public static LibertyServer server;

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/CatalogFacilityTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/CatalogFacilityTest.java
@@ -19,26 +19,18 @@ import java.net.URL;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("jaxwsTest-2.3")
 public class CatalogFacilityTest {
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction().forServers("CatalogFacilityTestServer").addFeature("jaxws-2.3").removeFeature("jaxws-2.2").removeFeature("jsp-2.2").removeFeature("servlet-3.1").withID("jaxws-2.3"));
 
     @Server("CatalogFacilityTestServer")
     public static LibertyServer server;

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/EJBServiceRefBndTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/EJBServiceRefBndTest.java
@@ -26,7 +26,6 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -34,10 +33,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxws.fat.util.ExplodedShrinkHelper;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
@@ -47,10 +43,7 @@ import componenttest.topology.utils.HttpUtils;
  * so a jaxwsTest-2.3 feature is added to the Liberty image in order to expose those APIs.
  */
 @RunWith(FATRunner.class)
-@SkipForRepeat("jaxws-2.3")
 public class EJBServiceRefBndTest {
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction().forServers("EJBServiceRefBndTestServer").removeFeature("jaxwsTest-2.2").addFeature("timedexit-1.0").addFeature("jaxwsTest-2.3").withID("jaxwsTest-2.3"));
 
     private static final int CONN_TIMEOUT = 5;
 

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/EndpointPropertiesTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/EndpointPropertiesTest.java
@@ -17,7 +17,6 @@ import java.util.List;
 
 import org.junit.After;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -28,8 +27,6 @@ import com.ibm.ws.jaxws.fat.util.TestUtils;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 
 /**
@@ -37,8 +34,6 @@ import componenttest.topology.impl.LibertyServer;
  */
 @RunWith(FATRunner.class)
 public class EndpointPropertiesTest {
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction().forServers("EndpointPropertiesTestServer").addFeature("jaxws-2.3").removeFeature("jaxws-2.2").removeFeature("jsp-2.2").removeFeature("servlet-3.1").withID("jaxws-2.3"));
 
     @Server("EndpointPropertiesTestServer")
     public static LibertyServer server;

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/FATSuite.java
@@ -10,9 +10,14 @@
  *******************************************************************************/
 package com.ibm.ws.jaxws.fat;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+
+import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
 
 /*
  * TODO: Lite Mode
@@ -41,4 +46,12 @@ import org.junit.runners.Suite.SuiteClasses;
                 VirtualHostTest.class
 })
 public class FATSuite {
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly()).
+        andWith(FeatureReplacementAction.EE8_FEATURES().removeFeature("jsp-2.2").
+                removeFeature("jaxws-2.2").addFeature("jaxws-2.3").
+                removeFeature("jaxwstest-2.2").addFeature("jaxwstest-2.3").withID("jaxws-2.3"))/*.
+        andWith(FeatureReplacementAction.EE9_FEATURES().withID("xmlWS-3.0"))*/;
+
 }

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/HandlerChainTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/HandlerChainTest.java
@@ -23,7 +23,6 @@ import java.net.URL;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -33,17 +32,11 @@ import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
 @RunWith(FATRunner.class)
 public class HandlerChainTest {
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction().addFeature("jaxws-2.3").forServers("XmlOverrideHandlerChainTestServer",
-                                                                                                                                              "AnnotatedHandlerChainTestServer").removeFeature("jaxws-2.2").removeFeature("jsp-2.2").removeFeature("servlet-3.1").withID("jaxws-2.3"));
 
     private static final String CLIENT_APP_LOCATION_DROPINS = "dropins/testHandlerClient.war";
     private static final String CLIENT_APP_WITHOUTXML_LOCATION_DROPINS = "dropins/testHandlerClientWithoutXML.war";

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/HandlerChainWithWebServiceClientTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/HandlerChainWithWebServiceClientTest.java
@@ -18,7 +18,6 @@ import java.net.URL;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -26,16 +25,11 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
 @RunWith(FATRunner.class)
 public class HandlerChainWithWebServiceClientTest {
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction().addFeature("jaxws-2.3").forServers("HandlerChainWithWebServiceClientTest").removeFeature("jaxws-2.2").removeFeature("jsp-2.2").removeFeature("servlet-3.1").withID("jaxws-2.3"));
 
     @Server("HandlerChainWithWebServiceClientTest")
     public static LibertyServer server;

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/HttpConduitPropertiesTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/HttpConduitPropertiesTest.java
@@ -25,7 +25,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -33,10 +32,7 @@ import com.ibm.ws.jaxws.fat.util.ExplodedShrinkHelper;
 import com.ibm.ws.jaxws.fat.util.TestUtils;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
@@ -47,10 +43,7 @@ import componenttest.topology.utils.HttpUtils;
  *
  */
 @RunWith(FATRunner.class)
-@SkipForRepeat("jaxws-2.3")
 public class HttpConduitPropertiesTest {
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction().forServers("HttpConduitPropertiesTestServer").addFeature("timedexit-1.0").removeFeature("jaxwsTest-2.2").addFeature("jaxwsTest-2.3").withID("jaxwsTest-2.3"));
 
     private static final int CONN_TIMEOUT = 10;
 

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/MTOMTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/MTOMTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -32,8 +31,6 @@ import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
@@ -46,9 +43,6 @@ import componenttest.topology.utils.HttpUtils;
 @RunWith(FATRunner.class)
 public class MTOMTest {
     private static final int REQUEST_TIMEOUT = 10;
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction().addFeature("jaxws-2.3").forServers("MTOMTestServer").removeFeature("jaxws-2.2").removeFeature("jsp-2.2").removeFeature("servlet-3.1").withID("jaxws-2.3"));
 
     @Server("MTOMTestServer")
     public static LibertyServer server;

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/PortComponentRefTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/PortComponentRefTest.java
@@ -14,7 +14,6 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -23,8 +22,6 @@ import com.ibm.ws.jaxws.fat.util.TestUtils;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 
 /**
@@ -32,9 +29,6 @@ import componenttest.topology.impl.LibertyServer;
  */
 @RunWith(FATRunner.class)
 public class PortComponentRefTest {
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction().forServers("PortComponentRefTestServer").addFeature("jaxws-2.3").removeFeature("jaxws-2.2").removeFeature("jsp-2.2").removeFeature("servlet-3.1").withID("jaxws-2.3"));
 
     @Server("PortComponentRefTestServer")
     public static LibertyServer server;

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/PureCXFTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/PureCXFTest.java
@@ -28,7 +28,6 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
@@ -36,7 +35,6 @@ import componenttest.topology.utils.HttpUtils;
 // Capping this test to JDK 8, because the CXF libs checked in only work with the JDK's copy of JAX-B (which was removed in JDK 9)
 @MaximumJavaLevel(javaLevel = 8)
 @RunWith(FATRunner.class)
-@SkipForRepeat("jaxws-2.3")
 public class PureCXFTest {
 
     @Server("PureCXFTestServer")

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/ServerSideStubClientTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/ServerSideStubClientTest.java
@@ -19,7 +19,6 @@ import java.net.URL;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -27,17 +26,12 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
 @RunWith(FATRunner.class)
 
 public class ServerSideStubClientTest {
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction().forServers("ServerSideStubClientTestServer").addFeature("jaxws-2.3").removeFeature("jaxws-2.2").removeFeature("jsp-2.2").removeFeature("servlet-3.1").withID("jaxws-2.3"));
 
     private static final int CONN_TIMEOUT = 5;
 

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/VirtualHostTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/VirtualHostTest.java
@@ -21,7 +21,6 @@ import java.net.URL;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -29,16 +28,11 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
 
 public class VirtualHostTest {
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction().addFeature("jaxws-2.3").forServers("com.ibm.ws.jaxws.virtualhost").removeFeature("jaxws-2.2").removeFeature("jsp-2.2").removeFeature("servlet-3.1").withID("jaxws-2.3"));
 
     @Server("com.ibm.ws.jaxws.virtualhost")
     public static LibertyServer server;

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceContextTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceContextTest.java
@@ -19,7 +19,6 @@ import java.net.URL;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -30,15 +29,10 @@ import com.ibm.ws.liberty.test.wscontext.client.WebServiceContextTestServicePort
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
 public class WebServiceContextTest {
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction().addFeature("jaxws-2.3").forServers("WebServiceContextTestServer").removeFeature("jaxws-2.2").removeFeature("jsp-2.2").removeFeature("servlet-3.1").withID("jaxws-2.3"));
 
     @Server("WebServiceContextTestServer")
     public static LibertyServer server;

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceInWebXMLTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceInWebXMLTest.java
@@ -21,7 +21,6 @@ import java.net.URL;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.After;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -30,15 +29,10 @@ import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.Mode;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
 public class WebServiceInWebXMLTest extends WebServiceInWebXMLTest_Lite {
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction().addFeature("jaxws-2.3").forServers("WebServiceInWebXMLTestServerWithSharedLib").removeFeature("jaxws-2.2").removeFeature("jsp-2.2").removeFeature("servlet-3.1").withID("jaxws-2.3"));
 
     private final Class<?> c = WebServiceInWebXMLTest.class;
 

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceInWebXMLTest_Lite.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceInWebXMLTest_Lite.java
@@ -29,7 +29,6 @@ import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
@@ -162,7 +161,6 @@ public class WebServiceInWebXMLTest_Lite {
     /*
      * TODO: Fix jaxws-2.3 no longer printing message CWWKW0037E when WSDL is not generated (correct behavior no longer prints error).
      */
-    @SkipForRepeat("jaxws-2.3")
     @Test
     public void testSameWebServiceDiffBindingType_WSDL() throws Exception {
         String method = "testSameWebServiceDiffBindingType_WSDL";

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceMonitorTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceMonitorTest.java
@@ -42,7 +42,6 @@ import javax.net.ssl.X509TrustManager;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -51,16 +50,11 @@ import com.ibm.ws.jaxws.jmx.test.fat.util.ClientConnector;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
 @RunWith(FATRunner.class)
 public class WebServiceMonitorTest {
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction().addFeature("jaxws-2.3").forServers("WebServiceMonitorTestServer").removeFeature("jaxws-2.2").removeFeature("jsp-2.2").removeFeature("servlet-3.1").withID("jaxws-2.3"));
 
     private static final String REQUEST_STR = "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:jax=\"http://monitor.jaxws.ws.ibm.com/\">" +
                                               "<soapenv:Header/>" +

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceRefFeaturesTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceRefFeaturesTest.java
@@ -19,7 +19,6 @@ import java.net.URL;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -28,16 +27,11 @@ import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
 @RunWith(FATRunner.class)
 public class WebServiceRefFeaturesTest {
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction().addFeature("jaxws-2.3").forServers("WebServiceRefFeaturesTestServer").removeFeature("jaxws-2.2").removeFeature("jsp-2.2").removeFeature("servlet-3.1").withID("jaxws-2.3"));
 
     @Server("WebServiceRefFeaturesTestServer")
     public static LibertyServer server;

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceRefTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceRefTest.java
@@ -18,7 +18,6 @@ import java.net.URL;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -26,8 +25,6 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
@@ -36,9 +33,6 @@ import componenttest.topology.utils.HttpUtils;
  */
 @RunWith(FATRunner.class)
 public class WebServiceRefTest {
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction().forServers("WebServiceRefTestServer").addFeature("jaxws-2.3").removeFeature("jaxws-2.2").removeFeature("jsp-2.2").removeFeature("servlet-3.1").withID("jaxws-2.3"));
 
     @Server("WebServiceRefTestServer")
     public static LibertyServer server;

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WsBndEndpointOverrideTest_Lite.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WsBndEndpointOverrideTest_Lite.java
@@ -20,7 +20,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -29,8 +28,6 @@ import com.ibm.ws.jaxws.fat.util.ExplodedShrinkHelper;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
@@ -40,9 +37,6 @@ import componenttest.topology.utils.HttpUtils;
 @RunWith(FATRunner.class)
 
 public class WsBndEndpointOverrideTest_Lite {
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction().forServers("EJBinWarEndpointAddressOverrideServer",
-                                                                                                                      "EJBinWarOverrideServer").addFeature("jaxws-2.3").removeFeature("jaxws-2.2").removeFeature("jsp-2.2").removeFeature("servlet-3.1").withID("jaxws-2.3"));
 
     private static final int CONN_TIMEOUT = 5;
 

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WsBndServiceRefOverrideTest_Lite.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WsBndServiceRefOverrideTest_Lite.java
@@ -21,7 +21,6 @@ import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -30,15 +29,11 @@ import com.ibm.ws.jaxws.fat.util.TestUtils;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
 @RunWith(FATRunner.class)
 public class WsBndServiceRefOverrideTest_Lite {
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification().andWith(new FeatureReplacementAction().forServers("WsBndServiceRefOverrideTestServer").addFeature("jaxws-2.3").removeFeature("jaxws-2.2").removeFeature("jsp-2.2").removeFeature("servlet-3.1").withID("jaxws-2.3"));
 
     public static final int CONN_TIMEOUT = 5;
 

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/util/ExplodedShrinkHelper.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/util/ExplodedShrinkHelper.java
@@ -11,6 +11,7 @@
 package com.ibm.ws.jaxws.fat.util;
 
 import java.io.File;
+import java.nio.file.Paths;
 
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.exporter.ExplodedExporter;
@@ -20,6 +21,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 
 public class ExplodedShrinkHelper {
@@ -57,6 +59,9 @@ public class ExplodedShrinkHelper {
         outputFile.mkdirs();
         archive.as(ExplodedExporter.class).exportExploded(outputFile, archive.getName());
         copyFileToDirectory(server, outputFile, dest);
+        if (JakartaEE9Action.isActive()) {
+            JakartaEE9Action.transformApp(Paths.get(outputFile.getAbsolutePath(), archive.getName()));
+        }
         return archive;
     }
 


### PR DESCRIPTION
- Gets all the JAXWS 2.3 tests passing with using a ClassRule for RepeatTests on the Suite instead of each individual tests.
- Also has the scaffolding to get the tests running wtih xmlWS 3.0.