### PR TITLE
Ensure async servlet support is enabled when `@ApplicationPath` not used

### DIFF
--- a/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/component/RESTfulServletContainerInitializer.java
+++ b/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/component/RESTfulServletContainerInitializer.java
@@ -117,6 +117,7 @@ public class RESTfulServletContainerInitializer extends ResteasyServletInitializ
                 String servletClassName = servletReg.getClassName();
                 if (servletClassName == null) {
                     ServletRegistration.Dynamic dynReg = servletContext.addServlet(servletReg.getName(), HttpServlet30Dispatcher.class);
+                    dynReg.setAsyncSupported(true);
                     dynReg.setInitParameter(APPLICATION, applicationClass.getName());
                 }
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {


### PR DESCRIPTION
When there is a web.xml that specifies the JAX-RS application to use (and defines the app path in lieu of the `@ApplicationPath("/somePath")` annotation), we need to ensure that async servlet support is enabled.