### PR TITLE
test Subject from AccessControlContext after security context propagated

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp_fat/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent.mp_fat/bnd.bnd
@@ -38,6 +38,7 @@ tested.features: mpConfig-2.0
 	io.openliberty.org.eclipse.microprofile.contextpropagation.1.2;version=latest,\
 	com.ibm.websphere.org.eclipse.microprofile.config.1.3;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
+	com.ibm.websphere.security;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.concurrent;version=latest,\
     com.ibm.ws.org.osgi.annotation.versioning;version=latest,\

--- a/dev/com.ibm.ws.concurrent.mp_fat/build.gradle
+++ b/dev/com.ibm.ws.concurrent.mp_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2020 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@
 addRequiredLibraries.dependsOn addDerby
 
 dependencies {
+  requiredLibs project(':com.ibm.websphere.security')
   requiredLibs project(':com.ibm.ws.concurrent')
   requiredLibs project(':com.ibm.tx.core')
 }

--- a/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentConfigTestServer/server.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentConfigTestServer/server.xml
@@ -52,4 +52,12 @@
     <javaPermission codebase="${server.config.dir}/apps/MPConcurrentConfigApp.war" className="java.lang.RuntimePermission" name="modifyThread"/>
     <javaPermission codebase="${server.config.dir}/apps/MPConcurrentConfigApp.war" className="java.lang.RuntimePermission" name="setContextClassLoader"/>
     <javaPermission codebase="${server.config.dir}/apps/MPConcurrentConfigApp.war" className="java.util.PropertyPermission" name="java.util.concurrent.ForkJoinPool.*" actions="read"/>
+
+    <!-- Needed for the application to create and use Subjects for testing -->
+    <javaPermission codebase="${server.config.dir}/apps/MPConcurrentConfigApp.war" className="javax.security.auth.AuthPermission" name="doAs"/>
+    <javaPermission codebase="${server.config.dir}/apps/MPConcurrentConfigApp.war" className="javax.security.auth.AuthPermission" name="doAsPrivileged"/>
+    <javaPermission codebase="${server.config.dir}/apps/MPConcurrentConfigApp.war" className="javax.security.auth.AuthPermission" name="getSubject"/>
+    <javaPermission codebase="${server.config.dir}/apps/MPConcurrentConfigApp.war" className="javax.security.auth.AuthPermission" name="setReadOnly"/>
+    <javaPermission codebase="${server.config.dir}/apps/MPConcurrentConfigApp.war" className="javax.security.auth.AuthPermission" name="wssecurity.getCallerSubject"/>
+    <javaPermission codebase="${server.config.dir}/apps/MPConcurrentConfigApp.war" className="javax.security.auth.AuthPermission" name="wssecurity.getRunAsSubject"/>
 </server>


### PR DESCRIPTION
Write test to determine if OpenLiberty has the same issue with security context propagation as https://github.com/smallrye/smallrye-context-propagation/pull/260

It turns out that it does have the same issue, so some checks within the test are disabled and marked with comments.

I also tried with WSSubject in case the behavior might differ, but is the same with respect to getting the null Subject from the AccessControlContext.