### PR TITLE
Try 2GB max heap size for framework and servers

### DIFF
--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/servers/FATServer/jvm.options
@@ -5,7 +5,7 @@
 #-Dcom.ibm.tools.attach.enable=yes
 #-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777
 
--Xmx4096m
+-Xmx2048m
 
 # required for TCK:
 -Dmp.graphql.tck.endpoint.port=8010

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,2 +1,2 @@
 -Dcom.ibm.tools.attach.enable=yes
--Xmx4096m
+-Xmx2048m

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,3 +1,3 @@
 -Dcom.ibm.tools.attach.enable=yes
 -Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=20
--Xmx4096m
+-Xmx2048m

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom.xml
@@ -251,7 +251,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
-                    <argLine>-Xmx4096m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>-Xmx2048m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,3 +1,3 @@
 -Dcom.ibm.tools.attach.enable=yes
 -Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=20
--Xmx4096m
+-Xmx2048m

--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/pom.xml
@@ -302,7 +302,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
-                    <argLine>-Xmx4096m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>-Xmx2048m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,3 +1,3 @@
 -Dcom.ibm.tools.attach.enable=yes
 -Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=20
--Xmx4096m
+-Xmx2048m

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/pom.xml
@@ -302,7 +302,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
-                    <argLine>-Xmx4096m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>-Xmx2048m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,2 +1,2 @@
 -Dcom.ibm.tools.attach.enable=yes
--Xmx4096m
+-Xmx2048m

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,3 +1,3 @@
 -Dcom.ibm.tools.attach.enable=yes
 -Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=20
--Xmx4096m
+-Xmx2048m

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -338,7 +338,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
-                    <argLine>-Xmx4096m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>-Xmx2048m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>


### PR DESCRIPTION
A 4GB max heap size is too much for some of our build machines (VMs?) - resulting in errors like:
```
JVMJ9VM015W Initialization error for library j9gc29(2): Failed to instantiate heap; 4G requested
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

This PR reduces the max heap size to 2GB which hopefully is closer to the sweet spot of "enough heap to run the tests" vs "too much heap for our test VMs".