### PR TITLE
Remove FT 3.0 dependency on concurrency-1.0

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpFaultTolerance-3.0/com.ibm.websphere.appserver.mpFaultTolerance-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpFaultTolerance-3.0/com.ibm.websphere.appserver.mpFaultTolerance-3.0.feature
@@ -10,7 +10,6 @@ IBM-ShortName: mpFaultTolerance-3.0
 Subsystem-Name: MicroProfile Fault Tolerance 3.0
 -features=com.ibm.websphere.appserver.org.eclipse.microprofile.faulttolerance-3.0, \
  com.ibm.websphere.appserver.cdi-2.0, \
- com.ibm.websphere.appserver.concurrent-1.0,\
  com.ibm.websphere.appserver.mpConfig-2.0, \
  io.openliberty.mpCompatible-4.0
 -bundles=com.ibm.ws.microprofile.faulttolerance; apiJar=false; location:="lib/", \

--- a/dev/com.ibm.ws.microprofile.faulttolerance.1.0/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.1.0/bnd.bnd
@@ -35,24 +35,23 @@ src: src
 testsrc: test/src
 
 -buildpath: \
-        com.ibm.ws.microprofile.faulttolerance;version=latest, \
-        com.ibm.ws.net.jodah.failsafe.1.0.4;version=latest, \
-        com.ibm.ws.logging;version=latest, \
-        com.ibm.ws.logging.core;version=latest, \
-        org.eclipse.osgi;version=latest, \
-        com.ibm.websphere.appserver.spi.kernel.service;version=latest,\
-        com.ibm.websphere.org.osgi.core;version=latest, \
-        com.ibm.websphere.org.osgi.service.component;version=latest, \
-        com.ibm.wsspi.org.osgi.service.component.annotations;version=latest, \
-        com.ibm.websphere.org.eclipse.microprofile.faulttolerance.1.0;version=latest, \
-        com.ibm.ws.microprofile.faulttolerance.spi;version=latest, \
-        com.ibm.ws.kernel.service;version=latest, \
-        com.ibm.ws.context;version=latest, \
-        com.ibm.websphere.security;version=latest, \
-        com.ibm.websphere.javaee.annotation.1.2;version=latest, \
-        com.ibm.websphere.javaee.concurrent.1.0;version=latest, \
-        com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
-        com.ibm.ws.threading;version=latest
+	com.ibm.ws.microprofile.faulttolerance;version=latest,\
+	com.ibm.ws.net.jodah.failsafe.1.0.4;version=latest,\
+	com.ibm.ws.logging;version=latest,\
+	com.ibm.ws.logging.core;version=latest,\
+	org.eclipse.osgi;version=latest,\
+	com.ibm.websphere.appserver.spi.kernel.service;version=latest,\
+	com.ibm.websphere.org.osgi.core;version=latest,\
+	com.ibm.websphere.org.osgi.service.component;version=latest,\
+	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+	com.ibm.websphere.org.eclipse.microprofile.faulttolerance.1.0;version=latest,\
+	com.ibm.ws.microprofile.faulttolerance.spi;version=latest,\
+	com.ibm.ws.kernel.service;version=latest,\
+	com.ibm.ws.context;version=latest,\
+	com.ibm.websphere.security;version=latest,\
+	com.ibm.websphere.javaee.annotation.1.2;version=latest,\
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+	com.ibm.ws.threading;version=latest
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0/bnd.bnd
@@ -48,7 +48,6 @@ testsrc: test/src
         com.ibm.ws.context;version=latest, \
         com.ibm.websphere.security;version=latest, \
         com.ibm.websphere.javaee.annotation.1.2;version=latest, \
-        com.ibm.websphere.javaee.concurrent.1.0;version=latest, \
         com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
         com.ibm.ws.threading;version=latest
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi/bnd.bnd
@@ -55,7 +55,6 @@ WS-TraceGroup: FAULTTOLERANCE
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.websphere.javaee.interceptor.1.2;version=latest,\
 	com.ibm.websphere.javaee.annotation.1.2;version=latest,\
-	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
 	com.ibm.ws.microprofile.faulttolerance.spi;version=latest,\
 	com.ibm.ws.transaction.cdi;version=latest
 	

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/interceptors/InterceptorTest.java
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/fat/src/com/ibm/websphere/microprofile/faulttolerance_fat/tests/interceptors/InterceptorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -40,11 +40,11 @@ import componenttest.topology.utils.FATServletClient;
 public class InterceptorTest extends FATServletClient {
 
     @ClassRule
-    public static RepeatTests r = RepeatFaultTolerance.repeat("FaultToleranceMultiModule", TestMode.FULL, MicroProfileActions.LATEST, MicroProfileActions.MP22);
+    public static RepeatTests r = RepeatFaultTolerance.repeat("AsyncFaultTolerance", TestMode.FULL, MicroProfileActions.LATEST, MicroProfileActions.MP22);
 
     private static final String APP_NAME = "ftInterceptors";
 
-    @Server("FaultToleranceMultiModule")
+    @Server("AsyncFaultTolerance")
     @TestServlet(contextRoot = APP_NAME, servlet = InterceptorTestServlet.class)
     public static LibertyServer server;
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/AsyncFaultTolerance/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/AsyncFaultTolerance/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@
 		<feature>cdi-2.0</feature>
 		<feature>servlet-4.0</feature>
 		<feature>mpFaultTolerance-2.0</feature>
+		<feature>concurrent-1.0</feature>
 	</featureManager>
 
 	<logging traceSpecification="FAULTTOLERANCE=event"/>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/JaxRsFaultTolerance/server.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat/publish/servers/JaxRsFaultTolerance/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2019, 2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@
 		<feature>servlet-4.0</feature>
 		<feature>mpFaultTolerance-2.0</feature>
 		<feature>jaxrs-2.1</feature>
+		<feature>concurrent-1.0</feature>
 	</featureManager>
 
 	<logging traceSpecification="FAULTTOLERANCE=event"/>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.cdi_fat_metrics/bnd.bnd
@@ -45,6 +45,5 @@ tested.features: mpfaulttolerance-1.0,\
 	com.ibm.websphere.javaee.annotation.1.2;version=latest,\
 	com.ibm.ws.security;version=latest,\
 	com.ibm.websphere.security;version=latest,\
-	com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
 	com.ibm.websphere.javaee.cdi.1.2;version=latest,\
 	com.ibm.ws.microprofile.faulttolerance_repeat_tests;version=latest

--- a/dev/com.ibm.ws.microprofile.faulttolerance.spi/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.spi/bnd.bnd
@@ -45,7 +45,6 @@ testsrc: test/src
     com.ibm.websphere.javaee.cdi.1.2;version=latest,\
     com.ibm.websphere.javaee.interceptor.1.2;version=latest,\
     com.ibm.websphere.javaee.annotation.1.2;version=latest,\
-    com.ibm.websphere.javaee.concurrent.1.0;version=latest,\
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
     com.ibm.websphere.org.osgi.core;version=latest,\
     com.ibm.websphere.org.osgi.service.component;version=latest,\

--- a/dev/com.ibm.ws.microprofile.faulttolerance/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.faulttolerance/bnd.bnd
@@ -38,21 +38,20 @@ Private-Package: \
 src: src,resources
 
 -buildpath: \
-        com.ibm.ws.logging;version=latest, \
-        com.ibm.ws.logging.core;version=latest, \
-        org.eclipse.osgi;version=latest, \
-        com.ibm.websphere.appserver.spi.kernel.service;version=latest,\
-        com.ibm.websphere.org.osgi.core;version=latest, \
-        com.ibm.websphere.org.osgi.service.component;version=latest, \
-        com.ibm.wsspi.org.osgi.service.component.annotations;version=latest, \
-        com.ibm.websphere.org.eclipse.microprofile.faulttolerance.1.0;version=latest, \
-        com.ibm.ws.microprofile.faulttolerance.spi;version=latest, \
-        com.ibm.ws.kernel.service;version=latest, \
-        com.ibm.ws.context;version=latest, \
-        com.ibm.websphere.javaee.annotation.1.2;version=latest, \
-        com.ibm.websphere.javaee.concurrent.1.0;version=latest, \
-        com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
-        com.ibm.ws.threading;version=latest
+	com.ibm.ws.logging;version=latest,\
+	com.ibm.ws.logging.core;version=latest,\
+	org.eclipse.osgi;version=latest,\
+	com.ibm.websphere.appserver.spi.kernel.service;version=latest,\
+	com.ibm.websphere.org.osgi.core;version=latest,\
+	com.ibm.websphere.org.osgi.service.component;version=latest,\
+	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+	com.ibm.websphere.org.eclipse.microprofile.faulttolerance.1.0;version=latest,\
+	com.ibm.ws.microprofile.faulttolerance.spi;version=latest,\
+	com.ibm.ws.kernel.service;version=latest,\
+	com.ibm.ws.context;version=latest,\
+	com.ibm.websphere.javaee.annotation.1.2;version=latest,\
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+	com.ibm.ws.threading;version=latest
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \


### PR DESCRIPTION
Fault Tolerance has always had a dependency on the concurrency-1.0
feature, but it doesn't seem to be needed.

Remove the dependency and update the tests so that tests which use concurrency APIs run on servers which have `concurrency-1.0` added to the server.xml.

Fixes #15847 