### PR TITLE
11793 - remove webcontainer dependency on com.ibm.ws.org.apache.cxf.rt.transport.http.3.2

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
@@ -40,7 +40,8 @@ Export-Package: \
 	com.ibm.websphere.jaxrs20.multipart;version=1.1.0,\
 	com.ibm.ws.jaxrs20.clientconfig,\
 	org.apache.cxf.feature,\
-	org.apache.cxf.jaxrs.client;version=3.1.18
+	org.apache.cxf.jaxrs.client;version=3.1.18,\
+	com.ibm.ws.cxf.exceptions;version=3.1.18
 
 Import-Package: \
  !com.wordnik.swagger.jaxrs.config, \
@@ -188,8 +189,7 @@ instrument.classesExcludes: com/ibm/ws/jaxrs20/internal/resources/*.class, \
 	com.ibm.websphere.appserver.spi.threading, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
 	com.ibm.ws.jaxrs.2.x.config;version=latest,\
-	javax.activation:activation;version=1.1, \
-	com.ibm.ws.webcontainer;version=latest
+	javax.activation:activation;version=1.1
 
 -testpath: \
 	org.hamcrest:hamcrest-all;version=1.3, \

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/cxf/exceptions/InvalidCharsetException.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/cxf/exceptions/InvalidCharsetException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,12 +8,15 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.webcontainer.exception;
+package com.ibm.ws.cxf.exceptions;
 
-@SuppressWarnings("serial")
-public class InvalidMediaTypeException extends RuntimeException {
-    
-    public InvalidMediaTypeException(String message) {
-        super(message);
-    }
+import java.io.IOException;
+
+public class InvalidCharsetException extends IOException {
+
+    private static final long serialVersionUID = 1676878985438910205L;
+
+    public InvalidCharsetException(String m) {  
+        super(m);       
+    }   
 }

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/endpoint/AbstractJaxRsWebEndpoint.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/endpoint/AbstractJaxRsWebEndpoint.java
@@ -25,6 +25,8 @@ import org.apache.cxf.transport.servlet.BaseUrlHelper;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.cxf.exceptions.InvalidCharsetException;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.jaxrs20.JaxRsRuntimeException;
 import com.ibm.ws.jaxrs20.api.JaxRsProviderFactoryService;
 import com.ibm.ws.jaxrs20.metadata.EndpointInfo;
@@ -123,6 +125,7 @@ public abstract class AbstractJaxRsWebEndpoint implements JaxRsWebEndpoint {
      * {@inheritDoc}
      */
     @Override
+    @FFDCIgnore(InvalidCharsetException.class)
     public void invoke(HttpServletRequest request, HttpServletResponse response) throws ServletException {
         if (destination == null)
         {
@@ -132,6 +135,8 @@ public abstract class AbstractJaxRsWebEndpoint implements JaxRsWebEndpoint {
         try {
             updateDestination(request);
             destination.invoke(servletConfig, servletConfig.getServletContext(), request, response);
+        } catch (InvalidCharsetException e) {
+                response.setStatus(HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE);
         } catch (IOException e) {
             throw new ServletException(e);
         } catch (JaxRsRuntimeException ex) {

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
@@ -81,8 +81,8 @@ import org.apache.cxf.ws.addressing.EndpointReferenceUtils;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.cxf.exceptions.InvalidCharsetException;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
-import com.ibm.ws.webcontainer.exception.InvalidMediaTypeException;
 
 /**
  * Common base for HTTP Destination implementations.
@@ -467,7 +467,7 @@ public abstract class AbstractHTTPDestination
                 // Liberty Change Start
                 String m = "Invalid MediaType encoding: " + enc;
                 Tr.warning(tc, m);
-                throw new InvalidMediaTypeException(m); // throw so webcontainer returns a 415
+                throw new InvalidCharsetException(m);
                 // Liberty Change End
             }
             inMessage.put(Message.ENCODING, normalizedEncoding);

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/helloworld/HelloWorldTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/helloworld/HelloWorldTest.java
@@ -27,7 +27,6 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
-import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
@@ -98,7 +97,6 @@ public class HelloWorldTest {
 
     @Test
     @SkipForRepeat("EE9_FEATURES")
-    @ExpectedFFDC("com.ibm.ws.webcontainer.exception.InvalidMediaTypeException")
     public void testInvalidCharset() throws Exception {
         assertEquals(415, runGetMethodInvalidCharset("/helloworld/rest/helloworld"));
     }

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs20/endpoint/AbstractJaxRsWebEndpoint.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs20/endpoint/AbstractJaxRsWebEndpoint.java
@@ -25,6 +25,8 @@ import org.apache.cxf.transport.servlet.BaseUrlHelper;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.cxf.exceptions.InvalidCharsetException;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.jaxrs20.JaxRsRuntimeException;
 import com.ibm.ws.jaxrs20.api.JaxRsProviderFactoryService;
 import com.ibm.ws.jaxrs20.metadata.EndpointInfo;
@@ -123,6 +125,7 @@ public abstract class AbstractJaxRsWebEndpoint implements JaxRsWebEndpoint {
      * {@inheritDoc}
      */
     @Override
+    @FFDCIgnore(InvalidCharsetException.class)
     public void invoke(HttpServletRequest request, HttpServletResponse response) throws ServletException {
         if (destination == null)
         {
@@ -132,6 +135,8 @@ public abstract class AbstractJaxRsWebEndpoint implements JaxRsWebEndpoint {
         try {
             updateDestination(request);
             destination.invoke(servletConfig, servletConfig.getServletContext(), request, response);
+        } catch (InvalidCharsetException e) {
+            response.setStatus(HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE);
         } catch (IOException e) {
             throw new ServletException(e);
         } catch (JaxRsRuntimeException ex) {

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/bnd.bnd
@@ -24,7 +24,6 @@
   com.ibm.ws.logging.core,\
   com.ibm.ws.org.apache.cxf.cxf.core.3.2;version=latest,\
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-  com.ibm.wsspi.org.osgi.core, \
-  com.ibm.ws.webcontainer;version=latest
+  com.ibm.wsspi.org.osgi.core
 
 jakartaeeMe: true

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/bnd.overrides
@@ -15,7 +15,8 @@ Export-Package: \
   org.apache.cxf.transport.https;version=${exportVer},\
   org.apache.cxf.transport.servlet;version=${exportVer},\
   org.apache.cxf.transports.http;version=${exportVer},\
-  org.apache.cxf.transports.http.configuration;version=${exportVer}
+  org.apache.cxf.transports.http.configuration;version=${exportVer},\
+  com.ibm.ws.cxf.exceptions;version=${exportVer}
   
 Import-Package: \
   !org.apache.aries.*,\

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/com/ibm/ws/cxf/exceptions/InvalidCharsetException.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/com/ibm/ws/cxf/exceptions/InvalidCharsetException.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cxf.exceptions;
+
+import java.io.IOException;
+
+public class InvalidCharsetException extends IOException {
+
+    private static final long serialVersionUID = 1676878985438910205L;
+
+    public InvalidCharsetException(String m) {  
+        super(m);       
+    }   
+}

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
@@ -80,8 +80,8 @@ import org.apache.cxf.ws.addressing.EndpointReferenceUtils;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.cxf.exceptions.InvalidCharsetException;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
-import com.ibm.ws.webcontainer.exception.InvalidMediaTypeException;
 
 /**
  * Common base for HTTP Destination implementations.
@@ -469,7 +469,7 @@ public abstract class AbstractHTTPDestination
                 // Liberty Change Start
                 String m = "Invalid MediaType encoding: " + enc;
                 Tr.warning(tc, m);
-                throw new InvalidMediaTypeException(m); // throw so webcontainer returns a 415
+                throw new InvalidCharsetException(m);
                 // Liberty Change End
             }
             inMessage.put(Message.ENCODING, normalizedEncoding);

--- a/dev/com.ibm.ws.webcontainer/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer/bnd.bnd
@@ -97,8 +97,7 @@ Export-Package: !*.internal.*, \
     com.ibm.ws.webcontainer.webapp;provide:=true, \
     com.ibm.ws.webcontainer.servlet, \
     com.ibm.ws.webcontainer.spiadapter.collaborator, \
-    com.ibm.ws.container, \
-    com.ibm.ws.webcontainer.exception;provide=true
+    com.ibm.ws.container
     
 Private-Package: \
 	com.ibm.websphere.csi, \

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebAppErrorReport.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebAppErrorReport.java
@@ -24,7 +24,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.ibm.websphere.servlet.error.ServletErrorReport;
 import com.ibm.ws.webcontainer.exception.IncludeFileNotFoundException;
-import com.ibm.ws.webcontainer.exception.InvalidMediaTypeException;
 import com.ibm.ws.webcontainer.servlet.DefaultErrorReporter;
 import com.ibm.wsspi.webcontainer.RequestProcessor;
 import com.ibm.wsspi.webcontainer.WCCustomProperties;
@@ -176,9 +175,6 @@ public class WebAppErrorReport extends ServletErrorReport     // 96236
             } else {
                 r.setErrorCode(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
             }
-        }
-        else if (rootCause instanceof InvalidMediaTypeException) {
-            r.setErrorCode(HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE);
         }
         else {
             r.setErrorCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
updating my solution for #11793 to remove the webcontainer dependency on com.ibm.ws.org.apache.cxf.rt.transport.http.3.2 which was breaking the xmlWS-3.0 client.