### PR TITLE
Handle `JsonString` types

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/jsonpApp/src/jaxrs21/fat/jsonp/JsonpResource.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/jsonpApp/src/jaxrs21/fat/jsonp/JsonpResource.java
@@ -12,6 +12,7 @@ package jaxrs21.fat.jsonp;
 
 import javax.json.Json;
 import javax.json.JsonNumber;
+import javax.json.JsonString;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -28,5 +29,14 @@ public class JsonpResource {
         int input = num.intValue();
         JsonNumber jsonNum = Json.createValue(input + 1);
         return jsonNum;
+    }
+
+    @POST
+    @Path("/string/addBar")
+    @Consumes("application/json")
+    @Produces("application/json")
+    public JsonString addBar(JsonString jsonString) {
+        JsonString newString = Json.createValue(jsonString.getString() + "Bar");
+        return newString;
     }
 }

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/jsonpApp/src/jaxrs21/fat/jsonp/JsonpTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/test-applications/jsonpApp/src/jaxrs21/fat/jsonp/JsonpTestServlet.java
@@ -56,4 +56,11 @@ public class JsonpTestServlet extends FATServlet {
         int res = t.request().accept(MediaType.APPLICATION_JSON).post(Entity.json(jsonNum), Integer.class);
         assertEquals(4, res);
     }
+
+    @Test
+    public void testJsonString(HttpServletRequest req, HttpServletResponse resp) throws Exception {
+        WebTarget t = target(req, "/resource/string/addBar");
+        String res = t.request().accept(MediaType.APPLICATION_JSON).post(Entity.json("\"foo\""), String.class);
+        assertEquals("\"fooBar\"", res);
+    }
 }

--- a/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/restfulWS/providers/JsonPProvider.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/restfulWS/providers/JsonPProvider.java
@@ -26,6 +26,7 @@ import javax.json.Json;
 import javax.json.JsonException;
 import javax.json.JsonNumber;
 import javax.json.JsonReader;
+import javax.json.JsonString;
 import javax.json.JsonValue;
 import javax.json.JsonWriter;
 import javax.json.spi.JsonProvider;
@@ -128,6 +129,9 @@ public class JsonPProvider implements MessageBodyReader<Object>, MessageBodyWrit
             // TODO: consider checking charset in MediaType or headers and creating the reader with that...
             //reader = this.jsonProvider.createReaderFactory(null).createReader(entityStream, Charset.defaultCharset());
             if (reader != null) {
+                if (JsonString.class.isAssignableFrom(type)) {
+                    return reader.readValue();
+                }
                 return reader.read();
             }
         } catch (Throwable e) {


### PR DESCRIPTION
Fixes issue where JAX-RS resource expects a `JsonString` entity.