### PR TITLE
Fix issues with initDatabase() method

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/fat/src/com/ibm/ws/jdbc/fat/sqlserver/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/fat/src/com/ibm/ws/jdbc/fat/sqlserver/FATSuite.java
@@ -10,6 +10,11 @@
  *******************************************************************************/
 package com.ibm.ws.jdbc.fat.sqlserver;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -17,12 +22,16 @@ import org.junit.runners.Suite.SuiteClasses;
 import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import com.ibm.websphere.simplicity.log.Log;
+
 import componenttest.containers.ExternalTestServiceDockerClientStrategy;
 import componenttest.containers.SimpleLogConsumer;
 
 @RunWith(Suite.class)
 @SuiteClasses(SQLServerTest.class)
 public class FATSuite {
+
+    public static final String DB_NAME = "test";
 
     //Required to ensure we calculate the correct strategy each run even when
     //switching between local and remote docker hosts.
@@ -37,4 +46,43 @@ public class FATSuite {
     public static MSSQLServerContainer<?> sqlserver = new MSSQLServerContainer<>(sqlserverImage) //
                     .withLogConsumer(new SimpleLogConsumer(FATSuite.class, "sqlserver")) //
                     .acceptLicense();
+
+    /**
+     * Create database and tables needed by test servlet.
+     * Use a native JDBC connection from the driver so that there aren't any dependencies on the appserver.
+     * The SQLServer container already has knowledge of how to create a native JDBC connection.
+     *
+     * @throws SQLException
+     */
+    @BeforeClass
+    public static void setup() throws SQLException {
+        final String TABLE_NAME = "MYTABLE";
+
+        //Setup database and settings
+        Log.info(FATSuite.class, "setup", "Attempting to setup database with name: " + DB_NAME + "."
+                                          + " With connection URL: " + sqlserver.getJdbcUrl());
+        try (Connection conn = sqlserver.createConnection(""); Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE DATABASE [" + DB_NAME + "];");
+            stmt.execute("EXEC sp_sqljdbc_xa_install");
+            stmt.execute("ALTER DATABASE " + DB_NAME + " SET ALLOW_SNAPSHOT_ISOLATION ON");
+        }
+
+        //Create test table
+        sqlserver.withUrlParam("databaseName", DB_NAME);
+        Log.info(FATSuite.class, "setup", "Attempting to setup database table with name: " + TABLE_NAME + "."
+                                          + " With connection URL: " + sqlserver.getJdbcUrl());
+        try (Connection conn = sqlserver.createConnection(""); Statement stmt = conn.createStatement()) {
+            // Create tables
+            int version = conn.getMetaData().getDatabaseMajorVersion();
+            try {
+                if (version >= 13) // SQLServer 2016 or higher
+                    stmt.execute("DROP TABLE IF EXISTS " + TABLE_NAME);
+                else
+                    stmt.execute("DROP TABLE " + TABLE_NAME);
+            } catch (SQLException x) {
+                // probably didn't exist
+            }
+            stmt.execute("CREATE TABLE " + TABLE_NAME + " (ID SMALLINT NOT NULL PRIMARY KEY, STRVAL NVARCHAR(40))");
+        }
+    }
 }

--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/fat/src/com/ibm/ws/jdbc/fat/sqlserver/SQLServerTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/fat/src/com/ibm/ws/jdbc/fat/sqlserver/SQLServerTest.java
@@ -12,17 +12,12 @@ package com.ibm.ws.jdbc.fat.sqlserver;
 
 import static com.ibm.ws.jdbc.fat.sqlserver.FATSuite.sqlserver;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
-import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.JdbcDatabaseContainer.NoDriverFoundException;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
@@ -45,10 +40,7 @@ public class SQLServerTest extends FATServletClient {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        String dbName = "test";
-        initDatabase(sqlserver, dbName);
-
-        server.addEnvVar("DBNAME", dbName);
+        server.addEnvVar("DBNAME", FATSuite.DB_NAME);
         server.addEnvVar("HOST", sqlserver.getContainerIpAddress());
         server.addEnvVar("PORT", Integer.toString(sqlserver.getFirstMappedPort()));
         server.addEnvVar("USER", sqlserver.getUsername());
@@ -58,25 +50,6 @@ public class SQLServerTest extends FATServletClient {
         ShrinkHelper.defaultApp(server, APP_NAME, "web");
 
         server.startServer();
-
-        runTest(server, APP_NAME + '/' + SERVLET_NAME, "initDatabase");
-    }
-
-    //Helper method
-    private static void initDatabase(JdbcDatabaseContainer<?> cont, String dbName) throws NoDriverFoundException, SQLException {
-        // Create Database
-        try (Connection conn = cont.createConnection("")) {
-            Statement stmt = conn.createStatement();
-            stmt.execute("CREATE DATABASE [" + dbName + "];");
-            stmt.close();
-        }
-
-        //Setup distributed connection.
-        try (Connection conn = cont.createConnection("")) {
-            Statement stmt = conn.createStatement();
-            stmt.execute("EXEC sp_sqljdbc_xa_install");
-            stmt.close();
-        }
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/publish/servers/com.ibm.ws.jdbc.fat.sqlserver/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/publish/servers/com.ibm.ws.jdbc.fat.sqlserver/server.xml
@@ -75,7 +75,7 @@
 
   <javaPermission codebase="${server.config.dir}/apps/sqlserverfat.war" className="java.security.AllPermission"/>
   <javaPermission codebase="${shared.resource.dir}/sqlserver/anomyous.jar" className="java.security.AllPermission"/>
-  
+ 
   <!-- SQLServer JDBC test requirement -->
   <javaPermission className="java.util.PropertyPermission" name="java.specification.version" actions="read"/>
   <javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>

--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/test-applications/sqlserverfat/src/web/SQLServerTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/test-applications/sqlserverfat/src/web/SQLServerTestServlet.java
@@ -84,33 +84,6 @@ public class SQLServerTestServlet extends FATServlet {
     // Maximum amount of time the test will wait for an operation to complete
     private static final long TIMEOUT = TimeUnit.MINUTES.toNanos(2);
 
-    // One-time initialization of database before tests run
-    public void initDatabase() throws SQLException {
-        Connection con = ds.getConnection();
-        try {
-            // Enable the use of snapshot isolation level
-            String dbName = con.getCatalog();
-            Statement stmt = con.createStatement();
-            stmt.execute("ALTER DATABASE " + dbName + " SET ALLOW_SNAPSHOT_ISOLATION ON");
-
-            // Create tables
-            int version = con.getMetaData().getDatabaseMajorVersion();
-            if (version >= 13) // SQLServer 2016 or higher
-                stmt.execute("DROP TABLE IF EXISTS MYTABLE");
-            else
-                try {
-                    stmt.execute("DROP TABLE MYTABLE");
-                } catch (SQLException x) {
-                    // probably didn't exist
-                }
-            stmt.execute("CREATE TABLE MYTABLE (ID SMALLINT NOT NULL PRIMARY KEY, STRVAL NVARCHAR(40))");
-
-            stmt.close();
-        } finally {
-            con.close();
-        }
-    }
-
     // Verify that the responseBuffering attribute of cached statements is reset to the default from the data source
     @Test
     public void testResponseBuffering() throws Exception {


### PR DESCRIPTION
We had several places where we were setting up the database, table, and stored procedures for use by the test servlet. 
One of the setup steps was happening in the servlet itself, which was not good practice as some unrelated issue could affect the setup step and cause build failures unrelated to the root cause. 

Moving all setup to a single method that uses native JDBC driver connection to avoid any appserver issues from affecting setup. 