### PR TITLE
Disable authentication cache for JWT SSO FATs with auth filter

### DIFF
--- a/dev/com.ibm.ws.security.jwtsso_fat/publish/servers/com.ibm.ws.security.jwtsso.fat/configs/server_jwtSso_authFilter_empty.xml
+++ b/dev/com.ibm.ws.security.jwtsso_fat/publish/servers/com.ibm.ws.security.jwtsso.fat/configs/server_jwtSso_authFilter_empty.xml
@@ -16,6 +16,8 @@
     <include location="${shared.config.dir}/formloginApp.xml" />
     <include location="../fatTestPorts.xml"/>
 
+    <authentication cacheEnabled="false"/>
+
     <jwtSso id="myJwtSso" useLtpaIfJwtAbsent="false" includeLtpaCookie="false" setCookieSecureFlag="false" authFilterRef="" />
 
 </server>

--- a/dev/com.ibm.ws.security.jwtsso_fat/publish/servers/com.ibm.ws.security.jwtsso.fat/configs/server_jwtSso_authFilter_match.xml
+++ b/dev/com.ibm.ws.security.jwtsso_fat/publish/servers/com.ibm.ws.security.jwtsso.fat/configs/server_jwtSso_authFilter_match.xml
@@ -16,6 +16,8 @@
     <include location="${shared.config.dir}/formloginApp.xml" />
     <include location="../fatTestPorts.xml"/>
 
+    <authentication cacheEnabled="false"/>
+
     <jwtSso id="myJwtSso" useLtpaIfJwtAbsent="false" includeLtpaCookie="false" setCookieSecureFlag="false" authFilterRef="contains_simpleServlet" />
 
     <authFilter id="contains_simpleServlet">

--- a/dev/com.ibm.ws.security.jwtsso_fat/publish/servers/com.ibm.ws.security.jwtsso.fat/configs/server_jwtSso_authFilter_notMatch.xml
+++ b/dev/com.ibm.ws.security.jwtsso_fat/publish/servers/com.ibm.ws.security.jwtsso.fat/configs/server_jwtSso_authFilter_notMatch.xml
@@ -16,6 +16,8 @@
     <include location="${shared.config.dir}/formloginApp.xml" />
     <include location="../fatTestPorts.xml"/>
 
+    <authentication cacheEnabled="false"/>
+
     <jwtSso id="myJwtSso" useLtpaIfJwtAbsent="true" includeLtpaCookie="true" setCookieSecureFlag="false" authFilterRef="notContain_simpleServlet" />
 
     <authFilter id="notContain_simpleServlet">


### PR DESCRIPTION
The authentication cache needs to be disabled for the JWT SSO FATs to avoid having the core security functionality recreate a logged out SSO cookie from the auth cache.