### PR TITLE
allow shibboleth to run with Java 16

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/ShibbolethHelpers.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/ShibbolethHelpers.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.fat.common;
 
@@ -74,9 +74,9 @@ public class ShibbolethHelpers {
             def_port = realPort1;
         }
         String def_ssl_port = System.getProperty("ldap.1.ssl.port");
-//        if (realSSLPort != null) {
-//            def_ssl_port = realSSLPort;
-//        }
+        //        if (realSSLPort != null) {
+        //            def_ssl_port = realSSLPort;
+        //        }
         String def_host = "localhost";
         String def_url = "ldap://" + def_host + ":" + def_port;
         String def_princ = "uid=admin,ou=system";
@@ -186,6 +186,7 @@ public class ShibbolethHelpers {
         String logLoc = server.getServer().getLogsRoot().replace("\\", "/");
         bootstrapUtils.writeBootstrapProperty(server, "was.idp.logs", logLoc);
         fixShibbolethJDKSettings(server, curDir);
+        fixShibbolethJvmOptions(server);
 
     }
 
@@ -442,7 +443,7 @@ public class ShibbolethHelpers {
         // third parm is null and will result in the specified file to be updated instead of updated on the file copy
         cioTools.replaceStringsInFile(confHome + "/idp.properties", replaceVarMap, null);
 
-//      String metadataHome = shibbolethHome + "/metadata";
+        //      String metadataHome = shibbolethHome + "/metadata";
 
     }
 
@@ -458,4 +459,11 @@ public class ShibbolethHelpers {
         return new File(".").getAbsoluteFile().getCanonicalPath().replace("\\", "/") + "/shibboleth-idp";
     }
 
+    public void fixShibbolethJvmOptions(TestServer server) throws Exception {
+
+        if (!System.getProperty("java.specification.version").matches("1\\.[78]")) {
+            bootstrapUtils.writeJvmOptionProperty(server, "--add-opens", "java.xml/com.sun.org.apache.xerces.internal.util=ALL-UNNAMED");
+        }
+
+    }
 }

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/TestServer.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/TestServer.java
@@ -1300,4 +1300,11 @@ public class TestServer extends ExternalResource {
         Properties serverProperties = this.getServer().getBootstrapProperties();
         return serverProperties.getProperty(key, null);
     }
+    
+    public String getJvmOptionsFilePath() throws Exception {
+        String thisMethod = "getJvmOptionsFilePath";
+        String jvmProps = getServerFileLoc() + "/jvm.options";
+        Log.info(thisClass, thisMethod, "jvm.options property file path: " + jvmProps);
+        return jvmProps;
+    }
 }

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/servers/ServerBootstrapUtils.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/servers/ServerBootstrapUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -36,7 +36,7 @@ public class ServerBootstrapUtils {
     public void writeBootstrapProperty(TestServer server, String propKey, String propValue) throws Exception {
         writeBootstrapProperty(server.getServer(), propKey, propValue);
     }
-    
+
     /**
      * Writes the specified bootstrap property and value to the provided server's bootstrap.properties file.
      */
@@ -60,7 +60,6 @@ public class ServerBootstrapUtils {
             appendBootstrapPropertyToFile(bootPropFilePath, entry.getKey(), entry.getValue(), doNotLog);
         }
     }
-    
 
     /**
      * Writes each of the specified bootstrap properties and values to the provided server's bootstrap.properties file.
@@ -68,7 +67,7 @@ public class ServerBootstrapUtils {
     public void writeBootstrapProperties(TestServer server, Map<String, String> miscParms) throws Exception {
         writeBootstrapProperties(server.getServer(), miscParms);
     }
-    
+
     /**
      * Writes each of the specified bootstrap properties and values to the provided server's bootstrap.properties file.
      * Please use this method when including passwords and or user information.
@@ -107,5 +106,25 @@ public class ServerBootstrapUtils {
         String bootProps = serverFileUtils.getServerFileLoc(server) + "/bootstrap.properties";
         Log.info(thisClass, thisMethod, "Bootstrap property file path: " + bootProps);
         return bootProps;
+    }
+
+    /**
+     * Writes the specified bootstrap property and value to the provided server's bootstrap.properties file.
+     */
+    public void writeJvmOptionProperty(TestServer server, String propKey, String propValue) throws Exception {
+        String jvmProps = server.getJvmOptionsFilePath();
+        appendJvmOptionToFile(jvmProps, propKey, propValue);
+    }
+
+    private void appendJvmOptionToFile(String propertyFilePath, String propKey, String propValue) throws IOException {
+        String thisMethod = "appendJvmOptionToFile";
+        String newPropAndValue = createBootstrapPropertyString(propKey, propValue);
+        Log.info(thisClass, thisMethod, "Adding " + newPropAndValue + " to bootstrap.properties");
+
+        FileWriter writer = new FileWriter(propertyFilePath, true);
+        writer.append(System.getProperty("line.separator"));
+        writer.append(createBootstrapPropertyString(propKey, propValue));
+        writer.append(System.getProperty("line.separator"));
+        writer.close();
     }
 }

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/SAMLCommon.gradle
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/SAMLCommon.gradle
@@ -33,7 +33,8 @@ dependencies {
                'commons-logging:commons-logging:1.1.1',
                'httpunit:httpunit:1.6.2',                           // 1.7 has issues noted above
                'jtidy:jtidy:4aug2000r7-dev',
-               'rhino:js:1.6R5'
+               'rhino:js:1.6R5',
+               'xml-apis:xml-apis:1.4.01'
               
   /*
    * Previously we had an uber jar named htmlunit-2.20-OSGi.jar. It appears to have contained all of

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/build.gradle
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/build.gradle
@@ -22,6 +22,7 @@ dependencies {
                'httpunit:httpunit:1.6.2',                           
                'jtidy:jtidy:4aug2000r7-dev',
                'rhino:js:1.6R5',
+               'xml-apis:xml-apis:1.4.01',
                'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
                'org.brotli:dec:0.1.2',
                'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/build.gradle
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml/build.gradle
@@ -22,6 +22,7 @@ dependencies {
                'httpunit:httpunit:1.6.2',                           
                'jtidy:jtidy:4aug2000r7-dev',
                'rhino:js:1.6R5',
+               'xml-apis:xml-apis:1.4.01',
                'net.sourceforge.htmlunit:htmlunit-cssparser:1.6.0',
                'org.brotli:dec:0.1.2',
                'net.sourceforge.htmlunit:htmlunit-core-js:2.44.0',


### PR DESCRIPTION
Add --add-opens=java.xml/com.sun.org.apache.xerces.internal.util=ALL-UNNAMED to the com.ibm.ws.security.saml.sso-2.0_fat.shibboleth/jvm.options file.
We're investigating upgrading the shibboleth server that we embed for testing - in the meantine this jvm.options file update will allow us to run with Java16.
