### PR TITLE
Refactor SRTServletRequest to enable dynamic proxies

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/webcontainer/JAXRSWebContainerTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/webcontainer/JAXRSWebContainerTest.java
@@ -31,7 +31,6 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -41,7 +40,6 @@ import componenttest.topology.impl.LibertyServer;
  * Simple tests for web container spec compliance.
  */
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class JAXRSWebContainerTest {
 
     @Server("com.ibm.ws.jaxrs.fat.webcontainer")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/webcontainer/src/com/ibm/ws/jaxrs/fat/webcontainer/WebContainerContextInjectionResource.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/webcontainer/src/com/ibm/ws/jaxrs/fat/webcontainer/WebContainerContextInjectionResource.java
@@ -49,9 +49,9 @@ public class WebContainerContextInjectionResource {
         httpServletResponse.addHeader("responseheadername", "responseheadervalue");
         httpServletResponse.setStatus(HttpServletResponse.SC_OK);
 
-        try {
-            PrintWriter pw =
-                            new PrintWriter(new OutputStreamWriter(httpServletResponse.getOutputStream()));
+        try (PrintWriter pw =
+                        new PrintWriter(new OutputStreamWriter(httpServletResponse.getOutputStream()))) {
+
             /*
              * PrintWriter does not automatically flush so going to flush pw
              * manually. Reminder, cannot just flush HttpServletResponse

--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/config/MpConfigUtil.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/config/MpConfigUtil.java
@@ -21,10 +21,7 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.jwt.config.MpConfigProperties;
 import com.ibm.ws.security.mp.jwt.MpConfigProxyService;
 import com.ibm.ws.security.mp.jwt.TraceConstants;
-import com.ibm.ws.webcontainer.srt.SRTServletRequest;
-import com.ibm.ws.webcontainer.webapp.WebApp;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
-import com.ibm.wsspi.webcontainer.webapp.IWebAppDispatcherContext;
 
 /**
  *
@@ -51,17 +48,7 @@ public class MpConfigUtil {
     }
 
     protected ClassLoader getApplicationClassloader(HttpServletRequest req) {
-        ClassLoader cl = null;
-        //HttpServletRequest req
-        if (req instanceof SRTServletRequest) {
-            SRTServletRequest servletRequest = (SRTServletRequest) req;
-            IWebAppDispatcherContext webAppDispatchContext = servletRequest.getWebAppDispatcherContext();
-            WebApp webApp = webAppDispatchContext.getWebApp();
-            if (webApp != null) {
-                cl = webApp.getClassLoader();
-            }
-        }
-        return cl;
+        return req != null ? req.getServletContext().getClassLoader() : null;
     }
 
     // no null check. make sure that the caller sets non null objects.

--- a/dev/com.ibm.ws.security.mp.jwt/test/com/ibm/ws/security/mp/jwt/config/MpConfigUtilTest.java
+++ b/dev/com.ibm.ws.security.mp.jwt/test/com/ibm/ws/security/mp/jwt/config/MpConfigUtilTest.java
@@ -6,21 +6,20 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.mp.jwt.config;
 
 import com.ibm.ws.security.mp.jwt.MpConfigProxyService;
 import com.ibm.ws.webcontainer.srt.SRTServletRequest;
-import com.ibm.ws.webcontainer.webapp.WebApp;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
-import com.ibm.wsspi.webcontainer.webapp.IWebAppDispatcherContext;
 
 import java.util.HashSet;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 
 import static org.junit.Assert.assertEquals;
@@ -32,14 +31,11 @@ import org.jmock.integration.junit4.JUnit4Mockery;
 import org.jmock.lib.legacy.ClassImposteriser;
 import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
-
-import org.osgi.framework.ServiceReference;
 
 import test.common.SharedOutputManager;
 
@@ -59,9 +55,8 @@ public class MpConfigUtilTest {
     private final AtomicServiceReference<MpConfigProxyService> mpConfigProxyServiceRef = mockery.mock(AtomicServiceReference.class, "mpConfigProxyServiceRef");
     private final MpConfigProxyService mpConfigProxyService = mockery.mock(MpConfigProxyService.class);
     private final HttpServletRequest req = mockery.mock(HttpServletRequest.class);
+    private final ServletContext servletCtx = mockery.mock(ServletContext.class);
     private final SRTServletRequest srtReq = mockery.mock(SRTServletRequest.class);
-    private final IWebAppDispatcherContext webAppDispatcherContext = mockery.mock(IWebAppDispatcherContext.class);
-    private final WebApp webApp = mockery.mock(WebApp.class);
     private final ClassLoader cl = mockery.mock(ClassLoader.class);
 
     @Rule
@@ -125,6 +120,10 @@ public class MpConfigUtilTest {
     public void getMpConfigWithConfigProxyServiceNoSrtReq() {
         mockery.checking(new Expectations() {
             {
+                one(req).getServletContext();
+                will(returnValue(servletCtx));
+                one(servletCtx).getClassLoader();
+                will(returnValue(null));
                 one(mpConfigProxyServiceRef).getService();
                 will(returnValue(mpConfigProxyService));
                 one(mpConfigProxyService).getSupportedConfigPropertyNames();
@@ -156,14 +155,12 @@ public class MpConfigUtilTest {
     public void getMpConfigWithConfigProxyServiceSrtReq() {
         mockery.checking(new Expectations() {
             {
+                one(srtReq).getServletContext();
+                will(returnValue(servletCtx));
+                one(servletCtx).getClassLoader();
+                will(returnValue(cl));
                 one(mpConfigProxyServiceRef).getService();
                 will(returnValue(mpConfigProxyService));
-                one(srtReq).getWebAppDispatcherContext();
-                will(returnValue(webAppDispatcherContext));
-                one(webAppDispatcherContext).getWebApp();
-                will(returnValue(webApp));
-                one(webApp).getClassLoader();
-                will(returnValue(cl));
                 one(mpConfigProxyService).getSupportedConfigPropertyNames();
                 will(returnValue(getSupportedMpConfigProps()));
                 one(mpConfigProxyService).getConfigValue(cl, MpConstants.ISSUER, String.class);
@@ -193,14 +190,12 @@ public class MpConfigUtilTest {
     public void getMpConfigWithConfigProxyServiceSrtReqNoIssuer() {
         mockery.checking(new Expectations() {
             {
+                one(srtReq).getServletContext();
+                will(returnValue(servletCtx));
+                one(servletCtx).getClassLoader();
+                will(returnValue(cl));
                 one(mpConfigProxyServiceRef).getService();
                 will(returnValue(mpConfigProxyService));
-                one(srtReq).getWebAppDispatcherContext();
-                will(returnValue(webAppDispatcherContext));
-                one(webAppDispatcherContext).getWebApp();
-                will(returnValue(webApp));
-                one(webApp).getClassLoader();
-                will(returnValue(cl));
                 one(mpConfigProxyService).getSupportedConfigPropertyNames();
                 will(returnValue(getSupportedMpConfigProps()));
                 one(mpConfigProxyService).getConfigValue(cl, MpConstants.ISSUER, String.class);
@@ -228,14 +223,12 @@ public class MpConfigUtilTest {
     public void getMpConfigWithConfigProxyServiceSrtReqNoPublicKey() {
         mockery.checking(new Expectations() {
             {
+                one(srtReq).getServletContext();
+                will(returnValue(servletCtx));
+                one(servletCtx).getClassLoader();
+                will(returnValue(cl));
                 one(mpConfigProxyServiceRef).getService();
                 will(returnValue(mpConfigProxyService));
-                one(srtReq).getWebAppDispatcherContext();
-                will(returnValue(webAppDispatcherContext));
-                one(webAppDispatcherContext).getWebApp();
-                will(returnValue(webApp));
-                one(webApp).getClassLoader();
-                will(returnValue(cl));
                 one(mpConfigProxyService).getSupportedConfigPropertyNames();
                 will(returnValue(getSupportedMpConfigProps()));
                 one(mpConfigProxyService).getConfigValue(cl, MpConstants.ISSUER, String.class);
@@ -263,14 +256,12 @@ public class MpConfigUtilTest {
     public void getMpConfigWithConfigProxyServiceSrtReqNoKeyLocation() {
         mockery.checking(new Expectations() {
             {
+                one(srtReq).getServletContext();
+                will(returnValue(servletCtx));
+                one(servletCtx).getClassLoader();
+                will(returnValue(cl));
                 one(mpConfigProxyServiceRef).getService();
                 will(returnValue(mpConfigProxyService));
-                one(srtReq).getWebAppDispatcherContext();
-                will(returnValue(webAppDispatcherContext));
-                one(webAppDispatcherContext).getWebApp();
-                will(returnValue(webApp));
-                one(webApp).getClassLoader();
-                will(returnValue(cl));
                 one(mpConfigProxyService).getSupportedConfigPropertyNames();
                 will(returnValue(getSupportedMpConfigProps()));
                 one(mpConfigProxyService).getConfigValue(cl, MpConstants.ISSUER, String.class);
@@ -298,14 +289,12 @@ public class MpConfigUtilTest {
     public void getMpConfigWithConfigProxyServiceSrtReqNoProperties() {
         mockery.checking(new Expectations() {
             {
+                one(srtReq).getServletContext();
+                will(returnValue(servletCtx));
+                one(servletCtx).getClassLoader();
+                will(returnValue(cl));
                 one(mpConfigProxyServiceRef).getService();
                 will(returnValue(mpConfigProxyService));
-                one(srtReq).getWebAppDispatcherContext();
-                will(returnValue(webAppDispatcherContext));
-                one(webAppDispatcherContext).getWebApp();
-                will(returnValue(webApp));
-                one(webApp).getClassLoader();
-                will(returnValue(cl));
                 one(mpConfigProxyService).getSupportedConfigPropertyNames();
                 will(returnValue(getSupportedMpConfigProps()));
                 one(mpConfigProxyService).getConfigValue(cl, MpConstants.ISSUER, String.class);
@@ -329,14 +318,12 @@ public class MpConfigUtilTest {
     public void getMpConfigWithConfigProxyServiceSrtReqTrim() {
         mockery.checking(new Expectations() {
             {
+                one(srtReq).getServletContext();
+                will(returnValue(servletCtx));
+                one(servletCtx).getClassLoader();
+                will(returnValue(cl));
                 one(mpConfigProxyServiceRef).getService();
                 will(returnValue(mpConfigProxyService));
-                one(srtReq).getWebAppDispatcherContext();
-                will(returnValue(webAppDispatcherContext));
-                one(webAppDispatcherContext).getWebApp();
-                will(returnValue(webApp));
-                one(webApp).getClassLoader();
-                will(returnValue(cl));
                 one(mpConfigProxyService).getSupportedConfigPropertyNames();
                 will(returnValue(getSupportedMpConfigProps()));
                 one(mpConfigProxyService).getConfigValue(cl, MpConstants.ISSUER, String.class);

--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientImpl.java
@@ -62,12 +62,12 @@ import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
 import com.ibm.ws.webcontainer.security.ReferrerURLCookieHandler;
 import com.ibm.ws.webcontainer.security.UnprotectedResourceService;
 import com.ibm.ws.webcontainer.security.openidconnect.OidcClient;
-import com.ibm.ws.webcontainer.srt.SRTServletRequest;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 import com.ibm.wsspi.kernel.service.utils.ConcurrentServiceReferenceMap;
 import com.ibm.wsspi.security.oauth20.UserCredentialResolver;
 import com.ibm.wsspi.security.token.AttributeNameConstants;
 import com.ibm.wsspi.ssl.SSLSupport;
+import com.ibm.wsspi.webcontainer.servlet.IExtendedRequest;
 
 /**
  * This class is the OSGI service that is invoked from the main line Liberty
@@ -303,7 +303,7 @@ public class OidcClientImpl implements OidcClient, UnprotectedResourceService {
             Tr.debug(tc, "OIDC _SSO RP PROCESS IS STARTING.");
             Tr.debug(tc, "OIDC _SSO RP inbound URL " + WebUtils.getRequestStringForTrace(req, "client_secret"));
         }
-        PostParameterHelper.savePostParams((SRTServletRequest) req);
+        PostParameterHelper.savePostParams((IExtendedRequest) req);
         OidcClientConfig oidcClientConfig = oidcClientConfigRef.getService(provider);
         OidcClientRequest oidcClientRequest = new OidcClientRequest(req, res, oidcClientConfig, referrerURLCookieHandler);
         req.setAttribute(ClientConstants.ATTRIB_OIDC_CLIENT_REQUEST, oidcClientRequest);
@@ -340,7 +340,7 @@ public class OidcClientImpl implements OidcClient, UnprotectedResourceService {
                         Tr.debug(tc, "customCacheKey is :" + customCacheKey);
                     }
                     if (oidcClientConfig.isIncludeCustomCacheKeyInSubject()) {
-                      customProperties.put(AttributeNameConstants.WSCREDENTIAL_CACHE_KEY, customCacheKey);
+                        customProperties.put(AttributeNameConstants.WSCREDENTIAL_CACHE_KEY, customCacheKey);
                     }
                     customProperties.put(AuthenticationConstants.INTERNAL_ASSERTION_KEY, Boolean.TRUE);
                     result = new ProviderAuthenticationResult(AuthResult.SUCCESS,
@@ -521,7 +521,7 @@ public class OidcClientImpl implements OidcClient, UnprotectedResourceService {
         if (providerHint == null || providerHint.isEmpty())
             providerHint = getHeader(req, ClientConstants.OIDC_CLIENT);
         if (providerHint == null || providerHint.isEmpty()) {
-            PostParameterHelper.savePostParams((SRTServletRequest) req);
+            PostParameterHelper.savePostParams((IExtendedRequest) req);
             // otherwise get it from parameter
             providerHint = req.getParameter(ClientConstants.OIDC_CLIENT);
             if (providerHint != null)

--- a/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/TAIWebUtils.java
+++ b/dev/com.ibm.ws.security.social/src/com/ibm/ws/security/social/tai/TAIWebUtils.java
@@ -34,6 +34,7 @@ import com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl;
 import com.ibm.ws.webcontainer.security.WebAppSecurityConfig;
 import com.ibm.ws.webcontainer.srt.SRTServletRequest;
 import com.ibm.wsspi.security.tai.TAIResult;
+import com.ibm.wsspi.webcontainer.servlet.IExtendedRequest;
 
 public class TAIWebUtils {
 
@@ -109,11 +110,11 @@ public class TAIWebUtils {
     }
 
     public void savePostParameters(HttpServletRequest request) {
-        PostParameterHelper.savePostParams((SRTServletRequest) request);
+        PostParameterHelper.savePostParams((IExtendedRequest) request);
     }
 
     public void restorePostParameters(HttpServletRequest request) {
-        PostParameterHelper.restorePostParams((SRTServletRequest) request);
+        PostParameterHelper.restorePostParams((IExtendedRequest) request);
     }
 
     public ReferrerURLCookieHandler getCookieHandler() {

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/PostParameterHelper.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/PostParameterHelper.java
@@ -35,385 +35,385 @@ import com.ibm.wsspi.webcontainer.servlet.IExtendedRequest;
  * login with user id/pwd or single sign on cookie.
  */
 public class PostParameterHelper {
-	private static final TraceComponent tc = Tr.register(PostParameterHelper.class);
+    private static final TraceComponent tc = Tr.register(PostParameterHelper.class);
 
-	public static final String INITIAL_URL = "INITIAL_URL";
-	public static final String PARAM_NAMES = "PARAM_NAMES";
-	public static final String PARAM_VALUES = "PARAM_VALUES";
-	public static final String POSTPARAM_COOKIE = "WASPostParam";
+    public static final String INITIAL_URL = "INITIAL_URL";
+    public static final String PARAM_NAMES = "PARAM_NAMES";
+    public static final String PARAM_VALUES = "PARAM_VALUES";
+    public static final String POSTPARAM_COOKIE = "WASPostParam";
 
-	public static final String ATTRIB_HASH_MAP = "ServletRequestWrapperHashmap";
+    public static final String ATTRIB_HASH_MAP = "ServletRequestWrapperHashmap";
 
-	private static final int LENGTH_INT = 4;
-	private static final int OFFSET_REQURL = 0;
-	private static final int OFFSET_DATA = 1;
+    private static final int LENGTH_INT = 4;
+    private static final int OFFSET_REQURL = 0;
+    private static final int OFFSET_DATA = 1;
 
-	private final WebAppSecurityConfig webAppSecurityConfig;
+    private final WebAppSecurityConfig webAppSecurityConfig;
 
-	/**
-	 * @param webAppSecConfig
-	 */
-	public PostParameterHelper(WebAppSecurityConfig webAppSecConfig) {
-		webAppSecurityConfig = webAppSecConfig;
-	}
+    /**
+     * @param webAppSecConfig
+     */
+    public PostParameterHelper(WebAppSecurityConfig webAppSecConfig) {
+        webAppSecurityConfig = webAppSecConfig;
+    }
 
-	/**
-	 * Save POST parameters to the cookie or session.
-	 * 
-	 * @param req
-	 * @param res
-	 */
-	public void save(HttpServletRequest req, HttpServletResponse res) {
-		AuthenticationResult authResult = new AuthenticationResult(AuthResult.SUCCESS, (String) null);
-		save(req, res, authResult);
-		List<Cookie> cookieList = authResult.getCookies();
-		if (cookieList != null && cookieList.size() > 0) {
-			CookieHelper.addCookiesToResponse(cookieList, res);
-		}
-	}
+    /**
+     * Save POST parameters to the cookie or session.
+     * 
+     * @param req
+     * @param res
+     */
+    public void save(HttpServletRequest req, HttpServletResponse res) {
+        AuthenticationResult authResult = new AuthenticationResult(AuthResult.SUCCESS, (String) null);
+        save(req, res, authResult);
+        List<Cookie> cookieList = authResult.getCookies();
+        if (cookieList != null && cookieList.size() > 0) {
+            CookieHelper.addCookiesToResponse(cookieList, res);
+        }
+    }
 
-	/**
-	 * Save POST parameters to the cookie or session.
-	 * 
-	 * @param req
-	 * @param res
-	 * @param authResult
-	 */
-	public void save(HttpServletRequest req, HttpServletResponse res, AuthenticationResult authResult) {
-		save(req, res, authResult, false);
-	}
+    /**
+     * Save POST parameters to the cookie or session.
+     * 
+     * @param req
+     * @param res
+     * @param authResult
+     */
+    public void save(HttpServletRequest req, HttpServletResponse res, AuthenticationResult authResult) {
+        save(req, res, authResult, false);
+    }
 
-	/**
-	 * Save POST parameters to the cookie or session.
-	 * 
-	 * @param req
-	 * @param res
-	 * @param authResult
-	 * @param keepInput : preserve parameter buffer for further read operation. This is only valid for cookie.
-	 */
-	public void save(HttpServletRequest req, HttpServletResponse res, AuthenticationResult authResult, boolean keepInput) {
-		if (!req.getMethod().equalsIgnoreCase("POST")) {
-			return;
-		}
+    /**
+     * Save POST parameters to the cookie or session.
+     * 
+     * @param req
+     * @param res
+     * @param authResult
+     * @param keepInput : preserve parameter buffer for further read operation. This is only valid for cookie.
+     */
+    public void save(HttpServletRequest req, HttpServletResponse res, AuthenticationResult authResult, boolean keepInput) {
+        if (!req.getMethod().equalsIgnoreCase("POST")) {
+            return;
+        }
 
-		if (!(req instanceof IExtendedRequest)) {
-			if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-				Tr.debug(tc, "It is not an IExtendedRequest object");
-			}
-			return;
-		}
-		restorePostParams((SRTServletRequest) req);
+        if (!(req instanceof IExtendedRequest)) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "It is not an IExtendedRequest object");
+            }
+            return;
+        }
+        restorePostParams((SRTServletRequest) req);
 
-		String reqURL = req.getRequestURI();
-		try {
-			String postParamSaveMethod = webAppSecurityConfig.getPostParamSaveMethod();
-			if (postParamSaveMethod.equalsIgnoreCase(WebAppSecurityConfig.POST_PARAM_SAVE_TO_COOKIE)) {
-				saveToCookie((IExtendedRequest) req, reqURL, authResult, keepInput);
-			} else if (postParamSaveMethod.equalsIgnoreCase(WebAppSecurityConfig.POST_PARAM_SAVE_TO_SESSION)) {
-				IExtendedRequest extRequest = (IExtendedRequest) req;
-				Map params = extRequest.getInputStreamData();
-				saveToSession(req, reqURL, params);
-			}
-		} catch (IOException exc) {
-			if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-				Tr.debug(tc, "IO Exception storing POST parameters onto a cookie or session: ", new Object[] { exc });
-			}
-		}
-	}
+        String reqURL = req.getRequestURI();
+        try {
+            String postParamSaveMethod = webAppSecurityConfig.getPostParamSaveMethod();
+            if (postParamSaveMethod.equalsIgnoreCase(WebAppSecurityConfig.POST_PARAM_SAVE_TO_COOKIE)) {
+                saveToCookie((IExtendedRequest) req, reqURL, authResult, keepInput);
+            } else if (postParamSaveMethod.equalsIgnoreCase(WebAppSecurityConfig.POST_PARAM_SAVE_TO_SESSION)) {
+                IExtendedRequest extRequest = (IExtendedRequest) req;
+                Map params = extRequest.getInputStreamData();
+                saveToSession(req, reqURL, params);
+            }
+        } catch (IOException exc) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "IO Exception storing POST parameters onto a cookie or session: ", new Object[] { exc });
+            }
+        }
+    }
 
-	/**
-	 * Save POST parameters(reqURL, parameters) to the cookie
-	 * 
-	 * @param extReq
-	 * @param reqURL
-	 * @param result
-	 */
-	@SuppressWarnings("unchecked")
-	private void saveToCookie(IExtendedRequest req, String reqURL, AuthenticationResult result, boolean keepInput) {
+    /**
+     * Save POST parameters(reqURL, parameters) to the cookie
+     * 
+     * @param extReq
+     * @param reqURL
+     * @param result
+     */
+    @SuppressWarnings("unchecked")
+    private void saveToCookie(IExtendedRequest req, String reqURL, AuthenticationResult result, boolean keepInput) {
 
-		String strParam = null;
-		try {
-			strParam = serializePostParam(req, reqURL, keepInput);
-		} catch (Exception e) {
-			if (tc.isDebugEnabled()) {
-				Tr.debug(tc, "IO Exception storing POST parameters onto a cookie: ", new Object[] { e });
-			}
-		}
+        String strParam = null;
+        try {
+            strParam = serializePostParam(req, reqURL, keepInput);
+        } catch (Exception e) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "IO Exception storing POST parameters onto a cookie: ", new Object[] { e });
+            }
+        }
 
-		if (strParam != null) {
-			Cookie paramCookie = new Cookie(POSTPARAM_COOKIE, strParam);
-			paramCookie.setMaxAge(-1);
-			paramCookie.setPath(reqURL);
-			if (webAppSecurityConfig.getHttpOnlyCookies()) {
-				paramCookie.setHttpOnly(true);
-			}
-			if (webAppSecurityConfig.getSSORequiresSSL()) {
-				paramCookie.setSecure(true);
-			}
-			result.setCookie(paramCookie);
-		}
+        if (strParam != null) {
+            Cookie paramCookie = new Cookie(POSTPARAM_COOKIE, strParam);
+            paramCookie.setMaxAge(-1);
+            paramCookie.setPath(reqURL);
+            if (webAppSecurityConfig.getHttpOnlyCookies()) {
+                paramCookie.setHttpOnly(true);
+            }
+            if (webAppSecurityConfig.getSSORequiresSSL()) {
+                paramCookie.setSecure(true);
+            }
+            result.setCookie(paramCookie);
+        }
 
-		if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-			Tr.debug(tc, "encoded POST parameters: " + strParam);
-		}
-	}
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "encoded POST parameters: " + strParam);
+        }
+    }
 
-	/**
-	 * Save POST parameters (reqURL, parameters) to a session
-	 * 
-	 * @param req
-	 * @param reqURL
-	 * @param params
-	 */
-	private void saveToSession(HttpServletRequest req, String reqURL, Map params) {
-		HttpSession postparamsession = req.getSession(true);
-		if (postparamsession != null && params != null && !params.isEmpty()) {
-			postparamsession.setAttribute(INITIAL_URL, reqURL);
-			postparamsession.setAttribute(PARAM_NAMES, null);
-			postparamsession.setAttribute(PARAM_VALUES, params);
-			if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-				Tr.debug(tc, "URL saved: " + reqURL.toString());
-			}
-		}
-	}
+    /**
+     * Save POST parameters (reqURL, parameters) to a session
+     * 
+     * @param req
+     * @param reqURL
+     * @param params
+     */
+    private void saveToSession(HttpServletRequest req, String reqURL, Map params) {
+        HttpSession postparamsession = req.getSession(true);
+        if (postparamsession != null && params != null && !params.isEmpty()) {
+            postparamsession.setAttribute(INITIAL_URL, reqURL);
+            postparamsession.setAttribute(PARAM_NAMES, null);
+            postparamsession.setAttribute(PARAM_VALUES, params);
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "URL saved: " + reqURL.toString());
+            }
+        }
+    }
 
-	/**
-	 * Restore POST parameters from session or cookie.
-	 * 
-	 * @param req
-	 * @param res
-	 */
-	public void restore(HttpServletRequest req, HttpServletResponse res) {
-		restore(req, res, false);
-	}
+    /**
+     * Restore POST parameters from session or cookie.
+     * 
+     * @param req
+     * @param res
+     */
+    public void restore(HttpServletRequest req, HttpServletResponse res) {
+        restore(req, res, false);
+    }
 
-	/**
-	 * Restore POST parameters from session or cookie.
-	 * 
-	 * @param req
-	 * @param res
-	 */
-	public void restore(HttpServletRequest req, HttpServletResponse res, boolean anyMethod) {
-		if (!(req instanceof IExtendedRequest)) {
-			if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-				Tr.debug(tc, "It is not an IExtendedRequest object");
-			}
-			return;
-		}
-		if (!anyMethod && !req.getMethod().equalsIgnoreCase("GET")) {
-			return;
-		}
+    /**
+     * Restore POST parameters from session or cookie.
+     * 
+     * @param req
+     * @param res
+     */
+    public void restore(HttpServletRequest req, HttpServletResponse res, boolean anyMethod) {
+        if (!(req instanceof IExtendedRequest)) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "It is not an IExtendedRequest object");
+            }
+            return;
+        }
+        if (!anyMethod && !req.getMethod().equalsIgnoreCase("GET")) {
+            return;
+        }
 
-		String reqURL = req.getRequestURI();
-		IExtendedRequest extRequest = (IExtendedRequest) req;
-		if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-			Tr.debug(tc, " method : " + req.getMethod() + " URL:" + reqURL);
-		}
-		String postParamSaveMethod = webAppSecurityConfig.getPostParamSaveMethod();
-		if (postParamSaveMethod.equalsIgnoreCase(WebAppSecurityConfig.POST_PARAM_SAVE_TO_COOKIE)) {
-			restoreFromCookie(extRequest, res, reqURL);
-		} else if (postParamSaveMethod.equalsIgnoreCase(WebAppSecurityConfig.POST_PARAM_SAVE_TO_SESSION)) {
-			restoreFromSession(extRequest, req, reqURL);
-		}
-	}
+        String reqURL = req.getRequestURI();
+        IExtendedRequest extRequest = (IExtendedRequest) req;
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, " method : " + req.getMethod() + " URL:" + reqURL);
+        }
+        String postParamSaveMethod = webAppSecurityConfig.getPostParamSaveMethod();
+        if (postParamSaveMethod.equalsIgnoreCase(WebAppSecurityConfig.POST_PARAM_SAVE_TO_COOKIE)) {
+            restoreFromCookie(extRequest, res, reqURL);
+        } else if (postParamSaveMethod.equalsIgnoreCase(WebAppSecurityConfig.POST_PARAM_SAVE_TO_SESSION)) {
+            restoreFromSession(extRequest, req, reqURL);
+        }
+    }
 
-	/**
-	 * Restore the POST parameters from session
-	 * 
-	 * @param extRequest
-	 * @param req
-	 * @param reqURL
-	 */
-	private void restoreFromSession(IExtendedRequest extRequest, HttpServletRequest req, String reqURL) {
-		HttpSession postparamsession = req.getSession(false);
-		if (postparamsession == null) {
-			return;
-		}
-		String previousReq = (String) postparamsession.getAttribute(INITIAL_URL);
-		if (previousReq != null && previousReq.equals(reqURL)) {
-			try {
-				if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-					Tr.debug(tc, "Found the session, restoring POST parameters.");
-				}
-				extRequest.setMethod("POST");
-				Map paramValues = (Map) postparamsession.getAttribute(PARAM_VALUES);
+    /**
+     * Restore the POST parameters from session
+     * 
+     * @param extRequest
+     * @param req
+     * @param reqURL
+     */
+    private void restoreFromSession(IExtendedRequest extRequest, HttpServletRequest req, String reqURL) {
+        HttpSession postparamsession = req.getSession(false);
+        if (postparamsession == null) {
+            return;
+        }
+        String previousReq = (String) postparamsession.getAttribute(INITIAL_URL);
+        if (previousReq != null && previousReq.equals(reqURL)) {
+            try {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Found the session, restoring POST parameters.");
+                }
+                extRequest.setMethod("POST");
+                Map paramValues = (Map) postparamsession.getAttribute(PARAM_VALUES);
 
-				if (paramValues != null && !paramValues.isEmpty()) {
-					if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-						Tr.debug(tc, "Restoring POST paramameters for URL : " + reqURL);
-					}
-					extRequest.setInputStreamData((HashMap) paramValues);
-				}
-			} catch (IOException exc) {
-				if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-					Tr.debug(tc, "IOException restoring POST parameters onto a cookie: ", new Object[] { exc });
-				}
-			}
-		} else if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-			Tr.debug(tc, "Parameters NOT restored. Original URL : " + previousReq + " req. URL : " + reqURL);
-		}
+                if (paramValues != null && !paramValues.isEmpty()) {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "Restoring POST paramameters for URL : " + reqURL);
+                    }
+                    extRequest.setInputStreamData((HashMap) paramValues);
+                }
+            } catch (IOException exc) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "IOException restoring POST parameters onto a cookie: ", new Object[] { exc });
+                }
+            }
+        } else if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "Parameters NOT restored. Original URL : " + previousReq + " req. URL : " + reqURL);
+        }
 
-		postparamsession.setAttribute(INITIAL_URL, null);
-		postparamsession.setAttribute(PARAM_NAMES, null);
-		postparamsession.setAttribute(PARAM_VALUES, null);
-	}
+        postparamsession.setAttribute(INITIAL_URL, null);
+        postparamsession.setAttribute(PARAM_NAMES, null);
+        postparamsession.setAttribute(PARAM_VALUES, null);
+    }
 
-	/**
-	 * Restore POST parameter from cookie
-	 * 
-	 * @param extRequest
-	 * @param res
-	 * @param reqURL
-	 */
-	@SuppressWarnings("rawtypes")
-	private void restoreFromCookie(IExtendedRequest extRequest, HttpServletResponse res, String reqURL) {
-		byte[] cookieValueBytes = extRequest.getCookieValueAsBytes(POSTPARAM_COOKIE);
-		if (cookieValueBytes == null || cookieValueBytes.length <= 2) {
-			return;
-		}
-		if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-			Tr.debug(tc, "Found the cookie, restoring POST parameters: " + new String(cookieValueBytes));
-		}
-		try {
-			HashMap restoredParams = deserializePostParam(extRequest, cookieValueBytes, reqURL);
-			extRequest.setInputStreamData(restoredParams);
-			extRequest.setMethod("POST");
-		} catch (Exception e) {
-			if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-				Tr.debug(tc, "Exception restoring POST parameters from the cookie: ", new Object[] { e });
-			}
-		}
-		Cookie paramCookie = new Cookie(POSTPARAM_COOKIE, "");
-		paramCookie.setPath(reqURL);
-		paramCookie.setMaxAge(0);
-		if (webAppSecurityConfig.getHttpOnlyCookies()) {
-			paramCookie.setHttpOnly(true);
-		}
-		if (webAppSecurityConfig.getSSORequiresSSL()) {
-			paramCookie.setSecure(true);
-		}
-		res.addCookie(paramCookie);
-	}
+    /**
+     * Restore POST parameter from cookie
+     * 
+     * @param extRequest
+     * @param res
+     * @param reqURL
+     */
+    @SuppressWarnings("rawtypes")
+    private void restoreFromCookie(IExtendedRequest extRequest, HttpServletResponse res, String reqURL) {
+        byte[] cookieValueBytes = extRequest.getCookieValueAsBytes(POSTPARAM_COOKIE);
+        if (cookieValueBytes == null || cookieValueBytes.length <= 2) {
+            return;
+        }
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "Found the cookie, restoring POST parameters: " + new String(cookieValueBytes));
+        }
+        try {
+            HashMap restoredParams = deserializePostParam(extRequest, cookieValueBytes, reqURL);
+            extRequest.setInputStreamData(restoredParams);
+            extRequest.setMethod("POST");
+        } catch (Exception e) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Exception restoring POST parameters from the cookie: ", new Object[] { e });
+            }
+        }
+        Cookie paramCookie = new Cookie(POSTPARAM_COOKIE, "");
+        paramCookie.setPath(reqURL);
+        paramCookie.setMaxAge(0);
+        if (webAppSecurityConfig.getHttpOnlyCookies()) {
+            paramCookie.setHttpOnly(true);
+        }
+        if (webAppSecurityConfig.getSSORequiresSSL()) {
+            paramCookie.setSecure(true);
+        }
+        res.addCookie(paramCookie);
+    }
 
-	/**
-	 * serialize Post parameters.
-	 * The code doesn't expect that the req or reqURL is null.
-	 * The format of the data is as follows:
-	 * <base64 encoded byte array of the request URL>.<based64 encoded data[0] from serializeInputStreamData()>.<base 64 encoded data[1]>. and so on.
-	 */
-	private String serializePostParam(IExtendedRequest req, String reqURL, boolean keepInput) throws IOException, UnsupportedEncodingException, IllegalStateException {
-		String output = null;
-		HashMap params = req.getInputStreamData();
-		if (params != null) {
-			long size = req.sizeInputStreamData(params);
-			byte[] reqURLBytes = reqURL.getBytes("UTF-8");
-			long total = size + reqURLBytes.length + LENGTH_INT;
+    /**
+     * serialize Post parameters.
+     * The code doesn't expect that the req or reqURL is null.
+     * The format of the data is as follows:
+     * <base64 encoded byte array of the request URL>.<based64 encoded data[0] from serializeInputStreamData()>.<base 64 encoded data[1]>. and so on.
+     */
+    private String serializePostParam(IExtendedRequest req, String reqURL, boolean keepInput) throws IOException, UnsupportedEncodingException, IllegalStateException {
+        String output = null;
+        HashMap params = req.getInputStreamData();
+        if (params != null) {
+            long size = req.sizeInputStreamData(params);
+            byte[] reqURLBytes = reqURL.getBytes("UTF-8");
+            long total = size + reqURLBytes.length + LENGTH_INT;
 
-			long postParamSaveSize = webAppSecurityConfig.getPostParamCookieSize();
-			if (tc.isDebugEnabled()) {
-				Tr.debug(tc, "length:" + total + "  maximum length:" + postParamSaveSize);
-			}
+            long postParamSaveSize = webAppSecurityConfig.getPostParamCookieSize();
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "length:" + total + "  maximum length:" + postParamSaveSize);
+            }
 
-			if (total < postParamSaveSize) { // give up to enocde if the data is too large (>16K)
-				byte[][] data = req.serializeInputStreamData(params);
-				StringBuffer sb = new StringBuffer();
-				sb.append(StringUtil.toString(Base64Coder.base64Encode(reqURLBytes)));
-				for (int i = 0; i < data.length; i++) {
-					sb.append(".").append(StringUtil.toString(Base64Coder.base64Encode(data[i])));
-				}
-				output = sb.toString();
-				if (tc.isDebugEnabled()) {
-					Tr.debug(tc, "encoded length:" + output.length());
-				}
-			    if (keepInput) {
-			        // push back the data.
-					req.setInputStreamData(params);
-			    }
-			} else {
-				Tr.warning(tc, "SEC_FORM_POST_NULL_OR_TOO_LARGE");
-			}
-			if (tc.isDebugEnabled()) {
-				Tr.debug(tc, "encoded POST parameters: " + output);
-			}
-      
-		} else {
-			Tr.warning(tc, "SEC_FORM_POST_NULL_OR_TOO_LARGE");
-		}
-		return output;
-	}
+            if (total < postParamSaveSize) { // give up to enocde if the data is too large (>16K)
+                byte[][] data = req.serializeInputStreamData(params);
+                StringBuffer sb = new StringBuffer();
+                sb.append(StringUtil.toString(Base64Coder.base64Encode(reqURLBytes)));
+                for (int i = 0; i < data.length; i++) {
+                    sb.append(".").append(StringUtil.toString(Base64Coder.base64Encode(data[i])));
+                }
+                output = sb.toString();
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "encoded length:" + output.length());
+                }
+                if (keepInput) {
+                    // push back the data.
+                    req.setInputStreamData(params);
+                }
+            } else {
+                Tr.warning(tc, "SEC_FORM_POST_NULL_OR_TOO_LARGE");
+            }
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "encoded POST parameters: " + output);
+            }
 
-	/**
-	 * deserialize Post parameters.
-	 * The code doesn't expect that the req, cookieValueBytes, or reqURL is null.
-	 */
-	private HashMap deserializePostParam(IExtendedRequest req, byte[] cookieValueBytes, String reqURL) throws IOException, UnsupportedEncodingException, IllegalStateException {
-		HashMap output = null;
-		List<byte[]> data = splitBytes(cookieValueBytes, (byte) '.');
-		int total = data.size();
+        } else {
+            Tr.warning(tc, "SEC_FORM_POST_NULL_OR_TOO_LARGE");
+        }
+        return output;
+    }
 
-		if (total > OFFSET_DATA) {
-			// url and at least one data. now deserializing the url.
-			String url = new String(Base64Coder.base64Decode(data.get(OFFSET_REQURL)), "UTF-8");
-			if (url != null && url.equals(reqURL)) {
-				byte[][] bytes = new byte[total - OFFSET_DATA][];
-				for (int i = 0; i < (total - OFFSET_DATA); i++) {
-					bytes[i] = Base64Coder.base64Decode(data.get(OFFSET_DATA + i));
-				}
-				output = req.deserializeInputStreamData(bytes);
-			} else {
-				throw new IllegalStateException("The url in the post param cookie does not match the requested url");
-			}
-		} else {
-			throw new IllegalStateException("The data of the post param cookie is too short. The data might be truncated.");
-		}
-		return output;
-	}
+    /**
+     * deserialize Post parameters.
+     * The code doesn't expect that the req, cookieValueBytes, or reqURL is null.
+     */
+    private HashMap deserializePostParam(IExtendedRequest req, byte[] cookieValueBytes, String reqURL) throws IOException, UnsupportedEncodingException, IllegalStateException {
+        HashMap output = null;
+        List<byte[]> data = splitBytes(cookieValueBytes, (byte) '.');
+        int total = data.size();
 
-	/**
-	 * split the byte array with the specified delimiter. the expectation here is tha the byte array is a byte representation
-	 * of cookie value which was base64 encoded data.
-	 */
-	private List<byte[]> splitBytes(byte[] array, byte delimiter) {
-		List<byte[]> byteArrays = new ArrayList<byte[]>();
-		int begin = 0;
+        if (total > OFFSET_DATA) {
+            // url and at least one data. now deserializing the url.
+            String url = new String(Base64Coder.base64Decode(data.get(OFFSET_REQURL)), "UTF-8");
+            if (url != null && url.equals(reqURL)) {
+                byte[][] bytes = new byte[total - OFFSET_DATA][];
+                for (int i = 0; i < (total - OFFSET_DATA); i++) {
+                    bytes[i] = Base64Coder.base64Decode(data.get(OFFSET_DATA + i));
+                }
+                output = req.deserializeInputStreamData(bytes);
+            } else {
+                throw new IllegalStateException("The url in the post param cookie does not match the requested url");
+            }
+        } else {
+            throw new IllegalStateException("The data of the post param cookie is too short. The data might be truncated.");
+        }
+        return output;
+    }
 
-		for (int i = 0; i < array.length; i++) {
-			// first find delimiter.
-			while (i < array.length && array[i] != delimiter) {
-				i++;
-			}
-			byteArrays.add(Arrays.copyOfRange(array, begin, i));
-			begin = i + 1;
-		}
-		return byteArrays;
-	}
+    /**
+     * split the byte array with the specified delimiter. the expectation here is tha the byte array is a byte representation
+     * of cookie value which was base64 encoded data.
+     */
+    private List<byte[]> splitBytes(byte[] array, byte delimiter) {
+        List<byte[]> byteArrays = new ArrayList<byte[]>();
+        int begin = 0;
 
-	@SuppressWarnings("rawtypes")
-	public static void savePostParams(SRTServletRequest request) {
-		boolean bPost = request.getMethod().equalsIgnoreCase("POST");
-		if (bPost) {
-			HashMap postParams = (HashMap) request.getAttribute(ATTRIB_HASH_MAP);
-			if (postParams == null) {
-				// let's save the parameters for restore
-				try {
-					postParams = request.getInputStreamData();
-					request.setInputStreamData(postParams); // put it back immediately
-					request.setAttribute(ATTRIB_HASH_MAP, postParams);
-				} catch (IOException e) {
-				}
-			}
-		}
-	}
+        for (int i = 0; i < array.length; i++) {
+            // first find delimiter.
+            while (i < array.length && array[i] != delimiter) {
+                i++;
+            }
+            byteArrays.add(Arrays.copyOfRange(array, begin, i));
+            begin = i + 1;
+        }
+        return byteArrays;
+    }
 
-	@SuppressWarnings("rawtypes")
-	public static void restorePostParams(SRTServletRequest request) { // only get called when POST
-		HashMap postParams = (HashMap) request.getAttribute(ATTRIB_HASH_MAP);
-		if (postParams != null) {
-			try {
-				request.setAttribute(ATTRIB_HASH_MAP, null); // reset the attribute right after restore
-				request.setInputStreamData(postParams);
-			} catch (IOException e) {
-			}
-		}
-	}
+    @SuppressWarnings("rawtypes")
+    public static void savePostParams(IExtendedRequest request) {
+        boolean bPost = request.getMethod().equalsIgnoreCase("POST");
+        if (bPost) {
+            HashMap postParams = (HashMap) request.getAttribute(ATTRIB_HASH_MAP);
+            if (postParams == null) {
+                // let's save the parameters for restore
+                try {
+                    postParams = request.getInputStreamData();
+                    request.setInputStreamData(postParams); // put it back immediately
+                    request.setAttribute(ATTRIB_HASH_MAP, postParams);
+                } catch (IOException e) {
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("rawtypes")
+    public static void restorePostParams(IExtendedRequest request) { // only get called when POST
+        HashMap postParams = (HashMap) request.getAttribute(ATTRIB_HASH_MAP);
+        if (postParams != null) {
+            try {
+                request.setAttribute(ATTRIB_HASH_MAP, null); // reset the attribute right after restore
+                request.setInputStreamData(postParams);
+            } catch (IOException e) {
+            }
+        }
+    }
 }

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/osgi/webapp/WebAppDispatcherContext40.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/osgi/webapp/WebAppDispatcherContext40.java
@@ -19,7 +19,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.webcontainer.osgi.osgi.WebContainerConstants;
 import com.ibm.ws.webcontainer.osgi.webapp.WebApp;
 import com.ibm.ws.webcontainer.osgi.webapp.WebAppDispatcherContext;
-import com.ibm.ws.webcontainer40.srt.SRTServletRequest40;
+import com.ibm.ws.webcontainer40.srt.ISRTServletRequest40;
 import com.ibm.wsspi.webcontainer.servlet.AsyncContext;
 import com.ibm.wsspi.webcontainer.servlet.IExtendedRequest;
 import com.ibm.wsspi.webcontainer.servlet.IServletWrapper;
@@ -70,7 +70,7 @@ public class WebAppDispatcherContext40 extends WebAppDispatcherContext {
             Tr.debug(tc, "pushServletReference ENTRY, dispatchContext -> " + this + " _mapping [" + this._mapping + "]");
         }
 
-        _currentMapping = ((SRTServletRequest40) _request).getCurrentHttpServletMapping(this);
+        _currentMapping = ((ISRTServletRequest40) _request).getCurrentHttpServletMapping(this);
 
         //Check if this is the original servlet in the chain and set _originalMapping accordingly
         if (this.getParentContext() == null || ((WebAppDispatcherContext40) this.getParentContext())._originalMapping == null) {

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/servlet/CacheServletWrapper40.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/servlet/CacheServletWrapper40.java
@@ -21,7 +21,6 @@ import javax.servlet.http.HttpServletRequest;
 import com.ibm.ws.webcontainer.servlet.CacheServletWrapper;
 import com.ibm.ws.webcontainer.webapp.WebApp;
 import com.ibm.ws.webcontainer40.osgi.webapp.WebAppDispatcherContext40;
-import com.ibm.ws.webcontainer40.srt.SRTServletRequest40;
 import com.ibm.wsspi.webcontainer.logging.LoggerFactory;
 import com.ibm.wsspi.webcontainer.servlet.IExtendedRequest;
 import com.ibm.wsspi.webcontainer.servlet.IServletWrapper;
@@ -56,8 +55,8 @@ public class CacheServletWrapper40 extends CacheServletWrapper {
             logger.entering(CLASS_NAME, methodName);
         }
 
-        IExtendedRequest wasreq = (IExtendedRequest) ServletUtil.unwrapRequest(req);
-        WebAppDispatcherContext40 dispatchContext = (WebAppDispatcherContext40) ((SRTServletRequest40) wasreq).getWebAppDispatcherContext();
+        IExtendedRequest wasreq = ServletUtil.unwrapRequest(req);
+        WebAppDispatcherContext40 dispatchContext = (WebAppDispatcherContext40) wasreq.getWebAppDispatcherContext();
         mapping = dispatchContext.getServletMapping();
 
         if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {
@@ -76,7 +75,7 @@ public class CacheServletWrapper40 extends CacheServletWrapper {
         // set the MappingMatch here as when the CacheServletWrapper is being used we will not go
         // through the path of URIMatcher.
         //reqData.setMappingMatch(this.mapping.getMappingMatch());
-        WebAppDispatcherContext40 dispatchContext = (WebAppDispatcherContext40) ((SRTServletRequest40) req).getWebAppDispatcherContext();
+        WebAppDispatcherContext40 dispatchContext = (WebAppDispatcherContext40) ((IExtendedRequest) req).getWebAppDispatcherContext();
         dispatchContext.setMappingMatch(mapping.getMappingMatch());
 
         if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) {

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/srt/ISRTServletRequest40.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/srt/ISRTServletRequest40.java
@@ -11,9 +11,10 @@ package com.ibm.ws.webcontainer40.srt;
 
 import javax.servlet.http.HttpServletMapping;
 
+import com.ibm.ws.webcontainer.srt.ISRTServletRequest;
 import com.ibm.ws.webcontainer40.osgi.webapp.WebAppDispatcherContext40;
 
-public interface ISRTServletRequest40 {
+public interface ISRTServletRequest40 extends ISRTServletRequest {
 
     HttpServletMapping getCurrentHttpServletMapping(WebAppDispatcherContext40 dispatchContext);
 }

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/srt/ISRTServletRequest40.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/srt/ISRTServletRequest40.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.htmln *
+ * Contributors:
+ *      IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.webcontainer40.srt;
+
+import javax.servlet.http.HttpServletMapping;
+
+import com.ibm.ws.webcontainer40.osgi.webapp.WebAppDispatcherContext40;
+
+public interface ISRTServletRequest40 {
+
+    HttpServletMapping getCurrentHttpServletMapping(WebAppDispatcherContext40 dispatchContext);
+}

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/srt/SRTServletRequest40.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0/src/com/ibm/ws/webcontainer40/srt/SRTServletRequest40.java
@@ -39,7 +39,7 @@ import com.ibm.wsspi.webcontainer.logging.LoggerFactory;
 import com.ibm.wsspi.webcontainer.servlet.IServletWrapper;
 import com.ibm.wsspi.webcontainer40.WCCustomProperties40;
 
-public class SRTServletRequest40 extends SRTServletRequest31 implements HttpServletRequest {
+public class SRTServletRequest40 extends SRTServletRequest31 implements HttpServletRequest, ISRTServletRequest40 {
 
     protected static final Logger logger = LoggerFactory.getInstance().getLogger("com.ibm.ws.webcontainer40.srt");
     private static final String CLASS_NAME = "com.ibm.ws.webcontainer40.srt.SRTServletRequest40";
@@ -121,6 +121,7 @@ public class SRTServletRequest40 extends SRTServletRequest31 implements HttpServ
         return this.getCurrentHttpServletMapping(dispatchContext);
     }
 
+    @Override
     public HttpServletMapping getCurrentHttpServletMapping(WebAppDispatcherContext40 dispatchContext) {
         String methodName = "getCurrentHttpServletMapping";
 

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/WebContainer.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/WebContainer.java
@@ -924,7 +924,7 @@ public abstract class WebContainer extends BaseContainer {
                     }
                     // end 272738    Duplicate CacheServletWrappers when url-rewriting is enabled    WAS.webcontainer: rewritten to handle jsessionid.
 
-                    currDispatchContext.setQueryString(((SRTServletRequest) hreq).getQueryString());
+                    currDispatchContext.setQueryString(hreq.getQueryString());
                     hreq.setValuesIfMultiReadofPostdataEnabled(); //MultiRead
                     if (vhost != null) {
                         vhost.addSecureRedirect(hreq, vhostKey);

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/filter/WebAppFilterChain.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/filter/WebAppFilterChain.java
@@ -34,6 +34,7 @@ import com.ibm.ws.webcontainer.webapp.WebApp;
 import com.ibm.wsspi.http.HttpInboundConnection;
 import com.ibm.wsspi.webcontainer.RequestProcessor;
 import com.ibm.wsspi.webcontainer.logging.LoggerFactory;
+import com.ibm.wsspi.webcontainer.servlet.IExtendedRequest;
 import com.ibm.wsspi.webcontainer.util.ServletUtil;
 
 /**
@@ -156,8 +157,8 @@ protected static final Logger logger = LoggerFactory.getInstance().getLogger("co
                         logger.logp(Level.FINE, CLASS_NAME, "invokeTarget", " looking at H2 upgrade");
                     }
                     HttpInboundConnection httpInboundConnection = null;
-                    if (request instanceof SRTServletRequest) {
-                        SRTServletRequest srtReq = (SRTServletRequest)request;
+                    if (request instanceof IExtendedRequest) {
+                    	IExtendedRequest srtReq = (IExtendedRequest)request;
                         IRequestExtended iReq = (IRequestExtended)srtReq.getIRequest();
                         if (iReq != null) {
                             httpInboundConnection = iReq.getHttpInboundConnection();

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/filter/WebAppFilterManager.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/filter/WebAppFilterManager.java
@@ -52,6 +52,7 @@ import com.ibm.ws.webcontainer.servlet.FileServletWrapper;
 import com.ibm.ws.webcontainer.servlet.H2Handler;
 import com.ibm.ws.webcontainer.servlet.ServletWrapper;
 import com.ibm.ws.webcontainer.servlet.WsocHandler;
+import com.ibm.ws.webcontainer.srt.ISRTServletRequest;
 import com.ibm.ws.webcontainer.srt.SRTServletRequest;
 import com.ibm.ws.webcontainer.webapp.WebApp;
 import com.ibm.ws.webcontainer.webapp.WebApp.ANNOT_TYPE;
@@ -1116,7 +1117,7 @@ public class WebAppFilterManager implements com.ibm.wsspi.webcontainer.filter.We
             //PM92496  Start            
             if (httpServletReq.isSecure()) {
                 ServletRequest implRequest = ServletUtil.unwrapRequest(httpServletReq);
-                ((SRTServletRequest) implRequest).setSSLAttributesInRequest(httpServletReq, ((SRTServletRequest) implRequest).getCipherSuite());
+                ((ISRTServletRequest) implRequest).setSSLAttributesInRequest(httpServletReq, ((ISRTServletRequest) implRequest).getCipherSuite());
             }
             //PM92496  End
             
@@ -1173,8 +1174,8 @@ public class WebAppFilterManager implements com.ibm.wsspi.webcontainer.filter.We
                                     logger.logp(Level.FINE, CLASS_NAME, "invokeFilters", "looking at H2 handler");
                                 H2Handler h2Handler = ((com.ibm.ws.webcontainer.osgi.webapp.WebApp) webApp).getH2Handler();
                                 if (h2Handler != null) {
-                                    if (request instanceof SRTServletRequest) {
-                                        SRTServletRequest srtReq = (SRTServletRequest) request;
+                                    if (request instanceof IExtendedRequest) {
+                                        IExtendedRequest srtReq = (IExtendedRequest) request;
                                         IRequestExtended iReq = (IRequestExtended)srtReq.getIRequest();
                                         if (iReq != null) {
                                             httpInboundConnection = iReq.getHttpInboundConnection();

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/servlet/FileServletWrapper.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/servlet/FileServletWrapper.java
@@ -42,6 +42,7 @@ import com.ibm.websphere.servlet.filter.ChainedResponse;
 import com.ibm.ws.http2.upgrade.H2Exception;
 import com.ibm.ws.kernel.security.thread.ThreadIdentityManager;
 import com.ibm.ws.webcontainer.extension.DefaultExtensionProcessor;
+import com.ibm.ws.webcontainer.srt.ISRTServletRequest;
 import com.ibm.ws.webcontainer.srt.SRTOutputStream;
 import com.ibm.ws.webcontainer.srt.SRTServletRequest;
 import com.ibm.ws.webcontainer.srt.SRTServletResponse;
@@ -380,9 +381,9 @@ public abstract class FileServletWrapper implements IServletWrapper, IServletWra
                 
                 // we have an SSL connection...set the attributes
                 ServletRequest implRequest = ServletUtil.unwrapRequest(httpRequest); //PM88028
-                String cipherSuite = ((SRTServletRequest) implRequest).getCipherSuite();
+                String cipherSuite = ((ISRTServletRequest) implRequest).getCipherSuite();
 
-                ((SRTServletRequest) implRequest).setSSLAttributesInRequest(request, cipherSuite);
+                ((ISRTServletRequest) implRequest).setSSLAttributesInRequest(request, cipherSuite);
 
             }// PM92496 End
 

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/servlet/ServletWrapper.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/servlet/ServletWrapper.java
@@ -55,6 +55,7 @@ import com.ibm.ws.webcontainer.core.Request;
 import com.ibm.ws.webcontainer.core.Response;
 import com.ibm.ws.webcontainer.exception.WebContainerUnavailableException;
 import com.ibm.ws.webcontainer.spiadapter.collaborator.IInvocationCollaborator;
+import com.ibm.ws.webcontainer.srt.ISRTServletRequest;
 import com.ibm.ws.webcontainer.srt.SRTServletRequest;
 import com.ibm.ws.webcontainer.util.ApplicationErrorUtils;
 import com.ibm.ws.webcontainer.webapp.WebApp;
@@ -576,8 +577,8 @@ public abstract class ServletWrapper extends GenericServlet implements RequestPr
                 // we have an SSL connection...set the attributes
                 ServletRequest implRequest = ServletUtil.unwrapRequest(httpRequest);
                 
-                String cipherSuite = ((SRTServletRequest) implRequest).getCipherSuite();
-                ((SRTServletRequest) implRequest).setSSLAttributesInRequest(httpRequest, cipherSuite);
+                String cipherSuite = ((ISRTServletRequest) implRequest).getCipherSuite();
+                ((ISRTServletRequest) implRequest).setSSLAttributesInRequest(httpRequest, cipherSuite);
             }// PM92496 End
 
             WebAppServletInvocationEvent invocationEvent = null;
@@ -1356,7 +1357,7 @@ public abstract class ServletWrapper extends GenericServlet implements RequestPr
         } finally {
             WebContainerRequestState reqState = WebContainerRequestState.getInstance(false);
             if (reqState != null && reqState.getAttribute("webcontainer.resetAsyncStartedOnExit") != null){
-                ((SRTServletRequest) ServletUtil.unwrapRequest(req)).setAsyncStarted(false);
+                ServletUtil.unwrapRequest(req).setAsyncStarted(false);
                 reqState.removeAttribute("webcontainer.resetAsyncStartedOnExit");
             }
 

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/ISRTServletRequest.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/ISRTServletRequest.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.webcontainer.srt;
+
+import javax.servlet.http.HttpServletRequest;
+
+public interface ISRTServletRequest {
+
+    SRTRequestContext getRequestContext();
+
+    void resetPathElements();
+
+    void setSSLAttributesInRequest(HttpServletRequest httpServletReq, String cs);
+    
+    String getCipherSuite();
+}

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTServletRequest.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTServletRequest.java
@@ -105,7 +105,7 @@ import com.ibm.wsspi.webcontainer.webapp.IWebAppDispatcherContext;
 
 
 @SuppressWarnings("unchecked")
-public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, IServletRequest, IPrivateRequestAttributes, IInputStreamObserver, ServletRequestExtended, HttpInputStreamObserver
+public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, IServletRequest, IPrivateRequestAttributes, IInputStreamObserver, ServletRequestExtended, HttpInputStreamObserver, ISRTServletRequest
 {
     // Class level objects
     // =========================

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebApp.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebApp.java
@@ -4101,8 +4101,8 @@ public abstract class WebApp extends BaseContainer implements ServletContext, IS
         // PK82794
         if (WCCustomProperties.SUPPRESS_LAST_ZERO_BYTE_PACKAGE) {
            // reqState.setAttribute("com.ibm.ws.webcontainer.suppresslastzerobytepackage", "true");
-            if (req instanceof SRTServletRequest) {
-                SRTServletRequest srtReq = (SRTServletRequest) req;
+            if (req instanceof IExtendedRequest) {
+                IExtendedRequest srtReq = (IExtendedRequest) req;
                 IRequestExtended iReq = (IRequestExtended)srtReq.getIRequest();
                 if (iReq != null) {
                     HttpInboundConnection httpInboundConnection = iReq.getHttpInboundConnection();

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebAppDispatcherContext.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebAppDispatcherContext.java
@@ -32,6 +32,7 @@ import com.ibm.ejs.ras.TraceNLS;
 import com.ibm.websphere.servlet.error.ServletErrorReport;
 import com.ibm.ws.webcontainer.osgi.WebContainer;
 import com.ibm.ws.webcontainer.session.IHttpSessionContext;
+import com.ibm.ws.webcontainer.srt.ISRTServletRequest;
 import com.ibm.ws.webcontainer.srt.SRTRequestContext;
 import com.ibm.ws.webcontainer.srt.SRTServletRequest;
 import com.ibm.ws.webcontainer.util.UnsynchronizedStack;
@@ -142,7 +143,7 @@ public abstract class WebAppDispatcherContext implements Cloneable, IWebAppDispa
         _request = req;
         if (req != null)
         {
-            reqContext = ((SRTServletRequest)_request).getRequestContext();
+            reqContext = ((ISRTServletRequest)_request).getRequestContext();
         }
     }
 
@@ -921,7 +922,7 @@ public abstract class WebAppDispatcherContext implements Cloneable, IWebAppDispa
      */
     public void setPathElements(String servletPath, String pathInfo)
     {
-        ((SRTServletRequest)_request).resetPathElements();
+        ((ISRTServletRequest)_request).resetPathElements();
 
         if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable (Level.FINE)) {    //PI67942
             logger.logp(Level.FINE, CLASS_NAME,"setPathElements", "servletPath = " + servletPath +", pathInfo = " + pathInfo +" : this = " + this);

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebAppRequestDispatcher.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebAppRequestDispatcher.java
@@ -31,6 +31,7 @@ import com.ibm.ws.webcontainer.WebContainer;
 import com.ibm.ws.webcontainer.osgi.collaborator.CollaboratorHelperImpl;
 import com.ibm.ws.webcontainer.servlet.ServletWrapper;
 import com.ibm.ws.webcontainer.servlet.exception.NoTargetForURIException;
+import com.ibm.ws.webcontainer.srt.ISRTServletRequest;
 import com.ibm.ws.webcontainer.srt.SRTRequestContext;
 import com.ibm.ws.webcontainer.srt.SRTServletRequest;
 import com.ibm.ws.webcontainer.srt.SRTServletResponse;
@@ -193,7 +194,7 @@ public class WebAppRequestDispatcher implements RequestDispatcher, WebContainerC
     // of
     // iVar
     {
-        SRTRequestContext reqCtx = ((SRTServletRequest) wasReq).getRequestContext();
+        SRTRequestContext reqCtx = ((ISRTServletRequest) wasReq).getRequestContext();
         // Spec says that we SHOULD NOT perform security access checks in
         // forwards and includes. But this exposes a security hole where
         // an unauthenticated user can get into a secured app by simply
@@ -1170,7 +1171,7 @@ public class WebAppRequestDispatcher implements RequestDispatcher, WebContainerC
             //Setup to check is we dispatched from async to sync servlet
             wasAsyncSupported = wasReq.isAsyncSupported();            
 
-            if (((SRTServletRequest) wasReq).getRequestContext().isWithinApplication(webapp) == false) {
+            if (((ISRTServletRequest) wasReq).getRequestContext().isWithinApplication(webapp) == false) {
                 //PK91120 Start
                 if (reqState!=null&&reqState.getAttribute("com.ibm.ws.webcontainer.invokeListenerRequest") != null)
                     reqState.removeAttribute("com.ibm.ws.webcontainer.invokeListenerRequest");
@@ -1471,7 +1472,7 @@ public class WebAppRequestDispatcher implements RequestDispatcher, WebContainerC
             if (boundary_changed) {
                 // PK17095 Catching EmptyStackException for rollBackBoundary
                 try {
-                    ((SRTServletRequest) wasReq).getRequestContext().rollBackBoundary();
+                    ((ISRTServletRequest) wasReq).getRequestContext().rollBackBoundary();
                 } catch (EmptyStackException ese) {
                     com.ibm.wsspi.webcontainer.util.FFDCWrapper.processException(ese,
                                                                                  "com.ibm.ws.webcontainer.webapp.WebAppRequestDispatcher.forward", "367", this);

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/util/ServletUtil.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/util/ServletUtil.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package com.ibm.wsspi.webcontainer.util;
 
-import java.lang.reflect.Proxy;
 import java.text.MessageFormat;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -54,11 +53,6 @@ public class ServletUtil {
 	 */
 	public static com.ibm.wsspi.webcontainer.servlet.IExtendedRequest unwrapRequest(ServletRequest req)
 	{
-	        Class<?> reqClass = req.getClass();
-	        if (Proxy.isProxyClass(reqClass)) {
-	            if (req.toString().contains("SRTServletRequest40"))
-	                return (com.ibm.wsspi.webcontainer.servlet.IExtendedRequest) req;
-	        }
 		return unwrapRequest(req, com.ibm.wsspi.webcontainer.servlet.IExtendedRequest.class);
 	}
 
@@ -71,7 +65,6 @@ public class ServletUtil {
 	{
 		ServletRequest r = req;
 		while (!(requestClass.isInstance(r)))
-		//while (!(requestClass.isAssignableFrom(r.getClass())))
 		{
 			if (logWarning && logger.isLoggable(Level.WARNING)) {
 		            logger.logp(Level.WARNING, CLASS_NAME, "unwrapRequest",MessageFormat.format(nls.getString(

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/util/ServletUtil.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/util/ServletUtil.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.wsspi.webcontainer.util;
 
+import java.lang.reflect.Proxy;
 import java.text.MessageFormat;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -53,6 +54,11 @@ public class ServletUtil {
 	 */
 	public static com.ibm.wsspi.webcontainer.servlet.IExtendedRequest unwrapRequest(ServletRequest req)
 	{
+	        Class<?> reqClass = req.getClass();
+	        if (Proxy.isProxyClass(reqClass)) {
+	            if (req.toString().contains("SRTServletRequest40"))
+	                return (com.ibm.wsspi.webcontainer.servlet.IExtendedRequest) req;
+	        }
 		return unwrapRequest(req, com.ibm.wsspi.webcontainer.servlet.IExtendedRequest.class);
 	}
 
@@ -65,6 +71,7 @@ public class ServletUtil {
 	{
 		ServletRequest r = req;
 		while (!(requestClass.isInstance(r)))
+		//while (!(requestClass.isAssignableFrom(r.getClass())))
 		{
 			if (logWarning && logger.isLoggable(Level.WARNING)) {
 		            logger.logp(Level.WARNING, CLASS_NAME, "unwrapRequest",MessageFormat.format(nls.getString(

--- a/dev/io.openliberty.org.jboss.resteasy.common/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.common/bnd.bnd
@@ -129,7 +129,8 @@ DynamicImport-Package: \
   com.sun.xml.bind.marshaller, \
   org.jboss.resteasy.plugins.providers.jaxb, \
   org.jboss.resteasy.plugins.providers.validator, \
-  sun.misc
+  sun.misc, \
+  *
 
 
 Private-Package: \

--- a/dev/io.openliberty.org.jboss.resteasy.common/src/org/jboss/resteasy/core/ContextParameterInjector.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/org/jboss/resteasy/core/ContextParameterInjector.java
@@ -1,0 +1,223 @@
+package org.jboss.resteasy.core;
+
+import org.jboss.resteasy.plugins.providers.sse.SseImpl;
+import org.jboss.resteasy.resteasy_jaxrs.i18n.Messages;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.HttpResponse;
+import org.jboss.resteasy.spi.LoggableFailure;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.spi.ValueInjector;
+import org.jboss.resteasy.spi.util.Types;
+
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.ext.Providers;
+import javax.ws.rs.sse.Sse;
+import javax.ws.rs.sse.SseEventSink;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+@SuppressWarnings("unchecked")
+public class ContextParameterInjector implements ValueInjector
+{
+   private Class rawType;
+   private Class proxy;
+   private ResteasyProviderFactory factory;
+   private Type genericType;
+   private Annotation[] annotations;
+
+   public ContextParameterInjector(final Class proxy, final Class rawType, final Type genericType, final Annotation[] annotations, final ResteasyProviderFactory factory)
+   {
+      this.rawType = rawType;
+      this.genericType = genericType;
+      this.proxy = proxy;
+      this.factory = factory;
+      this.annotations = annotations;
+   }
+
+   @Override
+   public Object inject(HttpRequest request, HttpResponse response, boolean unwrapAsync)
+   {
+      // we always inject a proxy for interface types just in case the per-request target is a pooled object
+      // i.e. in the case of an SLSB
+      if (rawType.equals(Providers.class)) return factory;
+      if (!rawType.isInterface() || rawType.equals(SseEventSink.class) || hasAsyncContextData(factory, genericType))
+      {
+         return unwrapIfRequired(request, factory.getContextData(rawType, genericType, annotations, unwrapAsync), unwrapAsync);
+      }
+      else if (rawType.equals(Sse.class))
+      {
+         return new SseImpl();
+      } else if (rawType == CompletionStage.class) {
+         return new CompletionStageHolder((CompletionStage)createProxy());
+      }
+      return createProxy();
+   }
+
+   private static boolean hasAsyncContextData(ResteasyProviderFactory factory, Type genericType)
+   {
+      return factory.getAsyncContextInjectors().containsKey(Types.boxPrimitives(genericType));
+   }
+
+   private Object unwrapIfRequired(HttpRequest request, Object contextData, boolean unwrapAsync)
+   {
+      if(unwrapAsync && rawType != CompletionStage.class && contextData instanceof CompletionStage) {
+         // FIXME: do not unwrap if we have no request?
+         if(request != null )
+         {
+            boolean resolved = ((CompletionStage<Object>) contextData).toCompletableFuture().isDone();
+            if(!resolved)
+            {
+               // make request async
+               if(!request.getAsyncContext().isSuspended())
+                  request.getAsyncContext().suspend();
+
+               Map<Class<?>, Object> contextDataMap = ResteasyContext.getContextDataMap();
+               // Don't forget to restore the context
+               return ((CompletionStage<Object>) contextData).thenApply(value -> {
+                  ResteasyContext.pushContextDataMap(contextDataMap);
+                  return value;
+               });
+            }
+         }
+         return (CompletionStage<Object>) contextData;
+      } else if (rawType == CompletionStage.class && contextData instanceof CompletionStage) {
+         return new CompletionStageHolder((CompletionStage)contextData);
+      } else if (!unwrapAsync && rawType != CompletionStage.class && contextData instanceof CompletionStage) {
+         throw new LoggableFailure(Messages.MESSAGES.shouldBeUnreachable());
+      }
+      return contextData;
+   }
+
+   private class GenericDelegatingProxy implements InvocationHandler
+   {
+      public Object invoke(Object o, Method method, Object[] objects) throws Throwable
+      {
+         try
+         {
+
+            Object delegate = factory.getContextData(rawType, genericType, annotations, false);
+            if (delegate == null)
+            {
+               String name = method.getName();
+               if (o instanceof ResourceInfo && ("getResourceMethod".equals(name) || "getResourceClass".equals(name)))
+               {
+                  return null;
+               }
+
+               if ("getContextResolver".equals(name))
+               {
+                  return method.invoke(factory, objects);
+               }
+               throw new LoggableFailure(Messages.MESSAGES.unableToFindContextualData(rawType.getName()));
+            }
+            return method.invoke(delegate, objects);
+         }
+         catch (IllegalAccessException e)
+         {
+            throw new RuntimeException(e);
+         }
+         catch (IllegalArgumentException e)
+         {
+            throw new RuntimeException(e);
+         }
+         catch (InvocationTargetException e)
+         {
+            throw e.getCause();
+         }
+      }
+   }
+
+   @Override
+   public Object inject(boolean unwrapAsync)
+   {
+      //if (type.equals(Providers.class)) return factory;
+      if (rawType.equals(Application.class) || rawType.equals(SseEventSink.class) || hasAsyncContextData(factory, genericType))
+      {
+         return factory.getContextData(rawType, genericType, annotations, unwrapAsync);
+      }
+      else if (rawType.equals(Sse.class))
+      {
+         return new SseImpl();
+      }
+      else if (!rawType.isInterface())
+      {
+         Object delegate = factory.getContextData(rawType, genericType, annotations, unwrapAsync);
+         if (delegate != null) return unwrapIfRequired(null, delegate, unwrapAsync);
+         else throw new RuntimeException(Messages.MESSAGES.illegalToInjectNonInterfaceType());
+      } else if (rawType == CompletionStage.class) {
+         return new CompletionStageHolder((CompletionStage)createProxy());
+      }
+
+      return createProxy();
+  }
+
+   protected Object createProxy()
+   {
+      if (proxy != null)
+      {
+         try
+         {
+            return proxy.getConstructors()[0].newInstance(new GenericDelegatingProxy());
+         }
+         catch (Exception e)
+         {
+            throw new RuntimeException(e);
+         }
+      }
+      else
+      {
+         Object delegate = factory.getContextData(rawType, genericType, annotations, false);
+         Class[] intfs = computeInterfaces(delegate, rawType); //Liberty change //{rawType};
+         ClassLoader clazzLoader = null;
+         final SecurityManager sm = System.getSecurityManager();
+         if (sm == null) {
+            //clazzLoader = rawType.getClassLoader();
+            clazzLoader = this.getClass().getClassLoader();
+         } else {
+            clazzLoader = AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+               @Override
+               public ClassLoader run() {
+                  //return rawType.getClassLoader();
+                  return this.getClass().getClassLoader();
+               }
+            });
+         }
+         return Proxy.newProxyInstance(clazzLoader, intfs, new GenericDelegatingProxy());
+      }
+   }
+
+   //Liberty change start
+   Class<?>[] computeInterfaces(Object delegate, Class<?> cls) {
+       Set<Class<?>> set = new HashSet<>();
+       set.add(cls);
+       if (delegate != null) {
+           Class<?> delegateClass = delegate.getClass();
+           while (delegateClass != null) {
+               for (Class<?> intf : delegateClass.getInterfaces()) {
+                   set.add(intf);
+                   for (Class<?> superIntf : intf.getInterfaces()) {
+                       set.add(superIntf);
+                   }
+               }
+               delegateClass = delegateClass.getSuperclass();
+           }
+       }
+       return set.toArray(new Class<?>[] {});
+   }
+   //Liberty change end
+}


### PR DESCRIPTION
JAX-RS 3.0 (RESTEasy) injects `HttpServletRequest` instances using dynamic Java proxies that delegate to SRTServletRequest40. This causes problems with the existing web container code because it cannot cast a proxy (that implements the same interfaces as the SRTServletRequest40) to a SRTServletRequest40 or SRTServletRequest - this is because you cannot cast a proxy to a class - only an interface.

The solution I've proposed here is to create interfaces `ISRTServletRequest` and `ISRTServletRequest40` to define the methods needed - then the proxy can implement those interfaces and the casts will succeed.

While the main changes here are in the web container code, there are also some changes to security code and the JAX-RS code.