### PR TITLE
Output GenerateCategories stderr and save off stdout

### DIFF
--- a/.github/test-categories/JDBC
+++ b/.github/test-categories/JDBC
@@ -3,6 +3,7 @@ com.ibm.ws.jdbc_fat_db2
 com.ibm.ws.jdbc_fat_derby
 com.ibm.ws.jdbc_fat_driver
 com.ibm.ws.jdbc_fat_heritage
+com.ibm.ws.jdbc_fat_heritageinterop
 com.ibm.ws.jdbc_fat_krb5
 com.ibm.ws.jdbc_fat_loadfromapp
 com.ibm.ws.jdbc_fat_oracle

--- a/.github/test-categories/JDBC
+++ b/.github/test-categories/JDBC
@@ -2,7 +2,6 @@ com.ibm.ws.jdbc_fat
 com.ibm.ws.jdbc_fat_db2
 com.ibm.ws.jdbc_fat_derby
 com.ibm.ws.jdbc_fat_driver
-com.ibm.ws.jdbc_fat_heritage
 com.ibm.ws.jdbc_fat_heritageinterop
 com.ibm.ws.jdbc_fat_krb5
 com.ibm.ws.jdbc_fat_loadfromapp

--- a/.github/test-categories/LOGGING_2
+++ b/.github/test-categories/LOGGING_2
@@ -3,3 +3,4 @@ com.ibm.ws.request.probe.servlet_fat
 com.ibm.ws.request.probes_fat
 com.ibm.ws.request.timing_fat
 com.ibm.ws.request.timing.hung_fat
+com.ibm.ws.request.timing.monitor_fat

--- a/.github/workflow-scripts/GenerateCategories.java
+++ b/.github/workflow-scripts/GenerateCategories.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 public class GenerateCategories {
     
     //Constants
-    static final boolean DEBUG = false;
+    static final boolean DEBUG = true;
     static final String TEST_CATEGORY_DIR = ".github/test-categories/";
     static final String MODIFIED_FILES_DIFF = ".github/modified_files.diff";
 
@@ -200,12 +200,16 @@ public class GenerateCategories {
             if (modifiedFile.startsWith(TEST_CATEGORY_DIR))
                 continue;
             if (!modifiedFile.startsWith("dev/")) {
-                debug("WARN: Found modified file outside of 'dev/' tree.");
+                debug("WARN: Found modified file outside of 'dev/' tree: " + modifiedFile);
                 modifiedProjects.add("INFRA_OR_UNKNOWN");
             }
-            String projectName = modifiedFile.substring(4);
-            projectName = projectName.substring(0, projectName.indexOf('/'));
-            modifiedProjects.add(projectName);
+            try {
+                String projectName = modifiedFile.substring(4);
+                projectName = projectName.substring(0, projectName.indexOf('/'));
+                modifiedProjects.add(projectName);
+            } catch (StringIndexOutOfBoundsException e) {
+                debug("Could not parse modifiedFile=" + modifiedFile);
+            }
         }
 
         return modifiedProjects;
@@ -233,6 +237,6 @@ public class GenerateCategories {
     private static void debug(Object msg) {
         if (!DEBUG)
             return;
-        System.out.println(msg);
+        System.err.println(msg);
     }
 }

--- a/.github/workflow-scripts/build.sh
+++ b/.github/workflow-scripts/build.sh
@@ -12,11 +12,13 @@
 cd dev
 chmod +x gradlew
 
+# global variables
+OUTPUT_FILE=tmp/gradle.log && mkdir -p -- "$(dirname -- "$OUTPUT_FILE")" && touch -- "$OUTPUT_FILE"
+
 echo "::group::Building Liberty.  This will take approx. 30 minutes"
 
 #Initalize, assemble, and redirect output to a gradle.log file
-mkdir tmp && touch tmp/gradle.log
-./gradlew cnf:initialize assemble &> tmp/gradle.log
+./gradlew cnf:initialize assemble &> $OUTPUT_FILE
 
 echo "::endgroup::"
 

--- a/.github/workflow-scripts/generate-params.sh
+++ b/.github/workflow-scripts/generate-params.sh
@@ -14,6 +14,9 @@
 #   App: GenerateCategories.java        - calculates category matrix and outputs in json format
 ##############################
 
+# global variables
+OUTPUT_FILE=tmp/GenerateCategories.out && mkdir -p -- "$(dirname -- "$OUTPUT_FILE")" && touch -- "$OUTPUT_FILE"
+
 # Save off PR Summary
 echo $PRBODY >> .github/pull_request_body.txt
 echo "::group::PR Summary"
@@ -27,8 +30,12 @@ cat .github/modified_files.diff
 echo "::endgroup::"
 
 # Generate test categories
-MATRIX_RESULT=$(java .github/workflow-scripts/GenerateCategories.java .github/pull_request_body.txt)
+echo "::group::GenerateCategories Debug"
+java .github/workflow-scripts/GenerateCategories.java .github/pull_request_body.txt 1>> $OUTPUT_FILE
+echo "::endgroup::"
+
 echo "::group::MATRIX_RESULT"
+MATRIX_RESULT=$(cat $OUTPUT_FILE)
 echo $MATRIX_RESULT
 echo "::endgroup::"
 

--- a/.github/workflow-scripts/run-fat-build.sh
+++ b/.github/workflow-scripts/run-fat-build.sh
@@ -78,22 +78,23 @@ for FAT_BUCKET in $FAT_BUCKETS
 do
   echo "::group:: Run $FAT_BUCKET with FAT_ARGS=$FAT_ARGS"
   BUCKET_PASSED=true
-  TEMP_DIR=tmp/$FAT_BUCKET && mkdir -p $TEMP_DIR && touch $TEMP_DIR/gradle.log
+  OUTPUT_FILE=tmp/$FAT_BUCKET/gradle.log && mkdir -p -- "$(dirname -- "$OUTPUT_FILE")" && touch -- "$OUTPUT_FILE"
 
   #Run fat
-  ./gradlew :$FAT_BUCKET:buildandrun $FAT_ARGS &> $TEMP_DIR/gradle.log || BUCKET_PASSED=false
+  ./gradlew :$FAT_BUCKET:buildandrun $FAT_ARGS &> $OUTPUT_FILE || BUCKET_PASSED=false
 
   OUTPUT_DIR=$FAT_BUCKET/build/libs/autoFVT/output
   RESULTS_DIR=$FAT_BUCKET/build/libs/autoFVT/results
-  mkdir -p $OUTPUT_DIR && touch $OUTPUT_DIR/gradle.log && mv $TEMP_DIR/gradle.log $OUTPUT_DIR/gradle.log
 
   # Create a file to mark whether a bucket failed or passed
   if $BUCKET_PASSED; then
     echo "The bucket $FAT_BUCKET passed.";
     touch "$OUTPUT_DIR/passed.log";
+    rm -rf tmp/
   else
     echo "$FAT_BUCKET failed."
     touch "$OUTPUT_DIR/fail.log";
+    mv $OUTPUT_FILE $OUTPUT_DIR
   fi
   
   # Collect all junit files in a central location

--- a/.github/workflow-scripts/run-unit-tests.sh
+++ b/.github/workflow-scripts/run-unit-tests.sh
@@ -15,7 +15,7 @@ chmod +x gradlew
 
 # global variables
 OUTPUT_FILE=tmp/gradle.log && mkdir -p -- "$(dirname -- "$OUTPUT_FILE")" && touch -- "$OUTPUT_FILE"
-UNIT_DIR=unit-results/ && mkdir -p $UNIT_DIR
+UNIT_DIR=$PWD/unit-results/ && mkdir -p $UNIT_DIR
 
 # Redirect stdout to log file that will get archived if build fails
 echo "Running gradle test and testReport tasks.  This will take approx. 30 minutes."

--- a/.github/workflow-scripts/run-unit-tests.sh
+++ b/.github/workflow-scripts/run-unit-tests.sh
@@ -9,15 +9,18 @@
 #   Build Output: status          - Reports build status [failure/success]
 ############################## 
 
+#Setup gradle
 cd dev
 chmod +x gradlew
 
-echo "Running gradle test and testReport tasks.  This will take approx. 30 minutes."
+# global variables
+OUTPUT_FILE=tmp/gradle.log && mkdir -p -- "$(dirname -- "$OUTPUT_FILE")" && touch -- "$OUTPUT_FILE"
+UNIT_DIR=unit-results/ && mkdir -p $UNIT_DIR
 
 # Redirect stdout to log file that will get archived if build fails
-mkdir tmp && touch tmp/gradle.log
+echo "Running gradle test and testReport tasks.  This will take approx. 30 minutes."
 echo "::group::Gradle Output"
-./gradlew --continue cnf:initialize testResults -Dgradle.test.ignoreFailures=true &> tmp/gradle.log
+./gradlew --continue cnf:initialize testResults -Dgradle.test.ignoreFailures=true &> $OUTPUT_FILE
 echo "::endgroup::"
 
 # Gradle testResults task will save off results in generated.properties ensure that file exists otherwise fail
@@ -36,10 +39,6 @@ total=$(grep tests.total.all generated.properties | sed 's/[^0-9]*//g')
 successful=$(grep tests.total.successful generated.properties | sed 's/[^0-9]*//g')
 failed=$(grep tests.total.failed generated.properties | sed 's/[^0-9]*//g')
 skipped=$(grep tests.total.skipped generated.properties | sed 's/[^0-9]*//g')
-
-#Setup output directory 
-UNIT_DIR=$PWD/unit-results
-mkdir $UNIT_DIR
 
 #Collect test results in central location
 #Check each project

--- a/.github/workflow-scripts/validate-copyright-headers.sh
+++ b/.github/workflow-scripts/validate-copyright-headers.sh
@@ -7,6 +7,7 @@
 # Outputs: none (just fail and report if we find any)
 ##############################
 
+# Prevent script from reporting failures
 set +e
 
 # Strings indicating IBM-specific copyright notice.

--- a/.github/workflow-scripts/validate-fat-failures.sh
+++ b/.github/workflow-scripts/validate-fat-failures.sh
@@ -9,6 +9,7 @@
 #   Files: dev/failing_buckets/*  - Collection of failing bucket zips to be archived for debugging
 ##############################
 
+# Prevent script from reporting failures
 set +e
 
 echo "Done running all FAT buckets. Checking for failures now."

--- a/.github/workflow-scripts/validate-tests.sh
+++ b/.github/workflow-scripts/validate-tests.sh
@@ -10,11 +10,7 @@
 # This script performs validation for PRs that will fail if a fat was created/renamed/removed but not updated in test-categories
 TEST_CATEGORY_DIR=$PWD/.github/test-categories/
 DEV_DIR=$PWD/dev
-TEMP_COMPAR_DIR=$PWD/category-comparison/
-
-if [ ! -d $TEMP_COMPAR_DIR ]; then 
-    mkdir $TEMP_COMPAR_DIR
-fi
+TEMP_COMPAR_DIR=$PWD/category-comparison/ && mkdir -p $TEMP_COMPAR_DIR
 
 #Collect existing fats in test-categories
 awk 1 $TEST_CATEGORY_DIR* > $TEMP_COMPAR_DIR/expectedTmp


### PR DESCRIPTION
Recently seen errors during the GenerateCategories step.  Since we were using the stdout of GenerateCategories to set the category matrix we had no debug output to look at if there was an error at this step.  Therefore, I changed it to allow stderr to be output to GitHub actions, and stdout is saved off to a file. 