### PR TITLE
EJB change gradle task for pulling in rar fat tool project

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.injection_fat/build.gradle
+++ b/dev/com.ibm.ws.ejbcontainer.injection_fat/build.gradle
@@ -56,6 +56,8 @@ task addEJBTools {
 }
 
 task addTestResourceAdapter {
+  outputs.upToDateWhen { false }
+  enabled = true;
   dependsOn ':com.ibm.ws.ejbcontainer.fat_tools_rar:build' 
   doLast{
       copy {
@@ -72,12 +74,11 @@ task addTestResourceAdapter {
   }       
 }
 
-buildfat {
- dependsOn cleanFat
- dependsOn addTestResourceAdapter
- dependsOn assemble
- dependsOn build
- dependsOn zipProjectFVT
+
+assemble {
+    outputs.upToDateWhen { false }
+    enabled = true;
+    dependsOn addTestResourceAdapter
 }
 
 addRequiredLibraries {

--- a/dev/com.ibm.ws.ejbcontainer.mdb.ra_fat/build.gradle
+++ b/dev/com.ibm.ws.ejbcontainer.mdb.ra_fat/build.gradle
@@ -53,6 +53,8 @@ task addEnterpriseBeansTools {
 }
 
 task addTestResourceAdapter {
+  outputs.upToDateWhen { false }
+  enabled = true;
   dependsOn ':com.ibm.ws.ejbcontainer.fat_tools_rar:build' 
   doLast{
       copy {
@@ -69,12 +71,11 @@ task addTestResourceAdapter {
   }       
 }
 
-buildfat {
- dependsOn cleanFat
- dependsOn addTestResourceAdapter
- dependsOn assemble
- dependsOn build
- dependsOn zipProjectFVT
+
+assemble {
+    outputs.upToDateWhen { false }
+    enabled = true;
+    dependsOn addTestResourceAdapter
 }
 
 


### PR DESCRIPTION
Changes the logic to pull in the ejbcontainer.fat_rar_tools project to fats that use it to happen on the assemble step as some builds run that separately and then zip up the fat to be ran on a child build.