### PR TITLE
Issue 15945: move CWPKI2052I earlier when checking for renewed certs

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeValidityAndRenewTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeValidityAndRenewTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -408,10 +408,10 @@ public class AcmeValidityAndRenewTest {
 			Log.info(this.getClass(), testName.getMethodName(),
 					"Waiting for " + waitTime + " while checking for new certificate");
 
-			AcmeFatUtils.waitForNewCert(server, caContainer, startingCertificateChain, waitTime);
-
 			assertNotNull("Should log message that the certificate was renewed",
-					server.waitForStringInLogUsingMark("CWPKI2052I"));
+					server.waitForStringInLogUsingMark("CWPKI2052I", waitTime));
+
+			AcmeFatUtils.waitForNewCert(server, caContainer, startingCertificateChain, waitTime);
 
 			/**
 			 * Run "load" while the certificate checkers runs in the background and renews the cert
@@ -858,10 +858,10 @@ public class AcmeValidityAndRenewTest {
 			Log.info(this.getClass(), testName.getMethodName(),
 					"Waiting for " + waitTime + " while checking for new certificate");
 
-			AcmeFatUtils.waitForNewCert(server, caContainer, startingCertificateChain, waitTime);
-
 			assertNotNull("Should log message that the certificate was renewed",
-					server.waitForStringInLogUsingMark("CWPKI2052I"));
+					server.waitForStringInLogUsingMark("CWPKI2052I", waitTime));
+
+			AcmeFatUtils.waitForNewCert(server, caContainer, startingCertificateChain, waitTime);
 
 			assertNotNull("Should log message that the certificate was renewed after restarting Pebble",
 					server.waitForStringInLogUsingMark("CWPKI2007I"));


### PR DESCRIPTION
Fixes #15945

For better timing resilience, check for the CWPKI2052I expiration message first, then check for a new certificate, as that is how they occur naturally and there can be a time lag between marking a cert as expired and completing the renewal process.

```
com.ibm.ws.security.acme.internal.AcmeCertCheckerTask        I CWPKI2052I: The certificate with 406f788471526f67 serial number expires on 2026-02-10T01:31:09Z. The ACME service will request a new certificate from the ACME certificate authority at the https://test_machine:36643/dir URI.
 com.ibm.ws.security.acme.internal.AcmeProviderImpl           A CWPKI2007I: The ACME service installed a certificate with the 7c7dc81af4acf63f serial number that is signed by the ACME certificate authority at the https://test_machine:36643/dir URI. The expiration
```