### PR TITLE
Define exact version of SmallRye Config packages as 2.1.0

### DIFF
--- a/dev/io.openliberty.io.smallrye.config/bnd.bnd
+++ b/dev/io.openliberty.io.smallrye.config/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -44,9 +44,9 @@ Export-Package: \
 
 -buildpath: \
   io.openliberty.io.smallrye.common;version=latest, \
-  io.smallrye.config:smallrye-config;version=latest, \
-  io.smallrye.config:smallrye-config-common;version=latest, \
-  io.smallrye.config:smallrye-config-core;version=latest, \
+  io.smallrye.config:smallrye-config;version=2.1.0, \
+  io.smallrye.config:smallrye-config-common;version=2.1.0, \
+  io.smallrye.config:smallrye-config-core;version=2.1.0, \
   com.ibm.websphere.javaee.cdi.2.0;version=latest, \
   com.ibm.websphere.javaee.annotation.1.3;version=latest, \
   io.openliberty.org.eclipse.microprofile.config.2.0;version=latest, \


### PR DESCRIPTION
Manually define the versions to

1. Future proof the project for any new versions of mpConfig
2. Test when a change is made to `io.openliberty.io.smallrye.config` which buckets are spawned from #build
