### PR TITLE
Remove artifact manifest file after bvt

### DIFF
--- a/dev/com.ibm.ws.artifact_fat_bvt/fat/src/com/ibm/ws/artifact/fat_bvt/test/FATArtifactBVT.java
+++ b/dev/com.ibm.ws.artifact_fat_bvt/fat/src/com/ibm/ws/artifact/fat_bvt/test/FATArtifactBVT.java
@@ -53,6 +53,8 @@ public class FATArtifactBVT {
     }
 
     public static void tearDownServer() throws Exception {
+        
+        server.deleteFileFromLibertyInstallRoot( "/lib/features/artifactinternals-1.0.mf" );
         server = null;
     }
 

--- a/dev/com.ibm.ws.artifact_fat_bvt/fat/src/com/ibm/ws/artifact/fat_bvt/test/FATArtifactBVT.java
+++ b/dev/com.ibm.ws.artifact_fat_bvt/fat/src/com/ibm/ws/artifact/fat_bvt/test/FATArtifactBVT.java
@@ -55,7 +55,8 @@ public class FATArtifactBVT {
     public static void tearDownServer() throws Exception {
         
         server.deleteFileFromLibertyInstallRoot( "/lib/features/artifactinternals-1.0.mf" );
-        server = null;
+        server = null; 
+        
     }
 
     public static LibertyServer getServer() {


### PR DESCRIPTION
The artifact bvt test bucket is leaving a artifactinternals-1.0.mf file in /wlp/lib/features which is causing problems (manifest header not valid) in another test (PackageRunnableTest).  Updating bucket to delete this file upon exit.