### PR TITLE
Remove unwanted trace and move empty handle list out of JCA trace group

### DIFF
--- a/dev/io.openliberty.handlelist.context.internal/src/io/openliberty/handlelist/context/internal/EmptyHandleListContextProvider.java
+++ b/dev/io.openliberty.handlelist.context.internal/src/io/openliberty/handlelist/context/internal/EmptyHandleListContextProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.wsspi.threadcontext.ThreadContext;
 import com.ibm.wsspi.threadcontext.ThreadContextDeserializationInfo;
 import com.ibm.wsspi.threadcontext.ThreadContextProvider;
@@ -33,6 +34,7 @@ import com.ibm.wsspi.threadcontext.ThreadContextProvider;
            configurationPolicy = ConfigurationPolicy.IGNORE,
            property = "alwaysCaptureThreadContext:Boolean=true")
 @SuppressWarnings("deprecation")
+@Trivial
 public class EmptyHandleListContextProvider implements ThreadContextProvider {
     /**
      * {@inheritDoc}

--- a/dev/io.openliberty.handlelist.context.internal/src/io/openliberty/handlelist/context/internal/package-info.java
+++ b/dev/io.openliberty.handlelist.context.internal/src/io/openliberty/handlelist/context/internal/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,7 @@
  * @version 1.0.0
  */
 @org.osgi.annotation.versioning.Version("1.0.0")
-@TraceOptions(traceGroup = "WAS.j2c")
+@TraceOptions(traceGroup = "handlelist")
 package io.openliberty.handlelist.context.internal;
 
 import com.ibm.websphere.ras.annotation.TraceOptions;


### PR DESCRIPTION
Remove unnecessary tracing for the EmptyHandleListContextProvider and move tracing in general for the empty handle list to a separate trace group to keep it from cluttering up the JCA trace.