### PR TITLE
Update MPCompatible test to use MP Context Prop 1.2

### DIFF
--- a/dev/io.openliberty.microprofile.internal_fat/fat/src/io/openliberty/microprofile/internal/test/suite/MPCompatibleTest.java
+++ b/dev/io.openliberty.microprofile.internal_fat/fat/src/io/openliberty/microprofile/internal/test/suite/MPCompatibleTest.java
@@ -235,16 +235,16 @@ public class MPCompatibleTest {
     }
 
     /**
-     * microProfile-4.0 plus mpContextPropagation-1.1
+     * microProfile-4.0 plus mpContextPropagation-1.2
      * Should always pass
      *
      * @throws Exception
      */
     @Test
     @Mode(TestMode.LITE)
-    public void testMP40andCtxPropagtion11() throws Exception {
+    public void testMP40andCtxPropagtion12() throws Exception {
         try {
-            server.setServerConfigurationFromFilePath("MP40andMPCtx11.xml");
+            server.setServerConfigurationFromFilePath("MP40andMPCtx12.xml");
             server.startServer();
             runGetMethod(200, "/helloworld/helloworld", MESSAGE);
         } finally {

--- a/dev/io.openliberty.microprofile.internal_fat/publish/servers/MPCompatibleServer/MP40andMPCtx12.xml
+++ b/dev/io.openliberty.microprofile.internal_fat/publish/servers/MPCompatibleServer/MP40andMPCtx12.xml
@@ -4,6 +4,6 @@
 
     <featureManager>
         <feature>microProfile-4.0</feature>
-        <feature>mpContextPropagation-1.1</feature>
+        <feature>mpContextPropagation-1.2</feature>
     </featureManager>
 </server>


### PR DESCRIPTION
https://github.com/OpenLiberty/open-liberty/pull/15566 caused a soft merge conflict with the new MPCompatible tests I added just before. Seems simpler to fix than to revert 15566.