### PR TITLE
Wait for SSL initialization to complete before running tests

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicTest.java
@@ -60,9 +60,12 @@ public class BasicTest extends FATServletClient {
     public static void setUp() throws Exception {
         ShrinkHelper.defaultDropinApp(remoteAppServer, "basicRemoteApp", "remoteApp.basic");
         remoteAppServer.startServer();
+        remoteAppServer.waitForStringInLog("CWWKO0219I"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8040.
 
         ShrinkHelper.defaultDropinApp(server, appName, "mpRestClient10.basic");
         server.startServer();
+        server.waitForStringInLog("CWWKO0219I"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/CollectionsTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/CollectionsTest.java
@@ -69,9 +69,11 @@ public class CollectionsTest extends FATServletClient {
         app.addAsLibraries(new File(JSONB_API).listFiles());
         ShrinkHelper.exportDropinAppToServer(remoteAppServer, app);
         remoteAppServer.startServer();
+        remoteAppServer.waitForStringInLog("CWWKO0219I"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
 
         ShrinkHelper.defaultDropinApp(server, appName, "mpRestClient10.collections");
         server.startServer();
+        server.waitForStringInLog("CWWKO0219I"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HandleResponsesTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HandleResponsesTest.java
@@ -61,9 +61,11 @@ public class HandleResponsesTest extends FATServletClient {
     public static void setUp() throws Exception {
         ShrinkHelper.defaultDropinApp(remoteAppServer, "basicRemoteApp", "remoteApp.basic");
         remoteAppServer.startServer();
+        remoteAppServer.waitForStringInLog("CWWKO0219I"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
 
         ShrinkHelper.defaultDropinApp(server, appName, "mpRestClient10.handleresponses");
         server.startServer();
+        server.waitForStringInLog("CWWKO0219I"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/ProduceConsumeTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/ProduceConsumeTest.java
@@ -51,6 +51,7 @@ public class ProduceConsumeTest extends FATServletClient {
     public static void setUp() throws Exception {
         ShrinkHelper.defaultDropinApp(server, appName, "mpRestClient11.produceConsume");
         server.startServer();
+        server.waitForStringInLog("CWWKO0219I"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.basic/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.basic/server.xml
@@ -16,5 +16,6 @@
 
   <!--  Required to read the remote server's port system property -->
   <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
+  <javaPermission className="javax.net.ssl.SSLPermission" name="*" actions="setHostnameVerifier" />
 
 </server>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.collections/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.collections/server.xml
@@ -21,5 +21,6 @@
   <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
   <javaPermission className="java.lang.RuntimePermission" name="getProtectionDomain"/>
   <javaPermission className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
+  <javaPermission className="javax.net.ssl.SSLPermission" name="*" actions="setHostnameVerifier" />
 
 </server>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.handleresponses/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient10.handleresponses/server.xml
@@ -16,5 +16,6 @@
 
   <!--  Required to read the remote server's port system property -->
   <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
+  <javaPermission className="javax.net.ssl.SSLPermission" name="*" actions="setHostnameVerifier" />
 
 </server>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.produceConsume/server.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/publish/servers/mpRestClient11.produceConsume/server.xml
@@ -10,5 +10,6 @@
 
   <!--  Required to read the remote server's port system property 
   <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" /> -->
+  <javaPermission className="javax.net.ssl.SSLPermission" name="*" actions="setHostnameVerifier" />
 
 </server>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/basicClientApp/src/mpRestClient10/basic/BasicClientTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/basicClientApp/src/mpRestClient10/basic/BasicClientTestServlet.java
@@ -46,6 +46,22 @@ public class BasicClientTestServlet extends FATServlet {
         return AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty(key));
     }
 
+    static {
+        //for localhost testing only
+        javax.net.ssl.HttpsURLConnection.setDefaultHostnameVerifier(
+                new javax.net.ssl.HostnameVerifier() {
+
+            @Override
+            public boolean verify(String hostname,
+                    javax.net.ssl.SSLSession sslSession) {
+                if (hostname.contains("localhost")) {
+                    return true;
+                }
+                return false;
+            }
+        });
+    }
+
     @Override
     public void init() throws ServletException {
         String baseUrlStr = "https://localhost:" + getSysProp("bvt.prop.HTTP_secondary.secure") + "/basicRemoteApp";

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/collectionsApp/src/mpRestClient10/collections/CollectionsTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/collectionsApp/src/mpRestClient10/collections/CollectionsTestServlet.java
@@ -48,6 +48,22 @@ public class CollectionsTestServlet extends FATServlet {
 
     private RestClientBuilder builder;
 
+    static {
+        //for localhost testing only
+        javax.net.ssl.HttpsURLConnection.setDefaultHostnameVerifier(
+                new javax.net.ssl.HostnameVerifier() {
+
+            @Override
+            public boolean verify(String hostname,
+                    javax.net.ssl.SSLSession sslSession) {
+                if (hostname.contains("localhost")) {
+                    return true;
+                }
+                return false;
+            }
+        });
+    }
+
     private static String getSysProp(String key) {
         return AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty(key));
     }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/handleresponsesApp/src/mpRestClient10/handleresponses/ClientTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/handleresponsesApp/src/mpRestClient10/handleresponses/ClientTestServlet.java
@@ -44,6 +44,22 @@ public class ClientTestServlet extends FATServlet {
 
     private RestClientBuilder builder;
 
+    static {
+        //for localhost testing only
+        javax.net.ssl.HttpsURLConnection.setDefaultHostnameVerifier(
+                new javax.net.ssl.HostnameVerifier() {
+
+            @Override
+            public boolean verify(String hostname,
+                    javax.net.ssl.SSLSession sslSession) {
+                if (hostname.contains("localhost")) {
+                    return true;
+                }
+                return false;
+            }
+        });
+    }
+
     private static String getSysProp(String key) {
         return AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty(key));
     }

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/produceConsumeApp/src/mpRestClient11/produceConsume/ProduceConsumeTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/produceConsumeApp/src/mpRestClient11/produceConsume/ProduceConsumeTestServlet.java
@@ -34,6 +34,22 @@ import componenttest.app.FATServlet;
 public class ProduceConsumeTestServlet extends FATServlet {
     private final static Logger _log = Logger.getLogger(ProduceConsumeTestServlet.class.getName());
 
+    static {
+        //for localhost testing only
+        javax.net.ssl.HttpsURLConnection.setDefaultHostnameVerifier(
+                new javax.net.ssl.HostnameVerifier() {
+
+            @Override
+            public boolean verify(String hostname,
+                    javax.net.ssl.SSLSession sslSession) {
+                if (hostname.contains("localhost")) {
+                    return true;
+                }
+                return false;
+            }
+        });
+    }
+ 
     /**
      * Tests that MP Rest Client's <code>@Produces</code> annotation affects the value transmitted in
      * the <code>Accept</code> header, and that it's <code>@Consumes</code> annotation affects the


### PR DESCRIPTION
Fixes MP Rest Client tests that use SSL - on some build machines the SSL components do not initialize until after the server has declared that it is ready to serve requests. This results in tests starting too soon resulting in SSL errors.

UPDATE: Adding related changes that add a more lenient hostname verifier to avoid JDK behavior differences wrt cert hostname ("localhost" vs "cn=localhost", etc.).