### PR TITLE
Review JakartaEE9Action change that was done in PR #15307

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE9Action.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE9Action.java
@@ -224,7 +224,7 @@ public class JakartaEE9Action extends FeatureReplacementAction {
 
         // Setup FileOutputStream and never use.  JakartaTransformer defaults cause OOM
         FileOutputStream fos = null;
-        File throwAwayFile = appPath.resolveSibling(appPath.getFileName() + ".log").toFile();
+        File throwAwayFile = new File("transformer_output.log");
         try {
             fos = new FileOutputStream(throwAwayFile);
         } catch (FileNotFoundException e1) {
@@ -318,11 +318,6 @@ public class JakartaEE9Action extends FeatureReplacementAction {
             } else {
                 throw new RuntimeException("Jakarta transformer failed for: " + appPath);
             }
-
-            //If nothing failed
-            if (throwAwayFile.exists()) {
-                throwAwayFile.delete();
-            }
         } catch (Exception e) {
             Log.info(c, m, "Unable to transform app at path: " + appPath);
             Log.error(c, m, e);
@@ -331,6 +326,9 @@ public class JakartaEE9Action extends FeatureReplacementAction {
             try {
                 fos.close();
             } catch (IOException e) {
+            }
+            if (throwAwayFile.exists()) {
+                throwAwayFile.delete();
             }
             Log.info(c, m, "Transforming complete app: " + outputPath);
         }


### PR DESCRIPTION
- The change being reverted caused issues with tests failing because a log file is now in the dropins directory and the application runtime doesn't recognize files with a log extension as applications and outputs an error causing lots of tests to fail.
