### PR TITLE
Move beta flag setting earlier in bootstrap

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/BootstrapConfig.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/BootstrapConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2019 IBM Corporation and others.
+ * Copyright (c) 2010, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -36,6 +36,7 @@ import com.ibm.ws.kernel.boot.internal.KernelResolver;
 import com.ibm.ws.kernel.boot.internal.KernelUtils;
 import com.ibm.ws.kernel.boot.internal.PasswordGenerator;
 import com.ibm.ws.kernel.boot.internal.ServerLock;
+import com.ibm.ws.kernel.productinfo.ProductInfo;
 
 public class BootstrapConfig {
     /** ${} */
@@ -129,6 +130,8 @@ public class BootstrapConfig {
             });
         } catch (Exception ex) {
         }
+
+        ProductInfo.setBetaEditionJVMProperty();
 
         bootstrapLib = fbootstrapLib;
 

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/location/internal/Activator.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/location/internal/Activator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2020 IBM Corporation and others.
+ * Copyright (c) 2010, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -55,7 +55,6 @@ public class Activator implements BundleActivator {
             context.registerService(WsLocationAdmin.class.getName(), locServiceImpl, locServiceImpl.getServiceProps());
             VariableRegistryHelper variableRegistry = new VariableRegistryHelper();
             context.registerService(VariableRegistry.class.getName(), variableRegistry, null);
-            ProductInfo.setBetaEditionJVMProperty();
 
             // Assume this is the first place that tries to set this
             try {


### PR DESCRIPTION
Currently we set the flag that the server is in beta in an OSGi bundle activator.
This means it cannot be read early in startup by things like logging, or even things
that start sooner than the OSGi bundle that currently activates it. So moving it much
sooner in the startup routine. ProductInfo doesn't rely on anything setup in bootstrap
so can be called at any point safely.