### PR TITLE
Updates to SAF registry auth

### DIFF
--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/jaas/modules/UsernameAndPasswordLoginModule.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/jaas/modules/UsernameAndPasswordLoginModule.java
@@ -28,10 +28,11 @@ import com.ibm.websphere.security.auth.WSLoginFailedException;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.AccessIdUtil;
 import com.ibm.ws.security.authentication.AuthenticationException;
-import com.ibm.ws.security.authentication.UserRevokedException;
 import com.ibm.ws.security.authentication.PasswordExpiredException;
+import com.ibm.ws.security.authentication.UserRevokedException;
 import com.ibm.ws.security.authentication.internal.jaas.modules.ServerCommonLoginModule;
 import com.ibm.ws.security.authentication.principals.WSPrincipal;
+import com.ibm.ws.security.context.SubjectRegistryManager;
 import com.ibm.ws.security.registry.UserRegistry;
 
 /**
@@ -74,8 +75,16 @@ public class UsernameAndPasswordLoginModule extends ServerCommonLoginModule impl
             userRegistry = getUserRegistry();
             urAuthenticatedId = userRegistry.checkPassword(user, String.valueOf(passwordChars));
             if (urAuthenticatedId != null) {
-                username = getSecurityName(user, urAuthenticatedId);
-                setUpTemporarySubject();
+                try {
+                    //We only need to start registry detection if there is a SAF registry configured
+                    //This method doesn't provide information about the user logging in, only
+                    //that there is a SAF registry.
+                    SubjectRegistryManager.startSubjectRegistryDetectionOnZOS();
+                    username = getSecurityName(user, urAuthenticatedId);
+                    setUpTemporarySubject();
+                } finally {
+                    SubjectRegistryManager.clearSubjectRegistryDetectionOnZOS();
+                }
                 updateSharedState();
                 return true;
             } else {
@@ -86,13 +95,11 @@ public class UsernameAndPasswordLoginModule extends ServerCommonLoginModule impl
                                                                                new Object[] { user },
                                                                                "CWWKS1100A: Authentication failed for the userid {0}. A bad userid and/or password was specified."));
             }
-        } 
-        catch (com.ibm.ws.security.registry.PasswordExpiredException e) {
+        } catch (com.ibm.ws.security.registry.PasswordExpiredException e) {
             throw new PasswordExpiredException(e.getLocalizedMessage(), e);
         } catch (com.ibm.ws.security.registry.UserRevokedException e) {
             throw new UserRevokedException(e.getLocalizedMessage(), e);
-        } 
-        catch (AuthenticationException e) {
+        } catch (AuthenticationException e) {
 
             // NO FFDC: AuthenticationExceptions are expected (bad userid/password is pretty normal)
             throw e; // no-need to wrap

--- a/dev/com.ibm.ws.security.wim.registry/bnd.bnd
+++ b/dev/com.ibm.ws.security.wim.registry/bnd.bnd
@@ -33,6 +33,7 @@ IBM-Default-Config: OSGI-INF/wlp/defaultInstances.xml
 instrument.classesExcludes: com/ibm/ws/security/wim/registry/util/resources/*.class
 
 -buildpath: \
+	com.ibm.ws.security;version=latest,\
 	com.ibm.ws.security.wim.core;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.websphere.org.osgi.service.component;version=latest,\

--- a/dev/com.ibm.ws.security/src/com/ibm/ws/security/context/SubjectRegistryManager.java
+++ b/dev/com.ibm.ws.security/src/com/ibm/ws/security/context/SubjectRegistryManager.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.context;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.security.context.internal.SubjectRegistryThreadContext;
+
+/**
+ * The SubjectRegistryManager sets and gets caller/invocation subject information
+ * off the thread and provides the ability to clear the subject registry info off the thread.
+ * See {@link SubjectRegistryThreadContext} for more information.
+ */
+public class SubjectRegistryManager {
+
+    private static ThreadLocal<SubjectRegistryThreadContext> threadLocal = new SecurityThreadLocal();
+
+    /**
+     * Gets the subject registry thread context that is unique per thread.
+     * If/when a common thread storage framework is supplied, then this method
+     * implementation may need to be updated to take it into consideration.
+     *
+     * @return the subject registry thread context.
+     */
+    @Trivial
+    private static SubjectRegistryThreadContext getSubjectRegistryThreadContext() {
+        ThreadLocal<SubjectRegistryThreadContext> currentThreadLocal = getThreadLocal();
+        SubjectRegistryThreadContext subjectRegistryThreadContext = currentThreadLocal.get();
+        if (subjectRegistryThreadContext == null) {
+            subjectRegistryThreadContext = new SubjectRegistryThreadContext();
+            currentThreadLocal.set(subjectRegistryThreadContext);
+        }
+        return subjectRegistryThreadContext;
+    }
+
+    /**
+     * Set whether or not the subject is from the SAF registry.
+     *
+     * @param isSAF True if the subject is from the SAF registry.
+     */
+    public static void setSubjectIsSAF(boolean isSAF) {
+        if (!isZOS()) {
+            return;
+        }
+        SubjectRegistryThreadContext subjectRegistryThreadContext = getSubjectRegistryThreadContext();
+        subjectRegistryThreadContext.setIsSAF(isSAF);
+    }
+
+    /**
+     * Start subject registry detection. This is only required if a SAF
+     * registry is configured.
+     *
+     * @param isSAFRegistryConfigured
+     */
+    public static void startSubjectRegistryDetectionOnZOS() {
+        if (!isZOS()) {
+            return;
+        }
+        SubjectRegistryThreadContext subjectRegistryThreadContext = getSubjectRegistryThreadContext();
+        subjectRegistryThreadContext.detect();
+    }
+
+    /**
+     * Clear the subject registry detection. This is only required if a SAF
+     * registry is configured.
+     *
+     * @param isSAFRegistryConfigured
+     */
+    public static void clearSubjectRegistryDetectionOnZOS() {
+        if (!isZOS()) {
+            return;
+        }
+        SubjectRegistryThreadContext subjectRegistryThreadContext = getSubjectRegistryThreadContext();
+        subjectRegistryThreadContext.donotdetect();
+    }
+
+    /**
+     * Determine if a SAF credential should be created.
+     * The instances when a SAF credential should be
+     * created are:
+     * <ol>
+     * <li>SAF registry is configured and subject is from the SAF registry</li>
+     * <li>mapDistributedIdentities is true</li>
+     * <li>Subject is from the OS registry (and not logging in)</li>
+     * </ol>
+     *
+     * @return True if a SAF credential should be created and false if it should not
+     */
+    public static boolean isCreateSAFCredential() {
+        if (!isZOS()) {
+            return false;
+        }
+        SubjectRegistryThreadContext subjectRegistryThreadContext = getSubjectRegistryThreadContext();
+        return subjectRegistryThreadContext.isCreateSAFCredential();
+    }
+
+    /**
+     * Gets the thread local object.
+     * If/when a common thread storage framework is supplied, then this method
+     * implementation may need to be updated to take it into consideration.
+     *
+     * @return the thread local object.
+     */
+    @Trivial
+    private static ThreadLocal<SubjectRegistryThreadContext> getThreadLocal() {
+        return threadLocal;
+    }
+
+    /**
+     * Initialize the thread local object.
+     */
+    private static final class SecurityThreadLocal extends ThreadLocal<SubjectRegistryThreadContext> {
+        @Override
+        protected SubjectRegistryThreadContext initialValue() {
+            return new SubjectRegistryThreadContext();
+        }
+    }
+
+    /**
+     * Check if this is z/OS
+     *
+     * @return true if on z/OS
+     */
+    private static final boolean isZOS() {
+        String osName = System.getProperty("os.name");
+        if (osName.contains("OS/390") || osName.contains("z/OS") || osName.contains("zOS")) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/dev/com.ibm.ws.security/src/com/ibm/ws/security/context/internal/SubjectRegistryThreadContext.java
+++ b/dev/com.ibm.ws.security/src/com/ibm/ws/security/context/internal/SubjectRegistryThreadContext.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.context.internal;
+
+/**
+ * The thread context that holds the registry information for a subject.
+ * This is used to determine whether or not to create a SAF credential
+ * after authenticating. The instances when a SAF credential should be
+ * created are:
+ * <ol>
+ * <li>SAF registry is configured and subject is from the SAF registry</li>
+ * <li>mapDistributedIdentities is true</li>
+ * <li>Subject is from the OS registry (and not logging in)</li>
+ * </ol>
+ *
+ * The subject's registry is determined by following the subject's login
+ * path. In {@link UsernameAndPasswordLoginModule#login()}, start registry
+ * detection in a try/catch (DETECT). In getUserSecurityName, the SAFRegistry or
+ * SAFAuthorizedRegistry will be called if the user is from the SAF registry.
+ * Set the thread context in those classes to IS_SAF.
+ * <p>
+ * When SAFCredentialsServiceImpl.setCredential is called, the thread context
+ * is checked. If the value is DONT_DETECT, the subject is not logging in.
+ * This is the case for OS registry users, and they should create a credential.
+ * If the value is DETECT, the SAFRegistry classes were not accessed, meaning
+ * the subject is not from the SAF registry. In this case, do not attempt to
+ * create the credential. Lastly, IS_SAF means create the credential.
+ */
+public class SubjectRegistryThreadContext {
+
+    /**
+     * This is used to determine where we are in a user's login.
+     * When login begins, we DETECT. Once we see we are in the
+     * SAF registry, set IS_SAF or NOT_SAF. After login completes, DONT_DETECT.
+     */
+    private enum SAFDetectEnum {
+        DONT_DETECT,
+        DETECT,
+        IS_SAF,
+        NOT_SAF
+    }
+
+    /**
+     * This is used to determine where we are in a user's login.
+     * When login begins, we DETECT. Once we see we are in the
+     * SAF registry, set IS_SAF. After login completes, DONT_DETECT.
+     */
+    private SAFDetectEnum SAFDetector = SAFDetectEnum.DONT_DETECT;
+
+    /**
+     * Set the SAFDetector when the registry is known.
+     *
+     * @param isSAF True if the user is from the SAF registry.
+     */
+    public void setIsSAF(boolean isSAF) {
+        if (SAFDetector == SAFDetectEnum.DETECT) {
+            if (isSAF) {
+                SAFDetector = SAFDetectEnum.IS_SAF;
+            } else {
+                SAFDetector = SAFDetectEnum.NOT_SAF;
+            }
+        }
+    }
+
+    /**
+     * Stop detection. This is called when login is complete or
+     * there was an error.
+     */
+    public void donotdetect() {
+        SAFDetector = SAFDetectEnum.DONT_DETECT;
+    }
+
+    /**
+     * Start detection. This is called at the beginning of a login.
+     * This means the subject is not the initial OS subject.
+     */
+    public void detect() {
+        SAFDetector = SAFDetectEnum.DETECT;
+    }
+
+    /**
+     * Determine if the credential should be created. The credential
+     * should be created if detection has not started (DONT_DETECT)
+     * or if we have a SAF user.
+     *
+     * @return True if the credential should be created and False if
+     *         it should not.
+     */
+    public boolean isCreateSAFCredential() {
+        return SAFDetector == SAFDetectEnum.DONT_DETECT || SAFDetector == SAFDetectEnum.IS_SAF;
+    }
+
+}


### PR DESCRIPTION
fixes #16637 

A SAFException is thrown when a user is logging in.
This is a specific scenario when a user has:
- SAF registry
- Any additional registry inside a federated registry
- No element
When a non-SAF user attempts login, a SAFException is thrown when the z/os credential is being created:
```
com.ibm.ws.security.saf.SAFException: CWWKS2910E: SAF service WAS_INTERNAL did not succeed. SAF return code 0xffffffff. RACF return code 0xffffffff. RACF reason code 0xffffffff. Internal error code 0x00000001.
	at com.ibm.ws.security.saf.SAFServiceResult.getSAFException(SAFServiceResult.java:323)
	at com.ibm.ws.security.saf.SAFServiceResult.throwSAFException(SAFServiceResult.java:315)
	at com.ibm.ws.security.credentials.saf.internal.SAFCredentialsServiceImpl.createAssertedCredentialToken(SAFCredentialsServiceImpl.java:562)
	at com.ibm.ws.security.credentials.saf.internal.SAFCredentialsServiceImpl.createAssertedCredential(SAFCredentialsServiceImpl.java:508)
	at com.ibm.ws.security.credentials.saf.internal.SAFCredentialsServiceImpl.setCredential(SAFCredentialsServiceImpl.java:957)
```
When the SAF credential is not used, it should not be created.