### PR TITLE
Use Json factories to avoid having to lookup the provider

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -198,4 +198,5 @@ instrument.classesExcludes: com/ibm/ws/jaxrs20/internal/resources/*.class, \
 	org.jmock:jmock-junit4;strategy=exact;version=2.5.1, \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \
 	com.ibm.ws.junit.extensions;version=latest, \
-	com.ibm.websphere.org.eclipse.microprofile.rest.client.1.1;version=latest
+	com.ibm.websphere.org.eclipse.microprofile.rest.client.1.1;version=latest, \
+	com.ibm.ws.org.glassfish.json.1.0;version=latest

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/providers/jsonp/JsonPProvider.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/providers/jsonp/JsonPProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,8 +21,10 @@ import javax.json.JsonArray;
 import javax.json.JsonException;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
+import javax.json.JsonReaderFactory;
 import javax.json.JsonStructure;
 import javax.json.JsonWriter;
+import javax.json.JsonWriterFactory;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
@@ -41,6 +43,10 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 @Consumes({ "application/json", "application/*+json" })
 @Provider
 public class JsonPProvider implements MessageBodyReader, MessageBodyWriter {
+
+    private static final JsonWriterFactory writerFactory = Json.createWriterFactory(null);
+
+    private static final JsonReaderFactory readerFactory = Json.createReaderFactory(null);
 
     @Override
     public long getSize(Object obj, Class type, Type genericType, Annotation[] annotations, MediaType mediaType) {
@@ -63,7 +69,7 @@ public class JsonPProvider implements MessageBodyReader, MessageBodyWriter {
 
         JsonWriter writer = null;
         try {
-            writer = Json.createWriter(entityStream);
+            writer = writerFactory.createWriter(entityStream);
             if (writer != null) {
                 writer.write((JsonStructure) obj);
             }
@@ -97,7 +103,7 @@ public class JsonPProvider implements MessageBodyReader, MessageBodyWriter {
 
         JsonReader reader = null;
         try {
-            reader = Json.createReader(entityStream);
+            reader = readerFactory.createReader(entityStream);
             if (reader != null) {
                 return reader.read();
             }

--- a/dev/com.ibm.ws.jbatch.jms/src/com/ibm/ws/jbatch/jms/internal/events/impl/BatchEventsPublisherImpl.java
+++ b/dev/com.ibm.ws.jbatch.jms/src/com/ibm/ws/jbatch/jms/internal/events/impl/BatchEventsPublisherImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ package com.ibm.ws.jbatch.jms.internal.events.impl;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.logging.Logger;
 import java.util.Set;
 
 import javax.batch.runtime.BatchStatus;
@@ -26,6 +25,7 @@ import javax.jms.Session;
 import javax.jms.TextMessage;
 import javax.jms.Topic;
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonValue;
@@ -36,8 +36,6 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 
-import com.ibm.jbatch.container.RASConstants;
-import com.ibm.jbatch.container.impl.BatchKernelImpl;
 import com.ibm.jbatch.container.ws.WSJobExecution;
 import com.ibm.jbatch.container.ws.WSJobInstance;
 import com.ibm.jbatch.container.ws.WSStepThreadExecutionAggregate;
@@ -76,6 +74,8 @@ public class BatchEventsPublisherImpl implements BatchEventsPublisher {
 
 	private static final TraceComponent tc = Tr.register(BatchEventsPublisherImpl.class, "wsbatch", "com.ibm.ws.jbatch.jms.internal.resources.BatchJmsMessages");
 
+	private static final JsonBuilderFactory builderFactory = Json.createBuilderFactory(null);
+	    
 	/**
 	 * For creating jms dispatcher connection factory
 	 */
@@ -368,7 +368,7 @@ public class BatchEventsPublisherImpl implements BatchEventsPublisher {
 	//Return a copy of the json object with a k/v pair removed.
 	@Trivial
 	private JsonObject removeJsonPair( JsonObject jObj, String k ){
-		JsonObjectBuilder builder = Json.createObjectBuilder();
+		JsonObjectBuilder builder = builderFactory.createObjectBuilder();
 		Set<Entry<String,JsonValue>> jSet = jObj.entrySet();
 
 		for (Iterator<Entry<String, JsonValue>> iter = jSet.iterator(); iter.hasNext();) {

--- a/dev/com.ibm.ws.jbatch.rest/src/com/ibm/ws/jbatch/rest/internal/resources/BatchRoot.java
+++ b/dev/com.ibm.ws.jbatch.rest/src/com/ibm/ws/jbatch/rest/internal/resources/BatchRoot.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 
@@ -41,6 +42,8 @@ import com.ibm.wsspi.rest.handler.RESTResponse;
                             RESTHandler.PROPERTY_REST_HANDLER_CUSTOM_SECURITY + "=true" })
 public class BatchRoot implements RESTHandler {
 
+    private static final JsonBuilderFactory builderFactory = Json.createBuilderFactory(null);
+
     @Override
 	public void handleRequest(RESTRequest request, RESTResponse response)
 			throws IOException {
@@ -49,13 +52,13 @@ public class BatchRoot implements RESTHandler {
         String path = BatchRequestUtil.normalizeURLPath(request.getPath());
         if ("/batch".equals(path)) {
 
-            JsonObjectBuilder jsonObjBuilder = Json.createObjectBuilder();
+            JsonObjectBuilder jsonObjBuilder = builderFactory.createObjectBuilder();
 
             String requestUrl = BatchRequestUtil.normalizeURLPath(request.getURL());
 
 			jsonObjBuilder
-			.add("_links", Json.createArrayBuilder()
-			    .add(Json.createObjectBuilder()
+			.add("_links", builderFactory.createArrayBuilder()
+			    .add(builderFactory.createObjectBuilder()
 					.add("rel", "job instance")
 					.add("href",requestUrl + "/jobinstances" )));
 

--- a/dev/com.ibm.ws.jbatch.utility/src/com/ibm/ws/jbatch/utility/http/EntityReader.java
+++ b/dev/com.ibm.ws.jbatch.utility/src/com/ibm/ws/jbatch/utility/http/EntityReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,12 @@ package com.ibm.ws.jbatch.utility.http;
 import java.io.IOException;
 import java.io.InputStream;
 
+import javax.json.Json;
+import javax.json.JsonReaderFactory;
+
 public interface EntityReader<T> {
+
+    static final JsonReaderFactory readerFactory = Json.createReaderFactory(null);
 
     /**
      * @return the entity read from the given entityStream.

--- a/dev/com.ibm.ws.jbatch.utility/src/com/ibm/ws/jbatch/utility/http/EntityWriter.java
+++ b/dev/com.ibm.ws.jbatch.utility/src/com/ibm/ws/jbatch/utility/http/EntityWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,10 +12,18 @@ package com.ibm.ws.jbatch.utility.http;
 
 import java.io.OutputStream;
 
+import javax.json.Json;
+import javax.json.JsonBuilderFactory;
+import javax.json.JsonWriterFactory;
+
 /**
  * 
  */
 public interface EntityWriter {
+
+    static final JsonWriterFactory writerFactory = Json.createWriterFactory(null);
+
+    static final JsonBuilderFactory builderFactory = Json.createBuilderFactory(null);
 
     /**
      * Write the entity to the given entityStream.

--- a/dev/com.ibm.ws.jbatch.utility/src/com/ibm/ws/jbatch/utility/rest/JobExecutionListMessageBodyReader.java
+++ b/dev/com.ibm.ws.jbatch.utility/src/com/ibm/ws/jbatch/utility/rest/JobExecutionListMessageBodyReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@ package com.ibm.ws.jbatch.utility.rest;
 
 import java.io.InputStream;
 
-import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
@@ -29,7 +28,7 @@ public class JobExecutionListMessageBodyReader implements EntityReader<JobExecut
     @Override
     public JobExecutionList readEntity(InputStream entityStream) {
         // Read json
-        JsonReader jsonReader = Json.createReader(entityStream);
+        JsonReader jsonReader = readerFactory.createReader(entityStream);
         JsonArray jsonArray = jsonReader.readArray();
         jsonReader.close();
         

--- a/dev/com.ibm.ws.jbatch.utility/src/com/ibm/ws/jbatch/utility/rest/JobExecutionMessageBodyReader.java
+++ b/dev/com.ibm.ws.jbatch.utility/src/com/ibm/ws/jbatch/utility/rest/JobExecutionMessageBodyReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ package com.ibm.ws.jbatch.utility.rest;
 import java.io.InputStream;
 
 import javax.batch.runtime.JobExecution;
-import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
 
@@ -27,7 +26,7 @@ public class JobExecutionMessageBodyReader implements EntityReader<JobExecution>
     @Override
     public JobExecution readEntity(InputStream entityStream) {
         // Read json
-        JsonReader jsonReader = Json.createReader(entityStream);
+        JsonReader jsonReader = readerFactory.createReader(entityStream);
         JsonObject jsonObject = jsonReader.readObject();
         jsonReader.close();
 

--- a/dev/com.ibm.ws.jbatch.utility/src/com/ibm/ws/jbatch/utility/rest/JobInstanceListMessageBodyReader.java
+++ b/dev/com.ibm.ws.jbatch.utility/src/com/ibm/ws/jbatch/utility/rest/JobInstanceListMessageBodyReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.batch.runtime.JobInstance;
-import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
@@ -31,7 +30,7 @@ public class JobInstanceListMessageBodyReader implements EntityReader<List<JobIn
     @Override
     public List<JobInstance> readEntity(InputStream entityStream) {
 
-        JsonReader jsonReader = Json.createReader(entityStream);
+        JsonReader jsonReader = readerFactory.createReader(entityStream);
         JsonArray jsonArray = jsonReader.readArray();
         jsonReader.close();
         

--- a/dev/com.ibm.ws.jbatch.utility/src/com/ibm/ws/jbatch/utility/rest/JobInstanceMessageBodyReader.java
+++ b/dev/com.ibm.ws.jbatch.utility/src/com/ibm/ws/jbatch/utility/rest/JobInstanceMessageBodyReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ package com.ibm.ws.jbatch.utility.rest;
 import java.io.InputStream;
 
 import javax.batch.runtime.JobInstance;
-import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
 
@@ -27,7 +26,7 @@ public class JobInstanceMessageBodyReader implements EntityReader<JobInstance> {
     @Override
     public JobInstance readEntity(InputStream entityStream) {
         // Read json
-        JsonReader jsonReader = Json.createReader(entityStream);
+        JsonReader jsonReader = readerFactory.createReader(entityStream);
         JsonObject jsonObject = jsonReader.readObject();
         jsonReader.close();
 

--- a/dev/com.ibm.ws.jbatch.utility/src/com/ibm/ws/jbatch/utility/rest/JobRestartMessageBodyWriter.java
+++ b/dev/com.ibm.ws.jbatch.utility/src/com/ibm/ws/jbatch/utility/rest/JobRestartMessageBodyWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -37,7 +37,7 @@ public class JobRestartMessageBodyWriter implements EntityWriter {
      * @return a JsonObject for the given map
      */
     protected JsonObject buildJsonObjectFromMap( Map map ) {
-        JsonObjectBuilder builder = Json.createObjectBuilder();
+        JsonObjectBuilder builder = builderFactory.createObjectBuilder();
         
         for (Map.Entry entry : (Set<Map.Entry>) map.entrySet() ) {
             builder.add( (String) entry.getKey(), (String) entry.getValue() );
@@ -49,11 +49,11 @@ public class JobRestartMessageBodyWriter implements EntityWriter {
     @Override
     public void writeEntity(OutputStream entityStream) {
     
-        JsonObjectBuilder builder = Json.createObjectBuilder();
+        JsonObjectBuilder builder = builderFactory.createObjectBuilder();
         
         builder.add( "jobParameters", buildJsonObjectFromMap( jobRestart.getJobParameters() ) );
         
-        Json.createWriter(entityStream).writeObject( builder.build() );
+        writerFactory.createWriter(entityStream).writeObject( builder.build() );
     }
     
 

--- a/dev/com.ibm.ws.jbatch.utility/src/com/ibm/ws/jbatch/utility/rest/JobSubmissionMessageBodyWriter.java
+++ b/dev/com.ibm.ws.jbatch.utility/src/com/ibm/ws/jbatch/utility/rest/JobSubmissionMessageBodyWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -39,7 +39,7 @@ public class JobSubmissionMessageBodyWriter implements EntityWriter {
      * @return a JsonObject for the given map
      */
     protected JsonObject buildJsonObjectFromMap( Map map ) {
-        JsonObjectBuilder builder = Json.createObjectBuilder();
+        JsonObjectBuilder builder = builderFactory.createObjectBuilder();
         
         for (Map.Entry entry : (Set<Map.Entry>) map.entrySet() ) {
             builder.add( (String) entry.getKey(), (String) entry.getValue() );
@@ -54,7 +54,7 @@ public class JobSubmissionMessageBodyWriter implements EntityWriter {
     @Override
     public void writeEntity(OutputStream entityStream) {
         
-        JsonObjectBuilder builder = Json.createObjectBuilder();
+        JsonObjectBuilder builder = builderFactory.createObjectBuilder();
         
         builder.add( "applicationName", ObjectUtils.firstNonNull(jobSubmission.getApplicationName(), "") )
                .add( "moduleName", ObjectUtils.firstNonNull(jobSubmission.getModuleName(), "") )
@@ -63,7 +63,7 @@ public class JobSubmissionMessageBodyWriter implements EntityWriter {
                .add( "jobParameters", buildJsonObjectFromMap( jobSubmission.getJobParameters() )) 
                .add( "jobXML", ObjectUtils.firstNonNull(jobSubmission.getJobXMLFile(), "") );
    
-        Json.createWriter(entityStream).writeObject( builder.build() );
+        writerFactory.createWriter(entityStream).writeObject( builder.build() );
     }
     
 

--- a/dev/com.ibm.ws.jbatch.utility/src/com/ibm/ws/jbatch/utility/rest/JsonHelper.java
+++ b/dev/com.ibm.ws.jbatch.utility/src/com/ibm/ws/jbatch/utility/rest/JsonHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import javax.batch.runtime.BatchStatus;
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonValue;
@@ -29,6 +30,8 @@ import com.ibm.ws.jbatch.utility.utils.StringUtils;
  */
 public class JsonHelper {
     
+    private static final JsonBuilderFactory builderFactory = Json.createBuilderFactory(null);
+
     /**
      * @return batchStatus.name(), or null if batchStatus == null.
      */
@@ -48,7 +51,7 @@ public class JsonHelper {
      * 
      */
     public static JsonObject removeFields(JsonObject jsonObject, String... removeField) {
-        JsonObjectBuilder retMe = Json.createObjectBuilder();
+        JsonObjectBuilder retMe = builderFactory.createObjectBuilder();
         
         List<String> removeFieldList = Arrays.asList(removeField);
         

--- a/dev/com.ibm.ws.jbatch.utility/src/com/ibm/ws/jbatch/utility/rest/PurgeResponseMessageBodyReader.java
+++ b/dev/com.ibm.ws.jbatch.utility/src/com/ibm/ws/jbatch/utility/rest/PurgeResponseMessageBodyReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,7 +31,7 @@ public class PurgeResponseMessageBodyReader implements EntityReader<List<WSPurge
     @Override
     public List<WSPurgeResponse> readEntity(InputStream entityStream) {
 
-        JsonReader jsonReader = Json.createReader(entityStream);
+        JsonReader jsonReader = readerFactory.createReader(entityStream);
         JsonArray jsonArray = jsonReader.readArray();
         jsonReader.close();
         

--- a/dev/com.ibm.ws.security.jwtsso.token/bnd.bnd
+++ b/dev/com.ibm.ws.security.jwtsso.token/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017,2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -68,4 +68,5 @@ Private-Package: \
     com.ibm.ws.org.jose4j;version=latest, \
     com.ibm.ws.org.apache.commons.codec;version=latest, \
     com.ibm.websphere.javaee.jsonp.1.0;version=latest, \
-    com.ibm.websphere.org.eclipse.microprofile.jwt.1.0;version=latest
+    com.ibm.websphere.org.eclipse.microprofile.jwt.1.0;version=latest, \
+    com.ibm.ws.org.glassfish.json.1.0;version=latest

--- a/dev/com.ibm.ws.security.mp.jwt.cdi/src/com/ibm/ws/security/mp/jwt/cdi/ClaimBean.java
+++ b/dev/com.ibm.ws.security.mp.jwt.cdi/src/com/ibm/ws/security/mp/jwt/cdi/ClaimBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,6 +31,7 @@ import javax.enterprise.inject.spi.PassivationCapable;
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
+import javax.json.JsonReaderFactory;
 import javax.json.JsonValue;
 
 import org.eclipse.microprofile.jwt.Claim;
@@ -46,6 +47,8 @@ import com.ibm.websphere.ras.TraceComponent;
 public class ClaimBean<T> implements Bean<T>, PassivationCapable {
 
     private static final TraceComponent tc = Tr.register(ClaimBean.class);
+
+    private static final JsonReaderFactory readerFactory = Json.createReaderFactory(null);
 
     private final Class<T> beanClass;
     private Type beanType;
@@ -278,7 +281,7 @@ public class ClaimBean<T> implements Bean<T>, PassivationCapable {
 
     private JsonValue getJsonValue(JsonWebToken jsonWebToken) {
         String jsonWebTokenAsString = jsonWebToken.toString();
-        JsonReader reader = Json.createReader(new StringReader(jsonWebTokenAsString));
+        JsonReader reader = readerFactory.createReader(new StringReader(jsonWebTokenAsString));
         JsonObject jsonObject = reader.readObject();
         return jsonObject.get(claimName);
     }
@@ -314,7 +317,7 @@ public class ClaimBean<T> implements Bean<T>, PassivationCapable {
 
                         return value;
                     } catch (IllegalStateException e) {
-                       return null;
+                        return null;
                     }
                 }
             };

--- a/dev/com.ibm.ws.security.mp.jwt.cdi/src/com/ibm/ws/security/mp/jwt/cdi/ClaimProducer.java
+++ b/dev/com.ibm.ws.security.mp.jwt.cdi/src/com/ibm/ws/security/mp/jwt/cdi/ClaimProducer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ import javax.json.JsonArray;
 import javax.json.JsonNumber;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
+import javax.json.JsonReaderFactory;
 import javax.json.JsonString;
 import javax.json.JsonStructure;
 import javax.json.JsonValue;
@@ -43,6 +44,8 @@ import com.ibm.websphere.ras.TraceComponent;
 public class ClaimProducer {
 
     private static final TraceComponent tc = Tr.register(ClaimProducer.class);
+
+    private static final JsonReaderFactory readerFactory = Json.createReaderFactory(null);
 
     @Inject
     private JsonWebToken jsonWebToken;
@@ -164,7 +167,7 @@ public class ClaimProducer {
     // TODO: Determine how to match JsonValue.TRUE/FALSE
 
     private JsonValue getAsJsonValue(String claimName) {
-        JsonReader reader = Json.createReader(new StringReader(jsonWebToken.toString()));
+        JsonReader reader = readerFactory.createReader(new StringReader(jsonWebToken.toString()));
         JsonObject jsonObject = reader.readObject();
         return jsonObject.get(claimName);
     }

--- a/dev/com.ibm.ws.security.mp.jwt/bnd.bnd
+++ b/dev/com.ibm.ws.security.mp.jwt/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2020 IBM Corporation and others.
+# Copyright (c) 2017, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -107,4 +107,5 @@ Include-Resource: \
     com.ibm.websphere.appserver.spi.servlet;version=latest, \
     com.ibm.ws.anno;version=latest, \
     com.ibm.ws.threading;version=latest, \
-    com.ibm.ws.security.test.common;version=latest
+    com.ibm.ws.security.test.common;version=latest, \
+    com.ibm.ws.org.glassfish.json.1.0;version=latest

--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/impl/utils/ClaimsUtils.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/impl/utils/ClaimsUtils.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.mp.jwt.impl.utils;
 
@@ -17,6 +17,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 
@@ -36,6 +37,8 @@ import com.ibm.ws.security.mp.jwt.TraceConstants;
  */
 public class ClaimsUtils {
     public static final TraceComponent tc = Tr.register(ClaimsUtils.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
+
+    private static final JsonBuilderFactory builderFactory = Json.createBuilderFactory(null);
 
     public ClaimsUtils() {
     }
@@ -158,7 +161,7 @@ public class ClaimsUtils {
     private void replaceMapWithJsonObject(String claimName, JwtClaims claimsSet) {
         try {
             Map<String, Object> map = claimsSet.getClaimValue(claimName, Map.class);
-            JsonObjectBuilder builder = Json.createObjectBuilder();
+            JsonObjectBuilder builder = builderFactory.createObjectBuilder();
             for (Map.Entry<String, Object> entry : map.entrySet()) {
                 builder.add(entry.getKey(), entry.getValue().toString());
             }

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/utils/IntrospectUserApiUtils.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/internal/utils/IntrospectUserApiUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@ package com.ibm.ws.security.social.internal.utils;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.io.StringReader;
 import java.net.HttpURLConnection;
 import java.util.HashMap;
@@ -20,28 +19,26 @@ import java.util.Map;
 
 import javax.json.Json;
 import javax.json.JsonObject;
-import javax.json.JsonObjectBuilder;
-import javax.json.JsonValue;
-import javax.json.JsonValue.ValueType;
+import javax.json.JsonReaderFactory;
 import javax.json.stream.JsonParsingException;
 import javax.net.ssl.SSLSocketFactory;
 import javax.servlet.http.HttpServletResponse;
 
-import org.jose4j.lang.JoseException;
-
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.ws.common.internal.encoder.Base64Coder;
 import com.ibm.ws.security.common.http.HttpUtils;
 import com.ibm.ws.security.social.SocialLoginConfig;
 import com.ibm.ws.security.social.TraceConstants;
 import com.ibm.ws.security.social.error.SocialLoginException;
 import com.ibm.ws.security.social.internal.Oauth2LoginConfigImpl;
-import com.ibm.ws.common.internal.encoder.Base64Coder;
 
 public class IntrospectUserApiUtils {
 
     public static final TraceComponent tc = Tr.register(IntrospectUserApiUtils.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
+
+    private static final JsonReaderFactory readerFactory = Json.createReaderFactory(null);
 
     SocialLoginConfig config = null;
 
@@ -111,7 +108,7 @@ public class IntrospectUserApiUtils {
             throw new SocialLoginException("RESPONSE_NOT_JSON", null, null);
         }
         try {
-            return Json.createReader(new StringReader(response)).readObject();
+            return readerFactory.createReader(new StringReader(response)).readObject();
         } catch (JsonParsingException e) {
             throw new SocialLoginException("RESPONSE_NOT_JSON", e, new Object[] { response, e });
         }

--- a/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/restfulWS/providers/JsonPProvider.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/restfulWS/providers/JsonPProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -52,7 +52,7 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 @Provider
 public class JsonPProvider implements MessageBodyReader<Object>, MessageBodyWriter<Object> {
 
-    JsonProvider jsonProvider = null;
+    final JsonProvider jsonProvider;
 
     public JsonPProvider() {
         jsonProvider = AccessController.doPrivileged(new PrivilegedAction<JsonProvider>(){
@@ -155,7 +155,7 @@ public class JsonPProvider implements MessageBodyReader<Object>, MessageBodyWrit
         return null;
     }
 
-    private static <T> T castNumber(InputStream in, Class<T> type) throws IOException {
+    private <T> T castNumber(InputStream in, Class<T> type) throws IOException {
         //read stream to string and then create a JsonNumber manually...
         String str;
         try (Scanner s = new Scanner(in).useDelimiter("\\A")) {
@@ -172,9 +172,9 @@ public class JsonPProvider implements MessageBodyReader<Object>, MessageBodyWrit
         if (type.isAssignableFrom(JsonNumber.class)) {
             // check for decimal point
             if (str.contains(".")) {
-                return type.cast(Json.createValue(Double.parseDouble(str)));
+                return type.cast(jsonProvider.createValue(Double.parseDouble(str)));
             }
-            return type.cast(Json.createValue(Long.parseLong(str)));
+            return type.cast(jsonProvider.createValue(Long.parseLong(str)));
         }
         if (type.isAssignableFrom(BigDecimal.class)) {
             return type.cast(new BigDecimal(str));


### PR DESCRIPTION
- Update to use JsonBuilderFactory.createObjectBuilder() instead of Json.createObjectBuilder()
- Update to use JsonReaderFactory.createReader() instead of Json.createReader()
- Update to use JsonWriterFactory.createWriter() instead of Json.createWriter()

Fixes #16395