### PR TITLE
Update cloudant FAT to use TLS1.2 for Java 16

### DIFF
--- a/dev/com.ibm.ws.cloudant_fat/fat/src/com/ibm/ws/cloudant/fat/FATSuite.java
+++ b/dev/com.ibm.ws.cloudant_fat/fat/src/com/ibm/ws/cloudant/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,7 +34,7 @@ public class FATSuite {
     }
 
     @ClassRule
-    public static CouchDBContainer cloudant = new CouchDBContainer("aguibert/couchdb-ssl:1.0")
+    public static CouchDBContainer cloudant = new CouchDBContainer("gjwatts/couchdb-tls12:1.0")
                     .withLogConsumer(new SimpleLogConsumer(FATSuite.class, "cloudant"));
 
 }

--- a/dev/com.ibm.ws.cloudant_fat/publish/files/couchdb-ssl/Dockerfile
+++ b/dev/com.ibm.ws.cloudant_fat/publish/files/couchdb-ssl/Dockerfile
@@ -6,4 +6,4 @@ COPY ssl-certs/privkey.pem /etc/couchdb/cert/
 
 RUN chmod 644 /etc/couchdb/cert/*
 
-# Currently tagged and pushed as aguibert/couchdb-ssl:1.0
+# Currently tagged and pushed as gjwatts/couchdb-tls12:1.0

--- a/dev/com.ibm.ws.cloudant_fat/publish/files/couchdb-ssl/couchdb-config/testcontainers_config.ini
+++ b/dev/com.ibm.ws.cloudant_fat/publish/files/couchdb-ssl/couchdb-config/testcontainers_config.ini
@@ -8,3 +8,4 @@ n = 1
 enable = true
 cert_file = /etc/couchdb/cert/couchdb.pem
 key_file = /etc/couchdb/cert/privkey.pem
+tls_versions = ['tlsv1.2']

--- a/dev/com.ibm.ws.cloudant_fat/publish/servers/com.ibm.ws.cloudant.fat.outboundSSL/jvm.options
+++ b/dev/com.ibm.ws.cloudant_fat/publish/servers/com.ibm.ws.cloudant.fat.outboundSSL/jvm.options
@@ -1,3 +1,2 @@
-# Need to cap ourselves to TLS 1.1 so that the Cloudant client does not initiate a handshake with TLS 1.2, which the DB test server does not understand 
--Djdk.tls.disabledAlgorithms=TLSv1.2,TLSv1.3
--Dhttps.protocols=SSLv3,TLSv1,TLSv1.1
+# Force the use of TLS1.2+ for supporting Java 16 which removes TLS1.0 and 1.1
+-Dhttps.protocols=TLSv1.2,TLSv1.3

--- a/dev/com.ibm.ws.cloudant_fat/publish/servers/com.ibm.ws.cloudant.fat/jvm.options
+++ b/dev/com.ibm.ws.cloudant_fat/publish/servers/com.ibm.ws.cloudant.fat/jvm.options
@@ -1,3 +1,2 @@
-# Need to cap ourselves to TLS 1.1 so that the Cloudant client does not initiate a handshake with TLS 1.2, which the DB test server does not understand 
--Djdk.tls.disabledAlgorithms=TLSv1.2,TLSv1.3
--Dhttps.protocols=SSLv3,TLSv1,TLSv1.1
+# Force the use of TLS1.2+ for supporting Java 16 which removes TLS1.0 and 1.1
+-Dhttps.protocols=TLSv1.2,TLSv1.3


### PR DESCRIPTION
Force the cloudant FAT to use TLS1.2+ for supporting Java 16 which removes TLS1.0 and 1.1.

