### PR TITLE
Update to use snapshot version of TCK with added timeout padding

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -95,6 +95,7 @@ org.apache.santuario:xmlsec:1.5.2-ibm
 org.apache.ws.security:wss4j:1.6.7-ibm-s20130913-2015
 org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.0-20191203
 org.eclipse.microprofile.graphql:microprofile-graphql-tck:1.0.0-20191203
+org.eclipse.microprofile.rest.client:microprofile-rest-client-tck:2.0.1-20210208
 org.mock-server:mockserver-core:3.10.7-IBM20191022
 org.mock-server:mockserver-core:3.10.7-IBM20191022
 org.openid4java:openid4java:0.9.7-ibm-s20130624-1827

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/fat/src/org/eclipse/microprofile/rest/client/tck/RestClientTckPackageTest.java
@@ -10,9 +10,17 @@
  *******************************************************************************/
 package org.eclipse.microprofile.rest.client.tck;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
@@ -29,6 +37,20 @@ public class RestClientTckPackageTest {
 
     @Server("FATServer")
     public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+    	String javaVersion = System.getProperty("java.version");
+    	Log.info(RestClientTckPackageTest.class, "setup", "javaVersion: " + javaVersion);
+    	System.out.println("java.version = " + javaVersion);
+    	if (javaVersion.startsWith("1.8")) {
+    		Path cwd = Paths.get(".");
+    		Log.info(RestClientTckPackageTest.class, "setup", "cwd = " +  cwd.toAbsolutePath());
+    		Path java8File = Paths.get("publish/tckRunner/tck/tck-suite.xml-java8");
+    	    Path tckSuiteFile = Paths.get("publish/tckRunner/tck/tck-suite.xml");
+    	    Files.copy(java8File, tckSuiteFile, StandardCopyOption.REPLACE_EXISTING);
+    	}
+    }
 
     @AfterClass
     public static void tearDown() throws Exception {

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,3 +1,3 @@
 -Dcom.ibm.tools.attach.enable=yes
--Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=20
+-Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=20000
 -Xmx1024m

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -17,8 +17,18 @@
     <version>2.0</version>
     <name>MicroProfile RestClient 2.0 TCK Runner TCK Module</name>
 
+    <repositories>
+    	<repository>
+    		<id>ibmdhe</id>
+    		<name>IBM_DHE File Server</name>
+    		<url>http://public.dhe.ibm.com/ibmdl/export/pub/software/olrepo</url>
+    		<releases><enabled>true</enabled><updatePolicy>always</updatePolicy></releases>
+            <snapshots><enabled>true</enabled><updatePolicy>always</updatePolicy></snapshots>
+    	</repository>
+    </repositories>
+
     <properties>
-        <microprofile.rest.client.version>2.0</microprofile.rest.client.version>
+        <microprofile.rest.client.version>2.0.1-20210208</microprofile.rest.client.version>
         <arquillian.version>1.1.13.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml-java8
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml-java8
@@ -1,0 +1,22 @@
+<!--Copyright (c) 2021 IBM Corporation and others. All rights reserved.
+    This program and the accompanying materials are made available under the 
+    terms of the Eclipse Public License v1.0 which accompanies this distribution, 
+    and is available at 
+        http://www.eclipse.org/legal/epl-v10.html 
+    Contributors: 
+        IBM Corporation - initial API and implementation
+-->
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="microprofile-rest.client-2.0-tck" verbose="2"
+    configfailurepolicy="continue">
+    <test name="tck-package-org.eclipse.microprofile.rest.client.tck">
+        <packages>
+            <package name="org.eclipse.microprofile.rest.client.tck"/>
+            <package name="org.eclipse.microprofile.rest.client.tck.asynctests"/>
+            <package name="org.eclipse.microprofile.rest.client.tck.cditests"/>
+            <package name="org.eclipse.microprofile.rest.client.tck.jsonb"/>
+            <package name="org.eclipse.microprofile.rest.client.tck.timeout"/>
+        </packages>
+    </test>
+</suite>


### PR DESCRIPTION
This pulls in a snapshot build of the MP Rest Client 2.0 TCK that has some extra padding allowing us to work around JDK issues with time unit conversion rounding and inaccuracies with `System.nanoTime()`.
