### PR TITLE
Fix Indirection Reference issue for TestContainers

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/bnd.bnd
@@ -31,6 +31,7 @@ tested.features: persistentExecutor-2.0, servlet-5.0
 
 -buildpath: \
 	fattest.databases;version=latest,\
+    com.github.docker-java:docker-java-api;version=latest,\
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/bnd.bnd
@@ -27,6 +27,7 @@ fat.test.databases: true
 #fat.test.use.remote.docker: true
 
 -buildpath: \
+    com.github.docker-java:docker-java-api;version=latest,\
 	com.ibm.ws.componenttest.2.0;version=latest,\
 	fattest.databases;version=latest,\
 	io.openliberty.jakarta.annotation.2.0;version=latest,\

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/bnd.bnd
@@ -28,6 +28,7 @@ fat.test.databases: true
 
 -buildpath: \
 	fattest.databases;version=latest,\
+    com.github.docker-java:docker-java-api;version=latest,\
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.ejb.3.2,\
 	com.ibm.websphere.javaee.servlet.4.0;version=latest,\

--- a/dev/com.ibm.ws.concurrent.persistent_fat_locking/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_locking/bnd.bnd
@@ -30,6 +30,7 @@ fat.test.databases: true
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)
 -buildpath: \
 	fattest.databases;version=latest,\
+    com.github.docker-java:docker-java-api;version=latest,\
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.0;version=latest,\
 	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\

--- a/dev/com.ibm.ws.concurrent.persistent_fat_multiple/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_multiple/bnd.bnd
@@ -28,6 +28,7 @@ fat.test.databases: true
 
 -buildpath: \
 	fattest.databases;version=latest,\
+    com.github.docker-java:docker-java-api;version=latest,\
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
@@ -38,5 +39,3 @@ fat.test.databases: true
 	org.testcontainers:testcontainers;version=1.15.0,\
 	org.rnorth.duct-tape:duct-tape;version=1.0.7,\
 	org.slf4j:slf4j-api;version=1.7.7
-	
-

--- a/dev/com.ibm.ws.concurrent.persistent_fat_timers/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_timers/bnd.bnd
@@ -27,6 +27,7 @@ fat.test.databases: true
 #fat.test.use.remote.docker: true
 
 -buildpath: \
+    com.github.docker-java:docker-java-api;version=latest,\
 	com.ibm.ws.componenttest.2.0;version=latest,\
 	fattest.databases;version=latest,\
 	io.openliberty.jakarta.annotation.2.0;version=latest,\

--- a/dev/com.ibm.ws.jdbc_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat/bnd.bnd
@@ -33,6 +33,7 @@ fat.test.databases: true
 -buildpath: \
 	fattest.databases;version=latest,\
 	org.slf4j:slf4j-api;version=1.7.7,\
+    com.github.docker-java:docker-java-api;version=latest,\
 	com.ibm.ws.componenttest,\
 	com.ibm.websphere.javaee.annotation.1.1,\
 	com.ibm.websphere.javaee.transaction.1.1,\

--- a/dev/com.ibm.ws.jpa_eclipselink_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa_eclipselink_fat/bnd.bnd
@@ -43,6 +43,7 @@ tested.features: el-3.0, persistence-3.0, servlet-5.0, cdi-3.0, beanValidation-3
 -buildpath: \
     com.ibm.ws.jpa_testframework;version=latest,\
     fattest.databases;version=latest,\
+    com.github.docker-java:docker-java-api;version=latest,\
     com.ibm.websphere.javaee.annotation.1.2;version=latest,\
     com.ibm.websphere.javaee.cdi.2.0;version=latest,\
     com.ibm.websphere.javaee.ejb.3.2;version=latest,\

--- a/dev/com.ibm.ws.jpa_locking_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa_locking_fat/bnd.bnd
@@ -32,6 +32,7 @@ tested.features: xmlBinding-3.0, servlet-5.0, jpacontainer-3.0, enterprisebeansl
 -buildpath: \
     com.ibm.ws.jpa_testframework;version=latest,\
     fattest.databases;version=latest,\
+    com.github.docker-java:docker-java-api;version=latest,\
     com.ibm.websphere.javaee.annotation.1.1;version=latest,\
     com.ibm.websphere.javaee.cdi.2.0;version=latest,\
     com.ibm.websphere.javaee.ejb.3.2;version=latest,\

--- a/dev/com.ibm.ws.jpa_ol_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa_ol_fat/bnd.bnd
@@ -33,6 +33,7 @@ tested.features: el-3.0, persistence-3.0, servlet-5.0, cdi-3.0, beanValidation-3
 -buildpath: \
     com.ibm.ws.jpa_testframework;version=latest,\
     fattest.databases;version=latest,\
+    com.github.docker-java:docker-java-api;version=latest,\
     com.ibm.websphere.javaee.annotation.1.2;version=latest,\
     com.ibm.websphere.javaee.cdi.2.0;version=latest,\
     com.ibm.websphere.javaee.ejb.3.2;version=latest,\

--- a/dev/com.ibm.ws.jpa_spec10_injection_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa_spec10_injection_fat/bnd.bnd
@@ -34,6 +34,7 @@ fat.bucket.db.type: Derby
 -buildpath: \
     com.ibm.ws.jpa_testframework;version=latest,\
     fattest.databases;version=latest,\
+    com.github.docker-java:docker-java-api;version=latest,\
     com.ibm.websphere.javaee.annotation.1.1;version=latest,\
     com.ibm.websphere.javaee.cdi.2.0;version=latest,\
     com.ibm.websphere.javaee.ejb.3.2;version=latest,\

--- a/dev/com.ibm.ws.jpa_spec10_part01_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa_spec10_part01_fat/bnd.bnd
@@ -37,6 +37,7 @@ tested.features: jdbc-4.0, beanvalidation-1.1, jpa-2.0, el-3.0, persistence-3.0,
 -buildpath: \
     com.ibm.ws.jpa_testframework;version=latest,\
     fattest.databases;version=latest,\
+    com.github.docker-java:docker-java-api;version=latest,\
     com.ibm.websphere.javaee.annotation.1.1;version=latest,\
     com.ibm.websphere.javaee.cdi.2.0;version=latest,\
     com.ibm.websphere.javaee.ejb.3.2;version=latest,\

--- a/dev/com.ibm.ws.jpa_spec10_part02_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa_spec10_part02_fat/bnd.bnd
@@ -36,6 +36,7 @@ tested.features: jdbc-4.0, beanvalidation-1.1, jpa-2.0, el-3.0, persistence-3.0,
 -buildpath: \
     com.ibm.ws.jpa_testframework;version=latest,\
     fattest.databases;version=latest,\
+    com.github.docker-java:docker-java-api;version=latest,\
     com.ibm.websphere.javaee.annotation.1.1;version=latest,\
     com.ibm.websphere.javaee.cdi.2.0;version=latest,\
     com.ibm.websphere.javaee.ejb.3.2;version=latest,\

--- a/dev/com.ibm.ws.jpa_spec10_query_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa_spec10_query_fat/bnd.bnd
@@ -37,6 +37,7 @@ tested.features: jdbc-4.0, beanvalidation-1.1, jpa-2.0, el-3.0, persistence-3.0,
 -buildpath: \
     com.ibm.ws.jpa_testframework;version=latest,\
     fattest.databases;version=latest,\
+    com.github.docker-java:docker-java-api;version=latest,\
     com.ibm.websphere.javaee.annotation.1.1;version=latest,\
     com.ibm.websphere.javaee.cdi.2.0;version=latest,\
     com.ibm.websphere.javaee.ejb.3.2;version=latest,\


### PR DESCRIPTION
I noticed a couple FATs in my Open Liberty workspace were suffering from a Test Containers exception:
```
The type com.github.dockerjava.api.command.CreateContainerCmd cannot be resolved. It is indirectly referenced from required .class files
```

#15398 fixed some of these, but these are some more that I noticed in my workspace

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>