### PR TITLE
Remove duplicate flushBuffer in AbstractHTTPDestination

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.2.6.2/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.2.6.2/src/org/apache/cxf/transport/http/AbstractHTTPDestination.java
@@ -707,8 +707,9 @@ public abstract class AbstractHTTPDestination
                 }
             }
             if (wrappedStream != null) {
+                // Liberty Change - Back port of CXF Fix: 
+                // closing the stream should indirectly call the servlet response's flushBuffer
                 wrappedStream.close();
-                response.flushBuffer();
             }
             /*
             try {


### PR DESCRIPTION
CXF's fixed an issue in AbstractHTTPDestination, we need to back port this fix to CXF 2.6.2 to prevent duplicate calls to flushBuffer(). 