### PR TITLE
Issue 16400: Fix message creation and FAT check for Krb5 Ldap

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/context/ContextManager.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/context/ContextManager.java
@@ -1956,7 +1956,8 @@ public class ContextManager {
                  * at java.security.jgss/javax.security.auth.kerberos.KerberosPrincipal.<init>(KerberosPrincipal.java:174)
                  */
                 String msg = Tr.formatMessage(tc, WIMMessageKey.INVALID_KRB5_PRINCIPAL, WIMMessageHelper.generateMsgParms(krb5Principal));
-                LoginException le = new LoginException(msg + " " + ie.getClass().getName() + ": " + ie.getMessage());
+                String rootMessage = ie.getMessage(); // Only print if there's info, sometimes the java.lang.IllegalArgumentException has no getMessage
+                LoginException le = new LoginException(msg + " " + ie.getClass().getName() + (rootMessage == null ? "" : ": " + ie.getMessage()));
                 le.initCause(ie);
                 throw le;
             }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBadPrincipalJava8.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBadPrincipalJava8.java
@@ -12,6 +12,7 @@ package com.ibm.ws.security.wim.adapter.ldap.fat.krb5;
 
 import static componenttest.topology.utils.LDAPFatUtils.updateConfigDynamically;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -40,7 +41,7 @@ public class TicketCacheBadPrincipalJava8 extends CommonBindTest {
 
     @BeforeClass
     public static void setStopMessages() {
-        stopStrings = new String[] { "CWIML4507E", "CWWKS4347E" };
+        stopStrings = new String[] { "CWIML4507E", "CWWKS4347E", "CWIML4512E" };
     }
 
     /**
@@ -64,8 +65,14 @@ public class TicketCacheBadPrincipalJava8 extends CommonBindTest {
         loginUserShouldFail();
 
         assertFalse("Expected to find Kerberos bind failure: CWIML4507E", server.findStringsInLogsAndTraceUsingMark("CWIML4507E").isEmpty());
-        // Message added to avoid an NPE when running on Java 8
-        assertFalse("Expected to find Kerberos bind failure: CWWKS4347E", server.findStringsInLogsAndTraceUsingMark("CWWKS4347E").isEmpty());
+        /*
+         * The same base exception is not always thrown, two options here, either confirms that we tried to use an
+         * invalid principal name.
+         */
+        boolean foundBadPrincipalName = !server.findStringsInLogsAndTraceUsingMark("CWIML4512E").isEmpty();
+        boolean foundKerberosLevelError = !server.findStringsInLogsAndTraceUsingMark("CWWKS4347E").isEmpty();
+        assertTrue("Expected to find Kerberos bind failure: Either `CWIML4512E` or `CWWKS4347E`", foundBadPrincipalName || foundKerberosLevelError);
+
     }
 
 }


### PR DESCRIPTION
Fixes #16400

Runtime fix: Avoid printing an Exception's getMessage() if it is null in `ContextManager.handleKerberos` -- example: `java.lang.IllegalArgumentException: null`

Test fix: Java 8 is more variable than I thought -- add second acceptable error message on a bad principalName.