### PR TITLE
Bundle Netty Maven Jars into an independant internal feature

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.io.netty.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.io.netty.feature
@@ -1,0 +1,7 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.io.netty
+singleton=true
+-bundles=io.openliberty.io.netty; location:="lib/";
+kind=noship
+edition=full
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.io.netty.ssl.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.io.netty.ssl.feature
@@ -1,0 +1,7 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.io.netty.ssl
+singleton=true
+-bundles=io.openliberty.io.netty.ssl; location:="lib/";
+kind=noship
+edition=full
+WLP-Activation-Type: parallel

--- a/dev/io.openliberty.io.netty.ssl/.classpath
+++ b/dev/io.openliberty.io.netty.ssl/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.io.netty.ssl/.project
+++ b/dev/io.openliberty.io.netty.ssl/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.io.netty.ssl</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.io.netty.ssl/.settings/bndtools.core.prefs
+++ b/dev/io.openliberty.io.netty.ssl/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/io.openliberty.io.netty.ssl/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/io.openliberty.io.netty.ssl/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/io.openliberty.io.netty.ssl/bnd.bnd
+++ b/dev/io.openliberty.io.netty.ssl/bnd.bnd
@@ -1,0 +1,39 @@
+#*******************************************************************************
+# Copyright (c) 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+nettyVersion=4.1.59.Final
+
+Bundle-Name: Netty SSL classes as an OSGi bundle
+Bundle-SymbolicName: io.openliberty.io.netty.ssl
+Bundle-Description: Netty SSL classes as an OSGi bundle for OpenLiberty, version ${bVersion}
+
+Import-Package: *
+
+Export-Package:\
+  io.netty.handler.ssl.*;version=${nettyVersion}; -split-package:=merge-first
+
+-fixupmessages.missingexport: "Used bundle version * for exported package";is:=ignore
+
+# These have been verified as the minimal set for the
+# io.netty.handler.ssl exported above
+-buildpath: \
+  io.netty:netty-buffer;version=${nettyVersion},\
+  io.netty:netty-codec;version=${nettyVersion},\
+  io.netty:netty-codec-http;version=${nettyVersion},\
+  io.netty:netty-codec-http2;version=${nettyVersion},\
+  io.netty:netty-codec-socks;version=${nettyVersion},\
+  io.netty:netty-common;version=${nettyVersion},\
+  io.netty:netty-handler;version=${nettyVersion},\
+  io.netty:netty-handler-proxy;version=${nettyVersion},\
+  io.netty:netty-resolver;version=${nettyVersion},\
+  io.netty:netty-transport;version=${nettyVersion}

--- a/dev/io.openliberty.io.netty/.classpath
+++ b/dev/io.openliberty.io.netty/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.io.netty/.project
+++ b/dev/io.openliberty.io.netty/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.io.netty</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.io.netty/.settings/bndtools.core.prefs
+++ b/dev/io.openliberty.io.netty/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/io.openliberty.io.netty/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/io.openliberty.io.netty/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/io.openliberty.io.netty/bnd.bnd
+++ b/dev/io.openliberty.io.netty/bnd.bnd
@@ -1,0 +1,60 @@
+#*******************************************************************************
+# Copyright (c) 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+nettyVersion=4.1.59.Final
+
+Bundle-Name: Netty as an OSGi bundle
+Bundle-SymbolicName: io.openliberty.io.netty
+Bundle-Description: Netty as an OSGi bundle for OpenLiberty, version ${bVersion}
+
+Import-Package: \
+  !com.google.protobuf.nano,\
+  !com.google.code.gson,\
+  !org.checkerframework,\
+  !com.jcraft.jzlib,\
+  !com.ning.*,\
+  !com.oracle.svm.core.annotate,\
+  !io.netty.internal.tcnative,\
+  !lzma.*,\
+  !net.jpountz.*,\
+  !org.apache.log4j.*,\
+  !org.apache.logging.*,\
+  !org.bouncycastle.*,\
+  !org.conscrypt,\
+  !org.eclipse.jetty.*,\
+  !org.jboss.*,\
+  !reactor.blockhound.*,\
+  !sun.*,\
+  javax.annotation;version=!,\
+  *
+
+Export-Package: \
+  !io.netty.handler.ssl.*,\
+  io.netty.*;version=${nettyVersion}; -split-package:=merge-first
+
+instrument.disabled: true
+
+-fixupmessages.missingexport: "Used bundle version * for exported package";is:=ignore
+
+-buildpath: \
+  io.netty:netty-buffer;version=${nettyVersion},\
+  io.netty:netty-codec;version=${nettyVersion},\
+  io.netty:netty-codec-http;version=${nettyVersion},\
+  io.netty:netty-codec-http2;version=${nettyVersion},\
+  io.netty:netty-codec-socks;version=${nettyVersion},\
+  io.netty:netty-common;version=${nettyVersion},\
+  io.netty:netty-handler;version=${nettyVersion},\
+  io.netty:netty-handler-proxy;version=${nettyVersion},\
+  io.netty:netty-resolver;version=${nettyVersion},\
+  io.netty:netty-transport;version=${nettyVersion}
+  


### PR DESCRIPTION
Puts the maven assets of Netty that grpc uses into a bundle.
(Does not yet make grpc use them from here though)
