### PR TITLE
Issue 15640: Add Ldap kerberos runtime support

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/ldapRegistry-3.0/com.ibm.websphere.appserver.ldapRegistry-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/ldapRegistry-3.0/com.ibm.websphere.appserver.ldapRegistry-3.0.feature
@@ -6,6 +6,7 @@ IBM-ShortName: ldapRegistry-3.0
 Subsystem-Name: LDAP User Registry 3.0
 -features=\
   com.ibm.websphere.appserver.federatedRegistry-1.0
--bundles=com.ibm.ws.security.wim.adapter.ldap
+-bundles=com.ibm.ws.security.wim.adapter.ldap, \
+ com.ibm.ws.security.kerberos.auth
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.security.wim.base/src/com/ibm/websphere/security/wim/ras/WIMMessageKey.java
+++ b/dev/com.ibm.websphere.security.wim.base/src/com/ibm/websphere/security/wim/ras/WIMMessageKey.java
@@ -1667,12 +1667,23 @@ public interface WIMMessageKey {
     String CANNOT_READ_KRB5_FILE = "CANNOT_READ_KRB5_FILE";
 
     /**
-     * CWIML4559E: The bind authentication mechanism on the {0} LdapRegistry is set to GSSAPI, but the required attribute, krb5Principal, is not configured.
+     * CWIML4560E: The [{0}] attribute from the {1} element is configured to a file that does not exist at: {2}
      */
-    String KRB5_PRINCIPAL_REQUIRED = "KRB5_PRINCIPAL_REQUIRED";
+    String KRB5_FILE_NOT_FOUND = "KRB5_FILE_NOT_FOUND";
+
+    /**
+     * CWIML4561I: The LdapRegistry component is configured to use a {0} file located at {1}
+     */
+    String KRB5_FILE_FOUND = "KRB5_FILE_FOUND";
 
     /**
      * CWIML4518W: The {0} {1} value is malformed. The value must be a series of objectclass:attribute or *:attribute pairs, where each pair is separated by a semi-colon.
      */
     String IDMAP_INVALID_FORMAT = "IDMAP_INVALID_FORMAT";
+
+    /**
+     * KRB5_SERVICE_NOT_AVAILABLE=CWIML4521E: The {0} LdapRegistry attempted to bind to the Ldap server using Kerberos credentials for {1} principal name, but the KerberosService
+     * is not available. The bind authentication mechanism is {2}.
+     */
+    String KRB5_SERVICE_NOT_AVAILABLE = "KRB5_SERVICE_NOT_AVAILABLE";
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/bnd.bnd
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/bnd.bnd
@@ -28,6 +28,7 @@ Private-Package: \
 Import-Package: \
   com.ibm.websphere.security.auth, \
   com.ibm.ws.ssl.protocol, \
+  com.ibm.ws.security.kerberos.auth, \
   !*.internal.*, *
 
 Include-Resource: \
@@ -52,7 +53,10 @@ instrument.classesExcludes: com/ibm/ws/security/wim/adapter/ldap/resources/*.cla
 	com.ibm.ws.logging;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.wsspi.org.osgi.service.metatype.annotations;version=latest, \
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
+	com.ibm.ws.security.kerberos.auth;version=latest, \
+	com.ibm.ws.security;version=latest,\
+	com.ibm.ws.kernel.boot.core;version=latest
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	com.ibm.ws.junit.extensions;version=latest, \

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/resources/OSGI-INF/metatype/metatype.xml
@@ -170,14 +170,21 @@
 		<AD id="timestampFormat" name="%timestampFormat" description="%timestampFormat.desc" required="false" type="String" />
 		<!-- End VMM ported Entries -->	
 
-	<AD id="bindAuthMechanism" name="internal" description="internal use only" required="false" type="String" ibm:beta="true">
-		<Option label="%bindAuthMechanism.none" value="none" />
-		<Option label="%bindAuthMechanism.simple" value="simple" />
-		<Option label="%bindAuthMechanism.GSSAPI" value="GSSAPI" />
-	</AD>
+	    <AD id="bindAuthMechanism" name="%bindAuthMechanism" description="%bindAuthMechanism.desc" required="false" type="String" ibm:beta="true">
+		    <Option label="%bindAuthMechanism.none" value="none" />
+		    <Option label="%bindAuthMechanism.simple" value="simple" />
+		    <Option label="%bindAuthMechanism.GSSAPI" value="GSSAPI" />
+	     </AD>
 
-	<AD id="krb5Principal" name="internal" description="internal use only" type="String" required="false" ibm:beta="true" />
-	<AD id="krb5TicketCache" name="internal" description="internal use only" type="String" required="false" ibm:beta="true" />
+	    <AD id="krb5Principal" name="%krb5Principal" description="%krb5Principal.desc" type="String" required="false" ibm:beta="true" />
+	    <AD id="krb5TicketCache" name="%krb5TicketCache" description="%krb5TicketCache.desc" type="String" required="false" ibm:type="location(file)" ibm:beta="true"/>
+	
+	    <AD name="internal" description="internal use only"
+        	id="kerberosService" required="false" type="String" default="*" cardinality="1"
+            ibm:type="pid" ibm:reference="com.ibm.ws.security.kerberos.auth.KerberosService" ibm:final="true"/>
+
+        <AD id="kerberosService.cardinality.minimum" name="internal"  description="internal use only" 
+            type="String" required="false" default="${count(kerberosService)}" />
 
     </OCD>
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/resources/com/ibm/ws/security/wim/adapter/ldap/resources/LdapUtilMessages.nlsprops
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/resources/com/ibm/ws/security/wim/adapter/ldap/resources/LdapUtilMessages.nlsprops
@@ -230,7 +230,6 @@ INVALID_LOGIN_PROPERTIES=CWIML4506E: The following login properties are not vali
 INVALID_LOGIN_PROPERTIES.explanation=One or more login properties are not valid WIM PersonAccount properties.
 INVALID_LOGIN_PROPERTIES.useraction=Either choose valid PersonAccount properties or add the properties to PersonAccount as extended properties. Ensure that the case for each login property matches the case for the corresponding PersonAccount property.
 
-
 KRB5_LOGIN_FAILED_CACHE=CWIML4507E: Kerberos login failed with the {0} Kerberos principal and the {1} Kerberos credential cache (ccache).
 KRB5_LOGIN_FAILED_CACHE.explanation=Either the specified Kerberos principal is invalid, or the Kerberos credential cache (ccache) is invalid or expired.
 KRB5_LOGIN_FAILED_CACHE.useraction=Ensure that a valid Kerberos principal is specified, and that the Kerberos credential cache (ccache) is not expired.
@@ -247,30 +246,36 @@ KRB5_LOGIN_FAILED_DEFAULT_KEYTAB=CWIML4510E: Kerberos login failed with the {0} 
 KRB5_LOGIN_FAILED_DEFAULT_KEYTAB.explanation=Either the specified Kerberos principal is invalid, or the default Kerberos keytab is invalid.
 KRB5_LOGIN_FAILED_DEFAULT_KEYTAB.useraction=Ensure that a valid Kerberos principal is specified and that the default Kerberos keytab is valid.
 
-KRB5_TICKETCACHE_USED=CWIML4511E: The {0} LdapRegistry is configured with the {1} Kerberos ticket cache (ccache) filename and the {2} keytab filename. The Kerberos credential cache (ccache) is used for Kerberos bind authentication to LDAP server.
+KRB5_TICKETCACHE_USED=CWIML4511E: The {0} LDAP registry is configured with the {1} Kerberos ticket cache (ccache) filename and the {2} keytab filename. The Kerberos credential cache (ccache) is used for Kerberos bind authentication to LDAP server.
 KRB5_TICKETCACHE_USED.explanation=To use the keytab file, the keytab filename must be specified and the Kerberos credential cache (ccache) filename must not be specified.
-KRB5_TICKETCACHE_USED.useraction=No action is required. To avoid this message, remove either the LdapRegistry ticketCache attribute or the Kerberos keytab attribute.
+KRB5_TICKETCACHE_USED.useraction=No action is required. To avoid this message, remove either the LDAP registry ticketCache attribute or the Kerberos keytab attribute.
 
 INVALID_KRB5_PRINCIPAL=CWIML4512E: The {0} Kerberos principal name is incorrectly formatted, or the realm name is missing, or a default realm name cannot be found.
 INVALID_KRB5_PRINCIPAL.explanation=The Kerberos principal name cannot be null. The principal name must either include the realm name or a default realm name must be defined in Kerberos configuration file.
 INVALID_KRB5_PRINCIPAL.useraction=Correct the principal name or add a default realm name.
 
-CANNOT_READ_KRB5_FILE=CWIML4513E: The {0} LdapRegistry cannot read the {1} Kerberos file.
+CANNOT_READ_KRB5_FILE=CWIML4513E: The {0} LDAP registry cannot read the {1} Kerberos file.
 CANNOT_READ_KRB5_FILE.explanation=The Kerberos file cannot be opened. Either the file permissions are incorrect, or the file does not exist.
 CANNOT_READ_KRB5_FILE.useraction=Verify that the file location is correct and that the server has read file permissions.
 
-KRB5_PRINCIPAL_REQUIRED=CWIML4514E: The bind authentication mechanism on the {0} LdapRegistry is set to GSSAPI, but the required attribute, krb5Principal, is not configured.
-KRB5_PRINCIPAL_REQUIRED.explanation=The Kerberos principal name is required when GSSAPI (Kerberos) is enabled.
-KRB5_PRINCIPAL_REQUIRED.useraction=Add a krb5Principal attribute to the krbAuthentication elemenent on the LdapRegistry element.
+# CWIML4514 already used
 
 KRB5_FILE_NOT_FOUND=CWIML4515E: The {0} attribute from the {1} element is configured to a file that does not exist at the following location: {2}
 KRB5_FILE_NOT_FOUND.explanation=The configuration refers to a file that is either unreadable or does not exist.
 KRB5_FILE_NOT_FOUND.useraction=Ensure that the configuration points to a file that exists and is readable by the application process.
 
-KRB5_FILE_FOUND=CWIML4516E: The LdapRegistry component is configured to use a {0} file that is located at {1}.
+KRB5_FILE_FOUND=CWIML4516E: The LDAP registry component is configured to use a {0} file that is located at {1}.
 KRB5_FILE_FOUND.explanation=The configured file was successfully located.
 KRB5_FILE_FOUND.useraction=No action is required.
 
-IDMAP_INVALID_FORMAT=CWIML4518W: The {0} {1} value is malformed. The value must be a series of objectclass:attribute or *:attribute pairs, where each pair is separated by a semi-colon.
+# CWIML4517 already used
+
+IDMAP_INVALID_FORMAT=CWIML4518W: The {0} {1} value is malformed. The value must be a semi-colon separated list of 'objectclass:attribute' or '*:attribute' pairs.
 IDMAP_INVALID_FORMAT.explanation=The userIdMap value must be in a valid format so that the objectclass and attribute can be parsed.
 IDMAP_INVALID_FORMAT.useraction=Update the userIdMap value so that it adheres to the specified format.
+
+# CWIML4519 and CWIML4520 already used
+
+KRB5_SERVICE_NOT_AVAILABLE=CWIML4521E: The {0} LDAP registry attempted to bind to the LDAP server by using Kerberos credentials for the {1} principal name, but the Kerberos service that provides these credentials is not available. The bind authentication mechanism is {2}.
+KRB5_SERVICE_NOT_AVAILABLE.explanation=The Kerberos service was not available when the LDAP registry attempted to bind to the LDAP server. If the Kerberos service is not available, no users can authenticate.
+KRB5_SERVICE_NOT_AVAILABLE.useraction=Review the LDAP registry configuration settings for the bindAuthMechanism, krb5Principal, and krb5TicketCache attributes as well as the Kerberos configuration. Restart the server.

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/context/ContextManager.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/context/ContextManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,12 @@
  *******************************************************************************/
 package com.ibm.ws.security.wim.adapter.ldap.context;
 
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
@@ -19,6 +25,8 @@ import java.util.Properties;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -33,15 +41,20 @@ import javax.naming.directory.Attributes;
 import javax.naming.directory.DirContext;
 import javax.naming.ldap.Control;
 import javax.naming.ldap.LdapName;
+import javax.security.auth.Subject;
+import javax.security.auth.login.LoginException;
 
 import com.ibm.websphere.crypto.PasswordUtil;
 import com.ibm.websphere.ras.ProtectedString;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.websphere.security.wim.ConfigConstants;
 import com.ibm.websphere.security.wim.ras.WIMMessageHelper;
 import com.ibm.websphere.security.wim.ras.WIMMessageKey;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.security.authentication.utility.SubjectHelper;
+import com.ibm.ws.security.kerberos.auth.KerberosService;
 import com.ibm.ws.security.wim.adapter.ldap.BEROutputStream;
 import com.ibm.wsspi.kernel.service.utils.SerializableProtectedString;
 import com.ibm.wsspi.security.wim.exception.EntityAlreadyExistsException;
@@ -49,6 +62,7 @@ import com.ibm.wsspi.security.wim.exception.EntityHasDescendantsException;
 import com.ibm.wsspi.security.wim.exception.EntityNotFoundException;
 import com.ibm.wsspi.security.wim.exception.InvalidInitPropertyException;
 import com.ibm.wsspi.security.wim.exception.OperationNotSupportedException;
+import com.ibm.wsspi.security.wim.exception.PropertyNotDefinedException;
 import com.ibm.wsspi.security.wim.exception.WIMApplicationException;
 import com.ibm.wsspi.security.wim.exception.WIMSystemException;
 
@@ -235,6 +249,22 @@ public class ContextManager {
 
     /** Write to secondary server configuration. */
     private boolean iWriteToSecondary = false;
+
+    /** The Ldap repo ID for use in logging **/
+    private String reposId = null;
+
+    /** Sets the bind authentication mechanism for administrative binds to the Ldap server. None, simple, GSSAPI (Kerbers). */
+    private String bindAuthMechanism = null;
+
+    /** GSSAPI/Kerberos configuration. krb5Principal is required, krb5TicketCache is optional. Keytab/config can be configured in the <kerberos> element */
+    private String krb5Principal = null;
+    private Path krb5TicketCache = null;
+
+    /** The KerberosService for use when bindAuthMechanism is GSSAPI (Kerberos), also loads the keytab/config if configured in the <kerberos> element */
+    private KerberosService kerberosService = null;
+
+    /** Read/Write lock to prevent multiple processes from using and updating the KerberosService and/or context pool at the same time. **/
+    private final ReadWriteLock kerberServiceModifyLock = new ReentrantReadWriteLock();
 
     /**
      * Add a fail-over LDAP server hostname and port.
@@ -465,17 +495,34 @@ public class ContextManager {
      * @throws NamingException If there was an issue binding to the LDAP server.
      */
     private TimedDirContext createDirContext(Hashtable<String, Object> env, long createTimestamp) throws NamingException {
-
-        /*
-         * Check if the credential is a protected string. It will be unprotected if this is an anonymous bind
-         */
-        Object o = env.get(Context.SECURITY_CREDENTIALS);
-        if (o instanceof ProtectedString) {
-            // Reset the bindPassword to simple string.
-            ProtectedString sps = (ProtectedString) env.get(Context.SECURITY_CREDENTIALS);
-            String password = sps == null ? "" : new String(sps.getChars());
-            String decodedPassword = PasswordUtil.passwordDecode(password.trim());
-            env.put(Context.SECURITY_CREDENTIALS, decodedPassword);
+        if (isKerberosBindAuth()) {
+            try {
+                Subject subject = handleKerberos();
+                env.put(javax.security.sasl.Sasl.CREDENTIALS, SubjectHelper.getGSSCredentialFromSubject(subject));
+            } catch (LoginException e) {
+                NamingException ne = new NamingException(e.getMessage());
+                ne.setRootCause(e);
+                throw ne;
+            } catch (MalformedURLException mue) {
+                String msg = Tr.formatMessage(tc, WIMMessageKey.NAMING_EXCEPTION, WIMMessageHelper.generateMsgParms(krb5TicketCache));
+                WIMSystemException wimE = new WIMSystemException(WIMMessageKey.FILE_NOT_FOUND,
+                                                                 msg, mue);
+                NamingException ne = new NamingException(wimE.getMessage());
+                ne.setRootCause(wimE);
+                throw ne;
+            }
+        } else {
+            /*
+             * Check if the credential is a protected string. It will be unprotected if this is an anonymous bind
+             */
+            Object o = env.get(Context.SECURITY_CREDENTIALS);
+            if (o instanceof ProtectedString) {
+                // Reset the bindPassword to simple string.
+                ProtectedString sps = (ProtectedString) env.get(Context.SECURITY_CREDENTIALS);
+                String password = sps == null ? "" : new String(sps.getChars());
+                String decodedPassword = PasswordUtil.passwordDecode(password.trim());
+                env.put(Context.SECURITY_CREDENTIALS, decodedPassword);
+            }
         }
 
         SSLUtilImpl sslUtil = new SSLUtilImpl();
@@ -515,7 +562,10 @@ public class ContextManager {
     /**
      * Create a directory context.
      *
-     * @param principal The principal name to bind with.
+     * Supports authenticateWithPassword, sets Context.SECURITY_AUTHENTICATION to simple for user/password authentication (versus the
+     * value of bindAuthMechanism).
+     *
+     * @param principal  The principal name to bind with.
      * @param credential The password / credential.
      * @return The {@link TimedDirContext} of the new connection.
      * @throws NamingException If the bind failed.
@@ -528,7 +578,7 @@ public class ContextManager {
         Hashtable<String, Object> environment = getEnvironment(URLTYPE_SINGLE, activeURL);
         environment.put(Context.SECURITY_PRINCIPAL, principal);
         environment.put(Context.SECURITY_CREDENTIALS, credential);
-
+        environment.put(Context.SECURITY_AUTHENTICATION, ConfigConstants.CONFIG_AUTHENTICATION_TYPE_SIMPLE);
         SSLUtilImpl sslUtil = new SSLUtilImpl();
         Properties currentSSLProps = sslUtil.getSSLPropertiesOnThread();
         try {
@@ -1029,10 +1079,17 @@ public class ContextManager {
             iEnvironment.put(Context.PROVIDER_URL, url);
         }
 
+        if (bindAuthMechanism != null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, METHODNAME + " Using bindAuthMechanism for admin bind: " + bindAuthMechanism);
+            }
+            iEnvironment.put(Context.SECURITY_AUTHENTICATION, bindAuthMechanism);
+        }
+
         /*
          * If no administrative credentials, allow anonymous bind.
          */
-        if (iBindDN != null && !iBindDN.isEmpty()) {
+        if (!isKerberosBindAuth() && iBindDN != null && !iBindDN.isEmpty()) {
             iEnvironment.put(Context.SECURITY_PRINCIPAL, iBindDN);
             SerializableProtectedString sps = iBindPassword;
             String password = sps == null ? "" : new String(sps.getChars());
@@ -1045,6 +1102,12 @@ public class ContextManager {
                 return InitializeResult.MISSING_PASSWORD;
             }
             iEnvironment.put(Context.SECURITY_CREDENTIALS, new ProtectedString(decodedPassword.toCharArray()));
+        }
+
+        if (isKerberosBindAuth()) {
+            if (krb5Principal == null || krb5Principal.trim().isEmpty()) {
+                return InitializeResult.MISSING_KRB5_PRINCIPAL_NAME;
+            }
         }
 
         /*
@@ -1126,7 +1189,17 @@ public class ContextManager {
         if (tc.isDebugEnabled()) {
             StringBuffer strBuf = new StringBuffer();
             strBuf.append("\nLDAP Server(s): ").append(urlList).append("\n");
-            strBuf.append("\tBind DN: ").append(iBindDN).append("\n");
+            strBuf.append("\tBindAuthMechanism: ").append(bindAuthMechanism).append("\n");
+            if (isKerberosBindAuth()) {
+                strBuf.append("\tKrb5Principal: ").append(krb5Principal).append("\n");
+                strBuf.append("\tKrb5TicketCache: ").append(krb5TicketCache).append("\n");
+                if (kerberosService != null) {
+                    strBuf.append("\tkeytab (from KerberosService): ").append(kerberosService.getKeytab()).append("\n");
+                    strBuf.append("\tconfig (from KerberosService): ").append(kerberosService.getConfigFile()).append("\n");
+                }
+            } else {
+                strBuf.append("\tBind DN: ").append(iBindDN).append("\n");
+            }
             // strBuf.append("\tAuthenticate: ").append(authen).append("\n");
             strBuf.append("\tReferral: ").append(iReferral).append("\n");
             strBuf.append("\tDeref Aliases: ").append(iDerefAliases).append("\n");
@@ -1513,6 +1586,97 @@ public class ContextManager {
     }
 
     /**
+     * Set the bindAuthMechanism, this will control what type of Context.SECURITY_AUTHENTICATION to set for administrative credentials.
+     *
+     * @param bindAuthMech
+     */
+    public void setBindAuthMechanism(String bindAuthMech) {
+        this.bindAuthMechanism = bindAuthMech;
+    }
+
+    /**
+     * Set the repoID (for logging), the KerberosService and Kerberos principal name and ticketCache. The ticketCache is optional. The keytab and config file are set from the
+     * <kerberos> element and are loaded from the KerberosService. If the ticketCache and the keytab are defined, then the ticketCache is
+     * used first, then the keytab.
+     *
+     * @param id
+     * @param kerb
+     * @param krb5Principal
+     * @param krb5TicketCache
+     */
+    @FFDCIgnore({ MalformedURLException.class, URISyntaxException.class, IllegalArgumentException.class })
+    public void setKerberosCredentials(String id, KerberosService kerb, String krb5Principal, String rawKrb5TicketCache) throws PropertyNotDefinedException {
+        if (!isKerberosBindAuth()) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "setKerberosCredentials was called, but Kerberos is not enabled. BindAuthMechanism is " + bindAuthMechanism);
+            }
+        }
+        acquireKrb5WriteLock();
+        try {
+            // null or missing principal name will be processed during initialize
+            this.krb5Principal = krb5Principal;
+
+            reposId = id;
+            kerberosService = kerb;
+
+            if (rawKrb5TicketCache != null && !rawKrb5TicketCache.trim().isEmpty()) {
+                krb5TicketCache = Paths.get(rawKrb5TicketCache);
+                if (!krb5TicketCache.toFile().exists()) {
+                    try {
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                            Tr.debug(tc, "krb5TicketCache is not a path to a file. Checking if it is a file URL.");
+                        }
+                        URL krb5TicketCacheUrl = new URL(rawKrb5TicketCache);
+                        File krb5TicketCacheFile = new File(krb5TicketCacheUrl.toURI());
+                        if (!krb5TicketCacheFile.exists()) {
+                            Tr.error(tc, WIMMessageKey.KRB5_FILE_NOT_FOUND, "krb5TicketCache", "<ldapRegistry>", rawKrb5TicketCache);
+                        } else if (!krb5TicketCacheFile.canRead()) {
+                            Tr.error(tc, WIMMessageKey.CANNOT_READ_KRB5_FILE, reposId, rawKrb5TicketCache);
+                        }
+                    } catch (MalformedURLException ex) {
+                        // catch blocks are separate due to a limitation of @FFDCIgnore
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                            Tr.debug(tc, "Could not find krb5TicketCache as a Path or URL: ", ex);
+                        }
+                        Tr.error(tc, WIMMessageKey.KRB5_FILE_NOT_FOUND, "krb5TicketCache", "<ldapRegistry>", rawKrb5TicketCache);
+                    } catch (URISyntaxException ex) {
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                            Tr.debug(tc, "Could not find krb5TicketCache as a Path or URL: ", ex);
+                        }
+                        Tr.error(tc, WIMMessageKey.KRB5_FILE_NOT_FOUND, "krb5TicketCache", "<ldapRegistry>", rawKrb5TicketCache);
+                    } catch (IllegalArgumentException ex) {
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                            Tr.debug(tc, "Could not find krb5TicketCache as a Path or URL: ", ex);
+                        }
+                        Tr.error(tc, WIMMessageKey.KRB5_FILE_NOT_FOUND, "krb5TicketCache", "<ldapRegistry>", rawKrb5TicketCache);
+                    }
+                } else if (!(new File(rawKrb5TicketCache)).canRead()) {
+                    Tr.error(tc, WIMMessageKey.CANNOT_READ_KRB5_FILE, reposId, rawKrb5TicketCache);
+                }
+            }
+
+            if (this.krb5TicketCache != null && (kerberosService != null && kerberosService.getKeytab() != null)) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "setKerberosCredentials the ticketCache and keytab were both configured, ticketCache is tried first, then keytab");
+                }
+            }
+
+            if (tc.isDebugEnabled()) {
+                StringBuffer strBuf = new StringBuffer();
+                strBuf.append("\tKrb5Principal: ").append(krb5Principal).append("\n");
+                strBuf.append("\tKrb5TicketCache: ").append(krb5TicketCache).append("\n");
+                if (kerberosService != null) {
+                    strBuf.append("\tkeytab (from KerberosService): ").append(kerberosService.getKeytab()).append("\n");
+                    strBuf.append("\tconfig (from KerberosService): ").append(kerberosService.getConfigFile()).append("\n");
+                }
+                Tr.debug(tc, "setKerberosCredentials" + strBuf.toString());
+            }
+        } finally {
+            releaseKrb5WriteLock();
+        }
+    }
+
+    /**
      * Set the SSL alias.
      *
      * @param sslAlias The SSL alias to use for outgoing SSL connections.
@@ -1603,6 +1767,144 @@ public class ContextManager {
         MISSING_PRIMARY_SERVER,
 
         /** Initialization succeeded with no errors. */
-        SUCCESS;
+        SUCCESS,
+
+        /**
+         * Initialization failed because a bindAuthMechanism was set to GSSAPI but either no password or an empty
+         * krb5PrincipalName was supplied.
+         */
+        MISSING_KRB5_PRINCIPAL_NAME;
     }
+
+    /**
+     * Create a subject with the configure Kerberos information, to be used for
+     * creating a DirContext
+     *
+     * @return
+     */
+    private Subject handleKerberos() throws LoginException, MalformedURLException {
+        final String METHODNAME = "handleKerberos";
+        if (!isKerberosBindAuth()) {
+            /*
+             * Caller is also gated by isKerberosBindAuth, leaving this check in case future calls are added.
+             */
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, METHODNAME + " Kerberos login method was called, but Kerberos is not enabled. BindAuthMechanism is " + bindAuthMechanism);
+            }
+            return null;
+        }
+        Subject subject = null;
+        acquireKrb5ReadLock();
+        try {
+            if (kerberosService == null) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, METHODNAME + " Kerberos login method was called, but the KerberosService is null. BindAuthMechanism is " + bindAuthMechanism);
+                }
+                Tr.error(tc, WIMMessageKey.KRB5_SERVICE_NOT_AVAILABLE, reposId, krb5Principal, bindAuthMechanism);
+                String msg = Tr.formatMessage(tc, WIMMessageKey.KRB5_SERVICE_NOT_AVAILABLE, WIMMessageHelper.generateMsgParms(reposId, krb5Principal, bindAuthMechanism));
+                throw new LoginException(msg);
+            }
+
+            try {
+                subject = kerberosService.getOrCreateSubject(krb5Principal, null, krb5TicketCache);
+            } catch (LoginException e) {
+                /*
+                 * Customize the exception, based on the provided krb5 config: ticketCache vs keytab vs default
+                 */
+                String msg = null;
+                if (krb5TicketCache != null) {
+                    msg = Tr.formatMessage(tc, WIMMessageKey.KRB5_LOGIN_FAILED_CACHE, WIMMessageHelper.generateMsgParms(krb5Principal, krb5TicketCache));
+                } else if (kerberosService.getKeytab() != null) {
+                    msg = Tr.formatMessage(tc, WIMMessageKey.KRB5_LOGIN_FAILED_KEYTAB, WIMMessageHelper.generateMsgParms(krb5Principal, kerberosService.getKeytab()));
+                } else {
+                    msg = Tr.formatMessage(tc, WIMMessageKey.KRB5_LOGIN_FAILED_DEFAULT_KEYTAB, WIMMessageHelper.generateMsgParms(krb5Principal, kerberosService.getKeytab()));
+                }
+                LoginException le = new LoginException(msg + " " + e.getClass().getName() + ": " + e.getMessage());
+                le.initCause(e);
+                throw le;
+            }
+        } finally {
+            releaseKrb5ReadLock();
+        }
+
+        return subject;
+    }
+
+    /**
+     * Is the bindAuthMechanism set to GSSAPI (Kerberos) ?
+     *
+     * @return
+     */
+    @Trivial
+    private boolean isKerberosBindAuth() {
+        if (ConfigConstants.CONFIG_BIND_AUTH_KRB5.equals(bindAuthMechanism)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * When invoked, this will dump the context pool (if enabled) and recreate the pool with the new kerberos configuration.
+     *
+     * @param ks
+     */
+    public void updateKerberosService(KerberosService ks) {
+        if (isKerberosBindAuth()) {
+            acquireKrb5WriteLock();
+            try {
+                kerberosService = ks;
+                if (iContextPoolEnabled) {
+                    try {
+                        /*
+                         * Do we want to refresh if ticketCache is enabled and only keytab changes? This could be unnecessary churn if the keytab is
+                         * only used for another config. However, if the customer is banking on the keytab working if the ticketCache fails, then
+                         * we'll be delaying refreshing the context pool.
+                         */
+                        reCreateDirContext(getDirContext(), "The Kerberos configuration was updated, refresh the context pool.");
+                    } catch (WIMSystemException e) {
+
+                    }
+                }
+            } finally {
+                releaseKrb5WriteLock();
+            }
+        }
+    }
+
+    /**
+     * Acquire the writer lock. To be used to prevent concurrent Kerberos config
+     * changes. Must be used with releaseWriteLock
+     */
+    @Trivial
+    void acquireKrb5WriteLock() {
+        kerberServiceModifyLock.writeLock().lock();
+    }
+
+    /**
+     * Release the writer lock. To be used to prevent concurrent Kerberos config
+     * changes. Must be used with acquireWriteLock
+     */
+    @Trivial
+    void releaseKrb5WriteLock() {
+        kerberServiceModifyLock.writeLock().unlock();
+    }
+
+    /**
+     * Acquire the reader lock. To be used to prevent concurrent Kerberos config
+     * changes. Must be used with releaseReadLock
+     */
+    @Trivial
+    void acquireKrb5ReadLock() {
+        kerberServiceModifyLock.readLock().lock();
+    }
+
+    /**
+     * Release the reader lock. To be used to prevent concurrent Kerberos config
+     * changes. Must be used with acquireReadLock
+     */
+    @Trivial
+    void releaseKrb5ReadLock() {
+        kerberServiceModifyLock.readLock().unlock();
+    }
+
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/test/com/ibm/ws/security/wim/adapter/ldap/context/ContextManagerTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/test/com/ibm/ws/security/wim/adapter/ldap/context/ContextManagerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -39,6 +39,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.ibm.websphere.security.wim.ConfigConstants;
 import com.ibm.ws.apacheds.EmbeddedApacheDS;
 import com.ibm.ws.security.wim.adapter.ldap.context.ContextManager.InitializeResult;
 import com.ibm.wsspi.kernel.service.utils.SerializableProtectedString;
@@ -714,6 +715,22 @@ public class ContextManagerTest {
         assertTrue("Did not find Return to Primary in toString: " + toString, toString.contains("iReturnToPrimary=true"));
     }
 
+    //@Test
+    public void testToStringKRB5() throws Exception {
+        ContextManager cm = new ContextManager();
+        cm.setPrimaryServer("localhost", primaryLdapServer.getLdapServer().getPort());
+        cm.setBindAuthMechanism(ConfigConstants.CONFIG_BIND_AUTH_KRB5);
+        cm.setKerberosCredentials("UnitTestLdap", null, "testPrincipal", "DummyTicketCache");
+        cm.initialize();
+
+        String toString = cm.toString();
+        assertTrue("Found find Bind DN in toString: " + toString, toString.contains("iBindDN="));
+        assertTrue("Did not find Primary Server in toString: " + toString, toString.contains("iPrimaryServer=localhost:" + primaryLdapServer.getLdapServer().getPort()));
+        assertTrue("Did not find bindAuthMeach in toString: " + toString, toString.contains("bindAuthMechanism=" + ConfigConstants.CONFIG_BIND_AUTH_KRB5));
+        assertTrue("Did not find krb5PrincipalName in toString: " + toString, toString.contains("krb5PrincipalName=testPrincipal"));
+        assertTrue("Did not find krb5TicketCache in toString: " + toString, toString.contains("krb5TicketCache=DummyTicketCache"));
+    }
+
     /**
      * Test setting the connection timeout. For JNDI this appears to cover the entire amount of time it
      * takes to bind (open connection and read the bind response), not just connect. Notice that the
@@ -820,5 +837,84 @@ public class ContextManagerTest {
             time = System.currentTimeMillis() - time;
             assertTrue("Expected connect timeout to be " + expectedTimeout + " millisecond.", time >= expectedTimeout && time <= (expectedTimeout + 100));
         }
+    }
+
+    /**
+     * Test {@link ContextManager#createDirContext()} with new BindAuthMechanism set to simple
+     */
+    @Test
+    public void createDirContextSetSimpleBindAuthentication() throws Exception {
+        ContextManager cm = new ContextManager();
+        cm.setBindAuthMechanism(ConfigConstants.CONFIG_AUTHENTICATION_TYPE_SIMPLE);
+        cm.setPrimaryServer("localhost", primaryLdapServer.getLdapServer().getPort());
+        cm.initialize();
+
+        TimedDirContext ctx = null;
+        try {
+            assertNotNull(cm.createDirContext(USER_DN, "password".getBytes()));
+        } finally {
+            if (ctx != null) {
+                ctx.close();
+            }
+        }
+    }
+
+    /**
+     * Test {@link ContextManager#createDirContext()} with new BindAuthMechanism set to none
+     */
+    @Test
+    public void createDirContextSetNoneBindAuthentication() throws Exception {
+        ContextManager cm = new ContextManager();
+        cm.setBindAuthMechanism(ConfigConstants.CONFIG_AUTHENTICATION_TYPE_NONE);
+        cm.setPrimaryServer("localhost", primaryLdapServer.getLdapServer().getPort());
+        cm.initialize();
+
+        TimedDirContext ctx = null;
+        try {
+            assertNotNull(cm.createDirContext(USER_DN, "password".getBytes()));
+        } finally {
+            if (ctx != null) {
+                ctx.close();
+            }
+        }
+    }
+
+    /**
+     * Call {@link ContextManager#initialize()} with GSSAPI set, but no principal name
+     */
+    @Test
+    public void initialize_MissingKrb5PrincipalName() throws Exception {
+        ContextManager cm = new ContextManager();
+        cm.setBindAuthMechanism(ConfigConstants.CONFIG_BIND_AUTH_KRB5);
+        cm.setPrimaryServer("localhost", primaryLdapServer.getLdapServer().getPort());
+
+        assertEquals(InitializeResult.MISSING_KRB5_PRINCIPAL_NAME, cm.initialize());
+    }
+
+    /**
+     * Call {@link ContextManager#initialize()} with GSSAPI set, but null principal name
+     */
+    @Test
+    public void initialize_NullKrb5PrincipalName() throws Exception {
+        ContextManager cm = new ContextManager();
+        cm.setBindAuthMechanism(ConfigConstants.CONFIG_BIND_AUTH_KRB5);
+        cm.setPrimaryServer("localhost", primaryLdapServer.getLdapServer().getPort());
+        cm.setKerberosCredentials("UnitTestLdap", null, null, "badFileName");
+
+        assertEquals(InitializeResult.MISSING_KRB5_PRINCIPAL_NAME, cm.initialize());
+    }
+
+
+    /**
+     * Call {@link ContextManager#initialize()} with GSSAPI set, but empty principal name
+     */
+    @Test
+    public void initialize_EmptyKrb5PrincipalName() throws Exception {
+        ContextManager cm = new ContextManager();
+        cm.setBindAuthMechanism(ConfigConstants.CONFIG_BIND_AUTH_KRB5);
+        cm.setPrimaryServer("localhost", primaryLdapServer.getLdapServer().getPort());
+        cm.setKerberosCredentials("UnitTestLdap", null, "", "badFileName");
+
+        assertEquals(InitializeResult.MISSING_KRB5_PRINCIPAL_NAME, cm.initialize());
     }
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/LDAPRegressionTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/LDAPRegressionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -85,7 +85,8 @@ public class LDAPRegressionTest {
     public static void teardownClass() throws Exception {
         try {
             if (libertyServer != null) {
-                libertyServer.stopServer();
+                /* Temporarily allow CWWKE0701E for testBetaFenceForBindAuthMech */
+                libertyServer.stopServer("CWWKE0701E");
             }
         } finally {
             if (ds != null) {
@@ -374,5 +375,27 @@ public class LDAPRegressionTest {
         listResults = VmmServiceServletConnection.convertToList("searchWithExpression", results);
         assertEquals(1, listResults.size());
         assertEquals("uid=Bob (Contractor),o=ibm,c=us", listResults.get(0));
+    }
+
+    /**
+     * Temporary fat test to ensure our Beta fence for bindAuthmechanism/GSSPI/Kerberos is working as expected.
+     *
+     * Can be removed when betaFence code is removed from LdapConnection
+     *
+     * Also remove CWWKE0701E from teardownClass
+     */
+    @Test
+    public void testBetaFenceForBindAuthMech() throws Exception {
+        final String methodName = "testBetaFenceForBindAuthMech";
+        ServerConfiguration clone = basicConfiguration.clone();
+        LdapRegistry ldap = createLdapRegistry(clone);
+        ldap.setBindAuthMechanism("simple");
+
+        updateConfigDynamically(libertyServer, clone);
+
+        Log.info(c, methodName, "Finished Liberty server update");
+
+        assertFalse("Did not find CWWKE0701E for beta fence in log", libertyServer.findStringsInLogs("CWWKE0701E").isEmpty());
+
     }
 }

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/wim/LdapRegistry.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/wim/LdapRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -69,6 +69,9 @@ public class LdapRegistry extends ConfigElement {
     private String certificateMapperId;
     private String timestampFormat;
     private ConfigElementList<LoginProperty> loginProperties;
+    private String bindAuthMechanism;
+    private String krb5PrincipalName;
+    private String krb5TicketCache;
 
     /**
      * @return the activedFilters
@@ -369,6 +372,27 @@ public class LdapRegistry extends ConfigElement {
      */
     public String getTimestampFormat() {
         return timestampFormat;
+    }
+
+    /**
+     * @return the bindAuthMechanism
+     */
+    public String getBindAuthMechanism() {
+        return bindAuthMechanism;
+    }
+
+    /**
+     * @return the krb5PrincipalName
+     */
+    public String getKrb5PrincipalName() {
+        return krb5PrincipalName;
+    }
+
+    /**
+     * @return the krb5TicketCache
+     */
+    public String getKrb5TicketCache() {
+        return krb5TicketCache;
     }
 
     /**
@@ -747,6 +771,30 @@ public class LdapRegistry extends ConfigElement {
         this.timestampFormat = timestampFormat;
     }
 
+    /**
+     * @param bindAuthMechanism the bindAuthMechanism to set
+     */
+    @XmlAttribute(name = "bindAuthMechanism")
+    public void setBindAuthMechanism(String bindAuthMechanism) {
+        this.bindAuthMechanism = bindAuthMechanism;
+    }
+
+    /**
+     * @param krb5PrincipalName the krb5PrincipalName to set
+     */
+    @XmlAttribute(name = "krb5PrincipalName")
+    public void setKrb5PrincipalName(String krb5PrincipalName) {
+        this.krb5PrincipalName = krb5PrincipalName;
+    }
+
+    /**
+     * @param TicketCache the TicketCache to set
+     */
+    @XmlAttribute(name = "TicketCache")
+    public void setKrb5TicketCache(String krb5TicketCache) {
+        this.krb5TicketCache = krb5TicketCache;
+    }
+
     @Override
     public String toString() {
         StringBuffer sb = new StringBuffer();
@@ -878,6 +926,15 @@ public class LdapRegistry extends ConfigElement {
         }
         if (loginProperties != null) {
             sb.append("loginProperty=\"").append(loginProperties).append("\" ");
+        }
+        if (bindAuthMechanism != null) {
+            sb.append("bindAuthMechanism=\"").append(bindAuthMechanism).append("\" ");
+        }
+        if (krb5PrincipalName != null) {
+            sb.append("krb5PrincipalName=\"").append(krb5PrincipalName).append("\" ");
+        }
+        if (krb5TicketCache != null) {
+            sb.append("krb5TicketCache=\"").append(krb5TicketCache).append("\" ");
         }
 
         sb.append("}");


### PR DESCRIPTION
Fixes #15640 

- Updated metatype to beta, added support to get notified on `<kerberos>` changes based on recommendations by Brent (the `default="*"` matches the `<kerberos>` config without needing an ID and to use wildcard, you need the `ibm:final=true`
- Added runtime beta fence code into LdapConnection
- Added KerberosService ref to LdapAdapter, `updatedKerberosService` is called when a modify happens on `<kerberos>`
- Added code to pass along KerberosService, the LdapRegistry ID and the config info down to ContextManager
- Added Kerberos runtime updates to ContextManager
- Set the authenticateWithPassword version of createDirContext to use simple (we were leaving it as default before).
- Added a FAT test to ensure the beta fencing works.
- Added bindAuthMechanism/krbPrincipal/ticketcache to FAT helper
- Some limited Unit tests that can be done without KRB infrsastructure

To-do next until we have our FAT Ldap infrastructure prepped.
More Unit tests
BindAuth Unit tests for simpl/none.

Manual testing non-FAT Active Directory Ldap server.
- Start a server with ticketCache
- Start a server with keytab/config
- Start a server with a keytab/config, update the keytab and confirm ldapRegistry reloads (duplicate keytab used so new bind is successful
- Start a server with keytab/confg, remove `<keberos>` config and confirm ldapRegistry reloads (bind fails as no default keytab is available)
- Locally modify `FATTestAD` to work with non-FAT Active Directory, run `checkPasswordWithBadCredentials`, `checkPasswordWithGoodCredentials` and `getUsersWithWildcardPatternReturnsTwoEntries`