### PR TITLE
fix a jaxrs-2.1 client fat ssl build break

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientSSLTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientSSLTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -59,6 +59,10 @@ public class JAXRS21ClientSSLTest extends JAXRS21AbstractTest {
         // Pause for the smarter planet message
         assertNotNull("The smarter planet message did not get printed on server",
                       server.waitForStringInLog("CWWKF0011I"));
+
+        // wait for the tcp channel to start
+        assertNotNull("TCP Channel not started",
+                      server.waitForStringInLog("CWWKO0219I"));
     }
 
     @AfterClass


### PR DESCRIPTION
Test Failure: com.ibm.ws.jaxrs21.client.fat.test.JAXRS21ClientSSLTest.testClientBasicSSL_Client

```
testClientBasicSSL_Client:java.lang.NullPointerException: 2021-01-08-11:56:24:412 null
at com.ibm.ws.jaxrs21.client.fat.test.JAXRS21AbstractTest.runTestOnServer(JAXRS21AbstractTest.java:81)
at com.ibm.ws.jaxrs21.client.fat.test.JAXRS21ClientSSLTest.testClientBasicSSL_Client(JAXRS21ClientSSLTest.java:91)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at componenttest.custom.junit.runner.FATRunner$1.evaluate(FATRunner.java:197)
at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:318)
at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:171)
at componenttest.rules.repeater.RepeatTests$CompositeRepeatTestActionStatement.evaluate(RepeatTests.java:115)
```