### PR TITLE
Define jboss-servlet-api_3.0_spec version in all TCKs

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp.1.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017,2021 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.concurrent.mp</groupId>
@@ -100,7 +99,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.5</version> 
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
 
@@ -141,7 +140,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed because Arquillian calls string.getBtytes(). Attach is needed because Arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed because Arquillian calls string.getBtytes(). Attach is needed because Arquillian uses com.sun.tools.attach to find VMs -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.concurrent.mp.1.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp.1.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -48,6 +48,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/tckRunner/tck/pom.xml
@@ -44,6 +44,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017,2019 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.concurrent.mp</groupId>
@@ -89,7 +88,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.5</version> 
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
 
@@ -130,7 +129,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
-                <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed because Arquillian calls string.getBtytes(). Attach is needed because Arquillian uses com.sun.tools.attach to find VMs -->
+                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed because Arquillian calls string.getBtytes(). Attach is needed because Arquillian uses com.sun.tools.attach to find VMs -->
                     <systemPropertyVariables>
                         <wlp>${wlp}</wlp>
                         <tck_server>${tck_server}</tck_server>

--- a/dev/com.ibm.ws.microprofile.config.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017,2018 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.config</groupId>
@@ -52,7 +51,7 @@
 
     <dependencies>
 
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -96,7 +95,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.5</version> 
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
 

--- a/dev/com.ibm.ws.microprofile.config.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -43,10 +43,10 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-	          <groupId>org.jboss.spec.javax.servlet</groupId>
-	          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-	          <version>1.0.2.Final</version> <!-- Defines the version of this artifact that arquillian-liberty-managed should use -->
-	        </dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2018 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2018, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.config12</groupId>
@@ -51,7 +50,7 @@
     </dependencyManagement>
 
     <dependencies>
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -73,7 +72,7 @@
             <systemPath>${com.ibm.websphere.org.eclipse.microprofile.config.1.2.1_}</systemPath>
         </dependency>
 
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -87,7 +86,7 @@
             <version>1.2</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
@@ -103,7 +102,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.5</version> 
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
 

--- a/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -43,10 +43,10 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-	          <groupId>org.jboss.spec.javax.servlet</groupId>
-	          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-	          <version>1.0.2.Final</version> <!-- Defines the version of this artifact that arquillian-liberty-managed should use -->
-	        </dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -43,10 +43,10 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-	          <groupId>org.jboss.spec.javax.servlet</groupId>
-	          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-	          <version>1.0.2.Final</version> <!-- Defines the version of this artifact that arquillian-liberty-managed should use -->
-	        </dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2018 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2018, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.config13</groupId>
@@ -52,7 +51,7 @@
 
     <dependencies>
 
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -80,7 +79,7 @@
             <version>1.2</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
@@ -96,7 +95,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.5</version> 
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
 

--- a/dev/com.ibm.ws.microprofile.config.1.4_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.4_fat_tck/publish/tckRunner/tck/pom.xml
@@ -43,10 +43,10 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-	          <groupId>org.jboss.spec.javax.servlet</groupId>
-	          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-	          <version>1.0.2.Final</version> <!-- Defines the version of this artifact that arquillian-liberty-managed should use -->
-	        </dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.config.1.4_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.4_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2018, 2019 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2018, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.config14</groupId>
@@ -52,7 +51,7 @@
 
     <dependencies>
 
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -80,7 +79,7 @@
             <version>1.2</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
@@ -96,7 +95,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.5</version> 
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
 

--- a/dev/com.ibm.ws.microprofile.config_git_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config_git_fat_tck/publish/tckRunner/tck/pom.xml
@@ -6,8 +6,7 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
     the specific language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.config</groupId>
@@ -66,7 +65,7 @@
     </dependencyManagement>
 
     <dependencies>
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>

--- a/dev/com.ibm.ws.microprofile.config_git_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config_git_fat_tck/publish/tckRunner/tck/pom.xml
@@ -57,6 +57,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -6,8 +6,7 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
     the specific language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.faulttolerance</groupId>
@@ -50,7 +49,7 @@
     </dependencyManagement>
 
     <dependencies>
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -89,18 +88,18 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>1.1.14.Final</version> 
+            <version>1.1.14.Final</version>
         </dependency>
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.5</version> 
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
 
     <build>
-    <directory>${targetDirectory}</directory>
+        <directory>${targetDirectory}</directory>
         <defaultGoal>clean test</defaultGoal>
         <plugins>
             <plugin>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -42,10 +42,10 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-	          <groupId>org.jboss.spec.javax.servlet</groupId>
-	          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-	          <version>1.0.2.Final</version> <!-- Defines the version of this artifact that arquillian-liberty-managed should use -->
-	        </dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/pom.xml
@@ -13,8 +13,7 @@
     specific language governing permissions and limitations
     under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.faulttolerance</groupId>
@@ -50,25 +49,25 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    
+
     <build>
         <pluginManagement>
             <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>2.3.2</version>
+                    <configuration>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                    </configuration>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>2.5.3</version>
                     <configuration>
-                        <autoVersionSubmodules>true</autoVersionSubmodules> 
+                        <autoVersionSubmodules>true</autoVersionSubmodules>
                         <pushChanges>false</pushChanges>
                         <localCheckout>true</localCheckout>
                     </configuration>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -6,8 +6,7 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
     the specific language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.faulttolerance</groupId>
@@ -50,7 +49,7 @@
     </dependencyManagement>
 
     <dependencies>
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -77,7 +76,7 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-	    <version>2.0</version>
+            <version>2.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -89,7 +88,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>1.1.14.Final</version> 
+            <version>1.1.14.Final</version>
         </dependency>
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
@@ -100,7 +99,7 @@
     </dependencies>
 
     <build>
-    <directory>${targetDirectory}</directory>
+        <directory>${targetDirectory}</directory>
         <defaultGoal>clean test</defaultGoal>
         <plugins>
             <plugin>
@@ -140,7 +139,7 @@
                         <tck_server>${tck_server}</tck_server>
                         <tck_port>${tck_port}</tck_port>
                         <sun.rmi.transport.tcp.responseTimeout>${sun.rmi.transport.tcp.responseTimeout}</sun.rmi.transport.tcp.responseTimeout>
-			<org.eclipse.microprofile.fault.tolerance.tck.timeout.multiplier>6.0</org.eclipse.microprofile.fault.tolerance.tck.timeout.multiplier>
+                        <org.eclipse.microprofile.fault.tolerance.tck.timeout.multiplier>6.0</org.eclipse.microprofile.fault.tolerance.tck.timeout.multiplier>
                     </systemPropertyVariables>
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -42,10 +42,10 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-	          <groupId>org.jboss.spec.javax.servlet</groupId>
-	          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-	          <version>1.0.2.Final</version> <!-- Defines the version of this artifact that arquillian-liberty-managed should use -->
-	        </dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -41,10 +41,10 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-	          <groupId>org.jboss.spec.javax.servlet</groupId>
-	          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-	          <version>1.0.2.Final</version> <!-- Defines the version of this artifact that arquillian-liberty-managed should use -->
-	        </dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -6,8 +6,7 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
     the specific language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.faulttolerance</groupId>
@@ -49,7 +48,7 @@
     </dependencyManagement>
 
     <dependencies>
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -76,7 +75,7 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-	    <version>2.0</version>
+            <version>2.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -88,7 +87,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>1.1.14.Final</version> 
+            <version>1.1.14.Final</version>
         </dependency>
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
@@ -99,7 +98,7 @@
     </dependencies>
 
     <build>
-    <directory>${targetDirectory}</directory>
+        <directory>${targetDirectory}</directory>
         <defaultGoal>clean test</defaultGoal>
         <plugins>
             <plugin>

--- a/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/publish/tckRunner/tck/pom.xml
@@ -6,8 +6,7 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
     the specific language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.faulttolerance</groupId>
@@ -50,7 +49,7 @@
     </dependencyManagement>
 
     <dependencies>
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -99,13 +98,13 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.5</version> 
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
 
     <build>
-    <directory>${targetDirectory}</directory>
+        <directory>${targetDirectory}</directory>
         <defaultGoal>clean test</defaultGoal>
         <plugins>
             <plugin>

--- a/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/publish/tckRunner/tck/pom.xml
@@ -41,6 +41,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.faulttolerance_git_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_git_fat_tck/publish/tckRunner/tck/pom.xml
@@ -6,8 +6,7 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
     the specific language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.faulttolerance</groupId>
@@ -118,7 +117,7 @@
     </dependencies>
 
     <build>
-    <directory>${targetDirectory}</directory>
+        <directory>${targetDirectory}</directory>
         <defaultGoal>clean test</defaultGoal>
         <plugins>
             <plugin>

--- a/dev/com.ibm.ws.microprofile.faulttolerance_git_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_git_fat_tck/publish/tckRunner/tck/pom.xml
@@ -61,6 +61,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/pom.xml
@@ -52,6 +52,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2019 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2019, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,18 +8,23 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <repositories>
-    	<repository>
-    		<id>ibmdhe</id>
-    		<name>IBM_DHE File Server</name>
-    		<url>http://public.dhe.ibm.com/ibmdl/export/pub/software/olrepo</url>
-    		<releases><enabled>true</enabled><updatePolicy>always</updatePolicy></releases>
-            <snapshots><enabled>true</enabled><updatePolicy>always</updatePolicy></snapshots>
-    	</repository>
+        <repository>
+            <id>ibmdhe</id>
+            <name>IBM_DHE File Server</name>
+            <url>http://public.dhe.ibm.com/ibmdl/export/pub/software/olrepo</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
+        </repository>
     </repositories>
 
     <groupId>com.ibm.ws.microprofile.graphql</groupId>
@@ -61,7 +66,7 @@
     </dependencyManagement>
 
     <dependencies>
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -139,9 +144,9 @@
             <artifactId>arquillian-liberty-managed</artifactId>
             <version>1.0.5</version>
             <scope>test</scope>
-        </dependency> 
+        </dependency>
     </dependencies>
- 
+
     <build>
         <directory>${targetDirectory}</directory>
         <defaultGoal>clean test</defaultGoal>
@@ -181,7 +186,8 @@
                     <!-- <argLine>-verbose:class</argLine> -->
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>
-                        <wlp>${wlp}</wlp>>
+                        <wlp>${wlp}</wlp>
+                        >
                         <tck_server>${tck_server}</tck_server>
                         <tck_port>${tck_port}</tck_port>
                         <sun.rmi.transport.tcp.responseTimeout>${sun.rmi.transport.tcp.responseTimeout}</sun.rmi.transport.tcp.responseTimeout>

--- a/dev/com.ibm.ws.microprofile.health.1.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.health.1.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -42,6 +42,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.health.1.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.health.1.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2019 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2019, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.health</groupId>
@@ -18,7 +17,7 @@
     <name>MicroProfile Health 1.0 TCK Runner TCK Module</name>
 
     <properties>
-    	<microprofile.health.version>1.0</microprofile.health.version>
+        <microprofile.health.version>1.0</microprofile.health.version>
         <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
@@ -51,7 +50,7 @@
     </dependencyManagement>
 
     <dependencies>
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -79,7 +78,7 @@
             <version>1.2</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
@@ -95,7 +94,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.5</version> 
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
 

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -42,6 +42,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2019 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2019, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.health.2.0</groupId>
@@ -18,7 +17,7 @@
     <name>MicroProfile Health 2.0 TCK Runner TCK Module</name>
 
     <properties>
-    	<microprofile.health.version>2.0.1</microprofile.health.version>
+        <microprofile.health.version>2.0.1</microprofile.health.version>
         <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
@@ -51,7 +50,7 @@
     </dependencyManagement>
 
     <dependencies>
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -79,7 +78,7 @@
             <version>1.2</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
@@ -95,7 +94,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.5</version> 
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
 

--- a/dev/com.ibm.ws.microprofile.health.2.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -42,6 +42,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.health.2.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2019 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2019, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.health.2.1</groupId>
@@ -18,7 +17,7 @@
     <name>MicroProfile Health 2.1 TCK Runner TCK Module</name>
 
     <properties>
-    	<microprofile.health.version>2.1</microprofile.health.version>
+        <microprofile.health.version>2.1</microprofile.health.version>
         <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
@@ -51,7 +50,7 @@
     </dependencyManagement>
 
     <dependencies>
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -79,7 +78,7 @@
             <version>1.2</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
@@ -95,28 +94,28 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.5</version> 
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>27.0.1-jre</version>
         </dependency>
-        
+
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>failureaccess</artifactId>
             <version>1.0.1</version>
         </dependency>
-        
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>2.9.8</version>
         </dependency>
-        
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>

--- a/dev/com.ibm.ws.microprofile.health.2.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2020 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2020, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.health.2.2</groupId>
@@ -18,7 +17,7 @@
     <name>MicroProfile Health 2.2 TCK Runner TCK Module</name>
 
     <properties>
-    	<microprofile.health.version>2.2</microprofile.health.version>
+        <microprofile.health.version>2.2</microprofile.health.version>
         <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
@@ -51,7 +50,7 @@
     </dependencyManagement>
 
     <dependencies>
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -79,7 +78,7 @@
             <version>2.0</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
@@ -95,22 +94,22 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.5</version> 
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>failureaccess</artifactId>
             <version>1.0.1</version>
-        </dependency>        
-        
+        </dependency>
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>2.9.8</version>
         </dependency>
-        
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>

--- a/dev/com.ibm.ws.microprofile.health.2.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -42,6 +42,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.metrics.1.1.noAuth_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1.noAuth_fat_tck/publish/tckRunner/tck/pom.xml
@@ -6,8 +6,7 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for
     the specific language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.metrics11</groupId>

--- a/dev/com.ibm.ws.microprofile.metrics.1.1.noAuth_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1.noAuth_fat_tck/publish/tckRunner/tck/pom.xml
@@ -40,6 +40,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -6,8 +6,7 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for
     the specific language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.metrics11</groupId>

--- a/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -40,6 +40,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.metrics.2.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -6,8 +6,7 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for
     the specific language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.metrics20</groupId>

--- a/dev/com.ibm.ws.microprofile.metrics.2.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -40,6 +40,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.metrics.2.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -6,8 +6,7 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for
     the specific language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.metrics</groupId>

--- a/dev/com.ibm.ws.microprofile.metrics.2.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -40,6 +40,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.metrics.2.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -6,8 +6,7 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for
     the specific language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.metrics</groupId>
@@ -61,11 +60,11 @@
             <artifactId>microprofile-metrics-api</artifactId>
             <version>${microprofile.metrics.version}</version>
         </dependency>
-		<dependency>
+        <dependency>
             <groupId>org.eclipse.microprofile.metrics</groupId>
             <artifactId>microprofile-metrics-optional-tck</artifactId>
             <version>${microprofile.metrics.version}</version>
-        </dependency> 
+        </dependency>
 
         <dependency>
             <groupId>org.eclipse.microprofile.metrics</groupId>

--- a/dev/com.ibm.ws.microprofile.metrics.2.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -40,6 +40,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.metrics_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics_fat_tck/publish/tckRunner/tck/pom.xml
@@ -6,8 +6,7 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for
     the specific language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.metrics</groupId>

--- a/dev/com.ibm.ws.microprofile.metrics_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics_fat_tck/publish/tckRunner/tck/pom.xml
@@ -40,6 +40,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2018 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2018, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.mpjwt11</groupId>
@@ -51,7 +50,7 @@
     </dependencyManagement>
 
     <dependencies>
-    
+
         <dependency>
             <groupId>org.eclipse.microprofile.jwt</groupId>
             <artifactId>microprofile-jwt-auth-api</artifactId>
@@ -60,11 +59,11 @@
         
         <!--  impl -->
         <!-- https://mvnrepository.com/artifact/org.glassfish/javax.json -->
-		<dependency>
-		    <groupId>org.glassfish</groupId>
-		    <artifactId>javax.json</artifactId>
-		    <version>1.1</version>
-		</dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>1.1</version>
+        </dependency>
         
         <!--  api -->
         <!-- 
@@ -92,8 +91,8 @@
             <type>test-jar</type>        
             <!-- <systemPath>C:\mpjwt\tck\microprofile-jwt-auth\tck\target\microprofile-jwt-auth-tck-1.2-SNAPSHOT-tests.jar</systemPath> -->
             <!-- <scope>system</scope> -->
-           
-           
+
+
         </dependency>
         
           <!-- You need to specify your JAX-RS client implementation as the unit
@@ -111,7 +110,7 @@
             <version>1.2</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
@@ -127,7 +126,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.5</version> 
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
 

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -42,6 +42,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.openapi.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.openapi.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.openapi</groupId>
@@ -16,7 +15,7 @@
         <surefire.version>2.17</surefire.version> <!-- Any changes to the surefire version must be tested against ZOS -->
         <arquillian.version>1.1.13.Final</arquillian.version>
         <arquillian-wlp.version>1.0.0.Final-SNAPSHOT</arquillian-wlp.version>
-        
+
         <suiteXmlFile>${defaultSuiteFiles}</suiteXmlFile>
         <targetDirectory>${project.basedir}/target</targetDirectory>
         <testng.version>6.9.9</testng.version>

--- a/dev/com.ibm.ws.microprofile.openapi.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.openapi.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -28,10 +28,10 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-	          <groupId>org.jboss.spec.javax.servlet</groupId>
-	          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-	          <version>1.0.2.Final</version> <!-- Defines the version of this artifact that arquillian-liberty-managed should use -->
-	        </dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.openapi_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.openapi_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.openapi</groupId>
@@ -16,7 +15,7 @@
         <surefire.version>2.17</surefire.version> <!-- Any changes to the surefire version must be tested against ZOS -->
         <arquillian.version>1.1.13.Final</arquillian.version>
         <arquillian-wlp.version>1.0.0.Final-SNAPSHOT</arquillian-wlp.version>
-        
+
         <suiteXmlFile>${defaultSuiteFiles}</suiteXmlFile>
         <targetDirectory>${project.basedir}/target</targetDirectory>
         <testng.version>6.9.9</testng.version>

--- a/dev/com.ibm.ws.microprofile.openapi_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.openapi_fat_tck/publish/tckRunner/tck/pom.xml
@@ -25,6 +25,16 @@
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <directory>${targetDirectory}</directory>
         <defaultGoal>clean test</defaultGoal>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -42,6 +42,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.opentracing</groupId>
@@ -104,16 +103,16 @@
         </dependency>
 
         <dependency>
-             <groupId>io.opentracing</groupId>
-             <artifactId>opentracing-api</artifactId>
-             <version>0.31.0</version>
-         </dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+            <version>0.31.0</version>
+        </dependency>
 
-         <dependency>
-             <groupId>org.jboss.shrinkwrap.resolver</groupId>
-             <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-             <version>2.2.4</version>
-         </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <version>2.2.4</version>
+        </dependency>
          
         <!-- Include JAX-B API+Impl for Java 9+ -->
         <dependency>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -42,6 +42,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017, 2018 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.opentracing</groupId>
@@ -70,7 +69,7 @@
             <artifactId>microprofile-config-api</artifactId>
             <version>1.3</version>
         </dependency>
-        
+
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
@@ -110,16 +109,16 @@
         </dependency>
 
         <dependency>
-             <groupId>io.opentracing</groupId>
-             <artifactId>opentracing-api</artifactId>
-             <version>0.31.0</version>
-         </dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+            <version>0.31.0</version>
+        </dependency>
 
-         <dependency>
-             <groupId>org.jboss.shrinkwrap.resolver</groupId>
-             <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-             <version>2.2.4</version>
-         </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <version>2.2.4</version>
+        </dependency>
          
         <!-- Include JAX-B API+Impl for Java 9+ -->
         <dependency>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017, 2018 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.opentracing</groupId>
@@ -57,8 +56,8 @@
             <version>${microprofile.opentracing.version}</version>
         </dependency>
 
-		<dependency>
-        	<groupId>org.eclipse.microprofile.opentracing</groupId>
+        <dependency>
+            <groupId>org.eclipse.microprofile.opentracing</groupId>
             <artifactId>microprofile-opentracing-tck-rest-client</artifactId>
             <version>${microprofile.opentracing.version}</version>
         </dependency>
@@ -76,13 +75,13 @@
             <artifactId>microprofile-config-api</artifactId>
             <version>1.3</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.eclipse.microprofile.rest.client</groupId>
             <artifactId>microprofile-rest-client-api</artifactId>
             <version>1.2</version>
-		</dependency>
-		
+        </dependency>
+
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
@@ -122,16 +121,16 @@
         </dependency>
 
         <dependency>
-             <groupId>io.opentracing</groupId>
-             <artifactId>opentracing-api</artifactId>
-             <version>0.31.0</version>
-         </dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+            <version>0.31.0</version>
+        </dependency>
 
-         <dependency>
-             <groupId>org.jboss.shrinkwrap.resolver</groupId>
-             <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-             <version>2.2.4</version>
-         </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <version>2.2.4</version>
+        </dependency>
          
         <!-- Include JAX-B API+Impl for Java 9+ -->
         <dependency>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -42,6 +42,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.opentracing_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing_fat_tck/publish/tckRunner/tck/pom.xml
@@ -42,6 +42,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.opentracing_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.opentracing</groupId>
@@ -104,16 +103,16 @@
         </dependency>
 
         <dependency>
-             <groupId>io.opentracing</groupId>
-             <artifactId>opentracing-api</artifactId>
-             <version>0.30.0</version>
-         </dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+            <version>0.30.0</version>
+        </dependency>
 
-         <dependency>
-             <groupId>org.jboss.shrinkwrap.resolver</groupId>
-             <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-             <version>2.2.4</version>
-         </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <version>2.2.4</version>
+        </dependency>
          
         <!-- Include JAX-B API+Impl for Java 9+ -->
         <dependency>

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017,2018 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.reactive.messaging</groupId>
@@ -50,7 +49,7 @@
 
     <dependencies>
 
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -67,7 +66,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.5</version> 
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat_tck/publish/tckRunner/tck/pom.xml
@@ -40,6 +40,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_git_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_git_fat_tck/publish/tckRunner/tck/pom.xml
@@ -43,6 +43,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_git_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_git_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2019 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2019, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.reactive.streams</groupId>
@@ -53,7 +52,7 @@
 
     <dependencies>
 
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -109,7 +108,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.3</version> 
+            <version>1.0.3</version>
             <scope>test</scope>
         </dependency>
 

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017,2018 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.reactive.streams</groupId>
@@ -52,7 +51,7 @@
 
     <dependencies>
 
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -102,7 +101,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.5</version> 
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
 

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat_tck/publish/tckRunner/tck/pom.xml
@@ -42,6 +42,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2018 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2018, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.rest.client</groupId>
@@ -53,7 +52,7 @@
 
     <dependencies>
 
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -206,7 +205,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-	    <version>1.0.5</version>
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
 
@@ -232,20 +231,20 @@
             <type>pom</type>
             <scope>test</scope>
         </dependency>
- --> 
- 
+ -->
+
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-standalone</artifactId>
-            
+
             <version>2.14.0</version>
             <!-- <scope>system</scope>
             <systemPath>${basedir}/../../servers/FATServer/wiremock-standalone-2.14.0.jar</systemPath> -->
         </dependency>
-        
-        
+
+
     </dependencies>
- 
+
     <build>
         <directory>${targetDirectory}</directory>
         <defaultGoal>clean test</defaultGoal>
@@ -302,21 +301,21 @@
                 </configuration>
             </plugin>
             <plugin>
-               <groupId>uk.co.automatictester</groupId>
-               <artifactId>wiremock-maven-plugin</artifactId>
-               <version>4.1.0</version>
-               <executions>
-                   <execution>
-                       <phase>generate-test-sources</phase>
-                       <goals>
-                           <goal>run</goal>
-                       </goals>
-                       <configuration>
-                           <dir>target/classes</dir>
-                           <params>--port=8765 --verbose</params>
-                       </configuration>
-                   </execution>
-               </executions>
+                <groupId>uk.co.automatictester</groupId>
+                <artifactId>wiremock-maven-plugin</artifactId>
+                <version>4.1.0</version>
+                <executions>
+                    <execution>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <dir>target/classes</dir>
+                            <params>--port=8765 --verbose</params>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/pom.xml
@@ -43,6 +43,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2019 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2019, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.rest.client</groupId>
@@ -53,7 +52,7 @@
 
     <dependencies>
 
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -131,7 +130,7 @@
             <systemPath>${com.ibm.ws.jaxrs.2.1.common_}</systemPath>
         </dependency>
 
-        
+
 
         <dependency>
             <groupId>com.ibm.ws</groupId>
@@ -217,7 +216,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-	    <version>1.0.5</version>
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
 
@@ -234,17 +233,17 @@
             <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
- 
+
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-standalone</artifactId>
-            
+
             <version>2.14.0</version>
         </dependency>
-        
-        
+
+
     </dependencies>
- 
+
     <build>
         <directory>${targetDirectory}</directory>
         <defaultGoal>clean test</defaultGoal>
@@ -301,21 +300,21 @@
                 </configuration>
             </plugin>
             <plugin>
-               <groupId>uk.co.automatictester</groupId>
-               <artifactId>wiremock-maven-plugin</artifactId>
-               <version>4.1.0</version>
-               <executions>
-                   <execution>
-                       <phase>generate-test-sources</phase>
-                       <goals>
-                           <goal>run</goal>
-                       </goals>
-                       <configuration>
-                           <dir>target/classes</dir>
-                           <params>--port=8765 --verbose</params>
-                       </configuration>
-                   </execution>
-               </executions>
+                <groupId>uk.co.automatictester</groupId>
+                <artifactId>wiremock-maven-plugin</artifactId>
+                <version>4.1.0</version>
+                <executions>
+                    <execution>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <dir>target/classes</dir>
+                            <params>--port=8765 --verbose</params>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom.xml
@@ -43,6 +43,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/pom.xml
@@ -44,6 +44,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2019 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2019, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.rest.client</groupId>
@@ -54,7 +53,7 @@
 
     <dependencies>
 
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -216,7 +215,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-	    <version>1.0.5</version>
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
 
@@ -233,7 +232,7 @@
             <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
- 
+
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-standalone</artifactId>
@@ -245,7 +244,7 @@
             <artifactId>httpcore</artifactId>
             <version>4.4.11</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
@@ -276,15 +275,15 @@
             <artifactId>apache-jsp</artifactId>
             <version>${jetty.version}</version>
             <exclusions>
-              <exclusion>
-                <groupId>org.glassfish</groupId>
-                <artifactId>javax.el</artifactId>
-              </exclusion>
-              <exclusion>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-commons</artifactId>
-              </exclusion>
-            </exclusions> 
+                <exclusion>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>javax.el</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-commons</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
@@ -293,7 +292,7 @@
         </dependency>
 
     </dependencies>
- 
+
     <build>
         <directory>${targetDirectory}</directory>
         <defaultGoal>clean test</defaultGoal>
@@ -350,21 +349,21 @@
                 </configuration>
             </plugin>
             <plugin>
-               <groupId>uk.co.automatictester</groupId>
-               <artifactId>wiremock-maven-plugin</artifactId>
-               <version>4.1.0</version>
-               <executions>
-                   <execution>
-                       <phase>generate-test-sources</phase>
-                       <goals>
-                           <goal>run</goal>
-                       </goals>
-                       <configuration>
-                           <dir>target/classes</dir>
-                           <params>--port=8765 --verbose</params>
-                       </configuration>
-                   </execution>
-               </executions>
+                <groupId>uk.co.automatictester</groupId>
+                <artifactId>wiremock-maven-plugin</artifactId>
+                <version>4.1.0</version>
+                <executions>
+                    <execution>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <dir>target/classes</dir>
+                            <params>--port=8765 --verbose</params>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/pom.xml
@@ -44,6 +44,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2020 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2020 ,2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.rest.client</groupId>
@@ -54,7 +53,7 @@
 
     <dependencies>
 
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -216,7 +215,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-	    <version>1.0.5</version>
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
 
@@ -233,7 +232,7 @@
             <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
- 
+
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-standalone</artifactId>
@@ -245,7 +244,7 @@
             <artifactId>httpcore</artifactId>
             <version>4.4.11</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
@@ -276,15 +275,15 @@
             <artifactId>apache-jsp</artifactId>
             <version>${jetty.version}</version>
             <exclusions>
-              <exclusion>
-                <groupId>org.glassfish</groupId>
-                <artifactId>javax.el</artifactId>
-              </exclusion>
-              <exclusion>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-commons</artifactId>
-              </exclusion>
-            </exclusions> 
+                <exclusion>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>javax.el</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-commons</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
@@ -293,7 +292,7 @@
         </dependency>
 
     </dependencies>
- 
+
     <build>
         <directory>${targetDirectory}</directory>
         <defaultGoal>clean test</defaultGoal>
@@ -350,21 +349,21 @@
                 </configuration>
             </plugin>
             <plugin>
-               <groupId>uk.co.automatictester</groupId>
-               <artifactId>wiremock-maven-plugin</artifactId>
-               <version>4.1.0</version>
-               <executions>
-                   <execution>
-                       <phase>generate-test-sources</phase>
-                       <goals>
-                           <goal>run</goal>
-                       </goals>
-                       <configuration>
-                           <dir>target/classes</dir>
-                           <params>--port=8765 --verbose</params>
-                       </configuration>
-                   </execution>
-               </executions>
+                <groupId>uk.co.automatictester</groupId>
+                <artifactId>wiremock-maven-plugin</artifactId>
+                <version>4.1.0</version>
+                <executions>
+                    <execution>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <dir>target/classes</dir>
+                            <params>--port=8765 --verbose</params>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom.xml
@@ -42,6 +42,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+              <groupId>org.jboss.spec.javax.servlet</groupId>
+              <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+              <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.rest.client</groupId>
@@ -43,16 +42,16 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-              <groupId>org.jboss.spec.javax.servlet</groupId>
-              <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-              <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
             </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
 
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -178,12 +177,12 @@
             <type>pom</type>
             <scope>test</scope>
         </dependency>
- --> 
- 
+ -->
+
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-standalone</artifactId>
-            
+
             <version>2.14.0</version>
             <!-- <scope>system</scope>
             <systemPath>${basedir}/../../servers/FATServer/wiremock-standalone-2.14.0.jar</systemPath> -->
@@ -202,9 +201,9 @@
             <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
-        
+
     </dependencies>
- 
+
     <build>
         <directory>${targetDirectory}</directory>
         <defaultGoal>clean test</defaultGoal>
@@ -245,7 +244,8 @@
                     <!-- <argLine>-Dwas.debug.mode=true -Dcom.ibm.websphere.ras.inject.at.transform=true -Dsun.reflect.noInflation=true -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=7777</argLine> -->
                     <systemPropertyVariables>
                         <!-- <wlp>/home/andymc/mpRestClientTCK/open-liberty/dev/build.image/wlp</wlp> -->
-                        <wlp>${wlp}</wlp>>
+                        <wlp>${wlp}</wlp>
+                        >
                         <!-- <tck_server>${tck_server}</tck_server> -->
                         <tck_server>FATServer</tck_server>
                         <!-- <tck_port>${tck_port}</tck_port>  -->
@@ -261,21 +261,21 @@
                 </configuration>
             </plugin>
             <plugin>
-               <groupId>uk.co.automatictester</groupId>
-               <artifactId>wiremock-maven-plugin</artifactId>
-               <version>4.1.0</version>
-               <executions>
-                   <execution>
-                       <phase>generate-test-sources</phase>
-                       <goals>
-                           <goal>run</goal>
-                       </goals>
-                       <configuration>
-                           <dir>target/classes</dir>
-                           <params>--port=8765 --verbose</params>
-                       </configuration>
-                   </execution>
-               </executions>
+                <groupId>uk.co.automatictester</groupId>
+                <artifactId>wiremock-maven-plugin</artifactId>
+                <version>4.1.0</version>
+                <executions>
+                    <execution>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <dir>target/classes</dir>
+                            <params>--port=8765 --verbose</params>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2020 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2020, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.openliberty.microprofile.config20.internal</groupId>
@@ -49,22 +48,22 @@
             </dependency>
         </dependencies>
     </dependencyManagement> 
-    
+
     <!-- Whilst using an artifact that is in Maven (microprofile-config-tck:2.0-RC15) we shouldn't need this.
-	<repositories>
-		<! If the TCK is using a custom built artifact, e.g.- microprofile-config-tck:2.0-ibm20201020.
-		And Artifactory is unavailable, the following DHE repository should be searched for the artifact >
-		<repository>
-			<name>IBM DHE Maven repository</name>
-			<id>DHE</id>
-			<url>http://public.dhe.ibm.com/ibmdl/export/pub/software/olrepo</url>
-		</repository>
-	</repositories>
-	-->
+    <repositories>
+        <! If the TCK is using a custom built artifact, e.g.- microprofile-config-tck:2.0-ibm20201020.
+        And Artifactory is unavailable, the following DHE repository should be searched for the artifact >
+        <repository>
+            <name>IBM DHE Maven repository</name>
+            <id>DHE</id>
+            <url>http://public.dhe.ibm.com/ibmdl/export/pub/software/olrepo</url>
+        </repository>
+    </repositories>
+    -->
 
     <dependencies>
 
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -75,7 +74,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-tck</artifactId>
-            <version>2.0</version> 
+            <version>2.0</version>
         </dependency>
 
         <dependency>
@@ -92,7 +91,7 @@
             <version>2.0</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
@@ -108,7 +107,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.5</version> 
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
 

--- a/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -43,10 +43,10 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-	          <groupId>org.jboss.spec.javax.servlet</groupId>
-	          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-	          <version>1.0.2.Final</version> <!-- Defines the version of this artifact that arquillian-liberty-managed should use -->
-	        </dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement> 
     

--- a/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -6,8 +6,7 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
     the specific language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.openliberty.microprofile.faulttolerance</groupId>
@@ -52,7 +51,7 @@
     </dependencyManagement>
 
     <dependencies>
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -96,7 +95,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>1.1.14.Final</version> 
+            <version>1.1.14.Final</version>
         </dependency>
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
@@ -107,7 +106,7 @@
     </dependencies>
 
     <build>
-    <directory>${targetDirectory}</directory>
+        <directory>${targetDirectory}</directory>
         <defaultGoal>clean test</defaultGoal>
         <plugins>
             <plugin>

--- a/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -44,10 +44,10 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-	          <groupId>org.jboss.spec.javax.servlet</groupId>
-	          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-	          <version>1.0.2.Final</version> <!-- Defines the version of this artifact that arquillian-liberty-managed should use -->
-	        </dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/io.openliberty.microprofile.health.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.health.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -42,6 +42,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/io.openliberty.microprofile.health.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.health.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2020 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2020, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.openliberty.microprofile.health.3.0</groupId>
@@ -18,7 +17,7 @@
     <name>MicroProfile Health 3.0 TCK Runner TCK Module</name>
 
     <properties>
-    	<microprofile.health.version>3.0</microprofile.health.version>
+        <microprofile.health.version>3.0</microprofile.health.version>
         <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
@@ -51,7 +50,7 @@
     </dependencyManagement>
 
     <dependencies>
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -79,7 +78,7 @@
             <version>2.0</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
@@ -95,39 +94,39 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.5</version> 
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>failureaccess</artifactId>
             <version>1.0.1</version>
-        </dependency>        
-        
+        </dependency>
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>2.9.8</version>
         </dependency>
-        
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <version>2.9.5</version>
         </dependency>
-       
-       <dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.9.8</version>
-       </dependency>
-       
-       <dependency>
-    		<groupId>com.fasterxml.jackson.datatype</groupId>
-    		<artifactId>jackson-datatype-jdk8</artifactId>
-    		<version>2.9.8</version>
-		</dependency>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>2.9.8</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -42,6 +42,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2020 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2020, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.mpjwt12</groupId>
@@ -51,7 +50,7 @@
     </dependencyManagement>
 
     <dependencies>
-    
+
         <dependency>
             <groupId>org.eclipse.microprofile.jwt</groupId>
             <artifactId>microprofile-jwt-auth-api</artifactId>
@@ -60,11 +59,11 @@
         
         <!--  impl -->
         <!-- https://mvnrepository.com/artifact/org.glassfish/javax.json -->
-		<dependency>
-		    <groupId>org.glassfish</groupId>
-		    <artifactId>javax.json</artifactId>
-		    <version>1.1.4</version>
-		</dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>1.1.4</version>
+        </dependency>
         
         <!--  api -->
         <!-- 
@@ -92,8 +91,8 @@
             <type>test-jar</type>        
            <!-- <systemPath>/Users/kristenclarke/MPJWT12/clone111020_RC212/microprofile-jwt-auth/tck/target/microprofile-jwt-auth-tck-1.2.RC2-SNAPSHOT-tests.jar</systemPath>  -->
             <!--  <scope>system</scope> -->
-         
-           
+
+
         </dependency>
         
           <!-- You need to specify your JAX-RS client implementation as the unit
@@ -111,7 +110,7 @@
             <version>2.0</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
@@ -127,7 +126,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-            <version>1.0.5</version> 
+            <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
 

--- a/dev/io.openliberty.microprofile.lra.1.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.lra.1.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,163 +1,159 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Licensed under the Apache License, Version 2.0 (the "License"); you 
-	may not use this file except in compliance with the License. You may obtain 
-	a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless 
-	required by applicable law or agreed to in writing, software distributed 
-	under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
-	OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
-	the specific language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+    may not use this file except in compliance with the License. You may obtain 
+    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless 
+    required by applicable law or agreed to in writing, software distributed 
+    under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
+    OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
+    the specific language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<groupId>io.openliberty.microprofile.lra</groupId>
-	<artifactId>tck.runner.tck</artifactId>
-	<version>1.0-SNAPSHOT</version>
-	<name>MicroProfile LRA TCK Runner TCK Module</name>
+    <groupId>io.openliberty.microprofile.lra</groupId>
+    <artifactId>tck.runner.tck</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>MicroProfile LRA TCK Runner TCK Module</name>
 
-	<properties>
-		<microprofile.lra.version>1.0-M2</microprofile.lra.version>
-		<microprofile.config.version>1.3</microprofile.config.version>
+    <properties>
+        <microprofile.lra.version>1.0-M2</microprofile.lra.version>
+        <microprofile.config.version>1.3</microprofile.config.version>
 
-		<arquillian.version>1.3.0.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
 
-		<!-- the below is used in arquillian.xml -->
-		<wlp>${wlp}</wlp>
-		<defaultSuiteFiles>tck-suite.xml</defaultSuiteFiles>
-		<suiteXmlFile>${defaultSuiteFiles}</suiteXmlFile>
-		<targetDirectory>${project.basedir}/target</targetDirectory>
-		
-		<!-- This is usually overridden in the TCK launcher test which kicks off this maven build-->
-		<lraTestsToRun>**/*Test*.java</lraTestsToRun>
-	</properties>
+        <!-- the below is used in arquillian.xml -->
+        <wlp>${wlp}</wlp>
+        <defaultSuiteFiles>tck-suite.xml</defaultSuiteFiles>
+        <suiteXmlFile>${defaultSuiteFiles}</suiteXmlFile>
+        <targetDirectory>${project.basedir}/target</targetDirectory>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.jboss.arquillian</groupId>
-				<artifactId>arquillian-bom</artifactId>
-				<version>${arquillian.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
+        <!-- This is usually overridden in the TCK launcher test which kicks off this maven build-->
+        <lraTestsToRun>**/*Test*.java</lraTestsToRun>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${arquillian.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.jboss.spec.javax.servlet</groupId>
                 <artifactId>jboss-servlet-api_3.0_spec</artifactId>
                 <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
             </dependency>
-		</dependencies>
-	</dependencyManagement>
+        </dependencies>
+    </dependencyManagement>
 
-	<dependencies>
- 
-		<dependency>
-			<groupId>com.ibm.ws</groupId>
-			<artifactId>fattest.simplicity</artifactId>
-			<version>1</version>
-			<scope>system</scope>
-			<!-- This will point to build/libs/autoFVT/lib/fattest.simplicity.jar -->
-			<systemPath>${project.basedir}/../../../lib/fattest.simplicity.jar</systemPath> 
-			<!-- If running the maven pom file outside of a fat test build, then you need to run
-			mvn -Dwlp=<build-path>/build.image/wlp
-			And set the systemPath as below --> 
-			<!-- <systemPath>${project.basedir}/../../../build/libs/autoFVT/lib/fattest.simplicity.jar</systemPath>--> 
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.microprofile.lra</groupId>
-			<artifactId>microprofile-lra-tck</artifactId>
-			<version>${microprofile.lra.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.microprofile.lra</groupId>
-			<artifactId>microprofile-lra-api</artifactId>
-			<version>${microprofile.lra.version}</version>
-			<!-- TODO not sure why this was here for fault tolerance -->
-			<!-- but microprofile.metrics doesn't have this -->
-			<!-- <systemPath>${com.ibm.websphere.org.eclipse.microprofile.faulttolerance.2.0}</systemPath> 
-				<scope>system</scope> -->
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.microprofile.config</groupId>
-			<artifactId>microprofile-config-api</artifactId>
-			<version>${microprofile.config.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>javax.enterprise</groupId>
-			<artifactId>cdi-api</artifactId>
-			<version>2.0</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>javax.ws.rs</groupId>
-			<artifactId>javax.ws.rs-api</artifactId>
-			<version>2.1</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>io.openliberty.arquillian</groupId>
-			<artifactId>arquillian-liberty-managed</artifactId>
-			<version>1.0.6</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+    <dependencies>
 
-	<build>
-		<directory>${targetDirectory}</directory>
-		<defaultGoal>clean test</defaultGoal>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-dependency-plugin</artifactId>
-				<version>2.9</version>
-				<executions>
-					<execution>
-						<id>build-classpath</id>
-						<phase>generate-sources</phase>
-						<goals>
-							<goal>build-classpath</goal>
-						</goals>
-						<configuration>
-							<!-- configure the plugin here -->
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.2</version>
-				<configuration>
-					<!-- Needed for ZOS. sourceEncoding is needed because arquillian calls String.getBtytes(). 
-						Attach is needed because because Arquillian uses com.sun.tools.attach to find VMs -->
-					<argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> 
-					<systemPropertyVariables>
-						<wlp>${wlp}</wlp>
-						<tck_server>${tck_server}</tck_server>
-						<tck_port>${tck_port}</tck_port>
-						<lra.tck.base.url>http://localhost:${tck_port}</lra.tck.base.url>
-					</systemPropertyVariables>
-					<dependenciesToScan>
-						<dependency>org.eclipse.microprofile.lra:microprofile-lra-tck</dependency>
-					</dependenciesToScan>
-					<includes>
-						<include>${lraTestsToRun}</include>
-					</includes>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+        <dependency>
+            <groupId>com.ibm.ws</groupId>
+            <artifactId>fattest.simplicity</artifactId>
+            <version>1</version>
+            <scope>system</scope>
+            <!-- This will point to build/libs/autoFVT/lib/fattest.simplicity.jar -->
+            <systemPath>${project.basedir}/../../../lib/fattest.simplicity.jar</systemPath> 
+            <!-- If running the maven pom file outside of a fat test build, then you need to run
+            mvn -Dwlp=<build-path>/build.image/wlp
+            And set the systemPath as below --> 
+            <!-- <systemPath>${project.basedir}/../../../build/libs/autoFVT/lib/fattest.simplicity.jar</systemPath>-->
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.lra</groupId>
+            <artifactId>microprofile-lra-tck</artifactId>
+            <version>${microprofile.lra.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.lra</groupId>
+            <artifactId>microprofile-lra-api</artifactId>
+            <version>${microprofile.lra.version}</version>
+            <!-- TODO not sure why this was here for fault tolerance -->
+            <!-- but microprofile.metrics doesn't have this -->
+            <!-- <systemPath>${com.ibm.websphere.org.eclipse.microprofile.faulttolerance.2.0}</systemPath> 
+            <scope>system</scope> -->
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <version>${microprofile.config.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <version>2.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.openliberty.arquillian</groupId>
+            <artifactId>arquillian-liberty-managed</artifactId>
+            <version>1.0.6</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <directory>${targetDirectory}</directory>
+        <defaultGoal>clean test</defaultGoal>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.9</version>
+                <executions>
+                    <execution>
+                        <id>build-classpath</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>build-classpath</goal>
+                        </goals>
+                        <configuration>
+                            <!-- configure the plugin here -->
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine><!-- Needed for ZOS. sourceEncoding is needed because arquillian calls String.getBtytes(). Attach is needed because because Arquillian uses com.sun.tools.attach to find VMs -->
+                    <systemPropertyVariables>
+                        <wlp>${wlp}</wlp>
+                        <tck_server>${tck_server}</tck_server>
+                        <tck_port>${tck_port}</tck_port>
+                        <lra.tck.base.url>http://localhost:${tck_port}</lra.tck.base.url>
+                    </systemPropertyVariables>
+                    <dependenciesToScan>
+                        <dependency>org.eclipse.microprofile.lra:microprofile-lra-tck</dependency>
+                    </dependenciesToScan>
+                    <includes>
+                        <include>${lraTestsToRun}</include>
+                    </includes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/dev/io.openliberty.microprofile.lra.1.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.lra.1.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -45,6 +45,11 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/dev/io.openliberty.microprofile.metrics.internal.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -6,8 +6,7 @@
     under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
     OR CONDITIONS OF ANY KIND, either express or implied. See the License for
     the specific language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.openliberty.microprofile.metrics</groupId>
@@ -61,11 +60,11 @@
             <artifactId>microprofile-metrics-api</artifactId>
             <version>${microprofile.metrics.version}</version>
         </dependency>
-		<dependency>
+        <dependency>
             <groupId>org.eclipse.microprofile.metrics</groupId>
             <artifactId>microprofile-metrics-optional-tck</artifactId>
             <version>${microprofile.metrics.version}</version>
-        </dependency> 
+        </dependency>
 
         <dependency>
             <groupId>org.eclipse.microprofile.metrics</groupId>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -40,6 +40,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.openliberty.microprofile.openapi20.internal</groupId>
@@ -14,7 +13,6 @@
     <properties>
         <microprofile.openapi.version>2.0</microprofile.openapi.version>
 
-     
         <surefire.version>2.17</surefire.version> <!-- Any changes to the surefire version must be tested against ZOS-->
 <!--    
         <surefire.version>2.19.1</surefire.version>
@@ -24,7 +22,7 @@
  -->
         <arquillian.version>1.6.0.Final</arquillian.version>
         <arquillian-wlp.version>1.0.5</arquillian-wlp.version>
-        
+
         <suiteXmlFile>${defaultSuiteFiles}</suiteXmlFile>
         <targetDirectory>${project.basedir}/target</targetDirectory>
 <!-- 
@@ -79,7 +77,7 @@
                     </suiteXmlFiles>
  -->
 
-                 </configuration>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -119,9 +117,9 @@
             </exclusions>
         </dependency>
         <dependency>
-          <groupId>com.beust</groupId>
-          <artifactId>jcommander</artifactId>
-          <version>1.78</version>
+            <groupId>com.beust</groupId>
+            <artifactId>jcommander</artifactId>
+            <version>1.78</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
@@ -141,6 +139,6 @@
             <artifactId>xml-path</artifactId>
             <version>3.0.6</version>
         </dependency>
- -->        
+ -->
     </dependencies>
 </project>

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -43,10 +43,10 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-	          <groupId>org.jboss.spec.javax.servlet</groupId>
-	          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-	          <version>1.0.2.Final</version> <!-- Defines the version of this artifact that arquillian-liberty-managed should use -->
-	        </dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (c) 2020 IBM Corporation and others. All rights reserved. 
+<!-- Copyright (c) 2020, 2021 IBM Corporation and others. All rights reserved. 
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at http://www.eclipse.org/legal/epl-v10.html Contributors: 
     IBM Corporation - initial API and implementation -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.openliberty.microprofile.opentracing</groupId>

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -41,6 +41,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2020 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2020, 2021 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at 
@@ -8,8 +8,7 @@
     Contributors: 
         IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.ws.microprofile.rest.client</groupId>
@@ -18,13 +17,19 @@
     <name>MicroProfile RestClient 2.0 TCK Runner TCK Module</name>
 
     <repositories>
-    	<repository>
-    		<id>ibmdhe</id>
-    		<name>IBM_DHE File Server</name>
-    		<url>http://public.dhe.ibm.com/ibmdl/export/pub/software/olrepo</url>
-    		<releases><enabled>true</enabled><updatePolicy>always</updatePolicy></releases>
-            <snapshots><enabled>true</enabled><updatePolicy>always</updatePolicy></snapshots>
-    	</repository>
+        <repository>
+            <id>ibmdhe</id>
+            <name>IBM_DHE File Server</name>
+            <url>http://public.dhe.ibm.com/ibmdl/export/pub/software/olrepo</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
+        </repository>
     </repositories>
 
     <properties>
@@ -65,7 +70,7 @@
 
     <dependencies>
 
-       <dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>fattest.simplicity</artifactId>
             <version>1</version>
@@ -173,7 +178,7 @@
             <systemPath>${com.ibm.ws.logging_}</systemPath>
         </dependency>
 
-		<dependency>
+        <dependency>
             <groupId>com.ibm.ws</groupId>
             <artifactId>org.reactivestreams.reactive-streams</artifactId>
             <version>1.0</version>
@@ -243,7 +248,7 @@
         <dependency>
             <groupId>io.openliberty.arquillian</groupId>
             <artifactId>arquillian-liberty-managed</artifactId>
-	    <version>1.0.6</version>
+            <version>1.0.6</version>
             <scope>test</scope>
         </dependency>
 
@@ -260,7 +265,7 @@
             <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
- 
+
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-standalone</artifactId>
@@ -272,7 +277,7 @@
             <artifactId>httpcore</artifactId>
             <version>4.4.11</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
@@ -308,15 +313,15 @@
             <artifactId>apache-jsp</artifactId>
             <version>${jetty.version}</version>
             <exclusions>
-              <exclusion>
-                <groupId>org.glassfish</groupId>
-                <artifactId>javax.el</artifactId>
-              </exclusion>
-              <exclusion>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-commons</artifactId>
-              </exclusion>
-            </exclusions> 
+                <exclusion>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>javax.el</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-commons</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
@@ -325,7 +330,7 @@
         </dependency>
 
     </dependencies>
- 
+
     <build>
         <directory>${targetDirectory}</directory>
         <defaultGoal>clean test</defaultGoal>
@@ -382,21 +387,21 @@
                 </configuration>
             </plugin>
             <plugin>
-               <groupId>uk.co.automatictester</groupId>
-               <artifactId>wiremock-maven-plugin</artifactId>
-               <version>4.1.0</version>
-               <executions>
-                   <execution>
-                       <phase>generate-test-sources</phase>
-                       <goals>
-                           <goal>run</goal>
-                       </goals>
-                       <configuration>
-                           <dir>target/classes</dir>
-                           <params>--port=8765 --verbose</params>
-                       </configuration>
-                   </execution>
-               </executions>
+                <groupId>uk.co.automatictester</groupId>
+                <artifactId>wiremock-maven-plugin</artifactId>
+                <version>4.1.0</version>
+                <executions>
+                    <execution>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <dir>target/classes</dir>
+                            <params>--port=8765 --verbose</params>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -55,6 +55,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                <version>1.0.2.Final</version> <!-- Needed for ZOS. Defines the version of this artifact that arquillian-liberty-managed should use -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Should prevent Defect 280600 from occurring.

Manually defines `jboss-servlet-api_3.0_spec` as `1.0.2.Final` in all MicroProfile TCKs, which `arquillian-liberty-managed` defines as `[1.0,)`:
https://github.com/OpenLiberty/liberty-arquillian/blob/93c53b5e4af35709aace144634ffed1e98d150f5/liberty-managed/pom.xml#L260-L264

Without the version specified, maven tries to download `jboss-servlet-api_3.0_spec/maven-metadata.xml` which has been triggering Defect 280600 (though we don't believe this to be the **_cause_** of the defect. It seems like there's a genuine enderlying infrastructure issue on the `flash` machines)

This has been tested for 3 MicroProfile features here, and it seemed to work without creating any other issues: https://github.com/OpenLiberty/open-liberty/pull/15981

This PR also includes some file formatting, applying:
- Indents using 4 spaces
- Removal of whitespace in empty lines
- 1 line per tag

#build
