### PR TITLE
Update JPA Spec 1.0 Bucket with Postgres security policy fix in serve…

### DIFF
--- a/dev/com.ibm.ws.jpa_spec10_part01_fat/publish/servers/JPA10Server/server.xml
+++ b/dev/com.ibm.ws.jpa_spec10_part01_fat/publish/servers/JPA10Server/server.xml
@@ -38,6 +38,9 @@
     <!-- JDBC driver -->
     <javaPermission codebase="${shared.resource.dir}/jdbc/${env.DB_DRIVER}" className="java.security.AllPermission"/>
 
+    <!-- Permission needed for Postgres driver -->
+    <javaPermission className="java.util.PropertyPermission" name="org.postgresql.forceBinary" actions="read"/>
+    
     <!-- Permission needed for SQLServer driver -->
     <javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
 


### PR DESCRIPTION
Similar update, need to update server.xml to grant security privileges to postgresdb jdbc driver in JPA spec 1.0 bucket.