### PR TITLE
Issue #12029: ManagedBeans bindings FAT for Jakarta EE 9

### DIFF
--- a/dev/com.ibm.ws.managedbeans_fat/bnd.bnd
+++ b/dev/com.ibm.ws.managedbeans_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -34,7 +34,10 @@ tested.features:\
 	jdbc-4.2,\
 	jpa-2.2,\
 	jpaContainer-2.2,\
-	managedbeans-2.0,\
+	managedBeans-2.0,\
+	messagingClient-3.0,\
+	messagingServer-3.0,\
+	persistence-3.0,\
 	servlet-4.0,\
 	servlet-5.0
 

--- a/dev/com.ibm.ws.managedbeans_fat/fat/src/com/ibm/ws/managedbeans/fat/tests/ManagedBeanBindingsEJBTest.java
+++ b/dev/com.ibm.ws.managedbeans_fat/fat/src/com/ibm/ws/managedbeans/fat/tests/ManagedBeanBindingsEJBTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2020 IBM Corporation and others.
+ * Copyright (c) 2013, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -45,7 +46,8 @@ public class ManagedBeanBindingsEJBTest extends FATServletClient {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("ManagedBeansBindingsEjbServer"))
-                    .andWith(FeatureReplacementAction.EE8_FEATURES().forServers("ManagedBeansBindingsEjbServer"));
+                    .andWith(FeatureReplacementAction.EE8_FEATURES().forServers("ManagedBeansBindingsEjbServer"))
+                    .andWith(new JakartaEE9Action().fullFATOnly().forServers("ManagedBeansBindingsEjbServer"));
 
     @BeforeClass
     public static void setUp() throws Exception {


### PR DESCRIPTION
Enable the final ManagedBeans FAT to run with Jakarta EE 9,
includes testing with:
- injection into EJB
- injection of resources like datasources and message queues
into managed beans.

for #12029