### PR TITLE
Logstash ssl test failure

### DIFF
--- a/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
+++ b/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
@@ -370,11 +370,11 @@ public class LogstashSSLTest extends LogstashCollectorTest {
     //TODO add other methods to validate posted trace data
 
     /**
-     * Reset the servers.xml files to basic configurations.
-     * 
+     * Reset server configurations
+     *
      * @throws Exception
      */
-    @After
+    @Before
     public void resetServer() throws Exception {
         setConfig("server_reset.xml");
         clearContainerOutput();

--- a/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
+++ b/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
@@ -369,6 +369,17 @@ public class LogstashSSLTest extends LogstashCollectorTest {
 
     //TODO add other methods to validate posted trace data
 
+    /**
+     * Reset the servers.xml files to basic configurations.
+     * 
+     * @throws Exception
+     */
+    @After
+    public void resetServer() throws Exception {
+        setConfig("server_reset.xml");
+        clearContainerOutput();
+    }
+
     @AfterClass
     public static void completeTest() throws Exception {
         if (!runTest) {

--- a/dev/com.ibm.ws.logstash.collector_fat/publish/files/server_reset.xml
+++ b/dev/com.ibm.ws.logstash.collector_fat/publish/files/server_reset.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+    <logging traceSpecification="com.ibm.logs.TraceServlet=fine" />
+
+    <!-- Enable features -->
+    <featureManager>
+        <feature>jsp-2.2</feature>
+        <feature>logstashCollector-1.0</feature>
+        <feature>ssl-1.0</feature>
+        <feature>timedexit-1.0</feature>
+    </featureManager>
+
+    <httpEndpoint id="defaultHttpEndpoint"
+        httpPort="${bvt.prop.HTTP_default}"
+        httpsPort="${bvt.prop.HTTP_default.secure}">
+        <accessLogging enabled="true"
+            filepath="${server.output.dir}/logs/http_defaultEndpoint_access.log"
+            logFormat="%h %u %t &quot;%r&quot; %s %b %D %{User-agent}i" />
+    </httpEndpoint>
+
+    <!-- Automatically expand WAR files and EAR files -->
+    <applicationManager autoExpand="true" />
+
+
+    <logstashCollector port="${LOGSTASH_PORT}" hostName="${LOGSTASH_HOST}">
+        <source>message</source>
+        <source>accessLog</source>
+        <source>ffdc</source>
+        <source>garbageCollection</source>
+        <source>trace</source>
+    </logstashCollector>
+
+    <keyStore id="defaultKeyStore" password="{xor}Lz4sLChvLTs=" />
+    
+</server>


### PR DESCRIPTION
[fixes #15629](url)

There has been several Sun JDK builds that have resulted in unsuccessful builds, which have reported text exceptions within the LogstashSSLTest class. Sun JDK builds tend to randomize the order in which tests are executed.
Some of the server configurations are closely related in what features they may include and this may be causing the test failures within this class. 
So to resolve this issue, we will reset the server configurations (which will include ALL features) before running each test. 