### PR TITLE
legacy DataStoreHelper integration points for getXAExceptionContents and getPrintWriter

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/heritage/GenericDataStoreHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/heritage/GenericDataStoreHelper.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.jdbc.heritage;
 
+import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -104,6 +105,13 @@ public abstract class GenericDataStoreHelper {
      * @return metadata.
      */
     public abstract DataStoreHelperMetaData getMetaData();
+
+    /**
+     * Overrides the PrintWriter for JDBC driver trace.
+     *
+     * @return PrintWriter to use for JDBC driver trace.
+     */
+    public abstract PrintWriter getPrintWriter();
 
     /**
      * Provides additional logging information for an <code>XAException</code>.

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/heritage/GenericDataStoreHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/heritage/GenericDataStoreHelper.java
@@ -16,6 +16,7 @@ import java.sql.SQLException;
 
 import javax.resource.ResourceException;
 import javax.security.auth.Subject;
+import javax.transaction.xa.XAException;
 
 /**
  * Extension point for compatibility with data store helpers.
@@ -103,6 +104,14 @@ public abstract class GenericDataStoreHelper {
      * @return metadata.
      */
     public abstract DataStoreHelperMetaData getMetaData();
+
+    /**
+     * Provides additional logging information for an <code>XAException</code>.
+     *
+     * @param xae the exception.
+     * @return detailed information about the exception.
+     */
+    public abstract String getXAExceptionContents(XAException xae);
 
     /**
      * Supplies the dataSource configuration to the data store helper.

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2Helper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2Helper.java
@@ -60,7 +60,6 @@ public class DB2Helper extends DatabaseHelper {
     static int JDBC = 1; 
     static int SQLJ = 2; 
     int connType = 0; 
-    private transient PrintWriter db2Pw; 
 
     /**
      * Construct a helper class for common DB2 behavior. Do not instantiate this class directly.
@@ -236,12 +235,12 @@ public class DB2Helper extends DatabaseHelper {
         // and most likely the setting will be serially, even if its not,
         // it shouldn't matter here (tracing).
 
-        if (db2Pw == null) {
-            db2Pw = new PrintWriter(new TraceWriter(db2Tc), true);
+        if (genPw == null) {
+            genPw = new PrintWriter(new TraceWriter(db2Tc), true);
         }
         if (trace && tc.isDebugEnabled())
-            Tr.debug(this, tc, "returning", db2Pw);
-        return db2Pw;
+            Tr.debug(this, tc, "returning", genPw);
+        return genPw;
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2JCCHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2JCCHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2020 IBM Corporation and others.
+ * Copyright (c) 2003, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -107,7 +107,6 @@ public class DB2JCCHelper extends DB2Helper {
 
     private boolean tightBranchCouplingSupported; 
     private boolean tightBranchCouplingSupportedbyDB; 
-    private transient PrintWriter db2UPw; 
     private transient String traceFile; 
     private transient int configuredTraceLevel; 
     private transient Class<DB2JCCHelper> currClass = DB2JCCHelper.class;
@@ -209,7 +208,7 @@ public class DB2JCCHelper extends DB2Helper {
             try {
                 final String file = traceDir + traceFile;
                 final boolean append = traceAppend;
-                db2UPw = new PrintWriter(AccessController.doPrivileged(new PrivilegedExceptionAction<FileOutputStream>() {
+                genPw = new PrintWriter(AccessController.doPrivileged(new PrivilegedExceptionAction<FileOutputStream>() {
                     public FileOutputStream run() throws FileNotFoundException {
                         return new FileOutputStream(file, append);
                     }
@@ -226,7 +225,7 @@ public class DB2JCCHelper extends DB2Helper {
                     throw new ResourceException(x);
             }
         } else { // means need to integrate
-            db2UPw = new PrintWriter(new TraceWriter(db2Tc), true);
+            genPw = new PrintWriter(new TraceWriter(db2Tc), true);
         }
     }
     
@@ -420,12 +419,12 @@ public class DB2JCCHelper extends DB2Helper {
         //not synchronizing here since there will be one helper
         // and most likely the setting will be serially, even if its not,
         // it shouldn't matter here (tracing).
-        if (db2UPw == null) {
-            db2UPw = new PrintWriter(new TraceWriter(db2Tc), true);
+        if (genPw == null) {
+            genPw = new PrintWriter(new TraceWriter(db2Tc), true);
         }
         if (db2Tc.isDebugEnabled())
-            Tr.debug(db2Tc, "returning", db2UPw);
-        return db2UPw;
+            Tr.debug(db2Tc, "returning", genPw);
+        return genPw;
     }
 
     /*

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DataDirectConnectSQLServerHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DataDirectConnectSQLServerHelper.java
@@ -64,8 +64,6 @@ public class DataDirectConnectSQLServerHelper extends DatabaseHelper {
     @SuppressWarnings("deprecation")
     private transient com.ibm.ejs.ras.TraceComponent sqlserverTc = com.ibm.ejs.ras.Tr.register("com.ibm.ws.sqlserver.logwriter", "WAS.database", null);
 
-    private transient PrintWriter sqlServerPW;
-
     /**
      * SQLException error codes from the DataDirect Connect JDBC driver that indicate a stale connection.
      */
@@ -337,11 +335,11 @@ public class DataDirectConnectSQLServerHelper extends DatabaseHelper {
         //not synchronizing here since there will be one helper
         // and most likely the setting will be serially, even if its not, 
         // it shouldn't matter here (tracing).
-        if (sqlServerPW == null) {
-            sqlServerPW = new PrintWriter(new TraceWriter(sqlserverTc), true);
+        if (genPw == null) {
+            genPw = new PrintWriter(new TraceWriter(sqlserverTc), true);
         }
-        Tr.debug(sqlserverTc, "returning", sqlServerPW);
-        return sqlServerPW;
+        Tr.debug(sqlserverTc, "returning", genPw);
+        return genPw;
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DatabaseHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DatabaseHelper.java
@@ -66,7 +66,7 @@ public class DatabaseHelper {
     @SuppressWarnings("deprecation")
     private static final com.ibm.ejs.ras.TraceComponent databaseTc = com.ibm.ejs.ras.Tr.register("com.ibm.ws.database.logwriter", "WAS.database", null); 
     private static final TraceComponent tc = Tr.register(DatabaseHelper.class, "RRA", AdapterUtil.NLS_FILE); 
-    private transient PrintWriter genPw = null; 
+    transient PrintWriter genPw;
 
     /**
      * Default query timeout configured on the data source.

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DerbyHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DerbyHelper.java
@@ -33,7 +33,6 @@ import com.ibm.websphere.ras.TraceComponent;
 public class DerbyHelper extends DatabaseHelper {
     @SuppressWarnings("deprecation")
     protected static final com.ibm.ejs.ras.TraceComponent derbyTc = com.ibm.ejs.ras.Tr.register("com.ibm.ws.derby.logwriter", "WAS.database", null); // rename 
-    private transient PrintWriter derbyPw = null; 
 
     /**
      * Construct a helper class for Derby.
@@ -86,11 +85,11 @@ public class DerbyHelper extends DatabaseHelper {
         //not synchronizing here since there will be one helper
         // and most likely the setting will be serially, even if its not, 
         // it shouldn't matter here (tracing).
-        if (derbyPw == null) {
-            derbyPw = new java.io.PrintWriter(new TraceWriter(derbyTc), true);
+        if (genPw == null) {
+            genPw = new java.io.PrintWriter(new TraceWriter(derbyTc), true);
         }
-        Tr.debug(derbyTc, "returning", derbyPw);
-        return derbyPw;
+        Tr.debug(derbyTc, "returning", genPw);
+        return genPw;
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DerbyNetworkClientHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DerbyNetworkClientHelper.java
@@ -41,8 +41,6 @@ public class DerbyNetworkClientHelper extends DerbyHelper {
         TRACE_FILE_DIR = "traceDirectory",
         TRACE_FILE_APPEND = "traceFileAppend";
 
-    // move the derbyTc to the super class
-    private transient PrintWriter derbyNSPw; 
     private transient String traceFile; 	
     boolean traceAppend = false; 
     String traceDir = null; 
@@ -94,7 +92,7 @@ public class DerbyNetworkClientHelper extends DerbyHelper {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) 
                 Tr.debug(this, tc, "Derby network server JDBC trace was configured to go to a file, Thus no integration with WAS trace.  File name is: ", traceDir + traceFile); 
 
-            derbyNSPw = AccessController.doPrivileged(new PrivilegedAction<PrintWriter>() {
+            genPw = AccessController.doPrivileged(new PrivilegedAction<PrintWriter>() {
                 public PrintWriter run() {
                     try {
                         return new PrintWriter(new FileOutputStream(traceDir + traceFile, traceAppend), true); 
@@ -108,7 +106,7 @@ public class DerbyNetworkClientHelper extends DerbyHelper {
             });
         }
         else { // means need to integrate
-            derbyNSPw = new PrintWriter(new TraceWriter(derbyTc), true);
+            genPw = new PrintWriter(new TraceWriter(derbyTc), true);
         }
     }
     
@@ -151,11 +149,11 @@ public class DerbyNetworkClientHelper extends DerbyHelper {
         // first the retruned value from the externalhelper.getPrintWriter
         // then, based on the tracewriter.
 
-        if (derbyNSPw == null) {
-            derbyNSPw = new java.io.PrintWriter(new TraceWriter(derbyTc), true);
+        if (genPw == null) {
+            genPw = new java.io.PrintWriter(new TraceWriter(derbyTc), true);
         }
-        Tr.debug(derbyTc, "returning", derbyNSPw);
-        return derbyNSPw;
+        Tr.debug(derbyTc, "returning", genPw);
+        return genPw;
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/InformixHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/InformixHelper.java
@@ -35,7 +35,6 @@ public class InformixHelper extends DatabaseHelper {
     private static final TraceComponent tc = Tr.register(InformixHelper.class, "RRA", AdapterUtil.NLS_FILE); 
     @SuppressWarnings("deprecation")
     private transient com.ibm.ejs.ras.TraceComponent infxTc = com.ibm.ejs.ras.Tr.register("com.ibm.ws.informix.logwriter", "WAS.database", null);
-    private transient PrintWriter ifxPw = null;
 
     /**
      * Construct a helper class for the Informix JDBC driver.
@@ -80,11 +79,11 @@ public class InformixHelper extends DatabaseHelper {
         //not synchronizing here since there will be one helper
         // and most likely the setting will be serially, even if its not, 
         // it shouldn't matter here (tracing).
-        if (ifxPw == null) {
-            ifxPw = new java.io.PrintWriter(new TraceWriter(infxTc), true);
+        if (genPw == null) {
+            genPw = new java.io.PrintWriter(new TraceWriter(infxTc), true);
         }
-        Tr.debug(infxTc, "returning", ifxPw);
-        return ifxPw;
+        Tr.debug(infxTc, "returning", genPw);
+        return genPw;
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/MicrosoftSQLServerHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/MicrosoftSQLServerHelper.java
@@ -38,8 +38,6 @@ public class MicrosoftSQLServerHelper extends DatabaseHelper {
     @SuppressWarnings("deprecation")
     private transient com.ibm.ejs.ras.TraceComponent jdbcTC = com.ibm.ejs.ras.Tr.register("com.ibm.ws.sqlserver.logwriter", "WAS.database", null);
 
-    private transient PrintWriter jdbcTraceWriter;
-
     /**
      * Cached copy (per data store helper) of stmt.setResponseBuffering
      */
@@ -160,13 +158,13 @@ public class MicrosoftSQLServerHelper extends DatabaseHelper {
         //not synchronizing here since there will be one helper
         // and most likely the setting will be serially, even if it's not, 
         // it shouldn't matter here (tracing).
-        if (jdbcTraceWriter == null) {
-            jdbcTraceWriter = new PrintWriter(new TraceWriter(jdbcTC), true);
+        if (genPw == null) {
+            genPw = new PrintWriter(new TraceWriter(jdbcTC), true);
         }
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
-            Tr.exit(this, tc, "getPrintWriter", jdbcTraceWriter); 
-        return jdbcTraceWriter;
+            Tr.exit(this, tc, "getPrintWriter", genPw);
+        return genPw;
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/PostgreSQLHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/PostgreSQLHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -36,8 +36,6 @@ public class PostgreSQLHelper extends DatabaseHelper {
     @SuppressWarnings("deprecation")
     private transient com.ibm.ejs.ras.TraceComponent jdbcTC = com.ibm.ejs.ras.Tr.register("com.ibm.ws.postgresql.logwriter", "WAS.database", null);
 
-    private transient PrintWriter jdbcTraceWriter;
-    
     private Class<?> Autosave;
     private Class<?> LargeObjectManager;
     private Class<?> BaseConnection;
@@ -109,9 +107,9 @@ public class PostgreSQLHelper extends DatabaseHelper {
 
     @Override
     public PrintWriter getPrintWriter() throws ResourceException {
-        if (jdbcTraceWriter == null)
-            jdbcTraceWriter = new PrintWriter(new TraceWriter(jdbcTC), true);
-        return jdbcTraceWriter;
+        if (genPw == null)
+            genPw = new PrintWriter(new TraceWriter(jdbcTC), true);
+        return genPw;
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/SybaseHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/SybaseHelper.java
@@ -36,7 +36,6 @@ public class SybaseHelper extends DatabaseHelper
     private static final TraceComponent tc = Tr.register(SybaseHelper.class, "RRA", AdapterUtil.NLS_FILE); 
     @SuppressWarnings("deprecation")
     private transient com.ibm.ejs.ras.TraceComponent sybaseTc = com.ibm.ejs.ras.Tr.register("com.ibm.ws.sybase.logwriter", "WAS.database", null);
-    private transient PrintWriter sybasePw = null;
 
     /**
      * Construct a helper class for Sybase.
@@ -151,12 +150,12 @@ public class SybaseHelper extends DatabaseHelper
         //not synchronizing here since there will be one helper
         // and most likely the setting will be serially, even if its not, 
         // it shouldn't matter here (tracing).
-        if (sybasePw == null)
-            sybasePw = new PrintWriter(new TraceWriter(sybaseTc), true);
+        if (genPw == null)
+            genPw = new PrintWriter(new TraceWriter(sybaseTc), true);
 
         if (trace && tc.isDebugEnabled())
-            Tr.debug(this, tc, "returning", sybasePw);
-        return sybasePw;
+            Tr.debug(this, tc, "returning", genPw);
+        return genPw;
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
@@ -367,6 +367,8 @@ public class WSManagedConnectionFactoryImpl extends WSManagedConnectionFactory i
             dataStoreHelper = AccessController.doPrivileged((PrivilegedExceptionAction<GenericDataStoreHelper>) () ->
                 (GenericDataStoreHelper) jdbcDriverLoader.loadClass(config.heritageHelperClass).getConstructor(Properties.class).newInstance(helperProps));
             dataStoreHelper.setConfig(dsConfigRef);
+            if (helper.genPw == null)
+                helper.genPw = dataStoreHelper.getPrintWriter();
             DataStoreHelperMetaData metadata = dataStoreHelper.getMetaData();
             defaultIsolationLevel = dataStoreHelper.getIsolationLevel(null);
             doesStatementCacheIsoLevel = metadata.doesStatementCacheIsoLevel();
@@ -377,6 +379,9 @@ public class WSManagedConnectionFactoryImpl extends WSManagedConnectionFactory i
             supportsGetTypeMap = metadata.supportsGetTypeMap();
             supportsIsReadOnly = metadata.supportsIsReadOnly();
         }
+
+        if (helper.shouldTraceBeEnabled(this))
+            helper.enableJdbcLogging(this);
 
         if (config.supplementalJDBCTrace == null || config.supplementalJDBCTrace) {
             TraceComponent tracer = helper.getTracer();
@@ -466,9 +471,6 @@ public class WSManagedConnectionFactoryImpl extends WSManagedConnectionFactory i
         if (helper == null)
             if (dsClassName.startsWith("com.ibm.db2.jcc.")) helper = new DB2JCCHelper(this); // unable to distinguish between DB2/Informix
             else helper = new DatabaseHelper(this);
-
-        if (helper.shouldTraceBeEnabled(this))
-            helper.enableJdbcLogging(this);
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
@@ -2882,7 +2882,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
 
             modifiedByCleanup = mcf.dataStoreHelper == null
                               ? helper.doConnectionCleanup(sqlConn)
-                              : mcf.dataStoreHelper.doConnectionCleanup(sqlConn);
+                              : mcf.dataStoreHelper.doConnectionCleanup((Connection) WSJdbcTracer.getImpl(sqlConn));
 
             if (!connectionErrorDetected) 
             {
@@ -4316,7 +4316,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
             if (mcf.dataStoreHelper == null)
                 helper.doConnectionCleanup(sqlConn);
             else
-                mcf.dataStoreHelper.doConnectionCleanup(sqlConn);
+                mcf.dataStoreHelper.doConnectionCleanup((Connection) WSJdbcTracer.getImpl(sqlConn));
 
             // Clear the warning.
             sqlConn.clearWarnings();
@@ -4364,7 +4364,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                     if (mcf.dataStoreHelper == null)
                         helper.doConnectionCleanup(sqlConn);
                     else
-                        mcf.dataStoreHelper.doConnectionCleanup(sqlConn);
+                        mcf.dataStoreHelper.doConnectionCleanup((Connection) WSJdbcTracer.getImpl(sqlConn));
                 } catch (SQLException cleanEx) {
                     // No FFDC coded needed
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbXaResourceImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbXaResourceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2017 IBM Corporation and others.
+ * Copyright (c) 1997, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -247,7 +247,9 @@ public class WSRdbXaResourceImpl implements WSXAResource, FFDCSelfIntrospectable
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                     Tr.debug(this, tc,
                              "XA resource got XAER_NOTA (" + XAException.XAER_NOTA + ") during recovery. This happens when the XA resource previously committed successfully.",
-                             ivManagedConnection.mcf.helper.getXAExceptionContents(xae));
+                             ivManagedConnection.mcf.dataStoreHelper == null
+                                             ? ivManagedConnection.helper.getXAExceptionContents(xae)
+                                             : ivManagedConnection.mcf.dataStoreHelper.getXAExceptionContents(xae));
             } else {
                 FFDCFilter.processException(xae, "com.ibm.ws.rsadapter.spi.WSRdbXaResourceImpl.commit", "126", this);
                 traceXAException(xae, currClass);
@@ -1152,7 +1154,9 @@ public class WSRdbXaResourceImpl implements WSXAResource, FFDCSelfIntrospectable
      */
     public final XAException traceXAException(XAException xae, Class<?> callerClass) { 
 
-        String detailedMessage = ivManagedConnection.mcf.helper.getXAExceptionContents(xae); 
+        String detailedMessage = ivManagedConnection.mcf.dataStoreHelper == null
+                        ? ivManagedConnection.helper.getXAExceptionContents(xae)
+                        : ivManagedConnection.mcf.dataStoreHelper.getXAExceptionContents(xae);
         Tr.error(tc, "DISPLAY_XAEX_CONTENT", detailedMessage);
 
         Tr.error(tc, "THROW_XAEXCEPTION", new Object[]

--- a/dev/com.ibm.ws.jdbc_fat_heritage/fat/src/test/jdbc/heritage/HeritageJDBCTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/fat/src/test/jdbc/heritage/HeritageJDBCTest.java
@@ -10,6 +10,10 @@
  *******************************************************************************/
 package test.jdbc.heritage;
 
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -54,6 +58,13 @@ public class HeritageJDBCTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        try {
+            // Verify that DataStoreHelper getPrintWriter successfully overrides the
+            // JDBC trace location to System.out (appears in message.log),
+            List<String> found = server.findStringsInLogs(".*==> Connection.*.prepareStatement\\(\"VALUES \\('testDefaultQueryTimeout', SQRT\\(196\\)\\)\", 1003, 1007\\).*");
+            assertTrue(found.toString(), found.size() == 1);
+        } finally {
+            server.stopServer();
+        }
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_heritage/publish/servers/com.ibm.ws.jdbc.heritage/bootstrap.properties
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/publish/servers/com.ibm.ws.jdbc.heritage/bootstrap.properties
@@ -1,3 +1,3 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info=enabled:RRA=all
+com.ibm.ws.logging.trace.specification=*=info=enabled:RRA=all:com.ibm.ws.database.logwriter=all
 osgi.console=5678

--- a/dev/com.ibm.ws.jdbc_fat_heritage/publish/servers/com.ibm.ws.jdbc.heritage/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/publish/servers/com.ibm.ws.jdbc.heritage/server.xml
@@ -33,7 +33,7 @@
 
   <authData id="dbAuth" user="dbuser" password="{xor}Oz0vKDs=" />
 
-  <dataSource id="DefaultDataSource" containerAuthDataRef="dbAuth" queryTimeout="1m21s" type="javax.sql.DataSource">
+  <dataSource id="DefaultDataSource" containerAuthDataRef="dbAuth" queryTimeout="1m21s" supplementalJDBCTrace="true" type="javax.sql.DataSource">
     <jdbcDriver libraryRef="JDBCLib" javax.sql.DataSource="test.jdbc.heritage.driver.HDDataSource"/>
     <properties databaseName="memory:testdb" createDatabase="create"
                 supportsCatalog="false" supportsNetworkTimeout="false" supportsReadOnly="false" supportsSchema="false" supportsTypeMap="false"/>

--- a/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HDConnection.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HDConnection.java
@@ -307,7 +307,6 @@ public class HDConnection implements Connection, HeritageDBConnection {
      * information back to the application for testing purposes.
      */
     private String replace(String sql) {
-        System.out.println("In replace, the counts are CLEANUP:" + cleanupCount.get() + "; SETUP:" + setupCount.get());
         if ("CALL TEST.GET_CLEANUP_COUNT()".equalsIgnoreCase(sql))
             return "VALUES (" + cleanupCount.get() + ")";
 

--- a/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/helper/HDDataStoreHelper.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/helper/HDDataStoreHelper.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.security.auth.Subject;
+import javax.transaction.xa.XAException;
 
 import com.ibm.ws.jdbc.heritage.AccessIntent;
 import com.ibm.ws.jdbc.heritage.DataStoreHelperMetaData;
@@ -108,6 +109,12 @@ public class HDDataStoreHelper extends GenericDataStoreHelper {
     @Override
     public DataStoreHelperMetaData getMetaData() {
         return metadata;
+    }
+
+    @Override
+    public String getXAExceptionContents(XAException x) {
+        // This ought to be unreachable for non-xa-capable javax.sql.DataSource.
+        throw new UnsupportedOperationException("This driver does not provide an XADataSource.");
     }
 
     private Object readConfig(String fieldName) {

--- a/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/helper/HDDataStoreHelper.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/helper/HDDataStoreHelper.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package test.jdbc.heritage.driver.helper;
 
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -109,6 +111,12 @@ public class HDDataStoreHelper extends GenericDataStoreHelper {
     @Override
     public DataStoreHelperMetaData getMetaData() {
         return metadata;
+    }
+
+    @Override
+    public PrintWriter getPrintWriter() {
+        // Redirects to System.out instead of OpenLiberty trace, which will cause output to go into message.log where the test can scan for it
+        return new PrintWriter(new OutputStreamWriter(System.out));
     }
 
     @Override


### PR DESCRIPTION
Add integration points for legacy DataStoreHelper methods:
getXAExceptionContents
getPrintWriter (for swapping out how JDBC driver trace is logged)