### PR TITLE
Define cdi.3.0.internal_fat in GitHub Actions

### DIFF
--- a/.github/test-categories/CDI_3
+++ b/.github/test-categories/CDI_3
@@ -1,0 +1,1 @@
+io.openliberty.cdi.3.0.internal_fat


### PR DESCRIPTION
An attempt to fix the GitHub Actions builds from failing with:
```
Error: The following fat(s) need to be added to a category under .github/test-categories: > io.openliberty.cdi.3.0.internal_fat
```

Not sure if any other FAT buckets need adding to `.github/test-categories/CDI_3`
