### PR TITLE
CL22175 single catch-up for fixed-rate execution

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/ScheduledPolicyExecutorTask.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/ScheduledPolicyExecutorTask.java
@@ -29,6 +29,18 @@ public interface ScheduledPolicyExecutorTask {
     PolicyExecutor getExecutor();
 
     /**
+     * Computes the next fixed-rate execution time after the specified execution time,
+     * given the specified period.
+     *
+     * @param recentExecutionTime nanosecond timestamp at which the task most recently started executing.
+     * @param period              period in nanoseconds at which the fixed-rate task should execute.
+     * @return nanosecond timestamp of the next fixed-rate execution.
+     */
+    default long getNextFixedRateExecutionTime(long recentExecutionTime, long period) {
+        return recentExecutionTime + period;
+    }
+
+    /**
      * Provides a callback to be invoked when the task fails to resubmit to
      * the designated policy executor. Typically, this will be because the
      * policy executor has been shut down, suspended, or has reached its limit

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/SchedulingRunnableFixedHelper.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/SchedulingRunnableFixedHelper.java
@@ -20,6 +20,8 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import com.ibm.ws.threading.ScheduledPolicyExecutorTask;
+
 /**
  * Wrapper for the ScheduledFuture returned on overridden scheduleWithFixedRate and scheduleWithFixedDelay methods.
  * It's used to present a consistent state of the submitted Runnable as it progresses through the underlying
@@ -295,7 +297,11 @@ class SchedulingRunnableFixedHelper<V> implements ScheduledFuture<Object>, Runna
         try {
             long scheduleTime = this.m_periodInterval;
             if (!this.m_scheduledWithDelay) {
-                this.m_myNextExecutionTime = this.m_myNextExecutionTime + this.m_periodInterval;
+                if (m_runnable instanceof ScheduledPolicyExecutorTask) {
+                    this.m_myNextExecutionTime = ((ScheduledPolicyExecutorTask) m_runnable).getNextFixedRateExecutionTime(m_myNextExecutionTime, m_periodInterval);
+                } else {
+                    this.m_myNextExecutionTime = this.m_myNextExecutionTime + this.m_periodInterval;
+                }
                 long currentTime = System.nanoTime();
 
                 scheduleTime = (this.m_myNextExecutionTime > currentTime) ? (this.m_myNextExecutionTime - currentTime) : 0;

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
@@ -78,6 +78,12 @@ public class PolicyExecutorServlet extends FATServlet {
     // Maximum number of nanoseconds to wait for a task to complete
     static final long TIMEOUT_NS = TimeUnit.MINUTES.toNanos(2);
 
+    /**
+     * When checking that a timer didn't run too soon, it is permitted to be
+     * off by up to this amount.
+     */
+    private static final long TOLERANCE_NS = TimeUnit.MILLISECONDS.toNanos(200);
+
     @Resource(lookup = "test/CompletionStageFactory")
     private CompletionStageFactory completionStageFactory;
 
@@ -4149,6 +4155,84 @@ public class PolicyExecutorServlet extends FATServlet {
             fail("Should not be able to register callback after shutdown. Result of register was: " + previous);
         } catch (IllegalStateException x) {
         } // pass
+    }
+
+    /**
+     * Uses ScheduledPolicyExecutorTask to schedule a repeating fixed-rate task
+     * which, when delayed past multiple expected executions, runs just once to catch-up
+     * and thereafter returns to its original scheduled period for fixed-rate execution.
+     */
+    @Test
+    public void testLibertyScheduledExecutorFixedRateExecution() throws Exception {
+        PolicyExecutor executor = provider.create("testLibertyScheduledExecutorFixedRateExecution")
+                        .maxConcurrency(7)
+                        .maxQueueSize(Integer.MAX_VALUE)
+                        .maxWaitForEnqueue(0)
+                        .runIfQueueFull(false);
+
+        LinkedBlockingQueue<Long> startTimes = new LinkedBlockingQueue<Long>();
+
+        Runnable getNanoTime = () -> {
+            startTimes.add(System.nanoTime());
+            System.out.println("testLibertyScheduledExecutorFixedRateExecution task running");
+        };
+
+        Runnable twoSecondDelay = () -> {
+            try {
+                startTimes.add(System.nanoTime());
+                System.out.println("testLibertyScheduledExecutorFixedRateExecution task: start sleeping");
+                TimeUnit.MILLISECONDS.sleep(1100);
+                System.out.println("testLibertyScheduledExecutorFixedRateExecution task: wake up");
+            } catch (InterruptedException x) {
+                throw new CompletionException(x);
+            }
+        };
+
+        try {
+            ScheduledBlockingQueueTask task = new ScheduledBlockingQueueTask(executor, getNanoTime, twoSecondDelay, getNanoTime, getNanoTime, getNanoTime);
+
+            long scheduleAtNanos = System.nanoTime();
+            ScheduledFuture<?> future = libertyScheduledExecutor.scheduleAtFixedRate(task, 400, 500, TimeUnit.MILLISECONDS);
+
+            Long runAtNanos = null;
+            long elapsedNanos;
+
+            // Execution 1 after 400 ms
+            assertNotNull((runAtNanos = startTimes.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS)));
+            elapsedNanos = runAtNanos - scheduleAtNanos;
+            assertTrue("Executed [1] too soon: " + TimeUnit.NANOSECONDS.toMillis(elapsedNanos) + " ms from schedule",
+                       elapsedNanos > TimeUnit.MILLISECONDS.toNanos(400) - TOLERANCE_NS);
+
+            // Execution 2 after 900 ms
+            assertNotNull((runAtNanos = startTimes.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS)));
+            elapsedNanos = runAtNanos - scheduleAtNanos;
+            assertTrue("Executed [2] too soon: " + TimeUnit.NANOSECONDS.toMillis(elapsedNanos) + " ms from schedule",
+                       elapsedNanos > TimeUnit.MILLISECONDS.toNanos(900) - TOLERANCE_NS);
+
+            // [intentionally delayed] Does not execute at 1400 ms
+
+            // [intentionally delayed] Does not execute at 1900 ms
+
+            // Execution 3 after 2000 ms  :  this is the single catch-up execution
+            assertNotNull((runAtNanos = startTimes.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS)));
+            elapsedNanos = runAtNanos - scheduleAtNanos;
+            assertTrue("Executed [3] too soon: " + TimeUnit.NANOSECONDS.toMillis(elapsedNanos) + " ms from schedule",
+                       elapsedNanos > TimeUnit.MILLISECONDS.toNanos(2000) - TOLERANCE_NS);
+
+            // Execution 4 after 2400 ms
+            assertNotNull((runAtNanos = startTimes.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS)));
+            elapsedNanos = runAtNanos - scheduleAtNanos;
+            assertTrue("Executed [4] too soon: " + TimeUnit.NANOSECONDS.toMillis(elapsedNanos) + " ms from schedule",
+                       elapsedNanos > TimeUnit.MILLISECONDS.toNanos(2400) - TOLERANCE_NS);
+
+            // Execution 5 after 2900 ms
+            assertNotNull((runAtNanos = startTimes.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS)));
+            elapsedNanos = runAtNanos - scheduleAtNanos;
+            assertTrue("Executed [5] too soon: " + TimeUnit.NANOSECONDS.toMillis(elapsedNanos) + " ms from schedule",
+                       elapsedNanos > TimeUnit.MILLISECONDS.toNanos(2900) - TOLERANCE_NS);
+        } finally {
+            executor.shutdown();
+        }
     }
 
     /**

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/ScheduledBlockingQueueTask.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/ScheduledBlockingQueueTask.java
@@ -62,6 +62,22 @@ public class ScheduledBlockingQueueTask extends LinkedBlockingQueue<Integer> imp
         return executor;
     }
 
+    /**
+     * Limit to 1 catch-up execution when delayed.
+     */
+    @Override
+    public long getNextFixedRateExecutionTime(long recentExecutionTime, long period) {
+        long missedExecutions = (System.nanoTime() - recentExecutionTime) / period;
+        if (missedExecutions < 0)
+            missedExecutions = 0;
+        return recentExecutionTime + period * (1 + missedExecutions);
+    }
+
+    @Override
+    public Exception resubmitFailed(Exception failure) {
+        return failure;
+    }
+
     @Override
     public void run() {
         int count = counter.incrementAndGet();


### PR DESCRIPTION
Add the ability to override the algorithm for computing the next fixed-rate execution.  By default, when a fixed-rate scheduled task is delayed, the Liberty Scheduled Executor is continually running all missed executions until caught up.  In some cases, this might be the desired behavior, however in other cases only a single catch-up execution is wanted before returning to the fixed-rate schedule.