### PR TITLE
Check for null notification

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/BundleProcessor.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/BundleProcessor.java
@@ -374,7 +374,10 @@ class BundleProcessor implements SynchronousBundleListener, EventHandler, Runtim
                         }
                     }
 
-                    processed.setResult(true);
+                    if (processed != null) {
+                        // This can only be null if the server started shutting down after our shutdown check.
+                        processed.setResult(true);
+                    }
 
                 }
 


### PR DESCRIPTION
Check for a null notification object to avoid an extremely rare timing issue. 