### PR TITLE
Issue 15722: Update Kerberos for LDAP from beta to GA

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap/bnd.bnd
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/bnd.bnd
@@ -56,8 +56,7 @@ instrument.classesExcludes: com/ibm/ws/security/wim/adapter/ldap/resources/*.cla
 	com.ibm.wsspi.org.osgi.service.metatype.annotations;version=latest, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
 	com.ibm.ws.security.kerberos.auth;version=latest, \
-	com.ibm.ws.security;version=latest,\
-	com.ibm.ws.kernel.boot.core;version=latest
+	com.ibm.ws.security;version=latest
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	com.ibm.ws.junit.extensions;version=latest, \

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/resources/OSGI-INF/metatype/metatype.xml
@@ -173,14 +173,14 @@
 		<AD id="allowWriteToSecondaryServers" name="%allowWriteToSecondaryServers" description="%allowWriteToSecondaryServers.desc"
 			required="false" type="Boolean" default="false"/>	
 			
-	    <AD id="bindAuthMechanism" name="%bindAuthMechanism" description="%bindAuthMechanism.desc" required="false" type="String" ibm:beta="true">
+	    <AD id="bindAuthMechanism" name="%bindAuthMechanism" description="%bindAuthMechanism.desc" required="false" type="String" default="simple">
 		    <Option label="%bindAuthMechanism.none" value="none" />
 		    <Option label="%bindAuthMechanism.simple" value="simple" />
 		    <Option label="%bindAuthMechanism.GSSAPI" value="GSSAPI" />
 	     </AD>
 
-	    <AD id="krb5Principal" name="%krb5Principal" description="%krb5Principal.desc" type="String" required="false" ibm:beta="true" />
-	    <AD id="krb5TicketCache" name="%krb5TicketCache" description="%krb5TicketCache.desc" type="String" required="false" ibm:type="location(file)" ibm:beta="true"/>
+	    <AD id="krb5Principal" name="%krb5Principal" description="%krb5Principal.desc" type="String" required="false" />
+	    <AD id="krb5TicketCache" name="%krb5TicketCache" description="%krb5TicketCache.desc" type="String" required="false" ibm:type="location(file)" />
 	
 	    <AD name="internal" description="internal use only"
         	id="kerberosService" required="false" type="String" default="*" cardinality="1"

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapConnection.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapConnection.java
@@ -84,7 +84,6 @@ import com.ibm.websphere.security.wim.ras.WIMMessageKey;
 import com.ibm.websphere.security.wim.ras.WIMTraceHelper;
 import com.ibm.ws.config.xml.internal.nester.Nester;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
-import com.ibm.ws.kernel.productinfo.ProductInfo;
 import com.ibm.ws.security.kerberos.auth.KerberosService;
 import com.ibm.ws.security.wim.FactoryManager;
 import com.ibm.ws.security.wim.adapter.ldap.context.ContextManager;
@@ -375,54 +374,6 @@ public class LdapConnection {
         initializeCaches(configProps);
     }
 
-    // Flag tells us if the message for a call to a beta method has been issued
-    // Can be removed when bindAuthMechanism/KRB5 is GA
-    private static boolean issuedBetaMessage = false;
-
-    /**
-     * Beta fence check -- can be removed when bindAuthMechanism/KRB5 is GA
-     *
-     * To run with FATs, create a jvm.options file in your server directory and add the following argument: -Dcom.ibm.ws.beta.edition=true
-     *
-     * @throws UnsupportedOperationException
-     */
-    private static void betaFenceCheck() throws UnsupportedOperationException {
-        // Not running beta edition, throw exception
-        if (!ProductInfo.getBetaEdition()) {
-            throw new UnsupportedOperationException("The bindAuthMechanism attribute is beta and is not available.");
-        } else {
-            // Running beta exception, issue message if we haven't already issued one for this class
-            if (!issuedBetaMessage) {
-                Tr.info(tc, "BETA: A beta attribute, bindAuthMechanism, has been set for LdapRegistry for the first time.");
-                issuedBetaMessage = !issuedBetaMessage;
-            }
-        }
-    }
-
-    // Flag tells us if the message for a call to a beta method has been issued
-    // Can be removed when bindAuthMechanism/KRB5 is GA
-    private static boolean issuedBetaMessageKrb5 = false;
-
-    /**
-     * Beta fence check -- can be removed when bindAuthMechanism/KRB5 is GA
-     *
-     * To run with FATs, create a jvm.options file in your server directory and add the following argument: -Dcom.ibm.ws.beta.edition=true
-     *
-     * @throws UnsupportedOperationException
-     */
-    private static void betaFenceCheckKrb5() throws UnsupportedOperationException {
-        // Not running beta edition, throw exception
-        if (!ProductInfo.getBetaEdition()) {
-            throw new UnsupportedOperationException("The krb5Principal and krb5TicketCache attributes are beta and are not available.");
-        } else {
-            // Running beta exception, issue message if we haven't already issued one for this class
-            if (!issuedBetaMessageKrb5) {
-                Tr.info(tc, "BETA: Beta attributes, krb5Principal and krb5TicketCache, have been set for LdapRegistry for the first time.");
-                issuedBetaMessageKrb5 = !issuedBetaMessageKrb5;
-            }
-        }
-    }
-
     /**
      * Initialize the {@link ContextManager} to manage LDAP connections.
      *
@@ -459,10 +410,6 @@ public class LdapConnection {
 
         String bindAuthMech = ((String) configProps.get(ConfigConstants.CONFIG_PROP_BIND_AUTH_MECH));
         if (bindAuthMech != null) {
-            /*
-             * Beta fence check -- will fail unless beta edition is enabled.
-             */
-            betaFenceCheck();
             iContextManager.setBindAuthMechanism(bindAuthMech);
         }
 
@@ -472,8 +419,6 @@ public class LdapConnection {
              */
             iContextManager.setSimpleCredentials((String) configProps.get(CONFIG_PROP_BIND_DN), (SerializableProtectedString) configProps.get(CONFIG_PROP_BIND_PASSWORD));
         } else {
-            betaFenceCheckKrb5();
-
             iContextManager.setKerberosCredentials(iReposId, kerberosService, (String) configProps.get(ConfigConstants.CONFIG_PROP_KRB5_PRINCIPAL),
                                                    (String) configProps.get(ConfigConstants.CONFIG_PROP_KRB5_TICKET_CACHE), configAdmin);
         }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/test/com/ibm/ws/security/wim/adapter/ldap/context/ContextManagerTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/test/com/ibm/ws/security/wim/adapter/ldap/context/ContextManagerTest.java
@@ -715,7 +715,7 @@ public class ContextManagerTest {
         assertTrue("Did not find Return to Primary in toString: " + toString, toString.contains("iReturnToPrimary=true"));
     }
 
-    //@Test
+    @Test
     public void testToStringKRB5() throws Exception {
         ContextManager cm = new ContextManager();
         cm.setPrimaryServer("localhost", primaryLdapServer.getLdapServer().getPort());
@@ -724,10 +724,10 @@ public class ContextManagerTest {
         cm.initialize();
 
         String toString = cm.toString();
-        assertTrue("Found find Bind DN in toString: " + toString, toString.contains("iBindDN="));
+        assertTrue("Found Bind DN in toString: " + toString, toString.contains("iBindDN=null"));
         assertTrue("Did not find Primary Server in toString: " + toString, toString.contains("iPrimaryServer=localhost:" + primaryLdapServer.getLdapServer().getPort()));
         assertTrue("Did not find bindAuthMeach in toString: " + toString, toString.contains("bindAuthMechanism=" + ConfigConstants.CONFIG_BIND_AUTH_KRB5));
-        assertTrue("Did not find krb5PrincipalName in toString: " + toString, toString.contains("krb5PrincipalName=testPrincipal"));
+        assertTrue("Did not find krb5Principal in toString: " + toString, toString.contains("krb5Principal=testPrincipal"));
         assertTrue("Did not find krb5TicketCache in toString: " + toString, toString.contains("krb5TicketCache=DummyTicketCache"));
     }
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/CommonBindTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/CommonBindTest.java
@@ -158,7 +158,7 @@ public class CommonBindTest {
     @After
     public void resetServerConfig() throws Exception {
         Log.info(c, testName.getMethodName(), "Reset server config.");
-        server.setJvmOptions(Arrays.asList("-Dsun.security.krb5.debug=true", "-Dcom.ibm.security.krb5.krb5Debug=true", "-Dcom.ibm.ws.beta.edition=true"));
+        server.setJvmOptions(Arrays.asList("-Dsun.security.krb5.debug=true", "-Dcom.ibm.security.krb5.krb5Debug=true"));
         ServerConfiguration newServer = emptyConfiguration.clone();
         updateConfigDynamically(server, newServer);
     }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/Krb5ConfigJVMProp.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/Krb5ConfigJVMProp.java
@@ -66,7 +66,7 @@ public class Krb5ConfigJVMProp extends CommonBindTest {
 
         Log.info(c, testName.getMethodName(), "Add a valid config file with a new name as a JVM property, restart server to take effect");
         String altConfigFile = ApacheDSandKDC.createConfigFile("altConfig-", KDC_PORT, true, false);
-        server.setJvmOptions(Arrays.asList("-Djava.security.krb5.conf=" + altConfigFile, "-Dcom.ibm.ws.beta.edition=true"));
+        server.setJvmOptions(Arrays.asList("-Djava.security.krb5.conf=" + altConfigFile));
         server.restartServer();
 
         // Double check that login is still fine

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/RealmNameJVMProp.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/RealmNameJVMProp.java
@@ -78,7 +78,7 @@ public class RealmNameJVMProp extends CommonBindTest {
         server.stopServer(stopStrings);
 
         Log.info(c, testName.getMethodName(), "Add a realm name as a JVM property, restart server to take effect");
-        server.setJvmOptions(Arrays.asList("-Djava.security.krb5.realm=" + DOMAIN, "-Djava.security.krb5.kdc=localhost", "-Dcom.ibm.ws.beta.edition=true"));
+        server.setJvmOptions(Arrays.asList("-Djava.security.krb5.realm=" + DOMAIN, "-Djava.security.krb5.kdc=localhost"));
 
         server.startServer();
         startupChecks();

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/publish/servers/com.ibm.ws.security.registry.ldap.fat.krb5.base/jvm.options
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/publish/servers/com.ibm.ws.security.registry.ldap.fat.krb5.base/jvm.options
@@ -1,3 +1,2 @@
--Dcom.ibm.ws.beta.edition=true
 -Dsun.security.krb5.debug=true
 -Dcom.ibm.security.krb5.krb5Debug=true

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/LDAPRegressionTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/LDAPRegressionTest.java
@@ -85,8 +85,7 @@ public class LDAPRegressionTest {
     public static void teardownClass() throws Exception {
         try {
             if (libertyServer != null) {
-                /* Temporarily allow CWWKE0701E for testBetaFenceForBindAuthMech */
-                libertyServer.stopServer("CWIML4523E", "CWWKE0701E");
+                libertyServer.stopServer("CWIML4523E");
             }
         } finally {
             if (ds != null) {
@@ -375,27 +374,6 @@ public class LDAPRegressionTest {
         listResults = VmmServiceServletConnection.convertToList("searchWithExpression", results);
         assertEquals(1, listResults.size());
         assertEquals("uid=Bob (Contractor),o=ibm,c=us", listResults.get(0));
-    }
-
-    /**
-     * Temporary fat test to ensure our Beta fence for bindAuthmechanism/GSSPI/Kerberos is working as expected.
-     *
-     * Can be removed when betaFence code is removed from LdapConnection
-     *
-     * Also remove CWWKE0701E from teardownClass
-     */
-    @Test
-    public void testBetaFenceForBindAuthMech() throws Exception {
-        final String methodName = "testBetaFenceForBindAuthMech";
-        ServerConfiguration clone = basicConfiguration.clone();
-        LdapRegistry ldap = createLdapRegistry(clone);
-        ldap.setBindAuthMechanism("simple");
-
-        updateConfigDynamically(libertyServer, clone);
-
-        Log.info(c, methodName, "Finished Liberty server update");
-
-        assertFalse("Did not find CWWKE0701E for beta fence in log", libertyServer.findStringsInLogs("CWWKE0701E").isEmpty());
     }
 
     /**


### PR DESCRIPTION
Fixes #15722 

- Remove all the beta fencing (LdapConnection and com.ibm.ws.kernel.boot.core;version=latest from the wim.adapter.ldap bnd.bnd file and remove testBetaFenceForBindAuthMech from LdapRegressionTests and remove CWWKE0701E from teardown
- Update the metatype to have the appropriate tags and messages
- Enable simple as the default on the bindAuthMechanism
- Enable ContextManagerTest.testToStringKRB5
- Remove beta jvm options from com.ibm.ws.security.wim.adapter.ldap_fat.krb5 jvm.options
- Check com.ibm.ws.security.wim.adapter.ldap_fat.krb5 bootstrap.properties
- Remove runtime -Dcom.ibm.ws.beta.edition=true in krb fat tests