### PR TITLE
Update Postgres Test Container initialization to address removal of d…

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerFactory.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerFactory.java
@@ -128,7 +128,7 @@ public class DatabaseContainerFactory {
                     cont.withExposedPorts(1521, 5500, 8080); // need to manually expose ports due to regression in 1.14.0
                     break;
                 case Postgres:
-                    cont = (JdbcDatabaseContainer<?>) clazz.getConstructor().newInstance();
+                    cont = (JdbcDatabaseContainer<?>) clazz.getConstructor(String.class).newInstance("postgres");
                     //This allows postgres by default to participate in XA transactions (2PC).
                     //Documentation on the Prepare Transaction action in postgres: https://www.postgresql.org/docs/9.3/sql-prepare-transaction.html
 


### PR DESCRIPTION
Noticed JPA tests using Postgres test container started failing:

```
Caused by: java.lang.RuntimeException: Unable to create a Postgres TestContainer instance.
	at componenttest.topology.database.container.DatabaseContainerFactory.initContainer(DatabaseContainerFactory.java:159)
	at componenttest.topology.database.container.DatabaseContainerFactory.create(DatabaseContainerFactory.java:91)
	at componenttest.topology.database.container.DatabaseContainerFactory.create(DatabaseContainerFactory.java:63)
	at com.ibm.ws.jpa.FATSuite.&lt;clinit&gt;(FATSuite.java:51)
Caused by: java.lang.NoSuchMethodException: componenttest.topology.database.container.PostgreSQLContainer.&lt;init&gt;()
	at java.base/java.lang.Class.getConstructor0(Class.java:3349)
	at java.base/java.lang.Class.getConstructor(Class.java:2151)
	at componenttest.topology.database.container.DatabaseContainerFactory.initContainer(DatabaseContainerFactory.java:131)
```

This appears due to an update to a newer version of Test Containers, and DatabaseContainerFactory's initialization of the Postgres container can no longer rely on the default constructor.