### PR TITLE
JCA 1.7 FAT bucket not waiting for resource adapters to start

### DIFF
--- a/dev/com.ibm.ws.jca.1.7_fat/fat/src/com/ibm/ws/jca/fat/JCA17Test.java
+++ b/dev/com.ibm.ws.jca.1.7_fat/fat/src/com/ibm/ws/jca/fat/JCA17Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2020 IBM Corporation and others.
+ * Copyright (c) 2013, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -94,6 +94,12 @@ public class JCA17Test extends FATServletClient {
         ShrinkHelper.exportToServer(server, "apps", fvtapp_ear);
 
         server.startServer();
+
+        assertNotNull(server.waitForStringInLog("J2CA7001I.*ADO"));
+        assertNotNull(server.waitForStringInLog("J2CA7001I.*fvtapp.adapter"));
+        assertNotNull(server.waitForStringInLog("J2CA7001I.*HELLOWORLD1"));
+        assertNotNull(server.waitForStringInLog("J2CA7001I.*HELLOWORLD2"));
+        assertNotNull(server.waitForStringInLog("J2CA7001I.*ZRA"));
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.jca.1.7_fat/fat/src/com/ibm/ws/jca/fat/JCA17Test.java
+++ b/dev/com.ibm.ws.jca.1.7_fat/fat/src/com/ibm/ws/jca/fat/JCA17Test.java
@@ -93,6 +93,8 @@ public class JCA17Test extends FATServletClient {
         ShrinkHelper.exportToServer(server, "connectors", helloworldbeanra);
         ShrinkHelper.exportToServer(server, "apps", fvtapp_ear);
 
+        server.addInstalledAppForValidation("fvtapp");
+
         server.startServer();
 
         assertNotNull(server.waitForStringInLog("J2CA7001I.*ADO"));


### PR DESCRIPTION
JCA 1.7 FAT bucket needs to wait for resource adapters to finish installing before running tests.
Fixes #16148