### PR TITLE
Create new test-category for mpJwt Security FATs

### DIFF
--- a/.github/test-categories/MP_JWT_3
+++ b/.github/test-categories/MP_JWT_3
@@ -1,0 +1,2 @@
+com.ibm.ws.security.mp.jwt.1.1_fat
+com.ibm.ws.security.mp.jwt.1.2_fat


### PR DESCRIPTION
Creating a new sub test-category for the Security mp.jwt fat buckets.
The other buckets contained the jwt builder and consumer, as well as jwtsso and the mpJwt tck.
These 2 buckets will take some time to run, so, I'm creating a new category.

MP_JWT_3


#build