### PR TITLE
Remove file dependency on build.example.testcontainers_fat

### DIFF
--- a/dev/build.example.testcontainers_fat/test-applications/app/src/web/generic/ContainersTestServlet.java
+++ b/dev/build.example.testcontainers_fat/test-applications/app/src/web/generic/ContainersTestServlet.java
@@ -32,6 +32,19 @@ public class ContainersTestServlet extends FATServlet {
     @Resource(lookup = "jdbc/postgres")
     private DataSource ds_postgres;
 
+    public void setupDatabase() throws Exception {
+        try (Connection con = ds_postgres.getConnection(); Statement stmt = con.createStatement()) {
+            stmt.execute("DROP TABLE IF EXISTS testtable;");
+            stmt.execute("CREATE TABLE testtable (" +
+                         "PersonID int," +
+                         "LastName varchar(255)," +
+                         "FirstName varchar(255)," +
+                         "City varchar(255)" +
+                         ");");
+            stmt.execute("INSERT INTO testtable (PersonID, LastName, FirstName, City) VALUES (1, 'Doe', 'John', 'Rochester');");
+        }
+    }
+
     @Test
     public void testGenericContainer() throws Exception {
         try (Connection con = ds_postgres.getConnection(); Statement stmt = con.createStatement()) {


### PR DESCRIPTION
During builds gradle copies files under `/publish/files/` to `/build/autoFVT/lib/LibertyFATTestFiles/`. On some build systems the permissions of these files are preserved, and on others the permissions are not preserved.
Work around this limitation by instead running startup SQL via connection. 