### PR TITLE
update sqlserver security permissions

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/publish/servers/com.ibm.ws.jdbc.fat.sqlserver/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/publish/servers/com.ibm.ws.jdbc.fat.sqlserver/server.xml
@@ -70,5 +70,9 @@
   </dataSource>
 
   <javaPermission codebase="${server.config.dir}/apps/sqlserverfat.war" className="java.security.AllPermission"/>
-  <javaPermission codebase="${server.config.dir}/sqlserver/-" className="java.security.AllPermission"/>
+  <javaPermission codebase="${server.config.dir}/sqlserver/anomyous.jar" className="java.security.AllPermission"/>
+  
+  <!-- SQLServer JDBC test requirement -->
+  <javaPermission className="java.util.PropertyPermission" name="java.specification.version" actions="read"/>
+  <javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
 </server>


### PR DESCRIPTION
jdbc_sqlserver_fat is currently failing Java 2 Security builds with:

Caused by: java.security.AccessControlException: Access denied ("java.util.PropertyPermission" "java.specification.version" "read")
    at java.base/java.security.AccessController.throwACE(AccessController.java:176)
    at java.base/java.security.AccessController.checkPermissionHelper(AccessController.java:238)
    at java.base/java.security.AccessController.checkPermission(AccessController.java:385)
    at java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:322)
    at java.base/java.lang.SecurityManager.checkPropertyAccess(SecurityManager.java:1066)
    at java.base/java.lang.System.getProperty(System.java:506)
    at java.base/java.lang.System.getProperty(System.java:475)
    at com.microsoft.sqlserver.jdbc.Util.<clinit>(Util.java:30)

Adding in the extra permissions we have set in the jdbc_fat