### PR TITLE
Backport TCK snapshot with timeout changes to MP Rest Client 1.2-1.4

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -95,6 +95,9 @@ org.apache.santuario:xmlsec:1.5.2-ibm
 org.apache.ws.security:wss4j:1.6.7-ibm-s20130913-2015
 org.eclipse.microprofile.graphql:microprofile-graphql-api:1.0.0-20191203
 org.eclipse.microprofile.graphql:microprofile-graphql-tck:1.0.0-20191203
+org.eclipse.microprofile.rest.client:microprofile-rest-client-tck:1.2.2-20210215
+org.eclipse.microprofile.rest.client:microprofile-rest-client-tck:1.3.5-20210215
+org.eclipse.microprofile.rest.client:microprofile-rest-client-tck:1.4.2-20210215
 org.eclipse.microprofile.rest.client:microprofile-rest-client-tck:2.0.1-20210208
 org.mock-server:mockserver-core:3.10.7-IBM20191022
 org.mock-server:mockserver-core:3.10.7-IBM20191022

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,3 +1,3 @@
 -Dcom.ibm.tools.attach.enable=yes
--Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=20
+-Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=20000
 -Xmx1024m

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
     <name>MicroProfile RestClient 1.2 TCK Runner TCK Module</name>
 
     <properties>
-        <microprofile.rest.client.version>1.2.1</microprofile.rest.client.version>
+        <microprofile.rest.client.version>1.2.2-20210215</microprofile.rest.client.version>
         <arquillian.version>1.1.13.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->

--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,3 +1,3 @@
 -Dcom.ibm.tools.attach.enable=yes
--Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=20
+-Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=20000
 -Xmx1024m

--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
     <name>MicroProfile RestClient 1.3 TCK Runner TCK Module</name>
 
     <properties>
-        <microprofile.rest.client.version>1.3.3</microprofile.rest.client.version>
+        <microprofile.rest.client.version>1.3.5-20210215</microprofile.rest.client.version>
         <arquillian.version>1.1.13.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,3 +1,3 @@
 -Dcom.ibm.tools.attach.enable=yes
--Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=20
+-Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=20000
 -Xmx1024m

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
     <name>MicroProfile RestClient 1.4 TCK Runner TCK Module</name>
 
     <properties>
-        <microprofile.rest.client.version>1.4-RC2</microprofile.rest.client.version>
+        <microprofile.rest.client.version>1.4.2-20210215</microprofile.rest.client.version>
         <arquillian.version>1.1.13.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->


### PR DESCRIPTION
This PR backports the TCK changes made to improve timeout handling (cushion for slow build machines and cushion for rounding errors and time unit conversions) to the previous MP Rest Client TCK FATs - it was added to the 2.0 TCK FAT in PR #15844 