### PR TITLE
JSF 2.2 -- Update State Saving

### DIFF
--- a/dev/com.ibm.ws.jsf.2.2/src/org/apache/myfaces/application/StateCache.java
+++ b/dev/com.ibm.ws.jsf.2.2/src/org/apache/myfaces/application/StateCache.java
@@ -30,18 +30,18 @@ import org.apache.myfaces.buildtools.maven2.plugin.builder.annotation.JSFWebConf
  */
 public abstract class StateCache<K, V>
 {
-    
+    public static final String RANDOM_KEY_IN_CSRF_SESSION_TOKEN_SECURE_RANDOM = "secureRandom";
+    public static final String RANDOM_KEY_IN_CSRF_SESSION_TOKEN_RANDOM = "random";
+
     /**
      * Defines how to generate the csrf session token.
      */
     @JSFWebConfigParam(since="2.2.0", expectedValues="secureRandom, random", 
-            defaultValue="none", group="state")
+            defaultValue="secureRandom", group="state")
     public static final String RANDOM_KEY_IN_CSRF_SESSION_TOKEN_PARAM
             = "org.apache.myfaces.RANDOM_KEY_IN_CSRF_SESSION_TOKEN";
-    public static final String RANDOM_KEY_IN_CSRF_SESSION_TOKEN_PARAM_DEFAULT = "random";
-    
-    public static final String RANDOM_KEY_IN_CSRF_SESSION_TOKEN_SECURE_RANDOM = "secureRandom";
-    public static final String RANDOM_KEY_IN_CSRF_SESSION_TOKEN_RANDOM = "random";
+    public static final String RANDOM_KEY_IN_CSRF_SESSION_TOKEN_PARAM_DEFAULT = 
+            RANDOM_KEY_IN_CSRF_SESSION_TOKEN_SECURE_RANDOM;
 
     /**
      * Set the default length of the random key used for the csrf session token.

--- a/dev/com.ibm.ws.jsf.2.2/src/org/apache/myfaces/application/viewstate/ClientSideStateCacheImpl.java
+++ b/dev/com.ibm.ws.jsf.2.2/src/org/apache/myfaces/application/viewstate/ClientSideStateCacheImpl.java
@@ -55,13 +55,13 @@ class ClientSideStateCacheImpl extends StateCache<Object, Object>
         String csrfRandomMode = WebConfigParamUtils.getStringInitParameter(facesContext.getExternalContext(),
                 RANDOM_KEY_IN_CSRF_SESSION_TOKEN_PARAM, 
                 RANDOM_KEY_IN_CSRF_SESSION_TOKEN_PARAM_DEFAULT);
-        if (RANDOM_KEY_IN_CSRF_SESSION_TOKEN_SECURE_RANDOM.equals(csrfRandomMode))
+        if (RANDOM_KEY_IN_CSRF_SESSION_TOKEN_RANDOM.equals(csrfRandomMode))
         {
-            csrfSessionTokenFactory = new SecureRandomCsrfSessionTokenFactory(facesContext);
+            csrfSessionTokenFactory = new RandomCsrfSessionTokenFactory(facesContext);
         }
         else
         {
-            csrfSessionTokenFactory = new RandomCsrfSessionTokenFactory(facesContext);
+            csrfSessionTokenFactory = new SecureRandomCsrfSessionTokenFactory(facesContext);
         }
     }
 

--- a/dev/com.ibm.ws.jsf.2.2/src/org/apache/myfaces/application/viewstate/ServerSideStateCacheImpl.java
+++ b/dev/com.ibm.ws.jsf.2.2/src/org/apache/myfaces/application/viewstate/ServerSideStateCacheImpl.java
@@ -141,12 +141,12 @@ class ServerSideStateCacheImpl extends StateCache<Object, Object>
     /**
      * Adds a random key to the generated view state session token.
      */
-    @JSFWebConfigParam(since="2.1.9, 2.0.15", expectedValues="secureRandom, random, none", 
-            defaultValue="none", group="state")
+    @JSFWebConfigParam(since="2.1.9, 2.0.15", expectedValues="secureRandom, random", 
+            defaultValue="secureRandom", group="state")
     public static final String RANDOM_KEY_IN_VIEW_STATE_SESSION_TOKEN_PARAM
             = "org.apache.myfaces.RANDOM_KEY_IN_VIEW_STATE_SESSION_TOKEN";
     public static final String RANDOM_KEY_IN_VIEW_STATE_SESSION_TOKEN_PARAM_DEFAULT = 
-            RANDOM_KEY_IN_VIEW_STATE_SESSION_TOKEN_NONE;
+            RANDOM_KEY_IN_VIEW_STATE_SESSION_TOKEN_SECURE_RANDOM;
 
     /**
      * Set the default length of the random key added to the view state session token.
@@ -199,31 +199,31 @@ class ServerSideStateCacheImpl extends StateCache<Object, Object>
         String randomMode = WebConfigParamUtils.getStringInitParameter(facesContext.getExternalContext(),
                 RANDOM_KEY_IN_VIEW_STATE_SESSION_TOKEN_PARAM, 
                 RANDOM_KEY_IN_VIEW_STATE_SESSION_TOKEN_PARAM_DEFAULT);
-        if (RANDOM_KEY_IN_VIEW_STATE_SESSION_TOKEN_SECURE_RANDOM.equals(randomMode))
-        {
-            sessionViewStorageFactory = new RandomSessionViewStorageFactory(
-                    new SecureRandomKeyFactory(facesContext));
-        }
-        else if (RANDOM_KEY_IN_VIEW_STATE_SESSION_TOKEN_RANDOM.equals(randomMode))
+        if (RANDOM_KEY_IN_VIEW_STATE_SESSION_TOKEN_RANDOM.equals(randomMode))
         {
             sessionViewStorageFactory = new RandomSessionViewStorageFactory(
                     new RandomKeyFactory(facesContext));
         }
-        else
+        else if (RANDOM_KEY_IN_VIEW_STATE_SESSION_TOKEN_NONE.equals(randomMode))
         {
             sessionViewStorageFactory = new CounterSessionViewStorageFactory(new CounterKeyFactory());
+        }
+        else
+        {
+            sessionViewStorageFactory = new RandomSessionViewStorageFactory(
+                    new SecureRandomKeyFactory(facesContext));
         }
         
         String csrfRandomMode = WebConfigParamUtils.getStringInitParameter(facesContext.getExternalContext(),
                 RANDOM_KEY_IN_CSRF_SESSION_TOKEN_PARAM, 
                 RANDOM_KEY_IN_CSRF_SESSION_TOKEN_PARAM_DEFAULT);
-        if (RANDOM_KEY_IN_CSRF_SESSION_TOKEN_SECURE_RANDOM.equals(csrfRandomMode))
+        if (RANDOM_KEY_IN_CSRF_SESSION_TOKEN_RANDOM.equals(csrfRandomMode))
         {
-            csrfSessionTokenFactory = new SecureRandomCsrfSessionTokenFactory(facesContext);
+            csrfSessionTokenFactory = new RandomCsrfSessionTokenFactory(facesContext);
         }
         else
         {
-            csrfSessionTokenFactory = new RandomCsrfSessionTokenFactory(facesContext);
+            csrfSessionTokenFactory = new SecureRandomCsrfSessionTokenFactory(facesContext);
         }
     }
     

--- a/dev/com.ibm.ws.jsf.2.2/src/org/apache/myfaces/webapp/WebConfigParamsLogger.java
+++ b/dev/com.ibm.ws.jsf.2.2/src/org/apache/myfaces/webapp/WebConfigParamsLogger.java
@@ -1459,7 +1459,7 @@ public class WebConfigParamsLogger
             paramValue = facesContext.getExternalContext().getInitParameter("org.apache.myfaces.RANDOM_KEY_IN_CSRF_SESSION_TOKEN");
             if (paramValue == null)
             {
-                log.info("No context init parameter 'org.apache.myfaces.RANDOM_KEY_IN_CSRF_SESSION_TOKEN' found, using default value 'none'.");
+                log.info("No context init parameter 'org.apache.myfaces.RANDOM_KEY_IN_CSRF_SESSION_TOKEN' found, using default value 'secureRandom'.");
             }
             else
             {
@@ -1579,7 +1579,7 @@ public class WebConfigParamsLogger
             paramValue = facesContext.getExternalContext().getInitParameter("org.apache.myfaces.RANDOM_KEY_IN_VIEW_STATE_SESSION_TOKEN");
             if (paramValue == null)
             {
-                log.info("No context init parameter 'org.apache.myfaces.RANDOM_KEY_IN_VIEW_STATE_SESSION_TOKEN' found, using default value 'none'.");
+                log.info("No context init parameter 'org.apache.myfaces.RANDOM_KEY_IN_VIEW_STATE_SESSION_TOKEN' found, using default value 'secureRandom'.");
             }
             else
             {


### PR DESCRIPTION
fixes #15989 

Logging incorrect, so I need to make a manual change the `WebConfigParamsLogger` class.

Upstream branch shows that `WebConfigParamsLogger` is generated automatically: https://github.com/apache/myfaces/blob/2.2.x/impl/src/main/resources/META-INF/WebConfigParamsLogger.vm

Adding a test would be nice, but since I needed to change the strings in logs, it wouldn't be a very strong test.  No tests were added therefore.  Unless we add more logging within the ServerSideStateCacheImpl/ClientSideStateCacheImpl classes. 