### PR TITLE
Adding localConnector to jakartaee-9 package

### DIFF
--- a/dev/build.image/profiles/jakartaee9/features.xml
+++ b/dev/build.image/profiles/jakartaee9/features.xml
@@ -1,3 +1,4 @@
 <feature>jakartaee-9.0</feature>
 <feature>jakartaeeClient-9.0</feature>
 <feature>jdbc-4.3</feature>
+<feature>localConnector-1.0</feature>


### PR DESCRIPTION
This adds the localConnector-1.0 feature to the jakartaee 9 package for the beta....   but does NOT change the default server.xml. - The feature still needs to be added manually.