### PR TITLE
Include Jetty in MP Rest Client 1.4 TCK apps

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom.xml
@@ -127,6 +127,20 @@
         </dependency>
 
         <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams-tck</artifactId>
+            <version>1.0.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm.ws.org.reactivestreams</groupId>
+            <artifactId>reactive-streams</artifactId>
+            <version>1.0.3</version>
+            <scope>system</scope>
+            <systemPath>${com.ibm.ws.org.reactivestreams.reactive-streams.1.0_}</systemPath>
+        </dependency>
+
+        <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
             <version>1.1.2</version>

--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/pom.xml
@@ -128,6 +128,20 @@
         </dependency>
 
         <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams-tck</artifactId>
+            <version>1.0.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm.ws.org.reactivestreams</groupId>
+            <artifactId>reactive-streams</artifactId>
+            <version>1.0.3</version>
+            <scope>system</scope>
+            <systemPath>${com.ibm.ws.org.reactivestreams.reactive-streams.1.0_}</systemPath>
+        </dependency>
+
+        <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
             <version>1.1.2</version>

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/pom.xml
@@ -128,6 +128,20 @@
         </dependency>
 
         <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams-tck</artifactId>
+            <version>1.0.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm.ws.org.reactivestreams</groupId>
+            <artifactId>reactive-streams</artifactId>
+            <version>1.0.3</version>
+            <scope>system</scope>
+            <systemPath>${com.ibm.ws.org.reactivestreams.reactive-streams.1.0_}</systemPath>
+        </dependency>
+
+        <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
             <version>1.1.2</version>

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/src/test/java/com/ibm/ws/microprofile/rest/client/test/ArquillianLoadableExtension.java
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/src/test/java/com/ibm/ws/microprofile/rest/client/test/ArquillianLoadableExtension.java
@@ -19,6 +19,6 @@ import com.ibm.ws.fat.util.tck.TCKArchiveModifications;
 public class ArquillianLoadableExtension extends AbstractArquillianLoadableExtension {
     @Override
     public Set<TCKArchiveModifications> getModifications() {
-        return EnumSet.of(TCKArchiveModifications.TEST_LOGGER, TCKArchiveModifications.WIREMOCK);
+        return EnumSet.of(TCKArchiveModifications.TEST_LOGGER, TCKArchiveModifications.JETTY, TCKArchiveModifications.WIREMOCK);
     }
 }


### PR DESCRIPTION
Addresses issue where introspection fails to find Jetty classes by adding Jetty classes to installed TCK apps. This also includes Reactive Streams in the TCK framework - addresses issues seen in test builds like:

```
[1/23/21, 2:46:25:396 GMT] 0000001f com.ibm.ws.logging.internal.impl.IncidentImpl                I FFDC1015I: An FFDC Incident has been created: "java.lang.NoClassDefFoundError: org/eclipse/jetty/server/Handler com.ibm.ws.injectionengine.InjectionProcessorManager.getAllDeclaredFields 249" at ffdc_21.01.23_02.46.25.0.log
[1/23/21, 2:46:25:396 GMT] 0000001f com.ibm.ws.injectionengine.InjectionProcessorManager         W CWNEN0047W: Resource annotations on the fields of the org.eclipse.microprofile.rest.client.tck.ssl.HttpsServer class will be ignored. The annotations could not be obtained because of the exception : java.lang.NoClassDefFoundError: org/eclipse/jetty/server/Handler
```

and

```
java.lang.RuntimeException: java.lang.NoClassDefFoundError: org/reactivestreams/Publisher
	at org.apache.cxf.microprofile.client.cdi.CDIInstantiator.create(CDIInstantiator.java:50)
	at org.apache.cxf.jaxrs.impl.ConfigurableImpl.createProvider(ConfigurableImpl.java:294)
	at org.apache.cxf.jaxrs.impl.ConfigurableImpl.register(ConfigurableImpl.java:193)
	at org.apache.cxf.jaxrs.impl.ConfigurableImpl.register(ConfigurableImpl.java:188)
	at org.apache.cxf.microprofile.client.CxfTypeSafeClientBuilder.register(CxfTypeSafeClientBuilder.java:165)
	at org.apache.cxf.microprofile.client.CxfTypeSafeClientBuilder.build(CxfTypeSafeClientBuilder.java:143)
	at org.eclipse.microprofile.rest.client.tck.InvokeWithJsonBProviderTest.setupClient(InvokeWithJsonBProviderTest.java:78)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:85)
	at org.testng.internal.Invoker.invokeConfigurationMethod(Invoker.java:510)
	at org.testng.internal.Invoker.invokeConfigurations(Invoker.java:211)
	at org.testng.internal.Invoker.invokeConfigurations(Invoker.java:138)
	at org.testng.TestRunner.beforeRun(TestRunner.java:648)
	at org.testng.TestRunner.run(TestRunner.java:616)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:359)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:354)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:312)
	at org.testng.SuiteRunner.run(SuiteRunner.java:261)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1215)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1140)
	at org.testng.TestNG.run(TestNG.java:1048)
	at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:293)
	at org.apache.maven.surefire.testng.TestNGXmlTestSuite.execute(TestNGXmlTestSuite.java:84)
	at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:91)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:200)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:153)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)

```