### PR TITLE
mpOpenAPI API-Package Declaration

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-1.0/com.ibm.websphere.appserver.mpOpenAPI-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-1.0/com.ibm.websphere.appserver.mpOpenAPI-1.0.feature
@@ -31,9 +31,8 @@ IBM-API-Package: \
 	org.eclipse.microprofile.openapi.models.responses; type="stable",\
 	org.eclipse.microprofile.openapi.models.security; type="stable",\
 	org.eclipse.microprofile.openapi.models.servers; type="stable",\
-	org.eclipse.microprofile.openapi.models.tags; type="stable"
-IBM-SPI-Package: \
-    org.eclipse.microprofile.openapi.spi; type="stable"
+	org.eclipse.microprofile.openapi.models.tags; type="stable",\
+	org.eclipse.microprofile.openapi.spi; type="stable"
 -features=\
  com.ibm.websphere.appserver.org.eclipse.microprofile.openapi-1.0, \
  com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:=4.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-1.1/com.ibm.websphere.appserver.mpOpenAPI-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-1.1/com.ibm.websphere.appserver.mpOpenAPI-1.1.feature
@@ -31,8 +31,7 @@ IBM-API-Package: \
 	org.eclipse.microprofile.openapi.models.responses; type="stable",\
 	org.eclipse.microprofile.openapi.models.security; type="stable",\
 	org.eclipse.microprofile.openapi.models.servers; type="stable",\
-	org.eclipse.microprofile.openapi.models.tags; type="stable"
-IBM-SPI-Package: \
+	org.eclipse.microprofile.openapi.models.tags; type="stable",\
     org.eclipse.microprofile.openapi.spi; type="stable"
 -features=\
  com.ibm.websphere.appserver.org.eclipse.microprofile.openapi-1.1, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-2.0/com.ibm.websphere.appserver.mpOpenAPI-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-2.0/com.ibm.websphere.appserver.mpOpenAPI-2.0.feature
@@ -32,8 +32,7 @@ IBM-API-Package: \
     org.eclipse.microprofile.openapi.models.responses; type="stable",\
     org.eclipse.microprofile.openapi.models.security; type="stable",\
     org.eclipse.microprofile.openapi.models.servers; type="stable",\
-    org.eclipse.microprofile.openapi.models.tags; type="stable"
-IBM-SPI-Package: \
+    org.eclipse.microprofile.openapi.models.tags; type="stable",\
     org.eclipse.microprofile.openapi.spi; type="stable"
 -features=\
     com.ibm.websphere.appserver.org.eclipse.microprofile.openapi-2.0, \


### PR DESCRIPTION
resolves #15691 

- OpenAPI feature files now declare `org.eclipse.microprofile.openapi.spi` as a Liberty API-package, rather than an SPI-Package.

#build
#spawn.fullfat.buckets=com.ibm.ws.microprofile.openapi_fat,com.ibm.ws.microprofile.openapi_fat_tck,com.ibm.ws.microprofile.openapi.1.1_fat_tck,io.openliberty.microprofile.openapi.2.0.internal_fat,io.openliberty.microprofile.openapi.2.0.internal_fat_tck