### PR TITLE
Issue #16184: Fix EJB Timer DST Adjustment

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.interceptor_fat/fat/src/com/ibm/ws/ejbcontainer/interceptor/fat/AroundTimeoutTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.interceptor_fat/fat/src/com/ibm/ws/ejbcontainer/interceptor/fat/AroundTimeoutTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -57,15 +57,7 @@ import componenttest.topology.utils.FATServletClient;
 public class AroundTimeoutTest extends FATServletClient {
     private static final Logger logger = Logger.getLogger(AroundTimeoutTest.class.getCanonicalName());
     private static final Set<String> skipWhenLeavingDaylightSavings = new HashSet<String>( //
-                    Arrays.asList("testAdvancedAroundTimeoutInterceptorScheduleAnn", //
-                                  "testAdvancedAroundTimeoutInterceptorScheduleMix", //
-                                  "testAdvancedAroundTimeoutInterceptorScheduleXml", //
-                                  "testAroundTimeoutScheduleAppEx", //
-                                  "testAroundTimeoutScheduleNoEx", //
-                                  "testInheritedAroundTimeoutAnn", //
-                                  "testInheritedTimeoutCallbackAnn", //
-                                  "testMDBNonPersistentAutomaticTimerInterceptorsAnn", //
-                                  "testMDBPersistentAutomaticTimerInterceptorsAnn"));
+                    Arrays.asList("No tests currently skipped for DST"));
     private static boolean leavingDaylightSavings = false;
 
     @Server("com.ibm.ws.ejbcontainer.interceptor.fat.AroundTimeoutServer")

--- a/dev/com.ibm.ws.ejbcontainer.timer.auto_fat/fat/src/com/ibm/ws/ejbcontainer/timer/auto/fat/tests/AutoCreatedNPTimerTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.auto_fat/fat/src/com/ibm/ws/ejbcontainer/timer/auto/fat/tests/AutoCreatedNPTimerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2020 IBM Corporation and others.
+ * Copyright (c) 2013, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -47,6 +47,7 @@ public class AutoCreatedNPTimerTest extends FATServletClient {
     private static final String SERVLET = "AutoNPTimersWeb/AutoCreatedNPTimerServlet";
     private static final Logger logger = Logger.getLogger(AutoCreatedNPTimerTest.class.getCanonicalName());
 
+    private static boolean allowDaylightSavingsSkip = false;
     private static boolean skipTest = false;
 
     @Server("AutoNPTimerServer")
@@ -107,6 +108,10 @@ public class AutoCreatedNPTimerTest extends FATServletClient {
     }
 
     public static boolean leavingDaylightSavings() {
+        if (!allowDaylightSavingsSkip) {
+            return false;
+        }
+
         // Check if leaving daylight savings using local timezone
         ZonedDateTime now = ZonedDateTime.now();
         ZoneRules zoneRules = now.getZone().getRules();


### PR DESCRIPTION
Repeating EJB timers are not properly running through the first hour of
the fall daylight savings adjustment; they only run during the second
occurrence of 1AM, not the first 1AM.

An adjustment is made to getNextTimeout to ensure it properly advances
through both occurrences of 1AM during the DST fall adjustment.

fixes #16184 