### PR TITLE
cleanup gh-actions

### DIFF
--- a/.github/test-categories/QUARANTINE
+++ b/.github/test-categories/QUARANTINE
@@ -13,3 +13,15 @@ com.ibm.ws.security.saml.sso_fat.common
 
 # Does not have a valid build.gradle file
 com.ibm.ws.security.social_fat.oidcCertification
+
+# Temporary Quarantine
+com.ibm.ws.security.saml.sso_fat.2
+com.ibm.ws.security.saml.sso_fat.3
+com.ibm.ws.security.saml.sso_fat.config
+com.ibm.ws.security.saml.sso_fat.config.mapToUserRegistry
+com.ibm.ws.security.saml.sso_fat.endpoint.samlmetadata
+com.ibm.ws.security.saml.sso_fat.jaxrs
+com.ibm.ws.security.saml.sso_fat.jaxrs.config
+com.ibm.ws.security.saml.sso_fat.logout
+com.ibm.ws.security.saml.sso_fat.logout.httpServletRequest
+com.ibm.ws.security.saml.sso_fat.logout.IDP_initiated 

--- a/.github/test-categories/SECURITY_5
+++ b/.github/test-categories/SECURITY_5
@@ -3,4 +3,3 @@ com.ibm.websphere.security_fat.1
 com.ibm.ws.security.auth.data_fat
 com.ibm.ws.security.client_fat
 com.ibm.ws.wssecurity_fat.wsscxf
-


### PR DESCRIPTION
New FAT Suite was not added to a test category. 
com.ibm.ws.security.saml.sso_fat.2 
com.ibm.ws.security.saml.sso_fat.config
com.ibm.ws.security.saml.sso_fat.config.mapToUserRegistry
com.ibm.ws.security.saml.sso_fat.endpoint.samlmetadata
com.ibm.ws.security.saml.sso_fat.jaxrs
com.ibm.ws.security.saml.sso_fat.jaxrs.config
com.ibm.ws.security.saml.sso_fat.logout
com.ibm.ws.security.saml.sso_fat.logout.httpServletRequest
com.ibm.ws.security.saml.sso_fat.logout.IDP_initiated