### PR TITLE
Issue 15873: IMAP Mail server failed to start

### DIFF
--- a/dev/com.ibm.ws.javamail.1.6_fat/fat/src/com/ibm/ws/javamail/fat/IMAPTest.java
+++ b/dev/com.ibm.ws.javamail.1.6_fat/fat/src/com/ibm/ws/javamail/fat/IMAPTest.java
@@ -169,8 +169,10 @@ public class IMAPTest {
         // which is then used to create the actual GreenMail server.
         int imapPort = Integer.getInteger("imap_port"); // As per server.xml
         // Need to add -D to the start of the property name
-        System.out.println("Starting IMAP server on port "+imapPort);
+        System.out.println("Starting IMAP server on port " + imapPort);
         ServerSetup imapSetup = new ServerSetup(imapPort, "localhost", "imap");
+        // Allow 30 seconds for mail server to start
+        imapSetup.setServerStartupTimeout(30000);
         imapServer = new GreenMail(imapSetup);
         // Start the imapServer, the GreenMail server is now listening for connections
         imapServer.start();

--- a/dev/com.ibm.ws.javamail.1.6_fat/fat/src/com/ibm/ws/javamail/fat/SMTPTest.java
+++ b/dev/com.ibm.ws.javamail.1.6_fat/fat/src/com/ibm/ws/javamail/fat/SMTPTest.java
@@ -140,8 +140,10 @@ public class SMTPTest {
         // which is then used to create the actual GreenMail server
         int smtpPort = Integer.getInteger("smtp_port"); // As per server.xml
 
-        System.out.println("Starting SMTP server on port "+smtpPort);
+        System.out.println("Starting SMTP server on port " + smtpPort);
         ServerSetup smtpSetup = new ServerSetup(smtpPort, "localhost", "smtp");
+        // give mail server 30 seconds to start
+        smtpSetup.setServerStartupTimeout(30000);
 
         smtpServer = new GreenMail(smtpSetup);
         // Start the mailTestServer


### PR DESCRIPTION
IMAP Test Email server fails to start in the com.ibm.ws.javamail.1.6_fat fat bucket. Add timing parameter to email server setup. 