### PR TITLE
Update gradle heap size to 3G to handle increased memory usage

### DIFF
--- a/dev/gradle.properties
+++ b/dev/gradle.properties
@@ -33,7 +33,7 @@ bnd_preCompileRefresh=false
 # By default Gradle will reserve 1GB of heap space.
 # Very large builds might need more memory to hold Gradle’s model and caches.
 # Set file encoding to override the system encoding.
-org.gradle.jvmargs=-Xmx2560M -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx3072M -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # Fix for the TLS protocol version used to communicate with Maven Central when using the IBM JVM.
 systemProp.com.ibm.jsse2.overrideDefaultTLS=true


### PR DESCRIPTION
The CTS builds started failing with OutofMemoryErrors.  This was tracked down to a change to use gradle 6.8 instead of 6.4 in the builds.  It appears that with the increased number of FATs in open liberty and the introduction of gradle 6.8, the heap settings for gradle are not sufficient any longer.