### PR TITLE
Add ssl-1.0 feature to 1.4 and 2.0 TCK servers

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/servers/FATServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/servers/FATServer/server.xml
@@ -14,6 +14,7 @@
         <feature>jaxrsClient-2.1</feature>
         <feature>mpConfig-1.4</feature>
         <feature>mpRestClient-1.4</feature>
+        <feature>ssl-1.0</feature>
         <feature>arquillian-support-1.0</feature>
     </featureManager>
 

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/servers/FATServer/server.xml
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/servers/FATServer/server.xml
@@ -16,6 +16,7 @@
         <feature>mpConfig-2.0</feature>
         <feature>mpRestClient-2.0</feature>
         <feature>arquillian-support-1.0</feature>
+        <feature>ssl-1.0</feature>
     </featureManager>
 
     <include location="../fatTestPorts.xml" />


### PR DESCRIPTION
Ensure that SSL is enabled for the FAT server used in the MP Rest Client TCK.