### PR TITLE
Properly handle exceptions caught by Default Exception Mapper in mpMetrics-3.0.

### DIFF
--- a/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/MetricsJaxRsEMCallbackImpl.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/MetricsJaxRsEMCallbackImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,11 +10,15 @@
  *******************************************************************************/
 package io.openliberty.microprofile.metrics.internal.monitor;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.jaxrs.defaultexceptionmapper.DefaultExceptionMapperCallback;
 import com.ibm.ws.microprofile.metrics.impl.SharedMetricRegistries;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.util.AbstractMap;
 import java.util.Collections;
@@ -37,9 +41,9 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
 				"service.vendor=IBM" })
 public class MetricsJaxRsEMCallbackImpl  implements DefaultExceptionMapperCallback {
 
-	
+    private static final TraceComponent tc = Tr.register(MetricsJaxRsEMCallbackImpl.class);
 	public static final String EXCEPTION_KEY = MetricsJaxRsEMCallbackImpl.class.getName() + ".Exception";
-	
+	private static final String[] metriCDIBundles = {"io.astefanutti.metrics.cdi30", "io.openliberty.microprofile.metrics.internal.cdi30.interceptors"};
 	
 	public synchronized static Counter registerOrRetrieveRESTUnmappedExceptionMetric(String fullyQualifiedClassName, String methodSignature) {
 		MetricRegistry baseMetricRegistry = sharedMetricRegistry.getOrCreate(MetricRegistry.Type.BASE.getName());
@@ -57,14 +61,39 @@ public class MetricsJaxRsEMCallbackImpl  implements DefaultExceptionMapperCallba
 		
 		return counter;
 	}
-	
-	@Override
-	public Map<String, Object> onDefaultMappedException(Throwable t, int statusCode, ResourceInfo resourceInfo) {
-		Map.Entry<String, String> classXmethod = resolveSimpleTimerClassMethodTags(resourceInfo);
 
-		registerOrRetrieveRESTUnmappedExceptionMetric(classXmethod.getKey() ,classXmethod.getValue()).inc();
+	@Override
+	public Map<String, Object> onDefaultMappedException(Throwable throwable, int statusCode, ResourceInfo resourceInfo) {
+
+		StackTraceElement[] ste = throwable.getStackTrace();
+
+		/*
+		 * If the Exception originates from from the Metrics CDI Bundle we do not want to count
+		 * the exception.
+		 * 
+		 * Validate by checking the first element on the stack to see if it came from the two packages
+		 * in the Metrics CDI bundle that throws Exceptions.
+		 */
+		if (!(ste[0].getClassName().startsWith(metriCDIBundles[0]) || ste[0].getClassName().startsWith(metriCDIBundles[1]))) {
+			Map.Entry<String, String> classXmethod = resolveSimpleTimerClassMethodTags(resourceInfo);
+			registerOrRetrieveRESTUnmappedExceptionMetric(classXmethod.getKey() ,classXmethod.getValue()).inc();
+		}
+
+		/*
+		 * Will print out the stack trace as one string.
+		 * This is chosen over the alternative which is
+		 * throwable.printStackTrace() which will stream
+		 * every stack element/line as a logging event making
+		 * messages.log cluttered. The trade-off being that
+		 * internal classes are not hidden in the console
+		 * output.
+		 */
+		StringWriter sw = new StringWriter();
+		PrintWriter pw = new PrintWriter(sw);
+		throwable.printStackTrace(pw);
+		System.err.print(sw.toString());
 		
-		return Collections.singletonMap(EXCEPTION_KEY, t);
+		return Collections.singletonMap(EXCEPTION_KEY, throwable);
 	}
 
 	static SharedMetricRegistries sharedMetricRegistry;

--- a/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/MetricsJaxRsEMCallbackImpl.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/MetricsJaxRsEMCallbackImpl.java
@@ -41,9 +41,8 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
 				"service.vendor=IBM" })
 public class MetricsJaxRsEMCallbackImpl  implements DefaultExceptionMapperCallback {
 
-    private static final TraceComponent tc = Tr.register(MetricsJaxRsEMCallbackImpl.class);
 	public static final String EXCEPTION_KEY = MetricsJaxRsEMCallbackImpl.class.getName() + ".Exception";
-	private static final String[] metriCDIBundles = {"io.astefanutti.metrics.cdi30", "io.openliberty.microprofile.metrics.internal.cdi30.interceptors"};
+	private static final String[] metricCDIBundles = {"io.astefanutti.metrics.cdi30", "io.openliberty.microprofile.metrics.internal.cdi30.interceptors"};
 	
 	public synchronized static Counter registerOrRetrieveRESTUnmappedExceptionMetric(String fullyQualifiedClassName, String methodSignature) {
 		MetricRegistry baseMetricRegistry = sharedMetricRegistry.getOrCreate(MetricRegistry.Type.BASE.getName());
@@ -68,30 +67,18 @@ public class MetricsJaxRsEMCallbackImpl  implements DefaultExceptionMapperCallba
 		StackTraceElement[] ste = throwable.getStackTrace();
 
 		/*
-		 * If the Exception originates from from the Metrics CDI Bundle we do not want to count
+		 * If the Exception originates from the Metrics CDI Bundle we do not want to count
 		 * the exception.
 		 * 
 		 * Validate by checking the first element on the stack to see if it came from the two packages
 		 * in the Metrics CDI bundle that throws Exceptions.
 		 */
-		if (!(ste[0].getClassName().startsWith(metriCDIBundles[0]) || ste[0].getClassName().startsWith(metriCDIBundles[1]))) {
+		if (!(ste[0].getClassName().startsWith(metricCDIBundles[0]) || ste[0].getClassName().startsWith(metricCDIBundles[1]))) {
 			Map.Entry<String, String> classXmethod = resolveSimpleTimerClassMethodTags(resourceInfo);
 			registerOrRetrieveRESTUnmappedExceptionMetric(classXmethod.getKey() ,classXmethod.getValue()).inc();
 		}
 
-		/*
-		 * Will print out the stack trace as one string.
-		 * This is chosen over the alternative which is
-		 * throwable.printStackTrace() which will stream
-		 * every stack element/line as a logging event making
-		 * messages.log cluttered. The trade-off being that
-		 * internal classes are not hidden in the console
-		 * output.
-		 */
-		StringWriter sw = new StringWriter();
-		PrintWriter pw = new PrintWriter(sw);
-		throwable.printStackTrace(pw);
-		System.err.print(sw.toString());
+		throwable.printStackTrace();
 		
 		return Collections.singletonMap(EXCEPTION_KEY, throwable);
 	}

--- a/dev/io.openliberty.microprofile.metrics.internal.cdi.3.0/src/io/astefanutti/metrics/cdi30/MetricName.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.cdi.3.0/src/io/astefanutti/metrics/cdi30/MetricName.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2021 IBM Corporation and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -56,8 +56,18 @@ public class MetricName {
             return of((AnnotatedMember<?>) annotated);
         else if (annotated instanceof AnnotatedParameter)
             return of((AnnotatedParameter<?>) annotated);
-        else
-            throw new IllegalArgumentException("Unable to retrieve metric name for injection point [" + ip + "], only members and parameters are supported");
+        else {
+            /*
+             * Try and Catch to force an FFDC since the DefaultExceptionMapper is catching exceptions
+             * which does not result in FFDCs. Caught Exception generates an FFDC. The subsequent
+             * re-throw is caught by the DefaultExceptionMapper where it is printed out.
+             */
+            try {
+                throw new IllegalArgumentException("Unable to retrieve metric name for injection point [" + ip + "], only members and parameters are supported");
+            } catch (IllegalArgumentException exception) {
+                throw exception;
+            }
+        }
     }
 
     public String of(AnnotatedMember<?> member) {
@@ -104,8 +114,24 @@ public class MetricName {
                 throw new UnsupportedOperationException("Unable to retrieve name for parameter [" + parameter
                                                         + "], activate the -parameters compiler argument or annotate the injected parameter with the @Metric annotation");
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | ClassNotFoundException cause) {
-            throw new UnsupportedOperationException("Unable to retrieve name for parameter [" + parameter
-                                                    + "], @Metric annotation on injected parameter is required before Java 8");
+            /*
+             * Try and Catch to force an FFDC since the DefaultExceptionMapper is catching exceptions
+             * which does not result in FFDCs. Caught Exception generates an FFDC. The subsequent
+             * rethrow is caught by the DefaultExceptionMapper where it is printed out.
+             */
+            try {
+                throw new UnsupportedOperationException("Unable to retrieve name for parameter [" + parameter
+                                                        + "], @Metric annotation on injected parameter is required before Java 8");
+            } catch (UnsupportedOperationException exception) {
+                throw exception;
+            }
+        } catch (UnsupportedOperationException exception) {
+            /*
+             * This is to catch UnsupportedOperationException from above try block.
+             * Caught Exception here will generate an FFDC.
+             * Thrown Exception here will be caught by DefaultExceptionMapper to be printed out.
+             */
+            throw exception;
         }
     }
 

--- a/dev/io.openliberty.microprofile.metrics.internal.cdi.3.0/src/io/astefanutti/metrics/cdi30/MetricResolver.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.cdi.3.0/src/io/astefanutti/metrics/cdi30/MetricResolver.java
@@ -385,7 +385,7 @@ public class MetricResolver {
              */
             try {
                 throw new IllegalArgumentException("Cannot reuse metric with MetricID " + metricID.toString() + "with Metadata " + of.metadata().toString()
-                                                   + ". There already exists a Metadata fopr tthis metric name with different values: " + existingMetadata.toString());
+                                                   + ". There already exists a Metadata for this metric name with different values: " + existingMetadata.toString());
             } catch (IllegalArgumentException exception) {
                 throw exception;
             }

--- a/dev/io.openliberty.microprofile.metrics.internal.cdi.3.0/src/io/astefanutti/metrics/cdi30/MetricResolver.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.cdi.3.0/src/io/astefanutti/metrics/cdi30/MetricResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2021 IBM Corporation and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -229,7 +229,8 @@ public class MetricResolver {
         else if (SimplyTimed.class.isInstance(annotation))
             return ((SimplyTimed) annotation).name();
         else
-            throw new IllegalArgumentException("Unsupported Metrics forMethod [" + annotation.getClass().getName() + "]");
+            throwIAEUnsupportedMetric(annotation);
+        return null;
     }
 
     private boolean isMetricAbsolute(Annotation annotation) {
@@ -247,7 +248,8 @@ public class MetricResolver {
         else if (SimplyTimed.class.isInstance(annotation))
             return ((SimplyTimed) annotation).absolute();
         else
-            throw new IllegalArgumentException("Unsupported Metrics forMethod [" + annotation.getClass().getName() + "]");
+            throwIAEUnsupportedMetric(annotation);
+        return false;
     }
 
     private String[] getTags(Annotation annotation) {
@@ -264,7 +266,8 @@ public class MetricResolver {
         else if (SimplyTimed.class.isInstance(annotation))
             return ((SimplyTimed) annotation).tags();
         else
-            throw new IllegalArgumentException("Unsupported Metrics forMethod [" + annotation.getClass().getName() + "]");
+            throwIAEUnsupportedMetric(annotation);
+        return null;
 
     }
 
@@ -282,7 +285,8 @@ public class MetricResolver {
         else if (SimplyTimed.class.isInstance(annotation))
             return ((SimplyTimed) annotation).displayName();
         else
-            throw new IllegalArgumentException("Unsupported Metrics forMethod [" + annotation.getClass().getName() + "]");
+            throwIAEUnsupportedMetric(annotation);
+        return null;
 
     }
 
@@ -300,7 +304,8 @@ public class MetricResolver {
         else if (SimplyTimed.class.isInstance(annotation))
             return ((SimplyTimed) annotation).description();
         else
-            throw new IllegalArgumentException("Unsupported Metrics forMethod [" + annotation.getClass().getName() + "]");
+            throwIAEUnsupportedMetric(annotation);
+        return null;
     }
 
     private MetricType getType(Annotation annotation) {
@@ -317,7 +322,8 @@ public class MetricResolver {
         else if (SimplyTimed.class.isInstance(annotation))
             return MetricType.SIMPLE_TIMER;
         else
-            throw new IllegalArgumentException("Unsupported Metrics forMethod [" + annotation.getClass().getName() + "]");
+            throwIAEUnsupportedMetric(annotation);
+        return null;
     }
 
     private String getUnit(Annotation annotation) {
@@ -334,7 +340,21 @@ public class MetricResolver {
         else if (SimplyTimed.class.isInstance(annotation))
             return ((SimplyTimed) annotation).unit();
         else
-            throw new IllegalArgumentException("Unsupported Metrics forMethod [" + annotation.getClass().getName() + "]");
+            throwIAEUnsupportedMetric(annotation);
+        return null;
+    }
+
+    private void throwIAEUnsupportedMetric(Annotation annotation) throws IllegalArgumentException {
+        /*
+         * Try and Catch to force an FFDC since the DefaultExceptionMapper is catching exceptions
+         * which does not result in FFDCs. Caught Exception generates an FFDC. The subsequent
+         * rethrow is caught by the DefaultExceptionMapper where it is printed out.
+         */
+        try {
+            throw new IllegalArgumentException("Unsupported Metrics for Method [" + annotation.getClass().getName() + "]");
+        } catch (IllegalArgumentException exception) {
+            throw exception;
+        }
     }
 
     /**
@@ -359,8 +379,16 @@ public class MetricResolver {
          * Type check is conducted when registering/retrieving metric.
          */
         if ((existingMetadata != null && !existingMetadata.equals(of.metadata()))) {
-            throw new IllegalArgumentException("Cannot reuse metric with MetricID " + metricID.toString() + "with Metadata " + of.metadata().toString()
-                                               + ". There already exists a Metadata fopr tthis metric name with different values: " + existingMetadata.toString());
+            /*
+             * Try and Catch to force an FFDC since the DefaultExceptionMapper is catching exceptions
+             * which does not result in FFDCs.
+             */
+            try {
+                throw new IllegalArgumentException("Cannot reuse metric with MetricID " + metricID.toString() + "with Metadata " + of.metadata().toString()
+                                                   + ". There already exists a Metadata fopr tthis metric name with different values: " + existingMetadata.toString());
+            } catch (IllegalArgumentException exception) {
+                throw exception;
+            }
         }
         return true;
 

--- a/dev/io.openliberty.microprofile.metrics.internal.cdi.3.0/src/io/openliberty/microprofile/metrics/internal/cdi30/interceptors/CountedInterceptor.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.cdi.3.0/src/io/openliberty/microprofile/metrics/internal/cdi30/interceptors/CountedInterceptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2021 IBM Corporation and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -81,9 +81,18 @@ public class CountedInterceptor {
         MetricResolver.Of<Counted> counted = resolver.counted(bean.getBeanClass(), element);
         MetricID tmid = new MetricID(counted.metricName(), Utils.tagsToTags(counted.tags()));
         Counter counter = (Counter) registry.getMetric(tmid);
-        if (counter == null)
-            throw new IllegalStateException("No counter with metricID [" + tmid + "] found in registry [" + registry + "]");
-
+        if (counter == null) {
+            /*
+             * Try and Catch to force an FFDC since the DefaultExceptionMapper is catching exceptions
+             * which does not result in FFDCs. Caught Exception generates an FFDC. The subsequent
+             * rethrow is caught by the DefaultExceptionMapper where it is printed out.
+             */
+            try {
+                throw new IllegalStateException("No counter with metricID [" + tmid + "] found in registry [" + registry + "]");
+            } catch (IllegalStateException exception) {
+                throw exception;
+            }
+        }
         counter.inc();
         return context.proceed();
     }

--- a/dev/io.openliberty.microprofile.metrics.internal.cdi.3.0/src/io/openliberty/microprofile/metrics/internal/cdi30/interceptors/MeteredInterceptor.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.cdi.3.0/src/io/openliberty/microprofile/metrics/internal/cdi30/interceptors/MeteredInterceptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2021 IBM Corporation and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -82,8 +82,18 @@ public class MeteredInterceptor {
         MetricID tmid = new MetricID(metered.metricName(), Utils.tagsToTags(metered.tags()));
         Meter meter = (Meter) registry.getMetric(tmid);
 
-        if (meter == null)
-            throw new IllegalStateException("No meter with metricID [" + tmid + "] found in registry [" + registry + "]");
+        if (meter == null) {
+            /*
+             * Try and Catch to force an FFDC since the DefaultExceptionMapper is catching exceptions
+             * which does not result in FFDCs. Caught Exception generates an FFDC. The subsequent
+             * rethrow is caught by the DefaultExceptionMapper where it is printed out.
+             */
+            try {
+                throw new IllegalStateException("No meter with metricID [" + tmid + "] found in registry [" + registry + "]");
+            } catch (IllegalStateException exception) {
+                throw exception;
+            }
+        }
 
         meter.mark();
         return context.proceed();

--- a/dev/io.openliberty.microprofile.metrics.internal.cdi.3.0/src/io/openliberty/microprofile/metrics/internal/cdi30/interceptors/MetricsInterceptor.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.cdi.3.0/src/io/openliberty/microprofile/metrics/internal/cdi30/interceptors/MetricsInterceptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2021 IBM Corporation and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -178,7 +178,7 @@ public class MetricsInterceptor {
         public Object getValue() {
             try {
                 return invokeMethod(method, object);
-            } catch (IllegalStateException e) {
+            } catch (IllegalStateException exception) {
                 // This is likely due to an Application being unloaded, we need to unregister the invalid metric
                 // Need to use Factory to get registry.
                 MetricRegistryFactory.getApplicationRegistry().removeMatching(new MetricFilter() {
@@ -192,7 +192,7 @@ public class MetricsInterceptor {
                         return false;
                     }
                 });
-                throw e;
+                throw exception;
             }
         }
     }

--- a/dev/io.openliberty.microprofile.metrics.internal.cdi.3.0/src/io/openliberty/microprofile/metrics/internal/cdi30/interceptors/SimplyTimedInterceptor.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.cdi.3.0/src/io/openliberty/microprofile/metrics/internal/cdi30/interceptors/SimplyTimedInterceptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -81,8 +81,18 @@ public class SimplyTimedInterceptor {
         MetricResolver.Of<SimplyTimed> simplyTimed = resolver.simplyTimed(bean.getBeanClass(), element);
         MetricID MetricID = new MetricID(simplyTimed.metricName(), Utils.tagsToTags(simplyTimed.tags()));
         SimpleTimer simpleTimer = (SimpleTimer) registry.getMetric(MetricID);
-        if (simpleTimer == null)
-            throw new IllegalStateException("No timer with metricID [" + MetricID + "] found in registry [" + registry + "]");
+        if (simpleTimer == null) {
+            /*
+             * Try and Catch to force an FFDC since the DefaultExceptionMapper is catching exceptions
+             * which does not result in FFDCs. Caught Exception generates an FFDC. The subsequent
+             * rethrow is caught by the DefaultExceptionMapper where it is printed out.
+             */
+            try {
+                throw new IllegalStateException("No simple timer with metricID [" + MetricID + "] found in registry [" + registry + "]");
+            } catch (IllegalStateException exception) {
+                throw exception;
+            }
+        }
 
         SimpleTimer.Context time = simpleTimer.time();
         try {


### PR DESCRIPTION
Metrics Exception Mapper callback is to print the stack trace from exceptions caught by the JAXRS Default Exception Mapper.
In beta they use to just be consumed and were "lost". This is a bug. 

~~Current approach will build it into a single string and have it be print out to the System Error stream. This is chosen over the alternative which is to just `printStackTrace()` directly to the `System.err` stream. This causes each line of the stack trace to be an individual log record. This clutters the `message.log` (i.e one message per stack element). In an intense multi-thread environment the stack trace may be interleaved with other messages. The draw back of combining into a singular string before writing to `System.err` is that internal classes are not _combined_ with `at [internal classes]` in the console.~~


The intention in the future is to log the caught exception as a `WARNING`. This is similar to the mpOT approach.

Exceptions in Metrics CDI bundle to also be surrounded by try and catch to capture and generate an FFDC. The exceptions are re-thrown in the catch block to be _caught_ again by the Default Exception Mapper where the exception is then printed out.
#build 
fix #15715 