### PR TITLE
Keep the order of subsystem content

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/openidConnectServer-1.0/com.ibm.websphere.appserver.openidConnectServer-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/openidConnectServer-1.0/com.ibm.websphere.appserver.openidConnectServer-1.0.feature
@@ -11,10 +11,10 @@ Subsystem-Endpoint-Names: clientManagement=OpenID Connect Client Management, per
 Subsystem-Endpoint-Urls: className=com.ibm.ws.security.openidconnect.server.plugins.UIHelperService, methodName=getProviderInfo
 Subsystem-Endpoint-ShortNames: clientManagement=clientManagement-1.0, personalTokenManagement=personalTokenManagement-1.0, usersTokenManagement=usersTokenManagement-1.0
 Subsystem-Endpoint-Icons: clientManagement=OSGI-INF/clientManagement_142.png,OSGI-INF/clientManagement_78.png;size=78,OSGI-INF/clientManagement_142.png;size=142, personalTokenManagement=OSGI-INF/personalTokenManagement_142.png,OSGI-INF/personalTokenManagement_78.png;size=78,OSGI-INF/personalTokenManagement_142.png;size=142, usersTokenManagement=OSGI-INF/usersTokenManagement_142.png,OSGI-INF/usersTokenManagement_78.png;size=78,OSGI-INF/usersTokenManagement_142.png;size=142
--features=com.ibm.websphere.appserver.httpcommons-1.0, \
-  io.openliberty.openidConnectServer1.0.internal.ee-6.0; ibm.tolerates:="9.0", \
-  com.ibm.websphere.appserver.oauth-2.0, \
+-features= com.ibm.websphere.appserver.oauth-2.0, \
   com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0", \
+  com.ibm.websphere.appserver.httpcommons-1.0, \
+  io.openliberty.openidConnectServer1.0.internal.ee-6.0; ibm.tolerates:="9.0", \
   com.ibm.websphere.appserver.internal.slf4j-1.7.7
 -bundles=\
   com.ibm.ws.net.oauth.jsontoken.1.1-r42, \

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureDefinitionUtils.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureDefinitionUtils.java
@@ -21,9 +21,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.jar.Manifest;
 import java.util.regex.Pattern;
 
@@ -682,10 +684,14 @@ public class FeatureDefinitionUtils {
                     return Collections.emptyList();
                 }
 
-                Map<String, Map<String, String>> data = ManifestHeaderProcessor.parseImportString(contents);
+                // using parseExportString to maintain order; but need to prevent dups
+                List<NameValuePair> data = ManifestHeaderProcessor.parseExportString(contents);
                 result = new ArrayList<FeatureResource>(data.size());
-                for (Map.Entry<String, Map<String, String>> entry : data.entrySet()) {
-                    result.add(new FeatureResourceImpl(entry.getKey(), entry.getValue(), iAttr.bundleRepositoryType, iAttr.featureName, iAttr.activationType));
+                Set<String> preventDups = new HashSet<>();
+                for (NameValuePair content : data) {
+                    if (preventDups.add(content.getName())) {
+                        result.add(new FeatureResourceImpl(content.getName(), content.getAttributes(), iAttr.bundleRepositoryType, iAttr.featureName, iAttr.activationType));
+                    }
                 }
 
                 subsystemContent = result;


### PR DESCRIPTION
ManifestHeaderProcessor.parseImportString does
not maintain the order specified in the header
in the returned map.  This change first
tries to use ManifestElement, which preserves
order and falls back to ManifestHeaderProcessor
on exception to try and maintain order
