### PR TITLE
Improve build performance

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.features/bnd.bnd
@@ -18,8 +18,6 @@ instrument.disabled: true
 
 feature.project: true
 
-copy.pii: false
-
 -dependson: \
 	com.ibm.ws.repository.generator;version=latest, \
 	wlp-bndPlugins;version=latest, \

--- a/dev/com.ibm.websphere.appserver.features/build.gradle
+++ b/dev/com.ibm.websphere.appserver.features/build.gradle
@@ -67,7 +67,7 @@ rootProject.ext.betaFeatures = {
     betaFeatures
 }
 
-task copyFeaturePiiFiles {
+copyPiiFiles {
   doLast {
     Map<String,Properties> map = getFeatureMap()
     map.keySet().each { featureName ->
@@ -82,8 +82,6 @@ task copyFeaturePiiFiles {
     }
   }
 }
-
-copyPiiFiles.dependsOn copyFeaturePiiFiles
 
 Set<String> obtain(Map<String, Set<String>> featureToEditions, String edition) {
   Set<String> features = featureToEditions.get(edition)

--- a/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/build.gradle
+++ b/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/build.gradle
@@ -34,20 +34,3 @@ task extractInjectedClasses(type: Copy) {
 }
 
 compileJava.dependsOn extractInjectedClasses
-
-task instrument {
-  if (!parseBoolean(bnd('instrument.disabled', 'false'))) {
-    inputs.files { rasInstrumentationInputFiles() }
-    def instrument = fileTree(dir: compileJava.destinationDir, include: bnd('instrument.classesIncludes').split("\\s*,\\s*"), exclude: bnd('instrument.classesExcludes').split("\\s*,\\s*"))
-    doLast {
-      if (instrument.isEmpty())
-        return
-      rasInstrumentationTaskdef(ant)
-      ant.instrumentForTrace(ffdc: bnd('instrument.ffdc'), taskInjection: bnd('instrument.taskInjection')) {
-          fileset(dir: compileJava.destinationDir, includes: bnd('instrument.classesIncludes'), excludes: bnd('instrument.classesExcludes'))
-      }
-    }
-  }
-}
-
-jar.dependsOn instrument

--- a/dev/com.ibm.ws.org.apache.cxf.ws.security.2.6.2/build.gradle
+++ b/dev/com.ibm.ws.org.apache.cxf.ws.security.2.6.2/build.gradle
@@ -34,20 +34,3 @@ task extractInjectedClasses(type: Copy) {
 }
 
 compileJava.dependsOn extractInjectedClasses
-
-task instrument {
-  if (!parseBoolean(bnd('instrument.disabled', 'false'))) {
-    inputs.files { rasInstrumentationInputFiles() }
-    def instrument = fileTree(dir: compileJava.destinationDir, include: bnd('instrument.classesIncludes').split("\\s*,\\s*"), exclude: bnd('instrument.classesExcludes').split("\\s*,\\s*"))
-    doLast {
-      if (instrument.isEmpty())
-        return
-      rasInstrumentationTaskdef(ant)
-      ant.instrumentForTrace(ffdc: bnd('instrument.ffdc'), taskInjection: bnd('instrument.taskInjection')) {
-          fileset(dir: compileJava.destinationDir, includes: bnd('instrument.classesIncludes'), excludes: bnd('instrument.classesExcludes'))
-      }
-    }
-  }
-}
-
-jar.dependsOn instrument

--- a/dev/com.ibm.ws.org.apache.cxf.ws.security/build.gradle
+++ b/dev/com.ibm.ws.org.apache.cxf.ws.security/build.gradle
@@ -34,20 +34,3 @@ task extractInjectedClasses(type: Copy) {
 }
 
 compileJava.dependsOn extractInjectedClasses
-
-task instrument {
-  if (!parseBoolean(bnd('instrument.disabled', 'false'))) {
-    inputs.files { rasInstrumentationInputFiles() }
-    def instrument = fileTree(dir: compileJava.destinationDir, include: bnd('instrument.classesIncludes').split("\\s*,\\s*"), exclude: bnd('instrument.classesExcludes').split("\\s*,\\s*"))
-    doLast {
-      if (instrument.isEmpty())
-        return
-      rasInstrumentationTaskdef(ant)
-      ant.instrumentForTrace(ffdc: bnd('instrument.ffdc'), taskInjection: bnd('instrument.taskInjection')) {
-          fileset(dir: compileJava.destinationDir, includes: bnd('instrument.classesIncludes'), excludes: bnd('instrument.classesExcludes'))
-      }
-    }
-  }
-}
-
-jar.dependsOn instrument

--- a/dev/com.ibm.ws.org.openid4java/build.gradle
+++ b/dev/com.ibm.ws.org.openid4java/build.gradle
@@ -23,20 +23,4 @@ task extractJarSelective(type: Copy) {
     into(compileJava.destinationDir)
 }
 
-task instrumentClass {
-  dependsOn extractJarSelective
-  if (!parseBoolean(bnd('instrument.disabled', 'false'))) {
-    inputs.files { rasInstrumentationInputFiles() }
-    def instrument = fileTree(dir: compileJava.destinationDir, include: bnd('instrument.classesIncludes'), exclude: bnd('instrument.classesExcludes'))
-    doLast {
-      if (instrument.isEmpty())
-        return
-      rasInstrumentationTaskdef(ant)
-      ant.instrumentForTrace(ffdc: bnd('instrument.ffdc'), taskInjection: bnd('instrument.taskInjection')) {
-          fileset(dir: compileJava.destinationDir, includes: bnd('instrument.classesIncludes'), excludes: bnd('instrument.classesExcludes'))
-      }
-    }
-  }
-}
-
-jar.dependsOn instrumentClass
+compileJava.dependsOn extractJarSelective

--- a/dev/com.ibm.ws.org.opensaml.opensaml.core.3.4.5/build.gradle
+++ b/dev/com.ibm.ws.org.opensaml.opensaml.core.3.4.5/build.gradle
@@ -24,20 +24,3 @@ task extractInjectedClasses(type: Copy) {
 }
 
 compileJava.dependsOn extractInjectedClasses
-
-task instrument {
-  if (!parseBoolean(bnd('instrument.disabled', 'false'))) {
-    inputs.files { rasInstrumentationInputFiles() }
-    def instrument = fileTree(dir: compileJava.destinationDir, include: bnd('instrument.classesIncludes').split("\\s*,\\s*"), exclude: bnd('instrument.classesExcludes').split("\\s*,\\s*"))
-    doLast {
-      if (instrument.isEmpty())
-        return
-      rasInstrumentationTaskdef(ant)
-      ant.instrumentForTrace(ffdc: bnd('instrument.ffdc'), taskInjection: bnd('instrument.taskInjection')) {
-          fileset(dir: compileJava.destinationDir, includes: bnd('instrument.classesIncludes'), excludes: bnd('instrument.classesExcludes'))
-      }
-    }
-  }
-}
-
-jar.dependsOn instrument

--- a/dev/com.ibm.ws.org.opensaml.opensaml.messaging.api.3.4.5/build.gradle
+++ b/dev/com.ibm.ws.org.opensaml.opensaml.messaging.api.3.4.5/build.gradle
@@ -23,20 +23,3 @@ task extractInjectedClasses(type: Copy) {
 }
 
 compileJava.dependsOn extractInjectedClasses
-
-task instrument {
-  if (!parseBoolean(bnd('instrument.disabled', 'false'))) {
-    inputs.files { rasInstrumentationInputFiles() }
-    def instrument = fileTree(dir: compileJava.destinationDir, include: bnd('instrument.classesIncludes').split("\\s*,\\s*"), exclude: bnd('instrument.classesExcludes').split("\\s*,\\s*"))
-    doLast {
-      if (instrument.isEmpty())
-        return
-      rasInstrumentationTaskdef(ant)
-      ant.instrumentForTrace(ffdc: bnd('instrument.ffdc'), taskInjection: bnd('instrument.taskInjection')) {
-          fileset(dir: compileJava.destinationDir, includes: bnd('instrument.classesIncludes'), excludes: bnd('instrument.classesExcludes'))
-      }
-    }
-  }
-}
-
-jar.dependsOn instrument

--- a/dev/com.ibm.ws.org.opensaml.opensaml.messaging.impl.3.4.5/build.gradle
+++ b/dev/com.ibm.ws.org.opensaml.opensaml.messaging.impl.3.4.5/build.gradle
@@ -23,20 +23,3 @@ task extractInjectedClasses(type: Copy) {
 }
 
 compileJava.dependsOn extractInjectedClasses
-
-task instrument {
-  if (!parseBoolean(bnd('instrument.disabled', 'false'))) {
-    inputs.files { rasInstrumentationInputFiles() }
-    def instrument = fileTree(dir: compileJava.destinationDir, include: bnd('instrument.classesIncludes').split("\\s*,\\s*"), exclude: bnd('instrument.classesExcludes').split("\\s*,\\s*"))
-    doLast {
-      if (instrument.isEmpty())
-        return
-      rasInstrumentationTaskdef(ant)
-      ant.instrumentForTrace(ffdc: bnd('instrument.ffdc'), taskInjection: bnd('instrument.taskInjection')) {
-          fileset(dir: compileJava.destinationDir, includes: bnd('instrument.classesIncludes'), excludes: bnd('instrument.classesExcludes'))
-      }
-    }
-  }
-}
-
-jar.dependsOn instrument

--- a/dev/com.ibm.ws.org.opensaml.opensaml/build.gradle
+++ b/dev/com.ibm.ws.org.opensaml.opensaml/build.gradle
@@ -24,20 +24,3 @@ task extractInjectedClasses(type: Copy) {
 }
 
 compileJava.dependsOn extractInjectedClasses
-
-task instrument {
-  if (!parseBoolean(bnd('instrument.disabled', 'false'))) {
-    inputs.files { rasInstrumentationInputFiles() }
-    def instrument = fileTree(dir: compileJava.destinationDir, include: bnd('instrument.classesIncludes').split("\\s*,\\s*"), exclude: bnd('instrument.classesExcludes').split("\\s*,\\s*"))
-    doLast {
-      if (instrument.isEmpty())
-        return
-      rasInstrumentationTaskdef(ant)
-      ant.instrumentForTrace(ffdc: bnd('instrument.ffdc'), taskInjection: bnd('instrument.taskInjection')) {
-          fileset(dir: compileJava.destinationDir, includes: bnd('instrument.classesIncludes'), excludes: bnd('instrument.classesExcludes'))
-      }
-    }
-  }
-}
-
-jar.dependsOn instrument

--- a/dev/com.ibm.ws.transport.iiop.open_fat/build.gradle
+++ b/dev/com.ibm.ws.transport.iiop.open_fat/build.gradle
@@ -22,8 +22,3 @@ dependencies {
   //compile "com.ibm.wsspi.org.osgi:org.osgi.core:.+"
   compile 'dev:com.ibm.ws.org.apache.yoko.osgi.1.5:1.+'
 }
-
-task xxx {
-  print "### requiredLibs = $configurations.requiredLibs.asPath ###"
-}
-

--- a/dev/gradle.properties
+++ b/dev/gradle.properties
@@ -38,7 +38,7 @@ org.gradle.jvmargs=-Xmx2560M -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF
 # Fix for the TLS protocol version used to communicate with Maven Central when using the IBM JVM.
 systemProp.com.ibm.jsse2.overrideDefaultTLS=true
 
-# When the build cache is enabled, it will store build outputs in the Gradle user home.
+org.gradle.parallel=true
 org.gradle.caching=true
 
 # Tweaks to better handle Artifactory connection flakiness.

--- a/dev/wlp-gradle/bndSettings.gradle
+++ b/dev/wlp-gradle/bndSettings.gradle
@@ -157,8 +157,9 @@ projectNames.each { projectName ->
     }
 }
 
-// A non-standared project. Just include it all the time
-include ':com.ibm.ws.springboot.support.version20.test.war.app:module'
+if (allBndProjects.contains('com.ibm.ws.springboot.support.version20.test.war.app')) {
+    include ':com.ibm.ws.springboot.support.version20.test.war.app:module'
+}
 
 private boolean parseBoolean(String value) {
     return 'on'.equalsIgnoreCase(value) || 'true'.equalsIgnoreCase(value)

--- a/dev/wlp-gradle/subprojects/assemble.gradle
+++ b/dev/wlp-gradle/subprojects/assemble.gradle
@@ -16,131 +16,140 @@
  *
  * Configure 'assemble' to depend on above tasks.
  */
-task publishWLPJars(type: Copy) {
-    dependsOn jar
-    dependsOn jakartaeeTransform
-    def publishWlpJarDefault = parseBoolean(bnd('test.project', 'false')) ? 'true' : 'false'
-    enabled bnd('publish.tool.jar', '').empty && !parseBoolean(bnd('publish.wlp.jar.disabled', publishWlpJarDefault))
-    from project.buildDir
-    into buildImage.file('wlp/' + bnd('publish.wlp.jar.suffix', 'lib'))
-    include bnd('publish.wlp.jar.include', '*.jar')
-    def hasIFIXHeaders = [:]
-    def fullVersions = [:]
-    if (parseBoolean(bnd('publish.wlp.jar.rename', 'true'))) {
-        def outerSymbolicName = bnd('Bundle-SymbolicName', project.name)
-        if (outerSymbolicName != null) {
-            int index = outerSymbolicName.indexOf(";")
-            if (index != -1) {
-                outerSymbolicName = outerSymbolicName.substring(0, index).trim()
+def publishWlpJarDefault = parseBoolean(bnd('test.project', 'false')) ? 'true' : 'false'
+if (bnd('publish.tool.jar', '').empty && !parseBoolean(bnd('publish.wlp.jar.disabled', publishWlpJarDefault))) {
+    task publishWLPJars(type: Copy) {
+        dependsOn jar
+        if ( parseBoolean( bnd('jakartaeeMe', 'true'))) {
+            dependsOn jakartaeeTransform
+        }
+        from project.buildDir
+        into buildImage.file('wlp/' + bnd('publish.wlp.jar.suffix', 'lib'))
+        include bnd('publish.wlp.jar.include', '*.jar')
+        def hasIFIXHeaders = [:]
+        def fullVersions = [:]
+        if (parseBoolean(bnd('publish.wlp.jar.rename', 'true'))) {
+            def outerSymbolicName = bnd('Bundle-SymbolicName', project.name)
+            if (outerSymbolicName != null) {
+                int index = outerSymbolicName.indexOf(";")
+                if (index != -1) {
+                    outerSymbolicName = outerSymbolicName.substring(0, index).trim()
+                }
             }
-        }
 
-        // store the full version information for the outer project from
-        // the projects bnd.bnd file.  
-        def outerVersion = bnd('bVersion')
-        def outerFullVersion = bnd('bFullVersion')
-        fullVersions.put(outerSymbolicName, outerFullVersion)
+            // store the full version information for the outer project from
+            // the projects bnd.bnd file.  
+            def outerVersion = bnd('bVersion')
+            def outerFullVersion = bnd('bFullVersion')
+            fullVersions.put(outerSymbolicName, outerFullVersion)
 
-        // iFixed jars should get renamed with a qualifier so they can exist in the filesystem
-        // next to the base version of the jar, *except* for jars that are directly
-        // referenced in a tool script's classpath...
-        if (((!bnd('IBM-Interim-Fixes', '').empty) || (!bnd('IBM-Test-Fixes', '').empty))
-                && (!project.name.equals("com.ibm.ws.kernel.boot"))
-                && (!project.name.equals("com.ibm.ws.kernel.boot.archive"))
-                && (!project.name.equals("com.ibm.ws.appclient.boot"))
-                && (!project.name.equals("com.ibm.ws.kernel.boot.cmdline"))) {
-            hasIFIXHeaders.put(outerSymbolicName, true)
-        }
+            // iFixed jars should get renamed with a qualifier so they can exist in the filesystem
+            // next to the base version of the jar, *except* for jars that are directly
+            // referenced in a tool script's classpath...
+            if (((!bnd('IBM-Interim-Fixes', '').empty) || (!bnd('IBM-Test-Fixes', '').empty))
+                    && (!project.name.equals("com.ibm.ws.kernel.boot"))
+                    && (!project.name.equals("com.ibm.ws.kernel.boot.archive"))
+                    && (!project.name.equals("com.ibm.ws.appclient.boot"))
+                    && (!project.name.equals("com.ibm.ws.kernel.boot.cmdline"))) {
+                hasIFIXHeaders.put(outerSymbolicName, true)
+            }
 
-        if (!bnd('-sub', '').empty) {
-            fileTree(dir: projectDir, include: bnd('-sub', '')).each { subBndFile ->
-                Properties subBndProperties = new Properties()
-                subBndFile.withInputStream { subBndProperties.load(it) }
-                def symbolicName = subBndProperties.getProperty("Bundle-SymbolicName")
-                if (symbolicName != null) {
-                    int index = symbolicName.indexOf(";")
-                    if (index != -1) {
-                        symbolicName = symbolicName.substring(0, index).trim()
-                    }
+            if (!bnd('-sub', '').empty) {
+                fileTree(dir: projectDir, include: bnd('-sub', '')).each { subBndFile ->
+                    Properties subBndProperties = new Properties()
+                    subBndFile.withInputStream { subBndProperties.load(it) }
+                    def symbolicName = subBndProperties.getProperty("Bundle-SymbolicName")
+                    if (symbolicName != null) {
+                        int index = symbolicName.indexOf(";")
+                        if (index != -1) {
+                            symbolicName = symbolicName.substring(0, index).trim()
+                        }
 
-                    if (subBndProperties.getProperty("IBM-Interim-Fixes") != null
-                        || subBndProperties.getProperty("IBM-Test-Fixes") != null) {
-                        hasIFIXHeaders.put(symbolicName, true)
-                    }
+                        if (subBndProperties.getProperty("IBM-Interim-Fixes") != null
+                            || subBndProperties.getProperty("IBM-Test-Fixes") != null) {
+                            hasIFIXHeaders.put(symbolicName, true)
+                        }
 
-                    // Sub bundles in a project can have a different bundle
-                    // version number than the outer project's bnd.bnd file
-                    // This logic stores the correctly full bundle version
-                    // for sub bundles in a project.
-                    def subBVersion = subBndProperties.getProperty('bVersion')
-                    if (outerVersion.equals(subBVersion)) {
-                        fullVersions.put(symbolicName, outerFullVersion)
-                    } else {
-                        fullVersions.put(symbolicName, subBVersion + outerFullVersion.substring(outerVersion.length()))
+                        // Sub bundles in a project can have a different bundle
+                        // version number than the outer project's bnd.bnd file
+                        // This logic stores the correctly full bundle version
+                        // for sub bundles in a project.
+                        def subBVersion = subBndProperties.getProperty('bVersion')
+                        if (outerVersion.equals(subBVersion)) {
+                            fullVersions.put(symbolicName, outerFullVersion)
+                        } else {
+                            fullVersions.put(symbolicName, subBVersion + outerFullVersion.substring(outerVersion.length()))
+                        }
                     }
                 }
             }
-        }
 
-        // Update each published bundle to have the full version suffix.
-        eachFile {
-            // If the sub.bnd that built this jar contains iFix headers, rename it with a qualifer.
-            def symbolicName = it.getSourceName().substring(0, it.getSourceName().lastIndexOf("."))
-            def fullVersion = fullVersions.get(symbolicName)
-            if (fullVersion == null) {
-                fullVersion = outerFullVersion
-            }
+            // Update each published bundle to have the full version suffix.
+            eachFile {
+                // If the sub.bnd that built this jar contains iFix headers, rename it with a qualifer.
+                def symbolicName = it.getSourceName().substring(0, it.getSourceName().lastIndexOf("."))
+                def fullVersion = fullVersions.get(symbolicName)
+                if (fullVersion == null) {
+                    fullVersion = outerFullVersion
+                }
 
-            def selectedSymbolicName = symbolicName
-            // If the jar is jakartaee transformed, then see if the pre-transformed bundle has iFix headers.
-            if (it.getSourceName().equals(bnd('jakartaee.transform.jar.name', '')) || symbolicName.endsWith(".jakarta")) {
-                selectedSymbolicName = outerSymbolicName
-            }
-                
-            if (!hasIFIXHeaders.get(selectedSymbolicName)) {
-                it.setName(symbolicName + "_" + fullVersion + ".jar")
-            } else {
-                it.setName(symbolicName + "_" + fullVersion + ".${qualifier}.jar")
+                def selectedSymbolicName = symbolicName
+                // If the jar is jakartaee transformed, then see if the pre-transformed bundle has iFix headers.
+                if (it.getSourceName().equals(bnd('jakartaee.transform.jar.name', '')) || symbolicName.endsWith(".jakarta")) {
+                    selectedSymbolicName = outerSymbolicName
+                }
+                    
+                if (!hasIFIXHeaders.get(selectedSymbolicName)) {
+                    it.setName(symbolicName + "_" + fullVersion + ".jar")
+                } else {
+                    it.setName(symbolicName + "_" + fullVersion + ".${qualifier}.jar")
+                }
             }
         }
     }
+    assemble.dependsOn publishWLPJars
 }
 
-task publishJavadoc(type: Copy) {
-    dependsOn zipJavadoc
-    from zipJavadoc
-    into rootProject.file("build.image/wlp/" + bnd('publish.wlp.jar.suffix', 'lib') + "/javadoc")
-    rename '.javadoc.zip', "_${bnd.bVersion}-javadoc.zip"
+if (bnd('publish.wlp.jar.suffix', 'lib').contains('api/ibm') || bnd('publish.wlp.jar.suffix', 'lib').contains('spi/ibm')) {
+    task publishJavadoc(type: Copy) {
+        dependsOn zipJavadoc
+        from zipJavadoc
+        into rootProject.file("build.image/wlp/" + bnd('publish.wlp.jar.suffix', 'lib') + "/javadoc")
+        rename '.javadoc.zip', "_${bnd.bVersion}-javadoc.zip"
+    }
+    assemble.dependsOn publishJavadoc
 }
 
 task publishToolScripts(type: Copy) {
-    dependsOn jar
     enabled !bnd('publish.tool.script', '').empty
+    dependsOn jar
     from cnf.file('resources/bin')
     into buildImage.file('wlp/bin/' + bnd('publish.tool.script.subdir', ''))
     fileMode 0755
     rename 'tool(.*)', bnd('publish.tool.script') + '$1'
     filter(org.apache.tools.ant.filters.ReplaceTokens,
             tokens: [TOOL_JAR: bnd('publish.tool.script.subdir', '') + 'tools/' + bnd('publish.tool.jar', ''),
-                     TOOL_SCRIPT: bnd('publish.tool.script.subdir', '') + bnd('publish.tool.script', ''),
-                     TOOL_SCRIPT_DIR_LENGTH: bnd('publish.tool.script.dir.length', '5'),
-                     TOOL_SCRIPT_RELATIVE: bnd('publish.tool.script.relative', '')])
+                    TOOL_SCRIPT: bnd('publish.tool.script.subdir', '') + bnd('publish.tool.script', ''),
+                    TOOL_SCRIPT_DIR_LENGTH: bnd('publish.tool.script.dir.length', '5'),
+                    TOOL_SCRIPT_RELATIVE: bnd('publish.tool.script.relative', '')])
 }
 
 task publishToolJars(type: Copy) {
+    enabled !bnd('publish.tool.jar', '').empty
     dependsOn jar
     dependsOn publishToolScripts
-    enabled !bnd('publish.tool.jar', '').empty
     from project.buildDir
     into buildImage.file('wlp/bin/' + bnd('publish.tool.script.subdir', '') + 'tools')
     include bnd('publish.tool.jar', '')
 }
+assemble.dependsOn publishToolJars
 
 task publishSchemaResources(type: Copy) {
     dependsOn jar
     from project.file('resources/schemas')
     into buildImage.file('wlp/dev/api/ibm/schema')
 }
+assemble.dependsOn publishSchemaResources
 
 task publishPlatformManifests(type: Copy) {
     dependsOn jar
@@ -150,20 +159,22 @@ task publishPlatformManifests(type: Copy) {
     filter(org.apache.tools.ant.filters.ConcatFilter,
             append: file(cnf.file('resources/IBM-ProductID.txt')))
 }
+assemble.dependsOn publishPlatformManifests
 
 task publishPlatformFiles(type: Copy) {
-    dependsOn jar
     dependsOn publishPlatformManifests
     from project.file('publish/platform')
     into buildImage.file('wlp/lib/platform')
     exclude '*.mf'
 }
+assemble.dependsOn publishPlatformFiles
 
 task publishTemplates(type: Copy) {
     dependsOn jar
     from project.file('publish/templates')
     into buildImage.file('wlp/templates')
 }
+assemble.dependsOn publishTemplates
 
 task publishBinScripts(type: Copy) {
     dependsOn jar
@@ -171,12 +182,15 @@ task publishBinScripts(type: Copy) {
     into buildImage.file('wlp/bin')
     fileMode 0755
 }
+assemble.dependsOn publishBinScripts
 
-task publishClientScripts(type: Copy) {
-    dependsOn jar
-    enabled parseBoolean(bnd('publish.wlp.clients', 'true'))
-    from project.file('publish/clients')
-    into buildImage.file('wlp/clients')
+if (parseBoolean(bnd('publish.wlp.clients', 'true'))) {
+    task publishClientScripts(type: Copy) {
+        dependsOn jar
+        from project.file('publish/clients')
+        into buildImage.file('wlp/clients')
+    }
+    assemble.dependsOn publishClientScripts
 }
 
 task publishLibNative(type: Copy) {
@@ -184,15 +198,4 @@ task publishLibNative(type: Copy) {
     from project.file('lib/native')
     into buildImage.file('wlp/lib/native')
 }
-
-assemble {
-    dependsOn publishWLPJars
-    dependsOn publishJavadoc
-    dependsOn publishToolJars
-    dependsOn publishSchemaResources
-    dependsOn publishPlatformFiles
-    dependsOn publishTemplates
-    dependsOn publishBinScripts
-    dependsOn publishClientScripts
-    dependsOn publishLibNative
-}
+assemble.dependsOn publishLibNative

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -140,7 +140,7 @@ task copyDatabaseRotationDrivers(type: Copy) {
 }
 
 task copyFeatureBundles {
-  mustRunAfter assemble
+  dependsOn assemble
   enabled project.file('test-bundles').exists()
   doLast {
     new File(project.buildDir, 'buildfiles').eachLine { String line ->

--- a/dev/wlp-gradle/subprojects/tasks.gradle
+++ b/dev/wlp-gradle/subprojects/tasks.gradle
@@ -20,12 +20,13 @@ jar {
   version=null
 }
 
-task globalize {
-  // Exclude messages from quotation validation if explicitly excluded via bnd.bnd
-  def quotationExcludes = bnd('globalize.quotation.excludes')
+if (parseBoolean(bnd('globalize', 'true'))) {
+  task globalize {
+    // Exclude messages from quotation validation if explicitly excluded via bnd.bnd
+    def quotationExcludes = bnd('globalize.quotation.excludes')
 
-  ext.destinationDir = new File(buildDir, "src/${name}/java")
-  if (parseBoolean(bnd('globalize', 'true'))) {
+    ext.destinationDir = new File(buildDir, "src/${name}/java")
+    
     inputs.files(fileTree(dir: project.file('resources'), include: '**/*.nlsprops')).skipWhenEmpty()
     outputs.dir destinationDir
     doFirst {
@@ -123,193 +124,199 @@ task globalize {
       }
     }
   }
-}
 
-task copyPiiFiles(type: Copy) {
-  enabled parseBoolean(bnd('copy.pii', 'true'))
-  ext.destinationDir = rootProject.file("build.pii.package/nlssrc/${project.name}")
-  from project.file('resources')
-  into ext.destinationDir
-  include '**/*.nlsprops'
-  include 'OSGI-INF/l10n/*'
-  include 'l10n/*'
-  include 'publish/features/l10n/*.properties'
-  include 'WEB-CONTENT/**/nls/*.js'
-  include 'OSGI-INF/**/nls/*.js'
-}
-
-sourceSets {
-  main {
-    if (parseBoolean(bnd('globalize', 'true'))) {
+  sourceSets {
+    main {
       java.srcDir globalize.destinationDir
     }
   }
 }
 
-configurations {
-  jakartaeeTransformJars
+if (parseBoolean(bnd('copy.pii', 'true'))) {
+  task copyPiiFiles(type: Copy) {
+    ext.destinationDir = rootProject.file("build.pii.package/nlssrc/${project.name}")
+    from project.file('resources')
+    into ext.destinationDir
+    include '**/*.nlsprops'
+    include 'OSGI-INF/l10n/*'
+    include 'l10n/*'
+    include 'publish/features/l10n/*.properties'
+    include 'WEB-CONTENT/**/nls/*.js'
+    include 'OSGI-INF/**/nls/*.js'
+  }
+} else {
+  task copyPiiFiles { }
 }
 
-dependencies {
-  jakartaeeTransformJars 'biz.aQute.bnd:biz.aQute.bnd.transform:5.1.1',
-                          'commons-cli:commons-cli:1.4',
-                          'org.slf4j:slf4j-simple:1.7.30',
-                          'org.slf4j:slf4j-api:1.7.26',
-                          'org.eclipse.transformer:org.eclipse.transformer:0.2.0',
-                          'org.eclipse.transformer:org.eclipse.transformer.cli:0.2.0'
-}
+if ( parseBoolean( bnd('jakartaeeMe', 'true'))) {
+  configurations {
+    jakartaeeTransformJars
+  }
 
-task jakartaeeTransform {
-  mustRunAfter project.tasks.jar
+  dependencies {
+    jakartaeeTransformJars 'biz.aQute.bnd:biz.aQute.bnd.transform:5.1.1',
+                            'commons-cli:commons-cli:1.4',
+                            'org.slf4j:slf4j-simple:1.7.30',
+                            'org.slf4j:slf4j-api:1.7.26',
+                            'org.eclipse.transformer:org.eclipse.transformer:0.2.0',
+                            'org.eclipse.transformer:org.eclipse.transformer.cli:0.2.0'
+  }
 
-  if ( parseBoolean( bnd('jakartaeeMe', 'true') ) ) {
+  task jakartaeeTransform {
+    mustRunAfter project.tasks.jar
+    dependsOn jar
+    inputs.files(fileTree(project.buildDir).matching {include '*.jar' exclude '*jakarta.jar' }).skipWhenEmpty()
+    outputs.dir project.buildDir
     doLast {
       fileTree(project.buildDir).matching { include '*jakarta.jar' }.each { delete it }
 
       FileTree bundles = fileTree(project.buildDir).matching {include '*.jar' }        
-          bundles.each { bundleJar ->
+      bundles.each { bundleJar ->
 
-      println 'BND [ jakartaeeMe ] detected; performing jakarta transform'
+        println 'BND [ jakartaeeMe ] detected; performing jakarta transform'
 
-      // Jakarta transform options always input the bundle jar and output
-      // a jakarta transformed copy of the bundle jar.
-      //
-      // Jakarta transform always uses a set of global properties files.
- 
-      def initialBundleJarName = project.buildDir.path + '/' + bundleJar.name
-      println 'Initial bundle jar name [ ' + initialBundleJarName + ' ]'
+        // Jakarta transform options always input the bundle jar and output
+        // a jakarta transformed copy of the bundle jar.
+        //
+        // Jakarta transform always uses a set of global properties files.
 
-      def finalBundleJarName = initialBundleJarName.replaceAll( '.jar', '.jakarta.jar' )
-      println 'Default jakarta final bundle jar name [ ' + finalBundleJarName + ' ]'
+        def initialBundleJarName = project.buildDir.path + '/' + bundleJar.name
+        println 'Initial bundle jar name [ ' + initialBundleJarName + ' ]'
 
-      def localBundleJarName = bnd('jakartaFinalJarName')
-      if ( (localBundleJarName != null) && !localBundleJarName.isEmpty() ) {
-        println 'Local jakarta final bundle jar name [ ' + localBundleJarName + ' ]'
-        println 'Ignoring default jakarta final bundle jar name'
-        finalBundleJarName = project.buildDir.path + '/' + localBundleJarName
-        println 'Override jakarta bundle final jar name [ ' + finalBundleJarName + ' ]'
-      } else {
-        println 'Using default jakarta final bundle jar name'
-      }
+        def finalBundleJarName = initialBundleJarName.replaceAll( '.jar', '.jakarta.jar' )
+        println 'Default jakarta final bundle jar name [ ' + finalBundleJarName + ' ]'
 
-      def transformProject = bndWorkspace.getProject('wlp-jakartaee-transform')
-      def globalRules = transformProject.getFile('rules')
-      println 'Using global rules [ ' + globalRules.path + ' ]'
- 
-      def transformerArgs = [
-        initialBundleJarName, finalBundleJarName,
-        '-tr', transformProject.getFile('rules/jakarta-renames.properties').path,
-        '-ts', transformProject.getFile('rules/jakarta-selections.properties').path,
-        '-tv', transformProject.getFile('rules/jakarta-versions.properties').path,
-        '-tb', transformProject.getFile('rules/jakarta-bundles.properties').path,
-        '-td', transformProject.getFile('rules/jakarta-direct.properties').path,
-        '-tf', transformProject.getFile('rules/jakarta-xml-master.properties').path ]
+        def localBundleJarName = bnd('jakartaFinalJarName')
+        if ( (localBundleJarName != null) && !localBundleJarName.isEmpty() ) {
+          println 'Local jakarta final bundle jar name [ ' + localBundleJarName + ' ]'
+          println 'Ignoring default jakarta final bundle jar name'
+          finalBundleJarName = project.buildDir.path + '/' + localBundleJarName
+          println 'Override jakarta bundle final jar name [ ' + finalBundleJarName + ' ]'
+        } else {
+          println 'Using default jakarta final bundle jar name'
+        }
 
-      // Add BND file specified local additions.
+        def transformProject = bndWorkspace.getProject('wlp-jakartaee-transform')
+        def globalRules = transformProject.getFile('rules')
+        println 'Using global rules [ ' + globalRules.path + ' ]'
 
-      project.ext.set( 'jakartaLocalSelections', 'local.selections.properties' )
+        def transformerArgs = [
+          initialBundleJarName, finalBundleJarName,
+          '-q', // quiet output
+          '-tr', transformProject.getFile('rules/jakarta-renames.properties').path,
+          '-ts', transformProject.getFile('rules/jakarta-selections.properties').path,
+          '-tv', transformProject.getFile('rules/jakarta-versions.properties').path,
+          '-tb', transformProject.getFile('rules/jakarta-bundles.properties').path,
+          '-td', transformProject.getFile('rules/jakarta-direct.properties').path,
+          '-tf', transformProject.getFile('rules/jakarta-xml-master.properties').path ]
 
-      def localOptions = [
-          [ 'Selections', '-ts' ],
-          [ 'Renames',    '-tr' ],
-          [ 'Versions',   '-tv' ],
-          [ 'Bundles',    '-tb' ],
-          [ 'Direct',     '-td' ],
-          [ 'TextMaster', '-tf' ]
-      ]
+        // Add BND file specified local additions.
 
-      for ( localEntry in localOptions ) {
-          def localName = localEntry[0]
-          def localOption = localEntry[1]
+        project.ext.set( 'jakartaLocalSelections', 'local.selections.properties' )
 
-          def bndProperty = 'jakartaLocal' + localName
-          def localAddition = bnd(bndProperty)
+        def localOptions = [
+            [ 'Selections', '-ts' ],
+            [ 'Renames',    '-tr' ],
+            [ 'Versions',   '-tv' ],
+            [ 'Bundles',    '-tb' ],
+            [ 'Direct',     '-td' ],
+            [ 'TextMaster', '-tf' ]
+        ]
 
-          if ( (localAddition == null) || localAddition.isEmpty() ) {
-              println 'BND [ ' + bndProperty + ' ] is not set'
+        for ( localEntry in localOptions ) {
+            def localName = localEntry[0]
+            def localOption = localEntry[1]
 
+            def bndProperty = 'jakartaLocal' + localName
+            def localAddition = bnd(bndProperty)
+
+            if ( (localAddition == null) || localAddition.isEmpty() ) {
+                println 'BND [ ' + bndProperty + ' ] is not set'
+
+            } else {
+                def localFile = project.file( 'rules/' + localAddition )
+
+                if ( !localFile.exists() ) {
+                    logger.error( 'ERROR: BND Ignoring [ ' + bndProperty + ' ]; [ ' + localFile.path + ' ] does not exist' )
+
+                } else {
+                    println 'BND adding [ ' + bndProperty + ' ]: [ ' + localFile.path + ' ]'
+                    transformerArgs.add( localOption )
+                    transformerArgs.add( localFile.path )
+                }
+            }
+        }
+
+        def initialBundleId = bnd('jakartaInitialBundleId')
+        if ( (initialBundleId != null) && !initialBundleId.isEmpty() ) {
+          println 'BND jakartaInitialBundleId [ ' + initialBundleId + ' ]'
+
+          def finalBundleId = bnd('jakartaFinalBundleId')
+          if ( (finalBundleId == null) || finalBundleId.isEmpty() ) {
+            logger.error( 'ERROR: BND Final bundle id property [ jakartaFinalBundleId ] is not set' )
           } else {
-              def localFile = project.file( 'rules/' + localAddition )
-
-              if ( !localFile.exists() ) {
-                  logger.error( 'ERROR: BND Ignoring [ ' + bndProperty + ' ]; [ ' + localFile.path + ' ] does not exist' )
-
-              } else {
-                  println 'BND adding [ ' + bndProperty + ' ]: [ ' + localFile.path + ' ]'
-                  transformerArgs.add( localOption )
-                  transformerArgs.add( localFile.path )
-             }
+            println 'BND jakartaFinalBundleId [ ' + finalBundleId + ' ]'
           }
-      }
 
-      def initialBundleId = bnd('jakartaInitialBundleId')
-      if ( (initialBundleId != null) && !initialBundleId.isEmpty() ) {
-        println 'BND jakartaInitialBundleId [ ' + initialBundleId + ' ]'
+          def finalBundleVersion = bnd('jakartaFinalBundleVersion')
+          if ( (finalBundleVersion == null) || finalBundleVersion.isEmpty() ) {
+            logger.error( 'ERROR: BND Final bundle version property [ jakartaFinalBundleVersion ] is not set' )
+          } else {
+            println 'BND jakartaFinalBundleVersion [ ' + finalBundleVersion + ' ]'
+          }
 
-        def finalBundleId = bnd('jakartaFinalBundleId')
-        if ( (finalBundleId == null) || finalBundleId.isEmpty() ) {
-          logger.error( 'ERROR: BND Final bundle id property [ jakartaFinalBundleId ] is not set' )
-        } else {
-          println 'BND jakartaFinalBundleId [ ' + finalBundleId + ' ]'
+          def finalBundleShortName = bnd('jakartaFinalBundleShortName')
+          if ( (finalBundleShortName == null) || finalBundleShortName.isEmpty() ) {
+            logger.error( 'ERROR: BND Final bundle short name property [ jakartaFinalBundleShortName ] is not set' )
+          } else {
+            println 'BND jakartaFinalBundleName [ ' + finalBundleShortName + ' ]'
+          }
+
+          def finalBundleDescription = bnd('jakartaFinalBundleDescription')
+          if ( (finalBundleDescription == null) || finalBundleDescription.isEmpty() ) {
+            logger.error( 'ERROR: BND Final bundle description property [ jakartaFinalBundleDescription ] is not set' )
+          } else {
+            println 'BND jakartaFinalBundleDescription [ ' + finalBundleDescription + ' ]'
+          }
+
+          def directBundleDataKey = initialBundleId
+          def directBundleDataValue =
+            finalBundleId + ',' +
+            finalBundleVersion + ',' + 
+            finalBundleShortName + ',' +
+            finalBundleDescription
+
+          println 'BND jakarta direct key [ ' + directBundleDataKey + ' ]'
+          println 'BND jakarta direct value [ ' + directBundleDataValue + ' ]'
+
+          transformerArgs.add( '-ti' )
+          transformerArgs.add( 'tb' )
+          transformerArgs.add( directBundleDataKey )
+          transformerArgs.add( directBundleDataValue )
         }
 
-        def finalBundleVersion = bnd('jakartaFinalBundleVersion')
-        if ( (finalBundleVersion == null) || finalBundleVersion.isEmpty() ) {
-          logger.error( 'ERROR: BND Final bundle version property [ jakartaFinalBundleVersion ] is not set' )
-        } else {
-          println 'BND jakartaFinalBundleVersion [ ' + finalBundleVersion + ' ]'
+        println 'Transformer options:'
+        transformerArgs.each {
+            println '  [ ' + it + ' ]'
         }
 
-        def finalBundleShortName = bnd('jakartaFinalBundleShortName')
-        if ( (finalBundleShortName == null) || finalBundleShortName.isEmpty() ) {
-          logger.error( 'ERROR: BND Final bundle short name property [ jakartaFinalBundleShortName ] is not set' )
-        } else {
-          println 'BND jakartaFinalBundleName [ ' + finalBundleShortName + ' ]'
+        javaexec {
+            classpath configurations.jakartaeeTransformJars
+            main = 'org.eclipse.transformer.jakarta.JakartaTransformer'
+            args = transformerArgs
         }
-
-        def finalBundleDescription = bnd('jakartaFinalBundleDescription')
-        if ( (finalBundleDescription == null) || finalBundleDescription.isEmpty() ) {
-          logger.error( 'ERROR: BND Final bundle description property [ jakartaFinalBundleDescription ] is not set' )
-        } else {
-          println 'BND jakartaFinalBundleDescription [ ' + finalBundleDescription + ' ]'
-        }
-
-        def directBundleDataKey = initialBundleId
-        def directBundleDataValue =
-          finalBundleId + ',' +
-          finalBundleVersion + ',' + 
-          finalBundleShortName + ',' +
-          finalBundleDescription
-
-        println 'BND jakarta direct key [ ' + directBundleDataKey + ' ]'
-        println 'BND jakarta direct value [ ' + directBundleDataValue + ' ]'
-
-        transformerArgs.add( '-ti' )
-        transformerArgs.add( 'tb' )
-        transformerArgs.add( directBundleDataKey )
-        transformerArgs.add( directBundleDataValue )
-      }
-
-      println 'Transformer options:'
-      transformerArgs.each {
-          println '  [ ' + it + ' ]'
-      }
-
-      javaexec {
-          classpath configurations.jakartaeeTransformJars
-          main = 'org.eclipse.transformer.jakarta.JakartaTransformer'
-          args = transformerArgs
       }
     }
-  } }
-}
+  }
 
-assemble.dependsOn(jakartaeeTransform)
+  assemble.dependsOn(jakartaeeTransform)
+}
 
 compileJava {
   if (!parseBoolean(bnd('instrument.disabled', 'false'))) {
     inputs.files { rasInstrumentationInputFiles() }
-    def instrument = fileTree(dir: compileJava.destinationDir, include: bnd('instrument.classesIncludes'), exclude: bnd('instrument.classesExcludes'))
+    outputs.dir compileJava.destinationDir
+    def instrument = fileTree(dir: compileJava.destinationDir, include: bnd('instrument.classesIncludes').split("\\s*,\\s*"), exclude: bnd('instrument.classesExcludes').split("\\s*,\\s*"))
     doLast {
       if (instrument.isEmpty())
         return
@@ -375,53 +382,53 @@ task buildfat {
   group = "build"
 }
 
-task apiSpiJavadoc(type: Javadoc) {
-  dependsOn jar
-  def publishSuffix = bnd('publish.wlp.jar.suffix', 'lib')
-  enabled publishSuffix.contains('api/ibm') || publishSuffix.contains('spi/ibm')
+if (bnd('publish.wlp.jar.suffix', 'lib').contains('api/ibm') || bnd('publish.wlp.jar.suffix', 'lib').contains('spi/ibm')) {
+  task apiSpiJavadoc(type: Javadoc) {
+    dependsOn jar
 
-  onlyIf {
-    !new File(buildDir, "javadoc").exists()
-  }
-
-  def sp = files()
-  def cp = files()
-  bndWorkspace.getProject(bnd('Bundle-SymbolicName', project.name))?.getBuildpath().each {
-    def proj = it.getProject()
-    sp += files(proj.getSourcePath())
-    cp += files(it.getFile())
-    cp += files(proj.getBuildpath()*.getFile())
-  }
-
-  destinationDir = file("$buildDir/javadoc")
-  classpath += cp
-  source = sp
-
-  include bnd('Export-Package', '').split(',').collect {
-    def pkg = it
-    int index = pkg.indexOf(";")
-    if (index != -1) {
-      pkg = pkg.substring(0, index)
+    onlyIf {
+      !new File(buildDir, "javadoc").exists()
     }
-    // Replace . with / (path separator) and * (package name wildcard) with **
-    pkg = pkg.trim().replaceAll("\\.", "/").replaceAll("\\*", "/**") + "/*.java"
-    return pkg
-  }
-  exclude "**/internal/**"
-  title = bnd('Bundle-Name')
-  options.source bnd('javac.source')
-  options.memberLevel = 'PUBLIC'
-  options.noIndex true
-  options.use true
-  if (JavaVersion.current().isJava8Compatible()) {
-    options.addStringOption('Xdoclint:none', '-quiet')
-  }
-}
 
-task zipJavadoc(type: Zip) {
-  dependsOn apiSpiJavadoc
-  archiveName bnd('Bundle-SymbolicName', project.name) + '.javadoc.zip'
-  from new File(project.buildDir, "javadoc")
+    def sp = files()
+    def cp = files()
+    bndWorkspace.getProject(bnd('Bundle-SymbolicName', project.name))?.getBuildpath().each {
+      def proj = it.getProject()
+      sp += files(proj.getSourcePath())
+      cp += files(it.getFile())
+      cp += files(proj.getBuildpath()*.getFile())
+    }
+
+    destinationDir = file("$buildDir/javadoc")
+    classpath += cp
+    source = sp
+
+    include bnd('Export-Package', '').split(',').collect {
+      def pkg = it
+      int index = pkg.indexOf(";")
+      if (index != -1) {
+        pkg = pkg.substring(0, index)
+      }
+      // Replace . with / (path separator) and * (package name wildcard) with **
+      pkg = pkg.trim().replaceAll("\\.", "/").replaceAll("\\*", "/**") + "/*.java"
+      return pkg
+    }
+    exclude "**/internal/**"
+    title = bnd('Bundle-Name')
+    options.source bnd('javac.source')
+    options.memberLevel = 'PUBLIC'
+    options.noIndex true
+    options.use true
+    if (JavaVersion.current().isJava8Compatible()) {
+      options.addStringOption('Xdoclint:none', '-quiet')
+    }
+  }
+
+  task zipJavadoc(type: Zip) {
+    dependsOn apiSpiJavadoc
+    archiveName bnd('Bundle-SymbolicName', project.name) + '.javadoc.zip'
+    from new File(project.buildDir, "javadoc")
+  }
 }
 
 /**

--- a/dev/wlp-gradle/utility/build.gradle
+++ b/dev/wlp-gradle/utility/build.gradle
@@ -67,3 +67,26 @@ task sortWlpBundleManifests {
         }
     }
 }
+
+gradle.taskGraph.afterTask { task ->
+  StringBuffer taskDetails = new StringBuffer()
+
+  taskDetails << """"-------------
+  name:$task.name group:$task.group : $task.description
+  conv:$task.convention.plugins
+  inputs:
+"""
+
+  task.inputs.files.each {
+    taskDetails << "${it.absolutePath}\n"
+  }
+
+  taskDetails << "outputs:\n"
+
+  task.outputs.files.each {
+    taskDetails << "${it.absolutePath}\n"
+  }
+
+  taskDetails << "-------------"
+  logger.info(taskDetails)
+}


### PR DESCRIPTION
This PR includes changes to improve the performance of clean and incremental builds.
- incremental builds would re-run `jakartaeeTransform` and `instrument` tasks. Fixed the tasks input/output configurations.
- enable parallel for local builds and fixed `copyFeatureBundles` to depend on `assemble`.

Still some more work to do here...
Clean build duration is 12:57.
First incremental build duration is 3:08 with 69 tasks executed.
Second incremental build duration is 2:48 with 30 tasks executed.