### PR TITLE
quarantine mislabeled projects

### DIFF
--- a/.github/test-categories/QUARANTINE
+++ b/.github/test-categories/QUARANTINE
@@ -6,6 +6,7 @@ com.ibm.ws.security.oauth_fat
 com.ibm.ws.repository_fat_shared
 com.ibm.ws.security.oauth.oidc_fat.common
 com.ibm.ws.security.audit_fat.common.tooling
+com.ibm.ws.security.saml.sso_fat.common
 
 # Does not have a valid build.gradle file
 com.ibm.ws.security.social_fat.oidcCertification

--- a/.github/test-categories/SECURITY_5
+++ b/.github/test-categories/SECURITY_5
@@ -1,5 +1,4 @@
 com.ibm.ws.security.saml.sso_fat
-com.ibm.ws.security.saml.sso_fat.common
 com.ibm.ws.security.spnego_fat
 com.ibm.ws.security.spnego_fat.1   
 com.ibm.ws.security.spnego_fat.2


### PR DESCRIPTION
com.ibm.ws.security.saml.sso_fat.common is not a fat suite and shouldn't have :buildandrun executed against it.
