### PR TITLE
Create atomic dispatcher state - improved

### DIFF
--- a/dev/com.ibm.ws.messaging.msgstore/src/com/ibm/ws/sib/msgstore/persistence/dispatcher/DispatcherState.java
+++ b/dev/com.ibm.ws.messaging.msgstore/src/com/ibm/ws/sib/msgstore/persistence/dispatcher/DispatcherState.java
@@ -1,0 +1,59 @@
+package com.ibm.ws.sib.msgstore.persistence.dispatcher;
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+final class DispatcherState {
+    // Flag set to indicate whether dispatcher is running.
+    final boolean isRunning;
+    // Flag set to indicate that the dispatcher should stop.
+    // This is caused by calling the {@link Dispatcher#stop()} method.
+    final boolean isStopRequested;
+    // Count of the number of worker threads experiencing write errors.
+    final int threadWriteErrors;
+
+    DispatcherState() {
+        this(false, false, 0);
+    }
+
+    private DispatcherState(boolean running, boolean stopRequested, int threadWriteErrors) {
+        this.isRunning = running;
+        this.isStopRequested = stopRequested;
+        this.threadWriteErrors = threadWriteErrors;
+    }
+
+    DispatcherState running(final boolean running) {
+        return (running == isRunning) ? this : new DispatcherState(running, this.isStopRequested, this.threadWriteErrors);
+    }
+
+    DispatcherState stopRequested(final boolean stopRequested) {
+        return (stopRequested == isStopRequested) ? this : new DispatcherState(this.isRunning, stopRequested, this.threadWriteErrors);
+    }
+
+    DispatcherState addThreadWriteError() {
+        return new DispatcherState(isRunning, isStopRequested, (threadWriteErrors + 1));
+    }
+
+    DispatcherState clearThreadWriteError() {
+        return (0 >= threadWriteErrors) ? this : new DispatcherState(isRunning, isStopRequested, (threadWriteErrors - 1));
+    }
+
+    boolean isHealthy() {
+        return isRunning && !isStopRequested && (0 == threadWriteErrors);
+    }
+
+    String desc() {
+        String s = "";
+        if (isStopRequested) s+= " (STOP REQUESTED)";
+        if (!isRunning) s+= " (STOPPED)";
+        if (0 < threadWriteErrors) s+= " (ERROR)";
+        return s;
+    }
+}

--- a/dev/com.ibm.ws.messaging.msgstore/src/com/ibm/ws/sib/msgstore/persistence/dispatcher/StateUtils.java
+++ b/dev/com.ibm.ws.messaging.msgstore/src/com/ibm/ws/sib/msgstore/persistence/dispatcher/StateUtils.java
@@ -1,0 +1,29 @@
+package com.ibm.ws.sib.msgstore.persistence.dispatcher;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+enum StateUtils {
+    ;
+
+    interface StateUpdater<T> {
+        T update(T currentState);
+    }
+    interface UpdateCallback<T> {
+        void updated(T newState);
+    }
+
+    public static final <T> boolean updateState(AtomicReference<T> ref, StateUpdater<T> updater) {
+        return updateState(ref, updater, null);
+    }
+
+    public static final <T> boolean updateState(AtomicReference<T> ref, StateUpdater<T> updater, UpdateCallback<T> callback) {
+        T curState, newState;
+        do {
+            curState = ref.get();
+            newState = updater.update(curState);
+            if (newState == curState) return false;
+        } while (false == ref.compareAndSet(curState, newState));
+        if (null != callback) callback.updated(newState);
+        return true;
+    }
+}


### PR DESCRIPTION
Create atomic dispatcher state - improved

Each instance of the new DispatcherState represents an immutable snapshot of a dispatcher's state.

As it is immutable, this can then be safely inspected without further locking (to check the dispatcher's health or describe its current state.

Transition from one state snapshot to the next is done using AtomicReference.compareAndSet() in the associated StateUtils.update() methods.

Supercedes #16517 

#build