### PR TITLE
Moved the RequestTiming enableThreadDumps attribute from beta to GA

### DIFF
--- a/dev/com.ibm.ws.request.timing.jdbc/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.request.timing.jdbc/resources/OSGI-INF/metatype/metatype.xml
@@ -22,7 +22,7 @@
 		<AD name="%hungRequestThreshold.name" description="%hungRequestThreshold.desc" id="hungRequestThreshold" 
         	required="false" type="String" ibm:type="duration(ms)"/>
 		<AD id="enableThreadDumps" name="%enableThreadDumps" description="%enableThreadDumps.desc" required="false"
-		    type="Boolean" default="true" ibm:beta="true"/>
+		    type="Boolean" default="true"/>
 		<AD name="%interruptHungRequest.name" description="%interruptHungRequest.desc" id="interruptHungRequests"
 			required="false" type="Boolean" default="false"/>
     </OCD>

--- a/dev/com.ibm.ws.request.timing.servlet/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.request.timing.servlet/resources/OSGI-INF/metatype/metatype.xml
@@ -22,7 +22,7 @@
 		<AD name="%hungRequestThreshold.name" description="%hungRequestThreshold.desc" id="hungRequestThreshold" 
         	required="false" type="String" ibm:type="duration(ms)"/>
 		<AD id="enableThreadDumps" name="%enableThreadDumps" description="%enableThreadDumps.desc" required="false"
-		    type="Boolean" default="true" ibm:beta="true"/>
+		    type="Boolean" default="true"/>
 		<AD name="%interruptHungRequest.name" description="%interruptHungRequest.desc" id="interruptHungRequests"
 			required="false" type="Boolean" default="false"/>
     </OCD>

--- a/dev/com.ibm.ws.request.timing/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.request.timing/resources/OSGI-INF/metatype/metatype.xml
@@ -20,7 +20,7 @@
         <AD name="%hungRequestThreshold" description="%hungRequestThreshold.desc"
             id="hungRequestThreshold" required="false" type="String" ibm:type="duration(ms)" default="10m" />
 		<AD id="enableThreadDumps" name="%enableThreadDumps" description="%enableThreadDumps.desc" required="false"
-		    type="Boolean" default="true" ibm:beta="true"/>
+		    type="Boolean" default="true"/>
         <AD name="%sampleRate" description="%sampleRate.desc"
             id="sampleRate" required="false" type="Integer" min="1" default="1" />
 		<AD id="includeContextInfo" name="%includeContextInfo" description="%includeContextInfo.desc" required="false" 

--- a/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/internal/config/HungRequestTimingConfig.java
+++ b/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/internal/config/HungRequestTimingConfig.java
@@ -158,10 +158,11 @@ public class HungRequestTimingConfig extends RequestTimingConfig {
 		hungReqTimingCfg.append("-------------------Hung Request Timing Settings-------------------" + String.format("%n"));
 		hungReqTimingCfg.append("Sample rate: " + getSampleRate() + String.format("%n"));
 		hungReqTimingCfg.append("Context info requirement: " + getContextInfoRequirement() + String.format("%n"));
+		hungReqTimingCfg.append("Enable Thread Dumps: " + isThreadDumpsEnabled() + String.format("%n"));
 		hungReqTimingCfg.append("-------------------Type Settings-------------------" + String.format("%n"));
 		for(List<Timing> typeList : getRequestTiming().values()) {
 			for (Timing t : typeList) {
-				hungReqTimingCfg.append(t.getType() + ": " + t.getContextInfoString() + ": " + "Request threshold (ms) - " +  t.getRequestThreshold() + String.format("%n"));
+				hungReqTimingCfg.append(t.getType() + ": " + t.getContextInfoString() + ": " + "Request threshold (ms) - " +  t.getRequestThreshold() + ", Enable Thread Dumps : " + t.isThreadDumpsEnabled() + String.format("%n"));
 			}
 		}
 		hungReqTimingCfg.append("-------------------------------------------------------------");

--- a/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/queue/HungRequest.java
+++ b/dev/com.ibm.ws.request.timing/src/com/ibm/ws/request/timing/queue/HungRequest.java
@@ -73,6 +73,7 @@ public class HungRequest extends QueueableRequest {
 		hungReq.append("Initial Delay (ms) : " + getInitialDelay() + String.format("%n"));
 		hungReq.append("Hung request threshold mean (ms) : " + hungRequestThreshold + String.format("%n"));
 		hungReq.append("Include Context Info : " + includeContextInfo + String.format("%n"));
+		hungReq.append("Enable Thread Dumps : " + enableThreadDumps + String.format("%n"));
 		hungReq.append("-----------------------------------------------------------------------");
 		return hungReq.toString();
 	}


### PR DESCRIPTION
fixes #16255 
- Moved the enableThreadDumps attribute from beta to GA in the metatype.xml
- Added enableThreadDumps to the HungRequestTimingConfig/HungRequest debug trace.