### PR TITLE
Added wait message for ltpa keys 

### DIFF
--- a/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/SecureTest.java
+++ b/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/SecureTest.java
@@ -109,6 +109,8 @@ public class SecureTest extends LoggingTest {
         bwst.setUp();
         // tests cannot work until ssl is up
         wlp.waitForStringInLog("CWWKO0219I:.*ssl.*");
+        // tests cannot work until ltpa keys are created
+        wlp.waitForStringInLog("CWWKS4104A:.*LTPA keys created.*");
     }
 
     @AfterClass

--- a/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/SecureTest.java
+++ b/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/SecureTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -107,10 +107,10 @@ public class SecureTest extends LoggingTest {
         SS.startIfNotStarted();
         wlp.waitForStringInLog("CWWKZ0001I.* " + SECURE_WAR_NAME);
         bwst.setUp();
+        // Make sure LTPA configuration is completed
+        wlp.waitForStringInLog("CWWKS4105I:.*configuration is ready.*");
         // tests cannot work until ssl is up
         wlp.waitForStringInLog("CWWKO0219I:.*ssl.*");
-        // tests cannot work until ltpa keys are created
-        wlp.waitForStringInLog("CWWKS4104A:.*LTPA keys created.*");
     }
 
     @AfterClass


### PR DESCRIPTION
Added wait message for ltpa keys to check ltpa keys were created before running the tests. Possible fix for BB 282097
fixes #16340 