### PR TITLE
Update test to run server features with the word client in them

### DIFF
--- a/dev/build.featureStart_fat/fat/src/com/ibm/ws/simple/FeaturesStartTest.java
+++ b/dev/build.featureStart_fat/fat/src/com/ibm/ws/simple/FeaturesStartTest.java
@@ -166,7 +166,8 @@ public class FeaturesStartTest {
                 String line = scanner.nextLine();
                 if (line.startsWith("IBM-ShortName:")) {
                     shortName = line.substring("IBM-ShortName:".length()).trim();
-                    if (shortName.toUpperCase().contains("CLIENT")) {
+                    String upperShortName = shortName.toUpperCase();
+                    if (upperShortName.contains("EECLIENT") || upperShortName.contains("SECURITYCLIENT")) {
                         Log.info(c, "parseShortName", "Skipping client-only feature: " + feature.getName());
                         return;
                     }

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appclient.appClient-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appclient.appClient-1.0.feature
@@ -9,7 +9,8 @@ visibility=private
  com.ibm.websphere.appserver.iiopclient-1.0
 -bundles=com.ibm.ws.clientcontainer, \
  com.ibm.ws.app.manager.war, \
- com.ibm.ws.app.manager.client
+ com.ibm.ws.app.manager.client, \
+ com.ibm.ws.managedobject
 kind=ga
 edition=base
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.appclient.appClient-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.appclient.appClient-2.0.feature
@@ -9,7 +9,8 @@ visibility=private
  com.ibm.websphere.appserver.iiopclient-1.0
 -bundles=com.ibm.ws.clientcontainer.jakarta, \
  com.ibm.ws.app.manager.war.jakarta, \
- com.ibm.ws.app.manager.client
+ com.ibm.ws.app.manager.client, \
+ com.ibm.ws.managedobject
 kind=beta
 edition=base
 WLP-Activation-Type: parallel


### PR DESCRIPTION
- If a feature name had the word client in it it was excluded from the build.featureStart_fat.  Only a few of the features that have the word client in them are client only features.
- It was discovered by updating the test that the appClientSupport feature did not start on its won.  Updated the feature files to add the missing bundle.
