### PR TITLE
Remove line feed chars ('\n' and '\r') when comparing multi-line strings

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/multipart/src/com/ibm/ws/jaxrs/fat/multipart/MultipartResource.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/multipart/src/com/ibm/ws/jaxrs/fat/multipart/MultipartResource.java
@@ -169,8 +169,8 @@ public class MultipartResource extends Application {
                                          @FormParam("file2") String part2,
                                          @FormParam("notAFile") String part3,
                                          @FormParam("noSpecifiedContentType") String part4) throws IOException {
-        assertEquals(Util.toString(Util.xmlFile()).trim(), part1.trim());
-        assertEquals(Util.toString(Util.asciidocFile()).trim(), part2.trim());
+        assertEquals(Util.removeLineFeeds(Util.toString(Util.xmlFile()).trim()), Util.removeLineFeeds(part1.trim()));
+        assertEquals(Util.removeLineFeeds(Util.toString(Util.asciidocFile()).trim()), Util.removeLineFeeds(part2.trim()));
         assertEquals("This is not a file...", part3.trim());
         assertEquals("No content type specified", part4.trim());
         return "SUCCESS";

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/multipart/src/com/ibm/ws/jaxrs/fat/multipart/Util.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/multipart/src/com/ibm/ws/jaxrs/fat/multipart/Util.java
@@ -123,18 +123,6 @@ public class Util {
                                            .collect(Collectors.joining("\n"));
         System.out.println("Util.toString " + str);
         return str;
-        /*
-        StringBuilder sb = new StringBuilder();
-        byte[] buf = new byte[1024];
-        int bytesRead = 0;
-        while (bytesRead > -1) {
-            bytesRead = is.read(buf);
-            sb.append(new String(buf, 0, bytesRead));
-        }
-        String str = sb.toString();
-        System.out.println("Util.toString " + str);
-        return str;
-        */
     }
 
     static String getPartName(IAttachment part) {
@@ -184,5 +172,10 @@ public class Util {
         public boolean isClosed() {
             return closed;
         }
+    }
+
+    static String removeLineFeeds(String original) {
+        String updated = original.replaceAll("\n", "");
+        return updated.replaceAll("\r", "");
     }
 }


### PR DESCRIPTION
Fixes test failures on Windows where line feed characters don't match: `\n` vs `\r\n`