### PR TITLE
Issue 16250: Fix NPE with bad KRB5PrincipalName

### DIFF
--- a/dev/com.ibm.ws.security.kerberos.auth/resources/com/ibm/ws/security/kerberos/auth/internal/resources/KerberosMessages.nlsprops
+++ b/dev/com.ibm.ws.security.kerberos.auth/resources/com/ibm/ws/security/kerberos/auth/internal/resources/KerberosMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -25,3 +25,15 @@ KRB5_FILE_NOT_FOUND_CWWKS4345E.useraction=Ensure that the configuration points t
 KRB5_FILE_FOUND_CWWKS4346I=CWWKS4346I: The Kerberos component is configured to use a {0} file located at {1}
 KRB5_FILE_FOUND_CWWKS4346I.explanation=The configured file was successfully located.
 KRB5_FILE_FOUND_CWWKS4346I.useraction=No action is required.
+
+KRB5_LOGIN_FAILED_CACHE_CWWKS4347E=CWWKS4347E: Kerberos login failed with the {0} Kerberos principal and the {1} Kerberos credential cache (ccache). A Kerberos ticket was not found.
+KRB5_LOGIN_FAILED_CACHE_CWWKS4347E.explanation=Either the specified Kerberos principal is invalid, or the Kerberos credential cache (ccache) is invalid or expired.
+KRB5_LOGIN_FAILED_CACHE_CWWKS4347E.useraction=Ensure that a valid Kerberos principal is specified and that the Kerberos credential cache (ccache) is valid and not expired.
+
+KRB5_LOGIN_FAILED_KEYTAB_CWWKS4348E=CWWKS4348E: Kerberos login failed with the {0} Kerberos principal and the {1} Kerberos keytab file. A Kerberos ticket was not found.
+KRB5_LOGIN_FAILED_KEYTAB_CWWKS4348E.explanation=Either the specified Kerberos principal or the Kerberos keytab file is invalid.
+KRB5_LOGIN_FAILED_KEYTAB_CWWKS4348E.useraction=Ensure that a valid Kerberos keytab file is specified and that it contains a valid Kerberos principal.
+		
+KRB5_LOGIN_FAILED_DEFAULT_KEYTAB_CWWKS4349E=CWWKS4349E: Kerberos login failed with the {0} Kerberos principal and the default Kerberos keytab file. A Kerberos ticket was not found.
+KRB5_LOGIN_FAILED_DEFAULT_KEYTAB_CWWKS4349E.explanation=Either the specified Kerberos principal or the default Kerberos keytab file is invalid.
+KRB5_LOGIN_FAILED_DEFAULT_KEYTAB_CWWKS4349E.useraction=Ensure that a valid Kerberos keytab file is specified and that it contains a valid Kerberos principal.

--- a/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/KerberosService.java
+++ b/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/KerberosService.java
@@ -272,6 +272,21 @@ public class KerberosService {
         Set<GSSCredential> gssCreds = subject.getPrivateCredentials(GSSCredential.class);
         if (gssCreds == null || gssCreds.size() == 0) {
             GSSCredential gssCred = SubjectHelper.createGSSCredential(subject);
+
+            if (gssCred == null) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "The createGSSCredential on subject " + subject + " using principal, " + principal + ", returned null. ");
+                }
+                String msg = null;
+                if (ccache != null) {
+                    msg = Tr.formatMessage(tc, "KRB5_LOGIN_FAILED_CACHE_CWWKS4347E", principal, ccache.toAbsolutePath());
+                } else if (keytab != null) {
+                    msg = Tr.formatMessage(tc, "KRB5_LOGIN_FAILED_KEYTAB_CWWKS4348E", principal, keytab.toAbsolutePath());
+                } else {
+                    msg = Tr.formatMessage(tc, "KRB5_LOGIN_FAILED_DEFAULT_KEYTAB_CWWKS4349E", principal);
+                }
+                throw new LoginException(msg);
+            }
             if (System.getSecurityManager() == null) {
                 subject.getPrivateCredentials().add(gssCred);
             } else {

--- a/dev/com.ibm.ws.security.kerberos.java8/resources/com/ibm/ws/security/kerberos/internal/resources/KerberosMessages.nlsprops
+++ b/dev/com.ibm.ws.security.kerberos.java8/resources/com/ibm/ws/security/kerberos/internal/resources/KerberosMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -40,6 +40,12 @@ KRB_S4U2PROXY_IS_NOT_SUPPORT.useraction=Use the Java vendor and version that is 
 # CWWKS4345E is used by the com.ibm.ws.security.kerberos.auth bundle
 
 # CWWKS4346I is used by the com.ibm.ws.security.kerberos.auth bundle
+
+# CWWKS4347E is used by the com.ibm.ws.security.kerberos.auth bundle
+
+# CWWKS4348E is used by the com.ibm.ws.security.kerberos.auth bundle
+
+# CWWKS4349E is used by the com.ibm.ws.security.kerberos.auth bundle
 
 
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/FATSuite.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/FATSuite.java
@@ -34,6 +34,7 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
                 TicketCacheBadPrincipalNameTest.class,
                 TicketCacheBindExpireTests.class,
                 RealmNameJVMProp.class,
+                TicketCacheBadPrincipalJava8.class,
                 /*
                  * vvv Leave Krb5ConfigJVMProp as the last test, the JVM prop changes the rest of the tests
                  */

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBadPrincipalJava8.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBadPrincipalJava8.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.wim.adapter.ldap.fat.krb5;
+
+import static componenttest.topology.utils.LDAPFatUtils.updateConfigDynamically;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.websphere.simplicity.config.wim.LdapRegistry;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.MaximumJavaLevel;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+
+/**
+ * Java 8 test where we hit an NPE if the krb5Principal name was not found in the ticketCache
+ *
+ */
+@RunWith(FATRunner.class)
+@Mode(TestMode.LITE)
+@MaximumJavaLevel(javaLevel = 8)
+public class TicketCacheBadPrincipalJava8 extends CommonBindTest {
+
+    private static final Class<?> c = TicketCacheBadPrincipalJava8.class;
+
+    @BeforeClass
+    public static void setStopMessages() {
+        stopStrings = new String[] { "CWIML4507E", "CWWKS4347E" };
+    }
+
+    /**
+     * Provide a principalName that doesn't exist in the cache
+     *
+     * @throws Exception
+     */
+    @AllowedFFDC({ "javax.security.auth.login.LoginException" })
+    @Test
+    public void badPrincipalName() throws Exception {
+        Log.info(c, testName.getMethodName(), "Run with a bad principal name");
+
+        ServerConfiguration newServer = emptyConfiguration.clone();
+        LdapRegistry ldap = getLdapRegistryWithTicketCache();
+        ldap.setKrb5Principal("badPrincipalName");
+        newServer.getLdapRegistries().add(ldap);
+        addKerberosConfig(newServer);
+        updateConfigDynamically(server, newServer);
+
+        Log.info(c, testName.getMethodName(), "Login expected to fail, config has a bad principalName");
+        loginUserShouldFail();
+
+        assertFalse("Expected to find Kerberos bind failure: CWIML4507E", server.findStringsInLogsAndTraceUsingMark("CWIML4507E").isEmpty());
+        // Message added to avoid an NPE when running on Java 8
+        assertFalse("Expected to find Kerberos bind failure: CWWKS4347E", server.findStringsInLogsAndTraceUsingMark("CWWKS4347E").isEmpty());
+    }
+
+}


### PR DESCRIPTION
Fixes #16250 

In Java 8, we ended up in a scenario where `createGSSCredential` during the login returned a null and we didn't handle it. This does not occur in OpenJDK11. I added a check for the null so we can throw an exception on the failed login.