### PR TITLE
isUnsupported legacy DataStoreHelper method

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/heritage/GenericDataStoreHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/heritage/GenericDataStoreHelper.java
@@ -132,6 +132,14 @@ public abstract class GenericDataStoreHelper {
     public abstract boolean isConnectionError(SQLException x);
 
     /**
+     * Determines if the exception indicates an unsupported operation.
+     *
+     * @param x the exception.
+     * @return true if the exception indicates an unsupported operation, otherwise false.
+     */
+    public abstract boolean isUnsupported(SQLException x);
+
+    /**
      * Used to identify an exception and possibly replace it (if replaceExceptions=true).
      *
      * @param x an exception.

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/AdapterUtil.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/AdapterUtil.java
@@ -1190,7 +1190,7 @@ public class AdapterUtil {
                 mappedX = mcf.dataStoreHelper.mapException(sqlX);
                 mapsToStaleConnection = isLegacyException(mappedX, IdentifyExceptionAs.StaleConnection.legacyClassName);
                 if (tc.isDebugEnabled())
-                    Tr.debug(tc, "mapped to " + mappedX.getClass().getName());
+                    Tr.debug(tc, mappedX == sqlX ? "not replaced" : ("mapped to " + mappedX.getClass().getName()));
                 // Legacy code does not replace BatchUpdateException
                 if (sqlX instanceof BatchUpdateException)
                     mappedX = sqlX;

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/AdapterUtil.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/AdapterUtil.java
@@ -1399,24 +1399,6 @@ public class AdapterUtil {
             return false;
         }
     }
-
-    /**
-     * Identifies if an exception indicates an unsupported operation.
-     * 
-     * @param sqle the exception.
-     * @return true if unsupported, otherwise false.
-     */
-    public static boolean isUnsupportedException(SQLException sqle){
-        if(sqle instanceof SQLFeatureNotSupportedException)
-            return true;
-        
-        String state = sqle.getSQLState() == null ? "" : sqle.getSQLState();
-        int code = sqle.getErrorCode();
-
-        return state.startsWith("0A") || 0x0A000 == code // standard code for unsupported operation
-            || state.startsWith("HYC00") // ODBC error code
-            || code == -79700 && "IX000".equals(state); // Informix specific
-    }
     
     public static ClassLoader getClassLoaderWithPriv(final Library lib) {
         if(System.getSecurityManager() == null)

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/IdentifyExceptionAs.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/IdentifyExceptionAs.java
@@ -15,10 +15,11 @@ package com.ibm.ws.rsadapter;
  * Values for <code>identifyException as=...</code>.
  */
 public enum IdentifyExceptionAs {
+    // TODO AuthorizationError(null),
     None("java.lang.Void"),
-    StaleConnection("com.ibm.websphere.ce.cm.StaleConnectionException");
-    // TODO StaleStatement("com.ibm.websphere.ce.cm.StaleStatementException"),
-    // TODO Unsupported(null)
+    StaleConnection("com.ibm.websphere.ce.cm.StaleConnectionException"),
+    StaleStatement("com.ibm.websphere.ce.cm.StaleStatementException");
+    // TODO Unsupported(null);
 
     public final String legacyClassName;
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/IdentifyExceptionAs.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/IdentifyExceptionAs.java
@@ -18,8 +18,8 @@ public enum IdentifyExceptionAs {
     // TODO AuthorizationError(null),
     None("java.lang.Void"),
     StaleConnection("com.ibm.websphere.ce.cm.StaleConnectionException"),
-    StaleStatement("com.ibm.websphere.ce.cm.StaleStatementException");
-    // TODO Unsupported(null);
+    StaleStatement("com.ibm.websphere.ce.cm.StaleStatementException"),
+    Unsupported(null);
 
     public final String legacyClassName;
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/IdentifyExceptionAs.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/IdentifyExceptionAs.java
@@ -15,7 +15,7 @@ package com.ibm.ws.rsadapter;
  * Values for <code>identifyException as=...</code>.
  */
 public enum IdentifyExceptionAs {
-    // TODO AuthorizationError(null),
+    AuthorizationError(null),
     None("java.lang.Void"),
     StaleConnection("com.ibm.websphere.ce.cm.StaleConnectionException"),
     StaleStatement("com.ibm.websphere.ce.cm.StaleStatementException"),

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2JCCHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2JCCHelper.java
@@ -229,13 +229,8 @@ public class DB2JCCHelper extends DB2Helper {
         } else { // means need to integrate
             genPw = new PrintWriter(new TraceWriter(db2Tc), true);
         }
-    }
-    
-    @Override
-    void customizeStaleStates() {
-        super.customizeStaleStates();
         
-        Collections.addAll(staleErrorCodes,
+        Collections.addAll(staleConCodes,
                            -4499,
                            -4498,
                            -1776);

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iNativeHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iNativeHelper.java
@@ -77,11 +77,6 @@ public class DB2iNativeHelper extends DB2Helper {
 
             switchingSupportDetermined = true;
         }
-    }
-    
-    @Override
-    void customizeStaleStates() {
-        super.customizeStaleStates();
         
         // --- The Native driver will return this CLI SQLState (HY017) whenever a connection is no longer available.
         //     This covers the case when an underlying iSeries QSQSRVR prestart job on the iSeries that represents
@@ -99,7 +94,7 @@ public class DB2iNativeHelper extends DB2Helper {
         // **** DuplicateKeyException *****
         //     SQLCode   SQLState  Toolbox  Native       DatabaseHelper         DB2Helper        DB2iNativeHelper
         //     SQL0803   23505        X       X           SQLState              SQLCode
-        Collections.addAll(staleSQLStates,
+        Collections.addAll(staleConCodes,
                            "HY017");
     }
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iToolboxHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iToolboxHelper.java
@@ -80,11 +80,6 @@ public class DB2iToolboxHelper extends DB2Helper {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(this, tc, "isolationSwitchingSupported property not set for this datasource");
         }
-    }
-    
-    @Override
-    void customizeStaleStates() {
-        super.customizeStaleStates();
         
         // --- The Native driver will return this CLI SQLState (HY017) whenever a connection is no longer available.
         //     This covers the case when an underlying iSeries QSQSRVR prestart job on the iSeries that represents
@@ -102,7 +97,7 @@ public class DB2iToolboxHelper extends DB2Helper {
         // **** DuplicateKeyException *****
         //     SQLCode   SQLState  Toolbox  Native       DatabaseHelper         DB2Helper        DB2iToolboxHelper
         //     SQL0803   23505        X       X           SQLState              SQLCode
-        Collections.addAll(staleSQLStates,
+        Collections.addAll(staleConCodes,
                 "HY017");
     }
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DataDirectConnectSQLServerHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DataDirectConnectSQLServerHelper.java
@@ -366,12 +366,12 @@ public class DataDirectConnectSQLServerHelper extends DatabaseHelper {
                 int errorCode = sqlX.getErrorCode();
                 SQLStateAndCode combo = sqlState == null ? null : new SQLStateAndCode(sqlState, errorCode);
 
-                if (config.identifyExceptions.get(combo) == null &&
-                                config.identifyExceptions.get(errorCode) == null &&
-                                config.identifyExceptions.get(sqlState) == null)
+                if ((combo == null || config.identifyExceptions.get(combo) == null)
+                                && config.identifyExceptions.get(errorCode) == null
+                                && (sqlState == null || config.identifyExceptions.get(sqlState) == null))
                     stale = isDataDirectExp(ex)
-                                    ? staleDDErrorCodes.contains(sqlX.getErrorCode()) || staleDDSQLStates.contains(sqlX.getSQLState())
-                                    : staleMSErrorCodes.contains(sqlX.getErrorCode());
+                                    ? staleDDErrorCodes.contains(errorCode) || staleDDSQLStates.contains(sqlState)
+                                    : staleMSErrorCodes.contains(errorCode);
                 // else already checked by super.isConnectionError
 
                 if (isTraceOn && tc.isDebugEnabled())

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DatabaseHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DatabaseHelper.java
@@ -507,12 +507,14 @@ public class DatabaseHelper {
         }
         if (target == null) {
             // No overrides, use built-in handling
-            // TODO use legacy DataStoreHelper instead if present
-            unsupported = sqlX instanceof SQLFeatureNotSupportedException
-                            || sqlState != null && sqlState.startsWith("0A")
-                            || 0x0A000 == errorCode // standard code for unsupported operation
-                            || sqlState != null && sqlState.startsWith("HYC00") // ODBC error code
-                            || errorCode == -79700 && "IX000".equals(sqlState); // Informix specific
+            if (mcf.dataStoreHelper == null)
+                unsupported = sqlX instanceof SQLFeatureNotSupportedException
+                                || sqlState != null && sqlState.startsWith("0A")
+                                || 0x0A000 == errorCode // standard code for unsupported operation
+                                || sqlState != null && sqlState.startsWith("HYC00") // ODBC error code
+                                || errorCode == -79700 && "IX000".equals(sqlState); // Informix specific
+            else
+                unsupported = mcf.dataStoreHelper.isUnsupported(sqlX);
         } else {
             // Override was found, need to interpret it
             unsupported = IdentifyExceptionAs.Unsupported.name().equals(target);

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DerbyNetworkClientHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DerbyNetworkClientHelper.java
@@ -110,13 +110,8 @@ public class DerbyNetworkClientHelper extends DerbyHelper {
         else { // means need to integrate
             genPw = new PrintWriter(new TraceWriter(derbyTc), true);
         }
-    }
-    
-    @Override
-    void customizeStaleStates() {
-        super.customizeStaleStates();
         
-        Collections.addAll(staleErrorCodes,
+        Collections.addAll(staleConCodes,
                            -4499);
     }
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/InformixHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/InformixHelper.java
@@ -17,8 +17,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException; 
 import java.sql.SQLInvalidAuthorizationSpecException; 
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 
 import javax.resource.ResourceException;
 
@@ -47,13 +45,8 @@ public class InformixHelper extends DatabaseHelper {
         dataStoreHelper = "com.ibm.websphere.rsadapter.InformixDataStoreHelper";
 
         mcf.defaultIsolationLevel = Connection.TRANSACTION_REPEATABLE_READ;
-    }
-    
-    @Override
-    void customizeStaleStates() {
-        super.customizeStaleStates();
-        
-        Collections.addAll(staleErrorCodes,
+
+        Collections.addAll(staleConCodes,
                            -79735,
                            -79716,
                            -43207,
@@ -61,6 +54,9 @@ public class InformixHelper extends DatabaseHelper {
                            -25580,
                            -908,
                            43012);
+
+        Collections.addAll(staleStmtCodes,
+                           -710);
     }
 
     @Override
@@ -144,24 +140,6 @@ public class InformixHelper extends DatabaseHelper {
                || -11033 == ec // Invalid authorization specification. 
                || -25590 == ec // Authentication error.
                || -29007 == ec; // RDB authorization failure. RDB-userID,RDB: RDB-userID,RDB-name. The user is not authorized to access the target RDB. The request is rejected. Contact the DBA of the RDB side if necessary. Correct the authorization problem and rerun the application program. 
-    }
-
-    /**
-     * @return true if the exception or a cause exception in the chain is known to indicate a stale statement. Otherwise false.
-     */
-    @Override
-    public boolean isStaleStatement(SQLException x) {
-        // check for cycles
-        Set<Throwable> chain = new HashSet<Throwable>();
-
-        for (Throwable t = x; t != null && chain.add(t); t = t.getCause())
-            if (t instanceof SQLException) {
-                SQLException sqlX = (SQLException) t;
-                int ec = sqlX.getErrorCode();
-                if (-710 == ec)
-                    return true;
-            }
-        return super.isStaleStatement(x);
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/InformixJCCHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/InformixJCCHelper.java
@@ -68,13 +68,8 @@ public class InformixJCCHelper extends InformixHelper {
         mcf.supportsGetTypeMap = false;
 
         configuredTraceLevel = 0; // value of DB2BaseDataSource.TRACE_NONE
-    }
-    
-    @Override
-    void customizeStaleStates() {
-        super.customizeStaleStates();
         
-        Collections.addAll(staleErrorCodes,
+        Collections.addAll(staleConCodes,
                            -4499);
     }
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/MicrosoftSQLServerHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/MicrosoftSQLServerHelper.java
@@ -75,13 +75,8 @@ public class MicrosoftSQLServerHelper extends DatabaseHelper {
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(this, tc, "Default responseBuffering = " + responseBuffering);
-    }
-    
-    @Override
-    void customizeStaleStates() {
-        super.customizeStaleStates();
         
-        Collections.addAll(staleErrorCodes,
+        Collections.addAll(staleConCodes,
                            230,
                            6001,
                            6002,

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
@@ -230,13 +230,8 @@ public class OracleHelper extends DatabaseHelper {
                     Tr.debug(oraTc, "Oracle trace file is not set, Oracle logging/tracing will be mergned with WAS logging based on WAS logging settings");
             }
         }
-    }
-    
-    @Override
-    void customizeStaleStates() {
-        super.customizeStaleStates();
         
-        Collections.addAll(staleErrorCodes,
+        Collections.addAll(staleConCodes,
                            20,
                            28,
                            1012,

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/SybaseHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/SybaseHelper.java
@@ -49,13 +49,8 @@ public class SybaseHelper extends DatabaseHelper
 
         mcf.defaultIsolationLevel = Connection.TRANSACTION_REPEATABLE_READ;
         mcf.supportsGetTypeMap = false;
-    }
-    
-    @Override
-    void customizeStaleStates() {
-        super.customizeStaleStates();
         
-        Collections.addAll(staleSQLStates,
+        Collections.addAll(staleConCodes,
                            "JZ0C0",
                            "JZ0C1");
     }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
@@ -502,8 +502,9 @@ public class WSManagedConnectionFactoryImpl extends WSManagedConnectionFactory i
                     try {
                         IdentifyExceptionAs identifyAs = IdentifyExceptionAs.valueOf(className);
                         if (identifyAs.legacyClassName == null)
-                            continue; // no equivalent legacy exception class, so ignore it
-                        className = identifyAs.legacyClassName;
+                            className = IdentifyExceptionAs.None.legacyClassName; // no equivalent legacy exception class, do not replace it
+                        else
+                            className = identifyAs.legacyClassName;
                     } catch (IllegalArgumentException x) {
                         // probably an error, but maybe the user has a custom exception class without a package, so continue on...
                     }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
@@ -501,8 +501,9 @@ public class WSManagedConnectionFactoryImpl extends WSManagedConnectionFactory i
                 if (!className.contains("."))
                     try {
                         IdentifyExceptionAs identifyAs = IdentifyExceptionAs.valueOf(className);
-                        if (identifyAs.legacyClassName != null)
-                            className = identifyAs.legacyClassName;
+                        if (identifyAs.legacyClassName == null)
+                            continue; // no equivalent legacy exception class, so ignore it
+                        className = identifyAs.legacyClassName;
                     } catch (IllegalArgumentException x) {
                         // probably an error, but maybe the user has a custom exception class without a package, so continue on...
                     }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
@@ -929,7 +929,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
         try{
             return getTypeMap();
         } catch (SQLException e) {
-            if (AdapterUtil.isUnsupportedException(e)) {
+            if (helper.isUnsupported(e)) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                     Tr.debug(this, tc, "supportsGetTypeMap false due to " + e);
                 mcf.supportsGetTypeMap = false;
@@ -2976,7 +2976,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                 } catch(UnsupportedOperationException uoe){
                     // Ignore since we are only attempting to cleanup
                 } catch (SQLException sqle) {
-                    if(AdapterUtil.isUnsupportedException(sqle)){
+                    if (helper.isUnsupported(sqle)){
                         // ignore unsupported exception
                     } else {
                         FFDCFilter.processException(sqle, getClass().getName() + ".cleanupStates",
@@ -3000,7 +3000,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                 } catch(UnsupportedOperationException uoe){
                     // Ignore since we are only attempting to cleanup
                 } catch (SQLException sqle) {
-                    if(AdapterUtil.isUnsupportedException(sqle)){
+                    if (helper.isUnsupported(sqle)){
                         // ignore unsupported exception
                     } else {
                         FFDCFilter.processException(sqle, getClass().getName() + ".cleanupStates",
@@ -3063,7 +3063,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                 } catch(UnsupportedOperationException uoe){
                     // Ignore since we are only attempting to cleanup
                 } catch (SQLException sqle) {
-                    if(AdapterUtil.isUnsupportedException(sqle)){
+                    if (helper.isUnsupported(sqle)){
                         // ignore unsupported exception
                     } else {
                         FFDCFilter.processException(sqle, getClass().getName() + ".cleanupStates",
@@ -4496,7 +4496,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
         } catch (SQLException e) {
             // In case the driver is not 4.1 compliant but says it is 
             String sqlMessge = e.getMessage() == null ? "" : e.getMessage();
-            if (AdapterUtil.isUnsupportedException(e))
+            if (helper.isUnsupported(e))
                 x = e;
             //try to catch any other variation of not supported, does not support, unsupported, etc.
             //this is needed by several JDBC drivers, but one known driver is DataDirect OpenEdge JDBC Driver
@@ -4576,7 +4576,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
         } catch (SQLException e) {
             // In case the driver is not 4.1 compliant but says it is 
             String sqlMessge = e.getMessage() == null ? "" : e.getMessage();
-            if (AdapterUtil.isUnsupportedException(e))
+            if (helper.isUnsupported(e))
                 x = e;
             //try to catch any other variation of not supported, does not support, unsupported, etc.
             //this is needed by several JDBC drivers, but one known driver is DataDirect OpenEdge JDBC Driver

--- a/dev/com.ibm.ws.jdbc_fat_heritage/publish/servers/com.ibm.ws.jdbc.heritage/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/publish/servers/com.ibm.ws.jdbc.heritage/server.xml
@@ -37,7 +37,7 @@
     <jdbcDriver libraryRef="JDBCLib" javax.sql.DataSource="test.jdbc.heritage.driver.HDDataSource"/>
     <properties databaseName="memory:testdb" createDatabase="create"
                 supportsCatalog="false" supportsNetworkTimeout="false" supportsReadOnly="false" supportsSchema="false" supportsTypeMap="false"/>
-                <!-- rely on custom DataStoreHelper to determine lack of support for the above attributes -->
+                <!-- rely on custom DataStoreHelper metadata to determine lack of support for the above attributes -->
     <heritageSettings helperClass="test.jdbc.heritage.driver.helper.HDDataStoreHelper" replaceExceptions="true"/>
     <identifyException as="None" sqlState="08004"/>
     <identifyException as="StaleConnection" sqlState="H8000"/>
@@ -49,7 +49,8 @@
   <dataSource jndiName="jdbc/helperDefaulted" containerAuthDataRef="dbAuth" type="javax.sql.DataSource">
     <jdbcDriver libraryRef="JDBCLib" javax.sql.DataSource="test.jdbc.heritage.driver.HDDataSource"/>
     <properties databaseName="memory:testdb" createDatabase="create"
-                supportsNetworkTimeout="false" supportsSchema="false" supportsTypeMap="false"/> <!-- rely on identifyExceptions to determine lack of support -->
+                supportsNetworkTimeout="false" supportsSchema="false" supportsTypeMap="false"/>
+                <!-- rely on identifyExceptions to determine lack of support for NetworkTimeout/Schema; DataStoreHelper.isUnsupported for TypeMap -->
     <heritageSettings replaceExceptions="true"/>
     <identifyException as="None" sqlState="S1000"/>
     <identifyException as="AuthorizationError" errorCode="28"/>
@@ -58,7 +59,6 @@
     <identifyException as="StaleStatement" sqlState="22013"/>
     <identifyException as="test.jdbc.heritage.driver.helper.HeritageDBDuplicateKeyException" sqlState="2300H"/>
     <identifyException as="test.jdbc.heritage.driver.helper.HeritageDBFeatureUnavailableException" sqlState="0A00H"/>
-    <identifyException as="Unsupported" errorCode="-40960"/>
     <identifyException as="Unsupported" errorCode="10"/>
     <identifyException as="Unsupported" sqlState="HDISA"/>
   </dataSource>

--- a/dev/com.ibm.ws.jdbc_fat_heritage/publish/servers/com.ibm.ws.jdbc.heritage/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/publish/servers/com.ibm.ws.jdbc.heritage/server.xml
@@ -37,6 +37,7 @@
     <jdbcDriver libraryRef="JDBCLib" javax.sql.DataSource="test.jdbc.heritage.driver.HDDataSource"/>
     <properties databaseName="memory:testdb" createDatabase="create"
                 supportsCatalog="false" supportsNetworkTimeout="false" supportsReadOnly="false" supportsSchema="false" supportsTypeMap="false"/>
+                <!-- rely on custom DataStoreHelper to determine lack of support for the above attributes -->
     <heritageSettings helperClass="test.jdbc.heritage.driver.helper.HDDataStoreHelper" replaceExceptions="true"/>
     <identifyException as="None" sqlState="08004"/>
     <identifyException as="StaleConnection" sqlState="H8000"/>
@@ -47,13 +48,17 @@
 
   <dataSource jndiName="jdbc/helperDefaulted" containerAuthDataRef="dbAuth" type="javax.sql.DataSource">
     <jdbcDriver libraryRef="JDBCLib" javax.sql.DataSource="test.jdbc.heritage.driver.HDDataSource"/>
-    <properties databaseName="memory:testdb" createDatabase="create"/>
+    <properties databaseName="memory:testdb" createDatabase="create"
+                supportsNetworkTimeout="false" supportsSchema="false" supportsTypeMap="false"/> <!-- rely on identifyExceptions to determine lack of support -->
     <heritageSettings replaceExceptions="true"/>
     <IdentifyException as="None" sqlState="S1000"/>
     <identifyException as="StaleConnection" errorCode="8008"/>
     <identifyException as="StaleStatement" sqlState="22013"/>
     <identifyException as="test.jdbc.heritage.driver.helper.HeritageDBDuplicateKeyException" sqlState="2300H"/>
     <identifyException as="test.jdbc.heritage.driver.helper.HeritageDBFeatureUnavailableException" sqlState="0A00H"/>
+    <identifyException as="Unsupported" errorCode="-40960"/>
+    <identifyException as="Unsupported" sqlState="HY000" errorCode="10"/>
+    <identifyException as="Unsupported" sqlState="HDISA"/>
   </dataSource>
 
   <javaPermission codeBase="${shared.resource.dir}derby/derby.jar" className="java.security.AllPermission"/>

--- a/dev/com.ibm.ws.jdbc_fat_heritage/publish/servers/com.ibm.ws.jdbc.heritage/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/publish/servers/com.ibm.ws.jdbc.heritage/server.xml
@@ -51,13 +51,15 @@
     <properties databaseName="memory:testdb" createDatabase="create"
                 supportsNetworkTimeout="false" supportsSchema="false" supportsTypeMap="false"/> <!-- rely on identifyExceptions to determine lack of support -->
     <heritageSettings replaceExceptions="true"/>
-    <IdentifyException as="None" sqlState="S1000"/>
+    <identifyException as="None" sqlState="S1000"/>
+    <identifyException as="AuthorizationError" errorCode="28"/>
+    <identifyException as="StaleConnection" errorCode="8008"/>
     <identifyException as="StaleConnection" errorCode="8008"/>
     <identifyException as="StaleStatement" sqlState="22013"/>
     <identifyException as="test.jdbc.heritage.driver.helper.HeritageDBDuplicateKeyException" sqlState="2300H"/>
     <identifyException as="test.jdbc.heritage.driver.helper.HeritageDBFeatureUnavailableException" sqlState="0A00H"/>
     <identifyException as="Unsupported" errorCode="-40960"/>
-    <identifyException as="Unsupported" sqlState="HY000" errorCode="10"/>
+    <identifyException as="Unsupported" errorCode="10"/>
     <identifyException as="Unsupported" sqlState="HDISA"/>
   </dataSource>
 

--- a/dev/com.ibm.ws.jdbc_fat_heritage/publish/servers/com.ibm.ws.jdbc.heritage/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/publish/servers/com.ibm.ws.jdbc.heritage/server.xml
@@ -51,7 +51,7 @@
     <heritageSettings replaceExceptions="true"/>
     <IdentifyException as="None" sqlState="S1000"/>
     <identifyException as="StaleConnection" errorCode="8008"/>
-    <identifyException as="com.ibm.websphere.ce.cm.StaleStatementException" sqlState="22013"/> <!-- TODO switch to "StaleStatement" once added -->
+    <identifyException as="StaleStatement" sqlState="22013"/>
     <identifyException as="test.jdbc.heritage.driver.helper.HeritageDBDuplicateKeyException" sqlState="2300H"/>
     <identifyException as="test.jdbc.heritage.driver.helper.HeritageDBFeatureUnavailableException" sqlState="0A00H"/>
   </dataSource>

--- a/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HDConnection.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HDConnection.java
@@ -184,7 +184,7 @@ public class HDConnection implements Connection, HeritageDBConnection {
         if (ds.supportsNetworkTimeout)
             return derbycon.getNetworkTimeout();
         else
-            throw new SQLException("You disabled the ability to get the network timeout.");
+            throw new SQLException("You disabled the ability to get the network timeout.", "HDISA", 0);
     }
 
     @Override
@@ -192,7 +192,7 @@ public class HDConnection implements Connection, HeritageDBConnection {
         if (ds.supportsSchema)
             return derbycon.getSchema();
         else
-            throw new SQLException("You disabled the ability to get the schema.");
+            throw new SQLException("You disabled the ability to get the schema.", "HY000", 10);
     }
 
     @Override
@@ -205,7 +205,7 @@ public class HDConnection implements Connection, HeritageDBConnection {
         if (ds.supportsTypeMap)
             return derbycon.getTypeMap();
         else
-            throw new SQLException("You disabled support for type map.");
+            throw new SQLException("You disabled support for type map.", null, -40960);
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/helper/HDDataStoreHelper.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/helper/HDDataStoreHelper.java
@@ -23,6 +23,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLNonTransientConnectionException;
 import java.sql.SQLRecoverableException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -51,7 +52,7 @@ public class HDDataStoreHelper extends GenericDataStoreHelper {
 
     private AtomicReference<?> dsConfigRef;
 
-    private Map<Object, Class<?>> exceptionIdentificationOverrides;
+    private Map<Object, Class<?>> exceptionIdentificationOverrides = Collections.emptyMap();
 
     private static final Map<Object, Class<?>> exceptionMap = new HashMap<Object, Class<?>>();
     {

--- a/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/helper/HDDataStoreHelper.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/helper/HDDataStoreHelper.java
@@ -21,6 +21,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLNonTransientConnectionException;
 import java.sql.SQLRecoverableException;
 import java.util.Collections;
@@ -41,6 +42,7 @@ import com.ibm.ws.jdbc.heritage.DataStoreHelperMetaData;
 import com.ibm.ws.jdbc.heritage.GenericDataStoreHelper;
 
 import test.jdbc.heritage.driver.HDConnection;
+import test.jdbc.heritage.driver.HeritageDBDoesNotImplementItException;
 
 /**
  * Data store helper for the test JDBC driver.
@@ -157,6 +159,13 @@ public class HDDataStoreHelper extends GenericDataStoreHelper {
                || x instanceof SQLNonTransientConnectionException
                || x instanceof StaleConnectionException
                || mapException(x) instanceof StaleConnectionException;
+    }
+
+    @Override
+    public boolean isUnsupported(SQLException x) {
+        return x instanceof SQLFeatureNotSupportedException
+               || x instanceof HeritageDBDoesNotImplementItException
+               || x instanceof HeritageDBFeatureUnavailableException;
     }
 
     @Override

--- a/dev/com.ibm.ws.jdbc_fat_heritage/test-bundles/jdbcHeritage/src/com/ibm/websphere/rsadapter/GenericDataStoreHelper.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/test-bundles/jdbcHeritage/src/com/ibm/websphere/rsadapter/GenericDataStoreHelper.java
@@ -21,6 +21,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLNonTransientConnectionException;
 import java.sql.SQLRecoverableException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -43,7 +44,7 @@ public class GenericDataStoreHelper extends com.ibm.ws.jdbc.heritage.GenericData
 
     private AtomicReference<?> dsConfigRef;
 
-    private Map<Object, Class<?>> exceptionIdentificationOverrides;
+    private Map<Object, Class<?>> exceptionIdentificationOverrides = Collections.emptyMap();
 
     private static final Map<Object, Class<?>> exceptionMap = new HashMap<Object, Class<?>>();
     {

--- a/dev/com.ibm.ws.jdbc_fat_heritage/test-bundles/jdbcHeritage/src/com/ibm/websphere/rsadapter/GenericDataStoreHelper.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/test-bundles/jdbcHeritage/src/com/ibm/websphere/rsadapter/GenericDataStoreHelper.java
@@ -19,6 +19,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLNonTransientConnectionException;
 import java.sql.SQLRecoverableException;
 import java.util.Collections;
@@ -130,6 +131,16 @@ public class GenericDataStoreHelper extends com.ibm.ws.jdbc.heritage.GenericData
                || x instanceof SQLNonTransientConnectionException
                || x instanceof StaleConnectionException
                || mapException(x) instanceof StaleConnectionException;
+    }
+
+    @Override
+    public boolean isUnsupported(SQLException x) {
+        String sqlState = x.getSQLState();
+        int errorCode = x.getErrorCode();
+        return x instanceof SQLFeatureNotSupportedException
+               || 0x0A000 == Math.abs(errorCode)
+               || sqlState != null && sqlState.startsWith("0A")
+               || sqlState != null && sqlState.startsWith("HYC00");
     }
 
     @Override


### PR DESCRIPTION
Add integration point for the isUnsupported DataStoreHelper method, such that the identifyException configuration overrides it if present.