### PR TITLE
Remove some overhead checking if http2 and encoding

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/inbound/HttpInboundLink.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/inbound/HttpInboundLink.java
@@ -11,6 +11,7 @@
 package com.ibm.ws.http.channel.internal.inbound;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -1040,10 +1041,7 @@ public class HttpInboundLink extends InboundProtocolLink implements InterChannel
         if (buffer.remaining() >= 24) {
             byte[] arr = new byte[24];
             buffer.get(arr);
-            String bufferString = new String(arr, 0, 24);
-            if (bufferString != null && !bufferString.isEmpty() && bufferString.startsWith(HttpConstants.HTTP2PrefaceString)) {
-                hasMagicString = true;
-            }
+            hasMagicString = Arrays.equals(arr, HttpConstants.HTTP2PrefaceBytes);
         }
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/channel/HttpConstants.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/http/channel/HttpConstants.java
@@ -28,5 +28,5 @@ public interface HttpConstants {
     /** Key used on z/OS for an unlimited HTTP body size */
     String HTTPUnlimitedMessageMark = "UNLIMITED_HTTP_MESSAGE_SIZE";
     /** HTTP/2 MAGIC string */
-    String HTTP2PrefaceString = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+    byte[] HTTP2PrefaceBytes = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes();
 }

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/WebContainer.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/WebContainer.java
@@ -14,6 +14,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.text.MessageFormat;
@@ -821,7 +822,7 @@ public abstract class WebContainer extends BaseContainer {
             if (decode) {
                 // URLs have been decoded with UTF-8 but not yet URLDecoded
                 //reqURI = URLDecoder.decode(reqURI, encoding); // encoding should be UTF-8
-                String isoURI = new String(reqURI.getBytes(encoding), ISO);
+                String isoURI = new String(reqURI.getBytes(encoding), StandardCharsets.ISO_8859_1);
                 hreq.setAttribute("com.ibm.websphere.servlet.uri_non_decoded", isoURI);
                 if (isTraceOn && logger.isLoggable(Level.FINE)) //306998.15 
                 {


### PR DESCRIPTION
- Do not convert to a String, but just compare the bytes to avoid having to make the String which adds extra overhead.
- Pass Charset instead of String for encoding to avoid looking it up each time.