### PR TITLE
Add flush to use of printwriter in the jwt builder fat

### DIFF
--- a/dev/com.ibm.ws.security.fat.common.jwt/src/com/ibm/ws/security/fat/common/jwt/utils/JWTApiApplicationUtils.java
+++ b/dev/com.ibm.ws.security.fat.common.jwt/src/com/ibm/ws/security/fat/common/jwt/utils/JWTApiApplicationUtils.java
@@ -45,7 +45,9 @@ public class JWTApiApplicationUtils {
      */
     public void logIt(PrintWriter pw, String msg) {
         System.out.println(msg);
+        System.out.flush();
         pw.print(msg + newLine);
+        pw.flush();
     }
 
     /***


### PR DESCRIPTION
When the builder test app runs, it builds a response with builder and token content - the response that is returned to the test app is truncated.
I'm going to add a flush to the routine that builds the response - I'm not convinced that it'll fix the issue (since the response has information from the beginning and end and is missing information from the middle - it shouldn't hurt...