### PR TITLE
Issue 16513: Remove sslProtocol on Oracle LDAP SSL test

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.sun.ssl/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.sun.ssl/server.xml
@@ -75,7 +75,7 @@
     </federatedRepository>
     
     <sslDefault sslRef="DefaultSSLSettings" />
-	<ssl id="LDAPSSLSettings" keyStoreRef="LDAPKeyStore" trustStoreRef="LDAPTrustStore" sslProtocol="TLSv1"/>
+	<ssl id="LDAPSSLSettings" keyStoreRef="LDAPKeyStore" trustStoreRef="LDAPTrustStore" />
 	<!-- keyStore id="LDAPKeyStore" location="${server.config.dir}/key.p12" type="PKCS12" password="{xor}CDo9Hgw=" />
 	<keyStore id="LDAPTrustStore" location="${server.config.dir}/trust.p12" type="PKCS12" password="{xor}CDo9Hgw=" /-->
 


### PR DESCRIPTION
Fixes #16513 

`URAPIs_SUNLDAP_SSLTest` has been converted to run on our UnboundIDServer, but it had previously had sslProtocol set to TLSv1 to talk to our standalone Oracle LDAP server. This seems to be causing an `The LDAP naming exception javax.naming.CommunicationException: localhost:55099 [Root exception is javax.net.ssl.SSLHandshakeException: No appropriate protocol (protocol is disabled or cipher suites are inappropriate)] occurred during processing.` on OpenJDK16 builds. 