### PR TITLE
Update FT 3.0 API link to maven central

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.faulttolerance-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.faulttolerance-3.0.feature
@@ -3,7 +3,7 @@ symbolicName=com.ibm.websphere.appserver.org.eclipse.microprofile.faulttolerance
 singleton=true
 -features=com.ibm.websphere.appserver.javax.cdi-2.0, \
           io.openliberty.mpCompatible-4.0
--bundles=io.openliberty.org.eclipse.microprofile.faulttolerance.3.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:3.0-RC1"
+-bundles=io.openliberty.org.eclipse.microprofile.faulttolerance.3.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:3.0"
 kind=beta
 edition=core
 WLP-Activation-Type: parallel


### PR DESCRIPTION
We are already using the final 3.0 version of the API, I just forgot to
update this maven central reference in the feature file.
