### PR TITLE
branch coupling extension point on legacy DataStoreHelper

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/heritage/GenericDataStoreHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/heritage/GenericDataStoreHelper.java
@@ -148,6 +148,15 @@ public abstract class GenericDataStoreHelper {
     public abstract SQLException mapException(SQLException x);
 
     /**
+     * Adds an XA start flag for loosely coupled transaction branches.
+     *
+     * @param xaStartFlags XA start flags to add to.
+     * @return updated XA start flags which are a combination of the flags supplied to this method
+     *         and the flag for loosely coupled transaction branches.
+     */
+    public abstract int modifyXAFlag(int xaStartFlags);
+
+    /**
      * Supplies the dataSource configuration to the data store helper.
      *
      * @param config AtomicReference to the dataSource configuration.

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/AdapterUtil.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/AdapterUtil.java
@@ -631,10 +631,13 @@ public class AdapterUtil {
                 return "TMRESUME (" + flag + ')';
 
             case 0x8000:
-                return "SSTRANSTIGHTLYCPLD (" + flag + ')';
+                return "SSTRANSTIGHTLYCPLD (" + flag + ')'; // Microsoft SQL Server JDBC driver
 
             case 0x10000:
-                return "ORATRANSLOOSE (" + flag + ')';
+                return "ORATRANSLOOSE (" + flag + ')'; // Oracle JDBC driver
+
+            case 0x800000:
+                return "TMLCS (" + flag + ')'; // DB2 JCC driver
         }
 
         return "UNKNOWN XA RESOURCE START FLAG (" + flag + ')'; 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
@@ -294,7 +294,10 @@ public class OracleHelper extends DatabaseHelper {
             return super.branchCouplingSupported(couplingType);
 
         if (couplingType == ResourceRefInfo.BRANCH_COUPLING_LOOSE)
-            return 0x10000; // value of oracle.jdbc.xa.OracleXAResource.ORATRANSLOOSE
+            if (mcf.dataStoreHelper == null)
+                return 0x10000; // value of oracle.jdbc.xa.OracleXAResource.ORATRANSLOOSE
+            else
+                return mcf.dataStoreHelper.modifyXAFlag(XAResource.TMNOFLAGS);
 
         // Tight branch coupling is default for Oracle
         return XAResource.TMNOFLAGS;

--- a/dev/com.ibm.ws.jdbc_fat_heritage/publish/servers/com.ibm.ws.jdbc.heritage/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/publish/servers/com.ibm.ws.jdbc.heritage/server.xml
@@ -29,12 +29,15 @@
 
   <application location="heritageApp.war">
     <classloader commonLibraryRef="JDBCLib"/>
+    <web-ext>
+      <resource-ref name="java:comp/jdbc/env/unsharable-ds-xa-loosely-coupled" branch-coupling="LOOSE" isolation-level="TRANSACTION_READ_COMMITTED"/>
+    </web-ext>
   </application>
 
   <authData id="dbAuth" user="dbuser" password="{xor}Oz0vKDs=" />
 
-  <dataSource id="DefaultDataSource" containerAuthDataRef="dbAuth" queryTimeout="1m21s" supplementalJDBCTrace="true" type="javax.sql.DataSource" validationTimeout="18s">
-    <jdbcDriver libraryRef="JDBCLib" javax.sql.DataSource="test.jdbc.heritage.driver.HDDataSource"/>
+  <dataSource id="DefaultDataSource" containerAuthDataRef="dbAuth" queryTimeout="1m21s" supplementalJDBCTrace="true" type="javax.sql.XADataSource" validationTimeout="18s">
+    <jdbcDriver libraryRef="JDBCLib" javax.sql.XADataSource="test.jdbc.heritage.driver.HDDataSource"/>
     <properties databaseName="memory:testdb" createDatabase="create"
                 supportsCatalog="false" supportsNetworkTimeout="false" supportsReadOnly="false" supportsSchema="false" supportsTypeMap="false"/>
                 <!-- rely on custom DataStoreHelper metadata to determine lack of support for the above attributes -->

--- a/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HDConnection.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HDConnection.java
@@ -25,12 +25,16 @@ import java.sql.NClob;
 import java.sql.PreparedStatement;
 import java.sql.SQLClientInfoException;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLWarning;
 import java.sql.SQLXML;
 import java.sql.Savepoint;
 import java.sql.Statement;
 import java.sql.Struct;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -39,9 +43,22 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class HDConnection implements Connection, HeritageDBConnection {
+import javax.sql.ConnectionEventListener;
+import javax.sql.StatementEventListener;
+import javax.sql.XAConnection;
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+public class HDConnection implements Connection, HeritageDBConnection, XAConnection, XAResource {
     private static final Set<String> DEFAULT_CLIENT_INFO_KEYS = Stream.of("ApplicationName", "ClientHostname", "ClientUser").collect(Collectors.toSet());
     public static final int DEFAULT_MAX_FIELD_SIZE = 225;
+
+    /**
+     * Simulates tightly coupled transaction branches by redirecting all transaction branches
+     * for the same global transaction ID to use the same connection for the duration of the transaction.
+     */
+    private static Map<List<Byte>, HDConnection> TIGHTLY_COUPLED_TRANSACTIONS = new HashMap<List<Byte>, HDConnection>();
 
     /**
      * Counts the number of times that doConnectionCleanupPerCloseConnection is invoked for this connection.
@@ -49,11 +66,24 @@ public class HDConnection implements Connection, HeritageDBConnection {
     public final AtomicInteger cleanupCount = new AtomicInteger();
 
     final HDDataSource ds;
-    final Connection derbycon;
+
+    /**
+     * Connection to Derby. Access this via the connection() helper method to allow for
+     * simulation of tightly coupled transaction branches.
+     */
+    private final Connection derbycon;
+
+    /**
+     * Connection to Derby that simulates tightly coupled transaction branches.
+     */
+    private Connection derbyconForTightlyCoupledBranch;
+
     Set<String> clientInfoKeys = DEFAULT_CLIENT_INFO_KEYS;
 
     private Map<Object, Class<?>> exceptionIdentificationOverrides;
     private boolean failOnIsValid;
+
+    private boolean restoreAutoCommitAfterTx;
 
     /**
      * Counts the number of times that doConnectionSetupPerGetConnection is invoked for this connection.
@@ -65,6 +95,11 @@ public class HDConnection implements Connection, HeritageDBConnection {
      */
     public final AtomicInteger transactionCount = new AtomicInteger(-1);
 
+    /**
+     * Xid of transaction that we are pretending to participate in.
+     */
+    public Xid xid;
+
     HDConnection(HDDataSource ds, Connection con) {
         this.ds = ds;
         this.derbycon = con;
@@ -72,96 +107,170 @@ public class HDConnection implements Connection, HeritageDBConnection {
 
     @Override
     public void abort(Executor executor) throws SQLException {
-        derbycon.abort(executor);
+        connection().abort(executor);
+    }
+
+    @Override
+    public void addConnectionEventListener(ConnectionEventListener listener) {
+    }
+
+    @Override
+    public void addStatementEventListener(StatementEventListener listener) {
+    }
+
+    /**
+     * Utility method to convert a global transaction ID into a list of Byte
+     * in order to make it comparable.
+     *
+     * @param bytes global transaction ID as a byte array
+     * @return global transaction ID as a list of Byte
+     */
+    private List<Byte> byteList(byte[] bytes) {
+        List<Byte> list = new ArrayList<Byte>(bytes.length);
+        for (byte b : bytes)
+            list.add(b);
+        return list;
     }
 
     @Override
     public void close() throws SQLException {
-        derbycon.close();
+        connection().close();
     }
 
     @Override
     public void clearWarnings() throws SQLException {
-        derbycon.clearWarnings();
+        connection().clearWarnings();
     }
 
     @Override
     public void commit() throws SQLException {
-        derbycon.commit();
+        if (xid == null)
+            connection().commit();
+        else
+            throw new SQLFeatureNotSupportedException("Connection.commit during XA transaction");
+    }
+
+    @Override
+    public void commit(Xid xid, boolean onePhase) throws XAException {
+        if (this.xid != xid)
+            throw new XAException(XAException.XAER_PROTO);
+        try {
+            if (derbyconForTightlyCoupledBranch == null) {
+                derbycon.commit();
+            } else {
+                derbyconForTightlyCoupledBranch = null;
+                List<Byte> globalTxId = byteList(xid.getGlobalTransactionId());
+                HDConnection c = TIGHTLY_COUPLED_TRANSACTIONS.get(globalTxId);
+                if (this == c) {
+                    TIGHTLY_COUPLED_TRANSACTIONS.remove(globalTxId);
+                    c.derbycon.commit();
+                }
+                // else let the first branch that enlisted perform the commit
+            }
+            if (restoreAutoCommitAfterTx) {
+                derbycon.setAutoCommit(true);
+                restoreAutoCommitAfterTx = false;
+            }
+        } catch (SQLException x) {
+            throw (XAException) new XAException(XAException.XAER_PROTO).initCause(x);
+        } finally {
+            this.xid = null;
+        }
+    }
+
+    /**
+     * Allows for swapping out the connection to simulate tightly coupled branches.
+     *
+     * @return the connection to use
+     */
+    private final Connection connection() {
+        return derbyconForTightlyCoupledBranch == null ? derbycon : derbyconForTightlyCoupledBranch;
     }
 
     @Override
     public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
-        return derbycon.createArrayOf(typeName, elements);
+        return connection().createArrayOf(typeName, elements);
     }
 
     @Override
     public Blob createBlob() throws SQLException {
-        return derbycon.createBlob();
+        return connection().createBlob();
     }
 
     @Override
     public Clob createClob() throws SQLException {
-        return derbycon.createClob();
+        return connection().createClob();
     }
 
     @Override
     public NClob createNClob() throws SQLException {
-        return derbycon.createNClob();
+        return connection().createNClob();
     }
 
     @Override
     public SQLXML createSQLXML() throws SQLException {
-        return derbycon.createSQLXML();
+        return connection().createSQLXML();
     }
 
     @Override
     public Statement createStatement() throws SQLException {
-        Statement s = derbycon.createStatement();
+        Statement s = connection().createStatement();
         s.setMaxFieldSize(DEFAULT_MAX_FIELD_SIZE);
         return s;
     }
 
     @Override
     public Statement createStatement(int resultSetType, int resultSetConcurrency) throws SQLException {
-        Statement s = derbycon.createStatement(resultSetType, resultSetConcurrency);
+        Statement s = connection().createStatement(resultSetType, resultSetConcurrency);
         s.setMaxFieldSize(DEFAULT_MAX_FIELD_SIZE);
         return s;
     }
 
     @Override
     public Statement createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
-        Statement s = derbycon.createStatement(resultSetType, resultSetConcurrency, resultSetHoldability);
+        Statement s = connection().createStatement(resultSetType, resultSetConcurrency, resultSetHoldability);
         s.setMaxFieldSize(DEFAULT_MAX_FIELD_SIZE);
         return s;
     }
 
     @Override
     public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
-        return derbycon.createStruct(typeName, attributes);
+        return connection().createStruct(typeName, attributes);
     }
 
     @Override
     public boolean getAutoCommit() throws SQLException {
-        return derbycon.getAutoCommit();
+        return connection().getAutoCommit();
+    }
+
+    @Override
+    public void end(Xid xid, int flags) throws XAException {
+        if (this.xid != xid || !(flags == XAResource.TMSUCCESS || flags == XAResource.TMFAIL))
+            throw new XAException(XAException.XAER_PROTO);
+    }
+
+    @Override
+    public void forget(Xid xid) throws XAException {
+        if (this.xid != xid)
+            throw new XAException(XAException.XAER_PROTO);
     }
 
     @Override
     public String getCatalog() throws SQLException {
         if (ds.supportsCatalog)
-            return derbycon.getCatalog();
+            return connection().getCatalog();
         else
             throw new SQLException("You disabled support for catalog.");
     }
 
     @Override
     public Properties getClientInfo() throws SQLException {
-        return derbycon.getClientInfo();
+        return connection().getClientInfo();
     }
 
     @Override
     public String getClientInfo(String name) throws SQLException {
-        return derbycon.getClientInfo(name);
+        return connection().getClientInfo(name);
     }
 
     @Override
@@ -170,19 +279,24 @@ public class HDConnection implements Connection, HeritageDBConnection {
     }
 
     @Override
+    public Connection getConnection() throws SQLException {
+        return this;
+    }
+
+    @Override
     public int getHoldability() throws SQLException {
-        return derbycon.getHoldability();
+        return connection().getHoldability();
     }
 
     @Override
     public DatabaseMetaData getMetaData() throws SQLException {
-        return derbycon.getMetaData();
+        return connection().getMetaData();
     }
 
     @Override
     public int getNetworkTimeout() throws SQLException {
         if (ds.supportsNetworkTimeout)
-            return derbycon.getNetworkTimeout();
+            return connection().getNetworkTimeout();
         else
             throw new SQLException("You disabled the ability to get the network timeout.", "HDISA", 0);
     }
@@ -190,45 +304,60 @@ public class HDConnection implements Connection, HeritageDBConnection {
     @Override
     public String getSchema() throws SQLException {
         if (ds.supportsSchema)
-            return derbycon.getSchema();
+            return connection().getSchema();
         else
             throw new SQLException("You disabled the ability to get the schema.", "HY000", 10);
     }
 
     @Override
     public int getTransactionIsolation() throws SQLException {
-        return derbycon.getTransactionIsolation();
+        return connection().getTransactionIsolation();
+    }
+
+    @Override
+    public int getTransactionTimeout() throws XAException {
+        return 0;
     }
 
     @Override
     public Map<String, Class<?>> getTypeMap() throws SQLException {
         if (ds.supportsTypeMap)
-            return derbycon.getTypeMap();
+            return connection().getTypeMap();
         else
             throw new SQLException("You disabled support for type map.", null, -40960);
     }
 
     @Override
     public SQLWarning getWarnings() throws SQLException {
-        return derbycon.getWarnings();
+        return connection().getWarnings();
+    }
+
+    @Override
+    public XAResource getXAResource() throws SQLException {
+        return this;
     }
 
     @Override
     public boolean isClosed() throws SQLException {
-        return derbycon.isClosed();
+        return connection().isClosed();
     }
 
     @Override
     public boolean isReadOnly() throws SQLException {
         if (ds.supportsReadOnly)
-            return derbycon.isReadOnly();
+            return connection().isReadOnly();
         else
             throw new SQLException("You disabled support for read only.");
     }
 
     @Override
+    public boolean isSameRM(XAResource xaResource) throws XAException {
+        return xaResource instanceof HDConnection;
+    }
+
+    @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        return derbycon.isWrapperFor(iface);
+        return connection().isWrapperFor(iface);
     }
 
     @Override
@@ -236,80 +365,100 @@ public class HDConnection implements Connection, HeritageDBConnection {
         if (failOnIsValid)
             throw new SQLException("Test case asked for isValid to fail, and so it is.", null, 44098);
 
-        return derbycon.isValid(timeout);
+        return connection().isValid(timeout);
     }
 
     @Override
     public String nativeSQL(String sql) throws SQLException {
-        return derbycon.nativeSQL(sql);
+        return connection().nativeSQL(sql);
+    }
+
+    @Override
+    public int prepare(Xid xid) throws XAException {
+        if (this.xid != xid)
+            throw new XAException(XAException.XAER_PROTO);
+        return XAResource.XA_OK;
     }
 
     @Override
     public CallableStatement prepareCall(String sql) throws SQLException {
-        CallableStatement s = derbycon.prepareCall(replace(sql));
+        CallableStatement s = connection().prepareCall(replace(sql));
         s.setMaxFieldSize(DEFAULT_MAX_FIELD_SIZE);
         return s;
     }
 
     @Override
     public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
-        CallableStatement s = derbycon.prepareCall(replace(sql), resultSetType, resultSetConcurrency);
+        CallableStatement s = connection().prepareCall(replace(sql), resultSetType, resultSetConcurrency);
         s.setMaxFieldSize(DEFAULT_MAX_FIELD_SIZE);
         return s;
     }
 
     @Override
     public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
-        CallableStatement s = derbycon.prepareCall(replace(sql), resultSetType, resultSetConcurrency, resultSetHoldability);
+        CallableStatement s = connection().prepareCall(replace(sql), resultSetType, resultSetConcurrency, resultSetHoldability);
         s.setMaxFieldSize(DEFAULT_MAX_FIELD_SIZE);
         return s;
     }
 
     @Override
     public PreparedStatement prepareStatement(String sql) throws SQLException {
-        PreparedStatement s = derbycon.prepareStatement(replace(sql));
+        PreparedStatement s = connection().prepareStatement(replace(sql));
         s.setMaxFieldSize(DEFAULT_MAX_FIELD_SIZE);
         return s;
     }
 
     @Override
     public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys) throws SQLException {
-        PreparedStatement s = derbycon.prepareStatement(replace(sql), autoGeneratedKeys);
+        PreparedStatement s = connection().prepareStatement(replace(sql), autoGeneratedKeys);
         s.setMaxFieldSize(DEFAULT_MAX_FIELD_SIZE);
         return s;
     }
 
     @Override
     public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
-        PreparedStatement s = derbycon.prepareStatement(replace(sql), resultSetType, resultSetConcurrency, resultSetHoldability);
+        PreparedStatement s = connection().prepareStatement(replace(sql), resultSetType, resultSetConcurrency, resultSetHoldability);
         s.setMaxFieldSize(DEFAULT_MAX_FIELD_SIZE);
         return s;
     }
 
     @Override
     public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
-        PreparedStatement s = derbycon.prepareStatement(replace(sql), resultSetType, resultSetConcurrency);
+        PreparedStatement s = connection().prepareStatement(replace(sql), resultSetType, resultSetConcurrency);
         s.setMaxFieldSize(DEFAULT_MAX_FIELD_SIZE);
         return s;
     }
 
     @Override
     public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
-        PreparedStatement s = derbycon.prepareStatement(replace(sql), columnIndexes);
+        PreparedStatement s = connection().prepareStatement(replace(sql), columnIndexes);
         s.setMaxFieldSize(DEFAULT_MAX_FIELD_SIZE);
         return s;
     }
 
     @Override
     public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
-        PreparedStatement s = derbycon.prepareStatement(replace(sql), columnNames);
+        PreparedStatement s = connection().prepareStatement(replace(sql), columnNames);
         s.setMaxFieldSize(DEFAULT_MAX_FIELD_SIZE);
         return s;
     }
 
     @Override
+    public Xid[] recover(int flags) throws XAException {
+        return new Xid[] {};
+    }
+
+    @Override
     public void releaseSavepoint(Savepoint savepoint) throws SQLException {
-        derbycon.releaseSavepoint(savepoint);
+        connection().releaseSavepoint(savepoint);
+    }
+
+    @Override
+    public void removeConnectionEventListener(ConnectionEventListener listener) {
+    }
+
+    @Override
+    public void removeStatementEventListener(StatementEventListener listener) {
     }
 
     /**
@@ -350,23 +499,61 @@ public class HDConnection implements Connection, HeritageDBConnection {
 
     @Override
     public void rollback() throws SQLException {
-        derbycon.rollback();
+        if (xid == null)
+            connection().rollback();
+        else
+            throw new SQLFeatureNotSupportedException("Connection.rollback during XA transaction");
     }
 
     @Override
     public void rollback(Savepoint savepoint) throws SQLException {
-        derbycon.rollback(savepoint);
+        if (xid == null)
+            connection().rollback(savepoint);
+        else
+            throw new SQLFeatureNotSupportedException("Connection.rollback during XA transaction");
+    }
+
+    @Override
+    public void rollback(Xid xid) throws XAException {
+        if (this.xid != xid)
+            throw new XAException(XAException.XAER_PROTO);
+        try {
+            if (derbyconForTightlyCoupledBranch == null) {
+                derbycon.rollback();
+            } else {
+                derbyconForTightlyCoupledBranch = null;
+                List<Byte> globalTxId = byteList(xid.getGlobalTransactionId());
+                HDConnection c = TIGHTLY_COUPLED_TRANSACTIONS.get(globalTxId);
+                if (this == c) {
+                    TIGHTLY_COUPLED_TRANSACTIONS.remove(globalTxId);
+                    c.derbycon.rollback();
+                }
+                // else let the first branch that enlisted perform the rollback
+            }
+            if (restoreAutoCommitAfterTx) {
+                derbycon.setAutoCommit(true);
+                restoreAutoCommitAfterTx = false;
+            }
+        } catch (SQLException x) {
+            throw (XAException) new XAException(XAException.XAER_PROTO).initCause(x);
+        } finally {
+            this.xid = null;
+        }
     }
 
     @Override
     public void setAutoCommit(boolean autoCommit) throws SQLException {
-        derbycon.setAutoCommit(autoCommit);
+        if (xid == null || autoCommit == false)
+            connection().setAutoCommit(autoCommit);
+        else
+            throw new SQLFeatureNotSupportedException("Autocommit during XA transaction");
+        restoreAutoCommitAfterTx = false;
     }
 
     @Override
     public void setCatalog(String catalog) throws SQLException {
         if (ds.supportsCatalog)
-            derbycon.setCatalog(catalog);
+            connection().setCatalog(catalog);
         else
             throw new SQLException("You disabled support for catalog.");
     }
@@ -379,14 +566,14 @@ public class HDConnection implements Connection, HeritageDBConnection {
         if (invalidEntries.size() > 0)
             throw new SQLClientInfoException("not supported", invalidEntries);
 
-        derbycon.setClientInfo(properties);
+        connection().setClientInfo(properties);
     }
 
     @Override
     public void setClientInfo(String name, String value) throws SQLClientInfoException {
         if (!clientInfoKeys.contains(name))
             throw new SQLClientInfoException("not supported", Collections.singletonMap(name, ClientInfoStatus.REASON_UNKNOWN_PROPERTY));
-        derbycon.setClientInfo(name, value);
+        connection().setClientInfo(name, value);
     }
 
     @Override
@@ -403,13 +590,13 @@ public class HDConnection implements Connection, HeritageDBConnection {
 
     @Override
     public void setHoldability(int holdability) throws SQLException {
-        derbycon.setHoldability(holdability);
+        connection().setHoldability(holdability);
     }
 
     @Override
     public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
         if (ds.supportsNetworkTimeout)
-            derbycon.setNetworkTimeout(executor, milliseconds);
+            connection().setNetworkTimeout(executor, milliseconds);
         else
             throw new SQLException("You disabled the ability to set the network timeout.");
     }
@@ -417,44 +604,72 @@ public class HDConnection implements Connection, HeritageDBConnection {
     @Override
     public void setReadOnly(boolean readOnly) throws SQLException {
         if (ds.supportsReadOnly)
-            derbycon.setReadOnly(readOnly);
+            connection().setReadOnly(readOnly);
         else
             throw new SQLException("You disabled support for read only.");
     }
 
     @Override
     public Savepoint setSavepoint() throws SQLException {
-        return derbycon.setSavepoint();
+        return connection().setSavepoint();
     }
 
     @Override
     public Savepoint setSavepoint(String name) throws SQLException {
-        return derbycon.setSavepoint(name);
+        return connection().setSavepoint(name);
     }
 
     @Override
     public void setSchema(String schema) throws SQLException {
         if (ds.supportsSchema)
-            derbycon.setSchema(schema);
+            connection().setSchema(schema);
         else
             throw new SQLException("You disabled the ability to set the schema.");
     }
 
     @Override
     public void setTransactionIsolation(int level) throws SQLException {
-        derbycon.setTransactionIsolation(level);
+        connection().setTransactionIsolation(level);
+    }
+
+    @Override
+    public boolean setTransactionTimeout(int timeout) throws XAException {
+        return false;
     }
 
     @Override
     public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
         if (ds.supportsTypeMap)
-            derbycon.setTypeMap(map);
+            connection().setTypeMap(map);
         else
             throw new SQLException("You disabled support for type map.");
     }
 
     @Override
+    public void start(Xid xid, int flags) throws XAException {
+        try {
+            if (getAutoCommit()) {
+                setAutoCommit(false);
+                restoreAutoCommitAfterTx = true;
+            }
+
+            if ((flags & LOOSELY_COUPLED_TRANSACTION_BRANCHES) == 0) {
+                // Simulate tight branch coupling by redirecting all branches to a single one-phase connection
+                List<Byte> globalTxId = byteList(xid.getGlobalTransactionId());
+                HDConnection c = TIGHTLY_COUPLED_TRANSACTIONS.get(globalTxId);
+                if (c == null)
+                    TIGHTLY_COUPLED_TRANSACTIONS.put(globalTxId, c = this);
+                derbyconForTightlyCoupledBranch = c.derbycon;
+            }
+
+            this.xid = xid;
+        } catch (IllegalStateException | SQLException x) {
+            throw (XAException) new XAException(XAException.XAER_PROTO).initCause(x);
+        }
+    }
+
+    @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
-        return derbycon.unwrap(iface);
+        return connection().unwrap(iface);
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HDDataSource.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HDDataSource.java
@@ -14,8 +14,12 @@ import java.sql.Connection;
 import java.sql.SQLException;
 
 import javax.sql.DataSource;
+import javax.sql.XAConnection;
+import javax.sql.XADataSource;
 
-public class HDDataSource extends org.apache.derby.jdbc.EmbeddedDataSource implements DataSource {
+public class HDDataSource extends org.apache.derby.jdbc.EmbeddedDataSource implements XADataSource, DataSource {
+    private static final long serialVersionUID = 1L;
+
     boolean supportsCatalog = true;
     boolean supportsNetworkTimeout = true;
     boolean supportsReadOnly = true;
@@ -29,6 +33,16 @@ public class HDDataSource extends org.apache.derby.jdbc.EmbeddedDataSource imple
 
     @Override
     public Connection getConnection(String username, String password) throws SQLException {
+        return new HDConnection(this, super.getConnection(username, password));
+    }
+
+    @Override
+    public XAConnection getXAConnection() throws SQLException {
+        return new HDConnection(this, super.getConnection());
+    }
+
+    @Override
+    public XAConnection getXAConnection(String username, String password) throws SQLException {
         return new HDConnection(this, super.getConnection(username, password));
     }
 

--- a/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HeritageDBConnection.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HeritageDBConnection.java
@@ -17,6 +17,11 @@ import java.util.Set;
  */
 public interface HeritageDBConnection {
     /**
+     * XA start flag for loosely coupled transaction branches.
+     */
+    public static int LOOSELY_COUPLED_TRANSACTION_BRANCHES = 0x1000;
+
+    /**
      * Obtains the list of valid client info keys.
      *
      * @return the list of valid client info keys.

--- a/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/helper/HDDataStoreHelper.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/test-applications/heritageDriver/src/test/jdbc/heritage/driver/helper/HDDataStoreHelper.java
@@ -42,6 +42,7 @@ import com.ibm.ws.jdbc.heritage.DataStoreHelperMetaData;
 import com.ibm.ws.jdbc.heritage.GenericDataStoreHelper;
 
 import test.jdbc.heritage.driver.HDConnection;
+import test.jdbc.heritage.driver.HeritageDBConnection;
 import test.jdbc.heritage.driver.HeritageDBDoesNotImplementItException;
 
 /**
@@ -149,8 +150,7 @@ public class HDDataStoreHelper extends GenericDataStoreHelper {
 
     @Override
     public String getXAExceptionContents(XAException x) {
-        // This ought to be unreachable for non-xa-capable javax.sql.DataSource.
-        throw new UnsupportedOperationException("This driver does not provide an XADataSource.");
+        return x.getClass().getName() + "(error code " + x.errorCode + "): " + x.getMessage() + " caused by " + x.getCause();
     }
 
     @Override
@@ -203,6 +203,11 @@ public class HDDataStoreHelper extends GenericDataStoreHelper {
         } catch (PrivilegedActionException privX) {
             return new SQLException(privX);
         }
+    }
+
+    @Override
+    public int modifyXAFlag(int xaStartFlags) {
+        return xaStartFlags |= HeritageDBConnection.LOOSELY_COUPLED_TRANSACTION_BRANCHES;
     }
 
     private Object readConfig(String fieldName) {

--- a/dev/com.ibm.ws.jdbc_fat_heritage/test-bundles/jdbcHeritage/src/com/ibm/websphere/rsadapter/GenericDataStoreHelper.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritage/test-bundles/jdbcHeritage/src/com/ibm/websphere/rsadapter/GenericDataStoreHelper.java
@@ -180,6 +180,11 @@ public class GenericDataStoreHelper extends com.ibm.ws.jdbc.heritage.GenericData
         }
     }
 
+    @Override
+    public int modifyXAFlag(int xaStartFlags) {
+        return xaStartFlags;
+    }
+
     private Object readConfig(String fieldName) {
         Object dsConfig = dsConfigRef.get();
         try {


### PR DESCRIPTION
Invoke the modifyXAFlags extention point on DataStoreHelper for loosely coupled transaction branches.
Update the fake JDBC driver and its DataStoreHelper to simulate support for tight and loose branch coupling and add tests for both.