### PR TITLE
Ensure JAX-RS JsonPProvider can work in Java SE environment

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/bnd.bnd
@@ -43,5 +43,6 @@
   javax.activation:activation;version=1.1
 
 -testpath: \
-	../build.sharedResources/lib/junit/old/junit.jar;version=file
+	../build.sharedResources/lib/junit/old/junit.jar;version=file,\
+	com.ibm.ws.org.glassfish.json.1.1
   

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs21/providers/json/JsonPProvider.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/com/ibm/ws/jaxrs21/providers/json/JsonPProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -46,8 +46,19 @@ public class JsonPProvider implements MessageBodyReader<Object>, MessageBodyWrit
 
     JsonProvider jsonProvider = null;
 
+    @FFDCIgnore(Throwable.class)
     public JsonPProvider(JsonProvider jsonProvider) {
-        this.jsonProvider = jsonProvider;
+        if(jsonProvider != null) {
+            this.jsonProvider = jsonProvider;
+        } else {
+            try {
+                this.jsonProvider = JsonProvider.provider();
+            } catch (Throwable t) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Unable to find a valid JSON-P provider implemenation", t);
+                }
+            }
+        }
     }
 
     @Override

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/test/com/ibm/ws/jaxrs21/providers/json/JavaSEJsonPProviderTest.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/test/com/ibm/ws/jaxrs21/providers/json/JavaSEJsonPProviderTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jaxrs21.providers.json;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.StringReader;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+
+import org.junit.Test;
+
+/**
+ * Tests that JsonPProvider will function in a Java SE environment
+ */
+public class JavaSEJsonPProviderTest {
+
+    @Test
+    public void testJsonPProvider() throws Exception {
+        JsonPProvider provider = new JsonPProvider(null);
+        ByteArrayInputStream in = new ByteArrayInputStream("{\"str\": \"foo\", \"num\": 123}".getBytes());
+        JsonObject jsonObject = (JsonObject) provider.readFrom(null, null, null, null, null, in);
+        assertNotNull(jsonObject);
+        assertEquals("foo", jsonObject.getString("str"));
+        assertEquals(123, jsonObject.getInt("num"));
+        
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        provider.writeTo(jsonObject, null, null, null, null, null, out);
+        String jsonOutput = out.toString();
+        assertNotNull(jsonOutput);
+        
+        JsonReader jsonReader = Json.createReader(new StringReader(jsonOutput));
+        JsonObject jsonObject2 = jsonReader.readObject();
+        assertNotNull(jsonObject2);
+        assertEquals("foo", jsonObject2.getString("str"));
+        assertEquals(123, jsonObject2.getInt("num"));
+    }
+}


### PR DESCRIPTION
The JsonPProvider that we ship with JAX-RS 2.1 works fine in OSGi environments (Liberty), but fails when run outside of Liberty.  This is because it depends on the JSON-P provider to be set using OSGi services.  This change enables the JsonPProvider message body reader/writer to function outside of Liberty so long as the JSON-P 1.1 APIs and a valid implementation are present on the classpath.