### PR TITLE
Update xmlWS-3.0 to beta

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.cdi3.0-xmlws3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.cdi3.0-xmlws3.0.feature
@@ -9,6 +9,6 @@ IBM-Provision-Capability: \
 IBM-Install-Policy: when-satisfied
 -features=com.ibm.websphere.appserver.jndi-1.0
 -bundles=com.ibm.ws.jaxws.cdi.jakarta
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.cdi3.0-xmlws3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.cdi3.0-xmlws3.0.feature
@@ -10,5 +10,5 @@ IBM-Install-Policy: when-satisfied
 -features=com.ibm.websphere.appserver.jndi-1.0
 -bundles=com.ibm.ws.jaxws.cdi.jakarta
 kind=beta
-edition=core
+edition=base
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.xmlWSClient.3.0-appSecurity.4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.xmlWSClient.3.0-appSecurity.4.0.feature
@@ -8,5 +8,5 @@ IBM-Provision-Capability:  osgi.identity; filter:="(&(type=osgi.subsystem.featur
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.appSecurity-4.0))"
 IBM-Install-Policy: when-satisfied
 -bundles=com.ibm.ws.jaxws.clientcontainer.security
-kind=noship
-edition=full
+kind=beta
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.xmlWSClient.3.0-appSecurity.4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.xmlWSClient.3.0-appSecurity.4.0.feature
@@ -9,4 +9,4 @@ IBM-Provision-Capability:  osgi.identity; filter:="(&(type=osgi.subsystem.featur
 IBM-Install-Policy: when-satisfied
 -bundles=com.ibm.ws.jaxws.clientcontainer.security
 kind=beta
-edition=core
+edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.xmlwsEjb-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.xmlwsEjb-3.0.feature
@@ -8,6 +8,6 @@ IBM-Provision-Capability: \
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.ejbLiteCore-2.0))"
 IBM-Install-Policy: when-satisfied
 -bundles=com.ibm.ws.jaxws.2.3.ejb.jakarta
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.xmlwsEjb-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.xmlwsEjb-3.0.feature
@@ -9,5 +9,5 @@ IBM-Provision-Capability: \
 IBM-Install-Policy: when-satisfied
 -bundles=com.ibm.ws.jaxws.2.3.ejb.jakarta
 kind=beta
-edition=core
+edition=base
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.xmlwsSecurity-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.xmlwsSecurity-3.0.feature
@@ -8,6 +8,6 @@ IBM-Provision-Capability: \
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.appSecurity-4.0))"
 IBM-Install-Policy: when-satisfied
 -bundles=com.ibm.ws.jaxws.2.3.security
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.xmlwsSecurity-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.xmlwsSecurity-3.0.feature
@@ -9,5 +9,5 @@ IBM-Provision-Capability: \
 IBM-Install-Policy: when-satisfied
 -bundles=com.ibm.ws.jaxws.2.3.security
 kind=beta
-edition=core
+edition=base
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlWSClient-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlWSClient-3.0.feature
@@ -11,5 +11,5 @@ IBM-Process-Types: client
   io.openliberty.xmlws.common-3.0
 -bundles=\
   com.ibm.ws.jaxws.2.3.clientcontainer.jakarta
-kind=noship
-edition=full
+kind=beta
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlWSClient-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlWSClient-3.0.feature
@@ -12,4 +12,4 @@ IBM-Process-Types: client
 -bundles=\
   com.ibm.ws.jaxws.2.3.clientcontainer.jakarta
 kind=beta
-edition=core
+edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlws.common-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlws.common-3.0.feature
@@ -55,6 +55,6 @@ IBM-API-Package:\
  com.ibm.ws.org.jvnet.mimepull, \
  io.openliberty.xmlWS.3.0.internal.tools, \
  io.openliberty.com.sun.xml.messaging.saaj
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlws.common-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlws.common-3.0.feature
@@ -56,5 +56,5 @@ IBM-API-Package:\
  io.openliberty.xmlWS.3.0.internal.tools, \
  io.openliberty.com.sun.xml.messaging.saaj
 kind=beta
-edition=core
+edition=base
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaee-9.0/io.openliberty.jakartaee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaee-9.0/io.openliberty.jakartaee-9.0.feature
@@ -25,6 +25,7 @@ Subsystem-Name: Jakarta EE 9.0 Platform
  io.openliberty.messagingSecurity-3.0,\
  io.openliberty.messagingServer-3.0,\
  io.openliberty.webProfile-9.0,\
- io.openliberty.xmlBinding-3.0
+ io.openliberty.xmlBinding-3.0, \
+ io.openliberty.xmlWS-3.0
 kind=beta
 edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaeeClient-9.0/io.openliberty.jakartaeeClient-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaeeClient-9.0/io.openliberty.jakartaeeClient-9.0.feature
@@ -20,6 +20,7 @@ Subsystem-Name: Jakarta EE 9.0 Application Client
   io.openliberty.managedBeans-2.0, \
   io.openliberty.messagingClient-3.0, \
   io.openliberty.persistence-3.0, \
-  io.openliberty.xmlBinding-3.0
+  io.openliberty.xmlBinding-3.0, \
+  io.openliberty.xmlWSClient-3.0
 kind=beta
 edition=base

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWS-3.0/io.openliberty.xmlWS-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWS-3.0/io.openliberty.xmlWS-3.0.feature
@@ -31,6 +31,6 @@ IBM-API-Package: \
  bin/xmlWS/wsgen.bat, \
  bin/xmlWS/tools/ws-wsgen.jar
 kind=beta
-edition=core
+edition=base
 WLP-AlsoKnownAs: jaxws-3.0
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWS-3.0/io.openliberty.xmlWS-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWS-3.0/io.openliberty.xmlWS-3.0.feature
@@ -30,7 +30,7 @@ IBM-API-Package: \
  bin/xmlWS/tools/ws-wsimport.jar, \
  bin/xmlWS/wsgen.bat, \
  bin/xmlWS/tools/ws-wsgen.jar
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-AlsoKnownAs: jaxws-3.0
 WLP-Activation-Type: parallel


### PR DESCRIPTION
This PR updates the xmlWS-3.0 related features to be in `kind=beta` and adds the `xmlWSClient-3.0` feature to the `jakartaeeClient-9.0` and the `xmlWS-3.0` feature to the `jakartaee-9.0` feature