### PR TITLE
Issue #16238: Remove PRO.narrow from EJB3 FAT

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/EJB3BndWeb.war/src/com/ibm/ws/ejbcontainer/bindings/bnd/web/BindingsServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/EJB3BndWeb.war/src/com/ibm/ws/ejbcontainer/bindings/bnd/web/BindingsServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2019 IBM Corporation and others.
+ * Copyright (c) 2007, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -161,8 +161,7 @@ public class BindingsServlet extends FATServlet {
         RemoteTargetOneBiz rto1 = null;
 
         try {
-            Object lookup = ctx.lookup("ejb/RemoteTargetOneBiz");
-            rto1 = (RemoteTargetOneBiz) PortableRemoteObject.narrow(lookup, RemoteTargetOneBiz.class);
+            rto1 = (RemoteTargetOneBiz) ctx.lookup("ejb/RemoteTargetOneBiz");
         } catch (Exception e) {
             e.printStackTrace(System.out);
             fail("1 ---> Check RemoteTargetOne lookup failed");
@@ -226,8 +225,7 @@ public class BindingsServlet extends FATServlet {
         RemoteTargetTwoBiz1 rt2b1 = null;
 
         try {
-            Object lookup = ctx.lookup("ejb/RemoteTargetTwoBiz1");
-            rt2b1 = (RemoteTargetTwoBiz1) PortableRemoteObject.narrow(lookup, RemoteTargetTwoBiz1.class);
+            rt2b1 = (RemoteTargetTwoBiz1) ctx.lookup("ejb/RemoteTargetTwoBiz1");
         } catch (Exception e) {
             e.printStackTrace(System.out);
             fail("1 ---> Check RemoteTargetTwoBiz1 lookup failed");
@@ -246,8 +244,7 @@ public class BindingsServlet extends FATServlet {
         RemoteTargetTwoBiz2 rt2b2 = null;
 
         try {
-            Object lookup = ctx.lookup("ejb/RemoteTargetTwoBiz2");
-            rt2b2 = (RemoteTargetTwoBiz2) PortableRemoteObject.narrow(lookup, RemoteTargetTwoBiz2.class);
+            rt2b2 = (RemoteTargetTwoBiz2) ctx.lookup("ejb/RemoteTargetTwoBiz2");
         } catch (Exception e) {
             e.printStackTrace(System.out);
             fail("1 ---> Check RemoteTargetTwoBiz2 lookup failed");
@@ -266,8 +263,7 @@ public class BindingsServlet extends FATServlet {
         RemoteTargetTwoBiz3 rt2b3 = null;
 
         try {
-            Object lookup = ctx.lookup("ejb/RemoteTargetTwoBiz3");
-            rt2b3 = (RemoteTargetTwoBiz3) PortableRemoteObject.narrow(lookup, RemoteTargetTwoBiz3.class);
+            rt2b3 = (RemoteTargetTwoBiz3) ctx.lookup("ejb/RemoteTargetTwoBiz3");
         } catch (Exception e) {
             e.printStackTrace(System.out);
             fail("1 ---> Check RemoteTargetTwoBiz3 lookup failed");
@@ -343,8 +339,7 @@ public class BindingsServlet extends FATServlet {
         RemoteTargetFourBiz1 rt4b1 = null;
 
         try {
-            Object lookup = ctx.lookup("ejb/RemoteTargetFourBiz1");
-            rt4b1 = (RemoteTargetFourBiz1) PortableRemoteObject.narrow(lookup, RemoteTargetFourBiz1.class);
+            rt4b1 = (RemoteTargetFourBiz1) ctx.lookup("ejb/RemoteTargetFourBiz1");
         } catch (Exception e) {
             e.printStackTrace(System.out);
             fail("1 ---> Check RemoteTargetFourBiz1 lookup failed");
@@ -363,8 +358,7 @@ public class BindingsServlet extends FATServlet {
         RemoteTargetFourBiz2 rt2b4 = null;
 
         try {
-            Object lookup = ctx.lookup("ejb/RemoteTargetFourBiz2");
-            rt2b4 = (RemoteTargetFourBiz2) PortableRemoteObject.narrow(lookup, RemoteTargetFourBiz2.class);
+            rt2b4 = (RemoteTargetFourBiz2) ctx.lookup("ejb/RemoteTargetFourBiz2");
         } catch (Exception e) {
             e.printStackTrace(System.out);
             fail("1 ---> Check RemoteTargetFourBiz2 lookup failed");

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/EJBinWARTest.war/src/com/ibm/ws/ejbcontainer/bindings/ejbinwar/web/LooseStatelessBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/EJBinWARTest.war/src/com/ibm/ws/ejbcontainer/bindings/ejbinwar/web/LooseStatelessBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2019 IBM Corporation and others.
+ * Copyright (c) 2010, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,6 @@ import javax.ejb.Remote;
 import javax.ejb.Stateless;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import javax.rmi.PortableRemoteObject;
 
 import com.ibm.ws.ejbcontainer.bindings.ejbinwar.ejb.BasicSingletonInterface;
 import com.ibm.ws.ejbcontainer.bindings.ejbinwar.ejb.BasicSingletonInterfaceRemote;
@@ -76,10 +75,7 @@ public class LooseStatelessBean {
         ivctx = new InitialContext();
 
         svLogger.info("--> Looking up generic object using: ejb/EJBinWARTestApp/EJBBean.jar/SingletonBean#com.ibm.ws.ejbcontainer.bindings.ejbinwar.ejb.BasicSingletonInterfaceRemote");
-        Object o = ivctx.lookup("ejb/EJBinWARTestApp/EJBBean.jar/SingletonBean#com.ibm.ws.ejbcontainer.bindings.ejbinwar.ejb.BasicSingletonInterfaceRemote");
-
-        svLogger.info("--> Narrowing the object to BasicSingletonInterfaceRemote... ");
-        BasicSingletonInterfaceRemote remoteStandaloneSing = (BasicSingletonInterfaceRemote) PortableRemoteObject.narrow(o, BasicSingletonInterfaceRemote.class);
+        BasicSingletonInterfaceRemote remoteStandaloneSing = (BasicSingletonInterfaceRemote) ivctx.lookup("ejb/EJBinWARTestApp/EJBBean.jar/SingletonBean#com.ibm.ws.ejbcontainer.bindings.ejbinwar.ejb.BasicSingletonInterfaceRemote");
 
         boolean result = false;
         result = remoteStandaloneSing.verifyStandaloneEJBLookup();

--- a/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/ServerXMLBindingsWeb.war/src/com/ibm/ws/ejbcontainer/bindings/serverxml/bnd/web/ServerXMLBindingsTestServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.bindings_fat/test-applications/ServerXMLBindingsWeb.war/src/com/ibm/ws/ejbcontainer/bindings/serverxml/bnd/web/ServerXMLBindingsTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -118,10 +118,9 @@ public class ServerXMLBindingsTestServlet extends FATServlet {
         assertNotNull("@EJB bean.method() for binding-name for local was null", bindingNameEJB.foo());
 
         // Remote
-        Object RBNlookup = ctx.lookup("ejb/ServerXMLBindingNameIntf5");
-        RemoteBindingNameIntf RBNbeanHome = (RemoteBindingNameIntf) PortableRemoteObject.narrow(RBNlookup, RemoteBindingNameIntf.class);
-        assertNotNull("lookup binding-name for remote was null", RBNbeanHome);
-        assertNotNull("bean.method() for binding-name for remote was null", RBNbeanHome.foo());
+        RemoteBindingNameIntf RBNbean = (RemoteBindingNameIntf) ctx.lookup("ejb/ServerXMLBindingNameIntf5");
+        assertNotNull("lookup binding-name for remote was null", RBNbean);
+        assertNotNull("bean.method() for binding-name for remote was null", RBNbean.foo());
 
         assertNotNull("@EJB binding-name for remote was null", remoteBindingNameEJB);
         assertNotNull("@EJB bean.method() for binding-name for remote was null", remoteBindingNameEJB.foo());

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/EnvEntryWeb.war/src/com/ibm/ws/ejbcontainer/remote/enventry/web/EnvEntryServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/EnvEntryWeb.war/src/com/ibm/ws/ejbcontainer/remote/enventry/web/EnvEntryServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2018 IBM Corporation and others.
+ * Copyright (c) 2010, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,6 @@ import java.util.logging.Logger;
 import javax.annotation.PostConstruct;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import javax.rmi.PortableRemoteObject;
 import javax.servlet.annotation.WebServlet;
 
 import org.junit.Test;
@@ -76,14 +75,12 @@ public class EnvEntryServlet extends FATServlet {
 
             if (svXmlTestDriver == null) {
                 // Lookup the Xml test driver EJB
-                Object obj = initCtx.lookup("java:app/EnvEntryEJB/EnvEntryXmlDriverBean");
-                svXmlTestDriver = (EnvEntryDriver) PortableRemoteObject.narrow(obj, EnvEntryDriver.class);
+                svXmlTestDriver = (EnvEntryDriver) initCtx.lookup("java:app/EnvEntryEJB/EnvEntryXmlDriverBean");
             }
 
             if (svAnnTestDriver == null) {
                 // Lookup the Ann test driver EJB
-                Object obj = initCtx.lookup("java:app/EnvEntryEJB/EnvEntryAnnDriverBean");
-                svAnnTestDriver = (EnvEntryDriver) PortableRemoteObject.narrow(obj, EnvEntryDriver.class);
+                svAnnTestDriver = (EnvEntryDriver) initCtx.lookup("java:app/EnvEntryEJB/EnvEntryAnnDriverBean");
             }
         } catch (NamingException ne) {
             throw new RuntimeException(ne);

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/JitDeployWeb.war/src/com/ibm/ws/ejbcontainer/remote/misc/jitdeploy/web/IDLEntityStubServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/JitDeployWeb.war/src/com/ibm/ws/ejbcontainer/remote/misc/jitdeploy/web/IDLEntityStubServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 IBM Corporation and others.
+ * Copyright (c) 2011, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,6 @@ import static org.omg.CORBA.CompletionStatus._COMPLETED_NO;
 import static org.omg.CORBA.CompletionStatus._COMPLETED_YES;
 
 import javax.naming.InitialContext;
-import javax.rmi.PortableRemoteObject;
 import javax.servlet.annotation.WebServlet;
 
 import org.junit.Test;
@@ -68,7 +67,7 @@ public class IDLEntityStubServlet extends FATServlet {
      */
     @Test
     public void testIDLEntityParametersAndReturnType() throws Exception {
-        IDLEntityRemote bean = (IDLEntityRemote) PortableRemoteObject.narrow(new InitialContext().lookup("java:app/JitDeployEJB/IDLEntityRemoteBean"), IDLEntityRemote.class);
+        IDLEntityRemote bean = (IDLEntityRemote) new InitialContext().lookup("java:app/JitDeployEJB/IDLEntityRemoteBean");
 
         CompletionStatus idlEntity = CompletionStatus.from_int(_COMPLETED_YES);
         CompletionStatus idlEntity2 = CompletionStatus.from_int(_COMPLETED_NO);
@@ -103,7 +102,7 @@ public class IDLEntityStubServlet extends FATServlet {
      */
     @Test
     public void testIDLEntityParametersAndReturnTypeWithRMIC() throws Exception {
-        IDLEntityRMIC bean = (IDLEntityRMIC) PortableRemoteObject.narrow(new InitialContext().lookup("java:app/JitDeployEJB/IDLEntityRMICBean"), IDLEntityRMIC.class);
+        IDLEntityRMIC bean = (IDLEntityRMIC) new InitialContext().lookup("java:app/JitDeployEJB/IDLEntityRMICBean");
 
         CompletionStatus idlEntity = CompletionStatus.from_int(_COMPLETED_YES);
         CompletionStatus idlEntity2 = CompletionStatus.from_int(_COMPLETED_NO);


### PR DESCRIPTION
Some FAT for the EJB 3.x APIs are unnecessarily performing PortableRemoteObject.narrow()
calls; remove those calls to ensure compliance with the specification.

for #16238 