### PR TITLE
Fix o auth java2

### DIFF
--- a/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/actions/JwtBuilderActions.java
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/actions/JwtBuilderActions.java
@@ -70,11 +70,12 @@ public class JwtBuilderActions extends TestActions {
         Page response = null;
         try {
             response = invokeUrlWithParameters(testName, webClient, jwtBuilderUrl, requestParams);
-            webClient.close();
             return response;
         } catch (Exception e) {
             Log.info(thisClass, "invokeJwtBuilder", e.getMessage());
             throw e;
+        } finally {
+            destroyWebClient(webClient);
         }
 
     }
@@ -136,11 +137,12 @@ public class JwtBuilderActions extends TestActions {
         try {
             response = invokeUrlWithParametersAndHeaders(testName, webClient, jwtBuilderUrl, requestParams,
                     requestHeaders);
-            webClient.close();
             return response;
         } catch (Exception e) {
             Log.info(thisClass, "invokeJwtBuilder", e.getMessage());
             throw e;
+        } finally {
+            destroyWebClient(webClient);
         }
 
     }

--- a/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/actions/JwtConsumerActions.java
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/actions/JwtConsumerActions.java
@@ -44,11 +44,12 @@ public class JwtConsumerActions extends JwtTokenActions {
         Page response = null;
         try {
             response = invokeUrlWithParameters(testName, webClient, jwtConsumerUrl, requestParams);
-            webClient.close();
             return response;
         } catch (Exception e) {
             Log.info(thisClass, "invokeJwtConsumer", e.getMessage());
             throw e;
+        } finally {
+            destroyWebClient(webClient);
         }
 
     }

--- a/dev/com.ibm.ws.security.oauth_fat/build.gradle
+++ b/dev/com.ibm.ws.security.oauth_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -140,6 +140,7 @@ autoFVT.doLast {
     copy {
       from configurations.mongoJavaDriver
       into new File(autoFvtDir, 'publish/servers/' + server + '/mongoDB')
+      rename 'mongo-java-driver-.*.jar', 'mongo-java-driver.jar'
     }
   }
 

--- a/dev/com.ibm.ws.security.oauth_fat/publish/servers/com.ibm.ws.security.oauth-2.0.fat/server.xml
+++ b/dev/com.ibm.ws.security.oauth_fat/publish/servers/com.ibm.ws.security.oauth-2.0.fat/server.xml
@@ -215,4 +215,7 @@
 			dir="${server.config.dir}"
 			includes="testLib.jar" />
 	</library>
+	
+	<javaPermission className="java.net.SocketPermission" actions="connect,resolve" name="*"/>
+	
 </server>


### PR DESCRIPTION
The OAuth FAT tests are failing when run with Java 2 enabled.
Add a permission and fix a jar name that should already have permissions.
