### PR TITLE
Allow FT warning if app stops before timeout

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client.FT_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/TimeoutTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client.FT_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/TimeoutTest.java
@@ -56,6 +56,6 @@ public class TimeoutTest extends FATServletClient {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        server.stopServer();
+        server.stopServer("CWMFT0002W");
     }
 }


### PR DESCRIPTION
If the app stops before a FT timer fires, it may print a warning in the server logs.  This is ok, and the test has already passed by this point.