### PR TITLE
Update folder check

### DIFF
--- a/.github/workflow-scripts/generate-params.sh
+++ b/.github/workflow-scripts/generate-params.sh
@@ -1,22 +1,29 @@
 #!/bin/bash
+
 # Save off PR Summary
 echo $PRBODY >> .github/pull_request_body.txt
-echo "PR Summary is:"
+echo "::group::PR Summary"
 cat .github/pull_request_body.txt
+echo "::endgroup::"
 
 # Save off modified files
 git diff --name-only HEAD^...HEAD^2 >> .github/modified_files.diff
-echo "Modified files in this PR are:"
+echo "::group::Modified files in this PR"
 cat .github/modified_files.diff
+echo "::endgroup::"
 
 # Generate test categories
 MATRIX_RESULT=$(java .github/workflow-scripts/GenerateCategories.java .github/pull_request_body.txt)
-echo "MATRIX_RESULT is $MATRIX_RESULT"
+echo "::group::MATRIX_RESULT"
+echo $MATRIX_RESULT
+echo "::endgroup::"
 
 # Report if we have modified files or not
-if [ -f .github/test-categories/MODIFIED_* ]; then
+if ls .github/test-categories/MODIFIED_* &> /dev/null ; then
+    echo "Modified test-categories found $(ls .github/test-categories/MODIFIED_*)"
     echo "::set-output name=modified-categories::true"
 else
+    echo "No modified test-categories found"
     echo "::set-output name=modified-categories::false"
 fi
 


### PR DESCRIPTION
```
if [ -f .github/test-categories/MODIFIED_* ]; then
```

worked on my local system and would return true/false depending on the existence of these files.

The github action's build instead returned a non failing error
```
.github/test-categories/MODIFIED_FULL_MODE_0: binary operator expected
```

Here the failure is due to the fact that bash substituted the GLOB with the actual file names meaning there was an extra argument since two files matched.

Instead, change it to a more shell agnostic check
```
if ls .github/test-categories/MODIFIED_* &> /dev/null ; then
```