### PR TITLE
Increase heap size for MP Rest Client and GraphQL TCK servers to 4GB

### DIFF
--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/servers/FATServer/jvm.options
@@ -5,6 +5,7 @@
 #-Dcom.ibm.tools.attach.enable=yes
 #-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777
 
+-Xmx4096m
 
 # required for TCK:
 -Dmp.graphql.tck.endpoint.port=8010

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,1 +1,2 @@
 -Dcom.ibm.tools.attach.enable=yes
+-Xmx4096m

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,2 +1,3 @@
 -Dcom.ibm.tools.attach.enable=yes
 -Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=20
+-Xmx4096m

--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,2 +1,3 @@
 -Dcom.ibm.tools.attach.enable=yes
 -Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=20
+-Xmx4096m

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,2 +1,3 @@
 -Dcom.ibm.tools.attach.enable=yes
 -Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=20
+-Xmx4096m

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,1 +1,2 @@
 -Dcom.ibm.tools.attach.enable=yes
+-Xmx4096m

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,2 +1,3 @@
 -Dcom.ibm.tools.attach.enable=yes
 -Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=20
+-Xmx4096m


### PR DESCRIPTION
This should fix some OOM issues seen on some platforms in automated FAT tests.