### PR TITLE
Issue 16231: Peek at KRB5 config on Ldap init

### DIFF
--- a/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/KerberosService.java
+++ b/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/KerberosService.java
@@ -92,14 +92,14 @@ public class KerberosService {
     @Trivial
     @FFDCIgnore({ MalformedURLException.class, URISyntaxException.class, IllegalArgumentException.class })
     protected void initialize(ComponentContext ctx, boolean modifyPath) {
-        String rawKeytab = (String) ctx.getProperties().get("keytab");
-        String rawConfigFile = (String) ctx.getProperties().get("configFile");
+        String rawKeytab = (String) ctx.getProperties().get(Krb5Constants.KEYTAB);
+        String rawConfigFile = (String) ctx.getProperties().get(Krb5Constants.CONFIG_FILE);
 
         if (rawKeytab != null) {
             keytab = Paths.get(rawKeytab);
             if (keytab.toFile().exists()) {
                 if (tc.isInfoEnabled()) {
-                    Tr.info(tc, "KRB5_FILE_FOUND_CWWKS4346I", "keytab", keytab.toAbsolutePath());
+                    Tr.info(tc, "KRB5_FILE_FOUND_CWWKS4346I", Krb5Constants.KEYTAB, keytab.toAbsolutePath());
                 }
             } else {
                 try {
@@ -110,27 +110,27 @@ public class KerberosService {
                     File keytabFile = new File(keytabUrl.toURI());
                     if (keytabFile.exists()) {
                         if (tc.isInfoEnabled()) {
-                            Tr.info(tc, "KRB5_FILE_FOUND_CWWKS4346I", "keytab", rawKeytab);
+                            Tr.info(tc, "KRB5_FILE_FOUND_CWWKS4346I", Krb5Constants.KEYTAB, rawKeytab);
                         }
                     } else {
-                        Tr.error(tc, "KRB5_FILE_NOT_FOUND_CWWKS4345E", "keytab", "<kerberos>", rawKeytab);
+                        Tr.error(tc, "KRB5_FILE_NOT_FOUND_CWWKS4345E", Krb5Constants.KEYTAB, "<kerberos>", rawKeytab);
                     }
                 } catch (MalformedURLException ex) {
                     // catch blocks are separate due to a limitation of @FFDCIgnore
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                         Tr.debug(tc, "Could not find keytab as a Path or URL: ", ex);
                     }
-                    Tr.error(tc, "KRB5_FILE_NOT_FOUND_CWWKS4345E", "keytab", "<kerberos>", rawKeytab);
+                    Tr.error(tc, "KRB5_FILE_NOT_FOUND_CWWKS4345E", Krb5Constants.KEYTAB, "<kerberos>", rawKeytab);
                 } catch (URISyntaxException ex) {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                         Tr.debug(tc, "Could not find keytab as a Path or URL: ", ex);
                     }
-                    Tr.error(tc, "KRB5_FILE_NOT_FOUND_CWWKS4345E", "keytab", "<kerberos>", rawKeytab);
+                    Tr.error(tc, "KRB5_FILE_NOT_FOUND_CWWKS4345E", Krb5Constants.KEYTAB, "<kerberos>", rawKeytab);
                 } catch (IllegalArgumentException ex) {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                         Tr.debug(tc, "Could not find keytab as a Path or URL: ", ex);
                     }
-                    Tr.error(tc, "KRB5_FILE_NOT_FOUND_CWWKS4345E", "keytab", "<kerberos>", rawKeytab);
+                    Tr.error(tc, "KRB5_FILE_NOT_FOUND_CWWKS4345E", Krb5Constants.KEYTAB, "<kerberos>", rawKeytab);
                 }
             }
         } else {
@@ -148,10 +148,10 @@ public class KerberosService {
 
             if (configFile.toFile().exists()) {
                 if (tc.isInfoEnabled()) {
-                    Tr.info(tc, "KRB5_FILE_FOUND_CWWKS4346I", "configFile", configFile.toAbsolutePath());
+                    Tr.info(tc, "KRB5_FILE_FOUND_CWWKS4346I", Krb5Constants.CONFIG_FILE, configFile.toAbsolutePath());
                 }
             } else {
-                Tr.error(tc, "KRB5_FILE_NOT_FOUND_CWWKS4345E", "configFile", "<kerberos>", configFile.toAbsolutePath());
+                Tr.error(tc, "KRB5_FILE_NOT_FOUND_CWWKS4345E", Krb5Constants.CONFIG_FILE, "<kerberos>", configFile.toAbsolutePath());
             }
         } else if (rawConfigFile == null && modifyPath) {
             /*

--- a/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/Krb5Constants.java
+++ b/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/Krb5Constants.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.kerberos.auth;
+
+/**
+ * Constants for KerberosService
+ */
+public interface Krb5Constants {
+
+    public final static String KEYTAB = "keytab"; // metatype key
+
+    public final static String CONFIG_FILE = "configFile"; // metatype key
+
+    public final static String PID_ID = "(service.pid=com.ibm.ws.security.kerberos.auth.KerberosService)"; // from the metatype.xml
+}

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/bnd.bnd
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/bnd.bnd
@@ -48,6 +48,7 @@ instrument.classesExcludes: com/ibm/ws/security/wim/adapter/ldap/resources/*.cla
 	com.ibm.ws.security.wim.core;version=latest,\
 	com.ibm.websphere.appserver.spi.kernel.service;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
+	com.ibm.websphere.org.osgi.service.cm;version=latest,\
 	com.ibm.websphere.org.osgi.service.component;version=latest,\
 	com.ibm.ws.bnd.annotations;version=latest,\
 	com.ibm.ws.logging;version=latest,\

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapConnection.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapConnection.java
@@ -73,6 +73,8 @@ import javax.naming.ldap.LdapName;
 import javax.naming.ldap.PagedResultsControl;
 import javax.naming.ldap.PagedResultsResponseControl;
 
+import org.osgi.service.cm.ConfigurationAdmin;
+
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
@@ -205,6 +207,8 @@ public class LdapConnection {
     /** The KerberosService for use when bindAuthMechanism is GSSAPI (Kerberos), also loads the keytab/config if configured in the <kerberos> element */
     private KerberosService kerberosService = null;
 
+    private ConfigurationAdmin configAdmin = null;
+
     /**
      * Returns a hash key for the name|filter|cons tuple used in the search
      * query-results cache.
@@ -304,9 +308,10 @@ public class LdapConnection {
      * @param ldapConfigMgr The {@link LdapConfigManager} to get configuration from.
      * @param ks            The {@link KerberosService} to get KRB5 configuration from (can be null).
      */
-    public LdapConnection(LdapConfigManager ldapConfigMgr, KerberosService ks) {
+    public LdapConnection(LdapConfigManager ldapConfigMgr, KerberosService ks, ConfigurationAdmin configAdminRef) {
         iLdapConfigMgr = ldapConfigMgr;
         kerberosService = ks;
+        configAdmin = configAdminRef;
     }
 
     /**
@@ -470,7 +475,7 @@ public class LdapConnection {
             betaFenceCheckKrb5();
 
             iContextManager.setKerberosCredentials(iReposId, kerberosService, (String) configProps.get(ConfigConstants.CONFIG_PROP_KRB5_PRINCIPAL),
-                                                   (String) configProps.get(ConfigConstants.CONFIG_PROP_KRB5_TICKET_CACHE));
+                                                   (String) configProps.get(ConfigConstants.CONFIG_PROP_KRB5_TICKET_CACHE), configAdmin);
         }
 
         /*

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/context/ContextManager.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/context/ContextManager.java
@@ -21,6 +21,7 @@ import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
+import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Properties;
@@ -46,6 +47,9 @@ import javax.naming.ldap.LdapName;
 import javax.security.auth.Subject;
 import javax.security.auth.login.LoginException;
 
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
 import com.ibm.websphere.crypto.PasswordUtil;
 import com.ibm.websphere.ras.ProtectedString;
 import com.ibm.websphere.ras.Tr;
@@ -57,6 +61,7 @@ import com.ibm.websphere.security.wim.ras.WIMMessageKey;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.authentication.utility.SubjectHelper;
 import com.ibm.ws.security.kerberos.auth.KerberosService;
+import com.ibm.ws.security.kerberos.auth.Krb5Constants;
 import com.ibm.ws.security.wim.adapter.ldap.BEROutputStream;
 import com.ibm.ws.security.wim.adapter.ldap.LdapConnection;
 import com.ibm.ws.security.wim.adapter.ldap.LdapConstants;
@@ -269,6 +274,8 @@ public class ContextManager {
 
     /** Read/Write lock to prevent multiple processes from using and updating the KerberosService and/or context pool at the same time. **/
     private final ReadWriteLock kerberServiceModifyLock = new ReentrantReadWriteLock();
+
+    private ConfigurationAdmin configAdmin = null;
 
     /**
      * Add a fail-over LDAP server hostname and port.
@@ -1196,10 +1203,75 @@ public class ContextManager {
          */
 
         /*
+         * If the contextPool is enabled and Kerberos is enabled, check if the current config and keytab are null from the <kerberos/> config. If they are null,
+         * use the config service to check if there's any config for them that is not processed yet (outstanding modify() that will happen after this initialize completes.
+         * If there's <kerberos/> config, delay creating the context pool and wait until LdapRegistry receives a modify and calls updateKerberosService. This avoids a
+         * temporary failure logged to FFDC connecting to the KDC/LDAP before updating with the complete <kerberos/> config.
+         */
+        boolean delayContextPool = false;
+        if (iContextPoolEnabled && isKerberosBindAuth() && kerberosService != null && kerberosService.getKeytab() == null && kerberosService.getConfigFile() == null
+            && configAdmin != null) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, METHODNAME
+                             + " The Kerberos config is currently null for the keytab and config file, double check that there isn't an incoming modify with non-null config");
+            }
+
+            try {
+                if (configAdmin != null) {
+                    Configuration[] kerbConfig = configAdmin.listConfigurations(Krb5Constants.PID_ID);
+
+                    if (kerbConfig != null) {
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                            Tr.debug(tc, METHODNAME + " Kerberos configuration ref found, check the config and keytab properties.");
+                        }
+                        for (int i = 0; i < kerbConfig.length; i++) { // really should be only 1 entry
+                            Dictionary<String, Object> props = kerbConfig[i].getProperties();
+                            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                                Tr.debug(tc, METHODNAME + " Checking props: " + props);
+                            }
+                            if (props != null) {
+                                Object keytab = props.get(Krb5Constants.KEYTAB);
+                                if (keytab != null) {
+                                    delayContextPool = true;
+                                    break;
+                                }
+
+                                Object config = props.get(Krb5Constants.CONFIG_FILE);
+                                if (config != null) {
+                                    delayContextPool = true;
+                                    break;
+                                }
+                            }
+                        }
+                    } else {
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                            Tr.debug(tc, METHODNAME + " The Kerberos config object is null, nothing to double check.");
+                        }
+                    }
+                } else {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, METHODNAME + " METHODNAME + \" ConfigAdmin is null, nothing to double check.");
+                    }
+                }
+            } catch (Exception e) {
+                if (tc.isEventEnabled()) {
+                    Tr.event(tc, METHODNAME + " Exception trying to review Kerberos config", e);
+                }
+            }
+
+
+        }
+        /*
          * Create Context Pool
          */
         try {
-            createContextPool(iInitPoolSize, null);
+            if (delayContextPool) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, METHODNAME + " Delay creating the context pool until the Kerberos service completes a config update and notifies LdapRegistry.");
+                }
+            } else {
+                createContextPool(iInitPoolSize, null);
+            }
         } catch (NamingException e) {
             if (tc.isDebugEnabled()) {
                 Tr.debug(tc, METHODNAME + " Can not create context pool: " + e.toString(true));
@@ -1625,7 +1697,8 @@ public class ContextManager {
      * @param krb5TicketCache
      */
     @FFDCIgnore({ MalformedURLException.class, URISyntaxException.class, IllegalArgumentException.class })
-    public void setKerberosCredentials(String id, KerberosService kerb, String krb5Principal, String rawKrb5TicketCache) throws PropertyNotDefinedException {
+    public void setKerberosCredentials(String id, KerberosService kerb, String krb5Principal, String rawKrb5TicketCache,
+                                       ConfigurationAdmin configAdmin) throws PropertyNotDefinedException {
         if (!isKerberosBindAuth()) {
             if (tc.isDebugEnabled()) {
                 Tr.debug(tc, "setKerberosCredentials was called, but Kerberos is not enabled. BindAuthMechanism is " + bindAuthMechanism);
@@ -1638,6 +1711,7 @@ public class ContextManager {
 
             reposId = id;
             kerberosService = kerb;
+            this.configAdmin = configAdmin;
 
             if (rawKrb5TicketCache != null && !rawKrb5TicketCache.trim().isEmpty()) {
                 krb5TicketCache = Paths.get(rawKrb5TicketCache);

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/test/com/ibm/ws/security/wim/adapter/ldap/context/ContextManagerTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/test/com/ibm/ws/security/wim/adapter/ldap/context/ContextManagerTest.java
@@ -720,7 +720,7 @@ public class ContextManagerTest {
         ContextManager cm = new ContextManager();
         cm.setPrimaryServer("localhost", primaryLdapServer.getLdapServer().getPort());
         cm.setBindAuthMechanism(ConfigConstants.CONFIG_BIND_AUTH_KRB5);
-        cm.setKerberosCredentials("UnitTestLdap", null, "testPrincipal", "DummyTicketCache");
+        cm.setKerberosCredentials("UnitTestLdap", null, "testPrincipal", "DummyTicketCache", null);
         cm.initialize();
 
         String toString = cm.toString();
@@ -899,7 +899,7 @@ public class ContextManagerTest {
         ContextManager cm = new ContextManager();
         cm.setBindAuthMechanism(ConfigConstants.CONFIG_BIND_AUTH_KRB5);
         cm.setPrimaryServer("localhost", primaryLdapServer.getLdapServer().getPort());
-        cm.setKerberosCredentials("UnitTestLdap", null, null, "badFileName");
+        cm.setKerberosCredentials("UnitTestLdap", null, null, "badFileName", null);
 
         assertEquals(InitializeResult.MISSING_KRB5_PRINCIPAL_NAME, cm.initialize());
     }
@@ -913,7 +913,7 @@ public class ContextManagerTest {
         ContextManager cm = new ContextManager();
         cm.setBindAuthMechanism(ConfigConstants.CONFIG_BIND_AUTH_KRB5);
         cm.setPrimaryServer("localhost", primaryLdapServer.getLdapServer().getPort());
-        cm.setKerberosCredentials("UnitTestLdap", null, "", "badFileName");
+        cm.setKerberosCredentials("UnitTestLdap", null, "", "badFileName", null);
 
         assertEquals(InitializeResult.MISSING_KRB5_PRINCIPAL_NAME, cm.initialize());
     }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/CommonBindTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/CommonBindTest.java
@@ -132,19 +132,6 @@ public class CommonBindTest {
         server.copyFileToLibertyServerRoot(expiredTicketCache);
         server.copyFileToLibertyServerRoot(wrongUserKeytab);
 
-        /*
-         * To-do: Working out the timing for a KerberosService modify and LdapRegistry init --
-         * Since KerberosService has a default instance, if LdapRegistry runs an init before a
-         * modify on dynamic update, we can use the default KerberosService values to initialize the contextPool
-         * and cause an extra FFDC (since the OS krb.config won't have the right info). Once the KerberosSevice
-         * modify runs, we are fine. Leaving this
-         * here temporarily so we don't have random FFDCs pop up until we resolve the modify/init
-         * dynamic update.
-         */
-        ServerConfiguration newServer = server.getServerConfiguration().clone();
-        addKerberosConfig(newServer);
-        updateConfigDynamically(server, newServer);
-
         if (emptyConfiguration == null) {
             emptyConfiguration = server.getServerConfiguration();
         }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/KeytabBindTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/KeytabBindTest.java
@@ -78,7 +78,6 @@ public class KeytabBindTest extends CommonBindTest {
      */
     @Test
     @CheckForLeakedPasswords(LdapKerberosUtils.BIND_PASSWORD)
-    @AllowedFFDC("javax.naming.NamingException") // temporary, remove when Issue #16231 is fixed
     public void basicLoginChecksWithContextPool() throws Exception {
         Log.info(c, testName.getMethodName(), "Run basic login checks with a standard configuration");
         ServerConfiguration newServer = emptyConfiguration.clone();

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBindLongRunTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBindLongRunTest.java
@@ -19,8 +19,11 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.websphere.simplicity.config.wim.LdapRegistry;
 import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.security.registry.test.UserRegistryServletConnection;
+import com.ibm.ws.security.wim.adapter.ldap.fat.krb5.utils.LdapKerberosUtils;
 
 import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.CheckForLeakedPasswords;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
@@ -82,6 +85,64 @@ public class TicketCacheBindLongRunTest extends CommonBindTest {
         updateConfigDynamically(server, newServer);
 
         bodyOfRestartServer();
+    }
+
+    /**
+     * Verify that when we dynamic add a <kerberos/> and <ldapRegistry/> config, we do a Kerberos modify
+     * before a LdapRegistry init to ensure we load with the valid config file.
+     *
+     * @throws Exception
+     */
+    @Test
+    @CheckForLeakedPasswords({ LdapKerberosUtils.BIND_PASSWORD, ApacheDSandKDC.vmmUser1pwd })
+    public void dynamimcUpdateLoop() throws Exception {
+        int numUpdates = 30;
+
+        Log.info(c, testName.getMethodName(), "Run login check with dynamic update " + numUpdates + " times.");
+
+        for (int i = 0; i < numUpdates; i++) {
+            ServerConfiguration newServer = emptyConfiguration.clone();
+            LdapRegistry ldap = getLdapRegistryWithTicketCacheWithContextPool();
+            addKerberosConfig(newServer);
+            newServer.getLdapRegistries().add(ldap);
+            updateConfigDynamically(server, newServer);
+
+            loginUser();
+
+            resetServerConfig();
+        }
+    }
+
+    /**
+     * Verify that when we start the server with <kerberos/> and <ldapRegistry/> config, we do a Kerberos init
+     * before a LdapRegistry init to ensure we load with the valid config file.
+     *
+     * @throws Exception
+     */
+    @Test
+    @CheckForLeakedPasswords({ LdapKerberosUtils.BIND_PASSWORD, ApacheDSandKDC.vmmUser1pwd })
+    public void serverRestartLoop() throws Exception {
+        int numUpdates = 5;
+
+        Log.info(c, testName.getMethodName(), "Run login check with sever restart " + numUpdates + " times.");
+
+        ServerConfiguration newServer = emptyConfiguration.clone();
+        LdapRegistry ldap = getLdapRegistryWithTicketCacheWithContextPool();
+        addKerberosConfig(newServer);
+        newServer.getLdapRegistries().add(ldap);
+        updateConfigDynamically(server, newServer);
+        loginUser();
+
+        for (int i = 0; i < numUpdates; i++) {
+            server.stopServer("CWIML4520E"); // have to supply stop server message here as it picks up the message from the LdapRestart tests
+            server.startServer();
+            startupChecks();
+
+            Log.info(c, "setUp", "Creating servlet connection the server");
+            servlet = new UserRegistryServletConnection(server.getHostname(), server.getHttpDefaultPort());
+
+            loginUser();
+        }
     }
 
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBindTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBindTest.java
@@ -74,7 +74,6 @@ public class TicketCacheBindTest extends CommonBindTest {
      */
     @Test
     @CheckForLeakedPasswords(LdapKerberosUtils.BIND_PASSWORD)
-    @AllowedFFDC("javax.naming.NamingException") // temporary, remove when Issue #16231 is fixed
     public void basicLoginChecksWithContextPool() throws Exception {
         Log.info(c, testName.getMethodName(), "Run basic login checks with a standard configuration");
         ServerConfiguration newServer = emptyConfiguration.clone();


### PR DESCRIPTION
Fixes #16231

- I added a Kerberos constants file to refer to the metatype attribute names.
- I added the ConfigurationAdmin ref to LdapAdapter to pass down to ContextManager
- If we're running Kerberos and a contextPool, check if there is config set on the KerberosService that we haven't received yet (while init is ordered, mixed init/modify is not -- the KerberosService modify can happen after LdapAdapter init). If there is config set on KerberosService, delay creating the context pool
- I added two variations of restart tests, although existing context tests hit this when I remove the temporary workarounds. I didn't hit this consistently on my Win10 box, but happens frequently on the Linux build.
- Removed the workarounds and extra allowedFFDCs added prior to this fix.