### PR TITLE
trusted header improvements: rework IP address validity check

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/filter/FilterList.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/filter/FilterList.java
@@ -120,6 +120,9 @@ public class FilterList {
                     try {
                         addressToAdd[slot] = Integer.parseInt(sub, radix);
                     } catch (NumberFormatException nfe) {
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                            Tr.debug(tc, "addAddressToList: [" + newAddress + "] is not a valid IP address");
+                        }
                         return false;
                     }
                 }
@@ -130,6 +133,9 @@ public class FilterList {
                     try {
                         addressToAdd[slot] = Integer.parseInt(addr, radix);
                     } catch (NumberFormatException nfe) {
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                            Tr.debug(tc, "addAddressToList: [" + newAddress + "] is not a valid IP address");
+                        }
                         return false;
                     }
                 }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/TrustedHeaderOriginLists.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/TrustedHeaderOriginLists.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -300,15 +300,7 @@ public class TrustedHeaderOriginLists {
      */
     private boolean isStringIPAddressesValid(String[] value) {
         FilterList f = new FilterList();
-        try {
-            if (value != null) {
-                f.buildData(value, true);
-            }
-        } catch (NumberFormatException x) {
-            return false;
-        }
-
-        return true;
+        return f.buildData(value, true);
     }
 
     /**


### PR DESCRIPTION
for #9809 

The `FilterList` class was borrowed from the TCP channel, and it relies on exception handling to validate address validity. To avoid unnecessary FFDCs in the logs, I'd rather avoid the exception checking.