### PR TITLE
Upgrade to bnd 5.2.0

### DIFF
--- a/dev/cnf/resources/bnd/anttaskdefs.bnd
+++ b/dev/cnf/resources/bnd/anttaskdefs.bnd
@@ -13,11 +13,11 @@ repo.rasInstrumentation.path: ${path;\
     ${repo;wlp-rasInstrumentation}}
     
 repo.generateChecksums.path: ${path;\
-	${repo;wlp-generateChecksums},\
+    ${repo;wlp-generateChecksums},\
     ${repo;com.ibm.ws.kernel.boot.core},\
     ${repo;com.ibm.ws.org.apache.ant},\
-	${repo;com.ibm.ws.org.apache.aries.util},\
-	${repo;com.ibm.websphere.org.osgi.core}}
+    ${repo;com.ibm.ws.org.apache.aries.util},\
+    ${repo;com.ibm.websphere.org.osgi.core}}
     
 repo.nlsTasks.path: ${path;\
     ${repo;commons-io:commons-io;2.4},\
@@ -80,3 +80,4 @@ repo.mavenRepoTasks.path: ${path;\
 
 repo.junitReportTask.path: ${path;\
     ${repo;org.apache.ant:ant-junit;1.9.6}}
+

--- a/dev/cnf/resources/bnd/bundle.props
+++ b/dev/cnf/resources/bnd/bundle.props
@@ -52,3 +52,6 @@ Import-Package: ${defaultPackageImport}
 #require explicitly specifying all ds and metatype annotated classes.
 -dsannotations:
 -metatypeannotations:
+
+# With bnd 5.2.0 The importing of java.* packages need to be disabled to maintain legacy behavior.
+-noimportjava: true

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.overrides
@@ -107,6 +107,7 @@ Private-Package: \
 # from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the
 # packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: \
+  !java.*, \
   !com.sun.codemodel.writer, \
   !com.sun.tools.internal.xjc.api, \
   !com.sun.tools.xjc.api, \

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2/bnd.overrides
@@ -16,6 +16,7 @@ Bundle-SymbolicName: com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.3.2
 
 
 Import-Package: \
+  !java.*, \
   !org.apache.aries.*;version="[0.3,2)", \
   !org.osgi.service.blueprint.*, \
   !org.springframework.*;resolution:=optional;version="[2.5,4)", \

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/bnd.overrides
@@ -12,6 +12,7 @@ Bundle-Activator: com.ibm.ws.jaxrs21.rt.frontend.jaxrs.NoOpActivator
 # from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
 # packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.
 Import-Package: \
+  !java.*, \
   !com.ibm.xml.xlxp2.api.stax, \
   !com.ibm.xml.xlxp2.api.wssec, \
   !org.apache.aries.*,\

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.3.2/bnd.overrides
@@ -16,6 +16,7 @@ Bundle-SymbolicName: com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxws.3.2
 
 
 Import-Package: \
+  !java.*, \
   javax.wsdl.*, \
   com.ibm.wsspi.classloading, \
   !com.ctc.wstx.*,\

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.simple.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.simple.3.2/bnd.overrides
@@ -16,6 +16,7 @@ Bundle-SymbolicName: com.ibm.ws.org.apache.cxf.cxf.rt.frontend.simple.3.2
 
 
 Import-Package: \
+ !java.*,\
  !com.ctc.wstx.*,\
  !org.codehaus.stax2.*,\
  !com.sun.msv.*,\

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/bnd.overrides
@@ -19,6 +19,7 @@ Export-Package: \
   com.ibm.ws.cxf.exceptions;version=${exportVer}
   
 Import-Package: \
+  !java.*,\
   !org.apache.aries.*,\
   !org.springframework.*,\
   javax.wsdl.*;resolution:=optional, \

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.addr.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.addr.3.2/bnd.overrides
@@ -15,6 +15,7 @@ cxfVersion=3.4.1
 Bundle-SymbolicName: com.ibm.ws.org.apache.cxf.cxf.rt.ws.addr.3.2
 
 Import-Package: \
+!java.*,\
 !com.ctc.wstx.*,\
 !org.codehaus.stax2.*,\
 !com.sun.msv.*,\

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2/bnd.overrides
@@ -16,6 +16,7 @@ Bundle-SymbolicName: com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2
 
 
 Import-Package: \
+!java.*,\
 !com.ctc.wstx.*,\
 !org.codehaus.stax2.*,\
 !com.sun.msv.*,\

--- a/dev/gradle.properties
+++ b/dev/gradle.properties
@@ -13,7 +13,7 @@ bnd_cnf=cnf
 
 # bnd_plugin is the dependency declaration for the bnd gradle plugin
 #bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:+
-bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:5.0.1
+bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:5.2.0
 
 # The URL to the bnd build repo.
 bnd_repourl=https://repo1.maven.org/maven2

--- a/dev/wlp-gradle/subprojects/maven-central-mirror.gradle
+++ b/dev/wlp-gradle/subprojects/maven-central-mirror.gradle
@@ -21,7 +21,26 @@ repositories {
         username userProps.getProperty("artifactory.download.user")
         password userProps.getProperty("artifactory.download.token")
       }
+      url ("https://" + userProps.getProperty("artifactory.download.server") + "/artifactory/wasliberty-open-liberty")
+      // for fats - this repository is used *only* contains artifacts with group "biz.aQute.bnd"
+      content {
+        includeGroup "biz.aQute.bnd"
+      }
+      metadataSources {
+        mavenPom()
+        artifact()
+      }
+    }
+    maven {
+      credentials {
+        username userProps.getProperty("artifactory.download.user")
+        password userProps.getProperty("artifactory.download.token")
+      }
       url ("https://" + gradle.userProps.getProperty("artifactory.download.server") + "/artifactory/wasliberty-maven-remote")
+      metadataSources {
+        mavenPom()
+        artifact()
+      }
     }
   } else {
     mavenCentral()

--- a/dev/wlp-gradle/utility/build.gradle
+++ b/dev/wlp-gradle/utility/build.gradle
@@ -59,7 +59,7 @@ def sortManifestFileInZip(String zipPath) throws IOException {
 
 task sortWlpBundleManifests {
     doLast {
-        fileTree(dir: file(workspaceDir + '/build.image/wlp/lib'), includes: ['*.jar']).each {
+        fileTree(dir: file(workspaceDir), includes: ['*.jar']).each {
             if (!it.isDirectory()) {
                 println it.toString()
                 sortManifestFileInZip(it.getPath())


### PR DESCRIPTION
Upgrading to bnd 5.2.0 has performance improvements mentioned by https://github.com/bndtools/bnd/wiki/Changes-in-5.2.0 and https://github.com/bndtools/bnd/pull/4038.