### PR TITLE
Add missing source paths to Eclipse classpath

### DIFF
--- a/dev/com.ibm.ws.messaging.open_jms20_fat/.classpath
+++ b/dev/com.ibm.ws.messaging.open_jms20_fat/.classpath
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="src" path="test-applications/mdbapp1/src"/>
+	<classpathentry kind="src" path="test-applications/jmsmdb/src"/>
+	<classpathentry kind="src" path="test-applications/mdbapp/src"/>
 	<classpathentry kind="src" path="test-applications/DurableUnshared/src"/>
 	<classpathentry kind="src" path="test-applications/JMSConsumer_118076/src"/>
 	<classpathentry kind="src" path="test-applications/JMSConsumer_118077/src"/>


### PR DESCRIPTION
This PR adds src paths for additional test-applications to the Eclipse .classpath

#build