### PR TITLE
Ensure streams close while scanning classes

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/utils/IndexUtils.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/utils/IndexUtils.java
@@ -106,7 +106,9 @@ public class IndexUtils {
                         qualifiedName = packageName + "." + className;
                     }
                     if (acceptClassForScanning(filter, qualifiedName)) {
-                        indexer.index(entry.adapt(InputStream.class));
+                        try (InputStream is = entry.adapt(InputStream.class)) {
+                            indexer.index(is);
+                        }
                     }
                 } else {
                     Container entryContainer = entry.adapt(Container.class);


### PR DESCRIPTION
Although the Jandex Indexer will consume the whole stream, it won't
close it so we have to ensure that we do.