### PR TITLE
Early exit when dir.listFiles() returns null

### DIFF
--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/java2sec/PermissionManager.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/java2sec/PermissionManager.java
@@ -717,6 +717,12 @@ public class PermissionManager implements PermissionsCombiner {
     
     private void RecursiveArchiveFind(File dir, String individualArchive, String codeBase, ArrayList<Permission> permissions) {
         File [] files = dir.listFiles();
+        if (files == null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Directory, " + dir + " does not exist or threw an IO exception while listing it's files - skipping");
+            }
+            return;
+        }
 
         // for every file in the current directory, see if it matches any of the individual archive files
         for (File file : files) {


### PR DESCRIPTION
Resolves NPE and traces condition where directory's `listFiles()` method returns null - according to the Javadoc, this can occur when the directory does not exist or if some sort of IOException has occurred.