### PR TITLE
Make OpenAPI test wait for HTTPS port to be open

### DIFF
--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/ApplicationProcessorTest.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/ApplicationProcessorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -84,6 +84,11 @@ public class ApplicationProcessorTest extends FATServletClient {
         assertNotNull("Server did not report that it has started",
             server.waitForStringInLog("CWWKF0011I.*"));
 
+        assertNotNull("Http port not opened",
+            server.waitForStringInLog("CWWKO0219I.* defaultHttpEndpoint ")); // Wait for http port
+        assertNotNull("Https port not opened",
+            server.waitForStringInLog("CWWKO0219I.* defaultHttpEndpoint-ssl ")); // Wait for https port to open (this
+                                                                                 // can sometimes take a while)
     }
 
     /**

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/DefaultHostListener.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/DefaultHostListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -61,7 +61,9 @@ public class DefaultHostListener {
      *          The ServerInfo object for the default_host virtual host.
      */
     public ServerInfo getDefaultHostServerInfo() {
-        return defaultHostServerInfo;
+        synchronized(defaultHostServerInfo) {
+            return new ServerInfo(defaultHostServerInfo);
+        }
     }
     
     @Activate


### PR DESCRIPTION
Make the ApplicationProcessorTest wait for the HTTPS port to be open. On mpOpenApi-2.0, we're sometimes seeing the test fail because it starts before the port is open.

In addition, make a small fix to the synchronization in `DefaultHostListener` which I discovered while debugging this issue. I doubt it's related to this issue but it's clearly a mistake.