### PR TITLE
16563 add exports for dump action for java16

### DIFF
--- a/dev/com.ibm.ws.request.timing.hung_fat/fat/src/com/ibm/ws/request/timing/hung/fat/HungRequestEnableThreadDumps.java
+++ b/dev/com.ibm.ws.request.timing.hung_fat/fat/src/com/ibm/ws/request/timing/hung/fat/HungRequestEnableThreadDumps.java
@@ -34,11 +34,12 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 
 /**
  *
- * This test class contains test cases that test the Hung Request Timing server configuration attribute enableThreadDumps, when enabl
+ * This test class contains test cases that test the Hung Request Timing server configuration attribute enableThreadDumps.
  *
  */
 @RunWith(FATRunner.class)
@@ -52,8 +53,14 @@ public class HungRequestEnableThreadDumps {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        JavaInfo java = JavaInfo.forCurrentVM();
         ShrinkHelper.defaultDropinApp(server, "TestWebApp", "com.ibm.testwebapp");
-        CommonTasks.writeLogMsg(Level.INFO, " Starting server..");
+        int javaVersion = java.majorVersion();
+        if (javaVersion != 8) {
+            CommonTasks.writeLogMsg(Level.INFO, " Java version = " + javaVersion + " - It is higher than 8, adding --add-exports...");
+            server.copyFileToLibertyServerRoot("add-exports/jvm.options");
+        }
+        CommonTasks.writeLogMsg(Level.INFO, " Starting server...");
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.request.timing.hung_fat/fat/src/com/ibm/ws/request/timing/hung/fat/HungRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing.hung_fat/fat/src/com/ibm/ws/request/timing/hung/fat/HungRequestTiming.java
@@ -47,6 +47,7 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
@@ -64,8 +65,14 @@ public class HungRequestTiming {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        JavaInfo java = JavaInfo.forCurrentVM();
         ShrinkHelper.defaultDropinApp(server, "TestWebApp", "com.ibm.testwebapp");
-        CommonTasks.writeLogMsg(Level.INFO, " starting server..");
+        int javaVersion = java.majorVersion();
+        if (javaVersion != 8) {
+            CommonTasks.writeLogMsg(Level.INFO, " Java version = " + javaVersion + " - It is higher than 8, adding --add-exports...");
+            server.copyFileToLibertyServerRoot("add-exports/jvm.options");
+        }
+        CommonTasks.writeLogMsg(Level.INFO, " starting server...");
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.request.timing.hung_fat/publish/files/add-exports/jvm.options
+++ b/dev/com.ibm.ws.request.timing.hung_fat/publish/files/add-exports/jvm.options
@@ -1,0 +1,3 @@
+# for dump action: com.ibm.ws.kernel.boot.internal.commands.HotSpotJavaDumperImpl$VirtualMachine.remoteDataDump(HotSpotJavaDumperImpl.java:342)
+--add-exports
+jdk.attach/sun.tools.attach=ALL-UNNAMED

--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/TimingRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/TimingRequestTiming.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -39,6 +39,7 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
@@ -60,8 +61,14 @@ public class TimingRequestTiming {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        JavaInfo java = JavaInfo.forCurrentVM();
         ShrinkHelper.defaultDropinApp(server, "jdbcTestPrj_3", "com.ibm.ws.request.timing");
-        CommonTasks.writeLogMsg(Level.INFO, " starting server..");
+        int javaVersion = java.majorVersion();
+        if (javaVersion != 8) {
+            CommonTasks.writeLogMsg(Level.INFO, " Java version = " + javaVersion + " - It is higher than 8, adding --add-exports...");
+            server.copyFileToLibertyServerRoot("add-exports/jvm.options");
+        }
+        CommonTasks.writeLogMsg(Level.INFO, " starting server...");
         server.startServer();
     }
 

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/add-exports/jvm.options
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/add-exports/jvm.options
@@ -1,0 +1,3 @@
+# for dump action: com.ibm.ws.kernel.boot.internal.commands.HotSpotJavaDumperImpl$VirtualMachine.remoteDataDump(HotSpotJavaDumperImpl.java:342)
+--add-exports
+jdk.attach/sun.tools.attach=ALL-UNNAMED


### PR DESCRIPTION
fixes #16563
- When using Java16 Hotspot, java.lang.IllegalAccessException occurs, when trying to create thread dumps. Used the `--add-exports jdk.attach/sun.tools.attach=ALL-UNNAMED`, to resolve this.