### PR TITLE
doConnectionCleanup from legacy DataStoreHelper

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/heritage/DataStoreHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/heritage/DataStoreHelper.java
@@ -21,6 +21,16 @@ import javax.security.auth.Subject;
  */
 public interface DataStoreHelper {
     /**
+     * Cleans up a connection before it is returned to the connection
+     * pool for later reuse. This method is also used when checking for invalid connections.
+     *
+     * @param conn the connection to clean up.
+     * @return true if any standard connection property was modified, otherwise false.
+     * @exception SQLException if an error occurs while cleaning up the connection.
+     */
+    boolean doConnectionCleanup(Connection conn) throws SQLException;
+
+    /**
      * Invoked after the last active connection handle is closed.
      * This provides an opportunity to undo connection setup that was previously performed by
      * <code>doConnectionSetupPerGetConnection</code>.

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
@@ -1674,7 +1674,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
             return;
         }
 
-        if (ex instanceof SQLException && mcf.helper.isAnAuthorizationException((SQLException) ex)) {
+        if (ex instanceof SQLException && helper.isAnAuthorizationException((SQLException) ex)) {
             if (isTraceOn && tc.isDebugEnabled())
                 Tr.debug(this, tc, "CONNECTION_ERROR_OCCURRED will fire an event to only purge and destroy this connection");
 
@@ -2044,7 +2044,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                     // the reuse call won't go down to the DB til the next execution of the.  DB optimizaiton.
                     // if we were in a tran, a connection will have to match as we do compare subject and CRI
                     // the fact that the gssNames don't match, means we are not in a tra.
-                    mcf.helper.reuseKerbrosConnection(sqlConn, cri.gssCredential, null);
+                    helper.reuseKerbrosConnection(sqlConn, cri.gssCredential, null);
 
                     //now save the cri props in the mc
                     mc_gssCredential = cri.gssCredential;
@@ -3302,7 +3302,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                 if (mcf.supportsUOWDetection) {
                     String operation = "none";
                     try {
-                        if (mcf.helper.isInDatabaseUnitOfWork(sqlConn)) {
+                        if (helper.isInDatabaseUnitOfWork(sqlConn)) {
                             /*
                              * If the DB supports UOW Detection and we are in a DB UOW we will commit or rollback per
                              * setting on the DataSource.
@@ -3426,7 +3426,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                  */
                 if (mcf.supportsUOWDetection) {
                     try {
-                        if (mcf.helper.isInDatabaseUnitOfWork(sqlConn)) {
+                        if (helper.isInDatabaseUnitOfWork(sqlConn)) {
 
                             if (!mcf.loggedImmplicitTransactionFound) {
                                 Tr.info(tc, "IMPLICIT_TRANSACTION_FOUND");
@@ -4314,7 +4314,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
 
             // Clean up the connection.
             if (mcf.dataStoreHelper == null)
-                mcf.helper.doConnectionCleanup(sqlConn);
+                helper.doConnectionCleanup(sqlConn);
             else
                 mcf.dataStoreHelper.doConnectionCleanup(sqlConn);
 
@@ -4362,7 +4362,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
 
                 try {
                     if (mcf.dataStoreHelper == null)
-                        mcf.helper.doConnectionCleanup(sqlConn);
+                        helper.doConnectionCleanup(sqlConn);
                     else
                         mcf.dataStoreHelper.doConnectionCleanup(sqlConn);
                 } catch (SQLException cleanEx) {

--- a/dev/com.ibm.ws.jdbc_fat_heritage/fat/src/test/jdbc/heritage/HeritageJDBCTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/fat/src/test/jdbc/heritage/HeritageJDBCTest.java
@@ -45,7 +45,7 @@ public class HeritageJDBCTest extends FATServletClient {
         // Test application
         WebArchive heritageApp = ShrinkWrap.create(WebArchive.class, "heritageApp.war")
                         .addPackage("test.jdbc.heritage.app");
-        ShrinkHelper.exportDropinAppToServer(server, heritageApp);
+        ShrinkHelper.exportAppToServer(server, heritageApp);
 
         server.addInstalledAppForValidation("heritageApp");
 

--- a/dev/com.ibm.ws.jdbc_fat_heritage/publish/servers/com.ibm.ws.jdbc.heritage/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/publish/servers/com.ibm.ws.jdbc.heritage/server.xml
@@ -27,6 +27,10 @@
     <fileset dir="${shared.resource.dir}/derby"/>
   </library>
 
+  <application location="heritageApp.war">
+    <classloader commonLibraryRef="JDBCLib"/>
+  </application>
+
   <authData id="dbAuth" user="dbuser" password="{xor}Oz0vKDs=" />
 
   <dataSource id="DefaultDataSource" containerAuthDataRef="dbAuth" type="javax.sql.DataSource">
@@ -38,7 +42,7 @@
 
   <javaPermission codeBase="${shared.resource.dir}derby/derby.jar" className="java.security.AllPermission"/>
 
-  <javaPermission codeBase="${server.config.dir}/dropins/heritageApp.war" className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
-  <javaPermission codeBase="${server.config.dir}/dropins/heritageApp.war" className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+  <javaPermission codeBase="${server.config.dir}/apps/heritageApp.war" className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
+  <javaPermission codeBase="${server.config.dir}/apps/heritageApp.war" className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
 
 </server>

--- a/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HeritageDBConnection.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HeritageDBConnection.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jdbc.heritage.driver;
+
+import java.util.Set;
+
+/**
+ * Interface for invoking vendor-specific API on the test Heritage JDBC Driver.
+ */
+public interface HeritageDBConnection {
+    /**
+     * Obtains the list of valid client info keys.
+     *
+     * @return the list of valid client info keys.
+     */
+    Set<String> getClientInfoKeys();
+
+    /**
+     * Sets the list of valid keys for client info.
+     *
+     * @param value the new list of valid keys for client info. If empty, the defaults are used.
+     */
+    void setClientInfoKeys(String... keys);
+}

--- a/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/helper/HDDataStoreHelper.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/helper/HDDataStoreHelper.java
@@ -31,6 +31,12 @@ public class HDDataStoreHelper implements DataStoreHelper {
     private final HDDataStoreHelperMetaData metadata = new HDDataStoreHelperMetaData();
 
     @Override
+    public boolean doConnectionCleanup(Connection con) throws SQLException {
+        ((HDConnection) con).setClientInfoKeys(); // defaults
+        return false;
+    }
+
+    @Override
     public boolean doConnectionCleanupPerCloseConnection(Connection con, boolean isCMP, Object unused) throws SQLException {
         ((HDConnection) con).cleanupCount.incrementAndGet();
         try (CallableStatement stmt = con.prepareCall("CALL SYSCS_UTIL.SYSCS_SET_STATISTICS_TIMING(0)")) {


### PR DESCRIPTION
Add the ability for the doConnectionCleanup implementation to be provided by a legacy DataStoreHelper.