### PR TITLE
Feature file updates to fix some errors

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.cdi3.0-xmlws3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.cdi3.0-xmlws3.0.feature
@@ -5,7 +5,7 @@ IBM-App-ForceRestart: uninstall, \
  install
 IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.xmlWS-3.0))", \
-  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.cdi3.0))"
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.cdi-3.0))"
 IBM-Install-Policy: when-satisfied
 -features=com.ibm.websphere.appserver.jndi-1.0
 -bundles=com.ibm.ws.jaxws.cdi.jakarta

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/persistence-3.0/io.openliberty.persistence-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/persistence-3.0/io.openliberty.persistence-3.0.feature
@@ -222,7 +222,7 @@ IBM-API-Package: org.eclipse.persistence.descriptors.changetracking; type="inter
  org.eclipse.persistence.transaction; type="third-party", \
  org.eclipse.persistence; type="third-party"
 IBM-ShortName: persistence-3.0
-IBM-AlsoKnownAs: jpa-3.0
+WLP-AlsoKnownAs: jpa-3.0
 Subsystem-Name: Jakarta Persistence 3.0
 -features=com.ibm.websphere.appserver.eeCompatible-9.0, \
  com.ibm.websphere.appserver.transaction-2.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/persistenceContainer-3.0/io.openliberty.persistenceContainer-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/persistenceContainer-3.0/io.openliberty.persistenceContainer-3.0.feature
@@ -6,7 +6,7 @@ kind=beta
 edition=core
 Subsystem-Name: Jakarta Persistence 3.0 Container
 IBM-ShortName: persistenceContainer-3.0
-IBM-AlsoKnownAs: jpaContainer-3.0
+WLP-AlsoKnownAs: jpaContainer-3.0
 IBM-API-Package: jakarta.persistence; type="spec", \
  jakarta.persistence.spi; type="spec", \
  jakarta.persistence.criteria; type="spec", \

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1


### PR DESCRIPTION
- Update to correct the name of the dependent feature in xmlws / cdi auto feature.
- Update to use WLP-AlsoKnownAs instead of IBM-AlsoKnownAs
- Add missing bndtools prefs files for new fat projects.
