### PR TITLE
Updated dependencies to pull SR OpenAPI-2.1.1

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -684,12 +684,12 @@
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-open-api-core</artifactId>
-      <version>2.1.0</version>
+      <version>2.1.1</version>
     </dependency>
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-open-api-jaxrs</artifactId>
-      <version>2.1.0</version>
+      <version>2.1.1</version>
     </dependency>
     <dependency>
       <groupId>jakarta.activation</groupId>

--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -684,12 +684,12 @@
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-open-api-core</artifactId>
-      <version>2.1.0-RC2</version>
+      <version>2.1.0</version>
     </dependency>
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-open-api-jaxrs</artifactId>
-      <version>2.1.0-RC2</version>
+      <version>2.1.0</version>
     </dependency>
     <dependency>
       <groupId>jakarta.activation</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -132,8 +132,8 @@ io.smallrye.config:smallrye-config:2.0.1
 io.smallrye:smallrye-graphql-client-api:1.0.9
 io.smallrye:smallrye-graphql-client:1.0.9
 io.smallrye:smallrye-graphql-schema-model:1.0.9
-io.smallrye:smallrye-open-api-core:2.1.0-RC2
-io.smallrye:smallrye-open-api-jaxrs:2.1.0-RC2
+io.smallrye:smallrye-open-api-core:2.1.0
+io.smallrye:smallrye-open-api-jaxrs:2.1.0
 jakarta.activation:jakarta.activation-api:2.0.0
 jakarta.annotation:jakarta.annotation-api:2.0.0
 jakarta.authentication:jakarta.authentication-api:2.0.0

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -132,8 +132,8 @@ io.smallrye.config:smallrye-config:2.0.1
 io.smallrye:smallrye-graphql-client-api:1.0.9
 io.smallrye:smallrye-graphql-client:1.0.9
 io.smallrye:smallrye-graphql-schema-model:1.0.9
-io.smallrye:smallrye-open-api-core:2.1.0
-io.smallrye:smallrye-open-api-jaxrs:2.1.0
+io.smallrye:smallrye-open-api-core:2.1.1
+io.smallrye:smallrye-open-api-jaxrs:2.1.1
 jakarta.activation:jakarta.activation-api:2.0.0
 jakarta.annotation:jakarta.annotation-api:2.0.0
 jakarta.authentication:jakarta.authentication-api:2.0.0


### PR DESCRIPTION
Updated references to consume the SmallRye OpenAPI 2.1.1 core and jax-rs libraries from artifactory & maven.

resolves #15538 

#build
#spawn.fullfat.buckets=com.ibm.ws.microprofile.openapi_fat,com.ibm.ws.microprofile.openapi_fat_tck,com.ibm.ws.microprofile.openapi.1.1_fat_tck,io.openliberty.microprofile.openapi.2.0.internal_fat,io.openliberty.microprofile.openapi.2.0.internal_fat_tck