### PR TITLE
Add getPolicy permission to http2_fat apps

### DIFF
--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2Config31H2Off.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2Config31H2Off.java
@@ -53,8 +53,8 @@ public class Http2Config31H2Off extends FATServletClient {
             LOGGER.logp(Level.INFO, CLASS_NAME, "before()", "Starting servers...");
         }
 
-        H2FATApplicationHelper.addWarToServerDropins(server, "H2TestModule.war", false, "http2.test.war.servlets");
-        H2FATApplicationHelper.addWarToServerDropins(runtimeServer, "H2FATDriver.war", false, "http2.test.driver.war.servlets");
+        H2FATApplicationHelper.addWarToServerDropins(server, "H2TestModule.war", true, "http2.test.war.servlets");
+        H2FATApplicationHelper.addWarToServerDropins(runtimeServer, "H2FATDriver.war", true, "http2.test.driver.war.servlets");
 
         server.startServer(true, true);
         runtimeServer.startServer(true, true);

--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2Config31H2On.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2Config31H2On.java
@@ -53,8 +53,8 @@ public class Http2Config31H2On extends FATServletClient {
             LOGGER.logp(Level.INFO, CLASS_NAME, "before()", "Starting servers...");
         }
 
-        H2FATApplicationHelper.addWarToServerDropins(server, "H2TestModule.war", false, "http2.test.war.servlets");
-        H2FATApplicationHelper.addWarToServerDropins(runtimeServer, "H2FATDriver.war", false, "http2.test.driver.war.servlets");
+        H2FATApplicationHelper.addWarToServerDropins(server, "H2TestModule.war", true, "http2.test.war.servlets");
+        H2FATApplicationHelper.addWarToServerDropins(runtimeServer, "H2FATDriver.war", true, "http2.test.driver.war.servlets");
 
         server.startServer(true, true);
         runtimeServer.startServer(true, true);

--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2Config40H2Off.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2Config40H2Off.java
@@ -58,8 +58,8 @@ public class Http2Config40H2Off extends FATServletClient {
             LOGGER.logp(Level.INFO, CLASS_NAME, "before()", "Starting servers...");
         }
 
-        H2FATApplicationHelper.addWarToServerDropins(server, "H2TestModule.war", false, "http2.test.war.servlets");
-        H2FATApplicationHelper.addWarToServerDropins(runtimeServer, "H2FATDriver.war", false, "http2.test.driver.war.servlets");
+        H2FATApplicationHelper.addWarToServerDropins(server, "H2TestModule.war", true, "http2.test.war.servlets");
+        H2FATApplicationHelper.addWarToServerDropins(runtimeServer, "H2FATDriver.war", true, "http2.test.driver.war.servlets");
 
         server.startServer(true, true);
         runtimeServer.startServer(true, true);

--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2FullModeTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2FullModeTests.java
@@ -62,8 +62,8 @@ public class Http2FullModeTests extends FATServletClient {
             LOGGER.logp(Level.INFO, CLASS_NAME, "before()", "Starting servers...");
         }
 
-        H2FATApplicationHelper.addWarToServerDropins(server, "H2TestModule.war", false, "http2.test.war.servlets");
-        H2FATApplicationHelper.addWarToServerDropins(runtimeServer, "H2FATDriver.war", false, "http2.test.driver.war.servlets");
+        H2FATApplicationHelper.addWarToServerDropins(server, "H2TestModule.war", true, "http2.test.war.servlets");
+        H2FATApplicationHelper.addWarToServerDropins(runtimeServer, "H2FATDriver.war", true, "http2.test.driver.war.servlets");
 
         server.startServer(true, true);
         runtimeServer.startServer(true, true);

--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2FullTracingTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2FullTracingTests.java
@@ -56,8 +56,8 @@ public class Http2FullTracingTests extends FATServletClient {
             LOGGER.logp(Level.INFO, CLASS_NAME, "before()", "Starting servers...");
         }
 
-        H2FATApplicationHelper.addWarToServerDropins(server, "H2TestModule.war", false, "http2.test.war.servlets");
-        H2FATApplicationHelper.addWarToServerDropins(runtimeServer, "H2FATDriver.war", false, "http2.test.driver.war.servlets");
+        H2FATApplicationHelper.addWarToServerDropins(server, "H2TestModule.war", true, "http2.test.war.servlets");
+        H2FATApplicationHelper.addWarToServerDropins(runtimeServer, "H2FATDriver.war", true, "http2.test.driver.war.servlets");
 
         server.startServer(true, true);
         runtimeServer.startServer(true, true);

--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2LiteModeTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2LiteModeTests.java
@@ -58,8 +58,8 @@ public class Http2LiteModeTests extends FATServletClient {
             LOGGER.logp(Level.INFO, CLASS_NAME, "before()", "Starting servers...");
         }
 
-        H2FATApplicationHelper.addWarToServerDropins(server, "H2TestModule.war", false, "http2.test.war.servlets");
-        H2FATApplicationHelper.addWarToServerDropins(runtimeServer, "H2FATDriver.war", false, "http2.test.driver.war.servlets");
+        H2FATApplicationHelper.addWarToServerDropins(server, "H2TestModule.war", true, "http2.test.war.servlets");
+        H2FATApplicationHelper.addWarToServerDropins(runtimeServer, "H2FATDriver.war", true, "http2.test.driver.war.servlets");
 
         server.startServer(true, true);
         runtimeServer.startServer(true, true);

--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/MultiSessionTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/MultiSessionTests.java
@@ -55,8 +55,8 @@ public class MultiSessionTests extends FATServletClient {
         }
 
         // I think we need this for tracing to turn on (as well as changes in bootstrap.properties)
-        H2FATApplicationHelper.addWarToServerDropins(server, "H2TestModule.war", false, "http2.test.war.servlets");
-        H2FATApplicationHelper.addWarToServerDropins(runtimeServer, "H2FATDriver.war", false, "http2.test.driver.war.servlets");
+        H2FATApplicationHelper.addWarToServerDropins(server, "H2TestModule.war", true, "http2.test.war.servlets");
+        H2FATApplicationHelper.addWarToServerDropins(runtimeServer, "H2FATDriver.war", true, "http2.test.driver.war.servlets");
 
         server.startServer(true, true);
         runtimeServer.startServer(true);

--- a/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/resources/META-INF/permissions.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+    version="7">
+
+   <permission>
+       <class-name>java.security.SecurityPermission</class-name>
+       <name>getPolicy</name>
+   </permission>
+
+</permissions>

--- a/dev/com.ibm.ws.transport.http2_fat/test-applications/H2TestModule.war/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.transport.http2_fat/test-applications/H2TestModule.war/resources/META-INF/permissions.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+    version="7">
+
+   <permission>
+       <class-name>java.security.SecurityPermission</class-name>
+       <name>getPolicy</name>
+   </permission>
+
+</permissions>


### PR DESCRIPTION
Running locally on mac JDK 15 I see java 2 security warnings along the lines of 
```
0000002e kernel.launch.internal.MissingDoPrivDetectionSecurityManager W CWWKE0921W: Current Java 2 Security policy reported a potential violation of Java 2 Security Permission. Detected a possible missing doPriv statement. There was Liberty code between the check and the application code.
Permission: 
("java.security.SecurityPermission" "getPolicy")
Stack: 
java.security.AccessControlException: access denied ("java.security.SecurityPermission" "getPolicy")java.base/java.security.AccessControlContext.checkPermission(AccessControlContext.java:472)
```
The apps causing this warning need to have that `getPolicy` permission added to their `permissions.xml`.