### PR TITLE
Enable jakartaee for ValidateDSCustomLoginModuleTest

### DIFF
--- a/dev/com.ibm.ws.rest.handler.validator_fat/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/bnd.bnd
@@ -24,7 +24,11 @@ tested.features: mpOpenApi-2.0,\
                  mpConfig-2.0,\
                  jsonp-1.1,\
                  jaxrsclient-2.1,\
-                 jaxrs-2.1
+                 jaxrs-2.1,\
+                 componenttest-2.0,\
+                 appSecurity-4.0,\
+                 messaging-3.0,\
+                 connectors-2.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.2;version=latest,\

--- a/dev/com.ibm.ws.rest.handler.validator_fat/build.gradle
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/build.gradle
@@ -15,3 +15,5 @@ dependencies {
   requiredLibs project(':com.ibm.ws.microprofile.openapi')
   requiredLibs project(path: ':com.ibm.websphere.org.eclipse.microprofile', configuration: 'openapi10')
 }
+
+addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/FATSuite.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/FATSuite.java
@@ -17,8 +17,10 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.MicroProfileActions;
 import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
 @RunWith(Suite.class)
@@ -31,21 +33,39 @@ import componenttest.topology.utils.HttpUtils;
 })
 
 public class FATSuite {
-// TODO: Enable this once a jakarta enabled mpopenapi is available
-//    @ClassRule
-//    public static RepeatTests r = RepeatTests.with(new EmptyAction())
-//                    .andWith(FeatureReplacementAction.EE9_FEATURES());
 
     @ClassRule
-    public static RepeatTests r = MicroProfileActions.repeat(null, TestMode.FULL,
-                                                             MicroProfileActions.MP40,
-                                                             MicroProfileActions.MP30,
-                                                             MicroProfileActions.MP20);
+    public static RepeatTests r1 = MicroProfileActions.repeat(null, TestMode.FULL,
+                                                              MicroProfileActions.MP40,
+                                                              MicroProfileActions.MP30,
+                                                              MicroProfileActions.MP20);
+
+    @ClassRule
+    public static RepeatTests r2 = RepeatTests.withoutModification() // run all tests as-is (e.g. EE8 features)
+                    .andWith(new JakartaEE9Action()); // run all tests again with EE9 features+package
 
     @BeforeClass
     public static void setup() throws Exception {
         HttpUtils.trustAllCertificates();
         HttpUtils.trustAllHostnames();
         HttpUtils.setDefaultAuth("adminuser", "adminpwd");
+    }
+
+    public static void setupServerSideAnnotations(LibertyServer server) {
+        if (JakartaEE9Action.isActive()) {
+            server.addEnvVar("CONNECTION_FACTORY", "jakarta.resource.cci.ConnectionFactory");
+            server.addEnvVar("QUEUE_FACTORY", "jakarta.jms.QueueConnectionFactory");
+            server.addEnvVar("TOPIC_FACTORY", "jakarta.jms.TopicConnectionFactory");
+            server.addEnvVar("QUEUE_INTERFACE", "jakarta.jms.Queue");
+            server.addEnvVar("TOPIC_INTERFACE", "jakarta.jms.Topic");
+            server.addEnvVar("DESTINATION_INTERFACE", "jakarta.jms.Destination");
+        } else {
+            server.addEnvVar("CONNECTION_FACTORY", "javax.resource.cci.ConnectionFactory");
+            server.addEnvVar("QUEUE_FACTORY", "javax.jms.QueueConnectionFactory");
+            server.addEnvVar("TOPIC_FACTORY", "javax.jms.TopicConnectionFactory");
+            server.addEnvVar("QUEUE_INTERFACE", "javax.jms.Queue");
+            server.addEnvVar("TOPIC_INTERFACE", "javax.jms.Topic");
+            server.addEnvVar("DESTINATION_INTERFACE", "javax.jms.Destination");
+        }
     }
 }

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
@@ -17,6 +17,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,6 +40,7 @@ import com.ibm.ws.rest.handler.validator.loginmodule.TestLoginModule;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import componenttest.topology.utils.HttpsRequest;
@@ -63,6 +66,17 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
                                         .addPackage("org.test.validator.adapter")
                                         .addPackage("org.test.validator.jmsadapter"));
         ShrinkHelper.exportToServer(server, "dropins", rar, SERVER_ONLY);
+
+        FATSuite.setupServerSideAnnotations(server);
+
+        if (JakartaEE9Action.isActive()) {
+            //Transforming the java permission
+            final String serverXml = "validatorCustomLoginModuleServer.xml";
+            Path serverXmlFile = Paths.get("lib/LibertyFATTestFiles", serverXml);
+            JakartaEE9Action.transformApp(serverXmlFile);
+            Log.info(c, "setUp", "TRANSFORMED SERVER XML: " + serverXmlFile);
+            server.setServerConfigurationFile(serverXml);
+        }
 
         server.startServer();
 

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.rest.handler.validator.fat;
 
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -32,12 +33,14 @@ import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import componenttest.topology.utils.HttpsRequest;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat(EE9_FEATURES) // TODO: Enable this once mpopenapi-2.0 (jakarta enabled) is available
 public class ValidateDataSourceTest extends FATServletClient {
 
     private static final Class<?> c = ValidateDataSourceTest.class;

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJCATest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJCATest.java
@@ -11,6 +11,7 @@
 package com.ibm.ws.rest.handler.validator.fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -36,12 +37,14 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import componenttest.topology.utils.HttpsRequest;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat(EE9_FEATURES) // TODO: Enable this once mpopenapi-2.0 (jakarta enabled) is available
 public class ValidateJCATest extends FATServletClient {
     @Server("com.ibm.ws.rest.handler.validator.jca.fat")
     public static LibertyServer server;

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJMSTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJMSTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.rest.handler.validator.fat;
 
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -29,12 +30,14 @@ import org.junit.runner.RunWith;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import componenttest.topology.utils.HttpsRequest;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat(EE9_FEATURES) // TODO: Enable this once mpopenapi-2.0 (jakarta enabled) is available
 public class ValidateJMSTest extends FATServletClient {
     @Server("com.ibm.ws.rest.handler.validator.jms.fat")
     public static LibertyServer server;

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateOpenApiSchemaTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateOpenApiSchemaTest.java
@@ -11,6 +11,7 @@
 package com.ibm.ws.rest.handler.validator.fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -43,12 +44,14 @@ import com.ibm.ws.microprofile.openapi.impl.parser.core.models.SwaggerParseResul
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import componenttest.topology.utils.HttpsRequest;
 
 @RunWith(FATRunner.class)
+@SkipForRepeat(EE9_FEATURES) // TODO: Enable this once mpopenapi-2.0 (jakarta enabled) is available
 public class ValidateOpenApiSchemaTest extends FATServletClient {
 
     @Server("com.ibm.ws.rest.handler.validator.openapi.fat")

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/files/validatorCustomLoginModuleServer.xml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/files/validatorCustomLoginModuleServer.xml
@@ -77,5 +77,4 @@
                   className="javax.security.auth.PrivateCredentialPermission"
                   signedBy="javax.resource.spi.security.PasswordCredential"
                   principalType="*" principalName="*" actions="read"/>
-                  
 </server>

--- a/dev/wlp-jakartaee-transform/rules/jakarta-metatype.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-metatype.properties
@@ -14,3 +14,5 @@ javax.enterprise.concurrent.ManagedScheduledExecutorService=jakarta.enterprise.c
 "javax.jms.QueueConnectionFactory,javax.jms.ConnectionFactory"="jakarta.jms.QueueConnectionFactory,jakarta.jms.ConnectionFactory"
 "javax.jms.Topic,javax.jms.Destination"="jakarta.jms.Topic,jakarta.jms.Destination"
 "javax.jms.TopicConnectionFactory,javax.jms.ConnectionFactory"="jakarta.jms.TopicConnectionFactory,jakarta.jms.ConnectionFactory"
+# For com.ibm.ws.rest.handler.validator_fat/publish/files/validatorCustomLoginModuleServer.xml
+javax.resource.spi.security.PasswordCredential=jakarta.resource.spi.security.PasswordCredential

--- a/dev/wlp-jakartaee-transform/rules/jakarta-xml-master.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-xml-master.properties
@@ -83,3 +83,6 @@ com.ibm.jbatch.container.impl.BatchKernelImpl.xml=jakarta-transactionManager.pro
 com.ibm.jbatch.container.api.impl.JobOperatorImpl.xml=jakarta-batch.properties
 com.ibm.jbatch.container.api.impl.JobOperatorImplSuspendTran.xml=jakarta-batch.properties
 com.ibm.ws.jbatch.cdi.BatchCDIInjectionExtension.xml=jakarta-batch.properties
+
+#Rest Handler validator FAT
+validatorCustomLoginModuleServer.xml=jakarta-metatype.properties


### PR DESCRIPTION
Only one test class ValidateDSCustomLoginModuleTest is enabled for jakartaee. All other tests classes in the `com.ibm.ws.rest.handler.validator_fat` FAT are skipped due to absence of jakartaee version of mpOpenApi-1.0

for #11885 and #11886