### PR TITLE
Reduce timestamp precision of bundle and feature caches

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/BundleProcessor.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/BundleProcessor.java
@@ -923,8 +923,13 @@ class BundleProcessor implements SynchronousBundleListener, EventHandler, Runtim
             return hasDefaultConfig.get();
         }
 
+        // Remove milliseconds from timestamp values to address inconsistencies in container file systems
+        long reduceTimestampPrecision(long value) {
+            return (value / 1000) * 1000;
+        }
+
         public boolean needsReprocessing() {
-            return lastProcessed.get() != bundle.getLastModified();
+            return reduceTimestampPrecision(lastProcessed.get()) != reduceTimestampPrecision(bundle.getLastModified());
         }
 
         public Bundle getBundle() {

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureRepository.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureRepository.java
@@ -594,12 +594,17 @@ public final class FeatureRepository implements FeatureResolver.Repository {
                && f.length() == bf.length;
     }
 
+    // Remove milliseconds from timestamp values to address inconsistencies in container file systems
+    long reduceTimestampPrecision(long value) {
+        return (value / 1000) * 1000;
+    }
+
     boolean isCachedEntryValid(File f, SubsystemFeatureDefinitionImpl def) {
         if (def != null) {
             ImmutableAttributes cachedAttr = def.getImmutableAttributes();
 
             // See if the file has changed: if it has, we need to start over
-            if (cachedAttr.lastModified == f.lastModified()) {
+            if (reduceTimestampPrecision(cachedAttr.lastModified) == reduceTimestampPrecision(f.lastModified())) {
                 if (cachedAttr.length == f.length())
                     return true;
             }


### PR DESCRIPTION
Docker container file systems can have inconsistent timestamps where at some point in the build process the file system has millisecond precision and in the final container it only has second precision. Neither the feature cache nor the bundle cache should care about millisecond level precision, so we can reduce the precision of these timestamps when we do comparisons. 