### PR TITLE
transaction branch coupling for Oracle

### DIFF
--- a/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/metatype/metatype.xml
@@ -79,9 +79,11 @@
    <Option value="rollback"                       label="%commitRollbk.rollback.desc"/>
   </AD>
   <AD id="enableBeginEndRequest"                  name="internal"      description="internal use only"  ibmui:group="Advanced" required="false" type="Boolean"/>
+  <AD id="enableBranchCouplingExtension"          name="internal"      description="internal use only"  ibmui:group="Advanced" required="false" type="Boolean"/>
   <AD id="enableConnectionCasting"                name="%enblConCast"  description="%enblConCast.desc"  ibmui:group="Advanced" type="Boolean" default="false"/>
   <AD id="heritage"                               name="internal"      description="internal use only"  ibmui:group="Advanced" required="false" type="String"  cardinality="1" ibm:type="pid" ibm:reference="com.ibm.ws.jdbc.dataSource.heritage" ibm:flat="true"/>
   <AD id="identifyException"                      name="internal"      description="internal use only"  ibmui:group="Advanced" required="false" type="String"  cardinality="1000" ibm:type="pid" ibm:reference="com.ibm.ws.jdbc.dataSource.identifyException" ibm:flat="true"/>
+  <!-- TODO both identifyException and enableBranchCouplingExtension should Beta together. But at GA, remove the latter altogether  -->
   <AD id="onConnect"                              name="%onConnect"    description="%onConnect.desc"    ibmui:group="Advanced" required="false" type="String"  cardinality="1000"/>
   <AD id="queryTimeout"                           name="%qryTimeout"   description="%qryTimeout.desc"   ibmui:group="Advanced" required="false" type="String"  ibm:type="duration(s)"/>
   <AD id="recoveryAuthDataRef"                    name="%recoveryAuth" description="%recoveryAuth.desc" ibmui:group="Advanced" required="false" type="String"  cardinality="1" ibm:type="pid" ibm:reference="com.ibm.ws.security.jca.internal.authdata.config"/>

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/DSConfig.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/DSConfig.java
@@ -166,6 +166,9 @@ public class DSConfig implements FFDCSelfIntrospectable {
      */
     public final boolean enableBeginEndRequest;
 
+    // TODO remove this once branch coupling support is GA
+    public final boolean enableBranchCouplingExtension;
+
     /**
      * Indicates to automatically create a dynamic proxy for interfaces implemented by the connection. 
      */
@@ -303,6 +306,7 @@ public class DSConfig implements FFDCSelfIntrospectable {
         CommitOrRollbackOnCleanup commitOrRollback = remove(COMMIT_OR_ROLLBACK_ON_CLEANUP, null, CommitOrRollbackOnCleanup.class);
         connectionSharing = remove(CONNECTION_SHARING, ConnectionSharing.MatchOriginalRequest, ConnectionSharing.class);
         enableBeginEndRequest = remove(ENABLE_BEGIN_END_REQUEST, false); // Not a supported property. Only for internal testing/experimentation.
+        enableBranchCouplingExtension = remove("enableBranchCouplingExtension", false); // TODO remove once GA
         enableConnectionCasting = remove(ENABLE_CONNECTION_CASTING, false);
         enableMultithreadedAccessDetection = false;
         heritageHelperClass = remove(HELPER_CLASS, (String) null);

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
@@ -45,12 +45,14 @@ import javax.resource.ResourceException;
 import javax.sql.CommonDataSource;
 import javax.sql.DataSource;
 import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.kernel.service.util.JavaInfo;
 import com.ibm.ws.kernel.service.util.JavaInfo.Vendor;
+import com.ibm.ws.resource.ResourceRefInfo;
 import com.ibm.ws.rsadapter.AdapterUtil;
 import com.ibm.ws.rsadapter.impl.WSManagedConnectionFactoryImpl.KerbUsage;
 import com.ibm.ws.rsadapter.jdbc.WSJdbcTracer;
@@ -278,6 +280,24 @@ public class OracleHelper extends DatabaseHelper {
     @Override
     public boolean alwaysSetAutoCommit() {
         return false;
+    }
+
+    /**
+     * Returns the XA start flag for loose or tight branch coupling
+     *
+     * @param couplingType branch coupling type
+     * @return XA start flag value for the specified coupling type
+     */
+    public int branchCouplingSupported(int couplingType) {
+        // TODO remove this check at GA
+        if (!mcf.dsConfig.get().enableBranchCouplingExtension)
+            return super.branchCouplingSupported(couplingType);
+
+        if (couplingType == ResourceRefInfo.BRANCH_COUPLING_LOOSE)
+            return 0x10000; // value of oracle.jdbc.xa.OracleXAResource.ORATRANSLOOSE
+
+        // Tight branch coupling is default for Oracle
+        return XAResource.TMNOFLAGS;
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbXaResourceImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbXaResourceImpl.java
@@ -1082,9 +1082,6 @@ public class WSRdbXaResourceImpl implements WSXAResource, FFDCSelfIntrospectable
         this.ivXid = xid;
 
         try {
-            // TODO if we add dsConfig.transactionBranchesLooselyCoupled, then for Oracle, do
-            // flags |= 0x10000; // value of oracle.jdbc.xa.OracleXAResource.ORATRANSLOOSE
-
             ivXaRes.start(xid, flags);
             ivStateManager.setState(WSStateManager.XA_START);
         } catch (TransactionException te) {

--- a/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/publish/servers/com.ibm.ws.jdbc.fat.oracle/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2016, 2019 IBM Corporation and others.
+    Copyright (c) 2016, 2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -20,13 +20,17 @@
 
     <application location="oraclejdbcfat.war" >
         <classloader commonLibraryRef="DBLib"/>
+        <web-ext>
+          <resource-ref name="java:comp/jdbc/env/unsharable-ds-xa-loosely-coupled" branch-coupling="LOOSE"/>
+          <resource-ref name="java:comp/jdbc/env/unsharable-ds-xa-tightly-coupled" branch-coupling="TIGHT"/>
+        </web-ext>
     </application>
-    
+
     <library id="DBLib">
     	<fileset dir="${shared.resource.dir}/oracle"/>
     </library>
     
-    <dataSource id="DefaultDataSource">
+    <dataSource id="DefaultDataSource" enableBranchCouplingExtension="true"><!-- TODO remove attribute once GA -->
     	<jdbcDriver libraryRef="DBLib"/>
     	<properties.oracle URL="${env.URL}" user="${env.USER}" password="${env.PASSWORD}"/>
     </dataSource>

--- a/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oraclejdbcfat/src/web/OracleTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oraclejdbcfat/src/web/OracleTestServlet.java
@@ -58,11 +58,10 @@ public class OracleTestServlet extends FATServlet {
     @Resource(lookup = "jdbc/inferred-ds")
     private DataSource inferred_ds;
 
-    // TODO add branch coupling extension
-    // @Resource(name = "java:comp/jdbc/env/unsharable-ds-xa-loosely-coupled", shareable = false)
+    @Resource(name = "java:comp/jdbc/env/unsharable-ds-xa-loosely-coupled", shareable = false)
     private DataSource unsharable_ds_xa_loosely_coupled;
 
-    @Resource(shareable = false)
+    @Resource(name = "java:comp/jdbc/env/unsharable-ds-xa-tightly-coupled", shareable = false)
     private DataSource unsharable_ds_xa_tightly_coupled;
 
     @Resource
@@ -334,7 +333,7 @@ public class OracleTestServlet extends FATServlet {
     /**
      * Confirm that locks are not shared between transaction branches that are loosely coupled.
      */
-    //@Test TODO enable once we add support for loosely coupled transaction branches for Oracle
+    @Test
     public void testTransactionBranchesLooselyCoupled() throws Exception {
         tx.begin();
         try {

--- a/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oraclejdbcfat/src/web/OracleTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/test-applications/oraclejdbcfat/src/web/OracleTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corporation and others.
+ * Copyright (c) 2016, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,6 +27,7 @@ import java.sql.Statement;
 import javax.annotation.Resource;
 import javax.servlet.annotation.WebServlet;
 import javax.sql.DataSource;
+import javax.transaction.UserTransaction;
 
 import org.junit.Test;
 
@@ -56,6 +57,16 @@ public class OracleTestServlet extends FATServlet {
 
     @Resource(lookup = "jdbc/inferred-ds")
     private DataSource inferred_ds;
+
+    // TODO add branch coupling extension
+    // @Resource(name = "java:comp/jdbc/env/unsharable-ds-xa-loosely-coupled", shareable = false)
+    private DataSource unsharable_ds_xa_loosely_coupled;
+
+    @Resource(shareable = false)
+    private DataSource unsharable_ds_xa_tightly_coupled;
+
+    @Resource
+    private UserTransaction tx;
 
     // Verify that connections are/are not castable to OracleConnection based on whether enableConnectionCasting=true/false.
     @Test
@@ -317,6 +328,49 @@ public class OracleTestServlet extends FATServlet {
             rs.close();
         } finally {
             conn.close();
+        }
+    }
+
+    /**
+     * Confirm that locks are not shared between transaction branches that are loosely coupled.
+     */
+    //@Test TODO enable once we add support for loosely coupled transaction branches for Oracle
+    public void testTransactionBranchesLooselyCoupled() throws Exception {
+        tx.begin();
+        try {
+            try (Connection con1 = unsharable_ds_xa_loosely_coupled.getConnection()) {
+                con1.createStatement().executeUpdate("INSERT INTO MYTABLE VALUES (31, 'thirty-one')");
+
+                // Obtain a second (unshared) connection so that we have 2 transaction branches
+                try (Connection con2 = unsharable_ds_xa_loosely_coupled.getConnection()) {
+                    ResultSet result = con2.createStatement().executeQuery("SELECT STRVAL FROM MYTABLE WHERE ID=31");
+                    assertFalse(result.next());
+                }
+            }
+        } finally {
+            tx.commit();
+        }
+    }
+
+    /**
+     * Confirm that locks are shared between transaction branches that are tightly coupled.
+     */
+    @Test
+    public void testTransactionBranchesTightlyCoupled() throws Exception {
+        tx.begin();
+        try {
+            try (Connection con1 = unsharable_ds_xa_tightly_coupled.getConnection()) {
+                con1.createStatement().executeUpdate("INSERT INTO MYTABLE VALUES (32, 'thirty-two')");
+
+                // Obtain a second (unshared) connection so that we have 2 transaction branches
+                try (Connection con2 = unsharable_ds_xa_tightly_coupled.getConnection()) {
+                    ResultSet result = con2.createStatement().executeQuery("SELECT STRVAL FROM MYTABLE WHERE ID=32");
+                    assertTrue(result.next());
+                    assertEquals("thirty-two", result.getString(1));
+                }
+            }
+        } finally {
+            tx.commit();
         }
     }
 }


### PR DESCRIPTION
Support the branch-coupling resource reference extension when Oracle is used.
Because this will need to introduced as nonship and separately be promoted to beta/GA, we will need to guard it with a temporary internal dataSource attribute for now.  Expect the attribute to be removed upon GA.
Add tests for both tight (default) and loose coupling with Oracle.