### PR TITLE
Upgrade oracle image versions

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_krb5/README.txt
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/README.txt
@@ -3,7 +3,7 @@
 This bucket uses several custom docker images:
  - A kerberos container (e.g. 'aguibert/krb5-server:1.1')
  - A DB2 container (e.g. '')
- - An Oracle container (e.g. 'aguibert/krb5-oracle:1.0')
+ - An Oracle container (e.g. 'kyleaure/krb5-oracle:2.0')
  
 The files necessary to build each container can be found under the 'publish/files/' folder. For example, to rebuild the Oracle container you can do:
 

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/containers/OracleKerberosContainer.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/containers/OracleKerberosContainer.java
@@ -37,7 +37,7 @@ public class OracleKerberosContainer extends OracleContainer {
     private static final Class<?> c = OracleKerberosContainer.class;
     private static final Path reuseCache = Paths.get("..", "..", "cache", "oracle.properties");
     // NOTE: If this is ever updated, don't forget to push to docker hub, but DO NOT overwrite existing versions
-    private static final String IMAGE = "aguibert/krb5-oracle:1.0";
+    private static final String IMAGE = "kyleaure/krb5-oracle:2.0";
 
     private boolean reused = false;
     private String reused_hostname;

--- a/dev/com.ibm.ws.jdbc_fat_krb5/publish/files/oracle/Dockerfile
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/publish/files/oracle/Dockerfile
@@ -1,4 +1,4 @@
-FROM kyleaure/oracle-18.4.0-xe-prebuilt
+FROM kyleaure/oracle-18.4.0-xe-prebuilt:2.0
 
 # Update and install Kerberos (server head)
 RUN yum update -y
@@ -25,7 +25,5 @@ RUN /opt/oracle/scripts/setup/2oracle.sh
 
 RUN rm /opt/oracle/scripts/setup/1kerberos.sh
 RUN rm /opt/oracle/scripts/setup/2oracle.sh 
-
-# currently tagged as aguibert/krb5-oracle:1.0
-
  
+# Currently tagged in DockerHub as: kyleaure/krb5-oracle:2.0

--- a/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/fat/src/com/ibm/ws/jdbc/fat/oracle/FATSuite.java
@@ -36,9 +36,8 @@ public class FATSuite {
         ExternalTestServiceDockerClientStrategy.setupTestcontainers();
     }
 
-    // TODO replace this container with the official oracle-xe container if/when it is available without a license
     @ClassRule
-    public static OracleContainer oracle = new OracleContainer("kyleaure/oracle-18.4.0-xe-prebuilt:1.0")
+    public static OracleContainer oracle = new OracleContainer("kyleaure/oracle-18.4.0-xe-prebuilt:2.0")
                     .withExposedPorts(1521, 5500, 8080) // need to manually expose ports due to regression in 1.14.0
                     .withLogConsumer(new SimpleLogConsumer(FATSuite.class, "Oracle"));
 

--- a/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerFactory.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerFactory.java
@@ -54,10 +54,10 @@ public class DatabaseContainerFactory {
      * If {fat.bucket.db.type} is not set with a value,
      * default to Derby Embedded.
      *
-     * @return JdbcDatabaseContainer - The test container.
+     * @return                          JdbcDatabaseContainer - The test container.
      *
      * @throws IllegalArgumentException - if database rotation {fat.test.databases} is not set or is false,
-     * or database type {fat.bucket.db.type} is unsupported.
+     *                                      or database type {fat.bucket.db.type} is unsupported.
      */
     public static JdbcDatabaseContainer<?> create() throws IllegalArgumentException {
         return create(DatabaseContainerType.Derby);
@@ -66,8 +66,8 @@ public class DatabaseContainerFactory {
     /**
      * @see #create()
      *
-     * This method let's you specify the default database type if one is not provided.
-     * This should mainly be used if you want to use derby client instead of derby embedded as your default.
+     *      This method let's you specify the default database type if one is not provided.
+     *      This should mainly be used if you want to use derby client instead of derby embedded as your default.
      */
     public static JdbcDatabaseContainer<?> create(DatabaseContainerType defaultType) throws IllegalArgumentException {
         String dbRotation = System.getProperty("fat.test.databases");
@@ -124,7 +124,7 @@ public class DatabaseContainerFactory {
                     cont = (JdbcDatabaseContainer<?>) clazz.getConstructor().newInstance();
                     break;
                 case Oracle:
-                    cont = (JdbcDatabaseContainer<?>) clazz.getConstructor(String.class).newInstance("kyleaure/oracle-18.4.0-xe-prebuilt:1.0");
+                    cont = (JdbcDatabaseContainer<?>) clazz.getConstructor(String.class).newInstance("kyleaure/oracle-18.4.0-xe-prebuilt:2.0");
                     cont.withExposedPorts(1521, 5500, 8080); // need to manually expose ports due to regression in 1.14.0
                     break;
                 case Postgres:


### PR DESCRIPTION
Old oracle docker image had a pre configured user `SYSTEM` whose password was set to expire 03/05/2021.  Upgraded container to have no password timeouts and pushed it here: https://hub.docker.com/r/kyleaure/oracle-18.4.0-xe-prebuilt

There was another image that was built on top of this one that I also updated and pushed here: https://hub.docker.com/r/kyleaure/krb5-oracle
