### PR TITLE
Fix handling Windows paths in mergeFile

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/utils/CommonMergeTools.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/CommonMergeTools.java
@@ -76,8 +76,8 @@ public class CommonMergeTools {
     public boolean mergeFile(String serverXmlPath, String autoFVTPath, String serverRootLoc) {
 
         String methodName = "mergeFile";
-        autoFVTDir = autoFVTPath;
-        autoFVTServerRoot = serverRootLoc;
+        autoFVTDir = autoFVTPath.replace("\\", "/");
+        autoFVTServerRoot = serverRootLoc.replace("\\", "/");
 
         /*
          * Get XML document.


### PR DESCRIPTION
File merge is failing on windows.  The backslashes are getting removed  as we try to process the include statements.

