### PR TITLE
Increase TCK app deploy timeout for slower build machines

### DIFF
--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
@@ -22,8 +22,8 @@
             <property name="serverName">${tck_server}</property>
             <property name="httpPort">${tck_port}</property>
             <property name="allowConnectingToRunningServer">true</property>
-            <property name="appDeployTimeout">60</property>
-            <property name="verifyAppDeployTimeout">60</property>
+            <property name="appDeployTimeout">120</property>
+            <property name="verifyAppDeployTimeout">120</property>
             <property name="failSafeUndeployment">${tck_failSafeUndeployment}</property>
             <property name="appUndeployTimeout">120</property>
             <property name="javaVmArguments">-Dcom.ibm.tools.attach.enable=yes</property> <!-- this goes here because this tck project asks arquillian to start the server -->

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
@@ -22,8 +22,8 @@
             <property name="serverName">${tck_server}</property>
             <property name="httpPort">${tck_port}</property>
             <property name="allowConnectingToRunningServer">true</property>
-            <property name="appDeployTimeout">60</property>
-            <property name="verifyAppDeployTimeout">60</property>
+            <property name="appDeployTimeout">120</property>
+            <property name="verifyAppDeployTimeout">120</property>
             <property name="failSafeUndeployment">${tck_failSafeUndeployment}</property>
             <property name="appUndeployTimeout">60</property>
             <!-- com.ibm.tools.attach.enable=yes is for using the localConnector-1.0 feature on zOS -->

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
@@ -22,8 +22,8 @@
             <property name="serverName">${tck_server}</property>
             <property name="httpPort">${tck_port}</property>
             <property name="allowConnectingToRunningServer">true</property>
-            <property name="appDeployTimeout">60</property>
-            <property name="verifyAppDeployTimeout">60</property>
+            <property name="appDeployTimeout">120</property>
+            <property name="verifyAppDeployTimeout">120</property>
             <property name="failSafeUndeployment">${tck_failSafeUndeployment}</property>
             <property name="appUndeployTimeout">60</property>
             <!-- com.ibm.tools.attach.enable=yes is for using the localConnector-1.0 feature on zOS -->

--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
@@ -22,8 +22,8 @@
             <property name="serverName">${tck_server}</property>
             <property name="httpPort">${tck_port}</property>
             <property name="allowConnectingToRunningServer">true</property>
-            <property name="appDeployTimeout">60</property>
-            <property name="verifyAppDeployTimeout">60</property>
+            <property name="appDeployTimeout">120</property>
+            <property name="verifyAppDeployTimeout">120</property>
             <property name="failSafeUndeployment">${tck_failSafeUndeployment}</property>
             <property name="appUndeployTimeout">60</property>
             <property name="javaVmArguments">-Dcom.ibm.tools.attach.enable=yes</property> <!-- this goes here because this tck project asks arquillian to start the server -->

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
@@ -22,8 +22,8 @@
             <property name="serverName">${tck_server}</property>
             <property name="httpPort">${tck_port}</property>
             <property name="allowConnectingToRunningServer">true</property>
-            <property name="appDeployTimeout">60</property>
-            <property name="verifyAppDeployTimeout">60</property>
+            <property name="appDeployTimeout">120</property>
+            <property name="verifyAppDeployTimeout">120</property>
             <property name="failSafeUndeployment">${tck_failSafeUndeployment}</property>
             <property name="appUndeployTimeout">60</property>
             <property name="javaVmArguments">-Dcom.ibm.tools.attach.enable=yes</property> <!-- this goes here because this tck project asks arquillian to start the server -->

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
@@ -22,8 +22,8 @@
             <property name="serverName">${tck_server}</property>
             <property name="httpPort">${tck_port}</property>
             <property name="allowConnectingToRunningServer">true</property>
-            <property name="appDeployTimeout">60</property>
-            <property name="verifyAppDeployTimeout">60</property>
+            <property name="appDeployTimeout">120</property>
+            <property name="verifyAppDeployTimeout">120</property>
             <property name="failSafeUndeployment">${tck_failSafeUndeployment}</property>
             <property name="appUndeployTimeout">${tck_appUndeployTimeout}</property>
             <!-- com.ibm.tools.attach.enable=yes is for using the localConnector-1.0 feature on zOS -->

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/src/test/resources/arquillian.xml
@@ -22,8 +22,8 @@
             <property name="serverName">${tck_server}</property>
             <property name="httpPort">${tck_port}</property>
             <property name="allowConnectingToRunningServer">true</property>
-            <property name="appDeployTimeout">60</property>
-            <property name="verifyAppDeployTimeout">60</property>
+            <property name="appDeployTimeout">120</property>
+            <property name="verifyAppDeployTimeout">120</property>
             <property name="failSafeUndeployment">${tck_failSafeUndeployment}</property>
             <property name="appUndeployTimeout">60</property>
             <property name="javaVmArguments">-Dcom.ibm.tools.attach.enable=yes</property> <!-- this goes here because this tck project asks arquillian to start the server -->


### PR DESCRIPTION
Resolves a few intermittent build breaks on slow build machines