### PR TITLE
Additional trasnsforms for xml WS

### DIFF
--- a/dev/wlp-jakartaee-transform/rules/jakarta-direct.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-direct.properties
@@ -146,6 +146,14 @@ javax.xml.ws.http.request.querystring=jakarta.xml.ws.http.request.querystring
 javax.xml.ws.http.request.pathinfo=jakarta.xml.ws.http.request.pathinfo
 javax.xml.ws.reference.parameters=jakarta.xml.ws.reference.parameters
 
+#xmlWS BindingProvider properties
+javax.xml.ws.security.auth.username=jakarta.xml.ws.security.auth.username
+javax.xml.ws.security.auth.password=jakarta.xml.ws.security.auth.password
+javax.xml.ws.service.endpoint.address=jakarta.xml.ws.service.endpoint.address
+javax.xml.ws.session.maintain=jakarta.xml.ws.session.maintain
+javax.xml.ws.soap.http.soapaction.use=jakarta.xml.ws.soap.http.soapaction.use
+javax.xml.ws.soap.http.soapaction.uri=jakarta.xml.ws.soap.http.soapaction.uri
+
 com.sun.xml.bind.v2.ContextFactory=org.glassfish.jaxb.runtime.v2.JAXBContextFactory
 com.ibm.xml.xlxp2.jaxb.JAXBContextFactory=org.glassfish.jaxb.runtime.v2.JAXBContextFactory
 

--- a/dev/wlp-jakartaee-transform/rules/jakarta-direct.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-direct.properties
@@ -117,6 +117,12 @@ javax.xml.ws.AsyncHandler=jakarta.xml.ws.AsyncHandler
 javax.xml.ws.FaultAction=jakarta.xml.ws.FaultAction
 javax.xml.ws.Action=jakarta.xml.ws.Action
 
+# SAAJ 2.0 properties
+javax.xml.soap.SOAPMessage=jakarta.xml.soap.SOAPMessage
+
+# xmlBinding-3.0 properties
+javax.xml.bind.JAXBElement=jakarta.xml.bind.JAXBElement
+
 # xmlWS-3.0 MessageContext properties
 javax.xml.ws.addressing.context=jakarta.xml.ws.addressing.context
 javax.xml.ws.addressing.context.inbound=jakarta.xml.ws.addressing.context.inbound
@@ -142,3 +148,5 @@ javax.xml.ws.reference.parameters=jakarta.xml.ws.reference.parameters
 
 com.sun.xml.bind.v2.ContextFactory=org.glassfish.jaxb.runtime.v2.JAXBContextFactory
 com.ibm.xml.xlxp2.jaxb.JAXBContextFactory=org.glassfish.jaxb.runtime.v2.JAXBContextFactory
+
+javax.annotation.security.RolesAllowed=jakarta.annotation.security.RolesAllowed


### PR DESCRIPTION
- Add transforms for classes that are referenced as Strings in CXF code
- Add transforms for BindingProvider properties which are referenced as string literals