### PR TITLE
Add synchronized blocks to mpConfig AppPropertiesTrackingComponent

### DIFF
--- a/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/AppPropertiesTrackingComponent.java
+++ b/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/AppPropertiesTrackingComponent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -94,17 +94,23 @@ public class AppPropertiesTrackingComponent {
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
     protected void addAppPropertiesComponent(AppPropertiesComponent apc) {
-        propertiesComponentByPid.put(apc.getPid(), apc);
-        updateAppsUsingProperties(apc.getPid());
+        synchronized (this) {
+            propertiesComponentByPid.put(apc.getPid(), apc);
+            updateAppsUsingProperties(apc.getPid());
+        }
     }
 
     protected void updatedAppPropertiesComponent(AppPropertiesComponent apc) {
-        updateAppsUsingProperties(apc.getPid());
+        synchronized (this) {
+            updateAppsUsingProperties(apc.getPid());
+        }
     }
 
     protected void removeAppPropertiesComponent(AppPropertiesComponent apc) {
-        propertiesComponentByPid.remove(apc.getPid(), apc);
-        updateAppsUsingProperties(apc.getPid());
+        synchronized (this) {
+            propertiesComponentByPid.remove(apc.getPid(), apc);
+            updateAppsUsingProperties(apc.getPid());
+        }
     }
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY, service = Application.class)


### PR DESCRIPTION
Hopefully resolves #15869 (Defect 281685)

The JavaDoc for `propertiesComponentByPid` and `updateAppsUsingProperties()` both claim `Must hold lock on {@code this} to access` and `Caller must hold lock on {@code this}.` respectively, hence the additional `synchronized ` blocks in this PR.

#build
#spawn.fullfat.buckets=com.ibm.ws.microprofile.config.1.1_fat, com.ibm.ws.microprofile.config.1.2_fat, com.ibm.ws.microprofile.config.1.3_fat, com.ibm.ws.microprofile.config.1.4_fat, io.openliberty.microprofile.config.2.0.internal_fat, com.ibm.ws.microprofile.config.1.1_fat_tck, com.ibm.ws.microprofile.config.1.2_fat_tck, com.ibm.ws.microprofile.config.1.3_fat_tck, com.ibm.ws.microprofile.config.1.4_fat_tck, io.openliberty.microprofile.config.2.0.internal_fat_tck

