### PR TITLE
Add JPA 3.0 enum to JPAVersion, properly report JPA 2.2 with JPA22 Ru…

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/persistenceContainer-3.0/io.openliberty.persistenceContainer-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/persistenceContainer-3.0/io.openliberty.persistenceContainer-3.0.feature
@@ -21,7 +21,7 @@ IBM-App-ForceRestart: uninstall, \
  com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:="4.3", \
  com.ibm.websphere.appserver.transaction-2.0, \
  com.ibm.websphere.appserver.eeCompatible-9.0
--bundles=com.ibm.ws.jpa.container.v22.jakarta, \
+-bundles=com.ibm.ws.jpa.container.v30.jakarta, \
  com.ibm.ws.jpa.container.jakarta, \
  com.ibm.ws.jpa.container.thirdparty.jakarta
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/AbstractJPAProviderIntegration.java
+++ b/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/AbstractJPAProviderIntegration.java
@@ -115,16 +115,20 @@ public abstract class AbstractJPAProviderIntegration implements JPAProviderInteg
     }
 
     @Override
-    public void moduleStarting(ModuleInfo moduleInfo) {}
+    public void moduleStarting(ModuleInfo moduleInfo) {
+    }
 
     @Override
-    public void moduleStarted(ModuleInfo moduleInfo) {}
+    public void moduleStarted(ModuleInfo moduleInfo) {
+    }
 
     @Override
-    public void moduleStopping(ModuleInfo moduleInfo) {}
+    public void moduleStopping(ModuleInfo moduleInfo) {
+    }
 
     @Override
-    public void moduleStopped(ModuleInfo moduleInfo) {}
+    public void moduleStopped(ModuleInfo moduleInfo) {
+    }
 
     /**
      * @see com.ibm.ws.jpa.JPAProviderIntegration#supportsEntityManagerPooling()
@@ -155,8 +159,11 @@ public abstract class AbstractJPAProviderIntegration implements JPAProviderInteg
              * the aggregate function is NULL.
              *
              * Set this property to so that EclipseLink does not return null by default
+             *
+             * JPA 3.0: Do not force this override with JPA 3.0 and later.
              */
-            if (!properties.containsKey("eclipselink.allow-null-max-min")) {
+            if (!properties.containsKey("eclipselink.allow-null-max-min") &&
+                JPAAccessor.getJPAComponent().getJPAVersion().lesserThan(JPAVersion.JPA30)) {
                 props.put("eclipselink.allow-null-max-min", "false");
             }
         } else if (PROVIDER_HIBERNATE.equals(providerName)) {
@@ -188,7 +195,8 @@ public abstract class AbstractJPAProviderIntegration implements JPAProviderInteg
      * @see com.ibm.ws.jpa.JPAProvider#modifyPersistenceUnitProperties(java.lang.String, java.util.Properties)
      */
     @Override
-    public void updatePersistenceUnitProperties(String providerClassName, Properties props) {}
+    public void updatePersistenceUnitProperties(String providerClassName, Properties props) {
+    }
 
     /**
      * As of Hibernate 5.2.13+ and 5.3+ built-in knowledge of Liberty's transaction integration was delivered as:

--- a/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/JPAComponent.java
+++ b/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/JPAComponent.java
@@ -64,6 +64,8 @@ public interface JPAComponent {
 
     public JPAProviderIntegration getJPAProviderIntegration();
 
+    public JPAVersion getJPAVersion();
+
     /**
      * Returns the EntityManagerFactory defines by the application/module/persistence unit spcified.
      * This is used by the resolver and naming object factory to retrieve the factory for
@@ -71,12 +73,12 @@ public interface JPAComponent {
      * @PersistenceUnit.
      *
      * @param puId
-     *            Persistence unit id
+     *                          Persistence unit id
      * @param j2eeName
-     *            JavaEE unique identifier for the component, identifying the
-     *            java:comp/env context used.
+     *                          JavaEE unique identifier for the component, identifying the
+     *                          java:comp/env context used.
      * @param getEmfWrapper
-     *            return a serializable EntityManagerFactory wrapper
+     *                          return a serializable EntityManagerFactory wrapper
      * @return EntityManagerFactory for the specified or null if none is found.
      */
     public EntityManagerFactory getEntityManagerFactory(JPAPuId puId,
@@ -90,16 +92,16 @@ public interface JPAComponent {
      * @PersistenceContext.
      *
      * @param puId
-     *            Persistence unit id
+     *                                  Persistence unit id
      * @param j2eeName
-     *            JavaEE unique identifier for the component, identifying the
-     *            java:comp/env context used.
+     *                                  JavaEE unique identifier for the component, identifying the
+     *                                  java:comp/env context used.
      * @param refName
-     *            Name of the PersistenceContext reference.
+     *                                  Name of the PersistenceContext reference.
      * @param isExtendedContextType
-     *            is the EntityManager extended scope.
+     *                                  is the EntityManager extended scope.
      * @param properties
-     *            additional properties to create the EntityManager
+     *                                  additional properties to create the EntityManager
      *
      * @return EntityManager for the specified or null if none is found.
      */
@@ -120,17 +122,17 @@ public interface JPAComponent {
      * </ul>
      *
      * @param injectionBindings
-     *            InjectionBindings to retrieve PuIds from.
+     *                                InjectionBindings to retrieve PuIds from.
      * @param ejbName
-     *            The EJB name.
+     *                                The EJB name.
      * @param persistenceRefNames
-     *            The set of persistence unit and context reference names to be
-     *            updated, or <tt>null</tt> if not needed
+     *                                The set of persistence unit and context reference names to be
+     *                                updated, or <tt>null</tt> if not needed
      * @param bindingList
-     *            A return-value List containing JPAPCtxtInjectionBinding objects.
-     *            If bindingList is not null, then for each @PersistenceContext associated with each
-     *            InjectionBinding, it will insert an JPAPCtxtInjectionBinding type entry to the List.
-     *            If null, this data will not be returned.
+     *                                A return-value List containing JPAPCtxtInjectionBinding objects.
+     *                                If bindingList is not null, then for each @PersistenceContext associated with each
+     *                                InjectionBinding, it will insert an JPAPCtxtInjectionBinding type entry to the List.
+     *                                If null, this data will not be returned.
      * @return Returns array of JPAPuId with container-managed extend-scoped persistence contexts;
      *         or JPAPuId[0] if none is found; updates bindingMap with JNDI -> JPAPCtxtInjectionBinding
      *         entries.
@@ -158,12 +160,12 @@ public interface JPAComponent {
      * This is determined by the existence of a PersistenceUnit annotation or xml ref.
      *
      * @param injectionBindings
-     *            to search for extend-scoped PersistenceUnit.
+     *                                to search for extend-scoped PersistenceUnit.
      * @param ejbName
-     *            The EJB name.
+     *                                The EJB name.
      * @param persistenceRefNames
-     *            The set of persistence unit and context reference names to be
-     *            updated, or <tt>null</tt> if not needed
+     *                                The set of persistence unit and context reference names to be
+     *                                updated, or <tt>null</tt> if not needed
      * @return boolean - indicating if a PersistenceUnit is found.
      */
     // d465813                        // switch to 'bindings' d511673
@@ -185,7 +187,7 @@ public interface JPAComponent {
      * @param isBMT
      * @param puIds
      * @param unsynchronizedJPAPuIdSet is a Set of JPAPuId associated UNSYNCHRONIZED Container Managed
-     *            Extended Scoped persistence contexts which are SynchronizationType.UNSYNCHRONIZED.
+     *                                     Extended Scoped persistence contexts which are SynchronizationType.UNSYNCHRONIZED.
      */
     public JPAExPcBindingContext onCreate(String j2eeName,
                                           boolean isBMT,

--- a/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/JPAVersion.java
+++ b/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/JPAVersion.java
@@ -8,11 +8,14 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.jpa.management;
+package com.ibm.ws.jpa;
 
 public enum JPAVersion {
+    UNKNOWN(1, "Unknown"),
     JPA20(6, "2.0"),
-    JPA21(7, "2.1");
+    JPA21(7, "2.1"),
+    JPA22(8, "2.2"),
+    JPA30(9, "3.0");
 
     private final int jeeSpecLevel;
     private final String versionStr;

--- a/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/management/JPA20Runtime.java
+++ b/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/management/JPA20Runtime.java
@@ -18,6 +18,7 @@ import javax.persistence.EntityManagerFactory;
 import com.ibm.websphere.csi.J2EEName;
 import com.ibm.ws.Transaction.UOWCoordinator;
 import com.ibm.ws.jpa.JPAPuId;
+import com.ibm.ws.jpa.JPAVersion;
 
 public class JPA20Runtime implements JPARuntime {
     @Override

--- a/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/management/JPARuntime.java
+++ b/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/management/JPARuntime.java
@@ -18,6 +18,7 @@ import javax.persistence.EntityManagerFactory;
 import com.ibm.websphere.csi.J2EEName;
 import com.ibm.ws.Transaction.UOWCoordinator;
 import com.ibm.ws.jpa.JPAPuId;
+import com.ibm.ws.jpa.JPAVersion;
 
 /**
  *

--- a/dev/com.ibm.ws.jpa.container.ormdiagnostics_3.0_fat/fat/src/com/ibm/ws/jpa/ormdiagnostics/tests/TestExample_WAR.java
+++ b/dev/com.ibm.ws.jpa.container.ormdiagnostics_3.0_fat/fat/src/com/ibm/ws/jpa/ormdiagnostics/tests/TestExample_WAR.java
@@ -139,7 +139,7 @@ public class TestExample_WAR {
         Assert.assertTrue(introspectorData.contains("JPA Runtime Internal State Information")); // Description
 
         Assert.assertTrue(introspectorData.contains("JPA Runtime Internal State Information")); // Description
-        Assert.assertTrue(introspectorData.contains("jpaRuntime = com.ibm.ws.jpa.container.v22.internal.JPA22Runtime"));
+        Assert.assertTrue(introspectorData.contains("jpaRuntime = com.ibm.ws.jpa.container.v30.internal.JPA30Runtime"));
 
         Assert.assertTrue(introspectorData.contains("Provider Runtime Integration Service = com.ibm.ws.jpa.container.eclipselink.EclipseLinkJPAProvider"));
 

--- a/dev/com.ibm.ws.jpa.container.v21/src/com/ibm/ws/jpa/container/v21/internal/JPA21Runtime.java
+++ b/dev/com.ibm.ws.jpa.container.v21/src/com/ibm/ws/jpa/container/v21/internal/JPA21Runtime.java
@@ -27,6 +27,7 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.Transaction.UOWCoordinator;
 import com.ibm.ws.jpa.JPAPuId;
+import com.ibm.ws.jpa.JPAVersion;
 import com.ibm.ws.jpa.container.v21.JPAEMFactoryV21;
 import com.ibm.ws.jpa.container.v21.JPAExEmInvocationV21;
 import com.ibm.ws.jpa.container.v21.JPAExEntityManagerV21;
@@ -38,15 +39,13 @@ import com.ibm.ws.jpa.management.JPAExEntityManager;
 import com.ibm.ws.jpa.management.JPAPUnitInfo;
 import com.ibm.ws.jpa.management.JPARuntime;
 import com.ibm.ws.jpa.management.JPATxEntityManager;
-import com.ibm.ws.jpa.management.JPAVersion;
 
 @Component(service = JPARuntime.class,
            property = Constants.SERVICE_RANKING + ":Integer=21")
 public class JPA21Runtime extends JPA20Runtime implements JPARuntime {
-    private static final TraceComponent tc = Tr.register
-                    (JPA21Runtime.class,
-                     JPA_TRACE_GROUP,
-                     JPA_RESOURCE_BUNDLE_NAME);
+    private static final TraceComponent tc = Tr.register(JPA21Runtime.class,
+                                                         JPA_TRACE_GROUP,
+                                                         JPA_RESOURCE_BUNDLE_NAME);
 
     private final static String JEE7_DEFAULT_JTA_DATASOURCE_JNDI = "java:comp/DefaultDataSource";
 

--- a/dev/com.ibm.ws.jpa.container.v30/.classpath
+++ b/dev/com.ibm.ws.jpa.container.v30/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/com.ibm.ws.jpa.container.v30/.project
+++ b/dev/com.ibm.ws.jpa.container.v30/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.ibm.ws.jpa.container.v30</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/com.ibm.ws.jpa.container.v30/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.jpa.container.v30/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.jpa.container.v30/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.jpa.container.v30/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,12 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/com.ibm.ws.jpa.container.v30/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.container.v30/bnd.bnd
@@ -1,0 +1,37 @@
+#*******************************************************************************
+# Copyright (c) 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+Bundle-Name: JPA 3.0 Container Runtime
+Bundle-SymbolicName: com.ibm.ws.jpa.container.v30
+Bundle-Description: JPA 3.0 Container Runtime; version=${bVersion}
+
+jakartaeeMe: true
+WS-TraceGroup: JPA
+
+Private-Package: \
+  com.ibm.ws.jpa.container.v30.*
+
+-dsannotations: \
+  com.ibm.ws.jpa.container.v30.JPAPCtxtAttributeAccessorV30, \
+  com.ibm.ws.jpa.container.v30.internal.JPA30Runtime
+
+-buildpath: \
+	com.ibm.ws.jpa.container;version=latest,\
+	com.ibm.websphere.javaee.persistence.2.2;version=latest,\
+	com.ibm.wsspi.org.osgi.core;version=latest,\
+	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+	com.ibm.tx.core;version=latest,\
+	com.ibm.ws.tx.embeddable;version=latest,\
+	com.ibm.ws.logging.core;version=latest,\
+	com.ibm.ws.container.service;version=latest,\
+	com.ibm.websphere.javaee.transaction.1.2;version=latest

--- a/dev/com.ibm.ws.jpa.container.v30/src/com/ibm/ws/jpa/container/v30/JPAEMFactoryV30.java
+++ b/dev/com.ibm.ws.jpa.container.v30/src/com/ibm/ws/jpa/container/v30/JPAEMFactoryV30.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jpa.container.v30;
+
+import java.util.Map;
+
+import javax.persistence.EntityGraph;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Query;
+import javax.persistence.SynchronizationType;
+
+import com.ibm.websphere.csi.J2EEName;
+import com.ibm.ws.jpa.JPAPuId;
+import com.ibm.ws.jpa.management.JPAEMFactory;
+
+@SuppressWarnings("serial")
+public class JPAEMFactoryV30 extends JPAEMFactory {
+    public JPAEMFactoryV30(JPAPuId puId, J2EEName j2eeName, EntityManagerFactory emf) {
+        super(puId, j2eeName, emf);
+    }
+
+    private Object writeReplace() {
+        // jpa-2.2 might not be enabled when this is deserialized, so serialize
+        // the base wrapper.  During deserialization, readResolve will rewrap
+        // with this class if needed.
+        return new JPAEMFactory(this);
+    }
+
+    @Override
+    public <T> void addNamedEntityGraph(String arg0, EntityGraph<T> arg1) {
+        ivFactory.addNamedEntityGraph(arg0, arg1);
+    }
+
+    @Override
+    public void addNamedQuery(String arg0, Query arg1) {
+        ivFactory.addNamedQuery(arg0, arg1);
+    }
+
+    @Override
+    public EntityManager createEntityManager(SynchronizationType arg0) {
+        return ivFactory.createEntityManager(arg0);
+    }
+
+    @Override
+    public EntityManager createEntityManager(SynchronizationType arg0, @SuppressWarnings("rawtypes") Map arg1) {
+        return ivFactory.createEntityManager(arg0, arg1);
+    }
+}

--- a/dev/com.ibm.ws.jpa.container.v30/src/com/ibm/ws/jpa/container/v30/JPAExEmInvocationV30.java
+++ b/dev/com.ibm.ws.jpa.container.v30/src/com/ibm/ws/jpa/container/v30/JPAExEmInvocationV30.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jpa.container.v30;
+
+import java.util.List;
+
+import javax.persistence.EntityGraph;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import javax.persistence.StoredProcedureQuery;
+import javax.persistence.criteria.CriteriaDelete;
+import javax.persistence.criteria.CriteriaUpdate;
+
+import com.ibm.ws.Transaction.UOWCoordinator;
+import com.ibm.ws.jpa.management.JPAExEmInvocation;
+
+public class JPAExEmInvocationV30 extends JPAExEmInvocation {
+    public JPAExEmInvocationV30(UOWCoordinator uowCoord, EntityManager em, boolean txIsUnsynchronized) {
+        super(uowCoord, em, null, txIsUnsynchronized);
+    }
+
+    @Override
+    public <T> EntityGraph<T> createEntityGraph(Class<T> arg0) {
+        return ivEm.createEntityGraph(arg0);
+    }
+
+    @Override
+    public EntityGraph<?> createEntityGraph(String arg0) {
+        return ivEm.createEntityGraph(arg0);
+    }
+
+    @Override
+    public StoredProcedureQuery createNamedStoredProcedureQuery(String arg0) {
+        return ivEm.createNamedStoredProcedureQuery(arg0);
+    }
+
+    @Override
+    public Query createQuery(@SuppressWarnings("rawtypes") CriteriaUpdate arg0) {
+        return ivEm.createQuery(arg0);
+    }
+
+    @Override
+    public Query createQuery(@SuppressWarnings("rawtypes") CriteriaDelete arg0) {
+        return ivEm.createQuery(arg0);
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String arg0) {
+        return ivEm.createStoredProcedureQuery(arg0);
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String arg0, @SuppressWarnings("rawtypes") Class... arg1) {
+        return ivEm.createStoredProcedureQuery(arg0, arg1);
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String arg0, String... arg1) {
+        return ivEm.createStoredProcedureQuery(arg0, arg1);
+    }
+
+    @Override
+    public EntityGraph<?> getEntityGraph(String arg0) {
+        return ivEm.getEntityGraph(arg0);
+    }
+
+    @Override
+    public <T> List<EntityGraph<? super T>> getEntityGraphs(Class<T> arg0) {
+        return ivEm.getEntityGraphs(arg0);
+    }
+
+    @Override
+    public boolean isJoinedToTransaction() {
+        return ivEm.isJoinedToTransaction();
+    }
+}

--- a/dev/com.ibm.ws.jpa.container.v30/src/com/ibm/ws/jpa/container/v30/JPAExEntityManagerV30.java
+++ b/dev/com.ibm.ws.jpa.container.v30/src/com/ibm/ws/jpa/container/v30/JPAExEntityManagerV30.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jpa.container.v30;
+
+import static com.ibm.ws.jpa.management.JPAConstants.JPA_RESOURCE_BUNDLE_NAME;
+import static com.ibm.ws.jpa.management.JPAConstants.JPA_TRACE_GROUP;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.persistence.EntityGraph;
+import javax.persistence.Query;
+import javax.persistence.StoredProcedureQuery;
+import javax.persistence.criteria.CriteriaDelete;
+import javax.persistence.criteria.CriteriaUpdate;
+
+import com.ibm.websphere.csi.J2EEName;
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.jpa.JPAPuId;
+import com.ibm.ws.jpa.management.AbstractJPAComponent;
+import com.ibm.ws.jpa.management.JPAExEntityManager;
+import com.ibm.ws.jpa.management.JPAPUnitInfo;
+
+@SuppressWarnings("serial")
+public class JPAExEntityManagerV30 extends JPAExEntityManager {
+    private static final TraceComponent tc = Tr.register(JPAExEntityManagerV30.class,
+                                                         JPA_TRACE_GROUP,
+                                                         JPA_RESOURCE_BUNDLE_NAME);
+
+    public JPAExEntityManagerV30(JPAPuId puRefId,
+                                 JPAPUnitInfo puInfo,
+                                 J2EEName j2eeName,
+                                 String refName,
+                                 Map<?, ?> properties,
+                                 boolean isUnsynchronized,
+                                 AbstractJPAComponent jpaComponent) {
+        super(puRefId, puInfo, j2eeName, refName, properties, isUnsynchronized, jpaComponent);
+    }
+
+    private Object writeReplace() {
+        // jpa-2.2 might not be enabled when this is deserialized, so serialize
+        // the base wrapper.  During deserialization, readResolve will rewrap
+        // with this class if needed.
+        return new JPAExEntityManager(ivPuRefId, ivPuInfo, ivJ2eeName, ivRefName, ivProperties, ivUnsynchronized, ivAbstractJPAComponent);
+    }
+
+    @Override
+    public Query createQuery(@SuppressWarnings("rawtypes") CriteriaUpdate arg0) {
+        return getEMInvocationInfo(false).createQuery(arg0);
+    }
+
+    @Override
+    public Query createQuery(@SuppressWarnings("rawtypes") CriteriaDelete arg0) {
+        return getEMInvocationInfo(false).createQuery(arg0);
+    }
+
+    @Override
+    public <T> EntityGraph<T> createEntityGraph(Class<T> arg0) {
+        return getEMInvocationInfo(false).createEntityGraph(arg0);
+    }
+
+    @Override
+    public EntityGraph<?> createEntityGraph(String arg0) {
+        return getEMInvocationInfo(false).createEntityGraph(arg0);
+    }
+
+    @Override
+    public EntityGraph<?> getEntityGraph(String arg0) {
+        return getEMInvocationInfo(false).getEntityGraph(arg0);
+    }
+
+    @Override
+    public <T> List<EntityGraph<? super T>> getEntityGraphs(Class<T> arg0) {
+        return getEMInvocationInfo(false).getEntityGraphs(arg0);
+    }
+
+    @Override
+    public StoredProcedureQuery createNamedStoredProcedureQuery(String arg0) {
+        return getEMInvocationInfo(false).createNamedStoredProcedureQuery(arg0);
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String arg0) {
+        return getEMInvocationInfo(false).createStoredProcedureQuery(arg0);
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String arg0, @SuppressWarnings("rawtypes") Class... arg1) {
+        return getEMInvocationInfo(false).createStoredProcedureQuery(arg0, arg1);
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String arg0, String... arg1) {
+        return getEMInvocationInfo(false).createStoredProcedureQuery(arg0, arg1);
+    }
+
+    @Override
+    public boolean isJoinedToTransaction() {
+        return getEMInvocationInfo(false).isJoinedToTransaction();
+    }
+}

--- a/dev/com.ibm.ws.jpa.container.v30/src/com/ibm/ws/jpa/container/v30/JPANoTxEmInvocationV30.java
+++ b/dev/com.ibm.ws.jpa.container.v30/src/com/ibm/ws/jpa/container/v30/JPANoTxEmInvocationV30.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jpa.container.v30;
+
+import java.util.List;
+
+import javax.persistence.EntityGraph;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import javax.persistence.StoredProcedureQuery;
+import javax.persistence.criteria.CriteriaDelete;
+import javax.persistence.criteria.CriteriaUpdate;
+
+import com.ibm.ws.Transaction.UOWCoordinator;
+import com.ibm.ws.jpa.management.JPAEntityManager;
+import com.ibm.ws.jpa.management.JPANoTxEmInvocation;
+
+public class JPANoTxEmInvocationV30 extends JPANoTxEmInvocation {
+    protected JPANoTxEmInvocationV30(UOWCoordinator uowCoord, EntityManager em, JPAEntityManager jpaEm, boolean txIsUnsynchronized) {
+        super(uowCoord, em, jpaEm, txIsUnsynchronized);
+        this.ivAllowPooling = false;
+    }
+
+    @Override
+    public <T> EntityGraph<T> createEntityGraph(Class<T> arg0) {
+        return ivEm.createEntityGraph(arg0);
+    }
+
+    @Override
+    public EntityGraph<?> createEntityGraph(String arg0) {
+        return ivEm.createEntityGraph(arg0);
+    }
+
+    @Override
+    public StoredProcedureQuery createNamedStoredProcedureQuery(String arg0) {
+        return ivEm.createNamedStoredProcedureQuery(arg0);
+    }
+
+    @Override
+    public Query createQuery(@SuppressWarnings("rawtypes") CriteriaUpdate arg0) {
+        return ivEm.createQuery(arg0);
+    }
+
+    @Override
+    public Query createQuery(@SuppressWarnings("rawtypes") CriteriaDelete arg0) {
+        return ivEm.createQuery(arg0);
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String arg0) {
+        return ivEm.createStoredProcedureQuery(arg0);
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String arg0, @SuppressWarnings("rawtypes") Class... arg1) {
+        return ivEm.createStoredProcedureQuery(arg0, arg1);
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String arg0, String... arg1) {
+        return ivEm.createStoredProcedureQuery(arg0, arg1);
+    }
+
+    @Override
+    public EntityGraph<?> getEntityGraph(String arg0) {
+        return ivEm.getEntityGraph(arg0);
+    }
+
+    @Override
+    public <T> List<EntityGraph<? super T>> getEntityGraphs(Class<T> arg0) {
+        return ivEm.getEntityGraphs(arg0);
+    }
+
+    @Override
+    public boolean isJoinedToTransaction() {
+        return ivEm.isJoinedToTransaction();
+    }
+}

--- a/dev/com.ibm.ws.jpa.container.v30/src/com/ibm/ws/jpa/container/v30/JPAPCtxtAttributeAccessorV30.java
+++ b/dev/com.ibm.ws.jpa.container.v30/src/com/ibm/ws/jpa/container/v30/JPAPCtxtAttributeAccessorV30.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jpa.container.v30;
+
+import javax.persistence.PersistenceContext;
+import javax.persistence.SynchronizationType;
+
+import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Component;
+
+import com.ibm.ws.jpa.management.JPAPCtxtAttributeAccessor;
+
+@Component(service = JPAPCtxtAttributeAccessor.class,
+           name = "com.ibm.ws.jpa.pctxtAttributeAccessor",
+           property = Constants.SERVICE_RANKING + ":Integer=21")
+public class JPAPCtxtAttributeAccessorV30 extends JPAPCtxtAttributeAccessor {
+    @Override
+    public boolean isUnsynchronized(PersistenceContext pCtxt) {
+        return pCtxt.synchronization() == SynchronizationType.UNSYNCHRONIZED;
+    }
+}

--- a/dev/com.ibm.ws.jpa.container.v30/src/com/ibm/ws/jpa/container/v30/JPATxEmInvocationV30.java
+++ b/dev/com.ibm.ws.jpa.container.v30/src/com/ibm/ws/jpa/container/v30/JPATxEmInvocationV30.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jpa.container.v30;
+
+import java.util.List;
+
+import javax.persistence.EntityGraph;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import javax.persistence.StoredProcedureQuery;
+import javax.persistence.criteria.CriteriaDelete;
+import javax.persistence.criteria.CriteriaUpdate;
+
+import com.ibm.ws.Transaction.UOWCoordinator;
+import com.ibm.ws.jpa.management.JPAEntityManager;
+import com.ibm.ws.jpa.management.JPATxEmInvocation;
+
+public class JPATxEmInvocationV30 extends JPATxEmInvocation {
+    protected JPATxEmInvocationV30(UOWCoordinator uowCoord, EntityManager em, JPAEntityManager jpaEm, boolean txIsUnsynchronized) {
+        super(uowCoord, em, jpaEm, txIsUnsynchronized);
+        this.ivPoolEM = false;
+    }
+
+    @Override
+    public <T> EntityGraph<T> createEntityGraph(Class<T> arg0) {
+        return ivEm.createEntityGraph(arg0);
+    }
+
+    @Override
+    public EntityGraph<?> createEntityGraph(String arg0) {
+        return ivEm.createEntityGraph(arg0);
+    }
+
+    @Override
+    public StoredProcedureQuery createNamedStoredProcedureQuery(String arg0) {
+        return ivEm.createNamedStoredProcedureQuery(arg0);
+    }
+
+    @Override
+    public Query createQuery(@SuppressWarnings("rawtypes") CriteriaUpdate arg0) {
+        return ivEm.createQuery(arg0);
+    }
+
+    @Override
+    public Query createQuery(@SuppressWarnings("rawtypes") CriteriaDelete arg0) {
+        return ivEm.createQuery(arg0);
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String arg0) {
+        return ivEm.createStoredProcedureQuery(arg0);
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String arg0, @SuppressWarnings("rawtypes") Class... arg1) {
+        return ivEm.createStoredProcedureQuery(arg0, arg1);
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String arg0, String... arg1) {
+        return ivEm.createStoredProcedureQuery(arg0, arg1);
+    }
+
+    @Override
+    public EntityGraph<?> getEntityGraph(String arg0) {
+        return ivEm.getEntityGraph(arg0);
+    }
+
+    @Override
+    public <T> List<EntityGraph<? super T>> getEntityGraphs(Class<T> arg0) {
+        return ivEm.getEntityGraphs(arg0);
+    }
+
+    @Override
+    public boolean isJoinedToTransaction() {
+        return ivEm.isJoinedToTransaction();
+    }
+}

--- a/dev/com.ibm.ws.jpa.container.v30/src/com/ibm/ws/jpa/container/v30/JPATxEntityManagerV30.java
+++ b/dev/com.ibm.ws.jpa.container.v30/src/com/ibm/ws/jpa/container/v30/JPATxEntityManagerV30.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jpa.container.v30;
+
+import static com.ibm.ws.jpa.management.JPAConstants.JPA_RESOURCE_BUNDLE_NAME;
+import static com.ibm.ws.jpa.management.JPAConstants.JPA_TRACE_GROUP;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.persistence.EntityGraph;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import javax.persistence.StoredProcedureQuery;
+import javax.persistence.criteria.CriteriaDelete;
+import javax.persistence.criteria.CriteriaUpdate;
+
+import com.ibm.websphere.csi.J2EEName;
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.Transaction.UOWCoordinator;
+import com.ibm.ws.jpa.JPAPuId;
+import com.ibm.ws.jpa.management.AbstractJPAComponent;
+import com.ibm.ws.jpa.management.JPANoTxEmInvocation;
+import com.ibm.ws.jpa.management.JPAPUnitInfo;
+import com.ibm.ws.jpa.management.JPATxEmInvocation;
+import com.ibm.ws.jpa.management.JPATxEntityManager;
+
+@SuppressWarnings("serial")
+public class JPATxEntityManagerV30 extends JPATxEntityManager {
+    private static final TraceComponent tc = Tr.register(JPATxEntityManagerV30.class,
+                                                         JPA_TRACE_GROUP,
+                                                         JPA_RESOURCE_BUNDLE_NAME);
+
+    public JPATxEntityManagerV30(JPAPuId puRefId, JPAPUnitInfo puInfo, J2EEName j2eeName, String refName, Map<?, ?> properties, boolean isUnsynchronized,
+                                 AbstractJPAComponent jpaComponent) {
+        super(puRefId, puInfo, j2eeName, refName, properties, isUnsynchronized, jpaComponent);
+    }
+
+    private Object writeReplace() {
+        // jpa-2.1 might not be enabled when this is deserialized, so serialize
+        // the base wrapper.  During deserialization, readResolve will rewrap
+        // with this class if needed.
+        return new JPATxEntityManager(ivPuRefId, ivPuInfo, ivJ2eeName, ivRefName, ivProperties, ivUnsynchronized, ivAbstractJPAComponent);
+    }
+
+    @Override
+    protected JPATxEmInvocation createJPATxEmInvocation(UOWCoordinator uowCoord, EntityManager em) {
+        return new JPATxEmInvocationV30(uowCoord, em, this, isTxUnsynchronized());
+    }
+
+    @Override
+    protected JPANoTxEmInvocation createJPANoTxEmInvocation(UOWCoordinator uowCoord, EntityManager em) {
+        return new JPANoTxEmInvocationV30(uowCoord, em, this, ivUnsynchronized);
+    }
+
+    @Override
+    public Query createQuery(@SuppressWarnings("rawtypes") CriteriaUpdate arg0) {
+        return getEMInvocationInfo(false).createQuery(arg0);
+    }
+
+    @Override
+    public Query createQuery(@SuppressWarnings("rawtypes") CriteriaDelete arg0) {
+        return getEMInvocationInfo(false).createQuery(arg0);
+    }
+
+    @Override
+    public <T> EntityGraph<T> createEntityGraph(Class<T> arg0) {
+        return getEMInvocationInfo(false).createEntityGraph(arg0);
+    }
+
+    @Override
+    public EntityGraph<?> createEntityGraph(String arg0) {
+        return getEMInvocationInfo(false).createEntityGraph(arg0);
+    }
+
+    @Override
+    public EntityGraph<?> getEntityGraph(String arg0) {
+        return getEMInvocationInfo(false).getEntityGraph(arg0);
+    }
+
+    @Override
+    public <T> List<EntityGraph<? super T>> getEntityGraphs(Class<T> arg0) {
+        return getEMInvocationInfo(false).getEntityGraphs(arg0);
+    }
+
+    @Override
+    public StoredProcedureQuery createNamedStoredProcedureQuery(String arg0) {
+        return getEMInvocationInfo(false).createNamedStoredProcedureQuery(arg0);
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String arg0) {
+        return getEMInvocationInfo(false).createStoredProcedureQuery(arg0);
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String arg0, @SuppressWarnings("rawtypes") Class... arg1) {
+        return getEMInvocationInfo(false).createStoredProcedureQuery(arg0, arg1);
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String arg0, String... arg1) {
+        return getEMInvocationInfo(false).createStoredProcedureQuery(arg0, arg1);
+    }
+
+    @Override
+    public boolean isJoinedToTransaction() {
+        return getEMInvocationInfo(false).isJoinedToTransaction();
+    }
+}

--- a/dev/com.ibm.ws.jpa.container.v30/src/com/ibm/ws/jpa/container/v30/internal/JPA30Runtime.java
+++ b/dev/com.ibm.ws.jpa.container.v30/src/com/ibm/ws/jpa/container/v30/internal/JPA30Runtime.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 IBM Corporation and others.
+ * Copyright (c) 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.jpa.container.v22.internal;
+package com.ibm.ws.jpa.container.v30.internal;
 
 import static com.ibm.ws.jpa.management.JPAConstants.JPA_RESOURCE_BUNDLE_NAME;
 import static com.ibm.ws.jpa.management.JPAConstants.JPA_TRACE_GROUP;
@@ -27,10 +27,10 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.Transaction.UOWCoordinator;
 import com.ibm.ws.jpa.JPAPuId;
-import com.ibm.ws.jpa.container.v22.JPAEMFactoryV22;
-import com.ibm.ws.jpa.container.v22.JPAExEmInvocationV22;
-import com.ibm.ws.jpa.container.v22.JPAExEntityManagerV22;
-import com.ibm.ws.jpa.container.v22.JPATxEntityManagerV22;
+import com.ibm.ws.jpa.container.v30.JPAEMFactoryV30;
+import com.ibm.ws.jpa.container.v30.JPAExEmInvocationV30;
+import com.ibm.ws.jpa.container.v30.JPAExEntityManagerV30;
+import com.ibm.ws.jpa.container.v30.JPATxEntityManagerV30;
 import com.ibm.ws.jpa.management.AbstractJPAComponent;
 import com.ibm.ws.jpa.management.JPA20Runtime;
 import com.ibm.ws.jpa.management.JPAExEmInvocation;
@@ -42,9 +42,9 @@ import com.ibm.ws.jpa.JPAVersion;
 
 @Component(service = JPARuntime.class,
            property = Constants.SERVICE_RANKING + ":Integer=21")
-public class JPA22Runtime extends JPA20Runtime implements JPARuntime {
+public class JPA30Runtime extends JPA20Runtime implements JPARuntime {
     private static final TraceComponent tc = Tr.register
-                    (JPA22Runtime.class,
+                    (JPA30Runtime.class,
                      JPA_TRACE_GROUP,
                      JPA_RESOURCE_BUNDLE_NAME);
 
@@ -52,7 +52,7 @@ public class JPA22Runtime extends JPA20Runtime implements JPARuntime {
 
     @Override
     public JPAVersion getJPARuntimeVersion() {
-        return JPAVersion.JPA22;
+        return JPAVersion.JPA30;
     }
 
     @Override
@@ -62,24 +62,24 @@ public class JPA22Runtime extends JPA20Runtime implements JPARuntime {
 
     @Override
     public EntityManagerFactory createJPAEMFactory(JPAPuId puId, J2EEName j2eeName, EntityManagerFactory emf) {
-        return new JPAEMFactoryV22(puId, j2eeName, emf);
+        return new JPAEMFactoryV30(puId, j2eeName, emf);
     }
 
     @Override
     public JPATxEntityManager createJPATxEntityManager(JPAPuId puRefId, JPAPUnitInfo puInfo, J2EEName j2eeName, String refName, Map<?, ?> properties,
                                                        boolean isUnsynchronized, AbstractJPAComponent jpaComponent) {
-        return new JPATxEntityManagerV22(puRefId, puInfo, j2eeName, refName, properties, isUnsynchronized, jpaComponent);
+        return new JPATxEntityManagerV30(puRefId, puInfo, j2eeName, refName, properties, isUnsynchronized, jpaComponent);
     }
 
     @Override
     public JPAExEntityManager createJPAExEntityManager(JPAPuId puRefId, JPAPUnitInfo puInfo, J2EEName j2eeName, String refName, Map<?, ?> properties,
                                                        boolean isUnsynchronized, AbstractJPAComponent jpaComponent) {
-        return new JPAExEntityManagerV22(puRefId, puInfo, j2eeName, refName, properties, isUnsynchronized, jpaComponent);
+        return new JPAExEntityManagerV30(puRefId, puInfo, j2eeName, refName, properties, isUnsynchronized, jpaComponent);
     }
 
     @Override
     public JPAExEmInvocation createExEmInvocation(UOWCoordinator uowCoord, EntityManager em, boolean txIsUnsynchronized) {
-        return new JPAExEmInvocationV22(uowCoord, em, txIsUnsynchronized);
+        return new JPAExEmInvocationV30(uowCoord, em, txIsUnsynchronized);
     }
 
     @Override

--- a/dev/com.ibm.ws.jpa.container.v30/src/com/ibm/ws/jpa/container/v30/internal/package-info.java
+++ b/dev/com.ibm.ws.jpa.container.v30/src/com/ibm/ws/jpa/container/v30/internal/package-info.java
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+@TraceOptions(traceGroup = JPAConstants.JPA_TRACE_GROUP, messageBundle = JPAConstants.JPA_RESOURCE_BUNDLE_NAME)
+package com.ibm.ws.jpa.container.v30.internal;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;
+import com.ibm.ws.jpa.management.JPAConstants;
+

--- a/dev/com.ibm.ws.jpa.container.v30/src/com/ibm/ws/jpa/container/v30/package-info.java
+++ b/dev/com.ibm.ws.jpa.container.v30/src/com/ibm/ws/jpa/container/v30/package-info.java
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+@TraceOptions(traceGroup = JPAConstants.JPA_TRACE_GROUP, messageBundle = JPAConstants.JPA_RESOURCE_BUNDLE_NAME)
+package com.ibm.ws.jpa.container.v30;
+
+import com.ibm.websphere.ras.annotation.TraceOptions;
+import com.ibm.ws.jpa.management.JPAConstants;
+

--- a/dev/com.ibm.ws.jpa.container/src/com/ibm/ws/jpa/container/osgi/internal/JPAComponentImpl.java
+++ b/dev/com.ibm.ws.jpa.container/src/com/ibm/ws/jpa/container/osgi/internal/JPAComponentImpl.java
@@ -65,6 +65,7 @@ import com.ibm.ws.jpa.JPAComponent;
 import com.ibm.ws.jpa.JPAExPcBindingContextAccessor;
 import com.ibm.ws.jpa.JPAProviderIntegration;
 import com.ibm.ws.jpa.JPAPuId;
+import com.ibm.ws.jpa.JPAVersion;
 import com.ibm.ws.jpa.container.osgi.jndi.JPAJndiLookupInfo;
 import com.ibm.ws.jpa.container.osgi.jndi.JPAJndiLookupInfoRefAddr;
 import com.ibm.ws.jpa.container.osgi.jndi.JPAJndiLookupObjectFactory;
@@ -331,10 +332,12 @@ public class JPAComponentImpl extends AbstractJPAComponent implements Applicatio
     }
 
     @Override
-    public void applicationStarted(ApplicationInfo appInfo) {}
+    public void applicationStarted(ApplicationInfo appInfo) {
+    }
 
     @Override
-    public void applicationStopping(ApplicationInfo appInfo) {}
+    public void applicationStopping(ApplicationInfo appInfo) {
+    }
 
     @Override
     public void applicationStopped(ApplicationInfo appInfo) {
@@ -857,9 +860,11 @@ public class JPAComponentImpl extends AbstractJPAComponent implements Applicatio
     }
 
     @Reference(name = REFERENCE_APP_COORD)
-    protected void setAppRecycleCoordinator(ServiceReference<ApplicationRecycleCoordinator> ref) {}
+    protected void setAppRecycleCoordinator(ServiceReference<ApplicationRecycleCoordinator> ref) {
+    }
 
-    protected void unsetAppRecycleCoordinator(ServiceReference<ApplicationRecycleCoordinator> ref) {}
+    protected void unsetAppRecycleCoordinator(ServiceReference<ApplicationRecycleCoordinator> ref) {
+    }
 
     @Override
     public void registerJPAExPcBindingContextAccessor(JPAExPcBindingContextAccessor accessor) {
@@ -1001,6 +1006,15 @@ public class JPAComponentImpl extends AbstractJPAComponent implements Applicatio
             JPAIntrospection.executeIntrospectionAnalysis(out);
         } finally {
             JPAIntrospection.endJPAIntrospection();
+        }
+    }
+
+    @Override
+    public JPAVersion getJPAVersion() {
+        try {
+            return getJPARuntime().getJPARuntimeVersion();
+        } catch (Throwable t) {
+            return JPAVersion.UNKNOWN;
         }
     }
 }


### PR DESCRIPTION
Add JPA 3.0 enum to JPAVersion, properly report JPA 2.2 with JPA22 Runtime, and add JPA30 Runtime.  Also, with JPA 3.0, the JPA runtime integration should not add the "eclipselink.allow-null-max-min" property.