### PR TITLE
test that ManagedThreadFactory is still working after app restart if looked up again

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_config/publish/servers/concurrent.config.fat/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_config/publish/servers/concurrent.config.fat/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017,2020 IBM Corporation and others.
+    Copyright (c) 2017,2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -18,6 +18,8 @@
     </featureManager>
 
     <include location="../fatTestPorts.xml"/>
+
+    <application id="concurrentApp" location="concurrent.war"/>
 
     <variable name="onError" value="FAIL"/>
     <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/> 

--- a/dev/com.ibm.ws.concurrent_fat_config/test-applications/concurrent/src/fat/concurrent/web/EEConcurrencyUtilsFATServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_config/test-applications/concurrent/src/fat/concurrent/web/EEConcurrencyUtilsFATServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2020 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,11 +33,9 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
-
 import jakarta.annotation.Resource;
 import jakarta.enterprise.concurrent.ManagedTask;
+import jakarta.enterprise.concurrent.ManagedThreadFactory;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -46,6 +44,9 @@ import jakarta.transaction.SystemException;
 import jakarta.transaction.Transaction;
 import jakarta.transaction.TransactionManager;
 import jakarta.transaction.UserTransaction;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 
 import componenttest.app.FATServlet;
 import fat.concurrent.ejb.EEConcurrencyUtilsStatelessBean;
@@ -202,6 +203,16 @@ public class EEConcurrencyUtilsFATServlet extends FATServlet {
         task.getExecutionProperties().put(ManagedTask.LONGRUNNING_HINT, Boolean.TRUE.toString());
         Future<Integer> future = executor.submit(task);
         assertEquals(Integer.valueOf(1), future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+    }
+
+    /**
+     * Verify that a ManagedThreadFactory can create and run a new thread.
+     */
+    public void testManagedThreadFactory() throws Exception {
+        ManagedThreadFactory tf = InitialContext.doLookup("concurrent/threadFactory1");
+        CountDownLatch isRunning = new CountDownLatch(1);
+        tf.newThread(() -> isRunning.countDown()).start();
+        assertTrue(isRunning.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
     }
 
     /**


### PR DESCRIPTION
Add test case that looks up a ManagedThreadFactory after application restart and verifies that it is still usable.