### PR TITLE
@SkipForRepeat cleanup - jaxrs.2.0_fat bucket

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/context/ContextTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/context/ContextTest.java
@@ -26,12 +26,10 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class ContextTest {
 
     @Server("com.ibm.ws.jaxrs.fat.context")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/ibm/json/IBMJSON4JTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/ibm/json/IBMJSON4JTest.java
@@ -29,7 +29,6 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
@@ -39,7 +38,6 @@ import componenttest.topology.impl.LibertyServer;
  * Not intended to test the com.ibm.json.* code.
  */
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class IBMJSON4JTest {
 
     @Server("com.ibm.ws.jaxrs.fat.ibmjson4j")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/jackson/JacksonPOJOTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/jackson/JacksonPOJOTest.java
@@ -23,12 +23,10 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class JacksonPOJOTest extends JacksonBaseTest {
 
     @Server("com.ibm.ws.jaxrs.fat.jackson")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/json/UTF8Test.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/json/UTF8Test.java
@@ -21,7 +21,6 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs20.fat.AbstractTest;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
@@ -30,7 +29,6 @@ import componenttest.topology.impl.LibertyServer;
  * INVALID UTF-8 middle byte error WITH DANISH CHARACTER SET
  */
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class UTF8Test extends AbstractTest {
 
     @Server("com.ibm.ws.jaxrs.fat.json")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/managedbeans/ManagedBeansTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/managedbeans/ManagedBeansTest.java
@@ -18,13 +18,11 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs.managedbeans.ManagedBeansTestServlet;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class ManagedBeansTest {
 
     @Server("JaxrsManagedBeansTestServer")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/multipart/MultipartTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/multipart/MultipartTest.java
@@ -24,7 +24,6 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
-//@SkipForRepeat("EE9_FEATURES") // multipart impl currently depends on CXF-classes - will need separate impl for RESTEasy
 @RunWith(FATRunner.class)
 public class MultipartTest extends FATServletClient {
     private static final String war = "multipart";

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/paramconverter/ParamConverterTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/paramconverter/ParamConverterTest.java
@@ -18,14 +18,12 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs.fat.paramconverter.ClientTestServlet;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class ParamConverterTest extends FATServletClient {
 
     private static final String app = "paramconverter";

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/readerwriterprovider/ReaderWriterProvidersTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/readerwriterprovider/ReaderWriterProvidersTest.java
@@ -31,7 +31,6 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
@@ -39,8 +38,6 @@ import componenttest.topology.impl.LibertyServer;
  * Centralized test for built-in standard providers required by the JAX-RS specification.
  */
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
-
 public class ReaderWriterProvidersTest {
 
     @Server("com.ibm.ws.jaxrs.fat.providers")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/security/ssl/SecuritySSLTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/security/ssl/SecuritySSLTest.java
@@ -31,12 +31,10 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class SecuritySSLTest {
 
     @Server("com.ibm.ws.jaxrs.fat.security.ssl")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/securitycontext/CustomSecurityContextTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/securitycontext/CustomSecurityContextTest.java
@@ -20,13 +20,11 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs.fat.customsecuritycontext.servlet.CustomSecurityContextTestServlet;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class CustomSecurityContextTest {
 
 

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/servletcoexist/JAXRSServletCoexistTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/servletcoexist/JAXRSServletCoexistTest.java
@@ -28,12 +28,10 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class JAXRSServletCoexistTest {
     private static final String bvwar = "servletcoexist";
     private static final String bvwar1 = bvwar + "1";

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/thirdpartyjerseywithinjection/JerseyInjectionTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/thirdpartyjerseywithinjection/JerseyInjectionTest.java
@@ -38,12 +38,10 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class JerseyInjectionTest {
 
     @Server("com.ibm.ws.jaxrs.fat.thirdpartyjerseywithinjection")

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/context/src/com/ibm/ws/jaxrs/fat/context/ContextUtil.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/context/src/com/ibm/ws/jaxrs/fat/context/ContextUtil.java
@@ -32,7 +32,7 @@ public class ContextUtil {
     /**
      * Test data
      */
-    public static final String ADDHEADERNAME = "ThreadLocalProviders";
+    public static final String ADDHEADERNAME = "MyHeader";
 
     /**
      * URI and Request Name

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/context/src/com/ibm/ws/jaxrs/fat/context/DemoApplication.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/context/src/com/ibm/ws/jaxrs/fat/context/DemoApplication.java
@@ -112,7 +112,7 @@ public class DemoApplication extends javax.ws.rs.core.Application {
                 throw new RuntimeException();
             }
             if (uriInfo.getRequestUri().toString().contains(ContextUtil.HTTPHEADERSNAME1)) {
-                context.getHeaders().add(providers.getClass().getSimpleName(), ContextUtil.METHODNAME1);
+                context.getHeaders().add(ContextUtil.ADDHEADERNAME, ContextUtil.METHODNAME1);
             }
         }
     }
@@ -135,7 +135,7 @@ public class DemoApplication extends javax.ws.rs.core.Application {
             }
 
             if (uriInfo.getRequestUri().toString().contains(ContextUtil.HTTPHEADERSNAME2)) {
-                context.getHeaders().add(providers.getClass().getSimpleName(), ContextUtil.METHODNAME2);
+                context.getHeaders().add(ContextUtil.ADDHEADERNAME, ContextUtil.METHODNAME2);
             }
         }
     }
@@ -158,7 +158,7 @@ public class DemoApplication extends javax.ws.rs.core.Application {
                 throw new RuntimeException();
             }
             if (uriInfo.getRequestUri().toString().contains(ContextUtil.HTTPHEADERSNAME3)) {
-                context.getHeaders().add(providers.getClass().getSimpleName(), ContextUtil.METHODNAME3);
+                context.getHeaders().add(ContextUtil.ADDHEADERNAME, ContextUtil.METHODNAME3);
             }
         }
     }
@@ -177,7 +177,7 @@ public class DemoApplication extends javax.ws.rs.core.Application {
                 throw new RuntimeException();
             }
             if (ui.getRequestUri().toString().contains(ContextUtil.HTTPHEADERSNAME4)) {
-                context.getHeaders().add(providers.getClass().getSimpleName(), ContextUtil.METHODNAME4);
+                context.getHeaders().add(ContextUtil.ADDHEADERNAME, ContextUtil.METHODNAME4);
             }
         }
 

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/customsecuritycontext/src/com/ibm/ws/jaxrs/fat/customsecuritycontext/servlet/CustomSecurityContextTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/test-applications/customsecuritycontext/src/com/ibm/ws/jaxrs/fat/customsecuritycontext/servlet/CustomSecurityContextTestServlet.java
@@ -15,16 +15,17 @@ import static org.junit.Assert.assertEquals;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Base64;
 
 import javax.servlet.annotation.WebServlet;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
-import javax.xml.bind.DatatypeConverter;
 
 import org.junit.Test;
 
+import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 @WebServlet(urlPatterns = "/CustomSecurityContextTestServlet")
@@ -36,10 +37,11 @@ public class CustomSecurityContextTestServlet extends FATServlet {
     private final String customEndpoint = "http://localhost:" + Integer.getInteger("bvt.prop.HTTP_default") + "/CustomSecurityContext/CustomSecurityContextResource/";
 
     @Test
+    @SkipForRepeat("EE9_FEATURES") // default authorization not yet implemented without web.xml?
     public void testDefaultSecurityContext() throws Exception {
         String uri = defaultEndpoint + "Get";
         String token = "adam:password1";
-        String basicAuthentication = "Basic " + DatatypeConverter.printBase64Binary(token.getBytes("UTF-8"));
+        String basicAuthentication = "Basic " + Base64.getEncoder().encodeToString(token.getBytes("UTF-8"));
 
         System.out.println("uri=" + uri);
         Response response = null;
@@ -49,7 +51,7 @@ public class CustomSecurityContextTestServlet extends FATServlet {
         assertEquals(403, response.getStatus());
 
         token = "bob:password1";
-        basicAuthentication = "Basic " + DatatypeConverter.printBase64Binary(token.getBytes("UTF-8"));
+        basicAuthentication = "Basic " + Base64.getEncoder().encodeToString(token.getBytes("UTF-8"));
 
         response = t.request().header("Authorization", basicAuthentication).get();
         assertEquals(200, response.getStatus());
@@ -61,7 +63,7 @@ public class CustomSecurityContextTestServlet extends FATServlet {
     public void testCustomSecurityContextSetInFilter() throws Exception {
         String uri = customEndpoint + "Get";
         String token = "adam:password1";
-        final String basicAuthentication = "Basic " + DatatypeConverter.printBase64Binary(token.getBytes("UTF-8"));
+        final String basicAuthentication = "Basic " + Base64.getEncoder().encodeToString(token.getBytes("UTF-8"));
 
         System.out.println("uri=" + uri);
         Response response = null;


### PR DESCRIPTION
Cleaning up some `@SkipForRepeat` annotations that are no longer necessary (with some minor test case fixes too).