### PR TITLE
Disable JPA Query tests affected by RTC282016

### DIFF
--- a/dev/com.ibm.ws.jpa_spec10_query_fat/test-applications/svlquery/src/com/ibm/ws/query/web/loopqueryano/JULoopQueryAnoTest_008_Servlet.java
+++ b/dev/com.ibm.ws.jpa_spec10_query_fat/test-applications/svlquery/src/com/ibm/ws/query/web/loopqueryano/JULoopQueryAnoTest_008_Servlet.java
@@ -216,7 +216,8 @@ public class JULoopQueryAnoTest_008_Servlet extends JPATestServlet {
         executeTest(testName, testMethod, testResource);
     }
 
-    @Test
+    // Disabled for RTC282016 until a better timezone adjustment can be finished.
+    //@Test
     public void jpa_spec10_query_svlquery_juloopquery_ano_test197_AMJTA_Web() throws Exception {
         final String testName = "jpa_spec10_query_svlquery_juloopquery_ano_test197_AMJTA_Web";
         final String testMethod = "testLoop197";

--- a/dev/com.ibm.ws.jpa_spec10_query_fat/test-applications/svlquery/src/com/ibm/ws/query/web/loopqueryano/JULoopQueryAnoTest_021_Servlet.java
+++ b/dev/com.ibm.ws.jpa_spec10_query_fat/test-applications/svlquery/src/com/ibm/ws/query/web/loopqueryano/JULoopQueryAnoTest_021_Servlet.java
@@ -71,7 +71,8 @@ public class JULoopQueryAnoTest_021_Servlet extends JPATestServlet {
         executeTest(testName, testMethod, testResource);
     }
 
-    @Test
+    // Disabled for RTC282016 until a better timezone adjustment can be finished.
+    //@Test
     public void jpa_spec10_query_svlquery_juloopquery_ano_test479_AMJTA_Web() throws Exception {
         final String testName = "jpa_spec10_query_svlquery_juloopquery_ano_test479_AMJTA_Web";
         final String testMethod = "testLoop479";
@@ -87,7 +88,8 @@ public class JULoopQueryAnoTest_021_Servlet extends JPATestServlet {
         executeTest(testName, testMethod, testResource);
     }
 
-    @Test
+    // Disabled for RTC282016 until a better timezone adjustment can be finished.
+    //@Test
     public void jpa_spec10_query_svlquery_juloopquery_ano_test481_AMJTA_Web() throws Exception {
         final String testName = "jpa_spec10_query_svlquery_juloopquery_ano_test481_AMJTA_Web";
         final String testMethod = "testLoop481";

--- a/dev/com.ibm.ws.jpa_spec10_query_fat/test-applications/svlquery/src/com/ibm/ws/query/web/loopqueryxml/JULoopQueryXMLTest_008_Servlet.java
+++ b/dev/com.ibm.ws.jpa_spec10_query_fat/test-applications/svlquery/src/com/ibm/ws/query/web/loopqueryxml/JULoopQueryXMLTest_008_Servlet.java
@@ -216,7 +216,8 @@ public class JULoopQueryXMLTest_008_Servlet extends JPATestServlet {
         executeTest(testName, testMethod, testResource);
     }
 
-    @Test
+    // Disabled for RTC282016 until a better timezone adjustment can be finished.
+    //@Test
     public void jpa_spec10_query_svlquery_juloopquery_xml_test197_AMJTA_Web() throws Exception {
         final String testName = "jpa_spec10_query_svlquery_juloopquery_xml_test197_AMJTA_Web";
         final String testMethod = "testLoop197";

--- a/dev/com.ibm.ws.jpa_spec10_query_fat/test-applications/svlquery/src/com/ibm/ws/query/web/loopqueryxml/JULoopQueryXMLTest_021_Servlet.java
+++ b/dev/com.ibm.ws.jpa_spec10_query_fat/test-applications/svlquery/src/com/ibm/ws/query/web/loopqueryxml/JULoopQueryXMLTest_021_Servlet.java
@@ -71,7 +71,8 @@ public class JULoopQueryXMLTest_021_Servlet extends JPATestServlet {
         executeTest(testName, testMethod, testResource);
     }
 
-    @Test
+    // Disabled for RTC282016 until a better timezone adjustment can be finished.
+    //@Test
     public void jpa_spec10_query_svlquery_juloopquery_xml_test479_AMJTA_Web() throws Exception {
         final String testName = "jpa_spec10_query_svlquery_juloopquery_xml_test479_AMJTA_Web";
         final String testMethod = "testLoop479";
@@ -87,7 +88,8 @@ public class JULoopQueryXMLTest_021_Servlet extends JPATestServlet {
         executeTest(testName, testMethod, testResource);
     }
 
-    @Test
+    // Disabled for RTC282016 until a better timezone adjustment can be finished.
+    //@Test
     public void jpa_spec10_query_svlquery_juloopquery_xml_test481_AMJTA_Web() throws Exception {
         final String testName = "jpa_spec10_query_svlquery_juloopquery_xml_test481_AMJTA_Web";
         final String testMethod = "testLoop481";


### PR DESCRIPTION
I need to find a better way to handle timezone translation for these tests, so disabling them until I find a more acceptable method.