### PR TITLE
Fix up eclipse settings after new fats added

### DIFF
--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink.2.7/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink.2.7/bnd.bnd
@@ -130,6 +130,7 @@ instrument.ffdc: false
     org.eclipse.persistence:org.eclipse.persistence.core;version=${eclFullVersion};strategy=exact,\
     org.eclipse.persistence:org.eclipse.persistence.jpa;version=${eclFullVersion};strategy=exact,\
     javax.persistence:javax.persistence-api;version=2.2, \
+    com.ibm.websphere.javaee.connector.1.7;version=latest, \
     com.ibm.websphere.org.osgi.core,\
     com.ibm.websphere.javaee.jsonp.1.0;version=latest,\
     com.ibm.websphere.javaee.persistence.2.2;version=latest,\

--- a/dev/com.ibm.ws.security.saml.sso_fat.2/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.security.saml.sso_fat.2/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.security.saml.sso_fat.2/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.security.saml.sso_fat.2/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/com.ibm.ws.security.saml.sso_fat.3/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.security.saml.sso_fat.3/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.security.saml.sso_fat.config.mapToUserRegistry/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.security.saml.sso_fat.config.mapToUserRegistry/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.security.saml.sso_fat.config/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.security.saml.sso_fat.config/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.security.saml.sso_fat.config/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.security.saml.sso_fat.config/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/com.ibm.ws.security.saml.sso_fat.endpoint.samlmetadata/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.security.saml.sso_fat.endpoint.samlmetadata/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.security.saml.sso_fat.endpoint.samlmetadata/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.security.saml.sso_fat.endpoint.samlmetadata/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/.classpath
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/.classpath
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
-	<classpathentry kind="src" path="test-applications/helloworld.war/src"/>
-	<classpathentry kind="src" path="test-applications/jaxrsclient.war/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout.IDP_initiated/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout.IDP_initiated/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout.IDP_initiated/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout.IDP_initiated/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout.httpServletRequest/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout.httpServletRequest/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout.httpServletRequest/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout.httpServletRequest/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.wsat_fat.assertion/.project
+++ b/dev/com.ibm.ws.wsat_fat.assertion/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>com.ibm.ws.wsat_fat.5</name>
+	<name>com.ibm.ws.wsat_fat.assertion</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/dev/com.ibm.ws.wsat_fat.db_optional/.project
+++ b/dev/com.ibm.ws.wsat_fat.db_optional/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>com.ibm.ws.wsat_fat.2</name>
+	<name>com.ibm.ws.wsat_fat.db_optional</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/dev/com.ibm.ws.wsat_fat.dbs/.project
+++ b/dev/com.ibm.ws.wsat_fat.dbs/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>com.ibm.ws.wsat_fat.3</name>
+	<name>com.ibm.ws.wsat_fat.dbs</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/dev/com.ibm.ws.wsat_fat.dbs_optional/.project
+++ b/dev/com.ibm.ws.wsat_fat.dbs_optional/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>com.ibm.ws.wsat_fat.4</name>
+	<name>com.ibm.ws.wsat_fat.dbs_optional</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/dev/com.ibm.ws.wsat_fat.multi/.project
+++ b/dev/com.ibm.ws.wsat_fat.multi/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>com.ibm.ws.wsat_fat.6</name>
+	<name>com.ibm.ws.wsat_fat.multi</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/dev/com.ibm.ws.wsat_fat.ssl/.project
+++ b/dev/com.ibm.ws.wsat_fat.ssl/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>com.ibm.ws.wsat_fat.7</name>
+	<name>com.ibm.ws.wsat_fat.ssl</name>
 	<comment></comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
- Add missing bndtools and jdt prefs files.
- Update .project files to have the right name of the project
- Remove non existent source directories from .classpath file.
- Update eclipselink buildpath to remove unresolved indirect reference error.
