### PR TITLE
Correctly handle ORA-12631

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/OracleKerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/OracleKerberosTest.java
@@ -31,6 +31,7 @@ import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.jdbc.fat.krb5.containers.KerberosPlatformRule;
 import com.ibm.ws.jdbc.fat.krb5.containers.OracleKerberosContainer;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
@@ -115,7 +116,7 @@ public class OracleKerberosTest extends FATServletClient {
      * set the keytab location to an invalid location to confirm that the supplied password actually gets used.
      */
     @Test
-    @Mode(TestMode.FULL)
+    @AllowedFFDC //Servlet attempts getConnection multiple times until the kerberos service is up.  Expect FFDCs
     public void testKerberosUsingPassword() throws Exception {
         ServerConfiguration config = server.getServerConfiguration();
         String originalKeytab = config.getKerberos().keytab;


### PR DESCRIPTION
We were correctly handling ORA-12631 issues due to a known race condition in our test infrastructure.  
However, these were still failing due to the FFDC check done by the FATServlet.  
- Cleaned up the getConnectionWithRetry() logic
- Added AllowedFFDCS to the test's that use getConnectionWithRetry()