### PR TITLE
DataStoreHelperMetaData methods for networktimeout readonly schema typemap

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/heritage/DataStoreHelperMetaData.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/heritage/DataStoreHelperMetaData.java
@@ -20,4 +20,33 @@ public interface DataStoreHelperMetaData {
      * @return true if the operation is supported, otherwise false.
      */
     boolean supportsGetCatalog();
+
+    /**
+     * Indicates whether the JDBC driver supports <code>java.sql.Connection.getNetworkTimeout</code>.
+     *
+     * @return true if the operation is supported, otherwise false.
+     */
+    boolean supportsGetNetworkTimeout();
+
+    /**
+     * Indicates whether the JDBC driver supports <code>java.sql.Connection.getSchema</code>.
+     *
+     * @return true if the operation is supported, otherwise false.
+     */
+    boolean supportsGetSchema();
+
+    /**
+     * Indicates whether the JDBC driver supports <code>java.sql.Connection.getTypeMap</code>.
+     *
+     * @return true if the operation is supported, otherwise false.
+     */
+    boolean supportsGetTypeMap();
+
+    /**
+     * Indicates whether the JDBC driver supports <code>java.sql.Connection.isReadOnly</code>.
+     *
+     * @return true if the operation is supported, otherwise false.
+     */
+    boolean supportsIsReadOnly();
+
 }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DatabaseHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DatabaseHelper.java
@@ -1212,7 +1212,27 @@ public class DatabaseHelper implements DataStoreHelper, DataStoreHelperMetaData 
 
     @Override
     public boolean supportsGetCatalog() {
-        return true;
+        return mcf.supportsGetCatalog;
+    }
+
+    @Override
+    public boolean supportsGetNetworkTimeout() {
+        return mcf.supportsGetNetworkTimeout;
+    }
+
+    @Override
+    public boolean supportsGetSchema() {
+        return mcf.supportsGetSchema;
+    }
+
+    @Override
+    public boolean supportsGetTypeMap() {
+        return mcf.supportsGetTypeMap;
+    }
+
+    @Override
+    public boolean supportsIsReadOnly() {
+        return mcf.supportsIsReadOnly;
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
@@ -322,8 +322,6 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
     /** Indicates whether catalog, typeMap, readOnly, schema, sharding key, super sharding key, or networkTimeout has been changed. */
     private boolean connectionPropertyChanged;
 
-    private final DataStoreHelperMetaData mData;
-
     /** current cursor holdability */
     private int currentHoldability; 
 
@@ -479,8 +477,6 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
         // Record the current thread id, for use in multithreaded access detection. 
         DSConfig config = dsConfig.get();
         threadID = config.enableMultithreadedAccessDetection ? Thread.currentThread() : threadID; 
-
-        mData = mcf1.dataStoreHelper.getMetaData();
 
         rrsTransactional = helper.getRRSTransactional(); 
 
@@ -658,7 +654,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                                 cri.ivUserName,
                                 cri.ivPassword,
                                 isolationChanged ? currentTransactionIsolation : cri.ivIsoLevel,
-                                connectionPropertyChanged && mData.supportsGetCatalog() ? getCatalog() : cri.ivCatalog,
+                                connectionPropertyChanged && mcf.supportsGetCatalog ? getCatalog() : cri.ivCatalog,
                                 connectionPropertyChanged && mcf.supportsIsReadOnly ? Boolean.valueOf(isReadOnly()) : cri.ivReadOnly,
                                 connectionPropertyChanged ? currentShardingKey : cri.ivShardingKey,
                                 connectionPropertyChanged ? currentSuperShardingKey : cri.ivSuperShardingKey,
@@ -996,7 +992,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                     Tr.debug(this, tc, "MCF is NOT rrsTransactional:  setting currentAutoCommit and defaultAutoCommit to " + defaultAutoCommit + " from underlying Connection"); 
                 } 
             } 
-            defaultCatalog = mData.supportsGetCatalog() ? sqlConn.getCatalog() : null;
+            defaultCatalog = mcf.supportsGetCatalog ? sqlConn.getCatalog() : null;
             defaultReadOnly = mcf.supportsIsReadOnly ? sqlConn.isReadOnly() : false;
             defaultTypeMap = getTypeMapSafely();
             currentShardingKey = initialShardingKey = cri.ivShardingKey;
@@ -2069,7 +2065,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                 setTransactionIsolation(cri.ivIsoLevel);
             }
 
-            if (cri.ivCatalog != null && !cri.ivCatalog.equals(defaultCatalog) && mData.supportsGetCatalog()) {
+            if (cri.ivCatalog != null && !cri.ivCatalog.equals(defaultCatalog) && mcf.supportsGetCatalog) {
                 setCatalog(cri.ivCatalog);
             }
 
@@ -2868,7 +2864,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                 }
             }
 
-            if (mData.supportsGetCatalog())
+            if (mcf.supportsGetCatalog)
             {
                 try {
                     setCatalog(defaultCatalog);

--- a/dev/com.ibm.ws.jdbc_fat_heritage/publish/servers/com.ibm.ws.jdbc.heritage/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/publish/servers/com.ibm.ws.jdbc.heritage/server.xml
@@ -32,7 +32,7 @@
   <dataSource id="DefaultDataSource" containerAuthDataRef="dbAuth" type="javax.sql.DataSource">
     <jdbcDriver libraryRef="JDBCLib" javax.sql.DataSource="test.jdbc.heritage.driver.HDDataSource"/>
     <properties databaseName="memory:testdb" createDatabase="create"
-                supportsCatalog="false"/>
+                supportsCatalog="false" supportsNetworkTimeout="false" supportsReadOnly="false" supportsSchema="false" supportsTypeMap="false"/>
     <heritageSettings helperClass="test.jdbc.heritage.driver.helper.HDDataStoreHelper"/>
   </dataSource>
 

--- a/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HDConnection.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HDConnection.java
@@ -138,12 +138,18 @@ public class HDConnection implements Connection {
 
     @Override
     public int getNetworkTimeout() throws SQLException {
-        return derbycon.getNetworkTimeout();
+        if (ds.supportsNetworkTimeout)
+            return derbycon.getNetworkTimeout();
+        else
+            throw new SQLException("You disabled the ability to get the network timeout.");
     }
 
     @Override
     public String getSchema() throws SQLException {
-        return derbycon.getSchema();
+        if (ds.supportsSchema)
+            return derbycon.getSchema();
+        else
+            throw new SQLException("You disabled the ability to get the schema.");
     }
 
     @Override
@@ -153,7 +159,10 @@ public class HDConnection implements Connection {
 
     @Override
     public Map<String, Class<?>> getTypeMap() throws SQLException {
-        return derbycon.getTypeMap();
+        if (ds.supportsTypeMap)
+            return derbycon.getTypeMap();
+        else
+            throw new SQLException("You disabled support for type map.");
     }
 
     @Override
@@ -168,7 +177,10 @@ public class HDConnection implements Connection {
 
     @Override
     public boolean isReadOnly() throws SQLException {
-        return derbycon.isReadOnly();
+        if (ds.supportsReadOnly)
+            return derbycon.isReadOnly();
+        else
+            throw new SQLException("You disabled support for read only.");
     }
 
     @Override
@@ -276,12 +288,18 @@ public class HDConnection implements Connection {
 
     @Override
     public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
-        derbycon.setNetworkTimeout(executor, milliseconds);
+        if (ds.supportsNetworkTimeout)
+            derbycon.setNetworkTimeout(executor, milliseconds);
+        else
+            throw new SQLException("You disabled the ability to set the network timeout.");
     }
 
     @Override
     public void setReadOnly(boolean readOnly) throws SQLException {
-        derbycon.setReadOnly(readOnly);
+        if (ds.supportsReadOnly)
+            derbycon.setReadOnly(readOnly);
+        else
+            throw new SQLException("You disabled support for read only.");
     }
 
     @Override
@@ -296,7 +314,10 @@ public class HDConnection implements Connection {
 
     @Override
     public void setSchema(String schema) throws SQLException {
-        derbycon.setSchema(schema);
+        if (ds.supportsSchema)
+            derbycon.setSchema(schema);
+        else
+            throw new SQLException("You disabled the ability to set the schema.");
     }
 
     @Override
@@ -306,7 +327,10 @@ public class HDConnection implements Connection {
 
     @Override
     public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
-        derbycon.setTypeMap(map);
+        if (ds.supportsTypeMap)
+            derbycon.setTypeMap(map);
+        else
+            throw new SQLException("You disabled support for type map.");
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HDDataSource.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HDDataSource.java
@@ -17,6 +17,10 @@ import javax.sql.DataSource;
 
 public class HDDataSource extends org.apache.derby.jdbc.EmbeddedDataSource implements DataSource {
     boolean supportsCatalog = true;
+    boolean supportsNetworkTimeout = true;
+    boolean supportsReadOnly = true;
+    boolean supportsSchema = true;
+    boolean supportsTypeMap = true;
 
     @Override
     public Connection getConnection() throws SQLException {
@@ -32,7 +36,39 @@ public class HDDataSource extends org.apache.derby.jdbc.EmbeddedDataSource imple
         return supportsCatalog;
     }
 
+    public boolean getSupportsNetworkTimeout() {
+        return supportsNetworkTimeout;
+    }
+
+    public boolean getSupportsReadOnly() {
+        return supportsReadOnly;
+    }
+
+    public boolean getSupportsSchema() {
+        return supportsSchema;
+    }
+
+    public boolean getSupportsTypeMap() {
+        return supportsTypeMap;
+    }
+
     public void setSupportsCatalog(boolean supports) {
         supportsCatalog = supports;
+    }
+
+    public void setSupportsNetworkTimeout(boolean supports) {
+        supportsNetworkTimeout = supports;
+    }
+
+    public void setSupportsReadOnly(boolean supports) {
+        supportsReadOnly = supports;
+    }
+
+    public void setSupportsSchema(boolean supports) {
+        supportsSchema = supports;
+    }
+
+    public void setSupportsTypeMap(boolean supports) {
+        supportsTypeMap = supports;
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/helper/HDDataStoreHelperMetaData.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/helper/HDDataStoreHelperMetaData.java
@@ -16,8 +16,29 @@ import com.ibm.ws.jdbc.heritage.DataStoreHelperMetaData;
  * Data store helper metadata for the test JDBC driver.
  */
 public class HDDataStoreHelperMetaData implements DataStoreHelperMetaData {
+
     @Override
     public boolean supportsGetCatalog() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsGetNetworkTimeout() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsGetSchema() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsGetTypeMap() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsIsReadOnly() {
         return false;
     }
 }


### PR DESCRIPTION
Add methods for indicating support of java.sql.Connection getters for network timeout, read-only, schema, and type map.