### PR TITLE
Use Files#move on second plugin-cfg rename attempt

### DIFF
--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
@@ -885,15 +885,11 @@ public class PluginGenerator {
                 
                 if(!result){
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                        Tr.debug(tc, "Rename to plugin-cfg.xml failed!");
+                        Tr.debug(tc, "Rename to plugin-cfg.xml failed! Trying again.");
                     }
-                    try {
-                        Files.move(outFile.asFile().toPath(), pluginFile.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
-                    } catch (IOException ex) {
-                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                            Tr.debug(tc, "Rename to plugin-cfg.xml failed on the second attempt!");
-                        }
-                    }
+
+                    Files.move(outFile.asFile().toPath(), pluginFile.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+
                 }
 
                 // tell the user where the file is - quietly for implicit requests

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
@@ -882,9 +882,17 @@ public class PluginGenerator {
                 boolean result = outFile.asFile().renameTo(pluginFile);
 
                 //See if rename was unsuccessful. 
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    if(!result){
+                
+                if(!result){
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                         Tr.debug(tc, "Rename to plugin-cfg.xml failed!");
+                    }
+                    try {
+                        Files.move(outFile.asFile().toPath(), pluginFile.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+                    } catch (IOException ex) {
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                            Tr.debug(tc, "Rename to plugin-cfg.xml failed on the second attempt!");
+                        }
                     }
                 }
 


### PR DESCRIPTION
fixes #16495 

https://docs.oracle.com/javase/7/docs/api/java/io/File.html#renameTo(java.io.File)

per the recommendation in the renameTo description: 

`Note that the Files class defines the move method to move or rename a file in a platform independent manner.` 