### PR TITLE
Use MP Rest Client 2.0 API from final Maven Repo instead of staging

### DIFF
--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -387,6 +387,7 @@ org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.1
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.2.0
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.3.1
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.4.0
+org.eclipse.microprofile.rest.client:microprofile-rest-client-api:2.0
 org.eclipse.transformer:org.eclipse.transformer.cli:0.2.0
 org.eclipse.transformer:org.eclipse.transformer:0.2.0
 org.eclipse:yasson:2.0.1

--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -97,7 +97,6 @@ org.apache.santuario:xmlsec:1.5.2-ibm
 org.apache.ws.security:wss4j:1.6.7-ibm-s20130913-2015
 org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.0-20191203
 org.eclipse.microprofile.graphql:microprofile-graphql-tck:1.0.0-20191203
-org.eclipse.microprofile.rest.client:microprofile-rest-client-api:2.0
 org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.7-69f2c2b
 org.eclipse.persistence:org.eclipse.persistence.asm:2.7.7-69f2c2b
 org.eclipse.persistence:org.eclipse.persistence.asm:3.0.0

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -17,13 +17,6 @@
     <version>2.0</version>
     <name>MicroProfile RestClient 2.0 TCK Runner TCK Module</name>
 
-	<repositories>
-		<repository>
-			<id>ossrepo</id>
-			<url>https://oss.sonatype.org/content/repositories/orgeclipsemicroprofile-1385/</url>
-		</repository>
-	</repositories>
-
     <properties>
         <microprofile.rest.client.version>2.0</microprofile.rest.client.version>
         <arquillian.version>1.1.13.Final</arquillian.version>


### PR DESCRIPTION
Now that the APIs have been promoted to Maven Central, we should pull from there (for external builds - we're still pulling from Artifactory for internal builds) and remove references to the staging repo.