### PR TITLE
Invalidate cached config when an error or warning occurs

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigUpdater.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ConfigUpdater.java
@@ -118,7 +118,7 @@ class ConfigUpdater {
                 if (failOnError) {
                     throw e;
                 } else {
-                    Tr.error(tc, "error.config.update.exception", new Object[] { nodeName, e.getMessage(), info.configElement.getId() });
+                    configEvaluator.issueError("error.config.update.exception", new Object[] { nodeName, e.getMessage(), info.configElement.getId() });
                     warnIfOldConfigExists(info, nodeName);
                 }
             } catch (AttributeValidationException e) {
@@ -126,8 +126,8 @@ class ConfigUpdater {
                 if (failOnError) {
                     throw new ConfigUpdateException(e);
                 } else {
-                    Tr.error(tc, "error.attribute.validation.exception",
-                             new Object[] { nodeName, e.getAttributeDefintion().getID(), e.getValue(), e.getMessage() });
+                    configEvaluator.issueError("error.attribute.validation.exception",
+                                               new Object[] { nodeName, e.getAttributeDefintion().getID(), e.getValue(), e.getMessage() });
                     warnIfOldConfigExists(info, nodeName);
                 }
             } catch (ConfigEvaluatorException e) {
@@ -135,7 +135,7 @@ class ConfigUpdater {
                 if (failOnError) {
                     throw new ConfigUpdateException(e);
                 } else {
-                    Tr.error(tc, "error.config.update.exception", new Object[] { nodeName, e.getMessage(), info.configElement.getId() });
+                    configEvaluator.issueError("error.config.update.exception", new Object[] { nodeName, e.getMessage(), info.configElement.getId() });
                     warnIfOldConfigExists(info, nodeName);
                 }
             }
@@ -425,9 +425,9 @@ class ConfigUpdater {
      * For Map of String value comparison, all keys and values must be equal.
      *
      * @param c1
-     *            config value
+     *               config value
      * @param c2
-     *            config value
+     *               config value
      * @return boolean
      */
     private static boolean equalConfigValues(Object c1, Object c2) {
@@ -596,7 +596,7 @@ class ConfigUpdater {
                 // throw an error
                 if (info != null) {
                     String id = failedUpdateAttrDef.get(value).getID();
-                    Tr.error(tc, "error.unique.value.conflict", id, value);
+                    configEvaluator.issueError("error.unique.value.conflict", id, value);
                     String nodeName = getNodeNameForExceptions(info.configElement);
                     String exceptionMessage = "The value " + value + " for attribute " + id + " is not unique";
 
@@ -606,7 +606,7 @@ class ConfigUpdater {
                     if (failOnError) {
                         throw new ConfigUpdateException(exceptionMessage);
                     } else {
-                        Tr.error(tc, "error.config.update.exception", new Object[] { nodeName, exceptionMessage, info.configElement.getId() });
+                        configEvaluator.issueError("error.config.update.exception", new Object[] { nodeName, exceptionMessage, info.configElement.getId() });
                         warnIfOldConfigExists(info, nodeName);
                     }
                 }

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ServerConfiguration.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ServerConfiguration.java
@@ -33,7 +33,8 @@ public class ServerConfiguration extends BaseConfiguration {
 
     protected BaseConfiguration defaultConfiguration;
 
-    public ServerConfiguration() {}
+    public ServerConfiguration() {
+    }
 
     public void setDefaultConfiguration(BaseConfiguration defaultConfiguration) {
         this.defaultConfiguration = defaultConfiguration;

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ServerXMLConfiguration.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/ServerXMLConfiguration.java
@@ -154,7 +154,11 @@ class ServerXMLConfiguration {
     }
 
     public void setConfigReadTime() {
-        long time = getLastResourceModifiedTime(); //serverConfiguration.getLastModified();
+        setConfigReadTime(getLastResourceModifiedTime());
+
+    }
+
+    public void setConfigReadTime(long time) {
         // Update time stamp for configReadTime on next run.
         TimestampUtils.writeTimeToFile(bundleContext.getDataFile("configStamp"), time);
         configReadTime = time;

--- a/dev/com.ibm.ws.config/test/com/ibm/ws/config/xml/internal/ConfigEvaluatorTest.java
+++ b/dev/com.ibm.ws.config/test/com/ibm/ws/config/xml/internal/ConfigEvaluatorTest.java
@@ -32,12 +32,15 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
 
+import org.jmock.Expectations;
+import org.jmock.Mockery;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.osgi.framework.BundleContext;
 import org.osgi.service.metatype.AttributeDefinition;
 
 import com.ibm.websphere.config.ConfigEvaluatorException;
@@ -155,7 +158,15 @@ public class ConfigEvaluatorTest {
     }
 
     private TestConfigEvaluator createConfigEvaluator(MetaTypeRegistry registry, ConfigVariableRegistry variableRegistry, ServerConfiguration serverConfiguration) {
-        ServerXMLConfiguration serverXMLConfiguration = new ServerXMLConfiguration(null, wsLocation, null);
+        Mockery mock = new Mockery();
+        BundleContext ctx = mock.mock(BundleContext.class);
+        mock.checking(new Expectations() {
+            {
+                allowing(ctx).getDataFile("configStamp");
+                will(returnValue(null));
+            }
+        });
+        ServerXMLConfiguration serverXMLConfiguration = new ServerXMLConfiguration(ctx, wsLocation, null);
         serverXMLConfiguration.setNewConfiguration(serverConfiguration);
         TestConfigEvaluator evaluator = new TestConfigEvaluator(null, registry, variableRegistry, serverXMLConfiguration);
         return evaluator;


### PR DESCRIPTION
Invalidate the configuration cache by setting the timestamp to '-1' when an error or warning during processing occurs. 