### PR TITLE
Fix java.security.egd JVM Property used by FATs

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -1269,7 +1269,7 @@ public class LibertyServer implements LogMonitorClient {
         // running Oracle/Sun JVMs - this results in buckets timing out as they wait for the entropy pool to be repopulated. Additionally,
         // from Java 9 onwards, IBM JDKs will also exhibit the same behaviour as it will start to use /dev/random by default.
         // The fix is thus to ensure we use the pseudorandom entropy pool (/dev/urandom) (which is also valid for Windows/zOS).
-        JVM_ARGS += " -Djava.security.egd=file:///dev/urandom";
+        JVM_ARGS += " -Djava.security.egd=file:/dev/urandom";
 
         JavaInfo info = JavaInfo.forServer(this);
         // Debug for a highly intermittent problem on IBM JVMs.

--- a/dev/wlp-gradle/java.gradle
+++ b/dev/wlp-gradle/java.gradle
@@ -83,7 +83,7 @@ subprojects {
     //  A number of tests make heavy use of java.util.Random, which can drain the entropy pool of /dev/random on Linux when
     // running on OpenJDK-based distributions. This results in large delays as tests wait for the entropy pool to be repopulated.
     // The fix is thus to ensure we use the pseudorandom entropy pool (/dev/urandom) (which is also valid for Windows/zOS).
-    jvmArgs '-Djava.security.egd=file:///dev/urandom'
+    jvmArgs '-Djava.security.egd=file:/dev/urandom'
   }
 
   


### PR DESCRIPTION
for #16093