### PR TITLE
CL22321 add callback for policy executor shutdown

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
@@ -272,6 +272,15 @@ public interface PolicyExecutor extends ExecutorService {
     Runnable registerQueueSizeCallback(int minAvailable, Runnable callback);
 
     /**
+     * Registers a one-time callback to be invoked inline when the
+     * policy executor shuts down. This method is intended for optional use
+     * on a newly created policy executor instance.
+     *
+     * @param callback the callback, or null to unregister.
+     */
+    void registerShutdownCallback(Runnable callback);
+
+    /**
      * Applies when using the <code>execute</code> or <code>submit</code> methods. Indicates whether or not to run the task on the
      * caller's thread when the queue is full and the <code>maxWaitForEnqueue</code> has been exceeded.
      * The default value is false, in which case the task submission is rejected after the <code>maxWaitForEnqueue</code> elapses

--- a/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
+++ b/dev/com.ibm.ws.threading_policy_fat/test-applications/basicfat/src/web/PolicyExecutorServlet.java
@@ -5341,6 +5341,19 @@ public class PolicyExecutorServlet extends FATServlet {
         assertTrue(executor.awaitTermination(TIMEOUT_NS, TimeUnit.NANOSECONDS));
     }
 
+    // Register a callback for shutdown. Verify that it gets invoked for both shutdown and shutdownNow methods.
+    @Test
+    public void testShutdownCallback() throws Exception {
+        PolicyExecutor executor1 = provider.create("testShutdownCallback-1");
+        PolicyExecutor executor2 = provider.create("testShutdownCallback-2");
+        AtomicInteger count = new AtomicInteger();
+        executor1.registerShutdownCallback(() -> count.addAndGet(1));
+        executor2.registerShutdownCallback(() -> count.addAndGet(2));
+        executor1.shutdown();
+        executor2.shutdownNow();
+        assertEquals(3, count.get());
+    }
+
     // Submit a task that gets queued but times out (due to startTimeout) before it can run.
     @Test
     public void testStartTimeout() throws Exception {


### PR DESCRIPTION
Add a shutdown callback to the policy executor to enable services that build on top of it which require additional shutdown logic.