### PR TITLE
Issue #15447: Fix CouchDB FAT

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1359,12 +1359,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-cache</artifactId>
-      <version>4.1.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient-cache</artifactId>
-      <version>4.3.1</version>
+      <version>4.5.13</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -1955,6 +1950,11 @@
       <groupId>org.eclipse.microprofile.rest.client</groupId>
       <artifactId>microprofile-rest-client-api</artifactId>
       <version>1.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.microprofile.rest.client</groupId>
+      <artifactId>microprofile-rest-client-api</artifactId>
+      <version>2.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.transformer</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -267,8 +267,7 @@ org.apache.httpcomponents.client5:httpclient5:5.0.2
 org.apache.httpcomponents.core5:httpcore5-h2:5.0.2
 org.apache.httpcomponents.core5:httpcore5:5.0.2
 org.apache.httpcomponents:fluent-hc:4.3.1
-org.apache.httpcomponents:httpclient-cache:4.1.2
-org.apache.httpcomponents:httpclient-cache:4.3.1
+org.apache.httpcomponents:httpclient-cache:4.5.13
 org.apache.httpcomponents:httpclient:4.1.2
 org.apache.httpcomponents:httpclient:4.5.13
 org.apache.httpcomponents:httpclient:4.5.4

--- a/dev/com.ibm.ws.couchdb_fat/bnd.bnd
+++ b/dev/com.ibm.ws.couchdb_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -24,9 +24,10 @@ tested.features:\
 
 -buildpath: \
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
+	com.github.docker-java:docker-java-api;version=3.2.5,\
+	io.openliberty.com.fasterxml.jackson;version=2.11.2,\
 	org.ektorp:org.ektorp;version=1.5.0,\
 	org.rnorth.duct-tape:duct-tape;version=1.0.7,\
-	com.github.docker-java:docker-java-api;version=3.2.5,\
 	org.testcontainers:database-commons;version=1.15.0,\
 	org.testcontainers:testcontainers;version=1.15.0,\
 	org.slf4j:slf4j-api;version=1.7.7

--- a/dev/com.ibm.ws.couchdb_fat/build.gradle
+++ b/dev/com.ibm.ws.couchdb_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019,2020 IBM Corporation and others.
+ * Copyright (c) 2019,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 configurations {
-  couchdb
+  couchdb {transitive = false}
 }
 
 dependencies {
@@ -19,7 +19,7 @@ dependencies {
           'commons-io:commons-io:2.6',
           'commons-logging:commons-logging:1.1.1',
           project(':com.ibm.ws.org.apache.httpcomponents'),
-          'org.apache.httpcomponents:httpclient-cache:4.3.1',
+          'org.apache.httpcomponents:httpclient-cache:4.5.13',
           'org.ektorp:org.ektorp:1.5.0',
           'org.slf4j:slf4j-api:1.7.7',
           'org.slf4j:slf4j-jdk14:1.7.7'

--- a/dev/com.ibm.ws.couchdb_fat/publish/servers/com.ibm.ws.couchdb.fat.server/server.xml
+++ b/dev/com.ibm.ws.couchdb_fat/publish/servers/com.ibm.ws.couchdb.fat.server/server.xml
@@ -23,22 +23,23 @@
         <classloader commonLibraryRef="couchdb-lib" />
     </application>
 
-    <variable name="EktorpCodebase" value="${server.config.dir}/couchdb/org.ektorp-1.4.1.jar"/>
+    <variable name="EktorpCodebase" value="${server.config.dir}/couchdb/org.ektorp-1.5.0.jar"/>
 
     <!-- Needed for commons-logging-1.1.1.jar -->
     <javaPermission codebase="${EktorpCodebase}" className="java.util.PropertyPermission" name="org.apache.commons.logging.*" actions="read"/>
     <javaPermission codebase="${EktorpCodebase}" className="java.lang.RuntimePermission" name="getClassLoader"/>
 
-    <!-- Needed for jackson-databind-2.2.3.jar & org.ektorp-1.4.1.jar -->
+    <!-- Needed for jackson-databind-2.11.2.jar & org.ektorp-1.5.0.jar -->
     <javaPermission codebase="${EktorpCodebase}" className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
 
-    <!-- Needed for httpclient-4.3.1.jar -->
+    <!-- Needed for httpclient-4.5.13.jar -->
     <javaPermission codebase="${EktorpCodebase}" className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
 
-    <!-- Needed for org.ektorp-1.4.1.jar -->
+    <!-- Needed for org.ektorp-1.5.0.jar -->
     <javaPermission codebase="${EktorpCodebase}" className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
 
-    <!-- Needed for jackson-core-2.2.3.jar -->
+    <!-- Needed for jackson-core-2.11.2.jar -->
     <javaPermission codebase="${EktorpCodebase}" className="java.util.PropertyPermission" name="line.separator" actions="read"/>
+    <javaPermission codebase="${EktorpCodebase}" className="java.util.PropertyPermission" name="com.fasterxml.jackson.*" actions="read"/>
 
 </server>

--- a/dev/fattest.simplicity/src/componenttest/containers/ExternalTestServiceDockerClientStrategy.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/ExternalTestServiceDockerClientStrategy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -81,8 +81,10 @@ public class ExternalTestServiceDockerClientStrategy extends DockerClientProvide
         try {
             Properties tcProps = new Properties();
             if (testcontainersConfigFile.exists()) {
-                tcProps.load(new FileInputStream(testcontainersConfigFile));
+                FileInputStream tcPropsInputStream = new FileInputStream(testcontainersConfigFile);
+                tcProps.load(tcPropsInputStream);
                 tcProps.remove("docker.client.strategy");
+                tcPropsInputStream.close(); // avoids delete failing on windows
                 Files.delete(testcontainersConfigFile.toPath());
             }
             tcProps.setProperty("image.substitutor", ArtifactoryImageNameSubstitutor.class.getCanonicalName().toString());


### PR DESCRIPTION
Fixes the following:
- updates Java 2 security permissions in server.xml after upgrade to new ektorp version
- sets transitive = false to avoid multiple versions of fasterxml.jackson
- fixes file locking problem replacing .testcontainers.properties file
- adds missing build dependeny on fasterxml.jackson

fixes #15447 