### PR TITLE
Upgrade Arquillian version to 1.3.0.Final in MP TCKs

### DIFF
--- a/dev/com.ibm.ws.microprofile.faulttolerance_git_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_git_fat_tck/publish/tckRunner/pom.xml
@@ -24,7 +24,7 @@
     <name>MicroProfile Fault Tolerance TCK Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/pom.xml
@@ -19,7 +19,7 @@
     <name>MicroProfile GraphQL TCK Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/pom.xml
@@ -136,7 +136,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>${arquillian.version}</version>
+            <version>1.1.14.Final</version>
         </dependency>
 
         <dependency>

--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <microprofile.graphql.version>1.0.2</microprofile.graphql.version>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.metrics.1.1.noAuth_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1.noAuth_fat_tck/publish/tckRunner/pom.xml
@@ -24,7 +24,7 @@
     <name>MicroProfile Metrics TCK 1.1 Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/dev/com.ibm.ws.microprofile.metrics.1.1.noAuth_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1.noAuth_fat_tck/publish/tckRunner/tck/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <microprofile.metrics.version>1.1.1</microprofile.metrics.version>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/publish/tckRunner/pom.xml
@@ -24,7 +24,7 @@
     <name>MicroProfile Metrics TCK 1.1 Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <microprofile.metrics.version>1.1.3</microprofile.metrics.version>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.metrics.2.0_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0_fat_tck/publish/tckRunner/pom.xml
@@ -24,7 +24,7 @@
     <name>MicroProfile Metrics TCK 2.0.1 Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/dev/com.ibm.ws.microprofile.metrics.2.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <microprofile.metrics.version>2.0.4</microprofile.metrics.version>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.metrics.2.2_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.2_fat_tck/publish/tckRunner/pom.xml
@@ -24,7 +24,7 @@
     <name>MicroProfile Metrics TCK 2.2 Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/dev/com.ibm.ws.microprofile.metrics.2.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <microprofile.metrics.version>2.2.3</microprofile.metrics.version>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.metrics.2.3_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.3_fat_tck/publish/tckRunner/pom.xml
@@ -24,7 +24,7 @@
     <name>MicroProfile Metrics TCK 2.3 Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/dev/com.ibm.ws.microprofile.metrics.2.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics.2.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <microprofile.metrics.version>2.3.3</microprofile.metrics.version>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.metrics_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics_fat_tck/publish/tckRunner/pom.xml
@@ -24,7 +24,7 @@
     <name>MicroProfile Metrics TCK 1.0 Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/dev/com.ibm.ws.microprofile.metrics_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.metrics_fat_tck/publish/tckRunner/tck/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <microprofile.metrics.version>1.0.2</microprofile.metrics.version>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.openapi.1.1_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.microprofile.openapi.1.1_fat_tck/publish/tckRunner/pom.xml
@@ -19,7 +19,7 @@
     <name>MicroProfile OpenAPI TCK Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/dev/com.ibm.ws.microprofile.openapi.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.openapi.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>${arquillian.version}</version>
+            <version>1.1.14.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dev/com.ibm.ws.microprofile.openapi.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.openapi.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <microprofile.openapi.version>1.1.2</microprofile.openapi.version>
         <surefire.version>2.17</surefire.version> <!-- Any changes to the surefire version must be tested against ZOS -->
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
         <arquillian-wlp.version>1.0.0.Final-SNAPSHOT</arquillian-wlp.version>
 
         <suiteXmlFile>${defaultSuiteFiles}</suiteXmlFile>

--- a/dev/com.ibm.ws.microprofile.openapi_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.microprofile.openapi_fat_tck/publish/tckRunner/pom.xml
@@ -19,7 +19,7 @@
     <name>MicroProfile OpenAPI TCK Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/dev/com.ibm.ws.microprofile.openapi_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.openapi_fat_tck/publish/tckRunner/tck/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>${arquillian.version}</version>
+            <version>1.1.14.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dev/com.ibm.ws.microprofile.openapi_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.openapi_fat_tck/publish/tckRunner/tck/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <microprofile.openapi.version>1.0.1</microprofile.openapi.version>
         <surefire.version>2.17</surefire.version> <!-- Any changes to the surefire version must be tested against ZOS -->
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
         <arquillian-wlp.version>1.0.0.Final-SNAPSHOT</arquillian-wlp.version>
 
         <suiteXmlFile>${defaultSuiteFiles}</suiteXmlFile>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/publish/tckRunner/pom.xml
@@ -19,7 +19,7 @@
     <name>MicroProfile Opentracing TCK Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>${arquillian.version}</version>
+            <version>1.1.14.Final</version>
         </dependency>
 
         <dependency>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <microprofile.opentracing.version>1.1.2</microprofile.opentracing.version>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/publish/tckRunner/pom.xml
@@ -19,7 +19,7 @@
     <name>MicroProfile Opentracing TCK Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <microprofile.opentracing.version>1.2.3</microprofile.opentracing.version>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>${arquillian.version}</version>
+            <version>1.1.14.Final</version>
         </dependency>
 
         <dependency>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/publish/tckRunner/pom.xml
@@ -19,7 +19,7 @@
     <name>MicroProfile Opentracing TCK Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>${arquillian.version}</version>
+            <version>1.1.14.Final</version>
         </dependency>
 
         <dependency>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <microprofile.opentracing.version>1.3.3</microprofile.opentracing.version>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.opentracing_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing_fat_tck/publish/tckRunner/pom.xml
@@ -19,7 +19,7 @@
     <name>MicroProfile Opentracing TCK Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/dev/com.ibm.ws.microprofile.opentracing_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing_fat_tck/publish/tckRunner/tck/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>${arquillian.version}</version>
+            <version>1.1.14.Final</version>
         </dependency>
 
         <dependency>

--- a/dev/com.ibm.ws.microprofile.opentracing_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <microprofile.opentracing.version>1.0.3</microprofile.opentracing.version>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_git_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_git_fat_tck/publish/tckRunner/pom.xml
@@ -24,7 +24,7 @@
     <name>MicroProfile Reactive Messaging TCK Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/pom.xml
@@ -19,7 +19,7 @@
     <name>MicroProfile RestClient 1.1 TCK Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/pom-manual.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/pom-manual.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <microprofile.rest.client.version>1.1</microprofile.rest.client.version>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
         <!-- <wlp>${wlp}</wlp>  -->

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/pom-manual.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/pom-manual.xml
@@ -184,7 +184,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>${arquillian.version}</version>
+            <version>1.1.14.Final</version>
         </dependency>
 
         <dependency>

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <microprofile.rest.client.version>1.1</microprofile.rest.client.version>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/pom.xml
@@ -199,7 +199,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>${arquillian.version}</version>
+            <version>1.1.14.Final</version>
         </dependency>
 
         <dependency>

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/pom.xml
@@ -19,7 +19,7 @@
     <name>MicroProfile RestClient 1.2 TCK Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom-manual.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom-manual.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <microprofile.rest.client.version>1.2.1</microprofile.rest.client.version>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
         <!-- <wlp>${wlp}</wlp>  -->

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom-manual.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom-manual.xml
@@ -176,7 +176,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>${arquillian.version}</version>
+            <version>1.1.14.Final</version>
         </dependency>
 
         <dependency>

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <microprofile.rest.client.version>1.2.2-20210215</microprofile.rest.client.version>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom.xml
@@ -210,7 +210,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>${arquillian.version}</version>
+            <version>1.1.14.Final</version>
         </dependency>
 
         <dependency>

--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/pom.xml
@@ -19,7 +19,7 @@
     <name>MicroProfile RestClient 1.3 TCK Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/pom.xml
@@ -209,7 +209,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>${arquillian.version}</version>
+            <version>1.1.14.Final</version>
         </dependency>
 
         <dependency>

--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <microprofile.rest.client.version>1.3.5-20210215</microprofile.rest.client.version>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/pom.xml
@@ -19,7 +19,7 @@
     <name>MicroProfile RestClient 1.4 TCK Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <microprofile.rest.client.version>1.4.2-20210215</microprofile.rest.client.version>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/pom.xml
@@ -209,7 +209,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>${arquillian.version}</version>
+            <version>1.1.14.Final</version>
         </dependency>
 
         <dependency>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/pom.xml
@@ -19,7 +19,7 @@
     <name>MicroProfile RestClient TCK Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom-manual.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom-manual.xml
@@ -150,7 +150,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>${arquillian.version}</version>
+            <version>1.1.14.Final</version>
         </dependency>
 
         <dependency>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom-manual.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom-manual.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <microprofile.rest.client.version>1.0</microprofile.rest.client.version>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
         <!-- <wlp>${wlp}</wlp>  -->

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <microprofile.rest.client.version>1.0</microprofile.rest.client.version>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom.xml
@@ -160,7 +160,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>${arquillian.version}</version>
+            <version>1.1.14.Final</version>
         </dependency>
 
         <dependency>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.0_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0_fat_tck/publish/tckRunner/pom.xml
@@ -24,7 +24,7 @@
     <name>MicroProfile Metrics TCK 3.0 Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/dev/io.openliberty.microprofile.metrics.internal.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <microprofile.metrics.version>3.0</microprofile.metrics.version>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/publish/tckRunner/pom.xml
@@ -19,7 +19,7 @@
     <name>MicroProfile OpenAPI TCK Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -18,7 +18,7 @@
         <surefire.version>2.19.1</surefire.version>
 -->
 <!-- 
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
  -->
         <arquillian.version>1.6.0.Final</arquillian.version>
         <arquillian-wlp.version>1.0.5</arquillian-wlp.version>

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/publish/tckRunner/pom.xml
@@ -19,7 +19,7 @@
     <name>MicroProfile Opentracing TCK Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>${arquillian.version}</version>
+            <version>1.1.14.Final</version>
         </dependency>
 
         <dependency>

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/pom.xml
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/pom.xml
@@ -19,7 +19,7 @@
     <name>MicroProfile RestClient 2.0 TCK Runner</name>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -242,7 +242,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>${arquillian.version}</version>
+            <version>1.1.14.Final</version>
         </dependency>
 
         <dependency>

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <microprofile.rest.client.version>2.0.1-20210208</microprofile.rest.client.version>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.3.0.Final</arquillian.version>
 
         <!-- the below is used in arquillian.xml -->
         <wlp>${wlp}</wlp>


### PR DESCRIPTION
Upgrading Arquillian from `1.1.3.Final` to `1.3.0.Final` in MicroProfile TCKs.