### PR TITLE
Add retry for slow request timing test failures

### DIFF
--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/SlowRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/SlowRequestTiming.java
@@ -818,7 +818,7 @@ public class SlowRequestTiming {
         //Retry the request again
         if (warnings == 0) {
             CommonTasks.writeLogMsg(Level.INFO, "$$$$ -----> Retry because no slow request warning found!");
-            createRequest("?sleepTime=3000");
+            createRequest("?sleepTime=13000");
             server.waitForStringInLog("TRAS0112W", 20000);
             warnings = fetchNoOfslowRequestWarnings();
         }

--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/SlowRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/SlowRequestTiming.java
@@ -381,11 +381,22 @@ public class SlowRequestTiming {
 
         createRequest("?sleepTime=3000");
 
-        server.waitForStringInLog("TRAS0112W", 15000);
-        List<String> lines = server.findStringsInFileInLibertyServerRoot("TRAS0112W", MESSAGE_LOG);
-        CommonTasks.writeLogMsg(Level.INFO, " Size : " + lines.size());
+        server.waitForStringInLog("TRAS0112W", 20000);
 
-        assertTrue("Expected 1 (or more) slow request warning  but found : " + lines.size(), (lines.size() > 0));
+        int slowCount = fetchNoOfslowRequestWarnings();
+
+        //Retry the request again
+        if (slowCount == 0) {
+            CommonTasks.writeLogMsg(Level.INFO, "$$$$ -----> Retry because no slow request warning found!");
+            createRequest("?sleepTime=3000");
+            server.waitForStringInLog("TRAS0112W", 20000);
+            slowCount = fetchNoOfslowRequestWarnings();
+        }
+
+        //List<String> lines = server.findStringsInFileInLibertyServerRoot("TRAS0112W", MESSAGE_LOG);
+        CommonTasks.writeLogMsg(Level.INFO, " Size : " + slowCount);
+
+        assertTrue("Expected 1 (or more) slow request warning  but found : " + slowCount, (slowCount > 0));
 
         CommonTasks.writeLogMsg(Level.INFO, "******* Slow request timing works for Zero Sample Rate*******");
     }
@@ -800,7 +811,18 @@ public class SlowRequestTiming {
         //Step 2 - create request of 13seconds. Fetch slow request warnings.
         createRequest("?sleepTime=13000");
 
+        server.waitForStringInLog("TRAS0112W", 20000);
+
         int warnings = fetchNoOfslowRequestWarnings();
+
+        //Retry the request again
+        if (warnings == 0) {
+            CommonTasks.writeLogMsg(Level.INFO, "$$$$ -----> Retry because no slow request warning found!");
+            createRequest("?sleepTime=3000");
+            server.waitForStringInLog("TRAS0112W", 20000);
+            warnings = fetchNoOfslowRequestWarnings();
+        }
+
         CommonTasks.writeLogMsg(Level.INFO, "$$$ -> No of Slow Request warnings : " + warnings);
 
         assertTrue("Expected 3 slow request warnings but found " + warnings, (warnings == 3));

--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/TimingRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/TimingRequestTiming.java
@@ -451,10 +451,18 @@ public class TimingRequestTiming {
 
         createRequests(6000, 1);
 
-        server.waitForStringInLogUsingMark("TRAS0112W", 10000);
+        server.waitForStringInLogUsingMark("TRAS0112W", 15000);
         server.waitForStringInLogUsingMark("TRAS0114W", 10000);
 
         int slow = fetchSlowRequestWarningsCount();
+
+        if (slow == 0) {
+            CommonTasks.writeLogMsg(Level.INFO, "$$$$ -----> Retry because no slow request warning found!");
+            createRequests(6000, 1);
+            server.waitForStringInLog("TRAS0112W", 15000);
+            slow = fetchSlowRequestWarningsCount();
+        }
+
         int hung = fetchHungRequestWarningsCount();
 
         assertTrue("Expected > 1 slow request warnings but found : " + slow, (slow > 1));
@@ -535,9 +543,17 @@ public class TimingRequestTiming {
 
         createRequests(5000, 1);
 
-        server.waitForStringInLogUsingMark("TRAS0112W", 10000);
+        server.waitForStringInLogUsingMark("TRAS0112W", 15000);
 
         int slow = fetchSlowRequestWarningsCount();
+
+        if (slow == 0) {
+            CommonTasks.writeLogMsg(Level.INFO, "$$$$ -----> Retry because no slow request warning found!");
+            createRequests(5000, 1);
+            server.waitForStringInLog("TRAS0112W", 15000);
+            slow = fetchSlowRequestWarningsCount();
+        }
+
         int hung = fetchHungRequestWarningsCount();
         assertTrue("Expected > 1 slow request warnings but found : " + slow, (slow > 1));
 


### PR DESCRIPTION
fixes: #15748

#build

Added a retry for slow requests in test cases: `testMaxSlowRequestTimingWarnings`, `testSlowReqSampleRateZero`, `testTimingLocalInheritsGlobalConfig`, and `testTimingGlobalConfigFollowsLocal` in the case of a slow request not being detected.
