### PR TITLE
Fix persistence 3.0 bottleneck

### DIFF
--- a/dev/io.openliberty.jakartapersistenceactivator/bnd.bnd
+++ b/dev/io.openliberty.jakartapersistenceactivator/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020,2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -22,4 +22,5 @@ Private-Package: \
 -buildpath: \
 	jakarta.persistence:jakarta.persistence-api;version=3.0.0,\
 	com.ibm.websphere.org.osgi.core,\
-	com.ibm.ws.kernel.service;version=latest
+	com.ibm.ws.kernel.service;version=latest,\
+	com.ibm.ws.container.service.compat;version=latest

--- a/dev/io.openliberty.org.eclipse.persistence-3.0/bnd.bnd
+++ b/dev/io.openliberty.org.eclipse.persistence-3.0/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020,2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@ Bundle-SymbolicName: io.openliberty.org.eclipse.persistence-3.0; singleton:=true
 Bundle-Activator: io.openliberty.jakarta.persistence.internal.JakartaPersistenceActivator
 
 Import-Package: \
+  com.ibm.ws.threadContext, \
+  com.ibm.ws.runtime.metadata, \
   org.osgi.framework;version="[1.6,2)", \
   org.osgi.util.tracker;version="[1.5,2)", \
   javax.sql; resolution:=optional


### PR DESCRIPTION
- Update JakartaPersistenceActivator to have a cache in it similar to the one in HybridPersistenceActivator that is used for JPA 2.x.
