### PR TITLE
Initial impl of enableThreadDumps for RequestTiming

### DIFF
--- a/dev/com.ibm.ws.request.timing.jdbc/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.request.timing.jdbc/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -27,6 +27,9 @@ slowRequestThreshold.desc=Duration of time that a JDBC request can run before be
 
 hungRequestThreshold.name=Hung request threshold
 hungRequestThreshold.desc=Duration of time that a JDBC request can run before being considered hung.
+
+enableThreadDumps=Enable thread dumps
+enableThreadDumps.desc=Indicates whether thread dumps are created when a hung request is detected. When this value is set to true (default), thread dumps are created. When set to false, thread dumps are not created.
 
 interruptHungRequest.name=Interrupt hung requests
 interruptHungRequest.desc=Indicates whether a JDBC request that is hung is to be interrupted. A value of true causes the requestTiming-1.0 feature to attempt to interrupt the hung request. A value of false allows the request to continue to run.

--- a/dev/com.ibm.ws.request.timing.jdbc/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.request.timing.jdbc/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2019, 2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -19,10 +19,12 @@
     	<AD name="%queryName.name" description="%queryName.desc" id="query" required="false" type="String"/>
     	<AD name="%slowRequestThreshold.name" description="%slowRequestThreshold.desc" id="slowRequestThreshold" 
         	required="false" type="String" ibm:type="duration(ms)"/>
-      <AD name="%hungRequestThreshold.name" description="%hungRequestThreshold.desc" id="hungRequestThreshold" 
+		<AD name="%hungRequestThreshold.name" description="%hungRequestThreshold.desc" id="hungRequestThreshold" 
         	required="false" type="String" ibm:type="duration(ms)"/>
-		  <AD name="%interruptHungRequest.name" description="%interruptHungRequest.desc" id="interruptHungRequests"
-		      required="false" type="Boolean" default="false"/>
+		<AD id="enableThreadDumps" name="%enableThreadDumps" description="%enableThreadDumps.desc" required="false"
+		    type="Boolean" default="true" ibm:beta="true"/>
+		<AD name="%interruptHungRequest.name" description="%interruptHungRequest.desc" id="interruptHungRequests"
+			required="false" type="Boolean" default="false"/>
     </OCD>
     
     <Designate factoryPid="com.ibm.ws.request.timing.jdbc.metatype">

--- a/dev/com.ibm.ws.request.timing.jdbc/src/com/ibm/ws/request/timing/jdbc/internal/ConfigParser.java
+++ b/dev/com.ibm.ws.request.timing.jdbc/src/com/ibm/ws/request/timing/jdbc/internal/ConfigParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -58,7 +58,7 @@ public class ConfigParser implements RequestTimingConfigParser {
      */
 	@Override
 	public TimingConfigGroup parseConfiguration(List<Dictionary<String, Object>> configElementList, long defaultSlowRequestThreshold,
-			long defaultHungRequestThreshold, boolean defaultInterruptHungRequest) {
+			long defaultHungRequestThreshold, boolean defaultInterruptHungRequest, boolean defaultEnableThreadDumps) {
 		
 		//Retrieve type specific settings
 		//Check if the configuration contains the relevant attribute
@@ -71,6 +71,7 @@ public class ConfigParser implements RequestTimingConfigParser {
 			try {			
 				String pid = null;
 				boolean typeInterruptHungRequest = false;
+				boolean typeEnableThreadDumps = true;
 				long typeSlowReqThreshold = 0, typeHungReqThreshold = 0; 
 				String[] contextInfo = new String[2];
 
@@ -114,14 +115,21 @@ public class ConfigParser implements RequestTimingConfigParser {
 				} else {
 					typeInterruptHungRequest = defaultInterruptHungRequest;
 				}
+				
+				// Check if Thread Dumps should be created for hung requests.
+				if (configElement.get(RequestTimingConstants.RT_ENABLE_THREAD_DUMPS) != null) {
+					typeEnableThreadDumps = Boolean.parseBoolean(configElement.get(RequestTimingConstants.RT_ENABLE_THREAD_DUMPS).toString());
+				} else {
+					typeEnableThreadDumps = defaultEnableThreadDumps;
+				}
 
 				if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
 					Tr.debug(tc, "Nested timing element found", new Object[] {contextInfo, typeSlowReqThreshold, typeHungReqThreshold, typeInterruptHungRequest});
 				}
 
 				for (String type : EVENT_TYPES) {
-					slowRequestTimings.add(new Timing(pid, type, contextInfo, typeSlowReqThreshold, false));
-					hungRequestTimings.add(new Timing(pid, type, contextInfo, typeHungReqThreshold, typeInterruptHungRequest));
+					slowRequestTimings.add(new Timing(pid, type, contextInfo, typeSlowReqThreshold, false, true));
+					hungRequestTimings.add(new Timing(pid, type, contextInfo, typeHungReqThreshold, typeInterruptHungRequest, typeEnableThreadDumps));
 				}
 			} catch (Exception e){
 				// FFDC is injected here 

--- a/dev/com.ibm.ws.request.timing.servlet/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.request.timing.servlet/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -27,6 +27,9 @@ slowRequestThreshold.desc=Duration of time that a servlet request can run before
 
 hungRequestThreshold.name=Hung request threshold
 hungRequestThreshold.desc=Duration of time that a servlet request can run before being considered hung.
+
+enableThreadDumps=Enable thread dumps
+enableThreadDumps.desc=Indicates whether thread dumps are created when a hung request is detected. When this value is set to true (default), thread dumps are created. When set to false, thread dumps are not created.
 
 interruptHungRequest.name=Interrupt hung requests
 interruptHungRequest.desc=Indicates whether a servlet request that is hung is to be interrupted. A value of true causes the requestTiming-1.0 feature to attempt to interrupt the hung request. A value of false allows the request to continue to run.

--- a/dev/com.ibm.ws.request.timing.servlet/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.request.timing.servlet/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2019, 2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -19,10 +19,12 @@
     	<AD name="%servletName.name" description="%servletName.desc" id="servletName" required="false" type="String"/>
     	<AD name="%slowRequestThreshold.name" description="%slowRequestThreshold.desc" id="slowRequestThreshold" 
         	required="false" type="String" ibm:type="duration(ms)"/>
-      <AD name="%hungRequestThreshold.name" description="%hungRequestThreshold.desc" id="hungRequestThreshold" 
+		<AD name="%hungRequestThreshold.name" description="%hungRequestThreshold.desc" id="hungRequestThreshold" 
         	required="false" type="String" ibm:type="duration(ms)"/>
-		  <AD name="%interruptHungRequest.name" description="%interruptHungRequest.desc" id="interruptHungRequests"
-		      required="false" type="Boolean" default="false"/>
+		<AD id="enableThreadDumps" name="%enableThreadDumps" description="%enableThreadDumps.desc" required="false"
+		    type="Boolean" default="true" ibm:beta="true"/>
+		<AD name="%interruptHungRequest.name" description="%interruptHungRequest.desc" id="interruptHungRequests"
+			required="false" type="Boolean" default="false"/>
     </OCD>
     
     <Designate factoryPid="com.ibm.ws.request.timing.servlet.metatype">

--- a/dev/com.ibm.ws.request.timing/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.request.timing/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -21,6 +21,9 @@ slowRequestThreshold.desc=Duration of time that a request can run before being c
 
 hungRequestThreshold=Hung request threshold
 hungRequestThreshold.desc=Duration of time that a request can run before being considered hung.
+
+enableThreadDumps=Enable thread dumps
+enableThreadDumps.desc=Indicates whether thread dumps are created when a hung request is detected. When this value is set to true (default), thread dumps are created. When set to false, thread dumps are not created.
 
 sampleRate=Sampling rate
 sampleRate.desc=Rate at which the sampling should happen for the slow request tracking.  To sample one out of every n requests, set sampleRate to n.  To sample all requests, set sampleRate to 1.

--- a/dev/com.ibm.ws.request.timing/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.request.timing/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2019, 2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -19,6 +19,8 @@
             id="slowRequestThreshold" required="false" type="String" ibm:type="duration(ms)" default="10s" />
         <AD name="%hungRequestThreshold" description="%hungRequestThreshold.desc"
             id="hungRequestThreshold" required="false" type="String" ibm:type="duration(ms)" default="10m" />
+		<AD id="enableThreadDumps" name="%enableThreadDumps" description="%enableThreadDumps.desc" required="false"
+		    type="Boolean" default="true" ibm:beta="true"/>
         <AD name="%sampleRate" description="%sampleRate.desc"
             id="sampleRate" required="false" type="Integer" min="1" default="1" />
 		<AD id="includeContextInfo" name="%includeContextInfo" description="%includeContextInfo.desc" required="false" 

--- a/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/RequestTimingConstants.java
+++ b/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/RequestTimingConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,6 +27,9 @@ public class RequestTimingConstants {
     
     /** Property name for interruptHungRequests of Request Timing **/
     public static final String RT_INTERRUPT_HUNG_REQUEST = "interruptHungRequests";
+    
+    /** Property name for enableThreadDumps of Request Timing **/
+    public static final String RT_ENABLE_THREAD_DUMPS = "enableThreadDumps";
     
     /** Name for timing element of Request Timing **/
     public static final String RT_TIMING = "timing";

--- a/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/config/RequestTimingConfigParser.java
+++ b/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/config/RequestTimingConfigParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,5 +30,5 @@ public interface RequestTimingConfigParser {
 	 * Process the configuration and generate Timing objects for any
 	 * configuration sub-elements that are recognized by the parser.
 	 */
-	public TimingConfigGroup parseConfiguration(List<Dictionary<String, Object>> configElementList, long defaultSlowRequestThreshold, long defaultHungRequestThreshold, boolean defaultInterruptHungRequest);
+	public TimingConfigGroup parseConfiguration(List<Dictionary<String, Object>> configElementList, long defaultSlowRequestThreshold, long defaultHungRequestThreshold, boolean defaultInterruptHungRequest, boolean defaultEnableThreadDumps);
 }

--- a/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/config/Timing.java
+++ b/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/config/Timing.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -62,6 +62,11 @@ public class Timing {
     private final boolean interruptHungRequest;
     
     /**
+     * Controls whether thread dumps are created (for hung requests only).
+     */
+    private final boolean enableThreadDumps;
+    
+    /**
      * The PID which generated this timing, if generated from a sub-type.
      */
     private final String timingPid;
@@ -81,18 +86,19 @@ public class Timing {
     transient private String[] historicalRequestData = new String[HISTORICAL_REQUEST_LIMIT];
     
     public Timing(String type, long requestThreshold){
-    	this(type, null, requestThreshold, false);
+    	this(type, null, requestThreshold, false, true);
 	}
     
-    public Timing(String type, String[] contextInfo, long requestThreshold, boolean interruptHungRequest){
-		this(null, type, contextInfo, requestThreshold, interruptHungRequest);
+    public Timing(String type, String[] contextInfo, long requestThreshold, boolean interruptHungRequest, boolean enableThreadDumps){
+		this(null, type, contextInfo, requestThreshold, interruptHungRequest, enableThreadDumps);
 	}
 
-    public Timing(String timingPid, String type, String[] contextInfo, long requestThreshold, boolean interruptHungRequest){
+    public Timing(String timingPid, String type, String[] contextInfo, long requestThreshold, boolean interruptHungRequest, boolean enableThreadDumps){
     	this.timingPid = timingPid;
 		this.type = type;
 		this.requestThreshold = requestThreshold;
 		this.interruptHungRequest = interruptHungRequest;
+		this.enableThreadDumps = enableThreadDumps;
 
 		if (contextInfo == null) {
 			this.contextInfo = null;
@@ -188,6 +194,10 @@ public class Timing {
 	
 	public boolean interruptHungRequest() {
 		return interruptHungRequest;
+	}
+	
+	public boolean isThreadDumpsEnabled() {
+		return enableThreadDumps;
 	}
 	
 	public void incrementCount(String requestContextInfo) {

--- a/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/internal/config/HungRequestTimingConfig.java
+++ b/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/internal/config/HungRequestTimingConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,8 +26,9 @@ public class HungRequestTimingConfig extends RequestTimingConfig {
 	
 	private final boolean keepStatistics;
 	private final boolean interruptHungRequest;
+	private final boolean enableThreadDumps;
 	
-	public HungRequestTimingConfig(int contextInfoRequirement, Map<String, List<Timing>> hungRequestTiming, boolean interruptHungRequest){
+	public HungRequestTimingConfig(int contextInfoRequirement, Map<String, List<Timing>> hungRequestTiming, boolean interruptHungRequest, boolean enableThreadDumps){
 		//Sample is always 1 for hung request detection
 		super(RequestTimingConstants.SAMPLE_RATE, contextInfoRequirement, hungRequestTiming);
 		
@@ -45,6 +46,7 @@ public class HungRequestTimingConfig extends RequestTimingConfig {
 			}
 		}
 		this.interruptHungRequest = isInterruptHungRequest; 
+		this.enableThreadDumps = enableThreadDumps;
 		
 		// See if the configuration contains more than just the default thresholds.  If it does, we'll
 		// be keeping statistics as to which embedded timing configurations are used.
@@ -55,6 +57,7 @@ public class HungRequestTimingConfig extends RequestTimingConfig {
 		super();
 		keepStatistics = false;
 		interruptHungRequest = false;
+		enableThreadDumps = true;
 	}
 
 	/**
@@ -121,9 +124,18 @@ public class HungRequestTimingConfig extends RequestTimingConfig {
 		return interruptHungRequest;
 	}
 	
+	public boolean isThreadDumpsEnabled() {
+		return enableThreadDumps;
+	}
+	
 	@Override
 	public boolean getInterruptRequest(String type, String[] contextInfo) {
 		return getTiming(type, contextInfo).interruptHungRequest();
+	}
+	
+	@Override
+	public boolean getEnableThreadDumps(String type, String[] contextInfo) {
+		return getTiming(type, contextInfo).isThreadDumpsEnabled();
 	}
 	
 	private int countTimingConfigs() {

--- a/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/internal/config/RequestTimingConfig.java
+++ b/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/internal/config/RequestTimingConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -92,6 +92,11 @@ public class RequestTimingConfig {
 	public boolean getInterruptRequest(String type, String[] contextInfo) {
 		return false;
 	}
+	
+	public boolean getEnableThreadDumps(String type, String[] contextInfo) {
+		// Thread dumps are enabled by default for hung requests.
+		return true; 
+	}
 
 	protected Timing getTiming(String type, String contextInfo[]) {
 		//Returns the threshold value for the type if present
@@ -160,4 +165,5 @@ public class RequestTimingConfig {
 		}
 		return requestThreasholdMax;
 	}
+
 }

--- a/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/manager/HungRequestManager.java
+++ b/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/manager/HungRequestManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -155,8 +155,15 @@ public class HungRequestManager {
 									String theId = requestContext.getRequestId().getId();
 									if(hungRequests.putIfAbsent(theId, requestContext) == null){
 										// A new hung thread was found!
+										if (request.isThreadDumpsEnabled()) {
 										// Start the task for creating javacore if its not already running.
 										threadDumpScheduler.startTimer();
+										}
+										else {
+											if(TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()){
+												Tr.debug(tc, "Creation of thread dumps for hung requests has been disabled in the server config.", request.toString());
+											}
+										}
 										// Notify the interrupt code, and then any other registered listeners.
 										long threadId = requestContext.getThreadId();
 										if ((interruptibleRequestLifecycle != null) && (request.interruptRequest())) {

--- a/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/queue/HungRequest.java
+++ b/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/queue/HungRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,11 +21,14 @@ public class HungRequest extends QueueableRequest {
 	
 	private final boolean interruptRequest;
 	
-	public HungRequest(RequestContext requestContext, long delay, long hungRequestThreshold, boolean includeContextInfo, boolean interruptRequest){
+	private final boolean enableThreadDumps;
+	
+	public HungRequest(RequestContext requestContext, long delay, long hungRequestThreshold, boolean includeContextInfo, boolean interruptRequest, boolean enableThreadDumps){
 		super(requestContext, delay);
 		this.hungRequestThreshold = hungRequestThreshold;
 		this.includeContextInfo = includeContextInfo;
 		this.interruptRequest = interruptRequest;
+		this.enableThreadDumps = enableThreadDumps;
 	}
 	
 	public long getHungRequestThreshold() {
@@ -39,6 +42,11 @@ public class HungRequest extends QueueableRequest {
 	@Override
 	public boolean interruptRequest() {
 		return interruptRequest;
+	}
+	
+	@Override
+	public boolean isThreadDumpsEnabled() {
+		return enableThreadDumps;
 	}
 
 	@Override

--- a/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/queue/QueueableRequest.java
+++ b/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/queue/QueueableRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -60,6 +60,11 @@ public class QueueableRequest implements Delayed {
 
 	public boolean interruptRequest() {
 		return false;
+	}
+	
+	public boolean isThreadDumpsEnabled() {
+		// Thread dumps are enabled by default for hung requests.
+		return true;
 	}
 
 	public long getInitialDelay(){

--- a/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/queue/SlowRequest.java
+++ b/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/queue/SlowRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@ public class SlowRequest extends QueueableRequest {
 	
 	private final boolean includeContextInfo;
 
-	public SlowRequest(RequestContext requestContext, long delay, long slowRequestThreshold, boolean includeContextInfo, boolean interruptRequest){
+	public SlowRequest(RequestContext requestContext, long delay, long slowRequestThreshold, boolean includeContextInfo, boolean interruptRequest, boolean enableThreadDumps){
 		super(requestContext, delay);
 		this.slowRequestThreshold = slowRequestThreshold;
 		slowRequestIterationsReq = RequestTimingConstants.SLOW_REQUEST_ITERATIONS_REQ;

--- a/dev/com.ibm.ws.request.timing/test/src/com/ibm/ws/request/timing/config/TimingTest.java
+++ b/dev/com.ibm.ws.request.timing/test/src/com/ibm/ws/request/timing/config/TimingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ public class TimingTest {
 	public void testContextInfoParsing() {
 		final String pid = "pid", type = "type";
 		String[] contextInfoArray = new String[] {"first", "second"};
-		Timing t = new Timing(pid, type, contextInfoArray, 10, false);
+		Timing t = new Timing(pid, type, contextInfoArray, 10, false, true);
 		
 		String contextInfoString = t.getContextInfoString();
 		String expectedContextInfoString = "first" + RequestProbeConstants.EVENT_CONTEXT_INFO_SEPARATOR + "second";
@@ -36,7 +36,7 @@ public class TimingTest {
 	@Test
 	public void testContextInfoParsingNull() {
 		final String pid = "pid", type = "type";
-		Timing t = new Timing(pid, type, null, 10, false);
+		Timing t = new Timing(pid, type, null, 10, false, true);
 		
 		assertNull(t.getContextInfoString());
 		assertFalse(t.isDefaultTiming());
@@ -46,7 +46,7 @@ public class TimingTest {
 	public void testDefaultTimingSingle() {
 		final String pid = "pid", type = "type";
 		String[] contextInfoArray = new String[] {"*"};
-		Timing t = new Timing(pid, type, contextInfoArray, 10, false);
+		Timing t = new Timing(pid, type, contextInfoArray, 10, false, true);
 		
 		String contextInfoString = t.getContextInfoString();
 		String expectedContextInfoString = "*";
@@ -59,7 +59,7 @@ public class TimingTest {
 	public void testDefaultTimingMultiple() {
 		final String pid = "pid", type = "type";
 		String[] contextInfoArray = new String[] {"*", "*", "*"};
-		Timing t = new Timing(pid, type, contextInfoArray, 10, false);
+		Timing t = new Timing(pid, type, contextInfoArray, 10, false, true);
 		
 		String contextInfoString = t.getContextInfoString();
 		String expectedContextInfoString = "*" + RequestProbeConstants.EVENT_CONTEXT_INFO_SEPARATOR + "*" + RequestProbeConstants.EVENT_CONTEXT_INFO_SEPARATOR + "*";
@@ -72,7 +72,7 @@ public class TimingTest {
 	public void testUnmatchedScore() {
 		final String pid = "pid", type = "type";
 		String[] contextInfoArray = new String[] {"first", "second"};
-		Timing t = new Timing(pid, type, contextInfoArray, 10, false);
+		Timing t = new Timing(pid, type, contextInfoArray, 10, false, true);
 		
 		String[] probeContextInfo = new String[] {"second", "first"};
 		assertEquals(Integer.MIN_VALUE, t.getContextInfoMatchScore(probeContextInfo));
@@ -82,7 +82,7 @@ public class TimingTest {
 	public void testWildcardMatchScore() {
 		final String pid = "pid", type = "type";
 		String[] contextInfoArray = new String[] {"*", "*"};
-		Timing t = new Timing(pid, type, contextInfoArray, 10, false);
+		Timing t = new Timing(pid, type, contextInfoArray, 10, false, true);
 		
 		String[] probeContextInfo = new String[] {"second", "first"};
 		assertEquals(0, t.getContextInfoMatchScore(probeContextInfo));
@@ -92,7 +92,7 @@ public class TimingTest {
 	public void testFirstWildcardMatchScore() {
 		final String pid = "pid", type = "type";
 		String[] contextInfoArray = new String[] {"*", "second"};
-		Timing t = new Timing(pid, type, contextInfoArray, 10, false);
+		Timing t = new Timing(pid, type, contextInfoArray, 10, false, true);
 		
 		String[] probeContextInfo = new String[] {"first", "second"};
 		assertEquals(60, t.getContextInfoMatchScore(probeContextInfo));
@@ -102,7 +102,7 @@ public class TimingTest {
 	public void testFirstWildcardNoMatchScore() {
 		final String pid = "pid", type = "type";
 		String[] contextInfoArray = new String[] {"*", "second"};
-		Timing t = new Timing(pid, type, contextInfoArray, 10, false);
+		Timing t = new Timing(pid, type, contextInfoArray, 10, false, true);
 		
 		String[] probeContextInfo = new String[] {"first", "third"};
 		assertEquals(Integer.MIN_VALUE, t.getContextInfoMatchScore(probeContextInfo));
@@ -112,7 +112,7 @@ public class TimingTest {
 	public void testSecondWildcardMatchScore() {
 		final String pid = "pid", type = "type";
 		String[] contextInfoArray = new String[] {"first", "*"};
-		Timing t = new Timing(pid, type, contextInfoArray, 10, false);
+		Timing t = new Timing(pid, type, contextInfoArray, 10, false, true);
 		
 		String[] probeContextInfo = new String[] {"first", "second"};
 		assertEquals(5, t.getContextInfoMatchScore(probeContextInfo));
@@ -122,7 +122,7 @@ public class TimingTest {
 	public void testSecondWildcardNoMatchScore() {
 		final String pid = "pid", type = "type";
 		String[] contextInfoArray = new String[] {"first", "*"};
-		Timing t = new Timing(pid, type, contextInfoArray, 10, false);
+		Timing t = new Timing(pid, type, contextInfoArray, 10, false, true);
 		
 		String[] probeContextInfo = new String[] {"third", "second"};
 		assertEquals(Integer.MIN_VALUE, t.getContextInfoMatchScore(probeContextInfo));
@@ -132,7 +132,7 @@ public class TimingTest {
 	public void testMultipleExactMatchScore() {
 		final String pid = "pid", type = "type";
 		String[] contextInfoArray = new String[] {"first", "second"};
-		Timing t = new Timing(pid, type, contextInfoArray, 10, false);
+		Timing t = new Timing(pid, type, contextInfoArray, 10, false, true);
 		
 		String[] probeContextInfo = new String[] {"first", "second"};
 		assertEquals(65, t.getContextInfoMatchScore(probeContextInfo));

--- a/dev/com.ibm.ws.request.timing/test/src/com/ibm/ws/request/timing/config/internal/RequestTimingConfigTest.java
+++ b/dev/com.ibm.ws.request.timing/test/src/com/ibm/ws/request/timing/config/internal/RequestTimingConfigTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,22 +30,22 @@ public class RequestTimingConfigTest {
 	private static final String TIMING_TYPE_B = "typeb";
 	
 	private static final List<Timing> timingListA = Arrays.asList(new Timing[] {
-			new Timing(TIMING_TYPE_A, new String[] {"first", "second"}, 10, false),
-			new Timing(TIMING_TYPE_A, new String[] {"first", "third"}, 20, false),
-			new Timing(TIMING_TYPE_A, new String[] {"first", "*"}, 30, false),
-			new Timing(TIMING_TYPE_A, new String[] {"*", "second"}, 40, false)});
+			new Timing(TIMING_TYPE_A, new String[] {"first", "second"}, 10, false, true),
+			new Timing(TIMING_TYPE_A, new String[] {"first", "third"}, 20, false, true),
+			new Timing(TIMING_TYPE_A, new String[] {"first", "*"}, 30, false, true),
+			new Timing(TIMING_TYPE_A, new String[] {"*", "second"}, 40, false, true)});
 	
 	private static final List<Timing> timingListB = Arrays.asList(new Timing[] {
-			new Timing(TIMING_TYPE_B, new String[] {"*", "*"}, 50, false)});
+			new Timing(TIMING_TYPE_B, new String[] {"*", "*"}, 50, false, true)});
 	
 	private static final List<Timing> timingListB2 = Arrays.asList(new Timing[] {
-			new Timing(TIMING_TYPE_B, new String[] {"*", "*"}, 50, false),
-			new Timing(TIMING_TYPE_B, new String[] {"fourth", "fifth"}, 55, false),
-			new Timing(TIMING_TYPE_B, new String[] {"fourth", "*"}, 56, false),
-			new Timing(TIMING_TYPE_B, new String[] {"*", "fifth"}, 57, false)});
+			new Timing(TIMING_TYPE_B, new String[] {"*", "*"}, 50, false, true),
+			new Timing(TIMING_TYPE_B, new String[] {"fourth", "fifth"}, 55, false, true),
+			new Timing(TIMING_TYPE_B, new String[] {"fourth", "*"}, 56, false, true),
+			new Timing(TIMING_TYPE_B, new String[] {"*", "fifth"}, 57, false, true)});
 
 	private static final List<Timing> defaultList = Arrays.asList(new Timing[] {
-			new Timing(RequestTimingConstants.ALL_TYPES, Timing.ALL_CONTEXT_INFO, 60, false)});
+			new Timing(RequestTimingConstants.ALL_TYPES, Timing.ALL_CONTEXT_INFO, 60, false, true)});
 
 	
 	@Test

--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/FATSuite.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,16 +23,13 @@ import componenttest.rules.repeater.RepeatTests;
 @SuiteClasses({
                 SlowRequestTiming.class,
                 HungRequestTiming.class,
-                TimingRequestTiming.class
+                TimingRequestTiming.class,
+                HungRequestEnableThreadDumps.class
 })
 
 public class FATSuite {
     // Using the RepeatTests @ClassRule in FATSuite will cause all tests in the FAT to be run twice.
     // First without any modifications, then again with all features in all server.xml's upgraded to their EE8 equivalents.
     @ClassRule
-    public static RepeatTests r = RepeatTests
-                    .with(new EmptyAction().fullFATOnly())
-                    .andWith(FeatureReplacementAction.EE8_FEATURES()
-                                    .fullFATOnly())
-                    .andWith(FeatureReplacementAction.EE9_FEATURES());
+    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly()).andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly()).andWith(FeatureReplacementAction.EE9_FEATURES());
 }

--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/HungRequestEnableThreadDumps.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/HungRequestEnableThreadDumps.java
@@ -1,0 +1,358 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.request.timing.fat;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.ProtocolException;
+import java.net.URL;
+import java.util.List;
+import java.util.logging.Level;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ *
+ * This test class contains test cases that test the Hung Request Timing server configuration attribute enableThreadDumps, when enabl
+ *
+ */
+@RunWith(FATRunner.class)
+public class HungRequestEnableThreadDumps {
+
+    private static final String MESSAGE_LOG = "logs/messages.log";
+    private static final String SERVER_NAME = "HungRequestTimingServer";
+
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultDropinApp(server, "TestWebApp", "com.ibm.testwebapp");
+        CommonTasks.writeLogMsg(Level.INFO, " Starting server..");
+        server.startServer();
+    }
+
+    @Before
+    public void setupTest() throws Exception {
+        if (server != null && !server.isStarted()) {
+            server.startServer();
+        }
+
+        // Allow the configuration to change back to the original and ensure the update is finished before starting a test
+        server.setServerConfigurationFile("server_original.xml");
+        server.waitForStringInLog("CWWKG0017I", 90000);
+        server.setMarkToEndOfLog();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (server != null && server.isStarted()) {
+            server.stopServer("TRAS0114W", "TRAS0115W", "CWWKG0011W", "CWWKG0083W");
+        }
+    }
+
+    /*
+     * Tests when the boolean "enableThreadDumps" attribute is not specified, the thread dumps should be created when the hung request is detected.
+     */
+    @Test
+    public void testEnableThreadDumpsNotSpecified() throws Exception {
+        CommonTasks.writeLogMsg(Level.INFO, "***** Begining testEnableThreadDumpsNotSpecified! *****");
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Setting hung threshold as 2s");
+        server.setServerConfigurationFile("server_hungRequestThreshold2.xml");
+        server.waitForStringInLog("CWWKG0017I", 90000);
+
+        createHungRequest(5000);
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Verifying if the hung detection warnings appeared...");
+        verifyHungRequestWarnings();
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Checking if any thread dumps are created...");
+        checkThreadDumpsCreated(true); // thread dumps are expected.
+
+        CommonTasks.writeLogMsg(Level.INFO, "***** testEnableThreadDumpsNotSpecified has completed! *****");
+    }
+
+    /*
+     * Tests when the boolean attribute "enableThreadDumps=false", the thread dumps will not be created when the hung request is detected.
+     */
+    @Test
+    public void testThreadDumpsDisabled() throws Exception {
+        CommonTasks.writeLogMsg(Level.INFO, "***** Begining testThreadDumpsDisabled! *****");
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Setting hung threshold as 2s and enableThreadDumps=false");
+        server.setServerConfigurationFile("server_hungRequestEnableThreadDumpsFalse.xml");
+        server.waitForStringInLog("CWWKG0017I", 90000);
+
+        createHungRequest(5000);
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Verifying if the hung detection warnings appeared...");
+        verifyHungRequestWarnings();
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Checking if any thread dumps are created...");
+        checkThreadDumpsCreated(false); // thread dumps are NOT expected.
+
+        CommonTasks.writeLogMsg(Level.INFO, "***** testThreadDumpsDisabled has completed! *****");
+    }
+
+    /*
+     * Tests when the boolean attribute "enableThreadDumps" is set to false dynamically, after server starts, with no attribute specified.
+     */
+    @Test
+    @Mode(TestMode.FULL)
+    public void testDynamicThreadDumpsDisable() throws Exception {
+        CommonTasks.writeLogMsg(Level.INFO, "***** Begining testDynamicThreadDumpsDisable! *****");
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Setting hung threshold as 2s");
+        server.setServerConfigurationFile("server_hungRequestThreshold2.xml");
+        server.waitForStringInLog("CWWKG0017I", 90000);
+
+        createHungRequest(180000); // We must wait this long to see 3 java cores are generated (we expect only 3)
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Verifying if the hung detection warnings appeared...");
+        verifyHungRequestWarnings();
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Checking if any thread dumps are created...");
+        checkThreadDumpsCreated(true); // thread dumps are expected.
+
+        server.setMarkToEndOfLog();
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Updating server config to add enableThreadDumps=false");
+        server.setServerConfigurationFile("server_hungRequestEnableThreadDumpsFalse.xml");
+        server.waitForStringInLogUsingMark("CWWKG0017I", 90000);
+
+        createHungRequest(5000);
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Waiting for hung detection warning...");
+        server.waitForStringInLog("TRAS0114W", 30000);
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Waiting for hung request complete message...");
+        server.waitForStringInLog("TRAS0115W", 30000);
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Checking if any thread dumps are created...");
+        checkThreadDumpsCreated(false); // thread dumps are NOT expected.
+
+        CommonTasks.writeLogMsg(Level.INFO, "***** testDynamicThreadDumpsDisable has completed! *****");
+    }
+
+    /*
+     * Tests when the boolean attribute "enableThreadDumps" is set to true dynamically, after server starts with "enableThreadDumps=false".
+     */
+    @Test
+    @Mode(TestMode.FULL)
+    public void testDynamicThreadDumpsEnable() throws Exception {
+        CommonTasks.writeLogMsg(Level.INFO, "***** Begining testDynamicThreadDumpsEnable! *****");
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Setting hung threshold as 2s and enableThreadDumps=false");
+        server.setServerConfigurationFile("server_hungRequestEnableThreadDumpsFalse.xml");
+        server.waitForStringInLog("CWWKG0017I", 90000);
+
+        createHungRequest(180000); // We must wait this long to see 3 java cores are generated (we expect only 3)
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Verifying if the hung detection warnings appeared...");
+        verifyHungRequestWarnings();
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Checking if any thread dumps are created...");
+        checkThreadDumpsCreated(false); // thread dumps are NOT expected.
+
+        server.setMarkToEndOfLog();
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Updating server config to add enableThreadDumps=true");
+        server.setServerConfigurationFile("server_hungRequestThreshold2.xml");
+        server.waitForStringInLogUsingMark("CWWKG0017I", 90000);
+
+        createHungRequest(5000);
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Waiting for hung detection warning...");
+        server.waitForStringInLog("TRAS0114W", 30000);
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Waiting for hung request complete message...");
+        server.waitForStringInLog("TRAS0115W", 30000);
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Checking if any thread dumps are created...");
+        checkThreadDumpsCreated(true); // thread dumps are expected.
+
+        CommonTasks.writeLogMsg(Level.INFO, "***** testDynamicThreadDumpsEnable has completed! *****");
+    }
+
+    /*
+     * Tests when the root requestTiming element has "enableThreadDumps=false" and the sub-element servletTiming has "enableThreadDumps=true".
+     * The sub-element configuration should override the root element configuration, hence when a hung request is detected, thread dumps will be created.
+     */
+    @Test
+    public void testGlobalThreadDumpsDisableLocalThreadDumpsEnable() throws Exception {
+        CommonTasks.writeLogMsg(Level.INFO, "***** Begining testGlobalThreadDumpsDisableLocalThreadDumpsEnable! *****");
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Setting hung threshold as 2s and enableThreadDumps=false in the requestTiming root element.");
+        server.setServerConfigurationFile("server_globalThreadDumpsFalse_localThreadDumpsTrue.xml");
+        server.waitForStringInLog("CWWKG0017I", 90000);
+
+        createHungRequest(5000);
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Verifying if the hung detection warnings appeared...");
+        verifyHungRequestWarnings();
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Checking if any thread dumps are created...");
+        checkThreadDumpsCreated(true); // thread dumps are expected.
+
+        CommonTasks.writeLogMsg(Level.INFO, "***** testGlobalThreadDumpsDisableLocalThreadDumpsEnable has completed! *****");
+    }
+
+    /*
+     * Tests when the root requestTiming element does not have the "enableThreadDumps" attribute specified and the sub-element servletTiming has "enableThreadDumps=false".
+     * The sub-element configuration should override the root element configuration, hence when a hung request is detected, thread dumps will not be created.
+     */
+    @Test
+    public void testGlobalThreadDumpsEnableLocalThreadDumpsDisable() throws Exception {
+        CommonTasks.writeLogMsg(Level.INFO, "***** Begining testGlobalThreadDumpsEnableLocalThreadDumpsDisable! *****");
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Setting hung threshold as 2s and enableThreadDumps=false in the requestTiming sub-element.");
+        server.setServerConfigurationFile("server_globalThreadDumpsTrue_localThreadDumpsFalse.xml");
+        server.waitForStringInLog("CWWKG0017I", 90000);
+
+        createHungRequest(5000);
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Verifying if the hung detection warnings appeared...");
+        verifyHungRequestWarnings();
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Checking if any thread dumps are created...");
+        checkThreadDumpsCreated(false); // thread dumps are NOT expected.
+
+        CommonTasks.writeLogMsg(Level.INFO, "***** testGlobalThreadDumpsEnableLocalThreadDumpsDisable has completed! *****");
+    }
+
+    /*
+     * Tests when the boolean attribute value ("enableThreadDumps=flase") is specified incorrectly in the server configuration.
+     * The default configuration will be used ("enableThreadDumps=true"), where thread dumps will be created.
+     */
+    @Test
+    public void testInvalidEnableThreadDumpsAttributeValue() throws Exception {
+        CommonTasks.writeLogMsg(Level.INFO, "***** Begining testInvalidEnableThreadDumpsAttributeValue! *****");
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Setting hung threshold as 2s and invalid enableThreadDumps=flase attribute");
+        server.setServerConfigurationFile("server_hungRequestInvalidEnableThreadDumpsFalse.xml");
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Waiting for server config validation not succeed warnings...");
+        server.waitForStringInLog("CWWKG0011W", 30000);
+        server.waitForStringInLog("CWWKG0083W", 30000);
+        server.waitForStringInLog("CWWKG0017I", 90000);
+
+        List<String> lines = server.findStringsInLogsUsingMark("CWWKG0011W", MESSAGE_LOG);
+        assertTrue("Expected at least one, server config validation did not succeed warning but found : " + lines.size(), (lines.size() > 0));
+        lines = server.findStringsInLogsUsingMark("CWWKG0083W", MESSAGE_LOG);
+        assertTrue("Expected at least one, server config validation failure and default in use warning but found : " + lines.size(), (lines.size() > 0));
+
+        createHungRequest(5000);
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Verifying if the hung detection warnings appeared...");
+        verifyHungRequestWarnings();
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Checking if any thread dumps are created...");
+        checkThreadDumpsCreated(true); // thread dumps are expected.
+
+        CommonTasks.writeLogMsg(Level.INFO, "***** testInvalidEnableThreadDumpsAttributeValue has completed! *****");
+    }
+
+    private void checkThreadDumpsCreated(boolean threadDumpsEnabled) throws Exception {
+        CommonTasks.writeLogMsg(Level.INFO, "----> Waiting for Thread dump request received message...");
+        server.waitForStringInLog("CWWKE0067I", 30000);
+        List<String> threadDumpRequestlines = server.findStringsInLogsUsingMark("CWWKE0067I", MESSAGE_LOG);
+        List<String> threadDumpCreationlines = server.findStringsInLogsUsingMark("CWWKE0068I", MESSAGE_LOG);
+
+        CommonTasks.writeLogMsg(Level.INFO, "----> No. of thread dumps requested : " + threadDumpRequestlines.size());
+        CommonTasks.writeLogMsg(Level.INFO, "----> No. of thread dumps created : " + threadDumpCreationlines.size());
+        for (String line : threadDumpCreationlines) {
+            CommonTasks.writeLogMsg(Level.INFO, "------> Created thread dump : " + line);
+        }
+
+        if (threadDumpsEnabled) {
+            assertTrue("No Thread dump request messages found!", (threadDumpRequestlines.size() > 0));
+            assertTrue("No Thread dump generated messages found!", (threadDumpCreationlines.size() > 0));
+        } else {
+            assertTrue("Thread dump request messages found : " + threadDumpRequestlines.size(), (threadDumpRequestlines.size() == 0));
+            assertTrue("Thread dump generated messages found : " + threadDumpCreationlines, (threadDumpCreationlines.size() == 0));
+        }
+    }
+
+    private void verifyHungRequestWarnings() throws Exception {
+        CommonTasks.writeLogMsg(Level.INFO, "------> Waiting for hung detection warning...");
+        server.waitForStringInLog("TRAS0114W", 30000);
+        int numOfhungRequestsWarnMsgs = fetchHungRequestWarningsCount("TRAS0114W");
+        assertTrue("No hung request warning message was found !", numOfhungRequestsWarnMsgs > 0);
+
+        CommonTasks.writeLogMsg(Level.INFO, "------> Waiting for hung request complete message...");
+        server.waitForStringInLog("TRAS0115W", 30000);
+        int numOfhungRequestCompletedMsgs = fetchHungRequestWarningsCount("TRAS0115W");
+        assertTrue("No hung request completed warning message was found !", numOfhungRequestCompletedMsgs > 0);
+    }
+
+    private int fetchHungRequestWarningsCount(String msgID) throws Exception {
+        List<String> lines = server.findStringsInLogsUsingMark(msgID, MESSAGE_LOG);
+        for (String line : lines) {
+            CommonTasks.writeLogMsg(Level.INFO, "------> Hung Request Warning for " + msgID + " : " + line);
+        }
+        return lines.size();
+    }
+
+    private void createHungRequest(int duration) throws Exception {
+        URL url = new URL("http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/TestWebApp/TestServlet?sleepTime=" + duration);
+        CommonTasks.writeLogMsg(Level.INFO, "----> Calling TestWebApp Application with URL=" + url.toString());
+        HttpURLConnection con = getHttpConnection(url);
+        BufferedReader br = getConnectionStream(con);
+        br.readLine();
+    }
+
+    /**
+     * This method is used to get a connection stream from an HTTP connection. It
+     * gives the output from the webpage that it gets from the connection
+     *
+     * @param con The connection to the HTTP address
+     * @return The Output from the webpage
+     */
+    private BufferedReader getConnectionStream(HttpURLConnection con) throws IOException {
+        InputStream is = con.getInputStream();
+        InputStreamReader isr = new InputStreamReader(is);
+        BufferedReader br = new BufferedReader(isr);
+        return br;
+    }
+
+    /**
+     * This method creates a connection to a webpage and then returns the connection
+     *
+     * @param url The Http Address to connect to
+     * @return The connection to the http address
+     */
+    private HttpURLConnection getHttpConnection(URL url) throws IOException, ProtocolException {
+        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        con.setDoInput(true);
+        con.setDoOutput(true);
+        con.setUseCaches(false);
+        con.setRequestMethod("GET");
+        return con;
+    }
+}

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_globalThreadDumpsFalse_localThreadDumpsTrue.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_globalThreadDumpsFalse_localThreadDumpsTrue.xml
@@ -1,0 +1,20 @@
+<server description="Disable Thread Dumps">
+
+  <!-- Enable features -->
+    <featureManager>
+      <feature>jsp-2.2</feature>
+      <feature>requestTiming-1.0</feature>
+    </featureManager>
+  
+	<httpEndpoint id="defaultHttpEndpoint" host="*" />
+
+	<include location="../fatTestPorts.xml"/>
+  	
+   <requestTiming slowRequestThreshold="0"/>
+   <requestTiming hungRequestThreshold = "2s" enableThreadDumps="false">
+     <servletTiming appName="TestWebApp" servletName="TestServlet" 
+    			slowRequestThreshold="0"
+    			hungRequestThreshold="2s"/>
+   </requestTiming>
+  
+</server>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_globalThreadDumpsTrue_localThreadDumpsFalse.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_globalThreadDumpsTrue_localThreadDumpsFalse.xml
@@ -1,0 +1,21 @@
+<server description="Disable Thread Dumps">
+
+  <!-- Enable features -->
+    <featureManager>
+      <feature>jsp-2.2</feature>
+      <feature>requestTiming-1.0</feature>
+    </featureManager>
+  
+	<httpEndpoint id="defaultHttpEndpoint" host="*" />
+
+	<include location="../fatTestPorts.xml"/>
+  	
+   <requestTiming slowRequestThreshold="0"/>
+   <requestTiming hungRequestThreshold = "2s">
+     <servletTiming appName="TestWebApp" servletName="TestServlet" 
+    			slowRequestThreshold="0"
+    			hungRequestThreshold="2s"
+    			enableThreadDumps="false"/>
+   </requestTiming>
+  
+</server>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_hungRequestEnableThreadDumpsFalse.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_hungRequestEnableThreadDumpsFalse.xml
@@ -1,0 +1,16 @@
+<server description="Disable Thread Dumps">
+
+  <!-- Enable features -->
+    <featureManager>
+      <feature>jsp-2.2</feature>
+      <feature>requestTiming-1.0</feature>
+    </featureManager>
+  
+	<httpEndpoint id="defaultHttpEndpoint" host="*" />
+
+	<include location="../fatTestPorts.xml"/>
+  	
+   <requestTiming slowRequestThreshold="0"/>
+   <requestTiming hungRequestThreshold = "2s" enableThreadDumps="false" />
+  
+</server>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_hungRequestInvalidEnableThreadDumpsFalse.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_hungRequestInvalidEnableThreadDumpsFalse.xml
@@ -1,0 +1,16 @@
+<server description="Disable Thread Dumps">
+
+  <!-- Enable features -->
+    <featureManager>
+      <feature>jsp-2.2</feature>
+      <feature>requestTiming-1.0</feature>
+    </featureManager>
+  
+	<httpEndpoint id="defaultHttpEndpoint" host="*" />
+
+	<include location="../fatTestPorts.xml"/>
+  	
+   <requestTiming slowRequestThreshold="0"/>
+   <requestTiming hungRequestThreshold = "2s" enableThreadDumps="flase" />
+  
+</server>


### PR DESCRIPTION
fixes #13984
fixes #13985
- Adds a new server configuration boolean attribute `enableThreadDumps` for RequestTiming, which allows users to control whether thread dumps should be created for the detected hung request.
- Default: `enableThreadDumps=true`
- New positive/negative FAT tests are also added to test the different usage scenarios of the new server config boolean attribute.