### PR TITLE
WIP: Change from HashTable to HashMap

### DIFF
--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/websphere/servlet/filter/ChainedRequest.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/websphere/servlet/filter/ChainedRequest.java
@@ -17,6 +17,8 @@ import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.util.Enumeration;
 import java.util.Hashtable;
+import java.util.HashMap;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -30,6 +32,7 @@ import com.ibm.websphere.servlet.request.ServletInputStreamAdapter;
 import com.ibm.ws.webcontainer.servlet.RequestUtils;
 import com.ibm.wsspi.webcontainer.logging.LoggerFactory;
 import com.ibm.wsspi.webcontainer.WCCustomProperties; //PM35450
+import com.ibm.ws.webcontainer.util.Enumerator;
 
 /**
  *
@@ -53,7 +56,7 @@ protected static Logger logger = LoggerFactory.getInstance().getLogger("com.ibm.
     private HttpServletRequest _req;
     private ServletInputStream _in;
     private BufferedReader _reader;
-    private Hashtable _parameters = new Hashtable();
+    private HashMap _parameters = new HashMap();
     private Hashtable _headers = new Hashtable(); //@bkm
     
     private static TraceNLS nls = TraceNLS.getTraceNLS(ChainedRequest.class, "com.ibm.ws.webcontainer.resources.Messages");
@@ -172,7 +175,7 @@ protected static Logger logger = LoggerFactory.getInstance().getLogger("com.ibm.
         {
             parseParameters();
         }
-        return _parameters.keys();
+        return (new Enumerator<String>(_parameters.keySet()));
     }
 
     public String[] getParameterValues(String name)
@@ -214,12 +217,12 @@ protected static Logger logger = LoggerFactory.getInstance().getLogger("com.ibm.
             }
             if (_parameters == null)
             {
-                _parameters = new Hashtable();
+                _parameters = new HashMap();
             }
         }
     }
 
-    private Hashtable parsePostData(int len, ServletInputStream in)
+    private HashMap parsePostData(int len, ServletInputStream in)
     {
         int inputLen, offset;
         byte[] postedBytes = null;
@@ -250,7 +253,7 @@ protected static Logger logger = LoggerFactory.getInstance().getLogger("com.ibm.
         catch (IOException e)
         {
             com.ibm.wsspi.webcontainer.util.FFDCWrapper.processException(e, "com.ibm.websphere.servlet.filter.ChainedResponse.parsePostData", "326", this);
-            return new Hashtable();
+            return new HashMap();
         }
 
         // XXX we shouldn't assume that the only kind of POST body

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/servlet/RequestUtils.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/servlet/RequestUtils.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.AccessController;
 import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.StringTokenizer;
 
@@ -280,7 +281,7 @@ public class RequestUtils extends com.ibm.wsspi.webcontainer.util.RequestUtils
     }
     
     @SuppressWarnings("rawtypes")
-    public static Hashtable parsePostData(int len, ServletInputStream in, String encoding, boolean multireadPropertyEnabled) /* 157338 add throws */ throws IOException // MultiRead
+    public static HashMap parsePostData(int len, ServletInputStream in, String encoding, boolean multireadPropertyEnabled) /* 157338 add throws */ throws IOException // MultiRead
     {    
         String postedBody = getPostBody(len, in, encoding);
 
@@ -294,7 +295,7 @@ public class RequestUtils extends com.ibm.wsspi.webcontainer.util.RequestUtils
     }
     
     @SuppressWarnings("rawtypes")
-    public static Hashtable parsePostDataLong(long len, ServletInputStream in, String encoding, boolean multireadPropertyEnabled) throws IOException // MultiRead
+    public static HashMap parsePostDataLong(long len, ServletInputStream in, String encoding, boolean multireadPropertyEnabled) throws IOException // MultiRead
     {
         if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE))
             logger.logp(Level.FINE,CLASS_NAME,"parsePostDataLong","len = " + len, ", encoding = " + encoding);
@@ -347,7 +348,7 @@ public class RequestUtils extends com.ibm.wsspi.webcontainer.util.RequestUtils
     
     // begin 231634    Support posts with query parms in chunked body    WAS.webcontainer    
     @SuppressWarnings("rawtypes")
-    public static Hashtable parsePostData(ServletInputStream in, String encoding, boolean multireadPropertyEnabled) /* 157338 add throws */ throws IOException
+    public static HashMap parsePostData(ServletInputStream in, String encoding, boolean multireadPropertyEnabled) /* 157338 add throws */ throws IOException
     {
         int inputLen;
         byte[] postedBytes = null;

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTServletRequest.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/srt/SRTServletRequest.java
@@ -37,6 +37,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.Vector;
 import java.util.logging.Level;
@@ -79,6 +80,7 @@ import com.ibm.ws.webcontainer.osgi.collaborator.CollaboratorHelperImpl;
 import com.ibm.ws.webcontainer.servlet.RequestUtils;
 import com.ibm.ws.webcontainer.session.SessionManagerConfigBase;
 import com.ibm.ws.webcontainer.util.EmptyEnumeration;
+import com.ibm.ws.webcontainer.util.Enumerator;
 import com.ibm.ws.webcontainer.util.UnsynchronizedStack;
 import com.ibm.ws.webcontainer.webapp.WebApp;
 import com.ibm.ws.webcontainer.webapp.WebAppConfiguration;
@@ -1700,7 +1702,7 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
         if (WCCustomProperties.CHECK_REQUEST_OBJECT_IN_USE){
             checkRequestObjectInUse();
         }
-        Hashtable aParam = new Hashtable(3);
+        HashMap aParam = new HashMap(3);
         aParam.put(name, values);
         mergeQueryParams(aParam);
     }
@@ -1852,7 +1854,7 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
     // PK57679 End
 
 
-    public void setRawParameters(Hashtable params)
+    public void setRawParameters(HashMap params)
     {
         if (WCCustomProperties.CHECK_REQUEST_OBJECT_IN_USE){
             checkRequestObjectInUse();
@@ -1864,7 +1866,7 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
         SRTServletRequestThreadData.getInstance().setParameters(params);
     }
 
-    public Hashtable getRawParameters()
+    public HashMap getRawParameters()
     {
         if (WCCustomProperties.CHECK_REQUEST_OBJECT_IN_USE){
             checkRequestObjectInUse();
@@ -1874,7 +1876,7 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
             logger.logp(Level.FINE, CLASS_NAME,"getRawParameters", "");
         }
         parseParameters();
-        return (Hashtable) SRTServletRequestThreadData.getInstance().getParameters();
+        return (HashMap) SRTServletRequestThreadData.getInstance().getParameters();
     }
 
     /**
@@ -1912,7 +1914,7 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
     }
 
     /**
-     * Returns an enumeration of strings representing the parameter names
+     * Returns an Set of strings representing the parameter names
      * for this request.
      */
     public Enumeration getParameterNames()
@@ -1925,7 +1927,8 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
             checkRequestObjectInUse();
         }
         parseParameters();
-        return ((Hashtable) SRTServletRequestThreadData.getInstance().getParameters()).keys();
+        return (new Enumerator<String>(SRTServletRequestThreadData.getInstance().getParameters().keySet()));
+       // return ( SRTServletRequestThreadData.getInstance().getParameters()).keys();
     }
 
     /**
@@ -2316,7 +2319,7 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
 
         try
         {
-            reqData.setParameters(new Hashtable());
+            reqData.setParameters(new HashMap());
             String ct = getContentType();
 
             if (ct != null)
@@ -2506,12 +2509,12 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
         // end pq70055: part 2
         if (reqData.getParameters() == null)
         {
-            reqData.setParameters(new Hashtable());
+            reqData.setParameters(new HashMap());
         }
     }
 
     // Added for servlet 3.1 support - method is overidden by SRTServletRequest31 
-    protected Hashtable parsePostData() throws IOException {
+    protected HashMap parsePostData() throws IOException {
         if( getContentLength() > 0){
             if (TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE))  //306998.15
                 logger.logp(Level.FINE, CLASS_NAME,"parsePostData", "parsing post data based upon content length");
@@ -2532,7 +2535,7 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
             checkRequestObjectInUse();
         }
         SRTServletRequestThreadData reqData = SRTServletRequestThreadData.getInstance();
-        Hashtable tmpQueryParams = null;
+        HashMap tmpQueryParams = null;
         LinkedList queryStringList = SRTServletRequestThreadData.getInstance().getQueryStringList();
         if (queryStringList ==null || queryStringList.isEmpty()){ //258025
             String queryString = getQueryString();
@@ -2557,19 +2560,19 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
                 if (TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)) {  //306998.15
                     logger.logp(Level.FINE, CLASS_NAME,"parseQueryStringList", "queryString --> " + queryString);
                 }
-                if (qsListItem._qsHashtable != null)
-                    mergeQueryParams(qsListItem._qsHashtable);
+                if (qsListItem._qsHashmap != null)
+                    mergeQueryParams(qsListItem._qsHashmap);
                 else if (queryString != null && ((queryString.indexOf('=') != -1) || WCCustomProperties.ALLOW_QUERY_PARAM_WITH_NO_EQUAL))//PM35450
                 {
                     if (reqData.getParameters() == null || reqData.getParameters().isEmpty())// 258025
                     {
-                        qsListItem._qsHashtable = RequestUtils.parseQueryString(queryString, getReaderEncoding());
-                        reqData.setParameters(qsListItem._qsHashtable);
+                        qsListItem._qsHashmap = RequestUtils.parseQueryString(queryString, getReaderEncoding());
+                        reqData.setParameters(qsListItem._qsHashmap);
                         qsListItem._qs = null;
                     }
                     else{
                         tmpQueryParams = RequestUtils.parseQueryString(queryString, getReaderEncoding());
-                        qsListItem._qsHashtable = tmpQueryParams;
+                        qsListItem._qsHashmap = tmpQueryParams;
                         qsListItem._qs = null;
                         mergeQueryParams(tmpQueryParams);
                     }
@@ -2579,7 +2582,7 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
     }
 
     // End 256836
-    private void mergeQueryParams(Hashtable tmpQueryParams)
+    private void mergeQueryParams(HashMap tmpQueryParams)
     {
         if (TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)) {  //306998.15
             logger.logp(Level.FINE, CLASS_NAME,"mergeQueryParams", "");
@@ -2595,10 +2598,10 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
                 logger.logp(Level.FINE, CLASS_NAME,"mergeQueryParams", "tmpQueryParams.size() " + tmpQueryParams.size());
                 logger.logp(Level.FINE, CLASS_NAME,"mergeQueryParams", "tmpQueryParams " + tmpQueryParams);
             }
-            Enumeration enumeration = tmpQueryParams.keys();
-            while (enumeration.hasMoreElements())
+            Iterator it = tmpQueryParams.keySet().iterator();
+            while (it.hasNext())
             {
-                Object key = enumeration.nextElement();
+                Object key = it.next();
                 // Check for QueryString parms with the same name
                 // pre-append to postdata values if necessary
                 if (reqData.getParameters() != null && reqData.getParameters().containsKey(key))
@@ -2628,7 +2631,7 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
                 else
                 {
                     if (reqData.getParameters() == null) // PK14900
-                        reqData.setParameters(new Hashtable());// PK14900
+                        reqData.setParameters(new HashMap());// PK14900
                     reqData.getParameters().put(key, tmpQueryParams.get(key));
                     if (TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE))  //306998.15
                     {
@@ -2640,7 +2643,7 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
     }
 
     // Begin 256836
-    private void removeQueryParams(Hashtable tmpQueryParams)
+    private void removeQueryParams(HashMap tmpQueryParams)
     {
         if (TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)) {  //306998.15
             logger.logp(Level.FINE, CLASS_NAME,"removeQueryParams", "");
@@ -2656,10 +2659,10 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
                 logger.logp(Level.FINE, CLASS_NAME,"removeQueryParams", "tmpQueryParams.size() " + tmpQueryParams.size());
                 logger.logp(Level.FINE, CLASS_NAME,"removeQueryParams", "tmpQueryParams " + tmpQueryParams);
             }
-            Enumeration enumeration = tmpQueryParams.keys();
-            while (enumeration.hasMoreElements())
+            Iterator it = tmpQueryParams.keySet().iterator();
+            while (it.hasNext())
             {
-                Object key = enumeration.nextElement();
+                Object key = it.next();
                 // Check for QueryString parms with the same name
                 // pre-append to postdata values if necessary
                 if (reqData.getParameters().containsKey(key))
@@ -2862,7 +2865,7 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
             reqData.pushParameterStack(null);
         } else
         {
-            _paramStack.push(((Hashtable) reqData.getParameters()).clone());
+            _paramStack.push(((HashMap) reqData.getParameters()).clone());
         }
         if (TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE) && reqData.getParameters() !=null)  //306998.15
         {
@@ -2885,7 +2888,7 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
 
         try
         {
-            SRTServletRequestThreadData.getInstance().setParameters((Hashtable) _paramStack.pop());
+            SRTServletRequestThreadData.getInstance().setParameters((HashMap) _paramStack.pop());
         } catch (java.util.EmptyStackException empty)
         {
             if (TraceComponent.isAnyTracingEnabled()&&logger.isLoggable (Level.FINE)) {  //306998.15
@@ -2950,7 +2953,7 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
             if (reqData.getParameters()==null&&_tmpParameters!=null) // Parameters above current inluce/forward were never parsed
             {
                 reqData.setParameters(_tmpParameters);
-                Hashtable tmpQueryParams = ((QSListItem) queryStringList.getLast())._qsHashtable;
+                HashMap tmpQueryParams = ((QSListItem) queryStringList.getLast())._qsHashmap;
                 if (tmpQueryParams == null)
                 {
                     tmpQueryParams = RequestUtils.parseQueryString(((QSListItem) queryStringList.getLast())._qs, getReaderEncoding(true));
@@ -3016,12 +3019,12 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
         // if _parameters is null, then the string will be parsed if needed
         if (reqData.getParameters() != null && additionalQueryString != null)
         {
-            Hashtable parameters = RequestUtils.parseQueryString(additionalQueryString, getReaderEncoding(true));
+            HashMap parameters = RequestUtils.parseQueryString(additionalQueryString, getReaderEncoding(true));
+
             // end 249841, 256836
             String[] valArray;
-            for (Enumeration e = parameters.keys(); e.hasMoreElements();)
+            for (String key : (Set<String>) parameters.keySet())
             {
-                String key = (String) e.nextElement();
                 String[] newVals = (String[]) parameters.get(key);
 
                 // Check to see if a parameter with the key already exists
@@ -3436,10 +3439,10 @@ public class SRTServletRequest implements HttpServletRequest, IExtendedRequest, 
     class QSListItem
     {
         String _qs = null;
-        Hashtable _qsHashtable = null;
-        QSListItem(String qs, Hashtable qsHashtable){
+        HashMap _qsHashmap = null;
+        QSListItem(String qs, HashMap qsHashmap){
             _qs = qs;
-            _qsHashtable = qsHashtable;
+            _qsHashmap = qsHashmap;
         }
     }
 

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/util/Enumerator.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/util/Enumerator.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2004 The Apache Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ibm.ws.webcontainer.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+
+/**
+ * Adapter class that wraps an <code>Enumeration</code> around a Java2
+ * collection classes object <code>Iterator</code> so that existing APIs
+ * returning Enumerations can easily run on top of the new collections.
+ * Constructors are provided to easliy create such wrappers.
+ *
+ * @author Craig R. McClanahan
+ * @version $Revision: 1.2 $ $Date: 2005/12/08 01:28:15 $
+ */
+
+public final class Enumerator<T> implements Enumeration<T> {
+
+
+    // ----------------------------------------------------------- Constructors
+
+
+    /**
+     * Return an Enumeration over the values of the specified Collection.
+     *
+     * @param collection Collection whose values should be enumerated
+     */
+    public Enumerator(Collection<T> collection) {
+
+        this(collection.iterator());
+
+    }
+
+
+    /**
+     * Return an Enumeration over the values of the specified Collection.
+     *
+     * @param collection Collection whose values should be enumerated
+     * @param clone true to clone iterator
+     */
+    public Enumerator(Collection<T> collection, boolean clone) {
+
+        this(collection.iterator(), clone);
+
+    }
+
+
+    /**
+     * Return an Enumeration over the values returned by the
+     * specified Iterator.
+     *
+     * @param iterator Iterator to be wrapped
+     */
+    public Enumerator(Iterator<T> iterator) {
+        this.iterator = iterator;
+
+    }
+
+
+    /**
+     * Return an Enumeration over the values returned by the
+     * specified Iterator.
+     *
+     * @param iterator Iterator to be wrapped
+     * @param clone true to clone iterator
+     */
+    public Enumerator(Iterator<T> iterator, boolean clone) {
+        if (!clone) {
+            this.iterator = iterator;
+        } else {
+            List<T> list = new ArrayList<T>();
+            while (iterator.hasNext()) {
+                list.add(iterator.next());
+            }
+            this.iterator = list.iterator();   
+        }
+
+    }
+
+
+    /**
+     * Return an Enumeration over the values of the specified Map.
+     *
+     * @param map Map whose values should be enumerated
+     */
+    public Enumerator(Map<?, T> map) {
+
+        this(map.values().iterator());
+
+    }
+
+
+    /**
+     * Return an Enumeration over the values of the specified Map.
+     *
+     * @param map Map whose values should be enumerated
+     * @param clone true to clone iterator
+     */
+    public Enumerator(Map<?, T> map, boolean clone) {
+
+        this(map.values().iterator(), clone);
+
+    }
+
+
+    // ----------------------------------------------------- Instance Variables
+
+
+    /**
+     * The <code>Iterator</code> over which the <code>Enumeration</code>
+     * represented by this class actually operates.
+     */
+    private Iterator<T> iterator;
+
+
+    // --------------------------------------------------------- Public Methods
+
+
+    /**
+     * Tests if this enumeration contains more elements.
+     *
+     * @return <code>true</code> if and only if this enumeration object
+     *  contains at least one more element to provide, <code>false</code>
+     *  otherwise
+     */
+    @Override
+    public boolean hasMoreElements() {
+
+        return iterator.hasNext();
+
+    }
+
+
+    /**
+     * Returns the next element of this enumeration if this enumeration
+     * has at least one more element to provide.
+     *
+     * @return the next element of this enumeration
+     *
+     * @exception NoSuchElementException if no more elements exist
+     */
+    @Override
+    public T nextElement() throws NoSuchElementException {
+
+        return iterator.next();
+
+    }
+
+
+}

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/util/RequestUtils.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/util/RequestUtils.java
@@ -13,6 +13,7 @@ package com.ibm.wsspi.webcontainer.util;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.text.MessageFormat;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.logging.Level;
@@ -84,12 +85,12 @@ public class RequestUtils {
     *
     */
     @SuppressWarnings("rawtypes")
-    static public Hashtable parseQueryString(String s) {
+    static public HashMap parseQueryString(String s) {
         return parseQueryString(new StringQueryString(s), SHORT_ENGLISH);
     }
 
     @SuppressWarnings("rawtypes")
-    static public Hashtable parseQueryString(String s, String encoding) {
+    static public HashMap parseQueryString(String s, String encoding) {
         return parseQueryString(new StringQueryString(s), encoding);
     }
 
@@ -522,13 +523,13 @@ public class RequestUtils {
     }
 
     @SuppressWarnings("rawtypes")
-    static private Hashtable parseQueryString(QueryString qs, String encoding) {
+    static private HashMap parseQueryString(QueryString qs, String encoding) {
         if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) { //PK75617
             logger.entering(CLASS_NAME, "parseQueryString( QueryString , encoding --> [" + encoding + "])"); //PM35450.1
         } //PK75617
         int totalSize = 0; //PM53930
         int dupSize = 0; // 728397
-        Hashtable<String, String[]> ht = new Hashtable<>();
+        HashMap<String, String[]> ht = new HashMap<>();
         HashSet<Integer> key_hset = new HashSet<>(); // 728397
         // PK23256 begin
         boolean encoding_is_ShortEnglish = isShortEnglishEncoding(encoding);
@@ -628,7 +629,7 @@ public class RequestUtils {
     }
 
     @SuppressWarnings("rawtypes")
-    static public Hashtable parseQueryString(char[][] cha, String encoding) {
+    static public HashMap parseQueryString(char[][] cha, String encoding) {
         if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE)) { //PK75617
             logger.entering(CLASS_NAME, "parseQueryString( query , encoding --> [" + encoding + "])"); //PM35450.1
         }                                                                                            //PK75617
@@ -639,7 +640,7 @@ public class RequestUtils {
 
         // Call optimized version if there is only 1 char[]
         if (cha.length == 1) {
-            Hashtable returnValue = parseQueryString(new CharArrayQueryString(cha[0]), encoding);
+            HashMap returnValue = parseQueryString(new CharArrayQueryString(cha[0]), encoding);
             cha[0] = null;
             return returnValue;
         }

--- a/dev/com.ibm.ws.webcontainer/test/com/ibm/ws/webcontainer/util/RequestUtilsTest.java
+++ b/dev/com.ibm.ws.webcontainer/test/com/ibm/ws/webcontainer/util/RequestUtilsTest.java
@@ -12,7 +12,7 @@ package com.ibm.ws.webcontainer.util;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.util.Hashtable;
+import java.util.HashMap;
 
 import org.junit.Test;
 
@@ -43,7 +43,7 @@ public class RequestUtilsTest {
         }
     }
 
-    private void validateParams(Hashtable params, String[] expectedKeys, String[][] expectedValues) {
+    private void validateParams(HashMap params, String[] expectedKeys, String[][] expectedValues) {
         Assert.assertEquals(expectedKeys.length, params.size());
         for (int i = 0; i < expectedKeys.length; ++i) {
             String[] val = (String[]) params.get(expectedKeys[i]);
@@ -56,7 +56,7 @@ public class RequestUtilsTest {
     }
 
     private void testString(String queryString, String encoding, String[] keys, String[][] values) throws Exception {
-        Hashtable params = RequestUtils.parseQueryString(queryString, encoding);
+        HashMap params = RequestUtils.parseQueryString(queryString, encoding);
         validateParams(params, keys, values);
     }
     
@@ -82,7 +82,7 @@ public class RequestUtilsTest {
             optimizedCase[0][i] = queryString.charAt(i);
         }
 
-        Hashtable params = RequestUtils.parseQueryString(optimizedCase, encoding);
+        HashMap params = RequestUtils.parseQueryString(optimizedCase, encoding);
         validateParams(params, keys, values);
 
         Assert.assertNull(optimizedCase[0]);


### PR DESCRIPTION
Draft -- We might need to use something other than a HashMap. Maybe this PR may not be deemed necessary. Or, alternatively, we can use #16531. 

Fixes #16589

Comments 
- Copied Enumerator.java from GlassFish 

Concerns
- Thread Safety / Synchronization 
  - Thought of using ConcurrentHashMap, but documentation had `Like Hashtable but unlike HashMap, this class does not allow null to be used as a key or value. ` And we want null values. 
  - _Collections.synchronizedMap_ may the preferred solution here. 
