### PR TITLE
Remove extra FAT from category

### DIFF
--- a/.github/test-categories/TRANSACTION_3
+++ b/.github/test-categories/TRANSACTION_3
@@ -2,6 +2,5 @@ com.ibm.ws.transaction.db_fat
 com.ibm.ws.transaction.recovery_fat.1
 com.ibm.ws.transaction.recovery_fat.2
 com.ibm.ws.transaction.recovery_fat.3
-com.ibm.ws.transaction.SQLServerHADB_fat
 com.ibm.ws.tx.jta_fat
 com.ibm.ws.tx.jta_fat_hibernate


### PR DESCRIPTION
com.ibm.ws.transaction.SQLServerHADB_fat
was listed in both TRANSACTION_1 and TRANSACTION_3 categories.  It can only be in one. 
