### PR TITLE
Guard against environments where chmod doesn't exist

### DIFF
--- a/dev/wlp.lib.extract/src/wlp/lib/extract/SelfExtractUtils.java
+++ b/dev/wlp.lib.extract/src/wlp/lib/extract/SelfExtractUtils.java
@@ -210,6 +210,10 @@ public class SelfExtractUtils {
             stdout.join();
             stderr.join();
             p.waitFor();
+        } catch (IOException e) {
+            if (e.getMessage().contains("Cannot run program \"chmod\"")) {
+                // "chmod" doesn't exist on this environment.
+            }
         } catch (Exception e) {
             return e;
         }


### PR DESCRIPTION
Recognize the exceptions thrown when the "chmod" command doesn't exist. - Assuming the user runs as root, or already has permission so skipping this step won't have an effect.

i tested creating a runnable jar before and after this change and deploying on a image based on gcr.io/distroless/java:11


