### PR TITLE
tests for app defined datasource with container auth for direct lookup

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/DataSourceTest.java
+++ b/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/DataSourceTest.java
@@ -171,8 +171,18 @@ public class DataSourceTest extends FATServletClient {
     }
 
     @Test
+    public void testEnableContainerAuthForDirectLookupsFalse() throws Exception {
+        runTest();
+    }
+
+    @Test
     public void testEnableContainerAuthForDirectLookupsTrue() throws Exception {
         runTest();
+    }
+
+    @Test
+    public void testEnableContainerAuthForDirectLookupsTrueOnAppDefinedDataSource() throws Exception {
+        runTest(server, dsdfat, testName);
     }
 
     @Test

--- a/dev/com.ibm.ws.jdbc_fat/test-applications/basicfat/src/basicfat/DataSourceTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat/test-applications/basicfat/src/basicfat/DataSourceTestServlet.java
@@ -12,6 +12,7 @@ package basicfat;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -124,7 +125,9 @@ import componenttest.app.FATServlet;
                                                        user = "dbuser1",
                                                        password = "{xor}Oz0vKDtu",
                                                        properties = {
+                                                                      "containerAuthDataRef=derbyAuth2",
                                                                       "createDatabase=create",
+                                                                      "enableContainerAuthForDirectLookups=false",
                                                                       "validationTimeout=10s"
                                                        })
 
@@ -1211,6 +1214,22 @@ public class DataSourceTestServlet extends FATServlet {
         } finally {
             con2.close();
             con.close();
+        }
+    }
+
+    /**
+     * Verify that connections do not use container authentication when enableContainerAuthForDirectLookups=false
+     * is configured on an application-defined data source.
+     */
+    public void testEnableContainerAuthForDirectLookupsFalse() throws Exception {
+        DataSource ds = (DataSource) new InitialContext().lookup("java:comp/env/jdbc/dsValTderbyAnn");
+        try (Connection con = ds.getConnection()) {
+            DatabaseMetaData metadata = con.getMetaData();
+            // dbuser2 indicates container auth
+            // dbuser1 indicates application auth
+            String user = metadata.getUserName();
+            assertNotNull(user);
+            assertEquals("dbuser1", user.toLowerCase());
         }
     }
 


### PR DESCRIPTION
As requested during the feature test summary review, I'm adding test coverage for application-defined data sources that configure container authentication for direct lookups, either to disabled or enabled, and expect results consistent with the application-defined configuration.