### PR TITLE
Issue 16356: Sentence case bindAuthMech label

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/resources/OSGI-INF/l10n/metatype.properties
@@ -452,7 +452,7 @@ contextPoolConfig.desc=Properties of the context pool.
 
 contextPoolConfig$Ref=Context pool properties reference
 
-bindAuthMechanism=Bind Authentication Mechanism
+bindAuthMechanism=Bind authentication mechanism
 bindAuthMechanism.desc=The authentication mechanism for binding to the LDAP server when searching or modifying an LDAP entry.
 
 bindAuthMechanism.none=Anonymous bind to the directory service. No additional login attributes are required.


### PR DESCRIPTION
Fixes #16456

While prepping for GA, my PB hit this failure: `junit.framework.AssertionFailedError: The label "Bind Authentication Mechanism" for attribute bindAuthMechanism of pid com.ibm.ws.security.registry.ldap.config should be in sentence case.`