### PR TITLE
CL22178 callback for handling failed resubmit

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/ScheduledPolicyExecutorTask.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/ScheduledPolicyExecutorTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.threading;
+
+import com.ibm.ws.ffdc.FFDCFilter;
 
 /**
  * When tasks implementing this interface are scheduled to the Liberty scheduled executor,
@@ -25,4 +27,18 @@ public interface ScheduledPolicyExecutorTask {
      * @return the policy executor upon which to run this task.
      */
     PolicyExecutor getExecutor();
+
+    /**
+     * Provides a callback to be invoked when the task fails to resubmit to
+     * the designated policy executor. Typically, this will be because the
+     * policy executor has been shut down, suspended, or has reached its limit
+     * for maximum queue capacity.
+     *
+     * @param failure the error that is raised by the resubmit attempt.
+     * @return error to report for the failure.
+     */
+    default Exception resubmitFailed(Exception failure) {
+        FFDCFilter.processException(failure, getClass().getName(), "38");
+        return failure;
+    }
 }

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/SchedulingRunnableFixedHelper.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/SchedulingRunnableFixedHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015,2020 IBM Corporation and others.
+ * Copyright (c) 2015,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Delayed;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -197,8 +198,10 @@ class SchedulingRunnableFixedHelper<V> implements ScheduledFuture<Object>, Runna
         if (m_pendingException != null) {
             if (m_pendingException instanceof ExecutionException) {
                 throw (ExecutionException) m_pendingException;
-            } else {
+            } else if (m_pendingException instanceof RuntimeException) {
                 throw (RuntimeException) m_pendingException;
+            } else {
+                throw new RejectedExecutionException(m_pendingException);
             }
         }
 
@@ -219,8 +222,10 @@ class SchedulingRunnableFixedHelper<V> implements ScheduledFuture<Object>, Runna
         if (m_pendingException != null) {
             if (m_pendingException instanceof ExecutionException) {
                 throw (ExecutionException) m_pendingException;
-            } else {
+            } else if (m_pendingException instanceof RuntimeException) {
                 throw (RuntimeException) m_pendingException;
+            } else {
+                throw new RejectedExecutionException(m_pendingException);
             }
         }
 

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
@@ -4155,7 +4155,6 @@ public class PolicyExecutorServlet extends FATServlet {
      * Uses ScheduledPolicyExecutorTask to schedule a one-shot Callable task for the
      * Liberty scheduled executor to run on a policy executor.
      */
-    @AllowedFFDC("java.util.concurrent.RejectedExecutionException") // when we intentionally schedule a task beyond the queue capacity
     @Test
     public void testLibertyScheduledExecutorRunsCallableOnPolicyExecutor() throws Exception {
         PolicyExecutor executor = provider.create("testLibertyScheduledExecutorRunsCallableOnPolicyExecutor")
@@ -4189,12 +4188,9 @@ public class PolicyExecutorServlet extends FATServlet {
             try {
                 Boolean result = future3.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
                 fail(future3 + " should not be able to run with queue full and concurrency at maximum. Result: " + result);
-            } catch (Exception x) {
+            } catch (RejectedExecutionException x) {
                 // Expect CWWKE1201E for exceeding queue capacity
-                boolean found = false;
-                for (Throwable cause = x; !found && cause != null; cause = cause.getCause())
-                    found = cause.getMessage() != null && cause.getMessage().startsWith("CWWKE1201E");
-                if (!found)
+                if (x.getMessage() == null || !x.getMessage().startsWith("CWWKE1201E"))
                     throw new RuntimeException("Test failed. See cause.", x);
             }
 
@@ -4232,8 +4228,7 @@ public class PolicyExecutorServlet extends FATServlet {
      */
     @AllowedFFDC({
                    "java.lang.NullPointerException", // test case schedules a task that intentionally raises this exception
-                   "java.util.concurrent.CompletionException", // can be raised by test task when cancel interrupts it
-                   "java.util.concurrent.RejectedExecutionException" // when we intentionally schedule a task beyond the queue capacity
+                   "java.util.concurrent.CompletionException" // can be raised by test task when cancel interrupts it
     })
     @Test
     public void testLibertyScheduledExecutorRunsFixedDelayTaskOnPolicyExecutor() throws Exception {
@@ -4269,12 +4264,9 @@ public class PolicyExecutorServlet extends FATServlet {
             try {
                 future3.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
                 fail(future3 + " should not be able to run with queue full and concurrency at maximum.");
-            } catch (Exception x) {
+            } catch (RejectedExecutionException x) {
                 // Expect CWWKE1201E for exceeding queue capacity
-                boolean found = false;
-                for (Throwable cause = x; !found && cause != null; cause = cause.getCause())
-                    found = cause.getMessage() != null && cause.getMessage().startsWith("CWWKE1201E");
-                if (!found)
+                if (x.getMessage() == null || !x.getMessage().startsWith("CWWKE1201E"))
                     throw new RuntimeException("Test failed. See cause.", x);
             }
 
@@ -4330,8 +4322,7 @@ public class PolicyExecutorServlet extends FATServlet {
      */
     @AllowedFFDC({
                    "java.lang.NullPointerException", // test case schedules a task that intentionally raises this exception
-                   "java.util.concurrent.CompletionException", // can be raised by test task when cancel interrupts it
-                   "java.util.concurrent.RejectedExecutionException" // when we intentionally schedule a task beyond the queue capacity
+                   "java.util.concurrent.CompletionException" // can be raised by test task when cancel interrupts it
     })
     @Test
     public void testLibertyScheduledExecutorRunsFixedRateTaskOnPolicyExecutor() throws Exception {
@@ -4367,12 +4358,9 @@ public class PolicyExecutorServlet extends FATServlet {
             try {
                 future3.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
                 fail(future3 + " should not be able to run with queue full and concurrency at maximum.");
-            } catch (Exception x) {
+            } catch (RejectedExecutionException x) {
                 // Expect CWWKE1201E for exceeding queue capacity
-                boolean found = false;
-                for (Throwable cause = x; !found && cause != null; cause = cause.getCause())
-                    found = cause.getMessage() != null && cause.getMessage().startsWith("CWWKE1201E");
-                if (!found)
+                if (x.getMessage() == null || !x.getMessage().startsWith("CWWKE1201E"))
                     throw new RuntimeException("Test failed. See cause.", x);
             }
 
@@ -4426,7 +4414,6 @@ public class PolicyExecutorServlet extends FATServlet {
      * Uses ScheduledPolicyExecutorTask to schedule a one-shot Runnable task for the
      * Liberty scheduled executor to run on a policy executor.
      */
-    @AllowedFFDC("java.util.concurrent.RejectedExecutionException") // when we intentionally schedule a task beyond the queue capacity
     @Test
     public void testLibertyScheduledExecutorRunsRunnableOnPolicyExecutor() throws Exception {
         PolicyExecutor executor = provider.create("testLibertyScheduledExecutorRunsRunnableOnPolicyExecutor")
@@ -4465,12 +4452,9 @@ public class PolicyExecutorServlet extends FATServlet {
             try {
                 future4.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
                 fail(future4 + " should not be able to run with queue full and concurrency at maximum.");
-            } catch (Exception x) {
+            } catch (RejectedExecutionException x) {
                 // Expect CWWKE1201E for exceeding queue capacity
-                boolean found = false;
-                for (Throwable cause = x; !found && cause != null; cause = cause.getCause())
-                    found = cause.getMessage() != null && cause.getMessage().startsWith("CWWKE1201E");
-                if (!found)
+                if (x.getMessage() == null || !x.getMessage().startsWith("CWWKE1201E"))
                     throw new RuntimeException("Test failed. See cause.", x);
             }
 

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/ScheduledCallableTask.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/ScheduledCallableTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,5 +30,10 @@ public class ScheduledCallableTask extends CountDownTask implements ScheduledPol
     @Override
     public PolicyExecutor getExecutor() {
         return executor;
+    }
+
+    @Override
+    public Exception resubmitFailed(Exception failure) {
+        return failure;
     }
 }

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/ScheduledRunnableTask.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/ScheduledRunnableTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -44,6 +44,11 @@ public class ScheduledRunnableTask implements Runnable, ScheduledPolicyExecutorT
     @Override
     public PolicyExecutor getExecutor() {
         return executor;
+    }
+
+    @Override
+    public Exception resubmitFailed(Exception failure) {
+        return failure;
     }
 
     @Override


### PR DESCRIPTION
For code that builds on the Liberty scheduled executor, add a callback mechanism to determine how to handle failures that arise when attempting to resubmit tasks to the policy executor.