### PR TITLE
Update JSF Container 

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2053,6 +2053,11 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
+      <artifactId>jakarta.faces</artifactId>
+      <version>3.0.0-RC3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish</groupId>
       <artifactId>jakarta.json</artifactId>
       <version>2.0.0</version>
     </dependency>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -406,6 +406,7 @@ org.glassfish.jersey.ext.rx:jersey-rx-client-rxjava2:2.30.1
 org.glassfish.jersey.ext.rx:jersey-rx-client-rxjava:2.30.1
 org.glassfish.jersey.inject:jersey-hk2:2.26
 org.glassfish.web:jakarta.servlet.jsp.jstl:2.0.0
+org.glassfish:jakarta.faces:3.0.0-RC3
 org.glassfish:jakarta.json:2.0.0
 org.glassfish:javax.faces:2.3.3
 org.glassfish:javax.json:1.0.4

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/build.gradle
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/build.gradle
@@ -50,8 +50,8 @@ dependencies {
       'commons-codec:commons-codec:1.11',
       'javax.xml.bind:jaxb-api:2.3.0'
     mojarra30 'org.glassfish:jakarta.faces:3.0.0-RC3'
-    myfaces30 'org.apache.myfaces.core:myfaces-api:3.0.0-RC1',
-      'org.apache.myfaces.core:myfaces-impl:3.0.0-RC1'
+    myfaces30 'org.apache.myfaces.core:myfaces-api:3.0.0',
+      'org.apache.myfaces.core:myfaces-impl:3.0.0'
     }
 
 task addMojarra(type: Copy) {
@@ -83,7 +83,6 @@ task copyPermissionFile(type: Copy) {
     from "publish/files/permissions"
     into "${buildDir}/autoFVT/publish/files/permissions"
 }
-
 
 addRequiredLibraries {
     dependsOn addMojarra

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/FATSuite.java
@@ -57,7 +57,7 @@ public class FATSuite {
     public static final String MYFACES_API = "publish/files/myfaces/myfaces-api-2.3.8.jar";
     public static final String MYFACES_IMP = "publish/files/myfaces/myfaces-impl-2.3.8.jar";
     // For ErrorPathsTest#testBadImplVersion_MyFaces Test
-    public static final String MYFACES_API_30 = "publish/files/myfaces30/myfaces-api-3.0.0-RC1.jar";
+    public static final String MYFACES_API_30 = "publish/files/myfaces30/myfaces-api-3.0.0.jar";
 
     public static WebArchive addMojarra(WebArchive app) throws Exception {
         if (JakartaEE9Action.isActive()) {

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/tests/JSF22StatelessViewTests.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/tests/JSF22StatelessViewTests.java
@@ -26,7 +26,6 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jsf.container.fat.FATSuite;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -290,7 +289,6 @@ public class JSF22StatelessViewTests extends FATServletClient {
      * Since the view here is stateless, the ViewScoped bean should be re-initialized on every submit.
      */
     @Test
-    @SkipForRepeat(SkipForRepeat.EE9_FEATURES) //  SKIPPING FOR MOJARRA 3.0.0-RC3
     public void JSF22StatelessView_TestViewScopeCDIBeanTransient_Mojarra() throws Exception {
         testViewScopeManagedBeanTransient(MOJARRA_APP, "/JSF22StatelessView_ViewScope_CDI_Transient.xhtml");
     }
@@ -305,7 +303,6 @@ public class JSF22StatelessViewTests extends FATServletClient {
      * Since the view here is NOT stateless, the ViewScoped bean should persist through a submit.
      */
     @Test
-    @SkipForRepeat(SkipForRepeat.EE9_FEATURES) //SKIPPING FOR MOJARRA 3.0.0-RC3
     public void JSF22StatelessView_TestViewScopeCDIBeanNotTransient_Mojarra() throws Exception {
         testViewScopeManagedBeanNotTransient(MOJARRA_APP, "/JSF22StatelessView_ViewScope_CDI_NotTransient.xhtml");
     }

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/tests/JSF22StatelessViewTests.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/tests/JSF22StatelessViewTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,8 @@
 package com.ibm.ws.jsf.container.fat.tests;
 
 import static org.junit.Assert.assertTrue;
+
+import java.io.File;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -49,6 +51,9 @@ public class JSF22StatelessViewTests extends FATServletClient {
         mojarraApp = FATSuite.addMojarra(mojarraApp);
         mojarraApp = (WebArchive) ShrinkHelper.addDirectory(mojarraApp, "publish/files/permissions");
         mojarraApp = (WebArchive) ShrinkHelper.addDirectory(mojarraApp, "test-applications/" + MOJARRA_APP + "/resources");
+        //Mojarra 3.0.0-RC3 (and possibily later versions) need a beans.xml for the
+        // JSF22StatelessView_TestViewScopeCDIBeanNotTransient_Mojarra test to pass 
+        mojarraApp.addAsWebInfResource(new File("lib/LibertyFATTestFiles/beans.xml"));
         ShrinkHelper.exportToServer(server, "dropins", mojarraApp);
         server.addInstalledAppForValidation(MOJARRA_APP);
 

--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/files/beans.xml
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/publish/files/beans.xml
@@ -1,0 +1,14 @@
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+ <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd" version="2.0">
+</beans>


### PR DESCRIPTION
fixes #15353 
fixes # #16028  -- Update to MyFaces 3.0.0 


The  JSF22StatelessView app needed a beans.xml to work properly. I'm not sure why as it was not needed before. I've found that the Mojarra 3.0.0 release is just different, and I can't explain why. 

I also noticed that "org.glassfish:jakarta.faces:3.0.0-RC1" was used as a dependency. It should be RC3. 