### PR TITLE
Synchronize access to configProperties map

### DIFF
--- a/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/restfulWS/config/ConfigImpl.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/restfulWS/config/ConfigImpl.java
@@ -55,12 +55,12 @@ public class ConfigImpl implements Config {
     }
 
     @Override
-    public Iterable<String> getPropertyNames() {
+    public synchronized Iterable<String> getPropertyNames() {
         return configProperties.keySet();
     }
 
     @Override
-    public <T> T getValue(String propName, Class<T> propType) {
+    public synchronized <T> T getValue(String propName, Class<T> propType) {
         String value = configProperties.get(propName);
         if (value == null || String.class.equals(propType)) {
             return (T) value;
@@ -68,7 +68,7 @@ public class ConfigImpl implements Config {
         return propType.cast(value);
     }
 
-    public void updateProperties(Map<String, String> map) {
+    public synchronized void updateProperties(Map<String, String> map) {
         configProperties.putAll(map);
     }
 }


### PR DESCRIPTION
Some test builds found a ConcurrentModificationException while accessing Liberty's RESTEasy config impl's config properties hashmap.  Synchronizing access to the map should prevent these exceptions.