### PR TITLE
Add main branch to GH Action build

### DIFF
--- a/.github/workflows/openliberty-ci.yml
+++ b/.github/workflows/openliberty-ci.yml
@@ -7,7 +7,9 @@ on:
   - cron: '0 0 * * 1-5'
   pull_request:
     branches: 
+    #TODO remove integration once main branch is adopted.
     - integration
+    - main
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - '.gitignore'


### PR DESCRIPTION
Plans to rename Integration to Main will affect GitHub actions build.  
When the branch is renamed merge this PR. 