### PR TITLE
Issue 15431: Update JWT metatype descriptions to make them clearer

### DIFF
--- a/dev/com.ibm.ws.security.jwt/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.jwt/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2020 IBM Corporation and others.
+# Copyright (c) 2016, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -33,7 +33,7 @@ valid.desc=Indicates the token expiration time in hours. ExpiresInSeconds takes 
 expiresInSeconds=Token expiration time in seconds
 expiresInSeconds.desc=Indicates the token expiration time in seconds. Takes precedence over expiry.
 claims=Supported claims
-claims.desc=Specify a comma separated list of claims to include in the token.
+claims.desc=Specify a comma separated list of claims to include in the token. These claims must be existing user attributes that are defined for the subject of the JWT in the user registry.
 
 scope=Supported scopes
 scope.desc=scope.desc=Specify a white space separated list of OAuth scopes.
@@ -46,7 +46,7 @@ keyAliasName.desc=A key alias name that is used to locate the private key for si
 trustedAliasName=Trusted alias name
 trustedAliasName.desc=A trusted key alias for using the public key to verify the signature of the token
 trustStoreRef=Trust keystore
-trustStoreRef.desc=A keystore containing the public key necessary for verifying a signature of the JWT token.
+trustStoreRef.desc=A keystore containing the public key necessary for verifying a signature of the JWT token. The keystore should also contain the key management key that is used to encrypt the Content Encryption Key of a JWE.
 
 jwkRotationTime=JWK rotation time
 jwkRotationTime.desc=Amount of time after which a new JWK will be generated.


### PR DESCRIPTION
Fixes #15431

Clarifies the `claims` and `trustStoreRef` metatype attributes in the JWT project.