### PR TITLE
Issue 16476: Longer wait and more trace for AcmeValidityAndRenewTest

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/docker/CAContainer.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/docker/CAContainer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -285,6 +285,8 @@ public abstract class CAContainer extends GenericContainer<CAContainer> {
 	 */
 	public void addDnsARecord(String host, String address) throws IOException {
 		final String METHOD_NAME = "addDnsARecord";
+		
+		Log.info(CAContainer.class, METHOD_NAME, "Adding DNS record for " + host + ":" + address);
 
 		try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
 
@@ -312,6 +314,8 @@ public abstract class CAContainer extends GenericContainer<CAContainer> {
 					throw new IOException(
 							METHOD_NAME + ": Expected response 200, but received response: " + statusLine);
 				}
+				
+				Log.info(CAContainer.class, METHOD_NAME, "DNS record update request was a success.");
 			}
 		}
 	}

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeValidityAndRenewTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeValidityAndRenewTest.java
@@ -879,7 +879,7 @@ public class AcmeValidityAndRenewTest {
 			 * DNS info can be cached, give more time for cache to expire
 			 */
 			assertNotNull("Should log message that the certificate renew failed",
-					server.waitForStringInLogUsingMark("CWPKI2065W", TIME_BUFFER_BEFORE_EXPIRE * 8));
+					server.waitForStringInLogUsingMark("CWPKI2065W", TIME_BUFFER_BEFORE_EXPIRE * 12));
 
 			/*
 			 * Clear the bad DNS record and the cert checker should recover and fetch a new


### PR DESCRIPTION
Fixes #16476 

Some automated FATs are still picking up the valid DNS name, depending on when the CertChecker runs. Trying a longer timeout.