### PR TITLE
Increase SCC size in debug mode and fix Windows SCC

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -2,7 +2,7 @@
 ###############################################################################
 # WebSphere Application Server liberty launch script
 #
-# Copyright IBM Corp. 2011, 2020
+# Copyright IBM Corp. 2011, 2021
 # The source code for this program is not published or other-
 # wise divested of its trade secrets, irrespective of what has
 # been deposited with the U.S. Copyright Office.
@@ -575,7 +575,7 @@ serverEnvDefaults()
     fi
   fi
 
-# Prefer OPENJ9_JAVA_OPTIONS to deprecated IBM_JAVA_OPTIONS
+  # Prefer OPENJ9_JAVA_OPTIONS to deprecated IBM_JAVA_OPTIONS
   if [ -z "${OPENJ9_JAVA_OPTIONS}" ]
   then
     SPECIFIED_JAVA_OPTIONS=${IBM_JAVA_OPTIONS}
@@ -592,11 +592,19 @@ serverEnvDefaults()
     if ( echo "${SPECIFIED_JAVA_OPTIONS}" | grep -q "Xshareclasses"); then
       SERVER_IBM_JAVA_OPTIONS=${SPECIFIED_JAVA_OPTIONS}
     else
+      # Set -Xscmx
+      if [ "${ACTION}" = "debug" ]
+      then
+        XSCMX_VAL="130m"
+      else
+        XSCMX_VAL="80m"
+      fi
+  
       if $shareclassesCacheDirPerm
       then
-        SERVER_IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty-%u,nonfatal,cacheDir=\"${WLP_OUTPUT_DIR}/.classCache\",cacheDirPerm=1000 -XX:ShareClassesEnableBCI -Xscmx80m ${SPECIFIED_JAVA_OPTIONS}"
+        SERVER_IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty-%u,nonfatal,cacheDir=\"${WLP_OUTPUT_DIR}/.classCache\",cacheDirPerm=1000 -XX:ShareClassesEnableBCI -Xscmx${XSCMX_VAL} ${SPECIFIED_JAVA_OPTIONS}"
       else
-        SERVER_IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty-%u,nonfatal,cacheDir=\"${WLP_OUTPUT_DIR}/.classCache\" -XX:ShareClassesEnableBCI -Xscmx80m ${SPECIFIED_JAVA_OPTIONS}"
+        SERVER_IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty-%u,nonfatal,cacheDir=\"${WLP_OUTPUT_DIR}/.classCache\" -XX:ShareClassesEnableBCI -Xscmx${XSCMX_VAL} ${SPECIFIED_JAVA_OPTIONS}"
       fi
     fi
   esac

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
@@ -521,16 +521,18 @@ goto:eof
   @REM Command-line parsing of -Xshareclasses does not allow "," in cacheDir.
   if "!WLP_OUTPUT_DIR:,=!" == "!WLP_OUTPUT_DIR!" (
 
-    @REM Skip if Xshareclasses is defined in IBM_JAVA_OPTIONS/OPENJ9_JAVA_OPTIONS
-    @REM First check if SPECIFIED_JAVA_OPTIONS is undefined as the second test does not seem to work with undefined variables
+    @REM Check if Xshareclasses is already defined in IBM_JAVA_OPTIONS/OPENJ9_JAVA_OPTIONS
+    @REM First check if SPECIFIED_JAVA_OPTIONS is undefined as the second test does not work with undefined variables
     if NOT defined SPECIFIED_JAVA_OPTIONS (
-      set SHARE_CLASSES=true
-    )
-    if "!SPECIFIED_JAVA_OPTIONS:Xshareclasses=!" == "!SPECIFIED_JAVA_OPTIONS!" (
-      set SHARE_CLASSES=true
+      set ADD_SHARE_CLASSES=true
+    ) else if "!SPECIFIED_JAVA_OPTIONS:Xshareclasses=!" == "!SPECIFIED_JAVA_OPTIONS!" (
+      set ADD_SHARE_CLASSES=true
+    ) else (
+      @REM Xshareclasses IS found in IBM_JAVA_OPTIONS/OPENJ9_JAVA_OPTIONS, skip adding it to SERVER_IBM_JAVA_OPTIONS below
+      set ADD_SHARE_CLASSES=false
     )
  
-    if "!SHARE_CLASSES!" == "true" (
+    if "!ADD_SHARE_CLASSES!" == "true" (
       @REM Set -Xscmx
       if "debug" == "%ACTION%" (
         set XSCMX_VAL="130m"

--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server.bat
@@ -1,7 +1,7 @@
 @echo off
 @REM WebSphere Application Server liberty launch script
 @REM
-@REM Copyright IBM Corp. 2011, 2020
+@REM Copyright IBM Corp. 2011, 2021
 @REM The source code for this program is not published or other-
 @REM wise divested of its trade secrets, irrespective of what has
 @REM been deposited with the U.S. Copyright Office.
@@ -511,7 +511,7 @@ goto:eof
     set JAVA_CMD_QUOTED="!JAVA_HOME!\bin\java"
   )
 
-@REM Use OPENJ9_JAVA_OPTIONS if defined, otherwise use IBM_JAVA_OPTIONS
+  @REM Use OPENJ9_JAVA_OPTIONS if defined, otherwise use IBM_JAVA_OPTIONS
   if NOT defined OPENJ9_JAVA_OPTIONS (
     set SPECIFIED_JAVA_OPTIONS=!IBM_JAVA_OPTIONS!
   ) else (
@@ -520,9 +520,24 @@ goto:eof
 
   @REM Command-line parsing of -Xshareclasses does not allow "," in cacheDir.
   if "!WLP_OUTPUT_DIR:,=!" == "!WLP_OUTPUT_DIR!" (
+
     @REM Skip if Xshareclasses is defined in IBM_JAVA_OPTIONS/OPENJ9_JAVA_OPTIONS
+    @REM First check if SPECIFIED_JAVA_OPTIONS is undefined as the second test does not seem to work with undefined variables
+    if NOT defined SPECIFIED_JAVA_OPTIONS (
+      set SHARE_CLASSES=true
+    )
     if "!SPECIFIED_JAVA_OPTIONS:Xshareclasses=!" == "!SPECIFIED_JAVA_OPTIONS!" (
-      set SERVER_IBM_JAVA_OPTIONS=-Xshareclasses:name=liberty-%%u,nonfatal,cacheDir="%WLP_OUTPUT_DIR%\.classCache" -XX:ShareClassesEnableBCI -Xscmx80m !SPECIFIED_JAVA_OPTIONS!
+      set SHARE_CLASSES=true
+    )
+ 
+    if "!SHARE_CLASSES!" == "true" (
+      @REM Set -Xscmx
+      if "debug" == "%ACTION%" (
+        set XSCMX_VAL="130m"
+      ) else (
+        set XSCMX_VAL="80m"
+      )
+      set SERVER_IBM_JAVA_OPTIONS=-Xshareclasses:name=liberty-%%u,nonfatal,cacheDir="%WLP_OUTPUT_DIR%\.classCache" -XX:ShareClassesEnableBCI -Xscmx!XSCMX_VAL! !SPECIFIED_JAVA_OPTIONS!
     ) else (
       set SERVER_IBM_JAVA_OPTIONS=!SPECIFIED_JAVA_OPTIONS!
     )


### PR DESCRIPTION
The JDK team is working on improving dev mode startup performance. To do this they need a bigger SCC.
Also, found an issue with the Windows Shared Class Cache logic.
