### PR TITLE
Change @SkipForRepeat to show up as skipped in junit results

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/custom/junit/runner/FATRunner.java
+++ b/dev/fattest.simplicity/src/componenttest/custom/junit/runner/FATRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 IBM Corporation and others.
+ * Copyright (c) 2011, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -186,7 +186,7 @@ public class FATRunner extends BlockJUnit4ClassRunner {
             @Override
             public void evaluate() throws Throwable {
                 if (!RepeatTestFilter.shouldRun(method)) {
-                    return;
+                    throw new AssumptionViolatedException("Test skipped for current RepeatAction");
                 }
                 Map<String, Long> tmpDirFilesBeforeTest = createDirectorySnapshot("/tmp");
                 try {


### PR DESCRIPTION
Currently if a test is marked `@SkipForRepeat` it still shows as ran and successful in the JUnit report which is confusing.

Updated to show as skipped instead.