### PR TITLE
NullPointerException on parked managed connection

### DIFF
--- a/dev/com.ibm.ws.jca.1.7_fat/test-resourceadapters/helloworldra/src/com/ibm/helloworldra/HelloWorldManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.jca.1.7_fat/test-resourceadapters/helloworldra/src/com/ibm/helloworldra/HelloWorldManagedConnectionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002 IBM Corporation and others.
+ * Copyright (c) 2002,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -70,7 +70,9 @@ public class HelloWorldManagedConnectionImpl implements ManagedConnection {
     @Override
     public void destroy() throws ResourceException {
 
-        connection.invalidate();
+        // Connection Manager never invokes getConnection when using this ManagedConnection for parked handles
+        if (connection != null)
+            connection.invalidate();
         connection = null;
         listeners = null;
     }
@@ -81,7 +83,9 @@ public class HelloWorldManagedConnectionImpl implements ManagedConnection {
     @Override
     public void cleanup() throws ResourceException {
 
-        connection.invalidate();
+        // Connection Manager never invokes getConnection when using this ManagedConnection for parked handles
+        if (connection != null)
+            connection.invalidate();
     }
 
     /**


### PR DESCRIPTION
Test resource adapter has a managed connection implementation that is unable to cope with a cleanup or destroy without an intermediate getConnection request.  This happens when the connection manager creates a managed connection for parked handles.