### PR TITLE
use default helper class if unspecified

### DIFF
--- a/dev/com.ibm.ws.jca.cm/bnd.bnd
+++ b/dev/com.ibm.ws.jca.cm/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2020 IBM Corporation and others.
+# Copyright (c) 2017,2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -55,7 +55,7 @@ Service-Component: \
   com.ibm.ws.jca.connector; \
     implementation:=com.ibm.ejs.j2c.ConnectorServiceImpl; \
     provide:='com.ibm.ws.jca.cm.ConnectorService'; \
-    configuration-policy:=ignore; \
+    configuration-policy:=optional; \
     authDataService=com.ibm.ws.security.jca.AuthDataService; \
     classLoaderIdentifierService=com.ibm.ws.classloading.ClassLoaderIdentifierService; \
     configAdmin=org.osgi.service.cm.ConfigurationAdmin; \

--- a/dev/com.ibm.ws.jca.cm/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.jca.cm/resources/OSGI-INF/metatype/metatype.xml
@@ -39,4 +39,14 @@
   <AD id="numConnectionsPerThreadLocal"       name="%numConPerThd"  description="%numConPerThd.desc"  ibmui:group="Advanced" required="false" type="Integer" min="0"/>
  </OCD>
 
+ <!-- Connector Service (internal) -->
+
+ <Designate factoryPid="com.ibm.ws.jca.connector">
+  <Object ocdref="com.ibm.ws.jca.connector" />
+ </Designate>
+
+ <OCD id="com.ibm.ws.jca.connector" ibm:alias="connectorService" name="internal" description="internal use only">
+  <AD id="enableHeritageBehavior" type="Boolean" default="false" name="internal" description="internal use only"/>
+ </OCD>
+
 </metatype:MetaData>

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectorServiceImpl.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ejs/j2c/ConnectorServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 IBM Corporation and others.
+ * Copyright (c) 2011, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -61,6 +61,11 @@ public class ConnectorServiceImpl extends ConnectorService {
     final AtomicServiceReference<ExecutorService> execSvcRef = new AtomicServiceReference<ExecutorService>("executor");
 
     /**
+     * Indicates if heritage/legacy behavior is enabled.
+     */
+    boolean isHeritageEnabled;
+
+    /**
      * Scheduled executor service for non-deferrable alarms.
      */
     final AtomicServiceReference<ScheduledExecutorService> nonDeferrableSchedXSvcRef = new AtomicServiceReference<ScheduledExecutorService>("nonDeferrableScheduledExecutor");
@@ -95,6 +100,8 @@ public class ConnectorServiceImpl extends ConnectorService {
         nonDeferrableSchedXSvcRef.activate(context);
         rrsXAResFactorySvcRef.activate(context);
         variableRegistrySvcRef.activate(context);
+
+        isHeritageEnabled = Boolean.TRUE.equals(context.getProperties().get("enableHeritageBehavior"));
 
         EmbeddableTransactionManagerFactory.getUOWCurrent().registerLTCCallback(ConnectionHandleManager.ltcHandleCollaborator); // TODO is there a way to unregister?
     }
@@ -163,11 +170,11 @@ public class ConnectorServiceImpl extends ConnectorService {
      * This is copied from Tim's code in tWAS and updated slightly to
      * override with the Liberty ignore/warn/fail setting.
      *
-     * @param tc the TraceComponent from where the message originates
-     * @param throwable an already created Throwable object, which can be used if the desired action is fail.
+     * @param tc                    the TraceComponent from where the message originates
+     * @param throwable             an already created Throwable object, which can be used if the desired action is fail.
      * @param exceptionClassToRaise the class of the Throwable object to return
-     * @param msgKey the NLS message key
-     * @param objs list of objects to substitute in the NLS message
+     * @param msgKey                the NLS message key
+     * @param objs                  list of objects to substitute in the NLS message
      * @return either null or the Throwable object
      */
     @Override
@@ -203,6 +210,11 @@ public class ConnectorServiceImpl extends ConnectorService {
         }
 
         return null;
+    }
+
+    @Override
+    public final boolean isHeritageEnabled() {
+        return isHeritageEnabled;
     }
 
     /**

--- a/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/ConnectorService.java
+++ b/dev/com.ibm.ws.jca.cm/src/com/ibm/ws/jca/cm/ConnectorService.java
@@ -72,7 +72,7 @@ public abstract class ConnectorService {
     /**
      * Get a translated message from J2CAMessages file.
      *
-     * @param key message key.
+     * @param key  message key.
      * @param args message parameters
      * @return a translated message.
      */
@@ -100,19 +100,26 @@ public abstract class ConnectorService {
      * This is copied from Tim's code in tWAS and updated slightly to
      * override with the Liberty ignore/warn/fail setting.
      *
-     * @param tc the TraceComponent from where the message originates
-     * @param throwable an already created Throwable object, which can be used if the desired action is fail.
+     * @param tc                    the TraceComponent from where the message originates
+     * @param throwable             an already created Throwable object, which can be used if the desired action is fail.
      * @param exceptionClassToRaise the class of the Throwable object to return
-     * @param msgKey the NLS message key
-     * @param objs list of objects to substitute in the NLS message
+     * @param msgKey                the NLS message key
+     * @param objs                  list of objects to substitute in the NLS message
      * @return either null or the Throwable object
      */
     public abstract <T extends Throwable> T ignoreWarnOrFail(TraceComponent tc, Throwable throwable, Class<T> exceptionClassToRaise, String msgKey, Object... objs);
 
     /**
+     * Indicates if heritage behavior is enabled.
+     *
+     * @return true if heritage/legacy behavior is enabled, otherwise false.
+     */
+    public abstract boolean isHeritageEnabled();
+
+    /**
      * Logs a message from the J2CAMessages file.
      *
-     * @param key message key.
+     * @param key  message key.
      * @param args message parameters
      */
     public static final void logMessage(Level level, String key, Object... args) {

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/AdapterUtil.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/AdapterUtil.java
@@ -1174,7 +1174,7 @@ public class AdapterUtil {
         SQLException mappedX;
         boolean alreadyMapped = sqlX != null && isLegacyException(sqlX, "com.ibm.websphere.ce.cm.PortableSQLException");
 
-        if (mcf == null                          // no access to helper or error detection model
+        if (mcf == null                          // no access to helper or replaceExceptions config
          || sqlX == null                         // nothing to map
          || alreadyMapped                        // already mapped
          || dsae != null && dsae.beenMapped())   // already mapped

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2JCCHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2JCCHelper.java
@@ -121,6 +121,8 @@ public class DB2JCCHelper extends DB2Helper {
 
         boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
 
+        dataStoreHelper = "com.ibm.websphere.rsadapter.DB2UniversalDataStoreHelper";
+
         configuredTraceLevel = 0; // value of DB2BaseDataSource.TRACE_NONE
 
         isRRSTransaction = false;

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iNativeHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iNativeHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corporation and others.
+ * Copyright (c) 2001, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -60,6 +60,8 @@ public class DB2iNativeHelper extends DB2Helper {
      */
     DB2iNativeHelper(WSManagedConnectionFactoryImpl mcf) throws Exception {
         super(mcf);
+
+        dataStoreHelper = "com.ibm.websphere.rsadapter.DB2AS400DataStoreHelper";
 
         // For the Native driver (unlike the Toolbox driver) the custom property isolationLevelSwitchingSupport is
         // optional and really is only needed if the target database is a remote one.  If this property is not set

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iToolboxHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iToolboxHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2001, 2017 IBM Corporation and others.
+ * Copyright (c) 2001, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -59,6 +59,8 @@ public class DB2iToolboxHelper extends DB2Helper {
      */
     DB2iToolboxHelper(WSManagedConnectionFactoryImpl mcf) throws Exception {
         super(mcf);
+
+        dataStoreHelper = "com.ibm.websphere.rsadapter.DB2AS400DataStoreHelper";
 
         localZOS = false;
         isRRSTransaction = false;

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DataDirectConnectSQLServerHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DataDirectConnectSQLServerHelper.java
@@ -99,6 +99,8 @@ public class DataDirectConnectSQLServerHelper extends DatabaseHelper {
     DataDirectConnectSQLServerHelper(WSManagedConnectionFactoryImpl mcf) {
         super(mcf);
 
+        dataStoreHelper = "com.ibm.websphere.rsadapter.ConnectJDBCDataStoreHelper";
+
         mcf.defaultIsolationLevel = Connection.TRANSACTION_REPEATABLE_READ;
 
         // Default values for the statement properties LongDataCacheSize and QueryTimeout are
@@ -401,12 +403,12 @@ public class DataDirectConnectSQLServerHelper extends DatabaseHelper {
 
         if (ind != -1) { // if none found ===> it is a datadirect one
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) 
-                Tr.debug(this, tc, "The exception is NOT a DataDirect exception ");
+                Tr.debug(this, tc, "The exception is NOT a DataDirect exception");
             return false;
         }
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) 
-            Tr.debug(this, tc, "the exception is a DataDirect exception  ");
+            Tr.debug(this, tc, "the exception is a DataDirect exception");
         return true;
     }
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DatabaseHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DatabaseHelper.java
@@ -69,6 +69,11 @@ public class DatabaseHelper {
     transient PrintWriter genPw;
 
     /**
+     * Class name of corresponding legacy data store helper class.
+     */
+    String dataStoreHelper = "com.ibm.websphere.rsadapter.GenericDataStoreHelper";
+
+    /**
      * Default query timeout configured on the data source.
      */
     protected int defaultQueryTimeout;
@@ -87,7 +92,7 @@ public class DatabaseHelper {
      * at the beginning we assume holdability is supported, if we get an exception when calling the getHolidablity
      * then we will mark the flag as false so that getHoldability is not called all the time
      */
-    protected boolean holdabilitySupported = true; 
+    protected boolean holdabilitySupported = true;
 
     private boolean setCursorNameSupported = true;
     

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DerbyHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DerbyHelper.java
@@ -43,6 +43,8 @@ public class DerbyHelper extends DatabaseHelper {
     DerbyHelper(WSManagedConnectionFactoryImpl mcf) {
         super(mcf);
 
+        dataStoreHelper = "com.ibm.websphere.rsadapter.DerbyDataStoreHelper";
+
         mcf.defaultIsolationLevel = Connection.TRANSACTION_REPEATABLE_READ;
         mcf.supportsGetTypeMap = false;
     }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DerbyNetworkClientHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DerbyNetworkClientHelper.java
@@ -53,6 +53,8 @@ public class DerbyNetworkClientHelper extends DerbyHelper {
     DerbyNetworkClientHelper(WSManagedConnectionFactoryImpl mcf) {
         super(mcf);
 
+        dataStoreHelper = "com.ibm.websphere.rsadapter.DerbyNetworkServerDataStoreHelper";
+
         mcf.doesStatementCacheIsoLevel = true;
 
         Properties props = mcf.dsConfig.get().vendorProps;

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/InformixHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/InformixHelper.java
@@ -44,6 +44,8 @@ public class InformixHelper extends DatabaseHelper {
     InformixHelper(WSManagedConnectionFactoryImpl mcf) {
         super(mcf);
 
+        dataStoreHelper = "com.ibm.websphere.rsadapter.InformixDataStoreHelper";
+
         mcf.defaultIsolationLevel = Connection.TRANSACTION_REPEATABLE_READ;
     }
     

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/InformixJCCHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/InformixJCCHelper.java
@@ -62,6 +62,8 @@ public class InformixJCCHelper extends InformixHelper {
     InformixJCCHelper(WSManagedConnectionFactoryImpl mcf) throws Exception {
         super(mcf);
 
+        dataStoreHelper = "com.ibm.websphere.rsadapter.InformixJccDataStoreHelper";
+
         mcf.doesStatementCacheIsoLevel = true;
         mcf.supportsGetTypeMap = false;
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/MicrosoftSQLServerHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/MicrosoftSQLServerHelper.java
@@ -58,6 +58,8 @@ public class MicrosoftSQLServerHelper extends DatabaseHelper {
     MicrosoftSQLServerHelper(WSManagedConnectionFactoryImpl mcf) {
         super(mcf);
 
+        dataStoreHelper = "com.ibm.websphere.rsadapter.MicrosoftSQLServerDataStoreHelper";
+
         mcf.defaultIsolationLevel = Connection.TRANSACTION_REPEATABLE_READ;
         mcf.supportsGetTypeMap = false;
         mcf.supportsIsReadOnly = false;

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2017 IBM Corporation and others.
+ * Copyright (c) 2003, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -127,6 +127,8 @@ public class OracleHelper extends DatabaseHelper {
      */
     OracleHelper(WSManagedConnectionFactoryImpl mcf) throws Exception {
         super(mcf);
+
+        dataStoreHelper = "com.ibm.websphere.rsadapter.Oracle11gDataStoreHelper";
 
         mcf.supportsIsReadOnly = false;
         xaEndResetsAutoCommit = true;

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/SybaseHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/SybaseHelper.java
@@ -45,6 +45,8 @@ public class SybaseHelper extends DatabaseHelper
     SybaseHelper(WSManagedConnectionFactoryImpl mcf) {
         super(mcf);
 
+        dataStoreHelper = "com.ibm.websphere.rsadapter.Sybase11DataStoreHelper";
+
         mcf.defaultIsolationLevel = Connection.TRANSACTION_REPEATABLE_READ;
         mcf.supportsGetTypeMap = false;
     }

--- a/dev/com.ibm.ws.jdbc_fat_heritage/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/bnd.bnd
@@ -28,7 +28,7 @@ fat.project: true
 	com.ibm.websphere.javaee.annotation.1.1;version=latest,\
 	com.ibm.websphere.javaee.connector.1.7;version=latest,\
 	com.ibm.websphere.javaee.servlet.4.0;version=latest,\
-	com.ibm.websphere.javaee.transaction.1.2;version=latest,\
+	com.ibm.websphere.javaee.transaction.1.1;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning,\
 	com.ibm.websphere.org.osgi.core,\
 	com.ibm.websphere.org.osgi.service.component,\

--- a/dev/com.ibm.ws.jdbc_fat_heritage/jdbcHeritage.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/jdbcHeritage.bnd
@@ -17,11 +17,18 @@ Bundle-Name: JDBC heritage simulation bundle
 Bundle-SymbolicName: jdbcHeritage
 Bundle-Description: Test bundle that simulates providing heritageSettings
 
+IBM-Default-Config: OSGI-INF/wlp/defaultInstances.xml
+
 WS-TraceGroup: jdbcHeritage
 
-Export-Package: com.ibm.websphere.ce.cm
+Export-Package:\
+ com.ibm.websphere.ce.cm,\
+ com.ibm.websphere.rsadapter
+
+Import-Package: *
 
 Private-Package: test.jdbc.heritage.bundle.*
 
 Include-Resource:\
- OSGI-INF/metatype/metatype.xml=test-bundles/jdbcHeritage/resources/OSGI-INF/metatype/metatype.xml
+ OSGI-INF/metatype/metatype.xml=test-bundles/jdbcHeritage/resources/OSGI-INF/metatype/metatype.xml,\
+ OSGI-INF/wlp/defaultInstances.xml=test-bundles/jdbcHeritage/resources/OSGI-INF/wlp/defaultInstances.xml

--- a/dev/com.ibm.ws.jdbc_fat_heritage/publish/files/features/jdbcHeritage-1.0.mf
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/publish/files/features/jdbcHeritage-1.0.mf
@@ -4,5 +4,6 @@ Subsystem-SymbolicName: ShortName:jdbcHeritage-1.0;visibility:=public
 Subsystem-Version: 1.0.0
 Subsystem-Content: jdbcHeritage; version="[1,1.0.100)"
 Subsystem-Type: osgi.subsystem.feature
-IBM-API-Package: com.ibm.websphere.ce.cm; type="ibm-api"
+IBM-API-Package: com.ibm.websphere.ce.cm; type="ibm-api",
+ com.ibm.websphere.rsadapter; type="ibm-api"
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.jdbc_fat_heritage/publish/servers/com.ibm.ws.jdbc.heritage/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/publish/servers/com.ibm.ws.jdbc.heritage/server.xml
@@ -45,6 +45,17 @@
     <identifyException as="test.jdbc.heritage.driver.helper.HeritageDBFeatureUnavailableException" errorCode="40960"/>
   </dataSource>
 
+  <dataSource jndiName="jdbc/helperDefaulted" containerAuthDataRef="dbAuth" type="javax.sql.DataSource">
+    <jdbcDriver libraryRef="JDBCLib" javax.sql.DataSource="test.jdbc.heritage.driver.HDDataSource"/>
+    <properties databaseName="memory:testdb" createDatabase="create"/>
+    <heritageSettings replaceExceptions="true"/>
+    <IdentifyException as="None" sqlState="S1000"/>
+    <identifyException as="StaleConnection" errorCode="8008"/>
+    <identifyException as="com.ibm.websphere.ce.cm.StaleStatementException" sqlState="22013"/> <!-- TODO switch to "StaleStatement" once added -->
+    <identifyException as="test.jdbc.heritage.driver.helper.HeritageDBDuplicateKeyException" sqlState="2300H"/>
+    <identifyException as="test.jdbc.heritage.driver.helper.HeritageDBFeatureUnavailableException" sqlState="0A00H"/>
+  </dataSource>
+
   <javaPermission codeBase="${shared.resource.dir}derby/derby.jar" className="java.security.AllPermission"/>
 
   <javaPermission codeBase="${server.config.dir}/apps/heritageApp.war" className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>

--- a/dev/com.ibm.ws.jdbc_fat_heritage/test-bundles/jdbcHeritage/resources/OSGI-INF/wlp/defaultInstances.xml
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/test-bundles/jdbcHeritage/resources/OSGI-INF/wlp/defaultInstances.xml
@@ -1,0 +1,15 @@
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+  <connectorService enableHeritageBehavior="true"/>
+
+</server>

--- a/dev/com.ibm.ws.jdbc_fat_heritage/test-bundles/jdbcHeritage/src/com/ibm/websphere/ce/cm/package-info.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/test-bundles/jdbcHeritage/src/com/ibm/websphere/ce/cm/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+package com.ibm.websphere.ce.cm;

--- a/dev/com.ibm.ws.jdbc_fat_heritage/test-bundles/jdbcHeritage/src/com/ibm/websphere/rsadapter/GenericDataStoreHelper.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/test-bundles/jdbcHeritage/src/com/ibm/websphere/rsadapter/GenericDataStoreHelper.java
@@ -1,0 +1,221 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.rsadapter;
+
+import java.io.PrintWriter;
+import java.lang.reflect.Constructor;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLNonTransientConnectionException;
+import java.sql.SQLRecoverableException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.security.auth.Subject;
+import javax.transaction.xa.XAException;
+
+import com.ibm.websphere.ce.cm.DuplicateKeyException;
+import com.ibm.websphere.ce.cm.StaleConnectionException;
+import com.ibm.ws.jdbc.heritage.AccessIntent;
+import com.ibm.ws.jdbc.heritage.DataStoreHelperMetaData;
+
+/**
+ * Simulates the legacy GenericDataStoreHelper, which is selected for the test JDBC driver
+ * in the absence of heritage helperClass configuration.
+ */
+public class GenericDataStoreHelper extends com.ibm.ws.jdbc.heritage.GenericDataStoreHelper implements DataStoreHelperMetaData {
+    private final int defaultQueryTimeout;
+
+    private AtomicReference<?> dsConfigRef;
+
+    private Map<Object, Class<?>> exceptionIdentificationOverrides;
+
+    private static final Map<Object, Class<?>> exceptionMap = new HashMap<Object, Class<?>>();
+    {
+        exceptionMap.put("08001", StaleConnectionException.class);
+        exceptionMap.put("08003", StaleConnectionException.class);
+        exceptionMap.put("08006", StaleConnectionException.class);
+        exceptionMap.put("08S01", StaleConnectionException.class);
+        exceptionMap.put("40003", StaleConnectionException.class);
+        exceptionMap.put("55032", StaleConnectionException.class);
+        exceptionMap.put("S1000", StaleConnectionException.class);
+        exceptionMap.put(23505, DuplicateKeyException.class);
+    }
+
+    public GenericDataStoreHelper(Properties props) {
+        String value = props == null ? null : props.getProperty("queryTimeout");
+        defaultQueryTimeout = value == null || value.length() <= 0 ? 0 : Integer.parseInt(value);
+    }
+
+    @Override
+    public boolean doConnectionCleanup(Connection con) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public boolean doConnectionCleanupPerCloseConnection(Connection con, boolean isCMP, Object unused) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public void doConnectionSetup(Connection con) throws SQLException {
+    }
+
+    @Override
+    public boolean doConnectionSetupPerGetConnection(Connection con, boolean isCMP, Object props) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public void doConnectionSetupPerTransaction(Subject subject, String user, Connection con, boolean reauthRequired, Object props) throws SQLException {
+    }
+
+    @Override
+    public boolean doesStatementCacheIsoLevel() {
+        return false;
+    }
+
+    @Override
+    public void doStatementCleanup(PreparedStatement stmt) throws SQLException {
+        stmt.setCursorName(null);
+        stmt.setFetchDirection(ResultSet.FETCH_FORWARD);
+        stmt.setMaxFieldSize(0);
+        stmt.setMaxRows(0);
+
+        Integer queryTimeout = dsConfigRef == null ? null : (Integer) readConfig("queryTimeout");
+        if (queryTimeout == null)
+            queryTimeout = defaultQueryTimeout;
+        stmt.setQueryTimeout(queryTimeout);
+    }
+
+    @Override
+    public int getIsolationLevel(AccessIntent unused) {
+        return Connection.TRANSACTION_READ_COMMITTED;
+    }
+
+    @Override
+    public DataStoreHelperMetaData getMetaData() {
+        return this;
+    }
+
+    @Override
+    public PrintWriter getPrintWriter() {
+        return null;
+    }
+
+    @Override
+    public String getXAExceptionContents(XAException x) {
+        return "cause: " + x.getCause();
+    }
+
+    @Override
+    public boolean isConnectionError(SQLException x) {
+        return x instanceof SQLRecoverableException
+               || x instanceof SQLNonTransientConnectionException
+               || x instanceof StaleConnectionException
+               || mapException(x) instanceof StaleConnectionException;
+    }
+
+    @Override
+    public SQLException mapException(SQLException x) {
+        String sqlState = x.getSQLState();
+        int errorCode = x.getErrorCode();
+        Class<?> exceptionClass = exceptionIdentificationOverrides.get(errorCode);
+        if (exceptionClass == null) {
+            exceptionClass = exceptionIdentificationOverrides.get(sqlState);
+            if (exceptionClass == null) {
+                exceptionClass = exceptionMap.get(errorCode);
+                if (exceptionClass == null) {
+                    exceptionClass = exceptionMap.get(sqlState);
+                    if (exceptionClass == null)
+                        return x;
+                }
+            }
+        }
+
+        System.out.println("datastorehelper.mapException sqlState: " + sqlState + ", errorCode: " + errorCode + " " + x.getClass().getName());
+        System.out.println("  --> " + exceptionClass.getName());
+        System.out.println("  based on map:  " + exceptionMap);
+        System.out.println("  and overrides: " + exceptionIdentificationOverrides);
+
+        if (Void.class.equals(exceptionClass))
+            return x;
+
+        try {
+            @SuppressWarnings("unchecked")
+            final Class<? extends SQLException> sqlXClass = (Class<? extends SQLException>) exceptionClass;
+            return AccessController.doPrivileged((PrivilegedExceptionAction<SQLException>) () -> {
+                Constructor<? extends SQLException> ctor = sqlXClass.getConstructor(SQLException.class);
+                return ctor.newInstance(x);
+            });
+        } catch (PrivilegedActionException privX) {
+            return new SQLException(privX);
+        }
+    }
+
+    private Object readConfig(String fieldName) {
+        Object dsConfig = dsConfigRef.get();
+        try {
+            return AccessController.doPrivileged((PrivilegedExceptionAction<?>) () -> //
+            dsConfig.getClass().getField(fieldName).get(dsConfig));
+        } catch (PrivilegedActionException x) {
+            throw new RuntimeException(x);
+        }
+    }
+
+    @Override
+    public void setConfig(Object configRef) {
+        dsConfigRef = (AtomicReference<?>) configRef;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void setUserDefinedMap(@SuppressWarnings("rawtypes") Map map) {
+        exceptionIdentificationOverrides = map;
+    }
+
+    @Override
+    public boolean supportsGetCatalog() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsGetNetworkTimeout() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsGetSchema() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsGetTypeMap() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsIsReadOnly() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsUOWDetection() {
+        return false;
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_heritage/test-bundles/jdbcHeritage/src/com/ibm/websphere/rsadapter/package-info.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/test-bundles/jdbcHeritage/src/com/ibm/websphere/rsadapter/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+package com.ibm.websphere.rsadapter;


### PR DESCRIPTION
If heritage behavior is switched on and a helper class isn't provided, we need to default it based on knowledge of which database/driver is being used.