### PR TITLE
Update JPA Eclipselink FAT for Postgres execution.

### DIFF
--- a/dev/com.ibm.ws.jpa_eclipselink_fat/publish/servers/EclipseLinkServer/server.xml
+++ b/dev/com.ibm.ws.jpa_eclipselink_fat/publish/servers/EclipseLinkServer/server.xml
@@ -37,6 +37,9 @@
     <!-- JDBC driver -->
     <javaPermission codebase="${shared.resource.dir}/jdbc/${env.DB_DRIVER}" className="java.security.AllPermission"/>
 
+    <!-- Permission needed for Postgres driver -->
+    <javaPermission className="java.util.PropertyPermission" name="org.postgresql.forceBinary" actions="read"/>
+    
     <!-- Permission needed for SQLServer driver -->
     <javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
 


### PR DESCRIPTION
As the title says, need to add a permission entry to the server.xml for the postgres jdbc driver to the Eclipselink FAT.