### PR TITLE
Temporarily remove dependency on mpCompatible-0.0

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.0.feature
@@ -2,7 +2,6 @@
 symbolicName=com.ibm.websphere.appserver.org.eclipse.microprofile.contextpropagation-1.0
 WLP-DisableAllFeatures-OnConflict: false
 singleton=true
--features=io.openliberty.mpCompatible-0.0
 -bundles=com.ibm.websphere.org.eclipse.microprofile.contextpropagation.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api:1.0.2"
 kind=ga
 edition=core


### PR DESCRIPTION
mpFaultTolerance-3.0 depends on mpCompatible-4.0 AND concurrent-1.0
concurrent-1.0 depends on the MP Context Propagation 1.0 API but tolerates the 1.2 version
The MP Context Propagation 1.0 API currently depends on mpCompatible-0.0 which makes it incompatible with anything depending on mpCompatible-4.0.
The MP Context Propagation 1.2 API depends on mpCompatible-4.0 but is not yet available in the beta package.

Until MP Context Propagation 1.2 becomes GA, we need to allow the MP Context Propagation 1.0 API to be compatible with MicroProfile 4.0 features.

An issue is open to add tests for this issue in future: https://github.com/OpenLiberty/open-liberty/issues/13643