### PR TITLE
Issue 16482: Correct message checking for TicketCacheBadPrincipalJava8

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBadPrincipalJava8.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBadPrincipalJava8.java
@@ -64,7 +64,6 @@ public class TicketCacheBadPrincipalJava8 extends CommonBindTest {
         Log.info(c, testName.getMethodName(), "Login expected to fail, config has a bad principalName");
         loginUserShouldFail();
 
-        assertFalse("Expected to find Kerberos bind failure: CWIML4507E", server.findStringsInLogsAndTraceUsingMark("CWIML4507E").isEmpty());
         /*
          * The same base exception is not always thrown, two options here, either confirms that we tried to use an
          * invalid principal name.
@@ -73,6 +72,9 @@ public class TicketCacheBadPrincipalJava8 extends CommonBindTest {
         boolean foundKerberosLevelError = !server.findStringsInLogsAndTraceUsingMark("CWWKS4347E").isEmpty();
         assertTrue("Expected to find Kerberos bind failure: Either `CWIML4512E` or `CWWKS4347E`", foundBadPrincipalName || foundKerberosLevelError);
 
+        if (foundKerberosLevelError) { // should be wrapped in a WIM level message.
+            assertFalse("Expected to find Kerberos bind failure: CWIML4507E", server.findStringsInLogsAndTraceUsingMark("CWIML4507E").isEmpty());
+        }
     }
 
 }


### PR DESCRIPTION
Fixes #16482 

Correct the error message checking. `CWIML4512E` is a standalone message. `CWWKS4347E` will be wrapped in a WIM message.