### PR TITLE
Fix test bug with MP JWT TCK FAT

### DIFF
--- a/dev/com.ibm.ws.security.mp.jwt_fat_tck/fat/src/org/eclipse/microprofile/jwt/tck/container/jaxrs/RolesAllowedTest.java
+++ b/dev/com.ibm.ws.security.mp.jwt_fat_tck/fat/src/org/eclipse/microprofile/jwt/tck/container/jaxrs/RolesAllowedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.
@@ -121,7 +121,7 @@ public class RolesAllowedTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server1.stopServer("CWWKS552[2-4]E");
+        server1.stopServer("CWWKS552[2-4]E", "CWWKS5604E");
     }
 
     @BeforeClass


### PR DESCRIPTION
Adds an allowed NLS message due to some test ordering changes that can evidently cause the CWWKS5604E message to be emitted if the `RolesAllowedTest.callHeartbeat()` test is run first.