### PR TITLE
Update mpOpenAPI-2.0 Artifacts

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -682,6 +682,16 @@
       <version>1.0.9</version>
     </dependency>
     <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-open-api-core</artifactId>
+      <version>2.1.0-RC2</version>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-open-api-jaxrs</artifactId>
+      <version>2.1.0-RC2</version>
+    </dependency>
+    <dependency>
       <groupId>jakarta.activation</groupId>
       <artifactId>jakarta.activation-api</artifactId>
       <version>2.0.0</version>
@@ -1889,7 +1899,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.openapi</groupId>
       <artifactId>microprofile-openapi-api</artifactId>
-      <version>2.0-RC3</version>
+      <version>2.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.opentracing</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -132,6 +132,8 @@ io.smallrye.config:smallrye-config:2.0.1
 io.smallrye:smallrye-graphql-client-api:1.0.9
 io.smallrye:smallrye-graphql-client:1.0.9
 io.smallrye:smallrye-graphql-schema-model:1.0.9
+io.smallrye:smallrye-open-api-core:2.1.0-RC2
+io.smallrye:smallrye-open-api-jaxrs:2.1.0-RC2
 jakarta.activation:jakarta.activation-api:2.0.0
 jakarta.annotation:jakarta.annotation-api:2.0.0
 jakarta.authentication:jakarta.authentication-api:2.0.0
@@ -373,7 +375,7 @@ org.eclipse.microprofile.metrics:microprofile-metrics-api:2.3
 org.eclipse.microprofile.metrics:microprofile-metrics-api:3.0
 org.eclipse.microprofile.openapi:microprofile-openapi-api:1.0.1
 org.eclipse.microprofile.openapi:microprofile-openapi-api:1.1.1
-org.eclipse.microprofile.openapi:microprofile-openapi-api:2.0-RC3
+org.eclipse.microprofile.openapi:microprofile-openapi-api:2.0
 org.eclipse.microprofile.opentracing:microprofile-opentracing-api:1.0.1
 org.eclipse.microprofile.opentracing:microprofile-opentracing-api:1.1
 org.eclipse.microprofile.opentracing:microprofile-opentracing-api:1.2

--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -81,8 +81,6 @@ com.ibm.ws.org.eclipse.platform:org.eclipse.osgi:3.15.200.v20200214-1600
 com.ibm.ws.org.objenesis:objenesis:1.0
 com.ibm.ws:geronimo-validation:1.1
 com.ibm.ws:nekohtml:1.9.18
-io.smallrye:smallrye-open-api-core:2.1.0-SNAPSHOT-20200917
-io.smallrye:smallrye-open-api-jaxrs:2.1.0-SNAPSHOT-20200917
 net.sf.jtidy:jtidy:9.3.8
 org.apache.aries.blueprint:org.apache.aries.blueprint:1.3.0-ibm-s20170710-0926
 org.apache.cxf:cxf-core:3.4.1-20201002

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.openapi-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.openapi-2.0.feature
@@ -2,7 +2,7 @@
 symbolicName=com.ibm.websphere.appserver.org.eclipse.microprofile.openapi-2.0
 singleton=true
 -features=io.openliberty.mpCompatible-4.0
--bundles=io.openliberty.org.eclipse.microprofile.openapi.2.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.openapi:microprofile-openapi-api:2.0-RC3"
+-bundles=io.openliberty.org.eclipse.microprofile.openapi.2.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.openapi:microprofile-openapi-api:2.0"
 kind=beta
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/io.openliberty.io.smallrye.openapi.core/bnd.bnd
+++ b/dev/io.openliberty.io.smallrye.openapi.core/bnd.bnd
@@ -38,7 +38,7 @@ Service-Component: \
     properties:="resources=META-INF/services/io.smallrye.openapi.runtime.scanner.spi.AnnotationScanner"
   
 -buildpath: \
-    io.smallrye:smallrye-open-api-core;strategy=exact;version=2.1.0.SNAPSHOT-20200917,\
+    io.smallrye:smallrye-open-api-core;version=latest,\
     io.openliberty.org.eclipse.microprofile.openapi.2.0;version=latest,\
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
     com.ibm.ws.logging;version=latest,\

--- a/dev/io.openliberty.io.smallrye.openapi.jaxrs/bnd.bnd
+++ b/dev/io.openliberty.io.smallrye.openapi.jaxrs/bnd.bnd
@@ -27,7 +27,7 @@ Export-Package: \
     io.smallrye.openapi.jaxrs;version=2.0.0
 
 -buildpath: \
-    io.smallrye:smallrye-open-api-jaxrs;strategy=exact;version=2.1.0.SNAPSHOT-20200917,\
+    io.smallrye:smallrye-open-api-jaxrs;version=latest,\
     io.openliberty.org.eclipse.microprofile.openapi.2.0;version=latest,\
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
     com.ibm.ws.logging;version=latest,\

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/cache/ConfigSerializer.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/cache/ConfigSerializer.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Function;
@@ -58,6 +59,9 @@ public class ConfigSerializer {
         INFO_LICENSE_NAME("getInfoLicenseName", OpenApiConfig::getInfoLicenseName),
         INFO_LICENSE_URL("getInfoLicenseUrl", OpenApiConfig::getInfoLicenseName),
         OPERATION_ID_STRATEGY("getOperationIdStrategy", OpenApiConfig::getOperationIdStrategy, OperationIdStrategy::name),
+        ARRAY_REFERENCES_ENABLE("arrayReferencesEnable", c -> Boolean.toString(c.arrayReferencesEnable())),
+        DEFAULT_PRODUCES("getDefaultProduces", OpenApiConfig::getDefaultProduces, Optional::toString),
+        DEFAULT_CONSUMES("getDefaultConsumes", OpenApiConfig::getDefaultConsumes, Optional::toString),
         ;
 
         Function<OpenApiConfig, String> function;

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -12,7 +12,7 @@
     <url>https://github.ibm.com/</url>
 
     <properties>
-        <microprofile.openapi.version>2.0-RC3</microprofile.openapi.version>
+        <microprofile.openapi.version>2.0</microprofile.openapi.version>
 
 <!--         
         <surefire.version>2.17</surefire.version> Any changes to the surefire version must be tested against ZOS

--- a/dev/io.openliberty.org.eclipse.microprofile/openapi.2.0.bnd
+++ b/dev/io.openliberty.org.eclipse.microprofile/openapi.2.0.bnd
@@ -18,6 +18,6 @@ Export-Package: \
   org.eclipse.microprofile.openapi.*
 
 Include-Resource: \
-  @${repo;org.eclipse.microprofile.openapi:microprofile-openapi-api;2.0.0.RC3;EXACT}
+  @${repo;org.eclipse.microprofile.openapi:microprofile-openapi-api;2.0}
 
 WS-TraceGroup: MPOPENAPI


### PR DESCRIPTION
Updated references to consume `mpOpenAPI-2.0` using MP2.0 and SmallRye 2.1.0-RC2 libraries from artifactory.

resolves #15451

#build 
#spawn.fullfat.buckets=com.ibm.ws.microprofile.openapi_fat,com.ibm.ws.microprofile.openapi_fat_tck,com.ibm.ws.microprofile.openapi.1.1_fat_tck,io.openliberty.microprofile.openapi.2.0.internal_fat,io.openliberty.microprofile.openapi.2.0.internal_fat_tck