### PR TITLE
RTC282304: Update tests to handle JDK 16 proxy name change. com.sun.proxy.$Proxy vs jdk.proxy9/jdk.proxy9.$Proxy

### DIFF
--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJCATest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJCATest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -167,7 +167,7 @@ public class ValidateJCATest extends FATServletClient {
         assertNotNull(err, stack);
         assertTrue(err, stack.size() > 10); // stack is actually much longer, but size could vary
         assertTrue(err, stack.getString(0).startsWith("org.test.validator.adapter.JDBCConnectionImpl.invoke("));
-        assertTrue(err, stack.getString(1).startsWith("com.sun.proxy.$Proxy"));
+        assertTrue(err, stack.getString(1).contains(".$Proxy"));
         assertTrue(err, stack.getString(2).startsWith("com."));
 
         assertNotNull(err, json = json.getJsonObject("cause"));
@@ -179,7 +179,7 @@ public class ValidateJCATest extends FATServletClient {
         assertNotNull(err, stack);
         assertTrue(err, stack.size() > 10); // stack is actually much longer, but size could vary
         assertTrue(err, stack.getString(0).startsWith("org.test.validator.adapter.JDBCConnectionImpl.invoke("));
-        assertTrue(err, stack.getString(1).startsWith("com.sun.proxy.$Proxy"));
+        assertTrue(err, stack.getString(1).contains(".$Proxy"));
         assertTrue(err, stack.getString(2).startsWith("com."));
 
         // cause
@@ -192,7 +192,7 @@ public class ValidateJCATest extends FATServletClient {
         assertNotNull(err, stack);
         assertTrue(err, stack.size() > 10); // stack is actually much longer, but size could vary
         assertTrue(err, stack.getString(0).startsWith("org.test.validator.adapter.JDBCConnectionImpl.invoke("));
-        assertTrue(err, stack.getString(1).startsWith("com.sun.proxy.$Proxy"));
+        assertTrue(err, stack.getString(1).contains(".$Proxy"));
         assertTrue(err, stack.getString(2).startsWith("com."));
         assertNull(err, json.getJsonObject("cause"));
     }


### PR DESCRIPTION
fixes #16387