### PR TITLE
Add new message and warnning for when exception is caught by the default exception mapper

### DIFF
--- a/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/resources/io/openliberty/microprofile/metrics/internal/monitor/resources/MonitorMetrics.nlsprops
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/resources/io/openliberty/microprofile/metrics/internal/monitor/resources/MonitorMetrics.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -25,3 +25,7 @@ FEATURE_REGISTERED.useraction=No user action is required.
 FEATURE_UNREGISTERED=CWPMI2004I: All monitoring metrics were unregistered from mpMetrics.
 FEATURE_UNREGISTERED.explanation=The Performance Monitoring feature, the MicroProfile Metrics feature, or both features were removed from the server. All monitoring metrics were unregistered from MicroProfile Metrics.
 FEATURE_UNREGISTERED.useraction=No user action is required.
+
+METRICS_UNHANDLED_JAXRS_EXCEPTION=CWPMI2005W: The MicroProfile Metrics exception mapper detected and is handling an unhandled exception from the JAX-RS application.
+METRICS_UNHANDLED_JAXRS_EXCEPTION.explanation=The JAX-RS-based application experienced an exception that is not handled within the application. The MicroProfile code handles it by logging the exception stack trace and returning a 500 Internal Server Error response.
+METRICS_UNHANDLED_JAXRS_EXCEPTION.useraction=This behavior might be acceptable. To handle the exception differently, the application developer can add an ExceptionMapper interface that handles the exception and maps it to a different response.

--- a/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/resources/io/openliberty/microprofile/metrics/internal/monitor/resources/MonitorMetrics.nlsprops
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/resources/io/openliberty/microprofile/metrics/internal/monitor/resources/MonitorMetrics.nlsprops
@@ -28,4 +28,4 @@ FEATURE_UNREGISTERED.useraction=No user action is required.
 
 METRICS_UNHANDLED_JAXRS_EXCEPTION=CWPMI2005W: The MicroProfile Metrics exception mapper detected and is handling an unhandled exception from the JAX-RS application.
 METRICS_UNHANDLED_JAXRS_EXCEPTION.explanation=The JAX-RS-based application experienced an exception that is not handled within the application. The MicroProfile code handles it by logging the exception stack trace and returning a 500 Internal Server Error response.
-METRICS_UNHANDLED_JAXRS_EXCEPTION.useraction=This behavior might be acceptable. To handle the exception differently, the application developer can add an ExceptionMapper interface that handles the exception and maps it to a different response.
+METRICS_UNHANDLED_JAXRS_EXCEPTION.useraction=This behavior might be acceptable. To handle the exception differently, add an ExceptionMapper interface that handles the exception and maps it to a different response.

--- a/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/MetricsJaxRsEMCallbackImpl.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/MetricsJaxRsEMCallbackImpl.java
@@ -41,6 +41,8 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
 				"service.vendor=IBM" })
 public class MetricsJaxRsEMCallbackImpl  implements DefaultExceptionMapperCallback {
 
+	private static final TraceComponent tc = Tr.register(MetricsJaxRsEMCallbackImpl.class);
+
 	public static final String EXCEPTION_KEY = MetricsJaxRsEMCallbackImpl.class.getName() + ".Exception";
 	private static final String[] metricCDIBundles = {"io.astefanutti.metrics.cdi30", "io.openliberty.microprofile.metrics.internal.cdi30.interceptors"};
 	
@@ -78,8 +80,8 @@ public class MetricsJaxRsEMCallbackImpl  implements DefaultExceptionMapperCallba
 			registerOrRetrieveRESTUnmappedExceptionMetric(classXmethod.getKey() ,classXmethod.getValue()).inc();
 		}
 
-		throwable.printStackTrace();
-		
+		Tr.warning(tc, "METRICS_UNHANDLED_JAXRS_EXCEPTION", throwable);
+
 		return Collections.singletonMap(EXCEPTION_KEY, throwable);
 	}
 

--- a/dev/io.openliberty.microprofile.metrics.internal.3.0_fat_tck/fat/src/io/openliberty/microprofile/metrics30/internal/tck/launcher/MetricsTCKLauncher.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0_fat_tck/fat/src/io/openliberty/microprofile/metrics30/internal/tck/launcher/MetricsTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -45,7 +45,7 @@ public class MetricsTCKLauncher {
     @AfterClass
     public static void tearDown() throws Exception {
         // Ignore CWWKZ0131W - In windows, some jars are being locked during the test. Issue #2768
-        server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWWKZ0002E", "CWWKZ0131W", "CWWKW1001W", "CWWKW1002W");
+        server.stopServer("CWMCG0007E", "CWMCG0014E", "CWMCG0015E", "CWMCG5003E", "CWWKZ0002E", "CWWKZ0131W", "CWWKW1001W", "CWWKW1002W", "CWPMI2005W");
     }
 
     @Test

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingRestClientTCKLauncher.java
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingRestClientTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -49,7 +49,7 @@ public class OpentracingRestClientTCKLauncher {
      */
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer("CWWKG0014E");
+        server.stopServer("CWWKG0014E", "CWPMI2005W");
     }
 
     @Test

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingTCKLauncher.java
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingTCKLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -40,7 +40,7 @@ public class OpentracingTCKLauncher {
      */
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer("CWMOT0009W", "CWWKG0014E");
+        server.stopServer("CWMOT0009W", "CWWKG0014E", "CWPMI2005W");
     }
 
     @Test

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingTCKLauncherMicroProfile.java
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/opentracing/internal/tck/OpentracingTCKLauncherMicroProfile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -42,7 +42,7 @@ public class OpentracingTCKLauncherMicroProfile {
      */
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer("CWMOT0009W", "CWWKG0014E");
+        server.stopServer("CWMOT0009W", "CWWKG0014E", "CWPMI2005W");
     }
 
     @Test


### PR DESCRIPTION
fixes #15955



```
Printing the stack trace when an exception is encountered in MetricsJaxRsEMCallbackImpl.java was a temporary measure.
We should log a a warning with a globalized message. The temporary work was due to the last-minute change and being unable to globalize a message.

The runtime exceptions caught are both exceptions emitted by the Metrics CDI Bundle (e.g exceptions thrown by an interceptor) or due to runtime exceptions thrown by the application itself).

The messages added are similar to that used with MP OpenTracing.
```

See also the MP Open Tracing  file:
https://github.com/OpenLiberty/open-liberty/blob/integration/dev/io.openliberty.opentracing.2.0.internal/resources/io/openliberty/opentracing/internal/resources/Opentracing.nlsprops#L77