### PR TITLE
Try defining jboss-servlet-api_3.0_spec version in TCKs

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -42,6 +42,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+	          <groupId>org.jboss.spec.javax.servlet</groupId>
+	          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+	          <version>1.0.2.Final</version> <!-- Defines the version of this artifact that arquillian-liberty-managed should use -->
+	        </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -42,6 +42,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+	          <groupId>org.jboss.spec.javax.servlet</groupId>
+	          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+	          <version>1.0.2.Final</version> <!-- Defines the version of this artifact that arquillian-liberty-managed should use -->
+	        </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -42,6 +42,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+	          <groupId>org.jboss.spec.javax.servlet</groupId>
+	          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+	          <version>1.0.2.Final</version> <!-- Defines the version of this artifact that arquillian-liberty-managed should use -->
+	        </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.config.1.4_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.4_fat_tck/publish/tckRunner/tck/pom.xml
@@ -42,6 +42,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+	          <groupId>org.jboss.spec.javax.servlet</groupId>
+	          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+	          <version>1.0.2.Final</version> <!-- Defines the version of this artifact that arquillian-liberty-managed should use -->
+	        </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -41,6 +41,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+	          <groupId>org.jboss.spec.javax.servlet</groupId>
+	          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+	          <version>1.0.2.Final</version> <!-- Defines the version of this artifact that arquillian-liberty-managed should use -->
+	        </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -41,6 +41,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+	          <groupId>org.jboss.spec.javax.servlet</groupId>
+	          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+	          <version>1.0.2.Final</version> <!-- Defines the version of this artifact that arquillian-liberty-managed should use -->
+	        </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -40,6 +40,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+	          <groupId>org.jboss.spec.javax.servlet</groupId>
+	          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+	          <version>1.0.2.Final</version> <!-- Defines the version of this artifact that arquillian-liberty-managed should use -->
+	        </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.openapi.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.openapi.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -25,6 +25,16 @@
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+	          <groupId>org.jboss.spec.javax.servlet</groupId>
+	          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+	          <version>1.0.2.Final</version> <!-- Defines the version of this artifact that arquillian-liberty-managed should use -->
+	        </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <directory>${targetDirectory}</directory>
         <defaultGoal>clean test</defaultGoal>

--- a/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -42,6 +42,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+	          <groupId>org.jboss.spec.javax.servlet</groupId>
+	          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+	          <version>1.0.2.Final</version> <!-- Defines the version of this artifact that arquillian-liberty-managed should use -->
+	        </dependency>
         </dependencies>
     </dependencyManagement> 
     

--- a/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -43,6 +43,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+	          <groupId>org.jboss.spec.javax.servlet</groupId>
+	          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+	          <version>1.0.2.Final</version> <!-- Defines the version of this artifact that arquillian-liberty-managed should use -->
+	        </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -40,6 +40,16 @@
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+	          <groupId>org.jboss.spec.javax.servlet</groupId>
+	          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+	          <version>1.0.2.Final</version> <!-- Defines the version of this artifact that arquillian-liberty-managed should use -->
+	        </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <directory>${targetDirectory}</directory>
         <defaultGoal>clean test</defaultGoal>


### PR DESCRIPTION
An attempt to solve defect 280600.

The defect is occurring when downloading `jboss-servlet-api_3.0_spec/maven-metadata.xml`. By defining a version for `jboss-servlet-api_3.0_spec` hopefully this will prevent ever needing the `maven-metadata.xml` in the first place.

Initially testing for the following buckets:
- mpConfig
- mpFaultTolerance
- mpOpenAPI

If this works, we can roll it out to the other TCK buckets.