### PR TITLE
Revert "Add --illegal-access=permit to ANT build process for Java 16"

### DIFF
--- a/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017, 2021 IBM Corporation and others.
+    Copyright (c) 2017 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -327,7 +327,6 @@
 					<jvmarg value="${framework.maxheap}" />
 					<!-- embedded trace conditionals -->
 					<jvmarg value="${framework.debug.embed.jvmarg1}" /> 
-					<jvmarg line="--illegal-access=permit" />
 				</junit>
 			</sequential>
 			<finally>

--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017, 2021 IBM Corporation and others.
+    Copyright (c) 2017, 2020 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -488,7 +488,6 @@
 					<jvmarg value="${framework.debug.embed.jvmarg1}" />
 					<jvmarg line="${extra.vmargs}" />
 					<jvmarg line="${zos.extra.vmargs}" />
-					<jvmarg line="--illegal-access=permit" />
 				</junit>
 			</sequential>
 			<finally>


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#15992

Breaking all Java8 builds need https://github.com/OpenLiberty/open-liberty/pull/16068 tested on Java8 and redelivered