### PR TITLE
Fix the GitHub Actions builds from failing validate-tests.sh

### DIFF
--- a/.github/test-categories/MP_MISC
+++ b/.github/test-categories/MP_MISC
@@ -1,3 +1,2 @@
-com.ibm.ws.microprofile.1.0_fat
-com.ibm.ws.microprofile.1.2_fat
+io.openliberty.microprofile.internal_fat
 io.openliberty.microprofile.lra.1.0.internal_fat_tck


### PR DESCRIPTION
An attempt to fix the GitHub Actions builds from failing with
```
Validate Tests
Run .github/workflow-scripts/validate-tests.sh
Error: The following fat(s) need to be added to a category under .github/test-categories: > io.openliberty.microprofile.internal_fat
Error: The following fat(s) need to be removed from a category under .github/test-categories: < com.ibm.ws.microprofile.1.0_fat
< com.ibm.ws.microprofile.1.2_fat
Error: Process completed with exit code 1.
```

