### PR TITLE
mpOpenAPI-2.0 Informative CWWKO1661E Error Message 

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/ApplicationProcessor.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/ApplicationProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -229,7 +229,7 @@ public class ApplicationProcessor {
                 final String message = String.format("Failed to process application %s: %s", moduleInfo.getApplicationInfo().getDeploymentName(), e.getMessage());
                 Tr.event(tc, "Failed to process application: " + message);
             }
-            Tr.error(tc, MessageConstants.OPENAPI_APPLICATION_PROCESSING_ERROR, moduleInfo.getApplicationInfo().getDeploymentName());
+            Tr.error(tc, MessageConstants.OPENAPI_APPLICATION_PROCESSING_ERROR, moduleInfo.getApplicationInfo().getDeploymentName(), e.toString());
         }
 
         if (LoggingUtils.isEventEnabled(tc)) {

--- a/dev/io.openliberty.microprofile.openapi.internal.common/resources/io/openliberty/microprofile/openapi/internal/resources/OpenAPI.nlsprops
+++ b/dev/io.openliberty.microprofile.openapi.internal.common/resources/io/openliberty/microprofile/openapi/internal/resources/OpenAPI.nlsprops
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2020 IBM Corporation and others.
+# Copyright (c) 2018, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -61,6 +61,6 @@ OPENAPI_APPLICATION_PROCESSED=CWWKO1660I: The application {0} was processed and 
 OPENAPI_APPLICATION_PROCESSED.explanation=Generated the OpenAPI document for the specified application. It can be viewed at /openapi endpoint.
 OPENAPI_APPLICATION_PROCESSED.useraction=No action is required.
 
-OPENAPI_APPLICATION_PROCESSING_ERROR=CWWKO1661E: An error occured when processing application {0} and an OpenAPI document was not produced.
-OPENAPI_APPLICATION_PROCESSING_ERROR.explanation=A runtime error occured when processing the application.
-OPENAPI_APPLICATION_PROCESSING_ERROR.useraction=Gather logs and contact IBM service.
+OPENAPI_APPLICATION_PROCESSING_ERROR=CWWKO1661E: An error occurred when processing application {0} and an OpenAPI document was not produced. The error was: {1}.
+OPENAPI_APPLICATION_PROCESSING_ERROR.explanation=A runtime error occurred when processing the application.
+OPENAPI_APPLICATION_PROCESSING_ERROR.useraction=Review the FFDC logs and exception text to identify the problem.


### PR DESCRIPTION
resolves #15650

- Updated `CWWKO1661E` within `mpOpenAPI-2.0` application processing code to include information about the cause of the error, rather than just 'there was an error'.
- Corrected typo in `CWWKO1661E`, from "occured" to "occurred"
- Updated `CWWKO1661E` user action.

#build
#spawn.fullfat.buckets=com.ibm.ws.microprofile.openapi_fat,com.ibm.ws.microprofile.openapi_fat_tck,com.ibm.ws.microprofile.openapi.1.1_fat_tck,io.openliberty.microprofile.openapi.2.0.internal_fat,io.openliberty.microprofile.openapi.2.0.internal_fat_tck