### PR TITLE
Resolve various MP Rest Client test issues

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.security/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.security/bnd.bnd
@@ -29,7 +29,8 @@ Import-Package: \
   javax.net.ssl.*, \
   com.ibm.wsspi.ssl, \
   com.ibm.wsspi.kernel.service.utils, \
-  com.ibm.ws.jaxrs20.api
+  com.ibm.ws.jaxrs20.api, \
+  com.ibm.ws.ffdc
   
 # If you need use MESSAGE, you must enable this Private-Package, or message will translate wrong
 Private-Package:\

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,2 +1,2 @@
 -Dcom.ibm.tools.attach.enable=yes
--Xmx2048m
+-Xmx1024m

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,3 +1,3 @@
 -Dcom.ibm.tools.attach.enable=yes
 -Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=20
--Xmx2048m
+-Xmx1024m

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom.xml
@@ -120,6 +120,16 @@
 
         <dependency>
             <groupId>com.ibm.ws</groupId>
+            <artifactId>jaxrs21.common</artifactId>
+            <version>1.0</version>
+            <scope>system</scope>
+            <systemPath>${com.ibm.ws.jaxrs.2.1.common_}</systemPath>
+        </dependency>
+
+        
+
+        <dependency>
+            <groupId>com.ibm.ws</groupId>
             <artifactId>logging</artifactId>
             <version>1.0</version>
             <scope>system</scope>
@@ -265,7 +275,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
-                    <argLine>-Xmx2048m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>-Xmx1024m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,3 +1,3 @@
 -Dcom.ibm.tools.attach.enable=yes
 -Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=20
--Xmx2048m
+-Xmx1024m

--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/pom.xml
@@ -121,6 +121,14 @@
 
         <dependency>
             <groupId>com.ibm.ws</groupId>
+            <artifactId>jaxrs21.common</artifactId>
+            <version>1.0</version>
+            <scope>system</scope>
+            <systemPath>${com.ibm.ws.jaxrs.2.1.common_}</systemPath>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm.ws</groupId>
             <artifactId>logging</artifactId>
             <version>1.0</version>
             <scope>system</scope>
@@ -316,7 +324,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
-                    <argLine>-Xmx2048m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>-Xmx1024m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,3 +1,3 @@
 -Dcom.ibm.tools.attach.enable=yes
 -Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=20
--Xmx2048m
+-Xmx1024m

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/pom.xml
@@ -121,6 +121,14 @@
 
         <dependency>
             <groupId>com.ibm.ws</groupId>
+            <artifactId>jaxrs21.common</artifactId>
+            <version>1.0</version>
+            <scope>system</scope>
+            <systemPath>${com.ibm.ws.jaxrs.2.1.common_}</systemPath>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm.ws</groupId>
             <artifactId>logging</artifactId>
             <version>1.0</version>
             <scope>system</scope>
@@ -316,7 +324,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
-                    <argLine>-Xmx2048m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>-Xmx1024m -Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicTest.java
@@ -60,11 +60,11 @@ public class BasicTest extends FATServletClient {
     public static void setUp() throws Exception {
         ShrinkHelper.defaultDropinApp(remoteAppServer, "basicRemoteApp", "remoteApp.basic");
         remoteAppServer.startServer();
-        remoteAppServer.waitForStringInLog("CWWKO0219I"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8040.
+        remoteAppServer.waitForStringInLog("CWWKO0219I.*ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8040.
 
         ShrinkHelper.defaultDropinApp(server, appName, "mpRestClient10.basic");
         server.startServer();
-        server.waitForStringInLog("CWWKO0219I"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        server.waitForStringInLog("CWWKO0219I.*ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
 
     }
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/CollectionsTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/CollectionsTest.java
@@ -69,11 +69,11 @@ public class CollectionsTest extends FATServletClient {
         app.addAsLibraries(new File(JSONB_API).listFiles());
         ShrinkHelper.exportDropinAppToServer(remoteAppServer, app);
         remoteAppServer.startServer();
-        remoteAppServer.waitForStringInLog("CWWKO0219I"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        remoteAppServer.waitForStringInLog("CWWKO0219I.*ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
 
         ShrinkHelper.defaultDropinApp(server, appName, "mpRestClient10.collections");
         server.startServer();
-        server.waitForStringInLog("CWWKO0219I"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        server.waitForStringInLog("CWWKO0219I.*ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HandleResponsesTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HandleResponsesTest.java
@@ -61,11 +61,11 @@ public class HandleResponsesTest extends FATServletClient {
     public static void setUp() throws Exception {
         ShrinkHelper.defaultDropinApp(remoteAppServer, "basicRemoteApp", "remoteApp.basic");
         remoteAppServer.startServer();
-        remoteAppServer.waitForStringInLog("CWWKO0219I"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        remoteAppServer.waitForStringInLog("CWWKO0219I.*ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
 
         ShrinkHelper.defaultDropinApp(server, appName, "mpRestClient10.handleresponses");
         server.startServer();
-        server.waitForStringInLog("CWWKO0219I"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        server.waitForStringInLog("CWWKO0219I.*ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/ProduceConsumeTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/ProduceConsumeTest.java
@@ -51,7 +51,7 @@ public class ProduceConsumeTest extends FATServletClient {
     public static void setUp() throws Exception {
         ShrinkHelper.defaultDropinApp(server, appName, "mpRestClient11.produceConsume");
         server.startServer();
-        server.waitForStringInLog("CWWKO0219I"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        server.waitForStringInLog("CWWKO0219I.*ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,2 +1,2 @@
 -Dcom.ibm.tools.attach.enable=yes
--Xmx2048m
+-Xmx1024m

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,3 +1,3 @@
 -Dcom.ibm.tools.attach.enable=yes
 -Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=20
--Xmx2048m
+-Xmx1024m

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -136,6 +136,14 @@
 
         <dependency>
             <groupId>com.ibm.ws</groupId>
+            <artifactId>jaxrs21.common</artifactId>
+            <version>1.0</version>
+            <scope>system</scope>
+            <systemPath>${com.ibm.ws.jaxrs.2.1.common_}</systemPath>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm.ws</groupId>
             <artifactId>jaxrs.2.1.common</artifactId>
             <version>1.0</version>
             <scope>system</scope>


### PR DESCRIPTION
- ensure JAX-RS security bundle imports everything it needs
 (currently failing because it does not import com.ibm.ws.ffdc)
- adding jaxrs.2.1.common dependency for overly eager classloading
- reducing max heap size to 1GB since zOS cannot create a 2GB JVM...
- update logic to wait for ssl channel before running tests
