### PR TITLE
Ignore AppForceRestart on quiesce

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
@@ -198,7 +198,7 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
         }
 
         void createNotifications() {
-            appForceRestart = runtimeUpdateManager.createNotification(RuntimeUpdateNotification.APP_FORCE_RESTART);
+            appForceRestart = runtimeUpdateManager.createNotification(RuntimeUpdateNotification.APP_FORCE_RESTART, true);
             featureBundlesResolved = runtimeUpdateManager.createNotification(RuntimeUpdateNotification.FEATURE_BUNDLES_RESOLVED);
         }
 

--- a/dev/com.ibm.ws.kernel.feature/test/com/ibm/ws/kernel/feature/internal/FeatureManagerTest.java
+++ b/dev/com.ibm.ws.kernel.feature/test/com/ibm/ws/kernel/feature/internal/FeatureManagerTest.java
@@ -239,7 +239,7 @@ public class FeatureManagerTest {
 
                     allowing(runtimeUpdateManager).createNotification(RuntimeUpdateNotification.FEATURE_UPDATES_COMPLETED);
                     will(returnValue(featureUpdatesCompleted));
-                    allowing(runtimeUpdateManager).createNotification(RuntimeUpdateNotification.APP_FORCE_RESTART);
+                    allowing(runtimeUpdateManager).createNotification(RuntimeUpdateNotification.APP_FORCE_RESTART, true);
                     will(returnValue(appForceRestart));
                     allowing(runtimeUpdateManager).createNotification(RuntimeUpdateNotification.FEATURE_BUNDLES_RESOLVED);
                     will(returnValue(featureBundlesResolved));


### PR DESCRIPTION
In rare situations, if a configuration update that includes a feature update is started as the server is shut down, the server quiesce will fail because it is waiting on applications to restart. 