### PR TITLE
Session active counter

### DIFF
--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/session/impl/HttpSessionContextImpl.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/session/impl/HttpSessionContextImpl.java
@@ -280,7 +280,12 @@ public class HttpSessionContextImpl extends SessionContext implements IHttpSessi
       /* PM73188 - Fixing regression from PM87133. Some customers were seeing a negative active count due to isValid being called multiple times in a row.
       * If the customer still needs this setting on, then they need to set ModifyActiveCountOnInvalidatedSession="true" in server.xml.
       */
-      if (_smc.getModifyActiveCountOnInvalidatedSession()) {
+      boolean active = isess.getRefCount() > 0;
+      if (isTraceOn && LoggingUtil.SESSION_LOGGER_CORE.isLoggable(Level.FINE))
+      {
+        LoggingUtil.SESSION_LOGGER_CORE.logp(Level.FINE, methodClassName, methodNames[IS_VALID], "Still in the service method " + active);
+      }
+      if (!active && _smc.getModifyActiveCountOnInvalidatedSession()) {
           _coreHttpSessionManager.getIStore().getStoreCallback().sessionReleased(isess); // PM87133, since the session is no longer valid, it's also no longer active, we need to decrement active count
       }
     }


### PR DESCRIPTION
Incorrectly decremented session active counter within the service method due to session being invalidated abnormally.

[2021-03-18T11:18:19.561+0100] 000000b0 WASSessionCor > HttpSessionContextImpl sessionPreInvoke ENTRY

[2021-03-18T11:18:19.562+0100] 000000b0 WASSessionCor 1 MemorySession incrementRefCount to 1 from 0 AppName=default_host/daytrader; Id=et_xuc6AM-HL_s8RGdRtao3 , _removeAttrOnInvalidate -->false

[2021-03-18T11:18:19.562+0100] 000000b0 SessionMonito >  IncrementActiveCount Entry

[2021-03-18T11:18:19.569+0100] 000000b0 SessionMonito >  InvalidatedSessions Entry

[2021-03-18T11:18:19.574+0100] 000000b0 SessionMonito >  DecrementActiveCount Entry <=========== incorrectly decremented within the service method

[2021-03-18T11:18:19.577+0100] 000000b0 WASSessionCor > SessionContext sessionPostInvoke ENTRY

[2021-03-18T11:18:19.577+0100] 000000b0 WASSessionCor 1 MemorySession decrementRefCount to 0 from 1 AppName=default_host/daytrader; Id=et_xuc6AM-HL_s8RGdRtao3 , _removeAttrOnInvalidate -->false

[2021-03-18T11:18:19.577+0100] 000000b0 SessionMonito >  DecrementActiveCount Entry 