### PR TITLE
Cleanup htmlunit WebClients at end of each SALML test to prevent OOM condition

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/CommonTest.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/CommonTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.fat.common;
 
@@ -20,6 +20,7 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
 import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.security.fat.common.utils.WebClientTracker;
 
 public class CommonTest {
 
@@ -28,6 +29,7 @@ public class CommonTest {
     protected static int timeoutCounter = 0;
     protected static int allowableTimeoutCount = 0;
     public static CommonMessageTools msgUtils = new CommonMessageTools();
+    protected WebClientTracker webClientTracker = new WebClientTracker();
 
     @Rule
     public TestWatcher watchman = new TestWatcher() {
@@ -146,8 +148,8 @@ public class CommonTest {
         if (timeoutFound && (timeoutCounter > allowableTimeoutCount)) {
             Log.info(thisClass, method, "Timeout messages found: " + timeoutCounter + ", number of allowed timeout messages: " + allowableTimeoutCount);
             throw new RuntimeException("Unexpected number of timed out messages found in output.txt - most likly a test case issue - search output.txt for 'Timed out'."
-                                       + System.getProperty("line.separator")
-                                       + "This exception is issued from an end of test class check and appears as an extra test case.  Fix the timed out msg issue and the test count will be correct!!!");
+                    + System.getProperty("line.separator")
+                    + "This exception is issued from an end of test class check and appears as an extra test case.  Fix the timed out msg issue and the test count will be correct!!!");
         }
 
     }

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/TestHelpers.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/TestHelpers.java
@@ -508,6 +508,16 @@ public class TestHelpers {
         return webClient;
     }
 
+    public static void destroyWebClient(WebClient webClient) throws Exception {
+        try {
+            if (webClient != null) {
+                webClient.close();
+            }
+        } catch (Exception e) {
+            Log.info(thisClass, "destroyWebClient", "Exception occurred trying to clean up the web client - tests will continue:  Exception was: " + e.toString());
+        }
+    }
+
     public void waitBeforeContinuing(WebClient webClient) throws Exception {
         Log.info(thisClass, "waitBeforeContinuing", "Waiting for HtmlUnit to finish its business");
         webClient.waitForBackgroundJavaScriptStartingBefore(5000);

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/utils/WebClientTracker.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/utils/WebClientTracker.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.fat.common.utils;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.ibm.websphere.simplicity.log.Log;
+
+public class WebClientTracker {
+
+    protected static Class<?> thisClass = WebClientTracker.class;
+
+    Set<WebClient> webClients = new HashSet<WebClient>();
+
+    public void addWebClient(WebClient client) {
+        if (client == null) {
+            return;
+        }
+        webClients.add(client);
+    }
+
+    public Set<WebClient> getWebClients() {
+        return new HashSet<WebClient>(webClients);
+    }
+
+    public void closeAllWebClients() throws Exception {
+
+        if (webClients != null) {
+            for (WebClient client : webClients) {
+                try {
+                    if (client != null) {
+                        Log.info(thisClass, "closeAllWebClients", "Closing WebClient");
+                        client.close();
+                    }
+                } catch (Exception e) {
+                    Log.info(thisClass, "closeAllWebClients", "An exception occurred while closing a WebClient: " + e.toString());
+                }
+            }
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/IDPInitiated/IDPInitiatedDefaultConfigTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/IDPInitiated/IDPInitiatedDefaultConfigTests.java
@@ -21,7 +21,6 @@ import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.saml.fat.common.DefaultConfigTests;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -71,7 +70,7 @@ public class IDPInitiatedDefaultConfigTests extends DefaultConfigTests {
     @Test
     public void IDPInitiatedDefaultConfigTests_defaultConfig_useNonDefaultSP() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
 

--- a/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/SPInitiated/SolicitedSPInitiatedDefaultConfigTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/SPInitiated/SolicitedSPInitiatedDefaultConfigTests.java
@@ -21,7 +21,6 @@ import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.utils.ConditionalIgnoreRule;
 import com.ibm.ws.security.saml.fat.common.DefaultConfigTests;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -72,7 +71,7 @@ public class SolicitedSPInitiatedDefaultConfigTests extends DefaultConfigTests {
     @Test
     public void SolicitedSPInitiatedDefaultConfigTests_defaultConfig_useNonDefaultSP() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
 

--- a/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/common/BasicEncryptionTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/common/BasicEncryptionTests.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.saml.fat.common;
 
@@ -18,7 +18,6 @@ import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTest;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -570,7 +569,7 @@ public class BasicEncryptionTests extends SAMLCommonTest {
 
     private void performSamlFlow(String sp, String[] flow, SAMLTestSettings settings, List<validationData> expectations) throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
         genericSAML(_testName, webClient, settings, flow, expectations);
     }
 }

--- a/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/common/DefaultConfigMissingMetaDataTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/common/DefaultConfigMissingMetaDataTests.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.saml.fat.common;
 
@@ -20,7 +20,6 @@ import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTest;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -65,7 +64,7 @@ public class DefaultConfigMissingMetaDataTests extends SAMLCommonTest {
     @Test
     public void testSaml_defaultConfig_IDPInitiated_missingIDPMetaDataFile() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
 
@@ -81,7 +80,7 @@ public class DefaultConfigMissingMetaDataTests extends SAMLCommonTest {
     @Test
     public void testSaml_defaultConfig_SolicitedSPInitiated_missingIDPMetaDataFile() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
 

--- a/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/common/DefaultConfigTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/common/DefaultConfigTests.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.saml.fat.common;
 
@@ -18,7 +18,6 @@ import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.fat.common.utils.ConditionalIgnoreRule;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTest;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
 
@@ -42,7 +41,7 @@ public class DefaultConfigTests extends SAMLCommonTest {
     public void testSaml_defaultConfig() throws Exception {
 
         //        WebClient webClient = getWebClient(true);
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         //		updatedTestSettings.updatePartnerInSettings("sp1", true) ;
@@ -57,7 +56,7 @@ public class DefaultConfigTests extends SAMLCommonTest {
     @Test
     public void testSaml_defaultConfig_noDefaultSSLConfig() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         testSAMLServer.reconfigServer("server_defaultConfig_noDefaultSSLConfig.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);

--- a/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/common/MultipleSPSAMLTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/common/MultipleSPSAMLTests.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.saml.fat.common;
 
@@ -19,7 +19,6 @@ import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.util.Cookie;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTest;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
 
@@ -68,7 +67,7 @@ public class MultipleSPSAMLTests extends SAMLCommonTest {
 
         //	testSAMLServer.reconfigServer(buildSPServerName("server_2Providers.xml"), _testName, Constants.NO_EXTRA_MSGS, Constants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings1 = testSettings.copyTestSettings();
         updatedTestSettings1.updatePartnerInSettings("sp1", true);
@@ -92,7 +91,7 @@ public class MultipleSPSAMLTests extends SAMLCommonTest {
     @Test
     public void multipleSPSAMLTests_accessMultipleAppsInSameConversation() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings1 = testSettings.copyTestSettings();
         updatedTestSettings1.updatePartnerInSettings("sp1", true);
@@ -107,7 +106,7 @@ public class MultipleSPSAMLTests extends SAMLCommonTest {
         // now, remove the ltpaToken2 cookie from the conversation (if we leave it in the conversation, the IDP will just return our original SAML Token -
         //   which if used should result in a replay attack
 
-        WebClient webClient2 = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient2 = getAndSaveWebClient();
         CookieManager cm1 = webClient.getCookieManager();
         Cookie cookie = cm1.getCookie("WASSamlSP_myTestName1");
         CookieManager cm2 = webClient2.getCookieManager();
@@ -144,7 +143,7 @@ public class MultipleSPSAMLTests extends SAMLCommonTest {
         //	testSAMLServer.reconfigServer(buildSPServerName("server_2Providers.xml"), _testName, Constants.NO_EXTRA_MSGS, Constants.JUNIT_REPORTING);
 
         // Create the conversation object which will maintain state for us
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings1 = testSettings.copyTestSettings();
         updatedTestSettings1.updatePartnerInSettings("sp1", true);
@@ -157,7 +156,7 @@ public class MultipleSPSAMLTests extends SAMLCommonTest {
 
         // now, remove the ltpaToken2 cookie from the conversation (if we leave it in the conversation, the IDP will just return our original SAML Token -
         //   which if used should result in a replay attack
-        WebClient webClient2 = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient2 = getAndSaveWebClient();
         CookieManager cm1 = webClient.getCookieManager();
         Cookie cookie = cm1.getCookie("WASSamlSP_myTestName1");
         Cookie cookie2 = cm1.getCookie("saml20_SP_sso");

--- a/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/common/UserFeatureOnlySAMLTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/common/UserFeatureOnlySAMLTests.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.saml.fat.common;
 
@@ -17,7 +17,6 @@ import org.junit.Test;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTest;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
 import com.ibm.ws.security.saml20.fat.commonTest.SampleUserFeatureInstaller;
@@ -48,7 +47,7 @@ public class UserFeatureOnlySAMLTests extends SAMLCommonTest {
     @Test
     public void userFeatureOnlySAMLTests_mainFlowTest() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);

--- a/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/common/UserFeatureSAMLTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/common/UserFeatureSAMLTests.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.saml.fat.common;
 
@@ -17,7 +17,6 @@ import org.junit.Test;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTest;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -86,7 +85,7 @@ public class UserFeatureSAMLTests extends SAMLCommonTest {
     @Test
     public void userFeatureSAMLTests_mainFlowTest() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -113,7 +112,7 @@ public class UserFeatureSAMLTests extends SAMLCommonTest {
     @Test
     public void userFeatureSAMLTests_userNotHandledByUserFeature() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -134,7 +133,7 @@ public class UserFeatureSAMLTests extends SAMLCommonTest {
     @Test
     public void userFeatureSAMLTests_usrFeatureReturnsEmptyString() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -160,7 +159,7 @@ public class UserFeatureSAMLTests extends SAMLCommonTest {
     @Test
     public void userFeatureSAMLTests_usrFeatureReturnsNullString() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -186,7 +185,7 @@ public class UserFeatureSAMLTests extends SAMLCommonTest {
     @Test
     public void userFeatureSAMLTests_usrFeatureReturnsUserNotInLocalRegistry() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -211,7 +210,7 @@ public class UserFeatureSAMLTests extends SAMLCommonTest {
     @Test
     public void userFeatureSAMLTests_mapToUserRegistry_User_goodIdentifiers() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp2", true);
@@ -236,7 +235,7 @@ public class UserFeatureSAMLTests extends SAMLCommonTest {
     @Test
     public void userFeatureSAMLTests_mapToUserRegistry_Group_goodIdentifiers() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp13", true);

--- a/dev/com.ibm.ws.security.saml.sso_fat.3/fat/src/com/ibm/ws/security/saml/fat/common/PkixSAMLTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.3/fat/src/com/ibm/ws/security/saml/fat/common/PkixSAMLTests.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.saml.fat.common;
 
@@ -18,7 +18,6 @@ import org.junit.Test;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTest;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -48,7 +47,7 @@ public class PkixSAMLTests extends SAMLCommonTest {
     @Test
     public void pkixSAMLTests_defaultTrustAnchorTest() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -66,7 +65,7 @@ public class PkixSAMLTests extends SAMLCommonTest {
     @Test
     public void pkixSAMLTests_SpecifiedTrustAnchorTest() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp2", true);
@@ -86,7 +85,7 @@ public class PkixSAMLTests extends SAMLCommonTest {
     @Test
     public void pkixSAMLTests_badTrustAnchorTest() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp13", true);
@@ -124,7 +123,7 @@ public class PkixSAMLTests extends SAMLCommonTest {
 
         testSAMLServer.reconfigServer(buildSPServerName("server_pkix_badTrustAnchorRef.xml"), _testName, startupExceptions, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -149,7 +148,7 @@ public class PkixSAMLTests extends SAMLCommonTest {
 
         testSAMLServer.reconfigServer(buildSPServerName("server_pkix_wrongCert.xml"), _testName, null, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp2", true);

--- a/dev/com.ibm.ws.security.saml.sso_fat.3/fat/src/com/ibm/ws/security/saml/fat/common/TimeSAMLTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.3/fat/src/com/ibm/ws/security/saml/fat/common/TimeSAMLTests.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.saml.fat.common;
 
@@ -17,7 +17,6 @@ import org.junit.Test;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTest;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -60,7 +59,7 @@ public class TimeSAMLTests extends SAMLCommonTest {
     @Test
     public void timeSAMLTests_useToken_before_NotBefore() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1NotSigned", true);
@@ -86,7 +85,7 @@ public class TimeSAMLTests extends SAMLCommonTest {
     @Test
     public void timeSAMLTests_useToken_after_NotOnOrAfter() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1NotSigned", true);
@@ -112,7 +111,7 @@ public class TimeSAMLTests extends SAMLCommonTest {
     @Test
     public void timeSAMLTests_useToken_after_SessionNotOnOrAfter() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1NotSigned", true);
@@ -139,7 +138,7 @@ public class TimeSAMLTests extends SAMLCommonTest {
     @Test
     public void timeSAMLTests_SPCookie_expired() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1NotSigned", true);
@@ -181,7 +180,7 @@ public class TimeSAMLTests extends SAMLCommonTest {
             expectations = vData.addExpectation(expectations, SAMLConstants.INVOKE_DEFAULT_APP, SAMLConstants.RESPONSE_FULL, SAMLConstants.STRING_CONTAINS, "Did not land on the IDP resend response form.", null, SAMLConstants.SAML_REQUEST);
         }
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1NotSigned", true);

--- a/dev/com.ibm.ws.security.saml.sso_fat.3/fat/src/com/ibm/ws/security/saml/fat/common/TrustedIssuerSAMLTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.3/fat/src/com/ibm/ws/security/saml/fat/common/TrustedIssuerSAMLTests.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.saml.fat.common;
 
@@ -18,7 +18,6 @@ import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.fat.common.utils.ConditionalIgnoreRule;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTest;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -46,7 +45,7 @@ public class TrustedIssuerSAMLTests extends SAMLCommonTest {
     @Test
     public void TrustedIssuerSAMLTests_validIssuer_IDPMetaData_validIssuer_TrustedIssuer() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -63,7 +62,7 @@ public class TrustedIssuerSAMLTests extends SAMLCommonTest {
     @Test
     public void TrustedIssuerSAMLTests_validIssuer_IDPMetaData_invalidIssuer_TrustedIssuer() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp2", true);
@@ -82,7 +81,7 @@ public class TrustedIssuerSAMLTests extends SAMLCommonTest {
     @Test
     public void TrustedIssuerSAMLTests_invalidIssuer_IDPMetaData_validIssuer_TrustedIssuer() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp13", true);
@@ -102,7 +101,7 @@ public class TrustedIssuerSAMLTests extends SAMLCommonTest {
     @Test
     public void TrustedIssuerSAMLTests_invalidIssuer_IDPMetaData_invalidIssuer_TrustedIssuer() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setSamlTokenValidationData(updatedTestSettings.getIdpUserName(), updatedTestSettings.getSamlTokenValidationData().getIssuer(), updatedTestSettings.getSamlTokenValidationData().getInResponseTo(), updatedTestSettings.getSamlTokenValidationData().getMessageID(), updatedTestSettings.getSamlTokenValidationData().getEncryptionKeyUser(), updatedTestSettings.getSamlTokenValidationData().getRecipient(), SAMLConstants.AES256);
@@ -125,7 +124,7 @@ public class TrustedIssuerSAMLTests extends SAMLCommonTest {
 
         testSAMLServer.reconfigServer(buildSPServerName("server_trustedIssuers_noIDPMetaData.xml"), _testName, null, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -157,7 +156,7 @@ public class TrustedIssuerSAMLTests extends SAMLCommonTest {
 
         testSAMLServer.reconfigServer(buildSPServerName("server_trustedIssuers_noIDPMetaData.xml"), _testName, null, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp2", true);
@@ -185,7 +184,7 @@ public class TrustedIssuerSAMLTests extends SAMLCommonTest {
 
         testSAMLServer.reconfigServer(buildSPServerName("server_trustedIssuers_ALL_ISSUERS.xml"), _testName, null, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp13", true);
@@ -206,7 +205,7 @@ public class TrustedIssuerSAMLTests extends SAMLCommonTest {
 
         testSAMLServer.reconfigServer(buildSPServerName("server_trustedIssuers_ALL_ISSUERS.xml"), _testName, null, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setSamlTokenValidationData(updatedTestSettings.getIdpUserName(), updatedTestSettings.getSamlTokenValidationData().getIssuer(), updatedTestSettings.getSamlTokenValidationData().getInResponseTo(), updatedTestSettings.getSamlTokenValidationData().getMessageID(), updatedTestSettings.getSamlTokenValidationData().getEncryptionKeyUser(), updatedTestSettings.getSamlTokenValidationData().getRecipient(), SAMLConstants.AES256);

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLCommonTest.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLCommonTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -526,7 +526,7 @@ public class SAMLCommonTest extends CommonTest {
                               String[] testActions, List<validationData> expectations, Object somePage) throws Exception {
 
         if (webClient == null) {
-            webClient = SAMLCommonTestHelpers.getWebClient();
+            webClient = getAndSaveWebClient();
         }
 
         // WebResponse response = null;
@@ -692,7 +692,7 @@ public class SAMLCommonTest extends CommonTest {
                                     String[] testActions, List<validationData> expectations, Object somePage) throws Exception {
 
         if (webClient == null) {
-            webClient = SAMLCommonTestHelpers.getWebClient();
+            webClient = getAndSaveWebClient();
         }
 
         // WebResponse response = null;
@@ -858,6 +858,15 @@ public class SAMLCommonTest extends CommonTest {
      */
     @After
     public void endTest() throws Exception {
+
+        try {
+
+            // clean up webClients
+            webClientTracker.closeAllWebClients();
+
+        } catch (Exception e) {
+            e.printStackTrace(System.out);
+        }
 
         try {
 
@@ -1213,5 +1222,19 @@ public class SAMLCommonTest extends CommonTest {
                 JakartaEE9Action.transformApp(someArchive);
             }
         }
+    }
+
+    public WebClient getAndSaveWebClient() throws Exception {
+
+        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        webClientTracker.addWebClient(webClient);
+        return webClient;
+    }
+
+    public WebClient getAndSaveWebClient(boolean override) throws Exception {
+
+        WebClient webClient = SAMLCommonTestHelpers.getWebClient(override);
+        webClientTracker.addWebClient(webClient);
+        return webClient;
     }
 }

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLCommonTestHelpers.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLCommonTestHelpers.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -825,7 +825,7 @@ public class SAMLCommonTestHelpers extends TestHelpers {
         String thisMethod = "invokeApp";
         msgUtils.printMethodName(thisMethod);
         Object thePage;
-
+        WebClient webClient2 = null;
         try {
 
             if (app == null) {
@@ -836,7 +836,7 @@ public class SAMLCommonTestHelpers extends TestHelpers {
 
             setMarkEndOfLogs();
 
-            WebClient webClient2 = getWebClient();
+            webClient2 = getWebClient();
 
             URL url = AutomationTools.getNewUrl(app);
             WebRequest request = new WebRequest(url, HttpMethod.POST);
@@ -929,6 +929,8 @@ public class SAMLCommonTestHelpers extends TestHelpers {
             Log.error(thisClass, testcase, e, "Exception occurred in " + thisMethod);
             System.err.println("Exception: " + e);
             validationTools.validateException(expectations, step, e);
+        } finally {
+            destroyWebClient(webClient2);
         }
 
     }
@@ -1061,6 +1063,10 @@ public class SAMLCommonTestHelpers extends TestHelpers {
 
         setMarkEndOfLogs();
 
+        boolean cleanupWebClient = false;
+        if (inWebClient == null) {
+            cleanupWebClient = true;
+        }
         WebClient webClient = getWebClient(inWebClient);
 
         URL url = AutomationTools.getNewUrl(settings.getSpMetaDataEdpt());
@@ -1076,6 +1082,9 @@ public class SAMLCommonTestHelpers extends TestHelpers {
         validationTools.setServers(testSAMLServer, testSAMLOIDCServer, testOIDCServer, testAppServer, testIDPServer);
         validationTools.validateResult(webClient, thePage, SAMLConstants.SAML_META_DATA_ENDPOINT, expectations, settings);
 
+        if (cleanupWebClient) {
+            destroyWebClient(webClient);
+        }
         return thePage;
     }
 

--- a/dev/com.ibm.ws.security.saml.sso_fat.config.mapToUserRegistry/fat/src/com/ibm/ws/security/saml/sso/fat/config/mapToUserRegistry/GeneralSAMLMapToUserRegistryConfigTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.config.mapToUserRegistry/fat/src/com/ibm/ws/security/saml/sso/fat/config/mapToUserRegistry/GeneralSAMLMapToUserRegistryConfigTests.java
@@ -22,7 +22,6 @@ import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.fat.common.utils.ConditionalIgnoreRule;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTest;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -84,7 +83,7 @@ public class GeneralSAMLMapToUserRegistryConfigTests extends SAMLCommonTest {
             List<validationData> expectations) throws Exception {
         if (runSolicitedSPInitiatedTests) {
             printTestTrace("solicited_SP_initiated_SAML", "Running Solicited SP Initiated SAML Flow");
-            WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+            WebClient webClient = getAndSaveWebClient();
             return genericSAML(testName, webClient, updatedTestSettings, actions, expectations);
         } else {
             return null;
@@ -96,7 +95,7 @@ public class GeneralSAMLMapToUserRegistryConfigTests extends SAMLCommonTest {
             List<validationData> expectations) throws Exception {
         if (runIDPInitiatedTests) {
             printTestTrace("IDP_initiated_SAML", "Running IDP Initiated SAML Flow");
-            WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+            WebClient webClient = getAndSaveWebClient();
             return genericSAML(testName, webClient, updatedTestSettings, actions, expectations);
         } else {
             return null;
@@ -108,7 +107,7 @@ public class GeneralSAMLMapToUserRegistryConfigTests extends SAMLCommonTest {
             List<validationData> expectations) throws Exception {
         if (runUnsolicitedSPInitiatedTests) {
             printTestTrace("unsolicited_SP_initiated_SAML", "Running Unsolicited SP Initiated SAML Flow");
-            WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+            WebClient webClient = getAndSaveWebClient();
             return genericSAML(testName, webClient, updatedTestSettings, actions, expectations);
         } else {
             return null;

--- a/dev/com.ibm.ws.security.saml.sso_fat.config/fat/src/com/ibm/ws/security/saml/sso/fat/config/SAMLConfigCommonTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.config/fat/src/com/ibm/ws/security/saml/sso/fat/config/SAMLConfigCommonTests.java
@@ -21,7 +21,6 @@ import com.gargoylesoftware.htmlunit.util.Cookie;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTest;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -116,7 +115,7 @@ public class SAMLConfigCommonTests extends SAMLCommonTest {
     public Object solicited_SP_initiated_SAML(String testName, SAMLTestSettings updatedTestSettings, String[] actions, List<validationData> expectations) throws Exception {
         if (runSolicitedSPInitiatedTests) {
             printTestTrace("solicited_SP_initiated_SAML", "Running Solicited SP Initiated SAML Flow");
-            WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+            WebClient webClient = getAndSaveWebClient();
             return genericSAML(testName, webClient, updatedTestSettings, actions, expectations);
         } else {
             return null;
@@ -127,7 +126,7 @@ public class SAMLConfigCommonTests extends SAMLCommonTest {
     public Object IDP_initiated_SAML(String testName, SAMLTestSettings updatedTestSettings, String[] actions, List<validationData> expectations) throws Exception {
         if (runIDPInitiatedTests) {
             printTestTrace("IDP_initiated_SAML", "Running IDP Initiated SAML Flow");
-            WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+            WebClient webClient = getAndSaveWebClient();
             return genericSAML(testName, webClient, updatedTestSettings, actions, expectations);
         } else {
             return null;
@@ -138,7 +137,7 @@ public class SAMLConfigCommonTests extends SAMLCommonTest {
     public Object unsolicited_SP_initiated_SAML(String testName, SAMLTestSettings updatedTestSettings, String[] actions, List<validationData> expectations) throws Exception {
         if (runUnsolicitedSPInitiatedTests) {
             printTestTrace("unsolicited_SP_initiated_SAML", "Running Unsolicited SP Initiated SAML Flow");
-            WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+            WebClient webClient = getAndSaveWebClient();
             return genericSAML(testName, webClient, updatedTestSettings, actions, expectations);
         } else {
             return null;

--- a/dev/com.ibm.ws.security.saml.sso_fat.config/fat/src/com/ibm/ws/security/saml/sso/fat/config/SAMLMisc1ConfigTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.config/fat/src/com/ibm/ws/security/saml/sso/fat/config/SAMLMisc1ConfigTests.java
@@ -19,7 +19,6 @@ import org.junit.runner.RunWith;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.fat.common.utils.ConditionalIgnoreRule;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -181,7 +180,7 @@ public class SAMLMisc1ConfigTests extends SAMLConfigCommonTests {
 
         testSAMLServer.reconfigServer("server_forceAuthn_true.xml", _testName, commonAddtlMsgs, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         // make a request using IDP flow and the force flag will be set to the
         // default value which is false (We're making the call directly, we're
@@ -196,7 +195,7 @@ public class SAMLMisc1ConfigTests extends SAMLConfigCommonTests {
         // to the configured value which is true
         // create a new client, so, there is no question about cookie
         // contamination
-        webClient = SAMLCommonTestHelpers.getWebClient();
+        webClient = getAndSaveWebClient();
         expectations = helpers.setDefaultGoodSAMLSolicitedSPInitiatedExpectations(updatedTestSettings);
         expectations = vData.addExpectation(expectations, SAMLConstants.BUILD_POST_SP_INITIATED_REQUEST, SAMLConstants.IDP_PROCESS_LOG, SAMLConstants.STRING_CONTAINS, "The forceAuthn flag is NOT set to true in the request received by the IDP", null, "forceAuthn=true");
         printTestTrace("_testName", "Invoking Solicited SP Initiated request");
@@ -231,7 +230,7 @@ public class SAMLMisc1ConfigTests extends SAMLConfigCommonTests {
 
         testSAMLServer.reconfigServer("server_isPassive_true.xml", _testName, commonAddtlMsgs, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         // make a request using IDP flow and the isPassive flag will be set to
         // the default value which is false (We're making the call directly,
@@ -246,7 +245,7 @@ public class SAMLMisc1ConfigTests extends SAMLConfigCommonTests {
         // set to the configured value which is true
         // create a new client, so, there is no question about cookie
         // contamination
-        webClient = SAMLCommonTestHelpers.getWebClient();
+        webClient = getAndSaveWebClient();
         expectations = vData.addSuccessStatusCodes();
         expectations = vData.addExpectation(expectations, SAMLConstants.BUILD_POST_SP_INITIATED_REQUEST, SAMLConstants.RESPONSE_TITLE, SAMLConstants.STRING_CONTAINS, "The Response from the IDP did NOT indicate a problem handling the request", null, SAMLConstants.SP_DEFAULT_ERROR_PAGE_TITLE);
         expectations = vData.addExpectation(expectations, SAMLConstants.BUILD_POST_SP_INITIATED_REQUEST, SAMLConstants.IDP_PROCESS_LOG, SAMLConstants.STRING_CONTAINS, "The isPassive flag is NOT set to true in the request received by the IDP", null, "isPassive=true");

--- a/dev/com.ibm.ws.security.saml.sso_fat.config/fat/src/com/ibm/ws/security/saml/sso/fat/config/SAMLMisc2ConfigTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.config/fat/src/com/ibm/ws/security/saml/sso/fat/config/SAMLMisc2ConfigTests.java
@@ -590,7 +590,7 @@ public class SAMLMisc2ConfigTests extends SAMLConfigCommonTests {
         testSAMLServer.reconfigServer(testServerConfigFile, _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
         // Create the conversation object which will maintain state for us
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -929,7 +929,7 @@ public class SAMLMisc2ConfigTests extends SAMLConfigCommonTests {
     public void test_createSession_true() throws Exception {
         testSAMLServer.reconfigServer("server_createSession_true.xml", _testName, commonAddtlMsgs, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -945,7 +945,7 @@ public class SAMLMisc2ConfigTests extends SAMLConfigCommonTests {
     public void test_createSession_false() throws Exception {
         testSAMLServer.reconfigServer("server_createSession_false.xml", _testName, commonAddtlMsgs, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);

--- a/dev/com.ibm.ws.security.saml.sso_fat.endpoint.samlmetadata/fat/src/com/ibm/ws/security/saml/sso/fat/endpoint/samlmetadata/GeneralSAMLMetaDataTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.endpoint.samlmetadata/fat/src/com/ibm/ws/security/saml/sso/fat/endpoint/samlmetadata/GeneralSAMLMetaDataTests.java
@@ -22,7 +22,6 @@ import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.CommonMessageTools;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTest;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -90,7 +89,7 @@ public class GeneralSAMLMetaDataTests extends SAMLCommonTest {
     @Test
     public void generalSAMLMetaDataTests_generalValidation() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -110,7 +109,7 @@ public class GeneralSAMLMetaDataTests extends SAMLCommonTest {
 
         testSAMLServer.reconfigServer("server_signing_false.xml", _testName, commongAddtlMsgs, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/fat/src/com/ibm/ws/security/saml/fat/jaxrs/config/IDPInitiated/RSSamlIDPInitiatedConfigCommonTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/fat/src/com/ibm/ws/security/saml/fat/jaxrs/config/IDPInitiated/RSSamlIDPInitiatedConfigCommonTests.java
@@ -27,7 +27,6 @@ import com.ibm.ws.security.fat.common.config.settings.SSLSettings;
 import com.ibm.ws.security.saml.fat.jaxrs.config.utils.RSSamlConfigSettings;
 import com.ibm.ws.security.saml.fat.jaxrs.config.utils.RSSamlProviderSettings;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTest;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestServer;
@@ -458,7 +457,7 @@ public class RSSamlIDPInitiatedConfigCommonTests extends SAMLCommonTest {
 
         testAppServer.reconfigServer(buildSPServerName(serverCfgFile), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         genericSAML(_testName, webClient, testSettings, throughJAXRSGet, buildExpectationsWithIdentityInfo(expectedRealm, expectedUser, expectedGroup));
 
@@ -477,7 +476,7 @@ public class RSSamlIDPInitiatedConfigCommonTests extends SAMLCommonTest {
 
         testAppServer.reconfigServer(buildSPServerName(serverCfgFile), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         List<validationData> expectations = get401ExpectationsForJaxrsGet("Did not get expected message saying no user registry service was available.",
                 SAMLMessageConstants.CWWKS3005E_NO_USER_REGISTRY);
@@ -504,7 +503,7 @@ public class RSSamlIDPInitiatedConfigCommonTests extends SAMLCommonTest {
 
         testAppServer.reconfigServer(buildSPServerName(serverCfgFile), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         List<validationData> expectations = get401ExpectationsForJaxrsGet("Did not get expected message saying a required attribute was missing",
                 SAMLMessageConstants.CWWKS5068E_MISSING_ATTRIBUTE + ".+\\[" + attrName + "\\]");
@@ -528,7 +527,7 @@ public class RSSamlIDPInitiatedConfigCommonTests extends SAMLCommonTest {
 
         testAppServer.reconfigServer(testServerConfigFile, testName.getMethodName(), Constants.NO_EXTRA_MSGS, Constants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         genericSAML(_testName, webClient, settings, throughJAXRSGet, expectations);
     }
@@ -626,7 +625,7 @@ public class RSSamlIDPInitiatedConfigCommonTests extends SAMLCommonTest {
     protected void successfulJaxRsInvocation(String appExtension) throws Exception {
         SAMLTestSettings updatedTestSettings = commonUtils.changeTestApps(testAppServer, testSettings, appExtension);
         List<validationData> expectations = commonUtils.getGoodExpectationsForJaxrsGet(flowType, updatedTestSettings);
-        genericSAML(_testName, SAMLCommonTestHelpers.getWebClient(), updatedTestSettings, throughJAXRSGet, expectations);
+        genericSAML(_testName, getAndSaveWebClient(), updatedTestSettings, throughJAXRSGet, expectations);
     }
 
     /**
@@ -690,7 +689,7 @@ public class RSSamlIDPInitiatedConfigCommonTests extends SAMLCommonTest {
             }
         }
 
-        genericSAML(_testName, SAMLCommonTestHelpers.getWebClient(), updatedTestSettings, throughJAXRSGet, expectations);
+        genericSAML(_testName, getAndSaveWebClient(), updatedTestSettings, throughJAXRSGet, expectations);
     }
 
     /**
@@ -728,7 +727,7 @@ public class RSSamlIDPInitiatedConfigCommonTests extends SAMLCommonTest {
         }
         expectations = vData.addExpectation(expectations, SAMLConstants.PERFORM_IDP_LOGIN, SAMLConstants.SAML_TOKEN_ENCRYPTED, SAMLConstants.STRING_CONTAINS, "Did not receive the expected encrypted SAML token content.", null, null);
 
-        genericSAML(_testName, SAMLCommonTestHelpers.getWebClient(), updatedTestSettings, throughJAXRSGet, expectations);
+        genericSAML(_testName, getAndSaveWebClient(), updatedTestSettings, throughJAXRSGet, expectations);
     }
 
 }

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/fat/src/com/ibm/ws/security/saml/fat/jaxrs/config/IDPInitiated/RSSamlIDPInitiatedMiscConfigTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/fat/src/com/ibm/ws/security/saml/fat/jaxrs/config/IDPInitiated/RSSamlIDPInitiatedMiscConfigTests.java
@@ -20,7 +20,6 @@ import com.ibm.ws.security.fat.common.Utils;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.saml.fat.jaxrs.config.utils.RSSamlConfigSettings;
 import com.ibm.ws.security.saml.fat.jaxrs.config.utils.RSSamlProviderSettings;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -60,7 +59,7 @@ public class RSSamlIDPInitiatedMiscConfigTests extends RSSamlIDPInitiatedConfigC
 
         testAppServer.reconfigServer(buildSPServerName("server_1.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         List<validationData> expectations = vData.addSuccessStatusCodes();
 

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/fat/src/com/ibm/ws/security/saml/fat/jaxrs/IDPInitiated/RSSamlIDPInitiatedBasic1ServerTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/fat/src/com/ibm/ws/security/saml/fat/jaxrs/IDPInitiated/RSSamlIDPInitiatedBasic1ServerTests.java
@@ -21,7 +21,6 @@ import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.saml.fat.jaxrs.common.RSSamlBasicTests;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 
@@ -136,7 +135,7 @@ public class RSSamlIDPInitiatedBasic1ServerTests extends RSSamlBasicTests {
 
         testAppServer.reconfigServer(buildSPServerName("server_1_noDefaultCfgs.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         List<validationData> expectations = commonUtils.getGoodExpectationsForJaxrsGet(flowType, testSettings);
 
@@ -160,7 +159,7 @@ public class RSSamlIDPInitiatedBasic1ServerTests extends RSSamlBasicTests {
 
         testAppServer.reconfigServer(buildSPServerName(order1), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient1 = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient1 = getAndSaveWebClient();
 
         List<validationData> expectations = addConfusedExpectation(SAMLConstants.INVOKE_JAXRS_GET, null);
 
@@ -169,7 +168,7 @@ public class RSSamlIDPInitiatedBasic1ServerTests extends RSSamlBasicTests {
 
         testAppServer.reconfigServer(buildSPServerName(order2), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient2 = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient2 = getAndSaveWebClient();
 
         // make sure we get the error page indicating that we're not authorized
         genericSAML(_testName, webClient2, testSettings, throughJAXRSGet, expectations);
@@ -192,7 +191,7 @@ public class RSSamlIDPInitiatedBasic1ServerTests extends RSSamlBasicTests {
 
         testAppServer.reconfigServer(buildSPServerName(order1a), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient1 = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient1 = getAndSaveWebClient();
 
         List<validationData> expectations = addConfusedExpectation(SAMLConstants.INVOKE_JAXRS_GET, null);
 
@@ -201,7 +200,7 @@ public class RSSamlIDPInitiatedBasic1ServerTests extends RSSamlBasicTests {
 
         testAppServer.reconfigServer(buildSPServerName(order2a), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient2 = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient2 = getAndSaveWebClient();
 
         // make sure we get the error page indicating that we're not authorized
         genericSAML(_testName, webClient2, testSettings, throughJAXRSGet, expectations);

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/fat/src/com/ibm/ws/security/saml/fat/jaxrs/SPInitiated/RSSamlSolicitedSPInitiatedAPITests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/fat/src/com/ibm/ws/security/saml/fat/jaxrs/SPInitiated/RSSamlSolicitedSPInitiatedAPITests.java
@@ -21,7 +21,6 @@ import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.saml.fat.jaxrs.common.RSSamlAPITests;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -116,10 +115,10 @@ public class RSSamlSolicitedSPInitiatedAPITests extends RSSamlAPITests {
 
         // commented out lines for wc2, wc3 and 2c4 copy all but the ltpatoken cookie from the previous conversation
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-        WebClient webClient2 = SAMLCommonTestHelpers.getWebClient();
-        WebClient webClient3 = SAMLCommonTestHelpers.getWebClient();
-        WebClient webClient4 = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
+        WebClient webClient2 = getAndSaveWebClient();
+        WebClient webClient3 = getAndSaveWebClient();
+        WebClient webClient4 = getAndSaveWebClient();
 
         List<validationData> expectations = commonUtils.getGoodExpectationsForJaxrsAIPTests(flowType, testSettings);
         Object page1 = genericSAML(_testName, webClient, testSettings, justGetSAMLToken, expectations);

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/fat/src/com/ibm/ws/security/saml/fat/jaxrs/common/RSSamlAPITests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/fat/src/com/ibm/ws/security/saml/fat/jaxrs/common/RSSamlAPITests.java
@@ -17,7 +17,6 @@ import org.junit.Test;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTest;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -60,7 +59,7 @@ public class RSSamlAPITests extends SAMLCommonTest {
     @Test
     public void RSSamlAPITests_useJaxRSCLientServlet_encodedAssertion() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setRSSettings(updatedTestSettings.getRSSettings().getHeaderName(), updatedTestSettings.getRSSettings().getHeaderFormat(), SAMLConstants.ASSERTION_ENCODED);
@@ -96,7 +95,7 @@ public class RSSamlAPITests extends SAMLCommonTest {
     @Test
     public void RSSamlAPITests_useJaxRSCLientServlet_compressedEncodedAssertion() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setRSSettings(updatedTestSettings.getRSSettings().getHeaderName(), updatedTestSettings.getRSSettings().getHeaderFormat(), SAMLConstants.ASSERTION_COMPRESSED_ENCODED);
@@ -138,7 +137,7 @@ public class RSSamlAPITests extends SAMLCommonTest {
             testSAMLServer.reconfigServer(buildSPServerName("server_apiTest_text_only.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
         }
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setRSSettings(updatedTestSettings.getRSSettings().getHeaderName(), updatedTestSettings.getRSSettings().getHeaderFormat(), SAMLConstants.ASSERTION_TEXT_ONLY);
@@ -170,7 +169,7 @@ public class RSSamlAPITests extends SAMLCommonTest {
     @Test
     public void RSSamlAPITests_useJaxRSCLientServlet_junkInAssertion() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setRSSettings(updatedTestSettings.getRSSettings().getHeaderName(), updatedTestSettings.getRSSettings().getHeaderFormat(), "junk");
@@ -196,7 +195,7 @@ public class RSSamlAPITests extends SAMLCommonTest {
     @Test
     public void RSSamlAPITests_useJaxRSCLientServlet_emptyAssertion() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setRSSettings(updatedTestSettings.getRSSettings().getHeaderName(), updatedTestSettings.getRSSettings().getHeaderFormat(), "empty");
@@ -226,7 +225,7 @@ public class RSSamlAPITests extends SAMLCommonTest {
     @Test
     public void RSSamlAPITests_useJaxRSCLientServlet_runtimePropagateToken_setStringTrue() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setRSSettings("Authorization", SAMLConstants.SAML_HEADER_5t, SAMLConstants.ASSERTION_ENCODED);
@@ -263,7 +262,7 @@ public class RSSamlAPITests extends SAMLCommonTest {
     @Test
     public void RSSamlAPITests_useJaxRSCLientServlet_runtimePropagateToken_setBooleanTrue() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setRSSettings("Authorization", SAMLConstants.SAML_HEADER_6t, SAMLConstants.ASSERTION_ENCODED);
@@ -297,7 +296,7 @@ public class RSSamlAPITests extends SAMLCommonTest {
     @Test
     public void RSSamlAPITests_useJaxRSCLientServlet_runtimePropagateToken_setStringFalse() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setRSSettings("Authorization", SAMLConstants.SAML_HEADER_5f, SAMLConstants.ASSERTION_ENCODED);
@@ -329,7 +328,7 @@ public class RSSamlAPITests extends SAMLCommonTest {
     @Test
     public void RSSamlAPITests_useJaxRSCLientServlet_runtimePropagateToken_setBooleanFalse() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setRSSettings("Authorization", SAMLConstants.SAML_HEADER_6f, SAMLConstants.ASSERTION_ENCODED);

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/fat/src/com/ibm/ws/security/saml/fat/jaxrs/common/RSSamlBasicTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/fat/src/com/ibm/ws/security/saml/fat/jaxrs/common/RSSamlBasicTests.java
@@ -18,7 +18,6 @@ import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTest;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -59,7 +58,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
     //	@AllowedFFDC("java.lang.NoClassDefFoundError")
     public void RSSamlBasicTests_mainFlow() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         List<validationData> expectations = commonUtils.getGoodExpectationsForJaxrsGet(flowType, testSettings);
 
@@ -75,7 +74,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
     @Test
     public void RSSamlBasicTests_mangleSAMLToken_sendGarbage() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setSamlTokenReplaceVars("*", "Just send a string of garbage", SAMLConstants.LOCATION_ALL);
@@ -95,7 +94,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
     @Test
     public void RSSamlBasicTests_mangleSAMLToken_removeSignature_serverRequiresSign() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setRemoveTagInResponse("ds:Signature"); // the whole ds:Signature element
@@ -114,7 +113,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
     @Test
     public void RSSamlBasicTests_mangleSAMLToken_userNameInAssertion() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
 
@@ -146,7 +145,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
         // need to reconfig instead of just using a different rs_saml config because we're updating the ssl config
         testAppServer.reconfigServer(buildSPServerName("server_samlCertNotInDefaultTrust.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         List<validationData> expectations = msgUtils.addrsSamlUnauthorizedExpectation(SAMLConstants.INVOKE_JAXRS_GET, null);
         expectations = helpers.addMessageExpectation(testAppServer, expectations, SAMLConstants.INVOKE_JAXRS_GET, SAMLConstants.APP_MESSAGES_LOG, SAMLConstants.STRING_CONTAINS, "Did not fail with a signature not trusted error.", SAMLMessageConstants.CWWKS5049E_SIGNATURE_NOT_TRUSTED_OR_VALID);
@@ -177,7 +176,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
         // need to reconfig instead of just using a different rs_saml config because we're updating the ssl config
         testAppServer.reconfigServer(buildSPServerName("server_samlCertNotInDefaultTrust_wantAssertionsSignedFalse.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = changeTestApps("mangled");
 
@@ -200,7 +199,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
     @Test
     public void RSSamlBasicTests_samlCertNotInRSSamlTrust_wantAssertionsSigned_true() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = changeTestApps("badTrust_mangled_true");
 
@@ -223,7 +222,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
     @Test
     public void RSSamlBasicTests_samlCertNotInRSSamlTrust_wantAssertionsSigned_false() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = changeTestApps("badTrust_mangled_false");
 
@@ -239,7 +238,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
     @Test
     public void RSSamlBasicTests_MinConfig() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", "sp2", true);
@@ -257,7 +256,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
     @Test
     public void RSSamlBasicTests_OmitSAMLAssertion() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setRSSettings(null, updatedTestSettings.getRSSettings().getHeaderFormat(), updatedTestSettings.getRSSettings().getSamlTokenFormat());
@@ -278,7 +277,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
     @Test
     public void RSSamlBasicTests_signatureAlgorithNotSatisfied() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.setSpTargetApp(testAppServer.getServerHttpsString() + "/" + SAMLConstants.PARTIAL_HELLO_WORLD_URI + "_sp2");
@@ -298,7 +297,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
     @Test
     public void RSSamlBasicTests_useSAMLAssertionAgain() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         List<validationData> expectations = commonUtils.getGoodExpectationsForJaxrsGet(flowType, testSettings);
 
@@ -322,7 +321,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
     @Test
     public void RSSamlBasicTests_mangleSAMLToken_removeSignature_serverDoesntRequiresSign() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         //		SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         SAMLTestSettings updatedTestSettings = changeTestApps("mangled");
@@ -337,7 +336,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
     @Test
     public void RSSamlBasicTests_mangleSAMLToken_missingNameId() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = changeTestApps("mangled");
 
@@ -354,7 +353,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
     @Test
     public void RSSamlBasicTests_useToken_before_NotBefore() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = changeTestApps("mangled");
 
@@ -371,7 +370,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
     @Test
     public void RSSamlBasicTests_useToken_after_NotOnOrAfter() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = changeTestApps("mangled");
 
@@ -396,7 +395,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
     @Test
     public void RSSamlBasicTests_useToken_after_SessionNotOnOrAfter() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = changeTestApps("mangled");
         updatedTestSettings.setRemoveTagInResponse("ds:Signature");
@@ -423,7 +422,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
 
         String unAuthenticated = "Principal: WSPrincipal:UNAUTHENTICATED";
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         // access unprotected app
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
@@ -485,7 +484,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
             testSAMLServer.reconfigServer(buildSPServerName("server_1_text_only.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
         }
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         List<validationData> expectations = commonUtils.getGoodExpectationsForJaxrsGet(flowType, testSettings);
 
@@ -505,7 +504,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
     @Test
     public void RSSamlBasicTests_headerFormatVariations_ASSERTION_ENCODED() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         List<validationData> expectations = commonUtils.getGoodExpectationsForJaxrsGet(flowType, testSettings);
 
@@ -526,7 +525,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
     @Test
     public void RSSamlBasicTests_headerFormatVariations_ASSERTION_COMPRESSED_ENCODED() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         List<validationData> expectations = commonUtils.getGoodExpectationsForJaxrsGet(flowType, testSettings);
 
@@ -550,7 +549,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
     @Test
     public void RSSamlBasicTests_defaultHeaderNames() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         List<validationData> expectations = commonUtils.getGoodExpectationsForJaxrsGet(flowType, testSettings);
 
@@ -574,7 +573,7 @@ public class RSSamlBasicTests extends SAMLCommonTest {
     @Test
     public void RSSamlBasicTests_otherHeaderNames() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         List<validationData> expectations = commonUtils.getGoodExpectationsForJaxrsGet(flowType, testSettings);
 

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/fat/src/com/ibm/ws/security/saml/fat/jaxrs/common/RSSamlPkixTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/fat/src/com/ibm/ws/security/saml/fat/jaxrs/common/RSSamlPkixTests.java
@@ -19,7 +19,6 @@ import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTest;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -109,7 +108,7 @@ public class RSSamlPkixTests extends SAMLCommonTest {
      */
     private void commonRunTest_GoodServerHasCert_GoodServerDoesNotHaveCert(String appName) throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = updateTestSettings(appName);
 
@@ -152,7 +151,7 @@ public class RSSamlPkixTests extends SAMLCommonTest {
      */
     private void commonRunTest_GoodServerHasCert_5049EServerDoesNotHaveCert(Boolean shouldSucceed, String appName) throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = updateTestSettings(appName);
 
@@ -252,7 +251,7 @@ public class RSSamlPkixTests extends SAMLCommonTest {
     @Test
     public void RSSamlPkixTests_badTrustAnchorReference() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = commonUtils.changeTestApps(testAppServer, testSettings, "missingJKSFile");
 

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/fat/src/com/ibm/ws/security/saml/fat/jaxrs/common/RSSamlTrustedIssuersTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/fat/src/com/ibm/ws/security/saml/fat/jaxrs/common/RSSamlTrustedIssuersTests.java
@@ -17,7 +17,6 @@ import org.junit.Test;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTest;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -62,7 +61,7 @@ public class RSSamlTrustedIssuersTests extends SAMLCommonTest {
      */
     private void commonRunTest_successful(String appName) throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = updateTestSettings(appName);
 
@@ -82,7 +81,7 @@ public class RSSamlTrustedIssuersTests extends SAMLCommonTest {
      */
     private void commonRunTest_missingIssuer(String appName) throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = updateTestSettings(appName);
 

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout/fat/src/com/ibm/ws/security/saml/fat/logout/common/OneServerLTPALogoutTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout/fat/src/com/ibm/ws/security/saml/fat/logout/common/OneServerLTPALogoutTests.java
@@ -22,7 +22,6 @@ import com.gargoylesoftware.htmlunit.util.Cookie;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.fat.common.utils.ConditionalIgnoreRule;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
 
@@ -102,7 +101,7 @@ public class OneServerLTPALogoutTests extends SAMLLogoutCommonTest {
     @Test
     public void OneServerLTPALogoutTests_mainPath() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp13", true);
@@ -130,7 +129,7 @@ public class OneServerLTPALogoutTests extends SAMLLogoutCommonTest {
     public void OneServerLTPALogoutTests_useCookie_afterLogout() throws Exception {
 
         //        useCookieAfterLogout(cookieInfo.getSp13CookieName(), "LTPA", "sp13");
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp13", true);
@@ -146,7 +145,7 @@ public class OneServerLTPALogoutTests extends SAMLLogoutCommonTest {
         Log.info(thisClass, _testName, "Extracted Cookie: " + cookie.getName() + " Value: " + cookie.getValue());
 
         // create a new client and use the sp1 cookie to access the app (just to show that with just the cookie, we can access the app)
-        WebClient webClient2 = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient2 = getAndSaveWebClient();
         webClient2.getCookieManager().addCookie(cookie);
         Log.info(thisClass, _testName, "Trying to access app with new client with " + "SP13" + " cookie added");
         helpers.invokeAppSameConversation(_testName, webClient2, null, updatedTestSettings, updatedTestSettings.getSpDefaultApp(), expectations, SAMLConstants.INVOKE_DEFAULT_APP);

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout/fat/src/com/ibm/ws/security/saml/fat/logout/common/OneServerSPCookieLogoutTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout/fat/src/com/ibm/ws/security/saml/fat/logout/common/OneServerSPCookieLogoutTests.java
@@ -24,7 +24,6 @@ import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.util.Cookie;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -116,7 +115,7 @@ public class OneServerSPCookieLogoutTests extends SAMLLogoutCommonTest {
     @Test
     public void OneServerSPCookieLogoutTests_mainPath() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -162,7 +161,7 @@ public class OneServerSPCookieLogoutTests extends SAMLLogoutCommonTest {
 
     public void multipleSPs_leaveIDPSessionCookie() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         // call helper method to log in to 3 different SPs
         loginTo3SPs(webClient);
@@ -232,7 +231,7 @@ public class OneServerSPCookieLogoutTests extends SAMLLogoutCommonTest {
 
     public void multipleSPs_removeIDPSessionCookie() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         // call helper method to log in to 3 different SPs
         loginTo3SPs(webClient);
@@ -248,7 +247,7 @@ public class OneServerSPCookieLogoutTests extends SAMLLogoutCommonTest {
         // different logout expectations for local/idp logout and different steps will remove the idp session...
         genericSAML(_testName, webClient, updatedTestSettings13, logoutFlow, expectationsLogout);
 
-        WebClient webClient2 = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient2 = getAndSaveWebClient();
         // Remove IDP session cookie (if it exists)
         Log.info(thisClass, null, "Removing IDP Session cookie from conversation before calling logout");
         webClient2 = helpers.addAllCookiesExcept(webClient2, helpers.extractAllCookiesExcept(webClient, SAMLConstants.IDP_SESSION_COOKIE_NAME), SAMLConstants.IDP_SESSION_COOKIE_NAME);
@@ -273,7 +272,7 @@ public class OneServerSPCookieLogoutTests extends SAMLLogoutCommonTest {
     @Test
     public void OneServerSPCookieLogoutTests_useCookie_afterLogout() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -289,7 +288,7 @@ public class OneServerSPCookieLogoutTests extends SAMLLogoutCommonTest {
         Log.info(thisClass, _testName, "Extracted Cookie: " + cookie.getName() + " Value: " + cookie.getValue());
 
         // create a new client and use the sp1 cookie to access the app (just to show that with just the cookie, we can access the app)
-        WebClient webClient2 = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient2 = getAndSaveWebClient();
         webClient2.getCookieManager().addCookie(cookie);
         Log.info(thisClass, _testName, "Trying to access app with new client with " + "SP1" + " cookie added");
         helpers.invokeAppSameConversation(_testName, webClient2, null, updatedTestSettings, updatedTestSettings.getSpDefaultApp(), expectations, SAMLConstants.INVOKE_DEFAULT_APP);
@@ -341,7 +340,7 @@ public class OneServerSPCookieLogoutTests extends SAMLLogoutCommonTest {
     @Test
     public void OneServerSPCookieLogoutTests_logoutSPNotLoggedInTo_noOtherSPLoggedIn() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -393,7 +392,7 @@ public class OneServerSPCookieLogoutTests extends SAMLLogoutCommonTest {
 
     public void logoutSPNotLoggedInTo_otherSPLoggedIn() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         loginTo3SPs(webClient);
 
@@ -507,7 +506,7 @@ public class OneServerSPCookieLogoutTests extends SAMLLogoutCommonTest {
     public void OneServerSPCookieLogoutTests_logoutUrlMissingFromSPMetaData() throws Exception {
 
         String[] spCookie = { cookieInfo.getSpUnderscoreCookieName() };
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp_underscore", true);
@@ -558,7 +557,7 @@ public class OneServerSPCookieLogoutTests extends SAMLLogoutCommonTest {
 
         String[] spCookie = { cookieInfo.getSpDashCookieName() };
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp-dash", true);
@@ -690,7 +689,7 @@ public class OneServerSPCookieLogoutTests extends SAMLLogoutCommonTest {
 
         String[] spCookie = { cookieInfo.getSp5CookieName() };
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp5", true);
@@ -743,8 +742,8 @@ public class OneServerSPCookieLogoutTests extends SAMLLogoutCommonTest {
         String[] client2_threeSPCookies = { cookieInfo.getSp13CookieName(), cookieInfo.getSp2CookieName(), cookieInfo.getSp5CookieName() };
         String[] client2_missingAfterCookies = { cookieInfo.getSp1CookieName(), cookieInfo.getSp5CookieName() };
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
-        WebClient webClient2 = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
+        WebClient webClient2 = getAndSaveWebClient();
 
         // log into 2 sps in 2 different webClients
         loginToSP(webClient, standardFlowKeepingCookies, testUsers.getUser1(), testUsers.getPassword1(), "sp1", client1_oneSPCookie);
@@ -806,7 +805,7 @@ public class OneServerSPCookieLogoutTests extends SAMLLogoutCommonTest {
      * @throws Exception
      */
     public void sp_missing_or_disabled(String sp) throws Exception {
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         // call helper method to log in to 3 different SPs
         loginTo3SPs(webClient);
@@ -876,7 +875,7 @@ public class OneServerSPCookieLogoutTests extends SAMLLogoutCommonTest {
 
         String[] cookieList = new String[] { spCookieName };
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings(spName, true);

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout/fat/src/com/ibm/ws/security/saml/fat/logout/common/TimeoutTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout/fat/src/com/ibm/ws/security/saml/fat/logout/common/TimeoutTests.java
@@ -17,7 +17,6 @@ import java.util.List;
 
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -99,7 +98,7 @@ public class TimeoutTests extends SAMLLogoutCommonTest {
      */
     public void test_logoutAfterIDPSessionExpires(String loginType, String logoutType, boolean localOnly, String[] flowOverride) throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
         boolean spCookieStillGood;
 
         SAMLTestSettings settings = testSettings.copyTestSettings();
@@ -152,7 +151,7 @@ public class TimeoutTests extends SAMLLogoutCommonTest {
 
     public void test_logoutAfterSAMLTokenExpires(String loginType, String logoutType, boolean localOnly, String[] flowOverride) throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings settings = testSettings.copyTestSettings();
         // Set test settings for requested flow type

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout/fat/src/com/ibm/ws/security/saml/fat/logout/common/TwoServerLogoutTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout/fat/src/com/ibm/ws/security/saml/fat/logout/common/TwoServerLogoutTests.java
@@ -19,7 +19,6 @@ import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.util.Cookie;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
 
@@ -131,7 +130,7 @@ public class TwoServerLogoutTests extends SAMLLogoutCommonTest {
         String[] server1Cookies = { cookieInfo.getSp1CookieName(), cookieInfo.getSp2CookieName() };
         String[] server2Cookies = { cookieInfo.getServer2Sp1CookieName(), cookieInfo.getServer2Sp2CookieName() };
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         // call helper method to log in to 4 different SPs (2 sp's on SP server1, and 2 on SP server2)
         loginTo4SPs(webClient, settings);
@@ -175,7 +174,7 @@ public class TwoServerLogoutTests extends SAMLLogoutCommonTest {
         String cookiePrintName = "server2_sp2";
         String spName = "server2_sp2";
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         // call helper method to log in to 4 different SPs (2 sp's on SP server1, and 2 on SP server2)
         loginTo4SPs(webClient, settings);
@@ -197,7 +196,7 @@ public class TwoServerLogoutTests extends SAMLLogoutCommonTest {
         //        expectations = vData.addExpectation(expectations, SAMLConstants.INVOKE_ACS_WITH_SAML_RESPONSE_KEEPING_COOKIES, SAMLConstants.COOKIES, SAMLConstants.STRING_CONTAINS, "Conversation did NOT have an SP Cookie.", cookieName, null);
 
         // create a new client and use the saved cookie to access the app (just to show that with just the cookie, we can access the app)
-        WebClient webClient2 = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient2 = getAndSaveWebClient();
         webClient2.getCookieManager().addCookie(cookie);
         Log.info(thisClass, _testName, "Trying to access app with new client with " + cookiePrintName + " cookie added");
         helpers.invokeAppSameConversation(_testName, webClient2, null, updatedTestSettingsServer2sp2, updatedTestSettingsServer2sp2.getSpDefaultApp(), expectations, SAMLConstants.INVOKE_DEFAULT_APP);

--- a/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/IDPInitiated/BasicIDPInitiatedTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/IDPInitiated/BasicIDPInitiatedTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,7 +21,6 @@ import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.saml.fat.common.BasicSAMLTests;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -80,7 +79,7 @@ public class BasicIDPInitiatedTests extends BasicSAMLTests {
 
         testSAMLServer.reconfigServer("server_8_FedMismatch.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp5", true);

--- a/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/SPInitiated/BasicSolicitedSPInitiatedTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/SPInitiated/BasicSolicitedSPInitiatedTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,7 +27,6 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.saml.fat.common.BasicSAMLTests;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -99,7 +98,7 @@ public class BasicSolicitedSPInitiatedTests extends BasicSAMLTests {
 
         testSAMLServer.reconfigServer("server_8_FedMismatch.xml", _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp5", true);
@@ -124,7 +123,7 @@ public class BasicSolicitedSPInitiatedTests extends BasicSAMLTests {
     public void basicSolicitedSPInitiatedTests_NoInResponseTo() throws Exception {
 
         // need to allow no signature, since we change the samlResponse
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
         updatedTestSettings.setRemoveAttribAll("InResponseTo");
@@ -152,7 +151,7 @@ public class BasicSolicitedSPInitiatedTests extends BasicSAMLTests {
         // create the test marker used to start checking
         Log.info(thisClass, _testName, statusCheck);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
         // turn off automatic redirect
         webClient.getOptions().setRedirectEnabled(false);
 
@@ -209,7 +208,7 @@ public class BasicSolicitedSPInitiatedTests extends BasicSAMLTests {
      */
     protected void sessionAffinityTest(HttpMethod method) throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
         // we want to pass some parms on the first request (without having to duplicate code)

--- a/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/common/BasicSAMLTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/common/BasicSAMLTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,7 +21,6 @@ import com.gargoylesoftware.htmlunit.WebClient;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.ValidationData.validationData;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTest;
-import com.ibm.ws.security.saml20.fat.commonTest.SAMLCommonTestHelpers;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLMessageConstants;
 import com.ibm.ws.security.saml20.fat.commonTest.SAMLTestSettings;
@@ -76,7 +75,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
         extraMsgs.add("CWWKS9122I:.*sp1/snoop");
         testSAMLServer.reconfigServer(buildSPServerName("server_1_withJwtSsoFeature.xml"), _testName, extraMsgs, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -113,7 +112,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
     @Test
     public void basicSAMLTests_idAssertNoUser_noIDPSign_noIDPEncrypt() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -171,7 +170,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
 
         testSAMLServer.reconfigServer(buildSPServerName("server_4.xml"), _testName, extraMsgs, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp2", true);
@@ -208,7 +207,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
 
         testSAMLServer.reconfigServer(buildSPServerName("server_.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp13", true);
@@ -252,7 +251,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
 
         testSAMLServer.reconfigServer(buildSPServerName("server_8.xml"), _testName, extraMsgs, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp5", true);
@@ -422,7 +421,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
 
         testSAMLServer.reconfigServer(buildSPServerName("server_13.xml"), _testName, extraMsgs, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp13", true);
@@ -447,7 +446,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
 
         testSAMLServer.reconfigServer(buildSPServerName("server_1_badFilter.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -472,7 +471,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
 
         testSAMLServer.reconfigServer(buildSPServerName("server_1_noFilter.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -493,7 +492,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
     @Test
     public void basicSAMLTests_useSAMLTokenAgain_replayAttack() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -523,7 +522,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
     @Test
     public void basicSAMLTests_badSAMLToken_thenGoodSAMLToken_usuallyNoReplayAttack() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -558,7 +557,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
     @Test
     public void basicSAMLTests_mangleSAMLToken_userNameInAssertion_notSigned() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1NotSigned", true);
@@ -576,7 +575,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
     @Test
     public void basicSAMLTests_mangleSAMLToken_userNameInAssertion_signed() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -595,7 +594,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
     @Test
     public void basicSAMLTests_mangleSAMLToken_badXMLFormatInResponse() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -613,7 +612,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
     @Test
     public void basicSAMLTests_mangleSAMLToken_sendGarbage() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -637,7 +636,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
     @Test
     public void basicSAMLTests_mangleSAMLToken_removeSignature_serverRequiresSign() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -663,7 +662,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
 
         //        testSAMLServer.reconfigServer(buildSPServerName("server_1_notSigned.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1NotSigned", true);
@@ -687,7 +686,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
 
         //        testSAMLServer.reconfigServer(buildSPServerName("server_1_notSigned.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1NotSigned", true);
@@ -710,7 +709,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
     @Test
     public void basicSAMLTests_invoke_ACS_withoutClearingCookies() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -727,7 +726,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
     @Test
     public void basicSAMLTests_unProtectedApp_then_protectedApp_SPCookie() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -775,7 +774,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
     @Test
     public void basicSAMLTests_protectedApp_then_unProtectedApp_SPCookie() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -804,7 +803,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
 
         testSAMLServer.reconfigServer(buildSPServerName("server_1_ltpaToken.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -855,7 +854,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
 
         testSAMLServer.reconfigServer(buildSPServerName("server_1_ltpaToken.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -884,7 +883,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
 
         testSAMLServer.reconfigServer(buildSPServerName("server_1_ltpaToken_missingIDPSSODescriptor.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -920,7 +919,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
 
         testSAMLServer.reconfigServer(buildSPServerName("server_chainedCert.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp50", true);
@@ -942,7 +941,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
 
         testSAMLServer.reconfigServer(buildSPServerName("server_chainedCert_useLeafInKeyStore.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp50", true);
@@ -980,7 +979,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
 
         testSAMLServer.reconfigServer(buildSPServerName("server_chainedCert_useIntermediateInKeyStore.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp50", true);
@@ -1018,7 +1017,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
 
         testSAMLServer.reconfigServer(buildSPServerName("server_chainedCert_useRootInKeyStore.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp50", true);
@@ -1040,7 +1039,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
     @Test
     public void basicSAMLTests_invokeACS_withNoToken_usingGet() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);
@@ -1059,7 +1058,7 @@ public class BasicSAMLTests extends SAMLCommonTest {
     @Test
     public void basicSAMLTests_invokeACS_withNoToken_usingPost() throws Exception {
 
-        WebClient webClient = SAMLCommonTestHelpers.getWebClient();
+        WebClient webClient = getAndSaveWebClient();
 
         SAMLTestSettings updatedTestSettings = testSettings.copyTestSettings();
         updatedTestSettings.updatePartnerInSettings("sp1", true);


### PR DESCRIPTION
Clean up htmlunit WebClients at the end of each test.
Create a tracker to clean up webClients in the @After method.

