### PR TITLE
Clear map after testHandleListClosesParkedHandleWhenMDBTransactionEnds

### DIFF
--- a/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/DerbyRAAnnoServlet.java
+++ b/dev/com.ibm.ws.jca_fat_derbyra/test-applications/fvtweb/src/web/DerbyRAAnnoServlet.java
@@ -224,6 +224,7 @@ public class DerbyRAAnnoServlet extends FATServlet {
 
             stmt.close();
         } finally {
+            map1.clear();
             con.close();
         }
     }


### PR DESCRIPTION
Fixes test bug where testAdminObjectInjected can fail due to:
```
testAdminObjectInjected:junit.framework.AssertionFailedError: 2021-04-05-19:32:46:770 The response did not contain "[SUCCESS]".  Full output is:"
ERROR: Caught exception attempting to call test method testAdminObjectInjected on servlet web.DerbyRAAnnoServlet
java.lang.Exception: Unexpected key: mdbtestHandleListClosesParkedHandleWhenTranEnds
at web.DerbyRAAnnoServlet.testAdminObjectInjected(DerbyRAAnnoServlet.java:240)
```

Caused by testHandleListClosesParkedHandleWhenMDBTransactionEnds not clearing the map after test is completed. 