### PR TITLE
Add timestamps to mvnOutput when downloading artifacts

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/utils/MvnUtils.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/MvnUtils.java
@@ -321,6 +321,11 @@ public class MvnUtils {
         // be different.
         stringArrayList.add("-DsuiteXmlFile=" + getSuiteFileName());
 
+        // add timestamps to mvnOutput
+        stringArrayList.add("-Dorg.slf4j.simpleLogger.showDateTime=true");
+        stringArrayList.add("-Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS");
+        stringArrayList.add("-B");
+
         // add any additional properties passed
         for (Entry<String, String> prop : getAdditionalMvnProps().entrySet()) {
             stringArrayList.add("-D" + prop.getKey() + "=" + prop.getValue());


### PR DESCRIPTION
Turns 
```
Downloading from central: https://repo.maven.apache.org/maven2/org/eclipse/microprofile/config/microprofile-config-parent/1.1/microprofile-config-parent-1.1.pom
Progress (1): 2.7/14 kB
Progress (1): 5.5/14 kB
Progress (1): 8.2/14 kB
Progress (1): 11/14 kB 
Progress (1): 14/14 kB
Progress (1): 14 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/eclipse/microprofile/config/microprofile-config-parent/1.1/microprofile-config-parent-1.1.pom (14 kB at 11 kB/s)

```
into
```
17:08:19,134 [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/eclipse/microprofile/config/microprofile-config-parent/1.1/microprofile-config-parent-1.1.pom
17:08:20,734 [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/eclipse/microprofile/config/microprofile-config-parent/1.1/microprofile-config-parent-1.1.pom (14 kB at 9.0 kB/s)
```
#build

(Note it may be 2021 if/when this file is merged so the copyright header may need updating)