### PR TITLE
Move Eclipselink 2.7.x and 3.0.x oss declarations to cnf/oss_dependen…

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1857,6 +1857,61 @@
       <version>2.0</version>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>org.eclipse.persistence.antlr</artifactId>
+      <version>2.7.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>org.eclipse.persistence.asm</artifactId>
+      <version>2.7.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>org.eclipse.persistence.asm</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>org.eclipse.persistence.core</artifactId>
+      <version>2.7.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>org.eclipse.persistence.core</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>org.eclipse.persistence.jpa.jpql</artifactId>
+      <version>2.7.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>org.eclipse.persistence.jpa.jpql</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>org.eclipse.persistence.jpa.modelgen.processor</artifactId>
+      <version>2.7.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>org.eclipse.persistence.jpa.modelgen.processor</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>org.eclipse.persistence.jpa</artifactId>
+      <version>2.7.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>org.eclipse.persistence.jpa</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.transformer</groupId>
       <artifactId>org.eclipse.transformer.cli</artifactId>
       <version>0.2.0</version>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -367,6 +367,17 @@ org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.2.0
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.3.1
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.4.0
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:2.0
+org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.8
+org.eclipse.persistence:org.eclipse.persistence.asm:2.7.8
+org.eclipse.persistence:org.eclipse.persistence.asm:3.0.0
+org.eclipse.persistence:org.eclipse.persistence.core:2.7.8
+org.eclipse.persistence:org.eclipse.persistence.core:3.0.0
+org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:2.7.8
+org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:3.0.0
+org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor:2.7.8
+org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor:3.0.0
+org.eclipse.persistence:org.eclipse.persistence.jpa:2.7.8
+org.eclipse.persistence:org.eclipse.persistence.jpa:3.0.0
 org.eclipse.transformer:org.eclipse.transformer.cli:0.2.0
 org.eclipse.transformer:org.eclipse.transformer:0.2.0
 org.eclipse:yasson:2.0.1

--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -95,17 +95,6 @@ org.apache.santuario:xmlsec:1.5.2-ibm
 org.apache.ws.security:wss4j:1.6.7-ibm-s20130913-2015
 org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.0-20191203
 org.eclipse.microprofile.graphql:microprofile-graphql-tck:1.0.0-20191203
-org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.8-ecdf3c3
-org.eclipse.persistence:org.eclipse.persistence.asm:2.7.8-ecdf3c3
-org.eclipse.persistence:org.eclipse.persistence.asm:3.0.0
-org.eclipse.persistence:org.eclipse.persistence.core:2.7.8-ecdf3c3
-org.eclipse.persistence:org.eclipse.persistence.core:3.0.0
-org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:2.7.8-ecdf3c3
-org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:3.0.0
-org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor:3.0.0
-org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen:2.7.8-ecdf3c3
-org.eclipse.persistence:org.eclipse.persistence.jpa:2.7.8-ecdf3c3
-org.eclipse.persistence:org.eclipse.persistence.jpa:3.0.0
 org.mock-server:mockserver-core:3.10.7-IBM20191022
 org.mock-server:mockserver-core:3.10.7-IBM20191022
 org.openid4java:openid4java:0.9.7-ibm-s20130624-1827

--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink.2.7/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink.2.7/bnd.bnd
@@ -14,7 +14,7 @@ bVersion=1.0
 # Eclipselink version info
 eclVersion=2.7.8
 eclHash=ecdf3c3
-eclFullVersion=${eclVersion}.${eclHash}
+eclFullVersion=${eclVersion}
 eclPackageVersion=2.0.16
 
 Bundle-SymbolicName: com.ibm.websphere.appserver.thirdparty.eclipselink.2.7
@@ -111,9 +111,9 @@ Include-Resource: \
   @${repo;org.eclipse.persistence:org.eclipse.persistence.antlr;${eclFullVersion};EXACT}!/!META-INF/maven/*,\
   @${repo;org.eclipse.persistence:org.eclipse.persistence.asm;${eclFullVersion};EXACT}!/!META-INF/maven/*,\
   @${repo;org.eclipse.persistence:org.eclipse.persistence.core;${eclFullVersion};EXACT}!/!META-INF/maven/*,\
-  @${repo;org.eclipse.persistence:org.eclipse.persistence.jpa.jpql;${eclFullVersion};EXACT}!/!META-INF/maven/*,\
-  @${repo;org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen;${eclFullVersion};EXACT}!/!META-INF/maven/*,\
   @${repo;org.eclipse.persistence:org.eclipse.persistence.jpa;${eclFullVersion};EXACT}!/!META-INF/maven/*,\
+  @${repo;org.eclipse.persistence:org.eclipse.persistence.jpa.jpql;${eclFullVersion};EXACT}!/!META-INF/maven/*,\
+  @${repo;org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor;${eclFullVersion};EXACT}!/!META-INF/maven/*,\
   org/eclipse/persistence/config=${bin}/org/eclipse/persistence/config,\
   org/eclipse/persistence/internal/databaseaccess=${bin}/org/eclipse/persistence/internal/databaseaccess,\
   org/eclipse/persistence/internal/helper=${bin}/org/eclipse/persistence/internal/helper,\


### PR DESCRIPTION
Eclipselink 2.7.x and 3.0.x belong in dev/cnf/oss_dependencies.maven rather than in dev/cnf/oss_ibm.maven.  Moving their entries over