### PR TITLE
Enable parallel activation for more features

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.beanValidationCDI-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.beanValidationCDI-2.0.feature
@@ -11,3 +11,4 @@ IBM-Install-Policy: when-satisfied
   com.ibm.ws.org.hibernate.validator.cdi
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jakarta-jdbc-4.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jakarta-jdbc-4.1.feature
@@ -9,3 +9,4 @@ IBM-Install-Policy: when-satisfied
  com.ibm.ws.jdbc.4.1.jakarta
 kind=beta
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jakarta-jdbc-4.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jakarta-jdbc-4.2.feature
@@ -10,3 +10,4 @@ IBM-Install-Policy: when-satisfied
  com.ibm.ws.jdbc.4.2.jakarta
 kind=beta
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jakarta-jdbc-4.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jakarta-jdbc-4.3.feature
@@ -11,3 +11,4 @@ IBM-Install-Policy: when-satisfied
  com.ibm.ws.jdbc.4.3.jakarta
 kind=beta
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.javaee-jdbc-4.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.javaee-jdbc-4.1.feature
@@ -9,3 +9,4 @@ IBM-Install-Policy: when-satisfied
  com.ibm.ws.jdbc.4.1
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.javaee-jdbc-4.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.javaee-jdbc-4.2.feature
@@ -10,3 +10,4 @@ IBM-Install-Policy: when-satisfied
  com.ibm.ws.jdbc.4.2
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.javaee-jdbc-4.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.javaee-jdbc-4.3.feature
@@ -11,3 +11,4 @@ IBM-Install-Policy: when-satisfied
  com.ibm.ws.jdbc.4.3
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jpa2.2-bv2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jpa2.2-bv2.0.feature
@@ -10,3 +10,4 @@ IBM-Provision-Capability: \
 IBM-Install-Policy: when-satisfied
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jpaContainer-cdi.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.jpaContainer-cdi.feature
@@ -10,3 +10,4 @@ IBM-Provision-Capability: \
 IBM-Install-Policy: when-satisfied
 kind=ga
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.beanValidationCDI-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.beanValidationCDI-3.0.feature
@@ -11,3 +11,4 @@ IBM-Install-Policy: when-satisfied
   io.openliberty.org.hibernate.validator.cdi.7.0
 kind=beta
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.jpa3.0-bv3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.jpa3.0-bv3.0.feature
@@ -10,3 +10,4 @@ IBM-Provision-Capability: \
 IBM-Install-Policy: when-satisfied
 kind=beta
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.jpaContainer-cdi.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.jpaContainer-cdi.feature
@@ -10,3 +10,4 @@ IBM-Provision-Capability: \
 IBM-Install-Policy: when-satisfied
 kind=beta
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.messaging.defaultresource-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.messaging.defaultresource-3.0.feature
@@ -9,3 +9,4 @@ IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature
 IBM-Install-Policy: when-satisfied
 kind=beta
 edition=base
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.restfulWS3.0-validator3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.restfulWS3.0-validator3.0.feature
@@ -8,3 +8,4 @@ visibility=private
 IBM-Install-Policy: when-satisfied
 kind=beta
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.restfulWS3.0-xmlBinding3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.restfulWS3.0-xmlBinding3.0.feature
@@ -7,3 +7,4 @@ IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature
 IBM-Install-Policy: when-satisfied
 kind=beta
 edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.restfulWSClient3.0-globalhandler2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.restfulWSClient3.0-globalhandler2.0.feature
@@ -7,3 +7,4 @@
  IBM-Install-Policy: when-satisfied
  kind=beta
  edition=core
+ WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jaxb-2.3/com.ibm.websphere.appserver.jaxb-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jaxb-2.3/com.ibm.websphere.appserver.jaxb-2.3.feature
@@ -31,3 +31,4 @@ Subsystem-Name: Java XML Bindings 2.3
   bin/jaxb/schemagen.bat
 kind=noship
 edition=full
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jdbc-4.3/com.ibm.websphere.appserver.jdbc-4.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jdbc-4.3/com.ibm.websphere.appserver.jdbc-4.3.feature
@@ -17,3 +17,4 @@ Subsystem-Name: Java Database Connectivity 4.3
   com.ibm.ws.jdbc.metatype
 kind=ga
 edition=core
+WLP-Activation-Type: parallel


### PR DESCRIPTION
- Enable parallel activation for auto features that are related to features that have parallel activation enabled.  This is done for the 8.0 and 9.0 version of the auto features.
- Enable parallel activation for jaxb-2.3 and jdbc-4.3.