### PR TITLE
Fix Defect 280598

### DIFF
--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/Krb5ConfigTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/Krb5ConfigTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/Krb5ConfigTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/Krb5ConfigTest.java
@@ -185,6 +185,7 @@ public class Krb5ConfigTest extends CommonTest {
                 testHelper.checkForMessages(true, MessageConstants.KRBCONFIGFILE_NOT_SPECIFIED_CWWKS4302I);
             } else {
                 Log.info(c, name.getMethodName(), "This is not Windows OS. Since the userID is not root, this test will be ignored");
+                testHelper.addShutdownMessages("CWWKS4312E");
             }
         } catch (Exception ex) {
             String message = CommonTest.maskHostnameAndPassword(ex.getMessage());
@@ -220,6 +221,7 @@ public class Krb5ConfigTest extends CommonTest {
 
             } else {
                 Log.info(c, name.getMethodName(), "This is not Windows OS. Since the userID is not root, this test will be ignored");
+                testHelper.addShutdownMessages("CWWKS4312E");
             }
         } catch (Exception ex) {
             String message = CommonTest.maskHostnameAndPassword(ex.getMessage());


### PR DESCRIPTION
Test Failure: junit.framework.TestSuite.com.ibm.ws.security.spnego.fat.Krb5ConfigTest is failing when running on MAC because CWWKS4312E is not being added as an expected message when the test runs on a non windows machine. This commit addresses that.

OpenLiberty Pull Requester,

ATTENTION, READ THIS: Updated 4/11/2018 - Read and understand this completely,
then delete this entire template. If a reviewer or merger sees this template,
they should fail the review or merge.

If this code change is fixing a user-visible bug in previously released code, it MUST
have an associated issue mentioned in the PR text or description. That Issue also
MUST be labelled “release bug”

This directs automation to scrape this fix for inclusion in the next release's
list of bugs fixed.

If this code is NOT for fixing a released bug, for example new function, fixing
a bug in unreleased function, or other improvements that do not affect the
user-space, no label is needed. An issue could or could not be used based
on the developer’s discretion, but do still delete this text block.

For full details, please see this wiki page:

https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions

