### PR TITLE
Change strings from 'javax' to 'jakarta' since we only run Resteasy in JakartaEE

### DIFF
--- a/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/component/LibertyResteasyCdiExtension.java
+++ b/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/component/LibertyResteasyCdiExtension.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -42,13 +42,13 @@ import io.openliberty.org.jboss.resteasy.common.cdi.LibertyCdiInjectorFactory;
     configurationPolicy = ConfigurationPolicy.IGNORE,
     immediate = true,
     property = { "api.classes=" +
-                "javax.ws.rs.Path;" +
-                "javax.ws.rs.core.Application;" +
-                "javax.ws.rs.ext.Provider",
+                "jakarta.ws.rs.Path;" +
+                "jakarta.ws.rs.core.Application;" +
+                "jakarta.ws.rs.ext.Provider",
              "bean.defining.annotations=" +
-                "javax.ws.rs.Path;" +
-                "javax.ws.rs.core.Application;" +
-                "javax.ws.rs.ext.Provider;" +
+                "jakarta.ws.rs.Path;" +
+                "jakarta.ws.rs.core.Application;" +
+                "jakarta.ws.rs.ext.Provider;" +
                 "jakarta.annotation.ManagedBean",
              "service.vendor=IBM" })
 

--- a/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/component/ResteasyInjectionClassListCollaborator.java
+++ b/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/component/ResteasyInjectionClassListCollaborator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -67,17 +67,17 @@ public class ResteasyInjectionClassListCollaborator implements WebAppInjectionCl
     private static final Set<String> RESTFUL_WS_INTERFACE_NAMES;
     static {
         RESTFUL_WS_INTERFACE_NAMES = new HashSet<String>();
-        RESTFUL_WS_INTERFACE_NAMES.add("javax.ws.rs.ext.MessageBodyWriter");
-        RESTFUL_WS_INTERFACE_NAMES.add("javax.ws.rs.ext.MessageBodyReader");
-        RESTFUL_WS_INTERFACE_NAMES.add("javax.ws.rs.ext.ExceptionMapper");
-        RESTFUL_WS_INTERFACE_NAMES.add("javax.ws.rs.ext.ContextResolver");
-        RESTFUL_WS_INTERFACE_NAMES.add("javax.ws.rs.ext.ReaderInterceptor");
-        RESTFUL_WS_INTERFACE_NAMES.add("javax.ws.rs.ext.WriterInterceptor");
-        RESTFUL_WS_INTERFACE_NAMES.add("javax.ws.rs.ext.ParamConverterProvider");
+        RESTFUL_WS_INTERFACE_NAMES.add("jakarta.ws.rs.ext.MessageBodyWriter");
+        RESTFUL_WS_INTERFACE_NAMES.add("jakarta.ws.rs.ext.MessageBodyReader");
+        RESTFUL_WS_INTERFACE_NAMES.add("jakarta.ws.rs.ext.ExceptionMapper");
+        RESTFUL_WS_INTERFACE_NAMES.add("jakarta.ws.rs.ext.ContextResolver");
+        RESTFUL_WS_INTERFACE_NAMES.add("jakarta.ws.rs.ext.ReaderInterceptor");
+        RESTFUL_WS_INTERFACE_NAMES.add("jakarta.ws.rs.ext.WriterInterceptor");
+        RESTFUL_WS_INTERFACE_NAMES.add("jakarta.ws.rs.ext.ParamConverterProvider");
 
-        RESTFUL_WS_INTERFACE_NAMES.add("javax.ws.rs.container.ContainerRequestFilter");
-        RESTFUL_WS_INTERFACE_NAMES.add("javax.ws.rs.container.ContainerResponseFilter");
-        RESTFUL_WS_INTERFACE_NAMES.add("javax.ws.rs.container.DynamicFeature");
+        RESTFUL_WS_INTERFACE_NAMES.add("jakarta.ws.rs.container.ContainerRequestFilter");
+        RESTFUL_WS_INTERFACE_NAMES.add("jakarta.ws.rs.container.ContainerResponseFilter");
+        RESTFUL_WS_INTERFACE_NAMES.add("jakarta.ws.rs.container.DynamicFeature");
 
         RESTFUL_WS_INTERFACE_NAMES.add("org.apache.cxf.jaxrs.ext.ContextResolver");
     }
@@ -85,7 +85,7 @@ public class ResteasyInjectionClassListCollaborator implements WebAppInjectionCl
     private static final Set<String> RESTFUL_WS_ABSTRACT_CLASS_NAMES;
     static {
         RESTFUL_WS_ABSTRACT_CLASS_NAMES = new HashSet<String>();
-        RESTFUL_WS_ABSTRACT_CLASS_NAMES.add("javax.ws.rs.core.Application");
+        RESTFUL_WS_ABSTRACT_CLASS_NAMES.add("jakarta.ws.rs.core.Application");
     }
 
     /**
@@ -184,28 +184,28 @@ public class ResteasyInjectionClassListCollaborator implements WebAppInjectionCl
         }
     }
 
-    private static final String INJECT_CLASS_NAME = "javax.inject.Inject";
-    private static final String RESOURCE_CLASS_NAME = "javax.annotation.Resource";
+    private static final String INJECT_CLASS_NAME = "jakarta.inject.Inject";
+    private static final String RESOURCE_CLASS_NAME = "jakarta.annotation.Resource";
 
     private static List<String> EXPLICIT_LIFECYCLE_CLASS_NAMES = new ArrayList<String>();
     static {
-        EXPLICIT_LIFECYCLE_CLASS_NAMES.add("javax.enterprise.context.RequestScoped");
-        EXPLICIT_LIFECYCLE_CLASS_NAMES.add("javax.enterprise.context.ApplicationScoped");
-        EXPLICIT_LIFECYCLE_CLASS_NAMES.add("javax.enterprise.context.SessionScoped");
-        EXPLICIT_LIFECYCLE_CLASS_NAMES.add("javax.enterprise.context.Dependent");
+        EXPLICIT_LIFECYCLE_CLASS_NAMES.add("jakarta.enterprise.context.RequestScoped");
+        EXPLICIT_LIFECYCLE_CLASS_NAMES.add("jakarta.enterprise.context.ApplicationScoped");
+        EXPLICIT_LIFECYCLE_CLASS_NAMES.add("jakarta.enterprise.context.SessionScoped");
+        EXPLICIT_LIFECYCLE_CLASS_NAMES.add("jakarta.enterprise.context.Dependent");
     }
 
     /**
      * Tell if a class should be selected for injection.
      *
      * A class is selected for injection if it or one of its superclasses
-     * has {@link javax.inject.Inject} as a class, method, field, or constructor
-     * annotation.  Except, {@link java.inject.Inject} is ignored as a class
+     * has {@link jakarta.inject.Inject} as a class, method, field, or constructor
+     * annotation.  Except, {@link jakarta.inject.Inject} is ignored as a class
      * annotations if the class has an explicit lifecycle class annotation.
-     * Lifecycle annotations are {@link javax.enterprise.context.ApplicationScoped},
-     * {@link javax.enterprise.context.SessionScoped},
-     * {@link javax.enterprise.context.RequestScoped}, and
-     * {@link javax.enterprise.context.Dependent}.
+     * Lifecycle annotations are {@link jakarta.enterprise.context.ApplicationScoped},
+     * {@link jakarta.enterprise.context.SessionScoped},
+     * {@link jakarta.enterprise.context.RequestScoped}, and
+     * {@link jakarta.enterprise.context.Dependent}.
      *
      * Note: This test is implemented using the raw class information.
      * Annotations are detected on the target class regardless of where the

--- a/dev/io.openliberty.restfulWS30.jsonb20provider/src/io/openliberty/restfulWS30/jsonb20provider/JsonBProvider.java
+++ b/dev/io.openliberty.restfulWS30.jsonb20provider/src/io/openliberty/restfulWS30/jsonb20provider/JsonBProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -196,7 +196,7 @@ public class JsonBProvider implements MessageBodyWriter<Object>, MessageBodyRead
     }
 
     private boolean isUntouchable(Class<?> clazz) {
-        final String[] jsonpClasses = new String[] { "javax.json.JsonArray", "javax.json.JsonObject", "javax.json.JsonStructure" };
+        final String[] jsonpClasses = new String[] { "jakarta.json.JsonArray", "jakarta.json.JsonObject", "jakarta.json.JsonStructure" };
 
         boolean untouchable = false;
         for (String c : jsonpClasses) {

--- a/dev/wlp-jakartaee-transform/rules/jakarta-direct.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-direct.properties
@@ -158,3 +158,14 @@ com.sun.xml.bind.v2.ContextFactory=org.glassfish.jaxb.runtime.v2.JAXBContextFact
 com.ibm.xml.xlxp2.jaxb.JAXBContextFactory=org.glassfish.jaxb.runtime.v2.JAXBContextFactory
 
 javax.annotation.security.RolesAllowed=jakarta.annotation.security.RolesAllowed
+
+# restfulWS 3.0 properties
+javax.ejb.Singleton=jakarta.ejb.Singleton
+javax.ejb.Stateful=jakarta.ejb.Stateful
+javax.ejb.Stateless=jakarta.ejb.Stateless
+javax.servlet.FilterConfig=jakarta.servlet.FilterConfig
+javax.servlet.http=jakarta.servlet.http
+javax.servlet.ServletConfig=jakarta.servlet.ServletConfig
+javax.servlet.ServletContext=jakarta.servlet.ServletContext
+javax.ws.rs.Application=jakarta.ws.rs.Application
+javax.xml.bind.annotation.XmlEnum=jakarta.xml.bind.annotation.XmlEnum


### PR DESCRIPTION
We suspect that these strings aren't being transformed and we should be looking for the jakarta versions of these classes at runtime.
