### PR TITLE
enable allowqueryparamwithnoequal by default in JAX-RS 3.0

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.beanparam/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/publish/servers/com.ibm.ws.jaxrs.fat.beanparam/server.xml
@@ -3,9 +3,7 @@
         <feature>componenttest-1.0</feature>
         <feature>jaxrs-2.0</feature>
     </featureManager>
-    
-    <!-- the following property is the webcontainer property that we do not want to have to rely on -->
-    <!-- <webContainer enablemultireadofpostdata="true" /> -->
+
   	<include location="../fatTestPorts.xml"/>
   	<javaPermission className="java.util.PropertyPermission" name="bvt.prop.HTTP_default" actions="read"/>
 </server>

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/beanparam/src/com/ibm/ws/jaxrs/fat/beanparam/BeanParamEntity.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/beanparam/src/com/ibm/ws/jaxrs/fat/beanparam/BeanParamEntity.java
@@ -11,12 +11,16 @@
 package com.ibm.ws.jaxrs.fat.beanparam;
 
 import javax.ws.rs.BeanParam;
+import javax.ws.rs.CookieParam;
 import javax.ws.rs.FormParam;
 
 public class BeanParamEntity {
 
     @FormParam("form")
     public String form;
+
+    @CookieParam("cookie")
+    public String cookie;
 
     @BeanParam
     public InnerBeanParamEntity inner;

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/beanparam/src/com/ibm/ws/jaxrs/fat/beanparam/ClientTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/beanparam/src/com/ibm/ws/jaxrs/fat/beanparam/ClientTestServlet.java
@@ -73,4 +73,16 @@ public class ClientTestServlet extends FATServlet {
         //if working correctly, the resource method always puts this at the end though:
         assertTrue("Bean param processing failed", actual.endsWith("&FIRST&SECOND"));
     }
+
+    @Test
+    public void testCookieParam() throws Exception {
+        String content = "Whatever";
+        Response response = client.target(URI_CONTEXT_ROOT)
+                        .path("cookieparam")
+                        .request(MediaType.TEXT_PLAIN_TYPE)
+                        .cookie("cookie", "Chocolate Chip")
+                        .cookie("innerCookie", "Snickerdoodle")
+                        .post(Entity.entity(content, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
+        assertEquals("Whatever&Chocolate Chip&Snickerdoodle", response.readEntity(String.class));
+    }
 }

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/beanparam/src/com/ibm/ws/jaxrs/fat/beanparam/InnerBeanParamEntity.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/beanparam/src/com/ibm/ws/jaxrs/fat/beanparam/InnerBeanParamEntity.java
@@ -10,10 +10,14 @@
  *******************************************************************************/
 package com.ibm.ws.jaxrs.fat.beanparam;
 
+import javax.ws.rs.CookieParam;
 import javax.ws.rs.FormParam;
 
 public class InnerBeanParamEntity {
 
     @FormParam("innerForm")
     public String innerForm;
+
+    @CookieParam("innerCookie")
+    public String innerCookie;
 }

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/beanparam/src/com/ibm/ws/jaxrs/fat/beanparam/TestResource.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/beanparam/src/com/ibm/ws/jaxrs/fat/beanparam/TestResource.java
@@ -31,4 +31,13 @@ public class TestResource {
         System.out.println("bean.inner.innerForm=" + bean.inner.innerForm);
         return content + "&" + bean.form + "&" + bean.inner.innerForm;
     }
+
+    @POST
+    @Path("cookieparam")
+    public String cookieParam(String content, @BeanParam BeanParamEntity bean) {
+        System.out.println("content=" + content);
+        System.out.println("bean.cookie=" + bean.cookie);
+        System.out.println("bean.inner.innerCookie=" + bean.inner.innerCookie);
+        return content + "&" + bean.cookie + "&" + bean.inner.innerCookie;
+    }
 }

--- a/dev/io.openliberty.org.jboss.resteasy.common/src/org/jboss/resteasy/core/FormParamInjector.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/org/jboss/resteasy/core/FormParamInjector.java
@@ -62,11 +62,11 @@ public class FormParamInjector extends StringParameterInjector implements ValueI
    @Override
    public Object inject(HttpRequest request, HttpResponse response, boolean unwrapAsync)
    {
-	  // Liberty change start
-      MultivaluedMap<String, String> formParams = request.getFormParameters(); 
+      // Liberty change start 
       MultivaluedMap<String, String> decodedFormParams = request.getDecodedFormParameters();
       MediaType mediaType = request.getHttpHeaders().getMediaType();
       if (String.class.equals(type) && mediaType != null && mediaType.getType().equalsIgnoreCase("multipart")) {
+          MultivaluedMap<String, String> formParams = request.getFormParameters(); 
           if (formParams == null || formParams.size() < 1) {
               try {
                   Type genericType = (new ArrayList<IAttachment>() {}).getClass().getGenericSuperclass();


### PR DESCRIPTION
This fix resolves a TCK issue where content send using content type of `application/x-www-form-urlencoded`.  The TCK sends content like "ABC", but when the JAX-RS resource method is invoked, the entity parameter is injected with "".  In our testing, if we send content of "ABC=", then the injected entity parameter is "ABC".  

The reason for this is that RESTEasy uses the `HttpServletRequest.getParameterMap()` to determine the content when handling `application/x-www-form-urlencoded` requests.  By default, the web container does not process parameters that do not contain an equals sign. Setting the `allowqueryparamwithnoequal` attribute to true fixes this.