### PR TITLE
Remove beta guard from OIDC FAT for WASReqURLOidc update

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rp/jvm.options
+++ b/dev/com.ibm.ws.security.oidc.client_fat/publish/servers/com.ibm.ws.security.openidconnect.client-1.0_fat.rp/jvm.options
@@ -15,5 +15,3 @@
 -Dhttps.proxyPort=34567
 -Dhttps.proxyHost=1.2.3.4
 
-# beta fence for WASReqURLOidc update
--Dcom.ibm.ws.beta.edition=true


### PR DESCRIPTION
Removes beta guard related to work from https://github.com/OpenLiberty/open-liberty/issues/14692.