### PR TITLE
Issue 16226: Add more Kerberos Ldap FATs

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/CommonBindTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/CommonBindTest.java
@@ -119,12 +119,7 @@ public class CommonBindTest {
 
         server.startServer();
 
-        assertNotNull("Application userRegistry does not appear to have started.",
-                      server.waitForStringInLog("CWWKZ0001I:.*userRegistry"));
-        assertNotNull("Security service did not report it was ready",
-                      server.waitForStringInLog("CWWKS0008I"));
-        assertNotNull("Server did not came up",
-                      server.waitForStringInLog("CWWKF0011I"));
+        startupChecks();
 
         Log.info(c, "setUp", "Creating servlet connection the server");
         servlet = new UserRegistryServletConnection(server.getHostname(), server.getHttpDefaultPort());
@@ -159,7 +154,8 @@ public class CommonBindTest {
     public static void tearDown() throws Exception {
         try {
             if (server != null) {
-                server.stopServer(stopStrings);;
+                Log.info(c, "tearDown", "stop strings provided: " + Arrays.toString(stopStrings));
+                server.stopServer(stopStrings);
             }
         } finally {
             stopUnboundIDLdapServer();
@@ -432,7 +428,16 @@ public class CommonBindTest {
      * @return
      */
     protected LdapRegistry getLdapRegistryWithTicketCacheWithContextPool() {
-        return LdapKerberosUtils.getTicketCache(ldapServerHostName, LDAP_PORT, ticketCacheFile, false);
+        return LdapKerberosUtils.getTicketCache(ldapServerHostName, LDAP_PORT, ticketCacheFile, false, false);
+    }
+
+    /**
+     * Return a basic LdapRegistry with the default ticketCacheFile, context pool enabled and caches disabled
+     *
+     * @return
+     */
+    protected LdapRegistry getLdapRegistryWithTicketCacheWithContextPoolWithoutCaches() {
+        return LdapKerberosUtils.getTicketCache(ldapServerHostName, LDAP_PORT, ticketCacheFile, false, true);
     }
 
     /**
@@ -450,7 +455,7 @@ public class CommonBindTest {
      * @return
      */
     protected LdapRegistry getLdapRegistryForKeytabWithContextPool() {
-        return LdapKerberosUtils.getKrb5PrincipalName(ldapServerHostName, LDAP_PORT, false);
+        return LdapKerberosUtils.getKrb5PrincipalName(ldapServerHostName, LDAP_PORT, false, false);
     }
 
     /**
@@ -505,5 +510,17 @@ public class CommonBindTest {
 
         loginUserShouldFail();
         assertFalse("Expected to find Kerberos principalName failure: " + failMessage, server.findStringsInLogsAndTraceUsingMark(failMessage).isEmpty());
+    }
+
+    /**
+     * Standard server startup message checks.
+     */
+    public static void startupChecks() {
+        assertNotNull("Application userRegistry does not appear to have started.",
+                      server.waitForStringInLog("CWWKZ0001I:.*userRegistry"));
+        assertNotNull("Security service did not report it was ready",
+                      server.waitForStringInLog("CWWKS0008I"));
+        assertNotNull("Server did not came up",
+                      server.waitForStringInLog("CWWKF0011I"));
     }
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/FATSuite.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/FATSuite.java
@@ -32,6 +32,8 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
                 TicketCacheBindMultiRegistryTest.class,
                 KeytabBadPrincipalNameTest.class,
                 TicketCacheBadPrincipalNameTest.class,
+                TicketCacheBindExpireTests.class,
+                RealmNameJVMProp.class,
                 /*
                  * vvv Leave Krb5ConfigJVMProp as the last test, the JVM prop changes the rest of the tests
                  */

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/KeytabBindTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/KeytabBindTest.java
@@ -14,6 +14,7 @@ import static componenttest.topology.utils.LDAPFatUtils.updateConfigDynamically;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 
@@ -224,4 +225,27 @@ public class KeytabBindTest extends CommonBindTest {
 
         loginUser();
     }
+
+    /**
+     * Set the keytab in the config file (default_keytab_name = key_tab_file.keytab), ensure we pick up the keytab correctly and can run
+     * the baseline tests.
+     *
+     * @throws Exception
+     */
+    @Test
+    @CheckForLeakedPasswords(LdapKerberosUtils.BIND_PASSWORD)
+    public void keytabDefinedInConfig() throws Exception {
+        assumeTrue(FATRunner.FAT_TEST_LOCALRUN); // Remote build wasn't picking up the keytab set in the config, despite using the same keytab for all the other keytab tests
+        Log.info(c, testName.getMethodName(), "Run basic login checks with the keytab defined in the krb5config file");
+        ServerConfiguration newServer = emptyConfiguration.clone();
+        LdapRegistry ldap = getLdapRegistryForKeytab();
+        String altConfigFile = ApacheDSandKDC.createConfigFile("keyTabInConfig-", KDC_PORT, true, true);
+        Kerberos kerb = newServer.getKerberos();
+        kerb.configFile = altConfigFile;
+        newServer.getLdapRegistries().add(ldap);
+        updateConfigDynamically(server, newServer);
+
+        baselineTests();
+    }
+
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBindExpireTests.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBindExpireTests.java
@@ -1,0 +1,235 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.wim.adapter.ldap.fat.krb5;
+
+import static componenttest.topology.utils.LDAPFatUtils.updateConfigDynamically;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.websphere.simplicity.config.wim.ContextPool;
+import com.ibm.websphere.simplicity.config.wim.LdapRegistry;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.MinimumJavaLevel;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+
+/**
+ * Tests Kerberos bind (GSSAPI) for Ldap, using primarily the krb5TicketCache
+ *
+ * The tests in this bucket deal with expiring tickets. Separated in their own bucket or
+ * we tend to get "Requested start time is later than end time" bleed into other tests.
+ *
+ */
+@RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
+@MinimumJavaLevel(javaLevel = 9)
+public class TicketCacheBindExpireTests extends CommonBindTest {
+
+    private static final Class<?> c = TicketCacheBindExpireTests.class;
+
+    @BeforeClass
+    public static void setStopMessages() {
+        stopStrings = new String[] { "CWIML4520E" };
+    }
+
+    /**
+     * Create a ticketCache with a short expiration. Confirm that we fail once the ticket is expired.
+     *
+     * The ticket is marked as renewable, we should not have to manually renew.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ticketExpiresAtRuntimeNoContextPool() throws Exception {
+        Log.info(c, testName.getMethodName(), "Provide an expiring ticket, renew at runtime");
+
+        String expiringTicketCache = ApacheDSandKDC.createTicketCacheShortLife(true);
+
+        ServerConfiguration newServer = emptyConfiguration.clone();
+        LdapRegistry ldap = getLdapRegistryWithTicketCache();
+        ldap.setKrb5TicketCache(expiringTicketCache);
+        newServer.getLdapRegistries().add(ldap);
+        addKerberosConfig(newServer);
+        updateConfigDynamically(server, newServer);
+
+        // Mark file so we can check for trace updates
+        server.setTraceMarkToEndOfDefaultTrace();
+
+        loginUser(); // createDirContext will do the initial bind
+
+        loginUser(); // principal will be fetched from the KerberosService cache and renewed.
+
+        /*
+         * Tried to check the ccache directly, but endTime is not updated.
+         * Checking trace that we had to do a renew.
+         */
+        String renewTrace = "Successfully renewed ticket"; // trace from  LRUCache for KerberosService, could vary on JDK types
+
+        assertNotNull("Expected to see trace that we renewed the ticket: " + renewTrace, server.waitForStringInTraceUsingMark(renewTrace));
+
+    }
+
+    /**
+     * Create a ticketCache with a short expiration. Confirm that we fail once the ticket is expired.
+     *
+     * The ticket is marked as renewable, we should not have to manually renew.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void ticketExpiresAtRuntimeWithContextPool() throws Exception {
+        Log.info(c, testName.getMethodName(), "Provide an expiring ticket, renew at runtime, context pool is enabled");
+
+        String expiringTicketCache = ApacheDSandKDC.createTicketCacheShortLife(true);
+
+        ServerConfiguration newServer = emptyConfiguration.clone();
+        LdapRegistry ldap = getLdapRegistryWithTicketCacheWithContextPoolWithoutCaches();
+        ldap.setKrb5TicketCache(expiringTicketCache);
+        ldap.setContextPool(new ContextPool(true, 0, 2, 1, "25s", "25s"));
+        newServer.getLdapRegistries().add(ldap);
+        addKerberosConfig(newServer);
+        updateConfigDynamically(server, newServer);
+
+        // Mark file so we can check for trace updates
+        server.setTraceMarkToEndOfDefaultTrace();
+
+        /*
+         * Tried to check the ccache directly, but endTime is not updated.
+         * Checking trace that we had to do a renew.
+         */
+        String renewTrace = "Successfully renewed ticket"; // trace from  LRUCache for KerberosService
+
+        /*
+         * Since we'll reuse the dirContext in the context pool, we won't renew until we get an error from
+         * the Ldap server.
+         */
+        boolean foundRenewMessage = false;
+        Log.info(c, testName.getMethodName(), "Sleep for ticket expiration time or ticket renews. Max Time: " + ApacheDSandKDC.MIN_LIFE);
+        long maxTime = System.currentTimeMillis() + ApacheDSandKDC.MIN_LIFE;
+        while (System.currentTimeMillis() < maxTime) {
+            Thread.sleep(30000);
+            servlet.checkPassword(vmmUser1, vmmUser1pwd);
+
+            if (!server.findStringsInLogsAndTrace(renewTrace).isEmpty()) {
+                foundRenewMessage = true;
+                break;
+            }
+        }
+
+        assertTrue("Expected to see trace that we renewed the ticket: " + renewTrace, foundRenewMessage);
+
+    }
+
+    /**
+     * Create a ticketCache with a short expiration. Confirm that we fail once the ticket is expired.
+     *
+     * The ticket is marked as not renewable, manually get an updated ticketCache and check that we
+     * can login again.
+     *
+     * @throws Exception
+     */
+    @Test
+    @AllowedFFDC("javax.security.auth.login.LoginException")
+    public void ticketExpiresAtRuntimeNoRenew() throws Exception {
+        Log.info(c, testName.getMethodName(), "Provide an expiring ticket that is not renewable");
+
+        String expiringTicketCache = ApacheDSandKDC.createTicketCacheShortLife(false);
+
+        ServerConfiguration newServer = emptyConfiguration.clone();
+        LdapRegistry ldap = getLdapRegistryWithTicketCache();
+        ldap.setKrb5TicketCache(expiringTicketCache);
+        newServer.getLdapRegistries().add(ldap);
+        addKerberosConfig(newServer);
+        updateConfigDynamically(server, newServer);
+
+        loginUser();
+
+        Log.info(c, testName.getMethodName(), "Sleep for ticket expiration time or login fails. Max Time: " + ApacheDSandKDC.MIN_LIFE);
+        long maxTime = System.currentTimeMillis() + ApacheDSandKDC.MIN_LIFE;
+        while (System.currentTimeMillis() < maxTime) {
+            Thread.sleep(30000);
+            if (servlet.checkPassword(vmmUser1, vmmUser1pwd) != null) {
+                Log.info(c, testName.getMethodName(), "Login not expired, sleep again.");
+            } else {
+                break;
+            }
+        }
+
+        Log.info(c, testName.getMethodName(), "Sleep complete! Log in user again, expect to fail.");
+        loginUserShouldFail();
+
+        Log.info(c, testName.getMethodName(), "Updating a fresh ticketCache, should be able to login again.");
+        expiringTicketCache = ApacheDSandKDC.createTicketCacheShortLife(true);
+        ldap.setKrb5TicketCache(expiringTicketCache);
+        updateConfigDynamically(server, newServer);
+
+        loginUser();
+
+    }
+
+    /**
+     * Create a ticketCache with a short expiration. Confirm that we fail once the ticket is expired.
+     *
+     * The ticket is marked as not renewable, manually get an updated ticketCache and check that we
+     * can login again.
+     *
+     * @throws Exception
+     */
+    @Test
+    @AllowedFFDC("javax.security.auth.login.LoginException")
+    public void ticketExpiresAtRuntimeNoRenewWithContextPool() throws Exception {
+        Log.info(c, testName.getMethodName(), "Provide an expiring ticket that is not renewable, context pool is enabled");
+
+        String expiringTicketCache = ApacheDSandKDC.createTicketCacheShortLife(false);
+
+        ServerConfiguration newServer = emptyConfiguration.clone();
+        LdapRegistry ldap = getLdapRegistryWithTicketCacheWithContextPoolWithoutCaches();
+        ldap.setKrb5TicketCache(expiringTicketCache);
+        ldap.setContextPool(new ContextPool(true, 0, 2, 1, "25s", "25s"));
+        newServer.getLdapRegistries().add(ldap);
+
+        addKerberosConfig(newServer);
+        updateConfigDynamically(server, newServer);
+
+        loginUser();
+
+        Log.info(c, testName.getMethodName(), "Sleep for ticket expiration time or login fails. Max Time: " + ApacheDSandKDC.MIN_LIFE);
+        long maxTime = System.currentTimeMillis() + ApacheDSandKDC.MIN_LIFE;
+        while (System.currentTimeMillis() < maxTime) {
+            Thread.sleep(30000);
+            if (servlet.checkPassword(vmmUser1, vmmUser1pwd) != null) {
+                Log.info(c, testName.getMethodName(), "Login not expired, sleep again.");
+            } else {
+                break;
+            }
+        }
+
+        Log.info(c, testName.getMethodName(), "Sleep complete! Log in user again, expect to fail.");
+        loginUserShouldFail();
+
+        Log.info(c, testName.getMethodName(), "Updating a fresh ticketCache, should be able to login again.");
+        expiringTicketCache = ApacheDSandKDC.createTicketCacheShortLife(true);
+        ldap.setKrb5TicketCache(expiringTicketCache);
+        updateConfigDynamically(server, newServer);
+
+        loginUser();
+
+    }
+
+}

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBindLongRunTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBindLongRunTest.java
@@ -11,7 +11,6 @@
 package com.ibm.ws.security.wim.adapter.ldap.fat.krb5;
 
 import static componenttest.topology.utils.LDAPFatUtils.updateConfigDynamically;
-import static org.junit.Assert.assertNotNull;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -30,8 +29,7 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 /**
  * Tests Kerberos bind (GSSAPI) for Ldap, using primarily the krb5TicketCache
  *
- * The tests in this bucket are longer running. Server restarts, restarting ApacheDS,
- * waiting for expiring tickets, etc.
+ * The tests in this bucket are longer running. Server restarts, restarting ApacheDS, etc.
  *
  */
 @RunWith(FATRunner.class)
@@ -84,90 +82,6 @@ public class TicketCacheBindLongRunTest extends CommonBindTest {
         updateConfigDynamically(server, newServer);
 
         bodyOfRestartServer();
-    }
-
-    /**
-     * Create a ticketCache with a short expiration. Confirm that we fail once the ticket is expired.
-     *
-     * The ticket is marked as renewable, we should not have to manually renew.
-     *
-     * @throws Exception
-     */
-    @Test
-    public void ticketExpiresAtRuntime() throws Exception {
-        Log.info(c, testName.getMethodName(), "Provide an expiring ticket, renew at runtime");
-
-        String expiringTicketCache = ApacheDSandKDC.createTicketCacheShortLife(true);
-
-        ServerConfiguration newServer = emptyConfiguration.clone();
-        LdapRegistry ldap = getLdapRegistryWithTicketCache();
-        ldap.setKrb5TicketCache(expiringTicketCache);
-        newServer.getLdapRegistries().add(ldap);
-        addKerberosConfig(newServer);
-        updateConfigDynamically(server, newServer);
-
-        // Mark file so we can check for trace updates
-        server.setMarkToEndOfLog(server.getDefaultTraceFile());
-
-        loginUser(); // createDirContext will do the initial bind
-
-        loginUser(); // principal will be fetch from the KerberosService cache and renewed.
-
-        /*
-         * Tried to check the ccache directly, but endTime is not updated.
-         * Checking trace that we had to do a renew.
-         */
-        String renewTrace = "Successfully renewed ticket"; // trace from  LRUCache for KerberosService
-
-        assertNotNull("Expected to see trace that we renewed the ticket: " + renewTrace, server.waitForStringInTraceUsingMark(renewTrace));
-
-    }
-
-    /**
-     * Create a ticketCache with a short expiration. Confirm that we fail once the ticket is expired.
-     *
-     * The ticket is marked as not renewable, manually get an updated ticketCache and check that we
-     * can login again.
-     *
-     * @throws Exception
-     */
-    @Test
-    @AllowedFFDC("javax.security.auth.login.LoginException")
-    public void ticketExpiresAtRuntimeNoRenew() throws Exception {
-        Log.info(c, testName.getMethodName(), "Provide an expiring ticket that is not renewable");
-
-        String expiringTicketCache = ApacheDSandKDC.createTicketCacheShortLife(false);
-
-        ServerConfiguration newServer = emptyConfiguration.clone();
-        LdapRegistry ldap = getLdapRegistryWithTicketCache();
-        ldap.setKrb5TicketCache(expiringTicketCache);
-        newServer.getLdapRegistries().add(ldap);
-        addKerberosConfig(newServer);
-        updateConfigDynamically(server, newServer);
-
-        loginUser();
-
-        Log.info(c, testName.getMethodName(), "Sleep for ticket expiration time. Max Time: " + ApacheDSandKDC.MIN_LIFE);
-        long maxTime = System.currentTimeMillis() + ApacheDSandKDC.MIN_LIFE;
-        while (System.currentTimeMillis() < maxTime) {
-            Thread.sleep(30000);
-            if (servlet.checkPassword(vmmUser1, vmmUser1pwd) != null) {
-                Log.info(c, testName.getMethodName(), "Login not expired, sleep again.");
-            } else {
-                break;
-            }
-        }
-
-        Log.info(c, testName.getMethodName(), "Sleep complete! Log in user again, expect to fail.");
-        loginUserShouldFail();
-
-        Log.info(c, testName.getMethodName(), "Updating a fresh ticketCache, should be able to login again.");
-        expiringTicketCache = ApacheDSandKDC.createTicketCacheShortLife(true);
-        ldap.setKrb5TicketCache(expiringTicketCache);
-        updateConfigDynamically(server, newServer);
-
-        loginUser();
-
     }
 
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/utils/LdapKerberosUtils.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/utils/LdapKerberosUtils.java
@@ -68,7 +68,7 @@ public class LdapKerberosUtils {
      * @return
      */
     public static LdapRegistry getTicketCacheWithoutContextPool(String hostname, int port, String ticketCacheFile) {
-        return getTicketCache(hostname, port, ticketCacheFile, true);
+        return getTicketCache(hostname, port, ticketCacheFile, true, true);
     }
 
     /**
@@ -80,10 +80,10 @@ public class LdapKerberosUtils {
      * @param disableCaches
      * @return
      */
-    public static LdapRegistry getTicketCache(String hostname, int port, String ticketCacheFile, boolean disableCaches) {
+    public static LdapRegistry getTicketCache(String hostname, int port, String ticketCacheFile, boolean disableContextPool, boolean disableCaches) {
         LdapRegistry ldap = new LdapRegistry();
 
-        getBasicsLdapRegistry(ldap, hostname, port, disableCaches);
+        getBasicsLdapRegistry(ldap, hostname, port, disableContextPool, disableCaches);
         ldap.setBindAuthMechanism(ConfigConstants.CONFIG_BIND_AUTH_KRB5);
         ldap.setKrb5Principal(BIND_PRINCIPAL_NAME);
         ldap.setKrb5TicketCache(ticketCacheFile);
@@ -102,7 +102,7 @@ public class LdapKerberosUtils {
      * @return
      */
     public static LdapRegistry getKrb5PrincipalNameWithoutContextPool(String hostname, int port) {
-        return getKrb5PrincipalName(hostname, port, true);
+        return getKrb5PrincipalName(hostname, port, true, true);
     }
 
     /**
@@ -113,9 +113,9 @@ public class LdapKerberosUtils {
      * @param disableCaches
      * @return
      */
-    public static LdapRegistry getKrb5PrincipalName(String hostname, int port, boolean disableCaches) {
+    public static LdapRegistry getKrb5PrincipalName(String hostname, int port, boolean disableContextPool, boolean disableCaches) {
         LdapRegistry ldap = new LdapRegistry();
-        getBasicsLdapRegistry(ldap, hostname, port, disableCaches);
+        getBasicsLdapRegistry(ldap, hostname, port, disableContextPool, disableCaches);
         ldap.setBindAuthMechanism(ConfigConstants.CONFIG_BIND_AUTH_KRB5);
         ldap.setKrb5Principal(BIND_PRINCIPAL_NAME);
 
@@ -132,7 +132,7 @@ public class LdapKerberosUtils {
      * @return
      */
     public static LdapRegistry getSimpleBind(String hostname, int port) {
-        return getSimpleBind(hostname, port, true);
+        return getSimpleBind(hostname, port, true, true);
     }
 
     /**
@@ -144,10 +144,10 @@ public class LdapKerberosUtils {
      * @param disableCaches
      * @return
      */
-    public static LdapRegistry getSimpleBind(String hostname, int port, boolean disableCaches) {
+    public static LdapRegistry getSimpleBind(String hostname, int port, boolean disableContextPool, boolean disableCaches) {
         LdapRegistry ldap = new LdapRegistry();
 
-        getBasicsLdapRegistry(ldap, hostname, port, disableCaches);
+        getBasicsLdapRegistry(ldap, hostname, port, disableContextPool, disableCaches);
         ldap.setBindAuthMechanism(ConfigConstants.CONFIG_AUTHENTICATION_TYPE_SIMPLE);
         ldap.setBindDN(BIND_SIMPLE_DN);
         ldap.setBindPassword(BIND_PASSWORD);
@@ -161,16 +161,20 @@ public class LdapKerberosUtils {
      *
      * @param ldap
      */
-    public static void disableCaches(LdapRegistry ldap) {
-        ContextPool cp = new ContextPool();
-        cp.setEnabled(false);
-        ldap.setContextPool(cp);
-        AttributesCache ac = new AttributesCache();
-        ac.setEnabled(false);
-        SearchResultsCache src = new SearchResultsCache();
-        src.setEnabled(false);
-        ldap.setLdapCache(new LdapCache(ac, src));
+    public static void disableCaches(LdapRegistry ldap, boolean disableContextPool, boolean disableCaches) {
+        if (disableContextPool) {
+            ContextPool cp = new ContextPool();
+            cp.setEnabled(false);
+            ldap.setContextPool(cp);
+        }
 
+        if (disableCaches) {
+            AttributesCache ac = new AttributesCache();
+            ac.setEnabled(false);
+            SearchResultsCache src = new SearchResultsCache();
+            src.setEnabled(false);
+            ldap.setLdapCache(new LdapCache(ac, src));
+        }
     }
 
     /**
@@ -181,7 +185,7 @@ public class LdapKerberosUtils {
      * @param port
      * @param disableCaches
      */
-    public static void getBasicsLdapRegistry(LdapRegistry ldap, String hostname, int port, boolean disableCaches) {
+    public static void getBasicsLdapRegistry(LdapRegistry ldap, String hostname, int port, boolean disableContextPool, boolean disableCaches) {
         ldap.setId("LDAP1");
         ldap.setRealm("LDAPRealm");
         ldap.setHost(hostname);
@@ -190,8 +194,8 @@ public class LdapKerberosUtils {
         ldap.setLdapType(LDAP_TYPE);
 
         // Force new connections for everything
-        if (disableCaches) {
-            disableCaches(ldap);
+        if (disableContextPool || disableCaches) {
+            disableCaches(ldap, disableContextPool, disableCaches);
         }
     }
 


### PR DESCRIPTION
Fixes #16226 

Added/changed
- Keytab is defined in the krb.conf file
- Realm is defined as a JVM property
- Move expiring cache tests to their own test
- Added a "with context pool" version to some tests.
- Added option to disable context pool and/or caches
- In order to do the realm JVM test, had to try and set the KDC to port 88. Then had to change the badPort test to use an actual bad port (instead of -1). This will also fix a BB on the Mac runs.