### PR TITLE
ExternalBuild needs 3.4.1 version

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1184,7 +1184,7 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-transports-http</artifactId>
-      <version>3.4.1-20201002</version>
+      <version>3.4.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -232,7 +232,7 @@ org.apache.cxf:cxf-rt-security:3.4.1
 org.apache.cxf:cxf-rt-transports-http-hc:3.4.1
 org.apache.cxf:cxf-rt-transports-http:2.6.2
 org.apache.cxf:cxf-rt-transports-http:3.1.18
-org.apache.cxf:cxf-rt-transports-http:3.4.1-20201002
+org.apache.cxf:cxf-rt-transports-http:3.4.1
 org.apache.cxf:cxf-rt-ws-addr:3.4.1
 org.apache.cxf:cxf-rt-ws-mex:3.4.1
 org.apache.cxf:cxf-rt-ws-policy:3.4.1


### PR DESCRIPTION
Reverting this change that used the version that existed in internal artifactory - but External build needs old version.