### PR TITLE
disable parking of managed connections

### DIFF
--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManagerServiceImpl.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectionManagerServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 IBM Corporation and others.
+ * Copyright (c) 2011, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -508,6 +508,9 @@ public class ConnectionManagerServiceImpl extends ConnectionManagerService {
             purgePolicy = validateProperty(map, J2CConstants.POOL_PurgePolicy, PurgePolicy.EntirePool, PurgePolicy.class, connectorSvc);
         }
 
+        value = map.remove(TEMPORARILY_ASSOCIATE_IF_DISSOCIATE_UNAVAILABLE);
+        boolean temporarilyAssociateIfDissociateUnavailable = value instanceof Boolean ? (Boolean) value : Boolean.parseBoolean((String) value);
+
         boolean throwExceptionOnMCThreadCheck = false;
 
         // Identify unrecognized properties - TODO: enable when we have a stricter variant of onError
@@ -552,6 +555,9 @@ public class ConnectionManagerServiceImpl extends ConnectionManagerService {
             if (pm.gConfigProps.getMaxNumberOfMCsAllowableInThread() != maxNumberOfMCsAllowableInThread)
                 pm.gConfigProps.setMaxNumberOfMCsAllowableInThread(maxNumberOfMCsAllowableInThread);
 
+            if (pm.gConfigProps.getParkIfDissociateUnavailable() != temporarilyAssociateIfDissociateUnavailable)
+                pm.gConfigProps.setParkIfDissociateUnavailable(temporarilyAssociateIfDissociateUnavailable);
+
             return null;
         } else {
             // Connection pool does not exist, create j2c global configuration properties for creating pool.
@@ -560,7 +566,8 @@ public class ConnectionManagerServiceImpl extends ConnectionManagerService {
                             100, // maxFreePoolHashSize,
                             false, // diagnoseConnectionUsage,
                             connectionTimeout, maxPoolSize, minPoolSize, purgePolicy, reapTime, maxIdleTime, agedTimeout, ConnectionPoolProperties.DEFAULT_HOLD_TIME_LIMIT, 0, // commit priority not supported
-                            autoCloseConnections, numConnectionsPerThreadLocal, maxNumberOfMCsAllowableInThread, throwExceptionOnMCThreadCheck);
+                            autoCloseConnections, numConnectionsPerThreadLocal, maxNumberOfMCsAllowableInThread, //
+                            temporarilyAssociateIfDissociateUnavailable, throwExceptionOnMCThreadCheck);
 
         }
     }

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/J2CGlobalConfigProperties.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/J2CGlobalConfigProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2020 IBM Corporation and others.
+ * Copyright (c) 1997, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.jca.adapter.PurgePolicy;
 import com.ibm.ws.jca.cm.AbstractConnectionFactoryService;
 import com.ibm.ws.jca.cm.AppDefinedResource;
+import com.ibm.ws.jca.cm.ConnectionManagerService;
 
 /**
  * The <B>J2CGlobalConfigProperties</B> will contain all the Configuration Related
@@ -353,6 +354,7 @@ public final class J2CGlobalConfigProperties implements PropertyChangeListener, 
     public int numberOfFreeConnections = 0;
     public transient Integer numberOfFreeConnectionsLockObject = new Integer(0);
     protected transient Integer maxNumberOfMCsAllowableInThread = null;
+    private transient boolean parkIfDissociateUnavailable;
     protected transient Boolean throwExceptionOnMCThreadCheck = null;
 
     String appName;
@@ -381,6 +383,7 @@ public final class J2CGlobalConfigProperties implements PropertyChangeListener, 
                                      boolean autoCloseConnections,
                                      int numConnectionsPerThreadLocal,
                                      Integer maxNumberOfMCsAllowableInThread,
+                                     boolean parkIfDissociateUnavailable,
                                      Boolean throwExceptionOnMCThreadCheck) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
             Tr.entry(this, tc, "<init>", "Full Constructor");
@@ -422,6 +425,7 @@ public final class J2CGlobalConfigProperties implements PropertyChangeListener, 
         this.autoCloseConnections = autoCloseConnections;
         this.numConnectionsPerThreadLocal = numConnectionsPerThreadLocal;
         this.maxNumberOfMCsAllowableInThread = maxNumberOfMCsAllowableInThread;
+        this.parkIfDissociateUnavailable = parkIfDissociateUnavailable;
         this.throwExceptionOnMCThreadCheck = throwExceptionOnMCThreadCheck;
 
         /*
@@ -964,6 +968,15 @@ public final class J2CGlobalConfigProperties implements PropertyChangeListener, 
                                                    Integer maxNumberOfMCsAllowableInThread) {
         changeSupport.firePropertyChange("maxNumberOfMCsAllowableInThread", this.maxNumberOfMCsAllowableInThread, maxNumberOfMCsAllowableInThread);
         this.maxNumberOfMCsAllowableInThread = maxNumberOfMCsAllowableInThread;
+    }
+
+    public final boolean getParkIfDissociateUnavailable() {
+        return parkIfDissociateUnavailable;
+    }
+
+    public final void setParkIfDissociateUnavailable(boolean value) {
+        changeSupport.firePropertyChange(ConnectionManagerService.TEMPORARILY_ASSOCIATE_IF_DISSOCIATE_UNAVAILABLE, parkIfDissociateUnavailable, value);
+        parkIfDissociateUnavailable = value;
     }
 
     public boolean getThrowExceptionOnMCThreadCheck() {

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/ConnectionManagerService.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/ConnectionManagerService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 IBM Corporation and others.
+ * Copyright (c) 2011, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -77,6 +77,12 @@ public abstract class ConnectionManagerService extends Observable {
     public static final String NUM_CONNECTIONS_PER_THREAD_LOCAL = "numConnectionsPerThreadLocal";
 
     /**
+     * Name of property controlling whether sharable connection handles for a non-DissociatableManagedConnection
+     * can be temporarily associated (parked) to a dedicated unused ManagedConnection.
+     */
+    public static final String TEMPORARILY_ASSOCIATE_IF_DISSOCIATE_UNAVAILABLE = "temporarilyAssociateIfDissociateUnavailable";
+
+    /**
      * List of connectionManager properties.
      */
     public static final List<String> CONNECTION_MANAGER_PROPS = Collections.unmodifiableList(Arrays.asList(
@@ -90,7 +96,8 @@ public abstract class ConnectionManagerService extends Observable {
                                                                                                            MIN_POOL_SIZE,
                                                                                                            NUM_CONNECTIONS_PER_THREAD_LOCAL,
                                                                                                            J2CConstants.POOL_PurgePolicy,
-                                                                                                           J2CConstants.POOL_ReapTime));
+                                                                                                           J2CConstants.POOL_ReapTime,
+                                                                                                           TEMPORARILY_ASSOCIATE_IF_DISSOCIATE_UNAVAILABLE));
 
     /**
      * List of connectionManager properties whose names were taken from DataSourceDefinition. To be

--- a/dev/com.ibm.ws.jca_fat/publish/servers/com.ibm.ws.jca.fat.jakarta/server.xml
+++ b/dev/com.ibm.ws.jca_fat/publish/servers/com.ibm.ws.jca.fat.jakarta/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020,2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@
     <variable name="onError" value="FAIL"/>
 
     <jmsConnectionFactory id="cf1" jndiName="jms/cf1">
-      <connectionManager maxPoolSize="2" connectionTimeout="0" autoCloseConnections="true"/>
+      <connectionManager maxPoolSize="2" connectionTimeout="0" autoCloseConnections="true" temporarilyAssociateIfDissociateUnavailable="true"/>
       <properties.FAT1 tableName="cf1tbl" userName="CF1USER"/>
     </jmsConnectionFactory>
 

--- a/dev/com.ibm.ws.jca_fat/publish/servers/com.ibm.ws.jca.fat/server.xml
+++ b/dev/com.ibm.ws.jca_fat/publish/servers/com.ibm.ws.jca.fat/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2011,2020 IBM Corporation and others.
+    Copyright (c) 2011,2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@
     <variable name="onError" value="FAIL"/>
 
     <jmsConnectionFactory id="cf1" jndiName="jms/cf1">
-      <connectionManager maxPoolSize="2" connectionTimeout="0" autoCloseConnections="true"/>
+      <connectionManager maxPoolSize="2" connectionTimeout="0" autoCloseConnections="true" temporarilyAssociateIfDissociateUnavailable="true"/>
       <properties.FAT1 tableName="cf1tbl" userName="CF1USER"/>
     </jmsConnectionFactory>
 

--- a/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/fat/src/com/ibm/ws/jca/fat/derbyra/DerbyResourceAdapterTest.java
@@ -190,6 +190,11 @@ public class DerbyResourceAdapterTest extends FATServletClient {
     }
 
     @Test
+    public void testParkNonDissociatableSharableHandle() throws Exception {
+        runTest(DerbyRAServlet);
+    }
+
+    @Test
     public void testRecursiveTimer() throws Exception {
         runTest(DerbyRAAnnoServlet);
     }

--- a/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/server.xml
+++ b/dev/com.ibm.ws.jca_fat_derbyra/publish/servers/com.ibm.ws.jca.fat.derbyra/server.xml
@@ -49,7 +49,7 @@
     </connectionFactory>
 
     <connectionFactory jndiName="eis/ds5">
-      <connectionManager maxPoolSize="1" connectionTimeout="0" autoCloseConnections="true"/>
+      <connectionManager maxPoolSize="1" connectionTimeout="0" autoCloseConnections="true" temporarilyAssociateIfDissociateUnavailable="true"/>
       <properties.DerbyRA dissociatable="false" lazyEnlistable="true" userName="DS1USER" password="{xor}GwxuDwgb"/>
     </connectionFactory>
 


### PR DESCRIPTION
The WMQ resource adapter has a bug on the associateConnection path for parking JMSContext connection handles, so we cannot have that path be default and need to disable it in order to avoid a breaking change.