### PR TITLE
CL22175 clarify getNextFixedRateExecutionTime

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/ScheduledPolicyExecutorTask.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/ScheduledPolicyExecutorTask.java
@@ -32,12 +32,13 @@ public interface ScheduledPolicyExecutorTask {
      * Computes the next fixed-rate execution time after the specified execution time,
      * given the specified period.
      *
-     * @param recentExecutionTime nanosecond timestamp at which the task most recently started executing.
-     * @param period              period in nanoseconds at which the fixed-rate task should execute.
+     * @param expectedExecutionTime nanosecond timestamp at which the task was expected to start executing.
+     *                                  If delayed, the current time will be later than this expected target execution time.
+     * @param period                period in nanoseconds at which the fixed-rate task should execute.
      * @return nanosecond timestamp of the next fixed-rate execution.
      */
-    default long getNextFixedRateExecutionTime(long recentExecutionTime, long period) {
-        return recentExecutionTime + period;
+    default long getNextFixedRateExecutionTime(long expectedExecutionTime, long period) {
+        return expectedExecutionTime + period;
     }
 
     /**

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/ScheduledBlockingQueueTask.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/ScheduledBlockingQueueTask.java
@@ -66,11 +66,11 @@ public class ScheduledBlockingQueueTask extends LinkedBlockingQueue<Integer> imp
      * Limit to 1 catch-up execution when delayed.
      */
     @Override
-    public long getNextFixedRateExecutionTime(long recentExecutionTime, long period) {
-        long missedExecutions = (System.nanoTime() - recentExecutionTime) / period;
+    public long getNextFixedRateExecutionTime(long expectedExecutionTime, long period) {
+        long missedExecutions = (System.nanoTime() - expectedExecutionTime) / period;
         if (missedExecutions < 0)
             missedExecutions = 0;
-        return recentExecutionTime + period * (1 + missedExecutions);
+        return expectedExecutionTime + period * (1 + missedExecutions);
     }
 
     @Override


### PR DESCRIPTION
One of the parameters to getNextFixedRateExecutionTime and its description are misleading.  This pull corrects this to clarify that it is provided with the nanosecond timestamp of the expected execution time of the task.  This method is not externalized to end users, but we should make its description and naming accurate in order to ensure proper usage internally.