### PR TITLE
Fixes the SocketTimeOutException in Health FAT

### DIFF
--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/ApplicationStateHealthCheck/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/publish/servers/ApplicationStateHealthCheck/bootstrap.properties
@@ -1,2 +1,3 @@
 bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:HEALTH=all:com.ibm.ws.webcontainer.extension.*=all
 osgi.console=7771


### PR DESCRIPTION
fixes #15443

- In the ApplicationStateHealthCheckTest FAT, the health check endpoints are repeatedly hit, however, sometimes due to a rare timing issue in the build, the `HTTPURLConnection` may throw a `SocketTimeoutException` / `SocketException`, due to the connection timing out. In these types of cases, we should retry the connection to the endpoints.