### PR TITLE
Fix test failure in RTC 280705: com.ibm.ws.security.spnego.fat.Servic…

### DIFF
--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/ServicePrincipalNamesTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/ServicePrincipalNamesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -266,7 +266,7 @@ public class ServicePrincipalNamesTest extends CommonTest {
     public void testInvalidSpnList_BadFormat() {
         try {
             testHelper.reconfigureServer("invalidSpnList_badFormat.xml", name.getMethodName(), SPNEGOConstants.RESTART_SERVER);
-            testHelper.setShutdownMessages("CWWKE0701E");
+            testHelper.setShutdownMessages("CWWKE0701E", "CWWKS4308E", "CWWKS4309E");
             List<String> checkMsgs = new ArrayList<String>();
 
             if (FATSuite.OTHER_SUPPORT_JDKS) {
@@ -302,8 +302,8 @@ public class ServicePrincipalNamesTest extends CommonTest {
      * - Multiple FFDCs for GSSExceptions should be thrown due to multiple invalid SPNs appearing in the list.
      * - Authentication will ultimately be successful for the default SPN.
      */
-//    @AllowedFFDC({ "org.ietf.jgss.GSSException" })
-//    @Test
+    @AllowedFFDC({ "org.ietf.jgss.GSSException" })
+    @Test
     public void testInvalidSpnList_BadFormatGoodSpn() {
         try {
             testHelper.reconfigureServer("invalidSpnList_badFormatGoodSpn.xml", name.getMethodName(), SPNEGOConstants.RESTART_SERVER);


### PR DESCRIPTION
…ePrincipalNamesTest.testInvalidSpnList_BadFormatGoodSpn

