### PR TITLE
Issue 15787: Move Kerberos messages to correct file

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap/resources/com/ibm/ws/security/wim/adapter/ldap/resources/LdapUtilMessages.nlsprops
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/resources/com/ibm/ws/security/wim/adapter/ldap/resources/LdapUtilMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2012, 2013 IBM Corporation and others.
+# Copyright (c) 2012, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -229,3 +229,44 @@ LOGINPROPERTY_OVERRIDE_USERFILTER.useraction=If the userFilter attribute is pref
 INVALID_LOGIN_PROPERTIES=CWIML4506E: The following login properties are not valid: {0}.
 INVALID_LOGIN_PROPERTIES.explanation=One or more login properties are not valid WIM PersonAccount properties.
 INVALID_LOGIN_PROPERTIES.useraction=Either choose valid PersonAccount properties or add the properties to PersonAccount as extended properties. Ensure that the case for each login property matches the case for the corresponding PersonAccount property.
+
+
+KRB5_LOGIN_FAILED_CACHE=CWIML4507E: Kerberos login failed with the {0} Kerberos principal and the {1} Kerberos credential cache (ccache).
+KRB5_LOGIN_FAILED_CACHE.explanation=Either the specified Kerberos principal is invalid, or the Kerberos credential cache (ccache) is invalid or expired.
+KRB5_LOGIN_FAILED_CACHE.useraction=Ensure that a valid Kerberos principal is specified, and that the Kerberos credential cache (ccache) is not expired.
+
+KRB5_LOGIN_FAILED_KEYTAB=CWIML4508E: Kerberos login failed with the {0} Kerberos principal and the {1} Kerberos keytab.
+KRB5_LOGIN_FAILED_KEYTAB.explanation=Either the specified Kerberos principal is invalid, or the Kerberos keytab is invalid.
+KRB5_LOGIN_FAILED_KEYTAB.useraction=Ensure that a valid Kerberos principal is specified, and that a valid Kerberos keytab containing the Kerberos principal is specified.
+		
+KRB5_LOGIN_FAILED_DEFAULT_CACHE=CWIML4509E: Kerberos login failed with the {0} Kerberos principal and the default Kerberos credential cache (ccache).
+KRB5_LOGIN_FAILED_DEFAULT_CACHE.explanation=Either the specified Kerberos principal is invalid, or the default Kerberos credential cache (ccache) is invalid or expired.
+KRB5_LOGIN_FAILED_DEFAULT_CACHE.useraction=Ensure that a valid Kerberos principal is specified, and that the default Kerberos credential cache (ccache) is not expired.
+
+KRB5_LOGIN_FAILED_DEFAULT_KEYTAB=CWIML4510E: Kerberos login failed with the {0} Kerberos principal and the default Kerberos keytab.
+KRB5_LOGIN_FAILED_DEFAULT_KEYTAB.explanation=Either the specified Kerberos principal is invalid, or the default Kerberos keytab is invalid.
+KRB5_LOGIN_FAILED_DEFAULT_KEYTAB.useraction=Ensure that a valid Kerberos principal is specified and that the default Kerberos keytab is valid.
+
+KRB5_TICKETCACHE_USED=CWIML4511E: The {0} LdapRegistry is configured with the {1} Kerberos ticket cache (ccache) filename and the {2} keytab filename. The Kerberos credential cache (ccache) is used for Kerberos bind authentication to LDAP server.
+KRB5_TICKETCACHE_USED.explanation=To use the keytab file, the keytab filename must be specified and the Kerberos credential cache (ccache) filename must not be specified.
+KRB5_TICKETCACHE_USED.useraction=No action is required. To avoid this message, remove either the LdapRegistry ticketCache attribute or the Kerberos keytab attribute.
+
+INVALID_KRB5_PRINCIPAL=CWIML4512E: The {0} Kerberos principal name is incorrectly formatted, or the realm name is missing, or a default realm name cannot be found.
+INVALID_KRB5_PRINCIPAL.explanation=The Kerberos principal name cannot be null. The principal name must either include the realm name or a default realm name must be defined in Kerberos configuration file.
+INVALID_KRB5_PRINCIPAL.useraction=Correct the principal name or add a default realm name.
+
+CANNOT_READ_KRB5_FILE=CWIML4513E: The {0} LdapRegistry cannot read the {1} Kerberos file.
+CANNOT_READ_KRB5_FILE.explanation=The Kerberos file cannot be opened. Either the file permissions are incorrect, or the file does not exist.
+CANNOT_READ_KRB5_FILE.useraction=Verify that the file location is correct and that the server has read file permissions.
+
+KRB5_PRINCIPAL_REQUIRED=CWIML4514E: The bind authentication mechanism on the {0} LdapRegistry is set to GSSAPI, but the required attribute, krb5Principal, is not configured.
+KRB5_PRINCIPAL_REQUIRED.explanation=The Kerberos principal name is required when GSSAPI (Kerberos) is enabled.
+KRB5_PRINCIPAL_REQUIRED.useraction=Add a krb5Principal attribute to the krbAuthentication elemenent on the LdapRegistry element.
+
+KRB5_FILE_NOT_FOUND=CWIML4515E: The {0} attribute from the {1} element is configured to a file that does not exist at the following location: {2}
+KRB5_FILE_NOT_FOUND.explanation=The configuration refers to a file that is either unreadable or does not exist.
+KRB5_FILE_NOT_FOUND.useraction=Ensure that the configuration points to a file that exists and is readable by the application process.
+
+KRB5_FILE_FOUND=CWIML4516E: The LdapRegistry component is configured to use a {0} file that is located at {1}.
+KRB5_FILE_FOUND.explanation=The configured file was successfully located.
+KRB5_FILE_FOUND.useraction=No action is required.

--- a/dev/com.ibm.ws.security.wim.core/resources/com/ibm/ws/security/wim/util/resources/WimUtilMessages.nlsprops
+++ b/dev/com.ibm.ws.security.wim.core/resources/com/ibm/ws/security/wim/util/resources/WimUtilMessages.nlsprops
@@ -271,35 +271,3 @@ CANNOT_WRITE_TO_READ_ONLY_REPOSITORY.useraction=Ensure that a write operation is
 REQUIRED_IDENTIFIERS_MISSING=CWIML3001W: The required identifiers for the entity are missing.
 REQUIRED_IDENTIFIERS_MISSING.explanation=The identifiers uniqueName and uniqueId are not specified. At least one identifier must be specified.
 REQUIRED_IDENTIFIERS_MISSING.useraction=Ensure that the identifier property is specified for each entity that is passed in. If an identifier is not specified, add the property and specify either the uniqueName or the uniqueId.
-
-KRB5_LOGIN_FAILED_CACHE=CWIML4553E: Kerberos login failed using Kerberos principal {0} and Kerberos credential cache (ccache) {1}.
-KRB5_LOGIN_FAILED_CACHE.explanation=Either the specified Kerberos principal is invalid, or the Kerberos credential cache (ccache) is invalid or expired.
-KRB5_LOGIN_FAILED_CACHE.useraction=Ensure that a valid Kerberos principal is specified, and that the Kerberos credential cache (ccache) is not expired.
-
-KRB5_LOGIN_FAILED_KEYTAB=CWIML4554E: Kerberos login failed using Kerberos principal {0} and Kerberos keytab {1}.
-KRB5_LOGIN_FAILED_KEYTAB.explanation=Either the specified Kerberos principal is invalid, or the Kerberos keytab is invalid.
-KRB5_LOGIN_FAILED_KEYTAB.useraction=Ensure that a valid Kerberos principal is specified, and that a valid Kerberos keytab containing the Kerberos principal is specified.
-		
-KRB5_LOGIN_FAILED_DEFAULT_CACHE=CWIML4555E: Kerberos login failed using Kerberos principal {0} and the default Kerberos credential cache (ccache).
-KRB5_LOGIN_FAILED_DEFAULT_CACHE.explanation=Either the specified Kerberos principal is invalid, or the default Kerberos credential cache (ccache) is invalid or expired.
-KRB5_LOGIN_FAILED_DEFAULT_CACHE.useraction=Ensure that a valid Kerberos principal is specified, and that the default Kerberos credential cache (ccache) is not expired.
-
-KRB5_LOGIN_FAILED_DEFAULT_KEYTAB=CWIML4556E: Kerberos login failed using Kerberos principal {0} and the default Kerberos keytab.
-KRB5_LOGIN_FAILED_DEFAULT_KEYTAB.explanation=Either the specified Kerberos principal is invalid, or the default Kerberos keytab is invalid.
-KRB5_LOGIN_FAILED_DEFAULT_KEYTAB.useraction=Ensure that a valid Kerberos principal is specified and that the default Kerberos keytab is valid.
-
-KRB5_TICKETCACHE_USED=CWIML4557I: The {0} LdapRegistry is configured with a Kerberos ticket cache (ccache) filename {1} and keytab filename {2}. The Kerberos credential cache (ccache) is used for Kerberos bind authentication to LDAP server.
-KRB5_TICKETCACHE_USED.explanation=In order to use the keytab file, the keytab filename must be specified and the Kerberos credential cache (ccache) filename must not be specified.
-KRB5_TICKETCACHE_USED.useraction=No action is required. To avoid this message, remove either the LdapRegistry ticketCache attribute or the Kerberos keytab attribute.
-
-INVALID_KRB5_PRINCIPAL=CWIML4558E: The {0} Kerberos principal name is incorrectly formatted, or the realm name is missing, or a default realm name cannot be found.
-INVALID_KRB5_PRINCIPAL.explanation=The Kerberos principal name cannot be null. The principal name must either include the realm name or a default realm name must be defined in Kerberos configuration file.
-INVALID_KRB5_PRINCIPAL.useraction=Correct the principal name or add a default realm name.
-
-CANNOT_READ_KRB5_FILE=CWIML4559E:The {0} LdapRegistry cannot read the Kerberos file at {1}.
-CANNOT_READ_KRB5_FILE.explanation=The Kerberos file cannot be opened. Either the file permissions are incorrect, or the file does not exist.
-CANNOT_READ_KRB5_FILE.useraction=Verify that the file location is correct and that the server has read file permissions.
-
-KRB5_PRINCIPAL_REQUIRED=CWIML4559E: The bind authentication mechanism on the {0} LdapRegistry is set to GSSAPI, but the required attribute, krb5Principal, is not configured.
-KRB5_PRINCIPAL_REQUIRED.explanation=The Kerberos principal name is required when GSSAPI (Kerberos) is enabled.
-KRB5_PRINCIPAL_REQUIRED.useraction=Add a krb5Principal attribute to the krbAuthentication elemenent on the LdapRegistry element.  


### PR DESCRIPTION
Fixes #15787 

Accidentally put the new Kerberos messages in the general WIM file instead of the LDAP file.