### PR TITLE
Handle beans.xml with discoveryMode="none" - no beanManager

### DIFF
--- a/dev/io.openliberty.org.jboss.resteasy.common/src/org/jboss/resteasy/plugins/server/servlet/ConfigurationBootstrap.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/org/jboss/resteasy/plugins/server/servlet/ConfigurationBootstrap.java
@@ -237,7 +237,7 @@ public abstract class ConfigurationBootstrap implements ResteasyConfiguration
 
       // Liberty Change: TODO: revert this back when we sort out the config via web fragments.
       //String injectorFactoryClass = "org.jboss.resteasy.cdi.CdiInjectorFactory"; // getParameter("resteasy.injector.factory");
-      String injectorFactoryClass = "io.openliberty.org.jboss.resteasy.common.cdi.LibertyCdiInjectorFactory";
+      String injectorFactoryClass = "io.openliberty.org.jboss.resteasy.common.cdi.LibertyFallbackInjectorFactory";
       if (injectorFactoryClass != null)
       {
          deployment.setInjectorFactoryClass(injectorFactoryClass);

--- a/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/cdi/LibertyCdiInjectorFactory.java
+++ b/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/cdi/LibertyCdiInjectorFactory.java
@@ -46,7 +46,7 @@ public class LibertyCdiInjectorFactory extends CdiInjectorFactory {
         try {
             return super.lookupBeanManager();
         } catch (Exception ex) {
-            return null;
+            throw new RuntimeException("Cannot load bean manager for module " + (cmd == null ? "unknown" :cmd.getJ2EEName()));
         }
     }
 

--- a/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/cdi/LibertyFallbackInjectorFactory.java
+++ b/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/cdi/LibertyFallbackInjectorFactory.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.org.jboss.resteasy.common.cdi;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Type;
+
+import org.jboss.resteasy.core.InjectorFactoryImpl;
+import org.jboss.resteasy.spi.ConstructorInjector;
+import org.jboss.resteasy.spi.InjectorFactory;
+import org.jboss.resteasy.spi.MethodInjector;
+import org.jboss.resteasy.spi.PropertyInjector;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.spi.ValueInjector;
+import org.jboss.resteasy.spi.metadata.Parameter;
+import org.jboss.resteasy.spi.metadata.ResourceClass;
+import org.jboss.resteasy.spi.metadata.ResourceConstructor;
+import org.jboss.resteasy.spi.metadata.ResourceLocator;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+@SuppressWarnings("rawtypes")
+public class LibertyFallbackInjectorFactory implements InjectorFactory {
+    private static final TraceComponent tc = Tr.register(LibertyFallbackInjectorFactory.class);
+
+    private final InjectorFactory delegate;
+    
+    public LibertyFallbackInjectorFactory() {
+        InjectorFactory factory;
+        try {
+            factory = new LibertyCdiInjectorFactory();
+        } catch (Throwable t) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Caught exception initializing LibertyCdiInjectorFactory - expected if module declines CDI", t);
+            }
+            factory = new InjectorFactoryImpl();
+        }
+        delegate = factory;
+    }
+    @Override
+    public ConstructorInjector createConstructor(Constructor constructor, ResteasyProviderFactory factory) {
+        return delegate.createConstructor(constructor, factory);
+    }
+
+    @Override
+    public PropertyInjector createPropertyInjector(Class resourceClass, ResteasyProviderFactory factory) {
+        return delegate.createPropertyInjector(resourceClass, factory);
+    }
+
+    @Override
+    public ValueInjector createParameterExtractor(Class injectTargetClass, AccessibleObject injectTarget, String defaultName, Class type, Type genericType, Annotation[] annotations, ResteasyProviderFactory factory) {
+        return delegate.createParameterExtractor(injectTargetClass, injectTarget, defaultName, type, genericType, annotations, factory);
+    }
+
+    @Override
+    public ValueInjector createParameterExtractor(Class injectTargetClass, AccessibleObject injectTarget, String defaultName, Class type, Type genericType, Annotation[] annotations, boolean useDefault, ResteasyProviderFactory factory) {
+        return delegate.createParameterExtractor(injectTargetClass, injectTarget, defaultName, type, genericType, annotations, useDefault, factory);
+    }
+
+    @Override
+    public ValueInjector createParameterExtractor(Parameter parameter, ResteasyProviderFactory providerFactory) {
+        return delegate.createParameterExtractor(parameter, providerFactory);
+    }
+
+    @Override
+    public MethodInjector createMethodInjector(ResourceLocator method, ResteasyProviderFactory factory) {
+        return delegate.createMethodInjector(method, factory);
+    }
+
+    @Override
+    public PropertyInjector createPropertyInjector(ResourceClass resourceClass, ResteasyProviderFactory providerFactory) {
+        return delegate.createPropertyInjector(resourceClass, providerFactory);
+    }
+
+    @Override
+    public ConstructorInjector createConstructor(ResourceConstructor constructor, ResteasyProviderFactory providerFactory) {
+        return delegate.createConstructor(constructor, providerFactory);
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/AppAndResourceCDIBeanDiscoveryModeDisabledTest.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/AppAndResourceCDIBeanDiscoveryModeDisabledTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS30.fat;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.restfulWS30.fat.appandresource.AppAndResourceTestServlet;
+
+/**
+ * Tests whether a class can be both an <code>Application</code> subclass
+ * <em>and<em> a resource class.
+ */
+@RunWith(FATRunner.class)
+public class AppAndResourceCDIBeanDiscoveryModeDisabledTest extends FATServletClient {
+
+    public static final String APP_NAME = "appandresource";
+    public static final String SERVER_NAME = APP_NAME;
+    private static final String BEANS_XML = "<beans xmlns=\"http://xmlns.jcp.org/xml/ns/javaee\"\n"
+                    + "       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+                    + "       xsi:schemaLocation=\"http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd\""
+                    + "       bean-discovery-mode=\"none\" version=\"2.0\"></beans>";
+
+    @Server(SERVER_NAME)
+    @TestServlet(servlet = AppAndResourceTestServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addAsWebInfResource(new StringAsset(BEANS_XML), "beans.xml")
+                        .addPackages(true, AppAndResourceTestServlet.class.getPackage());
+        
+
+        ShrinkHelper.exportDropinAppToServer(server, war, DeployOptions.SERVER_ONLY);
+
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/FATSuite.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/FATSuite.java
@@ -17,6 +17,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({
                 AppAndResourceTest.class,
+                AppAndResourceCDIBeanDiscoveryModeDisabledTest.class,
                 InjectAppTest.class,
                 JsonbTest.class,
                 ValidatorTest.class,


### PR DESCRIPTION
Fixes cases where a user app has a beans.xml that declares bean-discovery-mode="none" - in this case there would be no bean manager for the app/module, and so we want to resort back to the non-CDI injection factory to handle JAX-RS `@Context` injection, but not CDI `@Inject` injection.