### PR TITLE
Ignore error messages when the same application tries to to come up t…

### DIFF
--- a/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/fat/src/com/ibm/ws/webcontainer/security/jacc15/fat/BasicAuthTest.java
+++ b/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/fat/src/com/ibm/ws/webcontainer/security/jacc15/fat/BasicAuthTest.java
@@ -104,7 +104,7 @@ public class BasicAuthTest extends CommonServletTestScenarios {
     @AfterClass
     public static void tearDown() throws Exception {
         try {
-            myServer.stopServer("CWWKS5524E");
+            myServer.stopServer("CWWKZ0013E");
         } finally {
             JACCFatUtils.uninstallJaccUserFeature(myServer);
         }


### PR DESCRIPTION
…wice. This can occur when we are doing dynamic server configuration updates.

This fix overrides that made in #15718.