### PR TITLE
CL22150: Add getLongRunningPolicyExecutor method to WSManagedExecutorService.

### DIFF
--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/WSManagedExecutorService.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/WSManagedExecutorService.java
@@ -25,9 +25,10 @@ public interface WSManagedExecutorService {
     WSContextService getContextService();
 
     /**
-     * Returns the policy executor for running tasks against the long running concurrency policy.
+     * When the longRunningPolicy is configured, returns the policy executor for running tasks against the long running concurrency policy.
+     * Otherwise, returns null when the longRunningPolicy is not configured.
      *
-     * @return the policy executor for running tasks against the long running concurrency policy.
+     * @return the policy executor for running tasks if the long running concurrency policy is configured. Otherwise, returns null.
      */
     PolicyExecutor getLongRunningPolicyExecutor();
 

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/WSManagedExecutorService.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/WSManagedExecutorService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,12 @@ public interface WSManagedExecutorService {
      */
     WSContextService getContextService();
 
-    // TODO getLongRunningPolicyExecutor
+    /**
+     * Returns the policy executor for running tasks against the long running concurrency policy.
+     *
+     * @return the policy executor for running tasks against the long running concurrency policy.
+     */
+    PolicyExecutor getLongRunningPolicyExecutor();
 
     /**
      * Returns the policy executor for running tasks against the normal concurrency policy.

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/ext/ManagedExecutorExtension.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/ext/ManagedExecutorExtension.java
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 import javax.enterprise.concurrent.ManagedExecutorService;
 
 import org.eclipse.microprofile.context.ManagedExecutor;
+import org.eclipse.microprofile.context.ThreadContext;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrent.WSManagedExecutorService;

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/ext/ManagedExecutorExtension.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/ext/ManagedExecutorExtension.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,7 +25,6 @@ import java.util.function.Supplier;
 import javax.enterprise.concurrent.ManagedExecutorService;
 
 import org.eclipse.microprofile.context.ManagedExecutor;
-import org.eclipse.microprofile.context.ThreadContext;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrent.WSManagedExecutorService;
@@ -94,6 +93,11 @@ public class ManagedExecutorExtension implements CompletionStageExecutor, Manage
     @Override
     public final WSContextService getContextService() {
         return executor.getContextService();
+    }
+
+    @Override
+    public final PolicyExecutor getLongRunningPolicyExecutor() {
+        return executor.getLongRunningPolicyExecutor();
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextualDefaultExecutor.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextualDefaultExecutor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -68,6 +68,12 @@ class ContextualDefaultExecutor implements Executor, WSManagedExecutorService {
     @Trivial
     public WSContextService getContextService() {
         return contextService;
+    }
+
+    @Override
+    @Trivial
+    public PolicyExecutor getLongRunningPolicyExecutor() {
+        return defaultManagedExecutor.getLongRunningPolicyExecutor();
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corporation and others.
+ * Copyright (c) 2012, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -452,6 +452,11 @@ public class ManagedExecutorServiceImpl implements ExecutorService, //
         Set<String> members = new HashSet<String>(applications);
         applications.removeAll(members);
         return members;
+    }
+
+    @Override
+    public PolicyExecutor getLongRunningPolicyExecutor() {
+        return longRunningPolicyExecutorRef.get();
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/UnusableExecutor.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/UnusableExecutor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2019 IBM Corporation and others.
+ * Copyright (c) 2018,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -39,6 +39,11 @@ class UnusableExecutor implements Executor, WSManagedExecutorService {
     @Override
     public WSContextService getContextService() {
         return contextService;
+    }
+
+    @Override
+    public PolicyExecutor getLongRunningPolicyExecutor() {
+        throw new UnsupportedOperationException();
     }
 
     @Override


### PR DESCRIPTION
Make the long running policy executor available to CommonJ.