### PR TITLE
Issue 16511: Swap JVM change to after server stop

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/RealmNameJVMProp.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/RealmNameJVMProp.java
@@ -75,10 +75,11 @@ public class RealmNameJVMProp extends CommonBindTest {
 
         loginUserShouldFail();
 
+        server.stopServer(stopStrings);
+
         Log.info(c, testName.getMethodName(), "Add a realm name as a JVM property, restart server to take effect");
         server.setJvmOptions(Arrays.asList("-Djava.security.krb5.realm=" + DOMAIN, "-Djava.security.krb5.kdc=localhost", "-Dcom.ibm.ws.beta.edition=true"));
 
-        server.stopServer(stopStrings);
         server.startServer();
         startupChecks();
 


### PR DESCRIPTION
Fixes #16511 

Do JVM property update after server stop -- see if it resolves some odd stop/restart behavior in a test failure.