### PR TITLE
Reduce JPA Query FAT's multi-line Exception cause string analysis to …

### DIFF
--- a/dev/com.ibm.ws.jpa_spec10_query_fat/test-applications/svlquery/src/com/ibm/ws/query/testlogic/JULoopQueryAnoTest.java
+++ b/dev/com.ibm.ws.jpa_spec10_query_fat/test-applications/svlquery/src/com/ibm/ws/query/testlogic/JULoopQueryAnoTest.java
@@ -28584,8 +28584,10 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
                     eStr = e.toString();
                 }
                 if (pvdr == JPAProviderImpl.ECLIPSELINK) {
-                    String lookFor = "An exception occurred while creating a query in EntityManager: \n" +
-                                     "Exception Description: Internal problem encountered while compiling [select new com.dw.test.Detail (e.empid, e.salary) from EmpBean e].";
+//                    String lookFor = "An exception occurred while creating a query in EntityManager: \n" +
+//                                     "Exception Description: Internal problem encountered while compiling [select new com.dw.test.Detail (e.empid, e.salary) from EmpBean e].";
+                    String lookFor = "Exception Description: Internal problem encountered while compiling [select new com.dw.test.Detail (e.empid, e.salary) from EmpBean e].";
+
                     System.out.println("eStr = " + eStr);
                     System.out.println("lookFor = " + lookFor);
                     boolean result = eStr.contains(lookFor);
@@ -28656,8 +28658,10 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
                     eStr = e.toString();
                 }
                 if (pvdr == JPAProviderImpl.ECLIPSELINK) {
-                    String lookFor = "An exception occurred while creating a query in EntityManager: \n" +
-                                     "Exception Description: Internal problem encountered while compiling [select new com.dw.test.Detail (max(e.empid), max(e.salary)) from EmpBean e].";
+//                    String lookFor = "An exception occurred while creating a query in EntityManager: \n" +
+//                                     "Exception Description: Internal problem encountered while compiling [select new com.dw.test.Detail (max(e.empid), max(e.salary)) from EmpBean e].";
+                    String lookFor = "Exception Description: Internal problem encountered while compiling [select new com.dw.test.Detail (max(e.empid), max(e.salary)) from EmpBean e].";
+
                     System.out.println("eStr = " + eStr);
                     System.out.println("lookFor = " + lookFor);
                     boolean result = eStr.contains(lookFor);
@@ -28785,8 +28789,9 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
                     eStr = e.toString();
                 }
                 if (pvdr == JPAProviderImpl.ECLIPSELINK) {
-                    String lookFor = "An exception occurred while creating a query in EntityManager: \n" +
-                                     "Exception Description: Problem compiling [select new com.ibm.ws.query.utils.SimpleDeptEmpView (d.deptno, d.name) from DeptBean d ].";
+//                    String lookFor = "An exception occurred while creating a query in EntityManager: \n" +
+//                                     "Exception Description: Problem compiling [select new com.ibm.ws.query.utils.SimpleDeptEmpView (d.deptno, d.name) from DeptBean d ].";
+                    String lookFor = "Exception Description: Problem compiling [select new com.ibm.ws.query.utils.SimpleDeptEmpView (d.deptno, d.name) from DeptBean d ].";
                     System.out.println("eStr = " + eStr);
                     System.out.println("lookFor = " + lookFor);
                     boolean result = eStr.contains(lookFor);
@@ -29167,8 +29172,10 @@ public class JULoopQueryAnoTest extends AbstractTestLogic {
                     eStr = e.toString();
                 }
                 if (pvdr == JPAProviderImpl.ECLIPSELINK) {
-                    String lookFor = "Problem compiling [select new com.ibm.ws.query.utils.DeptEmpListView (d.no, d.name, d.budget, d.emps ) from DeptBean d ]. \n" +
-                                     "[74, 80] The state field path 'd.emps' cannot be resolved to a collection type.";
+//                    String lookFor = "Problem compiling [select new com.ibm.ws.query.utils.DeptEmpListView (d.no, d.name, d.budget, d.emps ) from DeptBean d ]. \n" +
+//                                     "[74, 80] The state field path 'd.emps' cannot be resolved to a collection type.";
+                    String lookFor = "[74, 80] The state field path 'd.emps' cannot be resolved to a collection type.";
+
                     System.out.println("eStr = " + eStr);
                     System.out.println("lookFor = " + lookFor);
                     boolean result = eStr.contains(lookFor);

--- a/dev/com.ibm.ws.jpa_spec10_query_fat/test-applications/svlquery/src/com/ibm/ws/query/testlogic/JULoopQueryXMLTest.java
+++ b/dev/com.ibm.ws.jpa_spec10_query_fat/test-applications/svlquery/src/com/ibm/ws/query/testlogic/JULoopQueryXMLTest.java
@@ -30943,8 +30943,9 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
                     eStr = e.toString();
                 }
                 if (pvdr == JPAProviderImpl.ECLIPSELINK) {
-                    String lookFor = "An exception occurred while creating a query in EntityManager: \n" +
-                                     "Exception Description: Internal problem encountered while compiling [select new com.dw.test.Detail (e.empid, e.salary) from EmpBean e].";
+//                    String lookFor = "An exception occurred while creating a query in EntityManager: \n" +
+//                                     "Exception Description: Internal problem encountered while compiling [select new com.dw.test.Detail (e.empid, e.salary) from EmpBean e].";
+                    String lookFor = "Exception Description: Internal problem encountered while compiling [select new com.dw.test.Detail (e.empid, e.salary) from EmpBean e].";
                     System.out.println("eStr = " + eStr);
                     System.out.println("lookFor = " + lookFor);
                     boolean result = eStr.contains(lookFor);
@@ -31020,8 +31021,9 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
                     eStr = e.toString();
                 }
                 if (pvdr == JPAProviderImpl.ECLIPSELINK) {
-                    String lookFor = "An exception occurred while creating a query in EntityManager: \n" +
-                                     "Exception Description: Internal problem encountered while compiling [select new com.dw.test.Detail (max(e.empid), max(e.salary)) from EmpBean e].";
+//                    String lookFor = "An exception occurred while creating a query in EntityManager: \n" +
+//                                     "Exception Description: Internal problem encountered while compiling [select new com.dw.test.Detail (max(e.empid), max(e.salary)) from EmpBean e].";
+                    String lookFor = "Exception Description: Internal problem encountered while compiling [select new com.dw.test.Detail (max(e.empid), max(e.salary)) from EmpBean e].";
                     System.out.println("eStr = " + eStr);
                     System.out.println("lookFor = " + lookFor);
                     boolean result = eStr.contains(lookFor);
@@ -31159,8 +31161,10 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
                     eStr = e.toString();
                 }
                 if (pvdr == JPAProviderImpl.ECLIPSELINK) {
-                    String lookFor = "An exception occurred while creating a query in EntityManager: \n" +
-                                     "Exception Description: Problem compiling [select new com.ibm.ws.query.utils.SimpleDeptEmpView (d.deptno, d.name) from DeptBean d ].";
+//                    String lookFor = "An exception occurred while creating a query in EntityManager: \n" +
+//                                     "Exception Description: Problem compiling [select new com.ibm.ws.query.utils.SimpleDeptEmpView (d.deptno, d.name) from DeptBean d ].";
+                    String lookFor = "Exception Description: Problem compiling [select new com.ibm.ws.query.utils.SimpleDeptEmpView (d.deptno, d.name) from DeptBean d ].";
+
                     System.out.println("eStr = " + eStr);
                     System.out.println("lookFor = " + lookFor);
                     boolean result = eStr.contains(lookFor);
@@ -31571,8 +31575,10 @@ public class JULoopQueryXMLTest extends AbstractTestLogic {
                     eStr = e.toString();
                 }
                 if (pvdr == JPAProviderImpl.ECLIPSELINK) {
-                    String lookFor = "Problem compiling [select new com.ibm.ws.query.utils.DeptEmpListView (d.no, d.name, d.budget, d.emps ) from DeptBean d ]. \n" +
-                                     "[74, 80] The state field path 'd.emps' cannot be resolved to a collection type.";
+//                    String lookFor = "Problem compiling [select new com.ibm.ws.query.utils.DeptEmpListView (d.no, d.name, d.budget, d.emps ) from DeptBean d ]. \n" +
+//                                     "[74, 80] The state field path 'd.emps' cannot be resolved to a collection type.";
+                    String lookFor = "[74, 80] The state field path 'd.emps' cannot be resolved to a collection type.";
+
                     System.out.println("eStr = " + eStr);
                     System.out.println("lookFor = " + lookFor);
                     boolean result = eStr.contains(lookFor);


### PR DESCRIPTION
It's possible for on Windows systems, for the multi-line String comparison for the Exception cause to fail because of differing new-line encodings.  Reduced the string comparison to a single line while still searching for the essential message parts.