### PR TITLE
CL22177 isSuspended and getMaxConcurrency for policy executor

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2019 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -55,7 +55,7 @@ public interface PolicyExecutor extends ExecutorService {
      * Canceled tasks which have already started might still be in progress when this method returns. How the tasks responds to the interrupt/cancel
      * signal depends on the task implementation.
      *
-     * @param identifier the identifier to match
+     * @param identifier         the identifier to match
      * @param interruptIfRunning indicates whether or not to allow interrupt on cancel
      * @return count of task Futures that were successfully put into the canceled state.
      */
@@ -71,7 +71,7 @@ public interface PolicyExecutor extends ExecutorService {
      * @param num number of tasks to expedite.
      * @return the executor.
      * @throws IllegalArgumentException if value is negative or greater than maximum concurrency.
-     * @throws IllegalStateException if the executor has been shut down.
+     * @throws IllegalStateException    if the executor has been shut down.
      */
     PolicyExecutor expedite(int num);
 
@@ -81,6 +81,13 @@ public interface PolicyExecutor extends ExecutorService {
      * @return the unique identifier for this policy executor.
      */
     String getIdentifier();
+
+    /**
+     * Returns the configured max concurrency value.
+     *
+     * @return the configured max concurrency value.
+     */
+    int getMaxConcurrency();
 
     /**
      * Returns the number of tasks from this PolicyExecutor currently running on the global executor.
@@ -131,6 +138,15 @@ public interface PolicyExecutor extends ExecutorService {
                     TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException;
 
     /**
+     * Indicates if the executor is configured to be unable to run tasks,
+     * and it isn't running any tasks, and hasn't been shut down yet.
+     *
+     * @return true if maximum concurrency is configured to 0, no tasks are running,
+     *         and the executor hasn't been shut down yet, otherwise false.
+     */
+    boolean isSuspended();
+
+    /**
      * Specifies the maximum number of tasks that can be running
      * at any given point in time. The default is Integer.MAX_VALUE.
      * Maximum concurrency can be updated while tasks are in progress. If the maximum concurrency
@@ -140,7 +156,7 @@ public interface PolicyExecutor extends ExecutorService {
      * @param max maximum concurrency.
      * @return the executor.
      * @throws IllegalArgumentException if value is not positive or -1 (which means Integer.MAX_VALUE) or less than the number to expedite.
-     * @throws IllegalStateException if the executor has been shut down.
+     * @throws IllegalStateException    if the executor has been shut down.
      */
     PolicyExecutor maxConcurrency(int max);
 
@@ -173,7 +189,7 @@ public interface PolicyExecutor extends ExecutorService {
      * @param max capacity of the task queue.
      * @return the executor.
      * @throws IllegalArgumentException if value is not positive or -1 (which means Integer.MAX_VALUE).
-     * @throws IllegalStateException if the executor has been shut down.
+     * @throws IllegalStateException    if the executor has been shut down.
      */
     PolicyExecutor maxQueueSize(int max);
 
@@ -188,7 +204,7 @@ public interface PolicyExecutor extends ExecutorService {
      * @param ms maximum number of milliseconds to wait when attempting to enqueue a submitted task.
      * @return the executor.
      * @throws IllegalArgumentException if value is negative.
-     * @throws IllegalStateException if the executor has been shut down.
+     * @throws IllegalStateException    if the executor has been shut down.
      */
     PolicyExecutor maxWaitForEnqueue(long ms);
 
@@ -208,7 +224,7 @@ public interface PolicyExecutor extends ExecutorService {
      * specify a null value for the callback.
      * The callback is automatically unregistered upon shutdown.
      *
-     * @param max threshold for maximum concurrency beyond which the callback should be notified.
+     * @param max      threshold for maximum concurrency beyond which the callback should be notified.
      * @param callback the callback, or null to unregister.
      * @return callback that was replaced or removed by the new registration.
      *         null if no previous callback was in place.
@@ -226,13 +242,13 @@ public interface PolicyExecutor extends ExecutorService {
      * The callback is automatically unregistered upon shutdown.
      *
      * @param maxDelay maximum delay for a task to start, beyond which the callback should be notified.
-     * @param unit unit of time.
+     * @param unit     unit of time.
      * @param callback the callback, or null to unregister.
      * @return callback that was replaced or removed by the new registration.
      *         null if no previous callback was in place.
      * @throws IllegalArgumentException if maxDelay is greater than or equal to the
-     *             maximum number of nanoseconds representable as a long value.
-     * @throws IllegalStateException if the executor has been shut down.
+     *                                      maximum number of nanoseconds representable as a long value.
+     * @throws IllegalStateException    if the executor has been shut down.
      */
     Runnable registerLateStartCallback(long maxDelay, TimeUnit unit, Runnable callback);
 
@@ -247,8 +263,8 @@ public interface PolicyExecutor extends ExecutorService {
      * The callback is automatically unregistered upon shutdown.
      *
      * @param minAvailable threshold for minimum available queue capacity
-     *            below which the callback should be notified.
-     * @param callback the callback, or null to unregister.
+     *                         below which the callback should be notified.
+     * @param callback     the callback, or null to unregister.
      * @return callback that was replaced or removed by the new registration.
      *         null if no previous callback was in place.
      * @throws IllegalStateException if the executor has been shut down.
@@ -262,7 +278,7 @@ public interface PolicyExecutor extends ExecutorService {
      * instead of running on the caller's thread.
      *
      * @param runIfFull true to indicate that a task which cannot be queued should run on the thread from which submit or execute is invoked;
-     *            false to abort the task in this case.
+     *                      false to abort the task in this case.
      * @return the executor.
      * @throws IllegalStateException if the executor has been shut down.
      */
@@ -278,7 +294,7 @@ public interface PolicyExecutor extends ExecutorService {
      * @param ms number of milliseconds beyond which a task should not start.
      * @return the executor.
      * @throws IllegalArgumentException if value is negative (other than -1) or too large to convert to a nanosecond <code>long</code> value.
-     * @throws IllegalStateException if the executor has been shut down.
+     * @throws IllegalStateException    if the executor has been shut down.
      */
     PolicyExecutor startTimeout(long ms);
 
@@ -291,8 +307,8 @@ public interface PolicyExecutor extends ExecutorService {
      * canceled if it is available at the time when the PolicyTaskFuture is canceled.
      *
      * @param cancellable represents a CompletionStage that the PolicyExecutor should
-     *            automatically cancel upon cancellation of the returned future.
-     * @param task the task to run
+     *                        automatically cancel upon cancellation of the returned future.
+     * @param task        the task to run
      * @return future for the task.
      */
     PolicyTaskFuture<Void> submit(CancellableStage cancellable, Runnable task);

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2019 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -244,13 +244,13 @@ public class PolicyExecutorImpl implements PolicyExecutor {
     /**
      * This constructor is used by PolicyExecutorProvider.
      *
-     * @param globalExecutor the Liberty global executor, which was obtained by the PolicyExecutorProvider via declarative services.
-     * @param identifier unique identifier for this instance, to be used for monitoring and problem determination.
-     * @param owner application that owns the policy executor instance. Null if not owned by a single application.
+     * @param globalExecutor  the Liberty global executor, which was obtained by the PolicyExecutorProvider via declarative services.
+     * @param identifier      unique identifier for this instance, to be used for monitoring and problem determination.
+     * @param owner           application that owns the policy executor instance. Null if not owned by a single application.
      * @param policyExecutors list of policy executor instances created by the PolicyExecutorProvider.
-     *            Each instance is responsible for adding and removing itself from the list per its life cycle.
+     *                            Each instance is responsible for adding and removing itself from the list per its life cycle.
      * @throws IllegalStateException if an instance with the specified unique identifier already exists and has not been shut down.
-     * @throws NullPointerException if the specified identifier is null
+     * @throws NullPointerException  if the specified identifier is null
      */
     public PolicyExecutorImpl(ExecutorServiceImpl globalExecutor, String identifier, String owner,
                               ConcurrentHashMap<String, PolicyExecutorImpl> policyExecutors) {
@@ -411,16 +411,16 @@ public class PolicyExecutorImpl implements PolicyExecutor {
      * As needed, ensure that tasks are submitted to the global executor to process
      * the queued up tasks.
      *
-     * @param policyTaskFuture submitted task and its Future.
-     * @param wait amount of time to wait for a queue position.
+     * @param policyTaskFuture       submitted task and its Future.
+     * @param wait                   amount of time to wait for a queue position.
      * @param runIfQueueFullOverride indicates if a task should always or may never run on the current thread
-     *            if no queue positions are available. A value of null means the runIfQueueFull configuration will determine.
-     *            A value of true must only be specified if the caller already has a permit or doesn't need one.
+     *                                   if no queue positions are available. A value of null means the runIfQueueFull configuration will determine.
+     *                                   A value of true must only be specified if the caller already has a permit or doesn't need one.
      * @return true if the task was enqueued for later execution by the global thread pool.
      *         If the task instead ran on the current thread, then returns false.
      * @throws RejectedExecutionException if the task is rejected rather than being queued.
-     *             If this method runs the task on the current thread and the task raises InterruptedException,
-     *             the InterruptedException is chained to the RejectedExecutionException.
+     *                                        If this method runs the task on the current thread and the task raises InterruptedException,
+     *                                        the InterruptedException is chained to the RejectedExecutionException.
      */
     @FFDCIgnore(value = { InterruptedException.class, RejectedExecutionException.class }) // these are raised directly to invoker, who decides how to handle
     private boolean enqueue(PolicyTaskFutureImpl<?> policyTaskFuture, long wait, Boolean runIfQueueFullOverride) {
@@ -601,6 +601,15 @@ public class PolicyExecutorImpl implements PolicyExecutor {
     @Trivial
     public String getIdentifier() {
         return identifier;
+    }
+
+    @Override
+    public int getMaxConcurrency() {
+        int max;
+        synchronized (configLock) {
+            max = maxConcurrency;
+        }
+        return max;
     }
 
     @Override
@@ -924,6 +933,14 @@ public class PolicyExecutorImpl implements PolicyExecutor {
     @Override
     public boolean isShutdown() {
         return state.get() != State.ACTIVE;
+    }
+
+    @Override
+    public boolean isSuspended() {
+        // If tasks are running while suspended, the maxConcurrencyConstraint will have a negative number of permits
+        // and will not allow an acquire -- even an acquire of 0 permits -- until the permits for the running tasks
+        // are released.  This gives us a convenient way to check for running tasks.
+        return maxConcurrencyConstraint.tryAcquire(0) && getMaxConcurrency() == 0 && state.get() == State.ACTIVE;
     }
 
     @Override


### PR DESCRIPTION
Add methods to obtain the maximum concurrency and an indicator of whether a suspend of a policy executor has completed.
Add/update test cases to provide some coverage.