### PR TITLE
Cleanup of eclipse files and other small cleanup items.

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaee-9.0/io.openliberty.jakartaee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaee-9.0/io.openliberty.jakartaee-9.0.feature
@@ -5,7 +5,7 @@ singleton=true
 IBM-App-ForceRestart: install, uninstall
 IBM-ShortName: jakartaee-9.0
 Subsystem-Version: 9.0.0
-Subsystem-Name: Jakarta EE 9.0 Platform
+Subsystem-Name: Jakarta EE Platform 9.0
 -features=\
  com.ibm.websphere.appserver.adminSecurity-2.0,\
  com.ibm.websphere.appserver.eeCompatible-9.0,\

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/webProfile-9.0/io.openliberty.webProfile-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/webProfile-9.0/io.openliberty.webProfile-9.0.feature
@@ -5,7 +5,7 @@ singleton=true
 IBM-App-ForceRestart: install, uninstall
 IBM-ShortName: webProfile-9.0
 Subsystem-Version: 9.0.0
-Subsystem-Name: Jakarta EE 9.0 Web Profile
+Subsystem-Name: Jakarta EE Web Profile 9.0
 -features=\
   com.ibm.websphere.appserver.builtinAuthentication-2.0,\
   com.ibm.websphere.appserver.eeCompatible-9.0, \

--- a/dev/com.ibm.ws.org.apache.taglibs.standard/.classpath
+++ b/dev/com.ibm.ws.org.apache.taglibs.standard/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-    <classpathentry kind="src" path="src"/>
     <classpathentry kind="con" path="aQute.bnd.classpath.container"/>
     <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
     <classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.wsat.recovery_fat.lps/.classpath
+++ b/dev/com.ibm.ws.wsat.recovery_fat.lps/.classpath
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="com.ibm.ws.wsat.recovery_fat.single-recoveryClient"/>
 	<classpathentry kind="src" path="com.ibm.ws.wsat.recovery_fat.single-recoveryServer"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>

--- a/dev/com.ibm.ws.wsat.recovery_fat.lps/.project
+++ b/dev/com.ibm.ws.wsat.recovery_fat.lps/.project
@@ -22,11 +22,6 @@
 	</natures>
 	<linkedResources>
 		<link>
-			<name>com.ibm.ws.wsat.recovery_fat.single-fatsrc</name>
-			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.wsat.recovery_fat.single/fat/src</locationURI>
-		</link>
-		<link>
 			<name>com.ibm.ws.wsat.recovery_fat.single-recoveryClient</name>
 			<type>2</type>
 			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.wsat.recovery_fat.single/test-applications/recoveryClient/src</locationURI>

--- a/dev/com.ibm.ws.wsat.recovery_fat.multi/.classpath
+++ b/dev/com.ibm.ws.wsat.recovery_fat.multi/.classpath
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="com.ibm.ws.wsat.recovery_fat.single-recoveryClient"/>
 	<classpathentry kind="src" path="com.ibm.ws.wsat.recovery_fat.single-recoveryServer"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>

--- a/dev/com.ibm.ws.wsat.recovery_fat.multi/.project
+++ b/dev/com.ibm.ws.wsat.recovery_fat.multi/.project
@@ -22,11 +22,6 @@
 	</natures>
 	<linkedResources>
 		<link>
-			<name>com.ibm.ws.wsat.recovery_fat.single-fatsrc</name>
-			<type>2</type>
-			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.wsat.recovery_fat.single/fat/src</locationURI>
-		</link>
-		<link>
 			<name>com.ibm.ws.wsat.recovery_fat.single-recoveryClient</name>
 			<type>2</type>
 			<locationURI>PARENT-1-PROJECT_LOC/com.ibm.ws.wsat.recovery_fat.single/test-applications/recoveryClient/src</locationURI>

--- a/dev/io.openliberty.jakarta.servlet.5.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.servlet.5.0/bnd.bnd
@@ -1,13 +1,13 @@
-/*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
- *******************************************************************************/
+#*******************************************************************************
+# Copyright (c) 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
 
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0

--- a/dev/io.openliberty.org.apache.taglibs.standard/.classpath
+++ b/dev/io.openliberty.org.apache.taglibs.standard/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-    <classpathentry kind="src" path="src"/>
     <classpathentry kind="con" path="aQute.bnd.classpath.container"/>
     <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
     <classpathentry kind="output" path="bin"/>

--- a/dev/wlp.lib.extract_fat/bnd.bnd
+++ b/dev/wlp.lib.extract_fat/bnd.bnd
@@ -18,7 +18,7 @@ src: \
 fat.project: true
 
 -dependson: \
-    build.changeDetector
+    build.changeDetector, \
 	com.ibm.ws.kernel.feature
 
 -buildpath: \


### PR DESCRIPTION
- Update taglibs project to not have a src directory in .classpath since there is no source.
- Update wsat.recovery fat .project files to remove fatsrc since it isn't used by .classpath
- Update wsat.recover.fat .classpath files to include fat/src directory.
- Fix up bnd files for jakarta.servlet.5.0 and wlp.lib.extract_fat to not have errors during the build
- Update the web profile and platform feature names to match the spec names.
