### PR TITLE
Support ManagedBeans as RESTful WS Components

### DIFF
--- a/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/component/LibertyResteasyCdiExtension.java
+++ b/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/component/LibertyResteasyCdiExtension.java
@@ -48,7 +48,8 @@ import io.openliberty.org.jboss.resteasy.common.cdi.LibertyCdiInjectorFactory;
              "bean.defining.annotations=" +
                 "javax.ws.rs.Path;" +
                 "javax.ws.rs.core.Application;" +
-                "javax.ws.rs.ext.Provider",
+                "javax.ws.rs.ext.Provider;" +
+                "jakarta.annotation.ManagedBean",
              "service.vendor=IBM" })
 
 public class LibertyResteasyCdiExtension extends ResteasyCdiExtension implements Extension, WebSphereCDIExtension {

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/FATSuite.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/FATSuite.java
@@ -20,6 +20,7 @@ import org.junit.runners.Suite.SuiteClasses;
                 AppAndResourceCDIBeanDiscoveryModeDisabledTest.class,
                 InjectAppTest.class,
                 JsonbTest.class,
+                ManagedBeansTest.class,
                 ValidatorTest.class,
                 WebXmlAppTest.class,
                 WebXmlNoAppTest.class,

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/ManagedBeansTest.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/ManagedBeansTest.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS30.fat;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.restfulWS30.fat.managedbeans.ManagedBeansTestServlet;
+
+/**
+ * Tests whether a class can be both an <code>Application</code> subclass
+ * <em>and<em> a resource class.
+ */
+@RunWith(FATRunner.class)
+public class ManagedBeansTest extends FATServletClient {
+
+    public static final String APP_NAME = "managedbeans";
+    public static final String SERVER_NAME = APP_NAME;
+
+    @Server(SERVER_NAME)
+    @TestServlet(servlet = ManagedBeansTestServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addPackages(true, ManagedBeansTestServlet.class.getPackage());
+
+        ShrinkHelper.exportDropinAppToServer(server, war, DeployOptions.SERVER_ONLY);
+
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/managedbeans/App.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/managedbeans/App.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS30.fat.managedbeans;
+
+import jakarta.annotation.ManagedBean;
+import jakarta.annotation.PostConstruct;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.UriInfo;
+
+@ManagedBean("application")
+@ApplicationPath("/app")
+public class App extends Application {
+
+
+    static boolean uriInfoInjectedBeforePostConstruct;
+
+    @Context
+    UriInfo uriInfo;
+
+    @PostConstruct
+    public void init() {
+        uriInfoInjectedBeforePostConstruct = uriInfo != null;
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/managedbeans/ManagedBeansTestServlet.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/managedbeans/ManagedBeansTestServlet.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS30.fat.managedbeans;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+
+import jakarta.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet("/ManagedBeansTestServlet")
+public class ManagedBeansTestServlet extends FATServlet {
+
+    @Test
+    public void testProviderInjectedIntoAppBeforePostConstruct() throws Exception {
+        URI uri = URI.create("http://localhost:" + System.getProperty("bvt.prop.HTTP_default") + "/managedbeans/app/resource/priorapp");
+        HttpURLConnection conn = (HttpURLConnection) uri.toURL().openConnection();
+        assertEquals(200, conn.getResponseCode());
+        assertEquals("true", readEntity(conn.getInputStream()));
+    }
+
+    @Test
+    public void testAppInjectedIntoResourceBeforePostConstruct() throws Exception {
+        URI uri = URI.create("http://localhost:" + System.getProperty("bvt.prop.HTTP_default") + "/managedbeans/app/resource/priorresource");
+        HttpURLConnection conn = (HttpURLConnection) uri.toURL().openConnection();
+        assertEquals(200, conn.getResponseCode());
+        assertEquals("true", readEntity(conn.getInputStream()));
+    }
+
+    @Test
+    public void testResourceIsRequestScoped() throws Exception {
+        URI uri = URI.create("http://localhost:" + System.getProperty("bvt.prop.HTTP_default") + "/managedbeans/app/resource/id");
+        HttpURLConnection conn = (HttpURLConnection) uri.toURL().openConnection();
+        assertEquals(200, conn.getResponseCode());
+        String firstInstanceId = readEntity(conn.getInputStream());
+        
+        conn = (HttpURLConnection) uri.toURL().openConnection();
+        assertEquals(200, conn.getResponseCode());
+        String secondInstanceId = readEntity(conn.getInputStream());
+        assertFalse(firstInstanceId.equals(secondInstanceId));
+    }
+
+    private String readEntity(InputStream is) throws Exception {
+        StringBuilder sb = new StringBuilder();
+        byte[] b = new byte[256];
+        int i = is.read(b);
+        while (i > 0) {
+            sb.append(new String(b, 0, i));
+            i = is.read(b);
+        }
+        return sb.toString().trim();
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/managedbeans/Resource.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/managedbeans/Resource.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS30.fat.managedbeans;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.annotation.ManagedBean;
+import jakarta.annotation.PostConstruct;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+
+@ManagedBean("resource")
+@Path("/resource")
+@Produces(MediaType.TEXT_PLAIN)
+public class Resource {
+
+    static AtomicInteger COUNTER = new AtomicInteger(0);
+
+    @Context
+    Application app;
+
+    private boolean appInjectedBeforePostConstruct;
+
+    private int id;
+
+    @PostConstruct
+    public void init() {
+        id = COUNTER.getAndIncrement();
+        appInjectedBeforePostConstruct = app != null;
+        System.out.println("Resource init");
+    }
+
+    @GET
+    @Path("/priorapp")
+    public boolean isUriInfoInjectedBeforeAppPostConstruct() {
+        return App.uriInfoInjectedBeforePostConstruct;
+    }
+
+    @GET
+    @Path("/priorresource")
+    public boolean isAppInjectedBeforeResourcePostConstruct() {
+        return appInjectedBeforePostConstruct;
+    }
+
+    @GET
+    @Path("/id")
+    public int getInstanceId() {
+        return id;
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/managedbeans/bootstrap.properties
+++ b/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/managedbeans/bootstrap.properties
@@ -1,0 +1,3 @@
+bootstrap.include=../testports.properties
+#com.ibm.ws.logging.max.files=1
+#com.ibm.ws.logging.trace.specification=LogService=all:RESTfulWS=all

--- a/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/managedbeans/server.xml
+++ b/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/managedbeans/server.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<server>
+    <featureManager>
+        <feature>componenttest-2.0</feature>
+        <feature>restfulWS-3.0</feature>
+        <feature>managedBeans-2.0</feature>
+    </featureManager>
+    <include location="../fatTestPorts.xml"/>
+    
+    <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
+    <javaPermission className="java.net.URLPermission" name="http://localhost:8010/managedbeans/app/-" actions="GET:"/>
+    <javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
+</server>


### PR DESCRIPTION
Resolves a couple TCK failures where application and resource are managed beans (as opposed to CDI beans).