### PR TITLE
Fix memory leak when applications do not close JAXRS Client objects.

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.client/src/com/ibm/ws/jaxrs20/client/JAXRSClientBuilderImpl.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client/src/com/ibm/ws/jaxrs20/client/JAXRSClientBuilderImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -39,8 +39,7 @@ public class JAXRSClientBuilderImpl extends ClientBuilderImpl {
 
     @Override
     public Client build() {
-
-        return new JAXRSClientImpl(super.getConfiguration(), secConfig);
+        return JAXRSClientImpl.newClient(super.getConfiguration(), secConfig);
     }
 
     @Override

--- a/dev/com.ibm.ws.jaxrs.2.0.client/src/com/ibm/ws/jaxrs20/client/JAXRSClientImpl.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client/src/com/ibm/ws/jaxrs20/client/JAXRSClientImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.jaxrs20.client;
 
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
 import java.net.URI;
 import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
@@ -61,8 +63,34 @@ import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 /**
  *
  */
-public class JAXRSClientImpl extends ClientImpl {
+public final class JAXRSClientImpl extends ClientImpl {
     private static final TraceComponent tc = Tr.register(JAXRSClientImpl.class);
+
+    private static final ReferenceQueue<JAXRSClientImpl> referenceQueue = new ReferenceQueue<>();
+
+    private static class ClientWeakReference extends WeakReference<JAXRSClientImpl> {
+
+        final String moduleName;
+        volatile boolean wasClosed = false;
+
+        ClientWeakReference(JAXRSClientImpl r, ReferenceQueue<JAXRSClientImpl> queue, String moduleName) {
+            super(r, queue);
+            this.moduleName = moduleName;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+
+            if (obj instanceof ClientWeakReference) {
+                return get() == ((ClientWeakReference) obj).get();
+            }
+
+            return false;
+        }
+    }
 
     protected final AtomicBoolean closed = new AtomicBoolean(false);
     protected Set<WebClient> baseClients = Collections.newSetFromMap(new WeakHashMap<WebClient, Boolean>());
@@ -72,13 +100,13 @@ public class JAXRSClientImpl extends ClientImpl {
     //Before this change, all the WebTarget has same url in a web module share a bus
     //After this change, all the WebTarget has same url in a JAXRSClientImpl share a bus
     private static final Map<String, LibertyApplicationBus> busCache = new ConcurrentHashMap<>();
-    private static final Map<String, List<JAXRSClientImpl>> clientsPerModule = new HashMap<>();
+    private static final Map<String, List<ClientWeakReference>> clientsPerModule = new HashMap<>();
 
     /**
      * @param config
      * @param secConfig
      */
-    public JAXRSClientImpl(Configuration config, TLSConfiguration secConfig) {
+    JAXRSClientImpl(Configuration config, TLSConfiguration secConfig) {
         super(config, secConfig);
         this.secConfig = secConfig;
         /**
@@ -144,13 +172,43 @@ public class JAXRSClientImpl extends ClientImpl {
 
         String moduleName = getModuleName();
         synchronized (clientsPerModule) {
-            List<JAXRSClientImpl> clients = clientsPerModule.get(moduleName);
+            List<ClientWeakReference> clients = clientsPerModule.get(moduleName);
             if (clients == null) {
                 clients = new ArrayList<>();
                 clientsPerModule.put(moduleName, clients);
             }
-            clients.add(this);
+            clients.add(new ClientWeakReference(this, referenceQueue, moduleName));
         }
+    }
+
+    private static void poll() {
+        ClientWeakReference clientRef;
+        while ((clientRef = (ClientWeakReference) referenceQueue.poll()) != null) {
+            // if closed was called, do not need to remove it since it was already removed.
+            if (!clientRef.wasClosed) {
+                synchronized (clientsPerModule) {
+                    List<ClientWeakReference> clients = clientsPerModule.get(clientRef.moduleName);
+
+                    if (clients != null) { // the only way this isn't null is if the same client was closed twice
+                        clients.remove(clientRef);
+                        if (clients.isEmpty()) {
+                            for (String id : busCache.keySet()) {
+                                if (id.startsWith(clientRef.moduleName) || id.startsWith("unknown:")) {
+                                    busCache.remove(id).shutdown(false);
+                                }
+                            }
+                            clientsPerModule.remove(clientRef.moduleName);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    static Client newClient(Configuration config, TLSConfiguration secConfig) {
+        Client jaxrsClient = new JAXRSClientImpl(config, secConfig);
+        poll();
+        return jaxrsClient;
     }
 
     /**
@@ -242,10 +300,17 @@ public class JAXRSClientImpl extends ClientImpl {
         if (doClose()) {
             String moduleName = getModuleName();
             synchronized (clientsPerModule) {
-                List<JAXRSClientImpl> clients = clientsPerModule.get(moduleName);
+                List<ClientWeakReference> clients = clientsPerModule.get(moduleName);
 
                 if (clients != null) { // the only way this isn't null is if the same client was closed twice
-                    clients.remove(this);
+                    for (int i = 0, size = clients.size(); i < size; ++i) {
+                        ClientWeakReference weakRef = clients.get(i);
+                        if (weakRef.get() == this) {
+                            weakRef.wasClosed = true;
+                            clients.remove(i);
+                            break;
+                        }
+                    }
                     if (clients.isEmpty()) {
                         for (String id : busCache.keySet()) {
                             if (id.startsWith(moduleName) || id.startsWith("unknown:")) {
@@ -257,17 +322,21 @@ public class JAXRSClientImpl extends ClientImpl {
                 }
             }
         }
+        poll();
     }
 
     public static void closeClients(ModuleMetaData mmd) {
         String moduleName = getModuleName(mmd);
-        List<JAXRSClientImpl> clients = null;
+        List<ClientWeakReference> clients = null;
         synchronized (clientsPerModule) {
             clients = clientsPerModule.remove(moduleName);
         }
         if (clients != null) {
-            for (JAXRSClientImpl client : clients) {
-                client.doClose();
+            for (ClientWeakReference client : clients) {
+                JAXRSClientImpl jaxrsClient = client.get();
+                if (jaxrsClient != null) {
+                    jaxrsClient.doClose();
+                }
             }
             synchronized (clientsPerModule) {
                 for (String id : busCache.keySet()) {

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientStandaloneTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientStandaloneTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -102,5 +102,17 @@ public class JAXRSClientStandaloneTest extends AbstractTest {
         this.runTestOnServer(target, "testFlowProgram_ClientStandalone", p, "[Basic Resource]:alex");
     }
 
+    /**
+     * This test validates new function in the JAXRS 2.0 and 2.1 function for a memory leak
+     * condition that is possible.  It looks like RESTEasy does not have similar issues.
+     * It handles things and outputs a warning to the user as:  RESTEASY004687: Closing a class 
+     * org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient43Engine instance for you. 
+     * Please close clients yourself.
+     */
+    @Test
+    public void testMemoryLeak_ClientStandalone() throws Exception {
+        this.runTestOnServer(target, "testMemoryLeak_ClientStandalone", null, "OK");
+    }
+    
     //TODO: we should also migrate more jaxrs-1.1 cases here
 }

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/jaxrs20.client.JAXRSClientStandaloneTest/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/jaxrs20.client.JAXRSClientStandaloneTest/server.xml
@@ -9,5 +9,6 @@
   	<javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
   	<javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
   	<javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
+        <javaPermission className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
 
 </server>

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/test-applications/jaxrsclientstandalone/src/com/ibm/ws/jaxrs20/client/JAXRSClientStandalone/client/ClientTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/test-applications/jaxrsclientstandalone/src/com/ibm/ws/jaxrs20/client/JAXRSClientStandalone/client/ClientTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,16 +12,22 @@ package com.ibm.ws.jaxrs20.client.JAXRSClientStandalone.client;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.client.AsyncInvoker;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Invocation;
@@ -131,5 +137,211 @@ public class ClientTestServlet extends HttpServlet {
                         .get(String.class);
         c.close();
         ret.append(res);
+    }
+
+
+    static class ClientFunction implements Function<Client, Client> {
+        @Override
+        public Client apply(Client client) {
+            return client;
+        }
+    }
+
+    static class WebTargetFunction implements Function<Client, WebTarget> {
+        @Override
+        public WebTarget apply(Client client) {
+            return client.target("http://localhost:8010/dumpservice/test");
+        }
+    }
+
+    static class InvocationBuilderFunction implements Function<Client, Builder> {
+        @Override
+        public Builder apply(Client client) {
+            WebTarget t = client.target("http://localhost:8010/dumpservice/test");
+            return t.request();
+        }
+    }
+
+    static class InvocationFunction implements Function<Client, Invocation> {
+        @Override
+        public Invocation apply(Client client) {
+            WebTarget t = client.target("http://localhost:8010/dumpservice/test");
+            return t.request().buildGet();
+        }
+    }
+
+    static class AsyncInvokerFunction implements Function<Client, AsyncInvoker> {
+        @Override
+        public AsyncInvoker apply(Client client) {
+            WebTarget t = client.target("http://localhost:8010/dumpservice/test");
+            return t.request().async();
+        }
+    }
+
+    static class CompletionStageRxInvokerFunction implements Function<Client, Object> {
+        @Override
+        public Object apply(Client client) {
+            WebTarget t = client.target("http://localhost:8010/dumpservice/test");
+            Builder builder = t.request();
+            try {
+                Method m = builder.getClass().getMethod("rx");
+                return m.invoke(builder);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /**
+     * This test makes sure that if an application doesn't call Client.close() on their
+     * JAXRS Client object that the runtime will not leak.  This was a problem in the past 
+     * and resolved by asking customers to update their application.  This was partially fixed
+     * by using a WeakHashMap in JAXRSClientImpl, but the clientsPerModule collection in JAXRSClientImpl
+     * still has a hard reference.  With the introduction of using weak references in clientsPerModule, 
+     * the liberty runtime now remove the weak reference object on the next time a Client is created
+     * or closed.  This test validates that that function works and will continue to work into the future.
+     */
+    public void testMemoryLeak_ClientStandalone(Map<String, String> param, StringBuilder ret) {
+        ClientBuilder cb = ClientBuilder.newBuilder();
+        Client c = cb.build();
+
+        Map<String, List<?>> clientsPerModule = null;
+        if (c.getClass().getName().equals("com.ibm.ws.jaxrs20.client.JAXRSClientImpl")) {
+            try {
+                Field clientsPerModuleField = c.getClass().getDeclaredField("clientsPerModule");
+                clientsPerModuleField.setAccessible(true);
+                clientsPerModule = (Map<String, List<?>>) clientsPerModuleField.get(null);
+
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        c.close();
+
+        List<Function<Client, ?>> functions = new ArrayList<>();
+        functions.add(new ClientFunction());
+        functions.add(new WebTargetFunction());
+        functions.add(new InvocationBuilderFunction());
+        functions.add(new InvocationFunction());
+        functions.add(new AsyncInvokerFunction());
+
+        // Add the 2.1 specific methods if they are found
+        boolean rxMethodsFound = false;
+        Method[] builderMethods = Builder.class.getMethods();
+        for (Method builderMethod : builderMethods) {
+            if (builderMethod.getName().equals("rx")) {
+                rxMethodsFound = true;
+                break;
+            }
+        }
+
+        if (rxMethodsFound) {
+            System.out.println("Adding reactive method functions");
+            functions.add(new CompletionStageRxInvokerFunction());
+        }
+
+        boolean[] useNewClientOption = new boolean[] {true, false};
+        for (Function<Client, ?> function : functions) {
+            for (boolean useNewClient : useNewClientOption) {
+                memoryLeakTest(function, clientsPerModule, ret, useNewClient);
+                if (ret.length() != 0) {
+                    return;
+                }
+            }
+        }
+
+        ret.append("OK");
+    }
+
+    private void memoryLeakTest(Function<Client, ?> testFunction, Map<String, List<?>> clientsPerModule, StringBuilder ret, boolean useNewClientToPoll) {
+        int startingStoredClients = clientsPerModule == null ? 0 : getStoredClientCount(clientsPerModule); 
+        ClientBuilder cb = ClientBuilder.newBuilder();
+        Client c = cb.build();
+
+        Object memoryLeakObject = testFunction.apply(c);
+
+        boolean isMemoryLeakObjectClient = memoryLeakObject != c;
+        WeakReference<Client> weakRef = new WeakReference<>(c);
+
+        // If using close we need to new up a new Client.  Doing it here so aren't triggering
+        // the clean from the new.
+        c = useNewClientToPoll ? null : cb.build();
+
+        WeakReference<Object> weakRef2 = null;
+        
+        if (!isMemoryLeakObjectClient) {
+            doGarbageCollectCheck(weakRef, false);
+
+            // At this point the underlying JAXRSClientImpl object is still in memory
+            // because the memoryLeakObject should still have a reference to it
+            if (weakRef.get() == null) {
+                ret.append("Expected JAXRSClientImpl reference still existing was not detected. " + memoryLeakObject);
+                return;
+            }
+            weakRef2 = new WeakReference<>(memoryLeakObject);
+        }
+
+        memoryLeakObject = null;
+
+        doGarbageCollectCheck(weakRef, true);
+
+        // At this point the Client object should be garbage collected..
+        if (weakRef.get() != null) {
+            ret.append("Expected Client to be garbage collected.");
+            return;
+        }
+
+        if (weakRef2 != null && weakRef2.get() != null) {
+            ret.append("Expected object that references the Client to be garbage collected. " + weakRef2.get());
+            return;
+        }
+
+        if (useNewClientToPoll) {
+            // making a new Client should trigger cleanup of the ClientWeakReference
+            // from the JAXRSClientImpl clientsPerModule Map.
+            c = cb.build();
+        } else {
+            c.close();
+        }
+
+        if (clientsPerModule != null) {
+            int endStoredClients = getStoredClientCount(clientsPerModule); 
+
+            if (endStoredClients > (useNewClientToPoll ? startingStoredClients + 1 : startingStoredClients)) {
+                ret.append("Leak was detected in clientsPerModule. " + useNewClientToPoll + " " + startingStoredClients + " " + endStoredClients);
+            }
+        }
+
+        if (useNewClientToPoll) {
+            c.close();
+        }
+    }
+
+    private int getStoredClientCount(Map<String, List<?>> clientsPerModule) {
+        int count = 0;
+        for (List<?> clients : clientsPerModule.values()) {
+            count += clients.size();
+        }
+        return count;
+    }
+    
+    private void doGarbageCollectCheck(WeakReference<Client> weakRef, boolean nullExpected) {
+        for (int i = 0; i < 10; ++i) {
+            System.out.println("calling system gc");
+            System.gc();
+            // give the GC some time to actually do its thing
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            if (nullExpected && weakRef.get() == null) {
+                break;
+            }
+
+            if (!nullExpected && weakRef.get() != null) {
+                break;
+            }
+        }
     }
 }


### PR DESCRIPTION
- Use a WeakReference to track when an application stops referencing a JAXRSClientImpl 
- When a Client is garbage collected, then remove the weak reference object from the collection in JAXRSClientImpl.

Fixes #11249