### PR TITLE
cleanup security fats

### DIFF
--- a/.github/test-categories/QUARANTINE
+++ b/.github/test-categories/QUARANTINE
@@ -1,6 +1,9 @@
 # Depend on IBM Network
 com.ibm.ws.mongo_fat
 com.ibm.ws.security.oauth_fat
+com.ibm.ws.security.spnego_fat
+com.ibm.ws.security.spnego_fat.1   
+com.ibm.ws.security.spnego_fat.2
 
 # Not a fat bucket, but still has '_fat' in name
 com.ibm.ws.repository_fat_shared

--- a/.github/test-categories/SECURITY_5
+++ b/.github/test-categories/SECURITY_5
@@ -1,4 +1,6 @@
 com.ibm.ws.security.saml.sso_fat
-com.ibm.ws.security.spnego_fat
-com.ibm.ws.security.spnego_fat.1   
-com.ibm.ws.security.spnego_fat.2
+com.ibm.websphere.security_fat.1
+com.ibm.ws.security.auth.data_fat
+com.ibm.ws.security.client_fat
+com.ibm.ws.wssecurity_fat.wsscxf
+

--- a/.github/test-categories/SECURITY_6
+++ b/.github/test-categories/SECURITY_6
@@ -1,4 +1,0 @@
-com.ibm.websphere.security_fat.1
-com.ibm.ws.security.auth.data_fat
-com.ibm.ws.security.client_fat
-com.ibm.ws.wssecurity_fat.wsscxf

--- a/dev/com.ibm.ws.security.saml.sso_fat/build.gradle
+++ b/dev/com.ibm.ws.security.saml.sso_fat/build.gradle
@@ -60,6 +60,7 @@ addRequiredLibraries.dependsOn addJakartaTransformer
  * Configure any auto FVT artifacts.
  */
 autoFVT.dependsOn ':com.ibm.ws.security.saml.sso_fat.common:assemble'
+autoFVT.dependsOn ':com.ibm.ws.security.fat.common:assemble'
 autoFVT.doLast {
 
   /*


### PR DESCRIPTION
Quarantined FATs from running in GH Actions build:
com.ibm.ws.security.spnego_fat
com.ibm.ws.security.spnego_fat.1
com.ibm.ws.security.spnego_fat.2
These all run against Consul servers which cannot be accessed unless on the IBM network

com.ibm.ws.security.saml.sso_fat/build.gradle 
Had a missing dependency on a project being assembled that is not guaranteed during a GH Actions build.