### PR TITLE
Initial design for HSTS header support in the HTTP transport

### DIFF
--- a/dev/com.ibm.ws.transport.http/resources/com/ibm/ws/http/channel/internal/resources/httpchannelmessages.nlsprops
+++ b/dev/com.ibm.ws.transport.http/resources/com/ibm/ws/http/channel/internal/resources/httpchannelmessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2002, 2020 IBM Corporation and others.
+# Copyright (c) 2002, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -185,3 +185,11 @@ trusted.header.origin.invalid.value.useraction=Ensure that configured IP address
 trusted.sensitive.header.origin.invalid.value=CWWKT0039W: The [{0}] configured trustedSensitiveHeaderOrigin value is invalid and cannot be used.
 trusted.sensitive.header.origin.invalid.value.explanation=The specified value must be either a full IP address or correctly formatted hostname.
 trusted.sensitive.header.origin.invalid.value.useraction=Ensure that configured IP addresses contain a value for each segment, and that hostnames do not contain any invalid characters.
+
+config.hsts.invalid.max.age.value=CWWKT0040W: The [{0}] configured value for the max-age directive is invalid and cannot be used. The value for the max-age directive must be a non-negative integer.
+config.hsts.invalid.max.age.value.explanation=The value for the max-age directive cannot be a negative integer.
+config.hsts.invalid.max.age.value.useraction=Ensure that the configured max-age directive contains a non-negative integer value.
+
+config.hsts.missing.max.age=CWWKT0041W: An attempt was made to configure [{0}] as the Strict-Transport-Security header. This configuration does not contain the mandatory max-age directive. A configuration that does not contain a max-age directive is invalid and cannot be used.
+config.hsts.missing.max.age.explanation=The specified configuration must contain a max-age directive with a non-negative integer value.
+config.hsts.missing.max.age.useraction=Ensure that the configuration contains a max-age directive with a non-negative integer value.

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpConfigConstants.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpConfigConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2020 IBM Corporation and others.
+ * Copyright (c) 2004, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -452,4 +452,7 @@ public class HttpConfigConstants {
             return this.name;
         }
     }
+
+    public static final String PROPNAME_HDR_HSTS_SHORTNAME = "addstricttransportsecurityheader";
+    public static final String PROPNAME_HDR_HSTS_FULLYQUALIFIED = "com.ibm.ws.webcontainer.addStrictTransportSecurityHeader";
 }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/channel/values/HttpHeaderKeys.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/channel/values/HttpHeaderKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2019 IBM Corporation and others.
+ * Copyright (c) 2004, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -222,6 +222,8 @@ public class HttpHeaderKeys extends HeaderKeys {
     public static final HttpHeaderKeys HDR_X_FORWARDED_PROTO = new HttpHeaderKeys("X-Forwarded-Proto");
     /** Private WAS header used by the HTTP Session Manager to determine if a request is failed over */
     public static final HttpHeaderKeys HDR_$WSFO = new HttpHeaderKeys("$WSFO");
+
+    public static final HttpHeaderKeys HDR_HSTS = new HttpHeaderKeys("Strict-Transport-Security");
     /** Max value of header keys that will be kept in key storage */
     public static final int ORD_MAX = 1024;
 

--- a/dev/com.ibm.ws.transport.http/test/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLinkTest.java
+++ b/dev/com.ibm.ws.transport.http/test/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLinkTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2017 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,8 +17,10 @@ import org.jmock.Mockery;
 import org.jmock.integration.junit4.JUnit4Mockery;
 import org.junit.Test;
 
+import com.ibm.wsspi.http.channel.HttpRequestMessage;
 import com.ibm.wsspi.http.channel.HttpResponseMessage;
 import com.ibm.wsspi.http.channel.values.ConnectionValues;
+import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
 import com.ibm.wsspi.http.channel.values.StatusCodes;
 
 /**
@@ -34,11 +36,13 @@ public class HttpDispatcherLinkTest {
     @Test
     public void setHttpResponseMessage() {
         final HttpDispatcherLink link = new HttpDispatcherLink();
+        final HttpRequestMessage rqMsg = mock.mock(HttpRequestMessage.class);
         final HttpResponseMessage rMsg = mock.mock(HttpResponseMessage.class);
         final StatusCodes code = StatusCodes.OK;
 
         mock.checking(new Expectations() {
             {
+                one(rMsg).getHeader(HttpHeaderKeys.HDR_HSTS);
                 one(rMsg).setStatusCode(code);
                 one(rMsg).setConnection(ConnectionValues.CLOSE);
                 one(rMsg).setCharset(Charset.forName("UTF-8"));
@@ -46,7 +50,7 @@ public class HttpDispatcherLinkTest {
             }
         });
 
-        link.setResponseProperties(rMsg, StatusCodes.OK);
+        link.setResponseProperties(rqMsg, rMsg, StatusCodes.OK);
         mock.assertIsSatisfied();
     }
 


### PR DESCRIPTION
This defect adresses issue #16054 

Issue description: 

There are scenarios where the HTTP Dispatcher will set a 404 status and send a response without ever engaging the Web Container/Servlet layer. There are increasing reports made regarding the HTTP `Strict Transport Security` header not be added in these scenarios. 

The current support for adding this header is limited to responses that pass through the container, and as such we need to find a way for this to be supported at the transport layer.

Specification of the HTTP `Strict Transport Security` header: https://tools.ietf.org/html/rfc6797#section-6

> 1.  The order of appearance of directives is not significant.
> 
>    2.  All directives MUST appear only once in an STS header field.
>        Directives are either optional or required, as stipulated in
>        their definitions.
> 
>    3.  Directive names are case-insensitive.
> 
>    4.  UAs MUST ignore any STS header field containing directives, or
>        other header field value data, that does not conform to the
>        syntax defined in this specification.
> 
>    5.  If an STS header field contains directive(s) not recognized by
>        the UA, the UA MUST ignore the unrecognized directives, and if
>        the STS header field otherwise satisfies the above requirements
>        (1 through 4), the UA MUST process the recognized directives.

Regarding the `max-age directive`:

> The syntax of the max-age directive's REQUIRED value (after
>    quoted-string unescaping, if necessary) is defined as:
> 
>     max-age-value = delta-seconds

The `includeSubDomains` is defined to be OPTIONAL. 


### Additional details 

The HTTP transport will read the <webContainer> options and support two formats:

- Fully qualified: `com.ibm.ws.webcontainer.addStrictTransportSecurityHeader`
- Shortname: `addstricttransportsecurityheader
`
The fully qualified format will be preferred over the shortname if for whatever reason both are present in the configuration. Empty values on either of these options will be ignored by the parsing logic. 

The HTTP transport's parsing of these properties will have new tracing, including some warning messages if a bad configuration is detected.  The `HTTPDispatcher=all` trace level can be used to see what the resulting header value will look like. 


