### PR TITLE
Update MP JWT 1.2 to use final version of MicroProfile API

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1839,7 +1839,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.jwt</groupId>
       <artifactId>microprofile-jwt-auth-api</artifactId>
-      <version>1.2-RC1</version>
+      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.lra</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -363,7 +363,7 @@ org.eclipse.microprofile.health:microprofile-health-api:2.1
 org.eclipse.microprofile.health:microprofile-health-api:2.2
 org.eclipse.microprofile.health:microprofile-health-api:3.0
 org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:1.0
-org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:1.2-RC1
+org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:1.2
 org.eclipse.microprofile.lra:microprofile-lra-api:1.0-M2
 org.eclipse.microprofile.metrics:microprofile-metrics-api:1.0
 org.eclipse.microprofile.metrics:microprofile-metrics-api:1.1.1

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpJwtPropagation-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.mpJwtPropagation-1.2.feature
@@ -4,7 +4,7 @@ visibility=private
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.jaxrsClient-2.1)))", \
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.mpJwt-1.2)))"
 IBM-Install-Policy: when-satisfied 
--bundles=io.openliberty.org.eclipse.microprofile.jwt.1.2; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:1.2-RC1",\
+-bundles=io.openliberty.org.eclipse.microprofile.jwt.1.2; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:1.2",\
  com.ibm.ws.security.mp.jwt.propagation, \
  com.ibm.ws.jaxrs.2.0.client
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.jwt-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.jwt-1.2.feature
@@ -3,7 +3,7 @@ symbolicName=com.ibm.websphere.appserver.org.eclipse.microprofile.jwt-1.2
 visibility=private
 singleton=true
 -features=io.openliberty.mpCompatible-4.0
--bundles=io.openliberty.org.eclipse.microprofile.jwt.1.2; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:1.2-RC1"
+-bundles=io.openliberty.org.eclipse.microprofile.jwt.1.2; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:1.2"
 kind=beta
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/Readme.txt
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/Readme.txt
@@ -60,7 +60,7 @@ Debugging:
    
 To debug with a local version of the tests, download the test jar to your local system and in the
 /io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/pom.xml, update and uncomment the following lines
-       <systemPath>/Users/YourName/MPJWT12/1.2-RC1/microprofile-jwt-auth-tck-1.2-RC1.jar</systemPath> 
+       <systemPath>/Users/YourName/MPJWT12/1.2/microprofile-jwt-auth-tck-1.2.jar</systemPath> 
        <scope>system</scope> 
    
    

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.jwt</groupId>
             <artifactId>microprofile-jwt-auth-api</artifactId>
-            <version>1.2-RC2</version>
+            <version>1.2</version>
         </dependency>
         
         <!--  impl -->
@@ -76,14 +76,14 @@
         <dependency>
             <groupId>org.eclipse.microprofile.jwt</groupId>
             <artifactId>microprofile-jwt-auth-tck</artifactId>
-            <version>1.2-RC2</version>
+            <version>1.2</version>
         </dependency>
        
         <!-- This is the actual MP-JWT TCK test classes -->
         <dependency>
             <groupId>org.eclipse.microprofile.jwt</groupId>
             <artifactId>microprofile-jwt-auth-tck</artifactId>
-            <version>1.2-RC2</version>
+            <version>1.2</version>
             <type>test-jar</type>        
            <!-- <systemPath>/Users/kristenclarke/MPJWT12/clone111020_RC212/microprofile-jwt-auth/tck/target/microprofile-jwt-auth-tck-1.2.RC2-SNAPSHOT-tests.jar</systemPath>  -->
             <!--  <scope>system</scope> -->

--- a/dev/io.openliberty.org.eclipse.microprofile/jwt.1.2.bnd
+++ b/dev/io.openliberty.org.eclipse.microprofile/jwt.1.2.bnd
@@ -21,6 +21,6 @@ Export-Package: org.eclipse.microprofile.jwt;version=1.2, \
                 org.eclipse.microprofile.auth;version=1.2
 
 Include-Resource: \
-  @${repo;org.eclipse.microprofile.jwt:microprofile-jwt-auth-api;1.2.0.RC1;EXACT}
+  @${repo;org.eclipse.microprofile.jwt:microprofile-jwt-auth-api;1.2;EXACT}
 
 WS-TraceGroup: MPJWT


### PR DESCRIPTION
Updates the MP JWT 1.2 feature to use version `1.2` of the API instead of `1.2-RC1`.