### PR TITLE
See if bnd dependency resolves project not found

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/bnd.bnd
@@ -57,4 +57,5 @@ tested.features: \
   org.mock-server:mockserver-client-java;version=3.10.7,\
   org.mock-server:mockserver-core;version=3.10.7.IBM20191022,\
   org.mock-server:mockserver-netty;version=3.10.7,\
+  io.openliberty.com.fasterxml.jackson;version=latest,\
   com.ibm.json4j;version=latest


### PR DESCRIPTION
During Github Actions gradle build com.ibm.ws.jaxrs.2.0.client_fat fails with:

```
  * What went wrong:
  A problem occurred evaluating project ':com.ibm.ws.jaxrs.2.0.client_fat'.
  > Project with path ':io.openliberty.com.fasterxml.jackson' could not be found in project ':com.ibm.ws.jaxrs.2.0.client_fat'.
  See docs.gradle.org/6.4/userguide/command_line_interface.html#sec:command_line_warnings
```

There are many other projects that depend on the same project but none of them fail. The only difference is this project doesn't have a bnd dependency. 

Testing to see if this works.


