### PR TITLE
Add --illegal-access=permit to ANT build process for Java 16

### DIFF
--- a/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017, 2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -327,6 +327,7 @@
 					<jvmarg value="${framework.maxheap}" />
 					<!-- embedded trace conditionals -->
 					<jvmarg value="${framework.debug.embed.jvmarg1}" /> 
+					<jvmarg line="--illegal-access=permit" />
 				</junit>
 			</sequential>
 			<finally>

--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017, 2020 IBM Corporation and others.
+    Copyright (c) 2017, 2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -488,6 +488,7 @@
 					<jvmarg value="${framework.debug.embed.jvmarg1}" />
 					<jvmarg line="${extra.vmargs}" />
 					<jvmarg line="${zos.extra.vmargs}" />
+					<jvmarg line="--illegal-access=permit" />
 				</junit>
 			</sequential>
 			<finally>


### PR DESCRIPTION
The default value of the [Java Platform Module System](http://openjdk.java.net/projects/jigsaw/spec/sotms/) "kill switch" changed from `--illegal-access=permit` to `--illegal-access=deny` in Java 16.  To compensate, the Liberty servers running our FAT tests need to explicitly have `--illegal-access=permit` set as well as in the ANT script JVMs.  The first issue (Liberty servers) was fixed by updating the Java 16 build definitions.  The second issue is fixed here by updating the default (and overridden) launch.xml files with the line:
```
<jvmarg line="--illegal-access=permit" />
```
by adding that line to the `<junit>` script tag.