### PR TITLE
create full fat sub categories

### DIFF
--- a/.github/workflow-scripts/GenerateCategories.java
+++ b/.github/workflow-scripts/GenerateCategories.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -16,43 +17,35 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 public class GenerateCategories {
-
-    /*
-     *
-     * Generate a JSON string in the format of:
-     //@formatter:off
-     {
-       "include": [
-         { "category": "foo" },
-         { "category": "bar" }
-       ]
-     }
-     //@formatter:on
-     */
-
+    
+    //Constants
     static final boolean DEBUG = false;
-
-    static final String TEST_CATEGORY_DIR = ".github/test-categories";
+    static final String TEST_CATEGORY_DIR = ".github/test-categories/";
     static final String MODIFIED_FILES_DIFF = ".github/modified_files.diff";
 
-    public static void main(String args[]) throws Exception {
+    //Calculations
+    static List<String> moddedFiles = getModifiedFiles();
+    static final Set<String> modifiedProjects = getModifiedProjects();
 
+
+    /**
+     * Main method - outputs a JSON string of in the format of: 
+     * <pre>
+     * {
+     *  "include": [
+     *      { "category": "foo" },
+     *      { "category": "bar" }
+     *  ]
+     * }
+     * </pre> 
+     * 
+     * @param args - Provide file location of PR summary so we can parse it for mentioned categories
+     * @throws Exception
+     */
+    public static void main(String args[]) throws Exception {
         debug("Starting");
 
-        debug("Inputs are: " + Arrays.toString(args));
-        Path prSummaryPath = null;
-        if (args != null && args.length > 0) {
-            prSummaryPath = Paths.get(args[0]);
-            if (!prSummaryPath.toFile().exists())
-                throw new FileNotFoundException(prSummaryPath.toAbsolutePath().toString());
-        }
-        debug("Received PR summary path: " + prSummaryPath);
-        String prSummary = prSummaryPath == null ? ""
-                : Files.readAllLines(prSummaryPath).stream().collect(Collectors.joining("\n"));
-        debug("PR summary text is:");
-        debug("=====================");
-        debug(prSummary);
-        debug("=====================");
+        String prSummary = getPRSummary(args);
 
         // Discover all categories by checking for files under .github/test-categories/
         SortedSet<String> allCategories = new TreeSet<>();
@@ -77,7 +70,7 @@ public class GenerateCategories {
         SortedSet<String> unmentionedCategories = new TreeSet<>(allCategories);
         unmentionedCategories.removeAll(mentionedCategories.values());
 
-        Set<String> modifiedProjects = getModifiedProjects();
+        // If this was a FAT Only change then we want to run Modified Categories + Mentioned Categories
         if (isFATOnlyChange()) {
             SortedSet<String> modifiedCategories = new TreeSet<>();
             debug("This is a FAT-only change. Will remove unrelated and unmentioned categories.");
@@ -101,11 +94,24 @@ public class GenerateCategories {
         List<String> finalCategories = new ArrayList<>();
         // If any FATs were modified at all, add special categories
         // that run directly modified buckets
-        if (getModifiedProjects().stream().anyMatch(proj -> proj.contains("_fat"))) {
+        List<String> modifiedFATs = modifiedProjects.stream().filter(f -> f.contains("_fat")).collect(Collectors.toList());
+        if (!modifiedFATs.isEmpty()) {
             debug("At least 1 FAT was modified in this PR.");
-            finalCategories.add("MODIFIED_LITE_MODE");
-            finalCategories.add("MODIFIED_FULL_MODE");
+
+            String liteCategory = "MODIFIED_LITE_MODE";
+            finalCategories.add(liteCategory);
+            Path liteOut = Paths.get(TEST_CATEGORY_DIR + liteCategory);
+
+            int partitionSize = 5;
+            for (int i = 0; i < modifiedFATs.size(); i += partitionSize) {
+                String fullCategory = "MODIFIED_FULL_MODE_" + (i / partitionSize);
+                finalCategories.add(fullCategory);
+                Path fullOut = Paths.get(TEST_CATEGORY_DIR + fullCategory);
+                Files.write(liteOut, modifiedFATs.subList(i, Math.min(i + partitionSize, modifiedFATs.size())), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+                Files.write(fullOut, modifiedFATs.subList(i, Math.min(i + partitionSize, modifiedFATs.size())), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+            }
         }
+        
         // now add mentioned categories in order
         finalCategories.addAll(mentionedCategories.values());
         // finally add all remaining categories
@@ -113,6 +119,11 @@ public class GenerateCategories {
 
         debug("Final categories are:");
         debug(finalCategories);
+
+        //Fail build here if we generate more categories than github can handle
+        if (finalCategories.size() >= 256) {
+            throw new RuntimeException("We generated 256 categories or more.  GitHub Actions has a hard limit on number of categories.");
+        }
 
         // Generate the result JSON
         String result = "{ \"include\": [";
@@ -133,6 +144,27 @@ public class GenerateCategories {
 
     }
 
+    // ####### HELPER METHODS ##########
+    private static String getPRSummary(String[] args) throws FileNotFoundException, IOException {
+        debug("Inputs are: " + Arrays.toString(args));
+        Path prSummaryPath = null;
+        if (args != null && args.length > 0) {
+            prSummaryPath = Paths.get(args[0]);
+            if (!prSummaryPath.toFile().exists())
+                throw new FileNotFoundException(prSummaryPath.toAbsolutePath().toString());
+        }
+        debug("Received PR summary path: " + prSummaryPath);
+        String prSummary = prSummaryPath == null ? ""
+                : Files.readAllLines(prSummaryPath).stream().collect(Collectors.joining("\n"));
+        debug("PR summary text is:");
+        debug("=====================");
+        debug(prSummary);
+        debug("=====================");
+
+        return prSummary;
+    }
+
+
     private static List<String> getBuckets(String category) throws IOException {
         Path categoryFile = Paths.get(TEST_CATEGORY_DIR + '/' + category);
         if (!categoryFile.toFile().exists()) {
@@ -142,29 +174,29 @@ public class GenerateCategories {
         return Files.readAllLines(categoryFile);
     }
 
-    private static List<String> moddedFiles = null;
-
-    private static List<String> getModifiedFiles() throws IOException {
-        if (moddedFiles != null)
-            return moddedFiles;
+    private static List<String> getModifiedFiles() {
         Path modifiedFilesPath = Paths.get(MODIFIED_FILES_DIFF);
         if (!modifiedFilesPath.toFile().exists()) {
             debug("Did not find any modified files.");
             return Collections.emptyList();
         }
 
-        return moddedFiles = Files.readAllLines(modifiedFilesPath).stream()//
-                .filter(f -> !f.isEmpty())//
-                .map(f -> {
-                    debug("Found modified file: " + f);
-                    return f;
-                }).collect(Collectors.toList());
+        try {
+            return Files.readAllLines(modifiedFilesPath).stream()
+            .filter(f -> !f.isEmpty())
+            .map(f -> {
+                debug("Found modified file: " + f);
+                return f;
+            }).collect(Collectors.toList());
+        } catch (IOException ioe) {
+            throw new RuntimeException("Tried to access " + modifiedFilesPath + ".  It exists but was inaccessible", ioe);
+        }
     }
 
-    private static Set<String> getModifiedProjects() throws IOException {
+    private static Set<String> getModifiedProjects() {
         Set<String> modifiedProjects = new HashSet<>();
 
-        for (String modifiedFile : getModifiedFiles()) {
+        for (String modifiedFile : moddedFiles) {
             if (modifiedFile.startsWith(TEST_CATEGORY_DIR))
                 continue;
             if (!modifiedFile.startsWith("dev/")) {
@@ -180,7 +212,6 @@ public class GenerateCategories {
     }
 
     private static boolean isFATOnlyChange() throws IOException {
-        Set<String> modifiedProjects = getModifiedProjects();
 
         if (modifiedProjects.isEmpty()) {
             debug("No modified projects found. Falling back to assuming NOT a FAT-only change.");
@@ -204,5 +235,4 @@ public class GenerateCategories {
             return;
         System.out.println(msg);
     }
-
 }

--- a/.github/workflow-scripts/check-fat-failures.sh
+++ b/.github/workflow-scripts/check-fat-failures.sh
@@ -3,25 +3,12 @@ set +e
 
 echo "Done running all FAT buckets. Checking for failures now."
 
-# If this is the special 'MODIFIED_*_MODE' job, figure out which buckets
-# were directly modfied so we can check for their results
-if [[ $CATEGORY =~ MODIFIED_.*_MODE ]]; then
-  git diff --name-only HEAD^...HEAD^2 >> modified_files.diff
-  echo "Modified files are:"
-  cat modified_files.diff
-  FAT_BUCKETS=$(sed -n "s/^dev\/\([^\/]*_fat[^\/]*\)\/.*$/\1/p" modified_files.diff | uniq)
-  if [[ -z $FAT_BUCKETS ]]; then
-    echo "No FATs were directly modfied. Skipping this job."
-    exit 0
-  fi
-else
-  # This is a regular category defined in .github/test-categories/
-  if [[ ! -f .github/test-categories/$CATEGORY ]]; then
-    echo "::error::Test category $CATEGORY does not exist. A file containing a list of FAT buckets was not found at .github/test-categories/$CATEGORY";
-    exit 1;
-  fi
-  FAT_BUCKETS=$(awk '!/^ *#/ && NF' .github/test-categories/$CATEGORY) #ignore comments starting with # and empty lines
+# This is a regular category defined in .github/test-categories/
+if [[ ! -f .github/test-categories/$CATEGORY ]]; then
+  echo "::error::Test category $CATEGORY does not exist. A file containing a list of FAT buckets was not found at .github/test-categories/$CATEGORY";
+  exit 1;
 fi
+FAT_BUCKETS=$(awk '!/^ *#/ && NF' .github/test-categories/$CATEGORY) #ignore comments starting with # and empty lines
 
 cd dev
 mkdir failing_buckets

--- a/.github/workflow-scripts/run-fat-build.sh
+++ b/.github/workflow-scripts/run-fat-build.sh
@@ -9,33 +9,23 @@ set +e
 # Override default LITE mode per-bucket timeout to 45m
 FAT_ARGS="-Dfattest.timeout=2700000"
 
-# If this is the special 'MODIFIED_*_MODE' job, figure out which buckets 
-# were directly modfied (if any) so they can be launched
-if [[ $CATEGORY =~ MODIFIED_.*_MODE ]]; then
-  if [[ $CATEGORY == 'MODIFIED_FULL_MODE' ]]; then
+# If this is the special 'MODIFIED_FULL_MODE' job then change the FAT_ARGS variable
+if [[ $CATEGORY =~ MODIFIED_FULL_MODE* ]]; then
     echo "FAT buckets in this job will run in FULL mode"
     # Give FULL mode buckets a 2h timeout each
     FAT_ARGS="-Dfat.test.mode=FULL -Dfattest.timeout=7200000"
-  fi
-  git diff --name-only HEAD^...HEAD^2 >> modified_files.diff
-  echo "Modified files are:"
-  cat modified_files.diff
-  FAT_BUCKETS=$(sed -n "s/^dev\/\([^\/]*_fat[^\/]*\)\/.*$/\1/p" modified_files.diff | uniq)
-  if [[ -z $FAT_BUCKETS ]]; then
-    echo "No FATs were directly modfied. Skipping this job."
-    exit 0
-  fi
-else
-  # This is a regular category defined in .github/test-categories/
-  if [[ ! -f .github/test-categories/$CATEGORY ]]; then
-    echo "::error::Test category [$CATEGORY] does not exist. A file containing a list of FAT buckets was not found at .github/test-categories/$CATEGORY";
-    exit 1;
-  fi
-  FAT_BUCKETS=$(awk '!/^ *#/ && NF' .github/test-categories/$CATEGORY) #ignore comments starting with # and empty lines
+fi 
+
+# This is a regular category defined in .github/test-categories/
+if [[ ! -f .github/test-categories/$CATEGORY ]]; then
+  echo "::error::Test category [$CATEGORY] does not exist. A file containing a list of FAT buckets was not found at .github/test-categories/$CATEGORY";
+  exit 1;
 fi
 
+FAT_BUCKETS=$(awk '!/^ *#/ && NF' .github/test-categories/$CATEGORY) #ignore comments starting with # and empty lines
+
 # Ensure all buckets we plan to run exist
-echo "::group:: Will be running buckets"
+echo "::group::Will be running buckets"
 for FAT_BUCKET in $FAT_BUCKETS
 do
   echo "$FAT_BUCKET"
@@ -47,7 +37,7 @@ done
 echo "::endgroup::"
 
 # For PR type events, set the git_diff for the change detector tool so unreleated FATs do not run
-if [[ $GH_EVENT_NAME == 'pull_request' && ! $CATEGORY =~ MODIFIED_.*_MODE ]]; then
+if [[ $GH_EVENT_NAME == 'pull_request' && ! $CATEGORY =~ MODIFIED_* ]]; then
   FAT_ARGS="$FAT_ARGS -Dgit_diff=HEAD^...HEAD^2"
   echo "This event is a pull request. Will run FATs with: $FAT_ARGS"
 fi

--- a/.github/workflows/openliberty-ci.yml
+++ b/.github/workflows/openliberty-ci.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
     branches: 
     - integration
-    - gh-actions
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - '.gitignore'
@@ -27,19 +26,20 @@ jobs:
   validate: #Perform validation before any other jobs run.  If we fail validation, don't run anything else.
     name: Validation
     runs-on: ubuntu-18.04
+    # Do not run on draft PRs
+    # Do not run scheduled builds on forked repos
+    if: |
+      github.event_name == 'pull_request' && (github.event.pull_request.draft == false && github.event.pull_request.state != 'closed') ||
+      github.event_name == 'schedule' && github.repository == 'OpenLiberty/open-liberty'
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 50
-    # - name: Validate rebase onto integration
-    #   if: "github.event_name == 'pull_request'"
-    #   run: .github/workflow-scripts/validate-rebase-integration.sh
     - name: Validate copyright headers
+      # Only validate copyright headers on Pull Requests
       if: "github.event_name == 'pull_request'"
       run: .github/workflow-scripts/validate-copyright-headers.sh
     - name: Validate tests
-      # Probably should only do this for PRs.  But for now always run so we can catch tests suites that get merged incorrectly
-      # if: "github.event_name == 'pull_request'"
       run: .github/workflow-scripts/validate-tests.sh
   build: #Main build always done on linix run in parallel to setup and unit-test
     name: Build Open Liberty
@@ -50,10 +50,10 @@ jobs:
       test-os: ${{ steps.gen-params.outputs.test-os }}
       test-java: ${{ steps.gen-params.outputs.test-java }}
     # Do not run on draft PRs
-    if: "github.event_name != 'pull_request' || ( \
-          github.event.pull_request.draft == false && \
-          github.event.pull_request.state != 'closed'
-        )"
+    # Do not run scheduled builds on forked repos
+    if: |
+      github.event_name == 'pull_request' && (github.event.pull_request.draft == false && github.event.pull_request.state != 'closed') ||
+      github.event_name == 'schedule' && github.repository == 'OpenLiberty/open-liberty'
     steps:
     - uses: actions/checkout@v2
       with:
@@ -103,16 +103,24 @@ jobs:
         name: openliberty-image
         if-no-files-found: error
         path: openliberty-image.zip
+    - name: Upload Modified Categories
+      uses: actions/upload-artifact@v2
+      with:
+        name: modified-categories
+        if-no-files-found: ignore
+        path: |
+          .github/test-categories/MODIFIED_LITE_MODE
+          .github/test-categories/MODIFIED_FULL_MODE*
   unit_tests: #Unit tests always run linux and java 11
     name: Unit Tests
     needs: validate
     runs-on: ubuntu-18.04
     timeout-minutes: 60
     # Do not run on draft PRs
-    if: "github.event_name != 'pull_request' || ( \
-          github.event.pull_request.draft == false && \
-          github.event.pull_request.state != 'closed'
-        )"
+    # Do not run scheduled builds on forked repos
+    if: |
+      github.event_name == 'pull_request' && (github.event.pull_request.draft == false && github.event.pull_request.state != 'closed') ||
+      github.event_name == 'schedule' && github.repository == 'OpenLiberty/open-liberty'
     steps:
     - uses: actions/checkout@v2
       with:
@@ -165,10 +173,10 @@ jobs:
     needs: [validate, build]
     runs-on: ${{ needs.build.outputs.test-os }}
     # Do not run on draft PRs
-    if: "github.event_name != 'pull_request' || ( \
-          github.event.pull_request.draft == false && \
-          github.event.pull_request.state != 'closed'
-        )"
+    # Do not run scheduled builds on forked repos
+    if: |
+      github.event_name == 'pull_request' && (github.event.pull_request.draft == false && github.event.pull_request.state != 'closed') ||
+      github.event_name == 'schedule' && github.repository == 'OpenLiberty/open-liberty'
     strategy:
       fail-fast: false
       max-parallel: 19
@@ -209,6 +217,12 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: openliberty-image
+    - name: Download modified categories
+      uses: actions/download-artifact@v2
+      id: modified-categories
+      with:
+        name: modified-categories
+        path: .github/test-categories
     - name: Run FAT buckets
       timeout-minutes: 150
       shell: bash

--- a/dev/com.ibm.ws.jdbc_fat_driver/fat/src/com/ibm/ws/jdbc/fat/driver/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_driver/fat/src/com/ibm/ws/jdbc/fat/driver/FATSuite.java
@@ -19,5 +19,4 @@ import org.junit.runners.Suite.SuiteClasses;
                 JDBCDriverManagerTest.class,
 })
 public class FATSuite {
-
 }

--- a/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_loadfromapp/fat/src/com/ibm/ws/jdbc/fat/loadfromapp/FATSuite.java
@@ -19,4 +19,5 @@ import org.junit.runners.Suite.SuiteClasses;
                 JDBCLoadFromAppTest.class
 
 })
-public class FATSuite {}
+public class FATSuite {
+}

--- a/dev/com.ibm.ws.jdbc_fat_v43/fat/src/com/ibm/ws/jdbc/fat/v43/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_v43/fat/src/com/ibm/ws/jdbc/fat/v43/FATSuite.java
@@ -18,4 +18,5 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({
                 JDBC43Test.class
 })
-public class FATSuite {}
+public class FATSuite {
+}


### PR DESCRIPTION
When making sweeping changes to many fat projects the MODIFIED_FULL_MODE job will typically timeout since all the FATs running in full mode takes too long.  Instead, break them into sub categories with 5 FAT buckets per category. 