### PR TITLE
Revert surefire.verison from 2.19.1 to 2.17 for mpOpenApi TCKs

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -14,10 +14,11 @@
     <properties>
         <microprofile.openapi.version>2.0</microprofile.openapi.version>
 
-<!--         
-        <surefire.version>2.17</surefire.version> Any changes to the surefire version must be tested against ZOS
- -->
+     
+        <surefire.version>2.17</surefire.version> <!-- Any changes to the surefire version must be tested against ZOS-->
+<!--    
         <surefire.version>2.19.1</surefire.version>
+-->
 <!-- 
         <arquillian.version>1.1.13.Final</arquillian.version>
  -->


### PR DESCRIPTION
Resolves defect 277893 (hopefully)

#build

