### PR TITLE
Update to use StandardCharsets for UTF-8 and ISO-8859-1

### DIFF
--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobInstanceEntity.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/persistence/jpa/JobInstanceEntity.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package com.ibm.jbatch.container.persistence.jpa;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -185,20 +185,12 @@ public class JobInstanceEntity implements JobInstance, WSJobInstance, EntityCons
 
     @Override
     public String getJobXml() {
-        try {
-            return (jobXml == null ? null : new String(jobXml, "UTF-8"));
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalStateException("Problem with UTF-8 encoding", e);
-        }
+        return (jobXml == null ? null : new String(jobXml, StandardCharsets.UTF_8));
     }
 
     public void setJobXml(String jobXml) {
-        try {
-            if (jobXml != null) {
-                this.jobXml = jobXml.getBytes("UTF-8");
-            }
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalStateException("Problem with UTF-8 encoding", e);
+        if (jobXml != null) {
+            this.jobXml = jobXml.getBytes(StandardCharsets.UTF_8);
         }
     }
 

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/JobXMLSource.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/services/impl/JobXMLSource.java
@@ -1,13 +1,13 @@
 /*
  * Copyright 2014 International Business Machines Corp.
- * 
+ *
  * See the NOTICE file distributed with this work for additional information
- * regarding copyright ownership. Licensed under the Apache License, 
+ * regarding copyright ownership. Licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import javax.batch.operations.BatchRuntimeException;
 import javax.xml.transform.stream.StreamSource;
@@ -29,48 +30,48 @@ import com.ibm.jbatch.container.ws.impl.IOUtils;
 
 public class JobXMLSource implements IJobXMLSource {
 
-	private StreamSource strSource;
-	private String jobXML;
-	private URL url;
+    private StreamSource strSource;
+    private String jobXML;
+    private URL url;
 
-	public JobXMLSource(URL url, StreamSource strSource) {
-		this.url = url;
-		this.strSource = strSource;
-	}
-	
-	public JobXMLSource(String jsl) {
-		this.jobXML = jsl;
-	}
+    public JobXMLSource(URL url, StreamSource strSource) {
+        this.url = url;
+        this.strSource = strSource;
+    }
 
-	@Override
-	public StreamSource getJSLStreamSource() {
-		return strSource;
-	}
+    public JobXMLSource(String jsl) {
+        this.jobXML = jsl;
+    }
 
-	@Override
-	public String getJSLString() {
-		if (jobXML == null) {
-			try {
-				jobXML = readJobXML();
-			} catch (Exception e) {
-				// By this point we should have already parsed the XML, so should not be later
-				// receiving an error looking at the String form.
-				throw new BatchRuntimeException(e);
-			}
-		} 
-		return jobXML;
-	}
-	
-	/**
-	 * @return the stringified job xml, as read from the url.
-	 */
-	private String readJobXML() throws IOException {
-		
-	    StringWriter sw = new StringWriter();
-	    
-	    IOUtils.copyReader( new InputStreamReader( url.openStream(), "UTF-8" ), sw);
-	    
-	    return sw.toString();
-	}
-	
+    @Override
+    public StreamSource getJSLStreamSource() {
+        return strSource;
+    }
+
+    @Override
+    public String getJSLString() {
+        if (jobXML == null) {
+            try {
+                jobXML = readJobXML();
+            } catch (Exception e) {
+                // By this point we should have already parsed the XML, so should not be later
+                // receiving an error looking at the String form.
+                throw new BatchRuntimeException(e);
+            }
+        }
+        return jobXML;
+    }
+
+    /**
+     * @return the stringified job xml, as read from the url.
+     */
+    private String readJobXML() throws IOException {
+
+        StringWriter sw = new StringWriter();
+
+        IOUtils.copyReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8), sw);
+
+        return sw.toString();
+    }
+
 }

--- a/dev/com.ibm.ws.adaptable.module/src/com/ibm/ws/adaptable/module/internal/AddEntryToOverlayContainerAdapter.java
+++ b/dev/com.ibm.ws.adaptable.module/src/com/ibm/ws/adaptable/module/internal/AddEntryToOverlayContainerAdapter.java
@@ -14,7 +14,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import com.ibm.wsspi.adaptable.module.AddEntryToOverlay;
 import com.ibm.wsspi.adaptable.module.Container;
@@ -26,9 +26,6 @@ import com.ibm.wsspi.artifact.overlay.OverlayContainer;
 import com.ibm.wsspi.kernel.service.utils.PathUtils;
 
 public class AddEntryToOverlayContainerAdapter implements ContainerAdapter<AddEntryToOverlay> {
-
-    // UTF-8 Charset must exist in any JVM, so no exception will occur.
-    static final Charset UTF8_CHARSET = Charset.forName("UTF-8");
 
     @Override
     public AddEntryToOverlay adapt(Container root, OverlayContainer rootOverlay,
@@ -67,7 +64,7 @@ public class AddEntryToOverlayContainerAdapter implements ContainerAdapter<AddEn
 
         public AddedArtifactEntry(String name, String data) {
             this.name = name;
-            this.bytes = data.getBytes(UTF8_CHARSET);
+            this.bytes = data.getBytes(StandardCharsets.UTF_8);
             this.lastModified = System.currentTimeMillis();
         }
 

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/jandex/internal/SparseDotName.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/jandex/internal/SparseDotName.java
@@ -23,6 +23,7 @@
 package com.ibm.ws.annocache.jandex.internal;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -54,10 +55,8 @@ public final class SparseDotName implements Comparable<SparseDotName> {
 
     //
 
-    private static Charset UTF8 = Charset.forName("UTF-8");
-
     public static SparseDotName createSimple(byte[] bytes) {
-        return createSimple(new String(bytes, UTF8));
+        return createSimple(new String(bytes, StandardCharsets.UTF_8));
     }
 
     /**

--- a/dev/com.ibm.ws.cdi.internal/src/com/ibm/ws/cdi/internal/interfaces/CDIUtils.java
+++ b/dev/com.ibm.ws.cdi.internal/src/com/ibm/ws/cdi/internal/interfaces/CDIUtils.java
@@ -18,6 +18,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Arrays;
@@ -40,19 +41,17 @@ import javax.enterprise.inject.Stereotype;
 import javax.enterprise.inject.spi.Extension;
 import javax.interceptor.Interceptor;
 
+import org.jboss.weld.bean.proxy.ProxyObject;
 import org.jboss.weld.bootstrap.spi.Metadata;
 import org.jboss.weld.bootstrap.spi.helpers.MetadataImpl;
 import org.jboss.weld.resources.spi.ResourceLoadingException;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.cdi.CDIException;
 import com.ibm.ws.cdi.CDIRuntimeException;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.util.ThreadContextAccessor;
-
-import org.jboss.weld.bean.proxy.ProxyObject;
 
 /**
  * Common constants and utility methods
@@ -208,7 +207,7 @@ public class CDIUtils {
             InputStreamReader isReader = null;
             try {
                 is = metaInfServicesUrl.openStream();
-                bfReader = new BufferedReader(isReader = new InputStreamReader(is, "UTF-8"));
+                bfReader = new BufferedReader(isReader = new InputStreamReader(is, StandardCharsets.UTF_8));
                 String line;
                 while ((line = bfReader.readLine()) != null) {
                     line = line.trim();

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/ws/tcpchannel/internal/TCPProxyResponse.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/ws/tcpchannel/internal/TCPProxyResponse.java
@@ -11,7 +11,7 @@
 package com.ibm.ws.tcpchannel.internal;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import com.ibm.websphere.ras.Tr;
@@ -61,7 +61,7 @@ public class TCPProxyResponse {
 
     /**
      * Constructor.
-     * 
+     *
      * @param _connLink
      */
     public TCPProxyResponse(TCPProxyConnLink _connLink) { // @350394C
@@ -70,19 +70,9 @@ public class TCPProxyResponse {
 
     // setup the proxy connect information
     static {
-        try {
-            PROXY_CONNECT = "CONNECT ".getBytes("ISO-8859-1");
-            PROXY_HTTPVERSION = " HTTP/1.0\r\n".getBytes("ISO-8859-1");
-            PROXY_AUTHORIZATION = "Proxy-authorization: basic ".getBytes("ISO-8859-1");
-        } catch (UnsupportedEncodingException x) {
-            // no FFDC required
-            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                Tr.event(tc, "ISO-8859-1 encoding not supported.  Exception: " + x);
-            }
-            PROXY_CONNECT = "CONNECT ".getBytes();
-            PROXY_HTTPVERSION = " HTTP/1.0\r\n".getBytes();
-            PROXY_AUTHORIZATION = "Proxy-authorization: basic ".getBytes();
-        }
+        PROXY_CONNECT = "CONNECT ".getBytes(StandardCharsets.ISO_8859_1);
+        PROXY_HTTPVERSION = " HTTP/1.0\r\n".getBytes(StandardCharsets.ISO_8859_1);
+        PROXY_AUTHORIZATION = "Proxy-authorization: basic ".getBytes(StandardCharsets.ISO_8859_1);
     }
 
     protected void setIsProxyResponseValid(boolean newValue) {
@@ -127,7 +117,7 @@ public class TCPProxyResponse {
 
     /**
      * Check for a proxy handshake response.
-     * 
+     *
      * @param rsc
      * @return int (status code)
      */
@@ -206,7 +196,7 @@ public class TCPProxyResponse {
     /**
      * Reads the entire proxy response and checks if the
      * proxyResponseBuffers contains "HTTP/1.0 200 Connection established"
-     * 
+     *
      * @param buffers
      *            the buffers on the TCPReadRequestContext
      * @return int true if the response is valid and false if otherwise
@@ -261,7 +251,7 @@ public class TCPProxyResponse {
      * or \n\n (LF-LF) in a byte array.
      * We dont care here about the order in which these 4
      * control characters appear.
-     * 
+     *
      * @param data
      *            search byte array
      * @return true if found; false if not found
@@ -331,8 +321,8 @@ public class TCPProxyResponse {
     // }
 
     /**
-     * Checks if the byte array contains "HTTP     200" in a byte array.
-     * 
+     * Checks if the byte array contains "HTTP 200" in a byte array.
+     *
      * @param data
      *            search byte array
      * @return true if found; false if not
@@ -362,12 +352,13 @@ public class TCPProxyResponse {
 
         /**
          * Called when the write of the proxy buffers has completed successfully.
-         * 
+         *
          * @param inVC
          *            virtual connection associated with this request.
          * @param wsc
          *            the TCPWriteRequestContext associated with this request.
          */
+        @Override
         public void complete(VirtualConnection inVC, TCPWriteRequestContext wsc) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "ProxyWriteCallback --> complete for " + inVC);
@@ -381,7 +372,7 @@ public class TCPProxyResponse {
 
         /**
          * Called back if an exception occurs while writing the data.
-         * 
+         *
          * @param inVC
          *            virtual connection associated with this request.
          * @param wsc
@@ -389,6 +380,7 @@ public class TCPProxyResponse {
          * @param ioe
          *            The exception.
          */
+        @Override
         public void error(VirtualConnection inVC, TCPWriteRequestContext wsc, IOException ioe) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "ProxyWriteCallback--> error for " + inVC);
@@ -408,12 +400,13 @@ public class TCPProxyResponse {
          * Called when the read of the response has completed successfully.
          * If the response contains "HTTP/1.0 200 Connection established" we
          * call the application callback and return the connect.
-         * 
+         *
          * @param inVC
          *            virtual connection associated with this request.
          * @param wsc
          *            the TCPReadRequestContext associated with this request.
          */
+        @Override
         public void complete(VirtualConnection inVC, TCPReadRequestContext wsc) {
 
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -438,7 +431,7 @@ public class TCPProxyResponse {
 
         /**
          * Called back if an exception occurs while reading the response.
-         * 
+         *
          * @param inVC
          *            virtual connection associated with this request.
          * @param wsc
@@ -446,6 +439,7 @@ public class TCPProxyResponse {
          * @param ioe
          *            The exception.
          */
+        @Override
         public void error(VirtualConnection inVC, TCPReadRequestContext wsc, IOException ioe) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "ProxyReadCallback--> error for " + inVC);
@@ -463,9 +457,9 @@ public class TCPProxyResponse {
      * "CONNECT <proxy.TargetHostname:proxy.TargetPort> HTTP/1.0CRLF"
      * "Proxy-authorization: basic <base64 encoded(username:password)>CRLF"
      * "CRLF"
-     * 
+     *
      * Note: Proxy-authorization is optional header.
-     * 
+     *
      * @return boolean true if the forward proxy buffers were set,
      *         false if otherwise
      */
@@ -510,7 +504,7 @@ public class TCPProxyResponse {
     /**
      * Start a read for the response from the target proxy, this is either the
      * first read or possibly secondary ones if necessary.
-     * 
+     *
      * @param inVC
      */
     protected void readProxyResponse(VirtualConnection inVC) {

--- a/dev/com.ibm.ws.common.encoder/src/com/ibm/ws/common/internal/encoder/Base64Coder.java
+++ b/dev/com.ibm.ws.common.encoder/src/com/ibm/ws/common/internal/encoder/Base64Coder.java
@@ -11,6 +11,7 @@
 package com.ibm.ws.common.internal.encoder;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Base64 Encoding and Decoding utility class
@@ -19,10 +20,10 @@ public final class Base64Coder {
     private static final byte Base64EncMap[];
     private static final byte Base64DecMap[];
 
-    // Tokens used in Base64-encoded data, indexed by their corresponding byte value.    
+    // Tokens used in Base64-encoded data, indexed by their corresponding byte value.
     private static final char[] TOKENS = { 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a',
-                                          'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1',
-                                          '2', '3', '4', '5', '6', '7', '8', '9', '+', '/' };
+                                           'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1',
+                                           '2', '3', '4', '5', '6', '7', '8', '9', '+', '/' };
 
     // Character used to pad encoding groups at the end of Base64-encoded content.
     private static final char PAD_TOKEN = '=';
@@ -43,8 +44,8 @@ public final class Base64Coder {
 
     static {
         byte map[] = { 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107,
-                      108,
-                      109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 43, 47 };
+                       108,
+                       109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 43, 47 };
         Base64EncMap = map;
         Base64DecMap = new byte[128];
         for (int idx = 0; idx < Base64EncMap.length; idx++)
@@ -53,11 +54,12 @@ public final class Base64Coder {
     }
 
     /** Prevent instantiation of this static-only class */
-    private Base64Coder() {}
+    private Base64Coder() {
+    }
 
     /**
      * Converts a String to a base64 encoded String.
-     * 
+     *
      * @param str String, may be {@code null}.
      * @return base64 encoded String {@code null} if the str was null.
      */
@@ -72,16 +74,17 @@ public final class Base64Coder {
 
     /**
      * Converts a raw byte array to a base64 encoded byte array.
-     * 
+     *
      * @param data raw byte array, may be {@code null}.
      * @return base64 encoded String or {@code null} if the data was null.
      */
     public static final String base64EncodeToString(byte data[]) {
         return toString(base64Encode(data));
     }
+
     /**
      * Converts a raw byte array to a base64 encoded byte array.
-     * 
+     *
      * @param data raw byte array, may be {@code null}.
      * @return base64 encoded byte array or {@code null} if the data was null.
      */
@@ -116,7 +119,7 @@ public final class Base64Coder {
 
     /**
      * Converts a base64 encoded byte array to a raw byte array.
-     * 
+     *
      * @param data base64 encoded byte array, may be {@code null}.
      * @return raw byte array or {@code null} if the data was null or
      *         not the expected size.
@@ -160,7 +163,7 @@ public final class Base64Coder {
     /**
      * Encode a byte array into a Base64-encoded string. The string is not
      * broken into 72 character lines.
-     * 
+     *
      * @param data Byte data to be encoded.
      * @return Base64-encoded string.
      */
@@ -171,7 +174,7 @@ public final class Base64Coder {
     /**
      * Encode a byte array into a Base64-encoded String. The String is not
      * broken into 72 character lines.
-     * 
+     *
      * @param data Byte data to be encoded
      * @param offset Starting index within the byte data to be encoded
      * @param length Number of bytes to encode
@@ -256,7 +259,7 @@ public final class Base64Coder {
 
     /**
      * Converts a String with the given encoding to a base64 encoded String.
-     * 
+     *
      * @param str
      * @param enc
      * @return
@@ -274,7 +277,7 @@ public final class Base64Coder {
 
     /**
      * Converts a base64 encoded String to a decoded String.
-     * 
+     *
      * @param str String, may be {@code null}.
      * @return base64 encoded String {@code null} if the str was null.
      */
@@ -289,17 +292,17 @@ public final class Base64Coder {
 
     /**
      * Converts a base64 encoded String to a decoded byte array.
-     * 
+     *
      * @param str String, may be {@code null}.
      * @return base64 encoded byte array {@code null} if the str was null.
      */
-    public static final byte []  base64DecodeString(String str) {
+    public static final byte[] base64DecodeString(String str) {
         return base64Decode(getBytes(str));
     }
 
     /**
      * Converts a byte array to a String. Only ASCII characters are supported.
-     * 
+     *
      * @param b byte array, may be {@code null}.
      * @return ASCII String representing the byte array or {@code null} if the array was null.
      */
@@ -319,20 +322,11 @@ public final class Base64Coder {
      * Converts a String to a byte array by using UTF-8 character sets.
      * This code is needed even converting US-ASCII characters since there are some character sets which are not compatible with US-ASCII code area.
      * For example, CP-1399, which is z/OS Japanese EBCDIC character sets, is one.
+     * 
      * @param input String, may be {@code null}.
      * @return byte array representing the String or {@code null} if the String was null or contained non ASCII character.
      */
     public static final byte[] getBytes(String input) {
-        byte output[] = null;
-        try {
-            if (input != null) {
-                output = input.getBytes("UTF-8");
-            }
-        } catch (UnsupportedEncodingException e) {
-            // This should not happen.
-            // If it happens, it would be some runtime or operating system issue, so just give up and return null.
-            // ffdc data will be logged automatically.
-        }
-        return output;
+        return input == null ? null : input.getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/schemagen/internal/SchemaWriter.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/schemagen/internal/SchemaWriter.java
@@ -18,6 +18,7 @@ import java.io.Reader;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.text.MessageFormat;
@@ -128,9 +129,9 @@ class SchemaWriter {
                     final File wasFile = new File(getInstallDir(), "lib/versions/WebSphereApplicationServer.properties");
                     final File olFile = new File(getInstallDir(), "lib/versions/openliberty.properties");
                     if (olFile.exists())
-                        r = new InputStreamReader(new FileInputStream(olFile), "UTF-8");
+                        r = new InputStreamReader(new FileInputStream(olFile), StandardCharsets.UTF_8);
                     else
-                        r = new InputStreamReader(new FileInputStream(wasFile), "UTF-8");
+                        r = new InputStreamReader(new FileInputStream(wasFile), StandardCharsets.UTF_8);
                     props.load(r);
                     r.close();
                 } catch (IOException e) {
@@ -274,7 +275,7 @@ class SchemaWriter {
             }
         }
 
-        Map<String, TypeBuilder.OCDTypeReference> typeReferences =  builder.getPidTypeMap();
+        Map<String, TypeBuilder.OCDTypeReference> typeReferences = builder.getPidTypeMap();
 
         for (TypeBuilder.OCDType type : types) {
             if (type.getParentPids() != null) {
@@ -523,13 +524,13 @@ class SchemaWriter {
     /**
      * This method takes a set of Attribute Definitions and processes them against an existing Map of attributes.
      *
-     * @param currDefId          - A String containing the id of the ObjectClassDefinition that we're processing.
-     * @param attrDefs           - The Attribute Definitions of the ObjectClassDefinition that we're processing
-     * @param currentAttributes  - The existing map of properties from previous ObjectClassDefinition's in the heirarchy.
+     * @param currDefId - A String containing the id of the ObjectClassDefinition that we're processing.
+     * @param attrDefs - The Attribute Definitions of the ObjectClassDefinition that we're processing
+     * @param currentAttributes - The existing map of properties from previous ObjectClassDefinition's in the heirarchy.
      * @param requiredAttributes - The current list of required Attributes from the processed definitions.
      * @param optionalAttributes - The current list of optional Attributes from the processed definitions.
-     * @param attributeMap       - The list of ExtendedDefinitionAttributes for all of the OCD's in the heirarchy.
-     * @param required           - A boolean indicating whether the list of currentAttributes are required or optional.
+     * @param attributeMap - The list of ExtendedDefinitionAttributes for all of the OCD's in the heirarchy.
+     * @param required - A boolean indicating whether the list of currentAttributes are required or optional.
      */
     private void processOCDAttributes(String currDefId, AttributeDefinition[] attrDefs, Map<String, AttributeDefinition> requiredAttributes,
                                       Map<String, AttributeDefinition> optionalAttributes, Map<String, ExtendedAttributeDefinition> attributeMap,
@@ -603,10 +604,10 @@ class SchemaWriter {
      * This method processes the rename attribute. It builds up a new attribute based on the original attribute, but override any values
      * that have been defined in the new attribute.
      *
-     * @param currDefId    - A String containing the id of the ObjectClassDefinition that we're processing.
+     * @param currDefId - A String containing the id of the ObjectClassDefinition that we're processing.
      * @param oldAttribute - The Attribute that is being renamed.
      * @param newAttribute - The new attribute that has the rename extension.
-     * @param required     - A boolean indicating whether this attribute is required or optional.
+     * @param required - A boolean indicating whether this attribute is required or optional.
      * @return - An AttributeDefinition object that contains the "merged" values.
      */
     private AttributeDefinition renameAttribute(String currDefId, ExtendedAttributeDefinition oldAttribute, ExtendedAttributeDefinition newAttribute, boolean required) {
@@ -1468,7 +1469,7 @@ class SchemaWriter {
      * This method adds additional annotations to required schema elements so that WDT is aware
      * that it needs to invoke server specific schema generation and use the generated schema.
      *
-     * @param action      The action that should be invoked by WDT on encountering this element
+     * @param action The action that should be invoked by WDT on encountering this element
      * @param currentType The current OCD type
      * @throws XMLStreamException
      */

--- a/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/metadata/internal/J2EENameImpl.java
+++ b/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/metadata/internal/J2EENameImpl.java
@@ -13,7 +13,7 @@ package com.ibm.ws.container.service.metadata.internal;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import com.ibm.websphere.csi.J2EEName;
 
@@ -124,11 +124,7 @@ public final class J2EENameImpl implements J2EEName {
     public byte[] getBytes() {
         byte[] bytes = this.j2eeNameBytes;
         if (bytes == null) {
-            try {
-                bytes = toString().getBytes("UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new IllegalStateException(e);
-            }
+            bytes = toString().getBytes(StandardCharsets.UTF_8);
 
             this.j2eeNameBytes = bytes;
         }
@@ -147,13 +143,7 @@ public final class J2EENameImpl implements J2EEName {
     }
 
     private void readObject(byte[] bytes) {
-        String string;
-        try {
-            string = new String(bytes, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalStateException(e);
-        }
-        this.string = string;
+        this.string = new String(bytes, StandardCharsets.UTF_8);
 
         int modSepIndex = string.indexOf('#');
         if (modSepIndex == -1) {

--- a/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/websphere/crypto/PasswordUtil.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/websphere/crypto/PasswordUtil.java
@@ -11,7 +11,7 @@
 
 package com.ibm.websphere.crypto;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -77,8 +77,6 @@ public class PasswordUtil {
     private static final String RB = "com.ibm.ws.crypto.util.internal.resources.Messages";
     private final static Logger logger = Logger.getLogger(CLASS_NAME.getCanonicalName(), RB);
 
-    private static final String STRING_CONVERSION_CODE = "UTF-8";
-
     private static final String CRYPTO_ALGORITHM_STARTED = "{";
     private static final String CRYPTO_ALGORITHM_STOPPED = "}";
 
@@ -87,7 +85,7 @@ public class PasswordUtil {
 
     /**
      * Return the default algorithm for the encoding or decoding.
-     * 
+     *
      * @return The default algorithm.
      */
     public static final String getDefaultEncoding() {
@@ -101,17 +99,16 @@ public class PasswordUtil {
      * <p>
      * An empty algorithm "{}" is treated as not encoded.
      * However, a missing algorithm will trigger the InvalidPasswordDecodingException.
-     * 
+     *
      * @param encoded_string the string to be decoded.
      * @return The decoded string
      * @throws InvalidPasswordDecodingException If the encoded_string is null or invalid. Or the decoded_string is null.
      * @throws UnsupportedCryptoAlgorithmException If the specified algorithm is not supported for decoding.
      */
-    public static String decode(String encoded_string)
-                    throws InvalidPasswordDecodingException, UnsupportedCryptoAlgorithmException {
+    public static String decode(String encoded_string) throws InvalidPasswordDecodingException, UnsupportedCryptoAlgorithmException {
         /*
          * check input:
-         * 
+         *
          * -- encoded_string: any string, any length, cannot be null,
          * must start with valid (supported) crypto algorithm tag
          */
@@ -152,13 +149,13 @@ public class PasswordUtil {
      * For example, {xor}CDo9Hgw=.
      * If the decoded_string is already encoded, the string will be decoded and then encoded by using the default encoding algorithm.
      * Use this method for encoding the string by using the default encoding algorithm.
+     * 
      * @param decoded_string the string to be encoded.
      * @return The encoded string.
      * @throws InvalidPasswordEncodingException If the decoded_string is null or invalid. Or the encoded_string is null.
      * @throws UnsupportedCryptoAlgorithmException If the algorithm is not supported.
      */
-    public static String encode(String decoded_string)
-                    throws InvalidPasswordEncodingException, UnsupportedCryptoAlgorithmException {
+    public static String encode(String decoded_string) throws InvalidPasswordEncodingException, UnsupportedCryptoAlgorithmException {
         return encode(decoded_string, PasswordCipherUtil.getSupportedCryptoAlgorithms()[0], (String) null);
     }
 
@@ -168,7 +165,7 @@ public class PasswordUtil {
      * If the decoded_string is already encoded, the string will be decoded and then encoded by using the specified crypto algorithm.
      * Use this method for encoding the string by using specific encoding algorithm.
      * Use securityUtility encode --listCustom command line utility to see if any additional custom encryptions are supported.
-     * 
+     *
      * @param decoded_string the string to be encoded.
      * @param crypto_algorithm the algorithm to be used for encoding. The supported values are xor, aes, or hash.
      * @return The encoded string.
@@ -184,6 +181,7 @@ public class PasswordUtil {
      * If the decoded_string is already encoded, the string will be decoded and then encoded by using the specified crypto algorithm.
      * Use this method for encoding the string by using the AES encryption with the specific crypto key.
      * Note that this method is only avaiable for the Liberty profile.
+     * 
      * @param decoded_string the string to be encoded.
      * @param crypto_algorithm the algorithm to be used for encoding.
      * @param crypto_key the key for the encryption. This value is only valid for aes algorithm.
@@ -191,8 +189,7 @@ public class PasswordUtil {
      * @throws InvalidPasswordEncodingException If the decoded_string is null or invalid. Or the encoded_string is null.
      * @throws UnsupportedCryptoAlgorithmException If the algorithm is not supported.
      */
-    public static String encode(String decoded_string, String crypto_algorithm, String crypto_key)
-                    throws InvalidPasswordEncodingException, UnsupportedCryptoAlgorithmException {
+    public static String encode(String decoded_string, String crypto_algorithm, String crypto_key) throws InvalidPasswordEncodingException, UnsupportedCryptoAlgorithmException {
         HashMap<String, String> props = new HashMap<String, String>();
         if (crypto_key != null) {
             props.put(PROPERTY_CRYPTO_KEY, crypto_key);
@@ -204,7 +201,7 @@ public class PasswordUtil {
      * Encode the provided string with the specified algorithm and the properties
      * If the decoded_string is already encoded, the string will be decoded and then encoded by using the specified crypto algorithm.
      * Note that this method is only avaiable for the Liberty profile.
-     * 
+     *
      * @param decoded_string the string to be encoded.
      * @param crypto_algorithm the algorithm to be used for encoding. The supported values are xor, aes, or hash.
      * @param properties the properties for the encryption.
@@ -212,14 +209,14 @@ public class PasswordUtil {
      * @throws InvalidPasswordEncodingException If the decoded_string is null or invalid. Or the encoded_string is null.
      * @throws UnsupportedCryptoAlgorithmException If the algorithm is not supported.
      */
-    public static String encode(String decoded_string, String crypto_algorithm, Map<String, String> properties)
-                    throws InvalidPasswordEncodingException, UnsupportedCryptoAlgorithmException {
+    public static String encode(String decoded_string, String crypto_algorithm,
+                                Map<String, String> properties) throws InvalidPasswordEncodingException, UnsupportedCryptoAlgorithmException {
         /*
          * check input:
-         * 
+         *
          * -- decoded_string: any string, any length, cannot be null,
          * cannot start with crypto algorithm tag
-         * 
+         *
          * -- crypto_algorithm: any string, any length, cannot be null,
          * must be valid (supported) crypto algorithm
          */
@@ -257,7 +254,7 @@ public class PasswordUtil {
     /**
      * Return the crypto algorithm of the provided password.
      * For example, if the password is {xor}CDo9Hgw=, "xor" will be returned.
-     * 
+     *
      * @param password the encoded string with encoding algorithm.
      * @return The encoding algorithm. Null if not present.
      */
@@ -283,7 +280,7 @@ public class PasswordUtil {
     /**
      * Return the algorithm tag of the provided string.
      * For example, if the password is {xor}CDo9Hgw=, "{xor}" will be returned.
-     * 
+     *
      * @param password the encoded string with encoding algorithm.
      * @return The encoding algorithm with algorithm tags. Null if not present.
      */
@@ -314,7 +311,7 @@ public class PasswordUtil {
     /**
      * Check whether the encoded string contains a valid crypto algorithm.
      * For example, "{xor}CDo9Hgw=" returns true, while "{unknown}CDo9Hgw=" or "CDo9Hgw=" returns false.
-     * 
+     *
      * @param encoded_string the encoded string.
      * @return true if the encoding algorithm is supported.
      */
@@ -327,7 +324,7 @@ public class PasswordUtil {
      * Determine if the provided algorithm string is valid.
      * The valid values are xor, aes, or hash.
      * Use securityUtility encode --listCustom command line utility to see if any additional custom encryptions are supported.
-     * 
+     *
      * @param crypto_algorithm the string of algorithm.
      * @return true if the algorithm is supported. false otherwise.
      */
@@ -353,7 +350,7 @@ public class PasswordUtil {
      * Determine if the provided algorithm tag is valid. the algorithm tag consists of "{<algorithm>}" such as "{xor}".
      * The valid values are {xor}, {aes}, or {hash}.
      * Use securityUtility encode --listCustom command line utility to see if any additional custom encryptions are supported.
-     * 
+     *
      * @param tag the string of algorithm tag to be examined.
      * @return true if the algorithm is supported. false otherwise.
      */
@@ -364,7 +361,7 @@ public class PasswordUtil {
     /**
      * Determine if the provided string is hashed by examining the algorithm tag.
      * Note that this method is only avaiable for the Liberty profile.
-     * 
+     *
      * @param encoded_string the string with the encoded algorithm tag.
      * @return true if the encoded algorithm is hash. false otherwise.
      */
@@ -392,14 +389,14 @@ public class PasswordUtil {
     /**
      * Decode the provided string. The string should consist of the algorithm to be used for decoding and encoded string.
      * For example, {xor}CDo9Hgw=.
-     * 
+     *
      * @param encoded_string the string to be decoded.
      * @return The decoded string, null if there is any failure during decoding, or invalid or null encoded_string.
      */
     public static String passwordDecode(String encoded_string) {
         /*
          * check input:
-         * 
+         *
          * -- encoded_string: any string, any length, cannot be null,
          * may start with valid (supported) crypto algorithm tag
          */
@@ -423,7 +420,7 @@ public class PasswordUtil {
     /**
      * Encode the provided password by using the default encoding algorithm. The encoded string consists of the algorithm of the encoding and the encoded value.
      * For example, {xor}CDo9Hgw=.
-     * 
+     *
      * @param decoded_string the string to be encoded.
      * @return The encoded string. null if there is any failure during encoding, or invalid or null decoded_string
      */
@@ -434,7 +431,7 @@ public class PasswordUtil {
     /**
      * Encode the provided password with the algorithm. If another algorithm
      * is already applied, it will be removed and replaced with the new algorithm.
-     * 
+     *
      * @param decoded_string the string to be encoded, or the encoded string.
      * @param crypto_algorithm the algorithm to be used for encoding. The supported values are xor, aes, or hash.
      * @return The encoded string. Null if there is any failure during encoding, or invalid or null decoded_string
@@ -442,10 +439,10 @@ public class PasswordUtil {
     public static String passwordEncode(String decoded_string, String crypto_algorithm) {
         /*
          * check input:
-         * 
+         *
          * -- decoded_string: any string, any length, cannot be null,
          * may start with valid (supported) crypto algorithm tag
-         * 
+         *
          * -- crypto_algorithm: any string, any length, cannot be null,
          * must be valid (supported) crypto algorithm
          */
@@ -472,7 +469,7 @@ public class PasswordUtil {
 
     /**
      * Remove the algorithm tag from the input encoded password.
-     * 
+     *
      * @param password the string which contains the crypto algorithm tag.
      * @return The string which the crypto algorithm tag is removed.
      */
@@ -502,7 +499,7 @@ public class PasswordUtil {
 
     /**
      * Convert the provided string to a byte[] using the UTF-8 encoding.
-     * 
+     *
      * @param string
      * @return byte[] - null if input is null or if UTF-8 is not supported
      */
@@ -513,17 +510,12 @@ public class PasswordUtil {
         if (0 == string.length()) {
             return EMPTY_BYTE_ARRAY;
         }
-        try {
-            return string.getBytes(STRING_CONVERSION_CODE);
-        } catch (UnsupportedEncodingException e) {
-            logger.logp(Level.SEVERE, PasswordUtil.class.getName(), "convert_to_bytes", "PASSWORDUTIL_UNSUPPORTEDENCODING_EXCEPTION", e);
-            return null;
-        }
+        return string.getBytes(StandardCharsets.UTF_8);
     }
 
     /**
      * Convert the byte[] data to a String using the UTF-8 encoding.
-     * 
+     *
      * @param bytes
      * @return String - null if input is null or if UTF-8 is not supported
      */
@@ -534,18 +526,13 @@ public class PasswordUtil {
         if (0 == bytes.length) {
             return EMPTY_STRING;
         }
-        try {
-            return new String(bytes, STRING_CONVERSION_CODE);
-        } catch (UnsupportedEncodingException e) {
-            logger.logp(Level.SEVERE, PasswordUtil.class.getName(), "convert_to_string", "PASSWORDUTIL_UNSUPPORTEDENCODING_EXCEPTION", e);
-            return null;
-        }
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     /**
      * Convert the string to bytes using UTF-8 encoding and then run it through
      * the base64 decoding.
-     * 
+     *
      * @param string
      * @return byte[] - null if null input or an error in the conversion happens
      */
@@ -562,7 +549,7 @@ public class PasswordUtil {
     /**
      * Use base64 encoding on the bytes and then convert them to a string using
      * UTF-8 encoding.
-     * 
+     *
      * @param bytes
      * @return String - null if input is null or an error happens during the conversion
      */
@@ -581,7 +568,7 @@ public class PasswordUtil {
 
     /**
      * Decode the provided string with the specified algorithm.
-     * 
+     *
      * @param encoded_string
      * @param crypto_algorithm
      * @return String
@@ -589,7 +576,7 @@ public class PasswordUtil {
     private static String decode_password(String encoded_string, String crypto_algorithm) {
         /*
          * decoding process:
-         * 
+         *
          * -- check for empty algorithm tag
          * -- convert input String to byte[] using base64 decoding
          * -- decipher byte[]
@@ -648,7 +635,7 @@ public class PasswordUtil {
 
     /**
      * Encode the provided string by using the specified encoding algorithm and properties
-     * 
+     *
      * @param decoded_string the string to be encoded.
      * @param crypto_algorithm the algorithm to be used for encoding. The supported values are xor, aes, or hash.
      * @param properties the properties for the encryption.
@@ -657,7 +644,7 @@ public class PasswordUtil {
     public static String encode_password(String decoded_string, String crypto_algorithm, Map<String, String> properties) {
         /*
          * encoding process:
-         * 
+         *
          * -- check for empty algorithm tag
          * -- convert input String to byte[] UTF8 conversion code
          * -- encipher byte[]

--- a/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/HashedData.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/HashedData.java
@@ -14,6 +14,7 @@ package com.ibm.ws.crypto.util;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -231,7 +232,7 @@ public class HashedData {
             if (length > 0) {
                 byte[] data = new byte[length];
                 input.read(data, 0, length);
-                output = new String(data, "UTF-8");
+                output = new String(data, StandardCharsets.UTF_8);
             }
         } else {
             throw new InvalidPasswordCipherException("null object");
@@ -266,7 +267,7 @@ public class HashedData {
         if (output != null && value != null) {
             byte[] b = toByte(value.length());
             output.write(b, 0, b.length);
-            b = value.getBytes("UTF-8");
+            b = value.getBytes(StandardCharsets.UTF_8);
             output.write(b, 0, b.length);
         } else {
             throw new InvalidPasswordCipherException("null object");

--- a/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/PasswordCipherUtil.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/PasswordCipherUtil.java
@@ -12,6 +12,7 @@
 package com.ibm.ws.crypto.util;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -106,7 +107,7 @@ public class PasswordCipherUtil {
     /**
      * Returns the list of custom password encryption if exists.
      * This method only works under the command line utility environment.
-     * 
+     *
      * @return list of the custom password encryption in JSON format
      * @throws UnsupportedConfigurationException If there are multiple custom password encryption exists.
      */
@@ -175,15 +176,14 @@ public class PasswordCipherUtil {
 
     /**
      * Decipher the input password using the provided algorithm.
-     * 
+     *
      * @param encrypted_bytes
      * @param crypto_algorithm
      * @return byte[] - decrypted password
      * @throws InvalidPasswordCipherException
      * @throws UnsupportedCryptoAlgorithmException
      */
-    public static byte[] decipher(byte[] encrypted_bytes, String crypto_algorithm)
-                    throws InvalidPasswordCipherException, UnsupportedCryptoAlgorithmException {
+    public static byte[] decipher(byte[] encrypted_bytes, String crypto_algorithm) throws InvalidPasswordCipherException, UnsupportedCryptoAlgorithmException {
 
         if (crypto_algorithm == null) {
             logger.logp(Level.SEVERE, PasswordCipherUtil.class.getName(), "decipher", "PASSWORDUTIL_UNKNOWN_ALGORITHM",
@@ -224,7 +224,7 @@ public class PasswordCipherUtil {
             }
         } else {
             logger.logp(Level.SEVERE, PasswordCipherUtil.class.getName(), "decipher", "PASSWORDUTIL_UNKNOWN_ALGORITHM", new Object[] { crypto_algorithm,
-                                                                                                                                      formatSupportedCryptoAlgorithms() });
+                                                                                                                                       formatSupportedCryptoAlgorithms() });
             throw new UnsupportedCryptoAlgorithmException();
         }
 
@@ -273,15 +273,14 @@ public class PasswordCipherUtil {
 
     /**
      * Encipher the raw password using the provided algorithm.
-     * 
+     *
      * @param decrypted_bytes
      * @param crypto_algorithm
      * @return byte[] - enciphered value
      * @throws InvalidPasswordCipherException
      * @throws UnsupportedCryptoAlgorithmException
      */
-    public static byte[] encipher(byte[] decrypted_bytes, String crypto_algorithm)
-                    throws InvalidPasswordCipherException, UnsupportedCryptoAlgorithmException {
+    public static byte[] encipher(byte[] decrypted_bytes, String crypto_algorithm) throws InvalidPasswordCipherException, UnsupportedCryptoAlgorithmException {
         EncryptedInfo info = encipher_internal(decrypted_bytes, crypto_algorithm, (String) null); // TODO check null
         return info.getEncryptedBytes();
     }
@@ -290,8 +289,8 @@ public class PasswordCipherUtil {
     // Method: encipher( decrypted password byte[], crypto algorithm string )
     // Return: encrypted password byte[]
     // ---------------------------------------------------------------------------
-    public static EncryptedInfo encipher_internal(byte[] decrypted_bytes, String crypto_algorithm, String cryptoKey)
-                    throws InvalidPasswordCipherException, UnsupportedCryptoAlgorithmException {
+    public static EncryptedInfo encipher_internal(byte[] decrypted_bytes, String crypto_algorithm,
+                                                  String cryptoKey) throws InvalidPasswordCipherException, UnsupportedCryptoAlgorithmException {
         HashMap<String, String> props = new HashMap<String, String>();
         if (cryptoKey != null) {
             props.put(PasswordUtil.PROPERTY_CRYPTO_KEY, cryptoKey);
@@ -299,8 +298,8 @@ public class PasswordCipherUtil {
         return encipher_internal(decrypted_bytes, crypto_algorithm, props);
     }
 
-    public static EncryptedInfo encipher_internal(byte[] decrypted_bytes, String crypto_algorithm, Map<String, String> properties)
-                    throws InvalidPasswordCipherException, UnsupportedCryptoAlgorithmException {
+    public static EncryptedInfo encipher_internal(byte[] decrypted_bytes, String crypto_algorithm,
+                                                  Map<String, String> properties) throws InvalidPasswordCipherException, UnsupportedCryptoAlgorithmException {
 
         EncryptedInfo info = null;
         byte[] encrypted_bytes = null;
@@ -318,7 +317,7 @@ public class PasswordCipherUtil {
         } else if (HASH.equalsIgnoreCase(crypto_algorithm)) {
             char[] decrypted_chars = null;
             try {
-                String originalString = new String(decrypted_bytes, "UTF-8");
+                String originalString = new String(decrypted_bytes, StandardCharsets.UTF_8);
                 decrypted_chars = originalString.toCharArray();
             } catch (Exception e) {
                 throw new InvalidPasswordCipherException();
@@ -341,7 +340,7 @@ public class PasswordCipherUtil {
             }
         } else {
             logger.logp(Level.SEVERE, PasswordCipherUtil.class.getName(), "encipher", "PASSWORDUTIL_UNKNOWN_ALGORITHM", new Object[] { crypto_algorithm,
-                                                                                                                                      formatSupportedCryptoAlgorithms() });
+                                                                                                                                       formatSupportedCryptoAlgorithms() });
             throw new UnsupportedCryptoAlgorithmException();
         }
 
@@ -372,7 +371,7 @@ public class PasswordCipherUtil {
             if (encodedString != null && PasswordUtil.isHashed(encodedString)) {
                 try {
                     String value = PasswordUtil.removeCryptoAlgorithmTag(encodedString);
-                    HashedData dd = new HashedData(Base64Coder.base64Decode(value.getBytes("UTF-8")));
+                    HashedData dd = new HashedData(Base64Coder.base64Decode(value.getBytes(StandardCharsets.UTF_8)));
                     algorithm = dd.getAlgorithm();
                     iteration = dd.getIteration();
                     length = dd.getOutputLength();
@@ -439,7 +438,8 @@ public class PasswordCipherUtil {
      * @throws UnsupportedCryptoAlgorithmException
      * @throws InvalidPasswordCipherException
      */
-    private static EncryptedInfo aesEncipher(byte[] decrypted_bytes, String cryptoKey, EncryptedInfo info, byte[] encrypted_bytes) throws UnsupportedCryptoAlgorithmException, InvalidPasswordCipherException {
+    private static EncryptedInfo aesEncipher(byte[] decrypted_bytes, String cryptoKey, EncryptedInfo info,
+                                             byte[] encrypted_bytes) throws UnsupportedCryptoAlgorithmException, InvalidPasswordCipherException {
         SecureRandom rand = new SecureRandom();
         byte[] seed = rand.generateSeed(20);
         byte[] preEncrypted = new byte[decrypted_bytes.length + 21];
@@ -474,7 +474,7 @@ public class PasswordCipherUtil {
 
     /**
      * Query the list of supported crypto algorithms.
-     * 
+     *
      * @return String[]
      */
     public static String[] getSupportedCryptoAlgorithms() {
@@ -483,7 +483,7 @@ public class PasswordCipherUtil {
 
     /**
      * Query the fail-safe crypto algorithm.
-     * 
+     *
      * @return String
      */
     public static String getFailSafeCryptoAlgorithm() {

--- a/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/PasswordHashGenerator.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/ws/crypto/util/PasswordHashGenerator.java
@@ -11,7 +11,7 @@
 
 package com.ibm.ws.crypto.util;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -42,12 +42,7 @@ public class PasswordHashGenerator {
             rand.setSeed(rand.generateSeed(SEED_LENGTH));
             rand.nextBytes(output);
         } else {
-            try {
-                output = saltString.getBytes("UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                // fall back to default encoding. since the value won't be converted to the string, this is not an issue.
-                output = saltString.getBytes();
-            }
+            output = saltString.getBytes(StandardCharsets.UTF_8);
         }
         return output;
     }

--- a/dev/com.ibm.ws.dynacache.web/src/com/ibm/ws/cache/web/config/ConfigManager.java
+++ b/dev/com.ibm.ws.dynacache.web/src/com/ibm/ws/cache/web/config/ConfigManager.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -116,7 +117,7 @@ public class ConfigManager {
                 URL u = bc.getBundle().getEntry("/META-INF/" + CACHE_SPEC_DTD);
                 
                 if (u != null) {
-                  isr = new InputStreamReader(u.openStream(), "UTF-8");
+                  isr = new InputStreamReader(u.openStream(), StandardCharsets.UTF_8);
                   in = new BufferedReader(isr);
                   String inputLine;
                   while ((inputLine = in.readLine()) != null)
@@ -360,7 +361,7 @@ public class ConfigManager {
 		
     	try {
     		if (u != null) {
-    			isr = new InputStreamReader(u.openStream(), "UTF-8");
+    			isr = new InputStreamReader(u.openStream(), StandardCharsets.UTF_8);
     			in = new BufferedReader(isr);
     			String inputLine;
 

--- a/dev/com.ibm.ws.dynacache/src/com/ibm/ws/cache/CacheOnDisk.java
+++ b/dev/com.ibm.ws.dynacache/src/com/ibm/ws/cache/CacheOnDisk.java
@@ -15,6 +15,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Calendar;
@@ -174,7 +175,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
 
     protected boolean doNotify = false;
     protected Object diskCacheMonitor = new Object() {
-                    };
+    };
 
     private String definedLocation = "";
     private String alternateLocation = "";
@@ -224,15 +225,15 @@ public class CacheOnDisk implements DynacacheOnDisk {
         this.diskCacheSizeInfo = new DiskCacheSizeInfo(this.cacheName);
 
         if (this.diskCachePerformanceLevel < CacheConfig.MIN_DISKCACHE_PERFORMANCE_LEVEL
-                || this.diskCachePerformanceLevel > CacheConfig.MAX_DISKCACHE_PERFORMANCE_LEVEL) {
+            || this.diskCachePerformanceLevel > CacheConfig.MAX_DISKCACHE_PERFORMANCE_LEVEL) {
             Tr.warning(tc, "DYNA0069W", new Object[] { new Integer(this.diskCachePerformanceLevel), "diskCachePerformanceLevel", this.cacheName,
-                                                      new Integer(CacheConfig.MIN_DISKCACHE_PERFORMANCE_LEVEL), new Integer(CacheConfig.MAX_DISKCACHE_PERFORMANCE_LEVEL),
-                                                      new Integer(CacheConfig.DEFAULT_DISKCACHE_PERFORMANCE_LEVEL) });
+                                                       new Integer(CacheConfig.MIN_DISKCACHE_PERFORMANCE_LEVEL), new Integer(CacheConfig.MAX_DISKCACHE_PERFORMANCE_LEVEL),
+                                                       new Integer(CacheConfig.DEFAULT_DISKCACHE_PERFORMANCE_LEVEL) });
             this.diskCachePerformanceLevel = CacheConfig.DEFAULT_DISKCACHE_PERFORMANCE_LEVEL;
         }
 
         if (this.diskCachePerformanceLevel == CacheConfig.HIGH || this.diskCachePerformanceLevel == CacheConfig.CUSTOM
-                || diskCachePerformanceLevel == CacheConfig.BALANCED) {
+            || diskCachePerformanceLevel == CacheConfig.BALANCED) {
             delayOffload = true;
             if (this.diskCachePerformanceLevel == CacheConfig.BALANCED) {
                 this.delayOffloadEntriesLimit = CacheConfig.DEFAULT_MAX_BUFFERED_CACHE_IDS_PER_METADATA;
@@ -245,23 +246,23 @@ public class CacheOnDisk implements DynacacheOnDisk {
             } else {
                 if (this.delayOffloadEntriesLimit < CacheConfig.MIN_DISKCACHE_BUFFERED_CACHE_IDS_PER_METADATA) {
                     Tr.warning(tc, "DYNA0069W", new Object[] { new Integer(delayOffloadEntriesLimit), "htodDelayOffloadEntriesLimit", this.cacheName,
-                                                              new Integer(CacheConfig.MIN_DISKCACHE_BUFFERED_CACHE_IDS_PER_METADATA),
-                                                              new Integer(CacheConfig.MAX_DISKCACHE_BUFFERED_CACHE_IDS_PER_METADATA),
-                                                              new Integer(CacheConfig.MIN_DISKCACHE_BUFFERED_CACHE_IDS_PER_METADATA) });
+                                                               new Integer(CacheConfig.MIN_DISKCACHE_BUFFERED_CACHE_IDS_PER_METADATA),
+                                                               new Integer(CacheConfig.MAX_DISKCACHE_BUFFERED_CACHE_IDS_PER_METADATA),
+                                                               new Integer(CacheConfig.MIN_DISKCACHE_BUFFERED_CACHE_IDS_PER_METADATA) });
                     this.delayOffloadEntriesLimit = CacheConfig.MIN_DISKCACHE_BUFFERED_CACHE_IDS_PER_METADATA;
                 }
                 if (this.delayOffloadDepIdBuckets < CacheConfig.MIN_DISKCACHE_BUFFERED_DEPENDENCY_IDS) {
                     Tr.warning(tc, "DYNA0069W", new Object[] { new Integer(delayOffloadDepIdBuckets), "htodDelayOffloadDepIdBuckets", this.cacheName,
-                                                              new Integer(CacheConfig.MIN_DISKCACHE_BUFFERED_DEPENDENCY_IDS),
-                                                              new Integer(CacheConfig.MAX_DISKCACHE_BUFFERED_DEPENDENCY_IDS),
-                                                              new Integer(CacheConfig.MIN_DISKCACHE_BUFFERED_DEPENDENCY_IDS) });
+                                                               new Integer(CacheConfig.MIN_DISKCACHE_BUFFERED_DEPENDENCY_IDS),
+                                                               new Integer(CacheConfig.MAX_DISKCACHE_BUFFERED_DEPENDENCY_IDS),
+                                                               new Integer(CacheConfig.MIN_DISKCACHE_BUFFERED_DEPENDENCY_IDS) });
                     this.delayOffloadDepIdBuckets = CacheConfig.MIN_DISKCACHE_BUFFERED_DEPENDENCY_IDS;
                 }
                 if (this.delayOffloadTemplateBuckets < CacheConfig.MIN_DISKCACHE_BUFFERED_TEMPLATES) {
                     Tr.warning(tc, "DYNA0069W",
                                new Object[] { new Integer(delayOffloadTemplateBuckets), "htodDelayOffloadTemplateBuckets",
-                                             this.cacheName, new Integer(CacheConfig.MIN_DISKCACHE_BUFFERED_TEMPLATES),
-                                             new Integer(CacheConfig.MAX_DISKCACHE_BUFFERED_TEMPLATES), new Integer(CacheConfig.MIN_DISKCACHE_BUFFERED_TEMPLATES) });
+                                              this.cacheName, new Integer(CacheConfig.MIN_DISKCACHE_BUFFERED_TEMPLATES),
+                                              new Integer(CacheConfig.MAX_DISKCACHE_BUFFERED_TEMPLATES), new Integer(CacheConfig.MIN_DISKCACHE_BUFFERED_TEMPLATES) });
                     this.delayOffloadTemplateBuckets = CacheConfig.MIN_DISKCACHE_BUFFERED_TEMPLATES;
                 }
             }
@@ -271,47 +272,47 @@ public class CacheOnDisk implements DynacacheOnDisk {
         if (this.diskCachePerformanceLevel != CacheConfig.HIGH) {
             if (this.cleanupFrequency < CacheConfig.MIN_CLEANUP_FREQUENCY) {
                 Tr.warning(tc, "DYNA0069W", new Object[] { new Integer(this.cleanupFrequency), "htodCleanupFrequency", this.cacheName,
-                                                          new Integer(CacheConfig.MIN_CLEANUP_FREQUENCY), new Integer(CacheConfig.MAX_CLEANUP_FREQUENCY),
-                                                          new Integer(CacheConfig.MIN_CLEANUP_FREQUENCY) });
+                                                           new Integer(CacheConfig.MIN_CLEANUP_FREQUENCY), new Integer(CacheConfig.MAX_CLEANUP_FREQUENCY),
+                                                           new Integer(CacheConfig.MIN_CLEANUP_FREQUENCY) });
                 this.cleanupFrequency = CacheConfig.MIN_CLEANUP_FREQUENCY;
             }
             if (this.cleanupFrequency > CacheConfig.MAX_CLEANUP_FREQUENCY) {
                 Tr.warning(tc, "DYNA0069W", new Object[] { new Integer(this.cleanupFrequency), "htodCleanupFrequency", this.cacheName,
-                                                          new Integer(CacheConfig.MIN_CLEANUP_FREQUENCY), new Integer(CacheConfig.MAX_CLEANUP_FREQUENCY),
-                                                          new Integer(CacheConfig.MAX_CLEANUP_FREQUENCY) });
+                                                           new Integer(CacheConfig.MIN_CLEANUP_FREQUENCY), new Integer(CacheConfig.MAX_CLEANUP_FREQUENCY),
+                                                           new Integer(CacheConfig.MAX_CLEANUP_FREQUENCY) });
                 this.cleanupFrequency = CacheConfig.MAX_CLEANUP_FREQUENCY;
             }
         }
 
         if (this.evictionPolicy < CacheConfig.MIN_DISKCACHE_EVICTION_POLICY || this.evictionPolicy > CacheConfig.MAX_DISKCACHE_EVICTION_POLICY) {
             Tr.warning(tc, "DYNA0069W", new Object[] { new Integer(this.evictionPolicy), "diskCacheEvictionPolicy", this.cacheName,
-                                                      new Integer(CacheConfig.MIN_DISKCACHE_EVICTION_POLICY), new Integer(CacheConfig.MAX_DISKCACHE_EVICTION_POLICY),
-                                                      new Integer(CacheConfig.DEFAULT_DISKCACHE_EVICTION_POLICY) });
+                                                       new Integer(CacheConfig.MIN_DISKCACHE_EVICTION_POLICY), new Integer(CacheConfig.MAX_DISKCACHE_EVICTION_POLICY),
+                                                       new Integer(CacheConfig.DEFAULT_DISKCACHE_EVICTION_POLICY) });
             this.evictionPolicy = CacheConfig.DEFAULT_DISKCACHE_EVICTION_POLICY;
         }
 
         if (diskCacheSizeLimit < 0 || (diskCacheSizeLimit > 0 && diskCacheSizeLimit < CacheConfig.MIN_DISKCACHE_SIZE)) {
             Tr.warning(tc, "DYNA0069W", new Object[] { new Integer(diskCacheSizeLimit), "diskCacheSize", this.cacheName,
-                                                      new Integer(CacheConfig.MIN_DISKCACHE_SIZE), new Integer(CacheConfig.MAX_DISKCACHE_SIZE),
-                                                      new Integer(CacheConfig.MIN_DISKCACHE_SIZE) });
+                                                       new Integer(CacheConfig.MIN_DISKCACHE_SIZE), new Integer(CacheConfig.MAX_DISKCACHE_SIZE),
+                                                       new Integer(CacheConfig.MIN_DISKCACHE_SIZE) });
             diskCacheSizeLimit = CacheConfig.MIN_DISKCACHE_SIZE;
         }
         if (diskCacheSizeInGBLimit < 0 || (diskCacheSizeInGBLimit > 0 && diskCacheSizeInGBLimit < CacheConfig.MIN_DISKCACHE_SIZE_GB)) {
             Tr.warning(tc, "DYNA0069W", new Object[] { new Integer(diskCacheSizeInGBLimit), "diskCacheSizeInGB", this.cacheName,
-                                                      new Integer(CacheConfig.MIN_DISKCACHE_SIZE_GB), new Integer(CacheConfig.MAX_DISKCACHE_SIZE_GB),
-                                                      new Integer(CacheConfig.MIN_DISKCACHE_SIZE_GB) });
+                                                       new Integer(CacheConfig.MIN_DISKCACHE_SIZE_GB), new Integer(CacheConfig.MAX_DISKCACHE_SIZE_GB),
+                                                       new Integer(CacheConfig.MIN_DISKCACHE_SIZE_GB) });
             diskCacheSizeInGBLimit = CacheConfig.MIN_DISKCACHE_SIZE_GB;
         }
         if (diskCacheEntrySizeInMBLimit < 0) {
             Tr.warning(tc, "DYNA0069W", new Object[] { new Integer(diskCacheEntrySizeInMBLimit), "diskCacheEntrySizeInMB", this.cacheName,
-                                                      new Integer(CacheConfig.MIN_DISKCACHE_ENTRY_SIZE_MB), new Integer(CacheConfig.MAX_DISKCACHE_ENTRY_SIZE_MB),
-                                                      new Integer(CacheConfig.MIN_DISKCACHE_ENTRY_SIZE_MB) });
+                                                       new Integer(CacheConfig.MIN_DISKCACHE_ENTRY_SIZE_MB), new Integer(CacheConfig.MAX_DISKCACHE_ENTRY_SIZE_MB),
+                                                       new Integer(CacheConfig.MIN_DISKCACHE_ENTRY_SIZE_MB) });
             diskCacheEntrySizeInMBLimit = CacheConfig.MIN_DISKCACHE_ENTRY_SIZE_MB;
         }
 
         if (this.evictionPolicy != CacheConfig.EVICTION_NONE) {
             if (highThreshold < CacheConfig.MIN_HIGH_THRESHOLD || highThreshold > CacheConfig.MAX_HIGH_THRESHOLD
-                    || lowThreshold < CacheConfig.MIN_LOW_THRESHOLD || lowThreshold > CacheConfig.MAX_LOW_THRESHOLD || highThreshold <= lowThreshold) {
+                || lowThreshold < CacheConfig.MIN_LOW_THRESHOLD || lowThreshold > CacheConfig.MAX_LOW_THRESHOLD || highThreshold <= lowThreshold) {
                 Tr.info(tc, "DYNA0068W", new Object[] { this.cacheName });
                 highThreshold = CacheConfig.DEFAULT_HIGH_THRESHOLD;
                 lowThreshold = CacheConfig.DEFAULT_LOW_THRESHOLD;
@@ -357,7 +358,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
         loadAndCheckPropertyFile();
         if (this.propertyFileStatus != 0) {
             if ((this.propertyFileStatus & PROPERTY_ERROR_FILE_CORRUPT) > 0 || (this.propertyFileStatus & PROPERTY_ERROR_CACHE_SIZE) > 0
-                    || (this.propertyFileStatus & PROPERTY_ERROR_FIELD_CHECK) > 0 || (this.propertyFileStatus & PROPERTY_ERROR_GB) > 0) {
+                || (this.propertyFileStatus & PROPERTY_ERROR_FIELD_CHECK) > 0 || (this.propertyFileStatus & PROPERTY_ERROR_GB) > 0) {
                 if (this.currentCacheSizeInBytes > 0) {
                     this.dataGB = this.dataFiles;
                     this.dependencyIdGB = this.dependencyIdFiles;
@@ -723,6 +724,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
         final CacheOnDisk cod = this;
         traceDebug(methodName, "cacheName=" + this.cacheName);
         AccessController.doPrivileged(new PrivilegedAction() {
+            @Override
             public Object run() {
                 cod.propertyFileStatus = PROPERTY_FILE_OK;
                 String[] files = swapDirPathFile.list();
@@ -768,10 +770,10 @@ public class CacheOnDisk implements DynacacheOnDisk {
                             cod.propertyFileStatus = (byte) (cod.propertyFileStatus | PROPERTY_ERROR_CACHE_SIZE);
                             return null;
                         }
-                        byte[] b = sTemp.getBytes("UTF-8");
+                        byte[] b = sTemp.getBytes(StandardCharsets.UTF_8);
                         int fieldCheck = 0;
                         for (int i = 0; i < b.length; i++) {
-                            fieldCheck += (int) b[i];
+                            fieldCheck += b[i];
                         }
                         fieldCheck = fieldCheck * 3;
                         sTemp = (String) htodProp.get(FIELD_CHECK);
@@ -854,6 +856,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
         final CacheOnDisk cod = this;
         traceDebug(methodName, "cacheName=" + this.cacheName);
         AccessController.doPrivileged(new PrivilegedAction() {
+            @Override
             public Object run() {
                 FileOutputStream fos = null;
                 Properties htodProp = new Properties();
@@ -872,10 +875,10 @@ public class CacheOnDisk implements DynacacheOnDisk {
                         cacheSizeInBytes = cod.currentCacheSizeInBytes;
                         htodProp.put(CACHE_SIZE_IN_BYTES, Long.toString(cacheSizeInBytes));
                         String s = String.valueOf(cacheSizeInBytes);
-                        byte[] b = s.getBytes("UTF-8");
+                        byte[] b = s.getBytes(StandardCharsets.UTF_8);
                         fieldCheck = 0;
                         for (int i = 0; i < b.length; i++) {
-                            fieldCheck += (int) b[i];
+                            fieldCheck += b[i];
                         }
                         fieldCheck = fieldCheck * 3;
                         htodProp.put(FIELD_CHECK, String.valueOf(fieldCheck));
@@ -919,6 +922,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
         final CacheOnDisk cod = this;
         traceDebug(methodName, "cacheName=" + this.cacheName);
         AccessController.doPrivileged(new PrivilegedAction() {
+            @Override
             public Object run() {
                 try {
                     f.delete();
@@ -934,12 +938,14 @@ public class CacheOnDisk implements DynacacheOnDisk {
     /**
      * Call this method to delete all disk cache files per cache instance.
      */
+    @Override
     public void deleteDiskCacheFiles() {
         final String methodName = "deleteDiskCacheFiles()";
         final File f = new File(swapDirPath);
         final CacheOnDisk cod = this;
         traceDebug(methodName, "cacheName=" + this.cacheName);
         AccessController.doPrivileged(new PrivilegedAction() {
+            @Override
             public Object run() {
                 // delete files
                 File fl[] = f.listFiles();
@@ -965,6 +971,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
         final CacheOnDisk cod = this;
         traceDebug(methodName, "cacheName=" + this.cacheName);
         AccessController.doPrivileged(new PrivilegedAction() {
+            @Override
             public Object run() {
                 // delete files
                 File fd[] = f.listFiles();
@@ -995,6 +1002,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
         final CacheOnDisk cod = this;
         traceDebug(methodName, "cacheName=" + this.cacheName + " file=" + this.inProgressFileName);
         AccessController.doPrivileged(new PrivilegedAction() {
+            @Override
             public Object run() {
                 try {
                     f.createNewFile();
@@ -1016,6 +1024,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
         final CacheOnDisk cod = this;
         traceDebug(methodName, "cacheName=" + this.cacheName);
         AccessController.doPrivileged(new PrivilegedAction() {
+            @Override
             public Object run() {
                 try {
                     f.delete();
@@ -1030,10 +1039,11 @@ public class CacheOnDisk implements DynacacheOnDisk {
 
     /**
      * Call this method to stop the LPBT.
-     * 
+     *
      * @param completeClear
      *            - boolean to select clear all invalidation buffers completely or not.
      */
+    @Override
     public void stop(boolean completeClear) {
         stopping = true;
         this.htod.invalidationBuffer.setStopping(true);
@@ -1058,10 +1068,11 @@ public class CacheOnDisk implements DynacacheOnDisk {
 
     /**
      * Call this method to stop the LPBT.
-     * 
+     *
      * @param completeClear
      *            - boolean to select clear all invalidation buffers completely or not.
      */
+    @Override
     public void stopOnError(Exception ex) {
         this.cache.setSwapToDisk(false);
         stop(HTODDynacache.COMPLETE_CLEAR);
@@ -1080,6 +1091,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
         this.valueSet = new ValueSet(1);
         if (f.exists()) {
             AccessController.doPrivileged(new PrivilegedAction() {
+                @Override
                 public Object run() {
                     FileInputStream fis = null;
                     ObjectInputStream ois = null;
@@ -1104,8 +1116,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
                             }
                             f.delete();
                         } catch (Throwable t2) {
-                            com.ibm.ws.ffdc.FFDCFilter
-                                            .processException(t2, "com.ibm.ws.cache.CacheOnDisk.readAndDeleteInvalidationFile", "1068", cod);
+                            com.ibm.ws.ffdc.FFDCFilter.processException(t2, "com.ibm.ws.cache.CacheOnDisk.readAndDeleteInvalidationFile", "1068", cod);
                             traceDebug(methodName, "cacheName=" + cod.cacheName + "\nException: " + ExceptionUtility.getStackTrace(t2));
                         }
                     }
@@ -1127,6 +1138,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
         final CacheOnDisk cod = this;
         traceDebug(methodName, "cacheName=" + this.cacheName + " valueSet=" + cod.valueSet.size());
         AccessController.doPrivileged(new PrivilegedAction() {
+            @Override
             public Object run() {
                 FileOutputStream fos = null;
                 ObjectOutputStream oos = null;
@@ -1185,6 +1197,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
         }
     }
 
+    @Override
     @Trivial
     public void invokeDiskCleanup(boolean scan) {
         if (scan || htod.invalidationBuffer.size() > 0 || htod.invalidationBuffer.size(HTODInvalidationBuffer.GC_BUFFER) > 0) {
@@ -1201,6 +1214,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
         }
     }
 
+    @Override
     public boolean invokeDiskCacheGarbageCollector(int GCType) {
         boolean notified = false;
         if (this.garbageCollectionThread != null) {
@@ -1219,6 +1233,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
     /**
      * Call this method to clear the disk cache per cache instance.
      */
+    @Override
     public void clearDiskCache() {
         if (htod.clearDiskCache() == HTODDynacache.DISK_EXCEPTION) {
             stopOnError(this.htod.diskCacheException);
@@ -1232,6 +1247,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
     /**
      * Call this method to write a cache entry to the disk.
      */
+    @Override
     public int writeCacheEntry(CacheEntry ce) { // @A5C
         int returnCode = htod.writeCacheEntry(ce);
         if (returnCode == HTODDynacache.DISK_EXCEPTION) {
@@ -1242,10 +1258,11 @@ public class CacheOnDisk implements DynacacheOnDisk {
 
     /**
      * Call this method to read a cache entry from the disk.
-     * 
+     *
      * @param id
      *            - cache id.
      */
+    @Override
     public CacheEntry readCacheEntry(Object id) { // SKS-O
         Result result = htod.readCacheEntry(id);
         if (result.returnCode == HTODDynacache.DISK_EXCEPTION) {
@@ -1260,12 +1277,13 @@ public class CacheOnDisk implements DynacacheOnDisk {
 
     /**
      * Call this method to read a cache entry from the disk.
-     * 
+     *
      * @param id
      *            - cache id.
      * @param checkDependency
      *            - true to check whether cache id is also depid id.
      */
+    @Override
     public CacheEntry readCacheEntry(Object id, boolean calledFromRemove) {
         Result result = htod.readCacheEntry(id, calledFromRemove);
         if (result.returnCode == HTODDynacache.DISK_EXCEPTION) {
@@ -1280,33 +1298,36 @@ public class CacheOnDisk implements DynacacheOnDisk {
 
     /**
      * Call this method to a cache entry from the disk.
-     * 
+     *
      * @param ce
      *            - cache entry.
      */
+    @Override
     public void delCacheEntry(CacheEntry ce, int cause, int source, boolean fromDepIdTemplateInvalidation) {
         htod.delCacheEntry(ce, cause, source, fromDepIdTemplateInvalidation);
     }
 
     /**
      * Call this method to remove multiple of cache ids from the disk.
-     * 
+     *
      * @param removeList
      *            - a collection of cache ids.
      */
+    @Override
     public void delCacheEntry(ValueSet removeList, int cause, int source, boolean fromDepIdTemplateInvalidation, boolean fireEvent) {
         htod.delCacheEntry(removeList, cause, source, fromDepIdTemplateInvalidation, fireEvent);
     }
 
     /**
      * Call this method to read a specified dependency id which contains the cache ids from the disk.
-     * 
+     *
      * @param id
      *            - dependency id.
      * @param delete
      *            - boolean to delete the dependency id after reading
      * @return valueSet - the collection of cache ids.
      */
+    @Override
     public ValueSet readDependency(Object id, boolean delete) { // SKS-O
         Result result = htod.readDependency(id, delete);
         if (result.returnCode == HTODDynacache.DISK_EXCEPTION) {
@@ -1324,13 +1345,14 @@ public class CacheOnDisk implements DynacacheOnDisk {
 
     /**
      * Call this method to read a specified template which contains the cache ids from the disk.
-     * 
+     *
      * @param template
      *            - template id.
      * @param delete
      *            - boolean to delete the template after reading
      * @return valueSet - the collection of cache ids.
      */
+    @Override
     public ValueSet readTemplate(String template, boolean delete) {
         Result result = htod.readTemplate(template, delete);
         if (result.returnCode == HTODDynacache.DISK_EXCEPTION) {
@@ -1348,7 +1370,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
 
     /**
      * Call this method to get the cache ids based on the index and the length from the disk.
-     * 
+     *
      * @param index
      *            If index = 0, it starts the beginning. If index = 1, it means "next". If Index = -1, it means
      *            "previous".
@@ -1356,6 +1378,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
      *            The max number of templates to be read. If length = -1, it reads all templates until the end.
      * @return valueSet - the collection of cache ids.
      */
+    @Override
     public ValueSet readCacheIdsByRange(int index, int length) {
         Result result = htod.readCacheIdsByRange(index, length);
         if (result.returnCode == HTODDynacache.DISK_EXCEPTION) {
@@ -1373,7 +1396,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
 
     /**
      * Call this method to get the dependency ids based on the index and the length from the disk.
-     * 
+     *
      * @param index
      *            If index = 0, it starts the beginning. If index = 1, it means "next". If Index = -1, it means
      *            "previous".
@@ -1381,6 +1404,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
      *            The max number of templates to be read. If length = -1, it reads all templates until the end.
      * @return valueSet - the collection of dependency ids.
      */
+    @Override
     public ValueSet readDependencyByRange(int index, int length) {
         Result result = htod.readDependencyByRange(index, length);
         if (result.returnCode == HTODDynacache.DISK_EXCEPTION) {
@@ -1398,7 +1422,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
 
     /**
      * Call this method to get the template ids based on the index and the length from the disk.
-     * 
+     *
      * @param index
      *            If index = 0, it starts the beginning. If index = 1, it means "next". If Index = -1, it means
      *            "previous".
@@ -1406,6 +1430,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
      *            The max number of templates to be read. If length = -1, it reads all templates until the end.
      * @return valueSet - the collection of templates.
      */
+    @Override
     public ValueSet readTemplatesByRange(int index, int length) {
         Result result = htod.readTemplatesByRange(index, length);
         if (result.returnCode == HTODDynacache.DISK_EXCEPTION) {
@@ -1423,12 +1448,13 @@ public class CacheOnDisk implements DynacacheOnDisk {
 
     /**
      * Call this method to get the number of the cache ids in the disk.
-     * 
+     *
      * @param filter
      *            if true, filter the size from the invalidation buffer. Else, no filter - real size of entries in the
      *            disk
      * @return int - the size
      */
+    @Override
     public int getCacheIdsSize(boolean filter) {
         if (filter == CacheOnDisk.FILTER) {
             return htod.getCacheIdsSize(filter) - htod.invalidationBuffer.size();
@@ -1440,35 +1466,40 @@ public class CacheOnDisk implements DynacacheOnDisk {
 
     /**
      * Call this method to get the number of the dependency ids in the disk.
-     * 
+     *
      * @return int - the size
      */
+    @Override
     public int getDepIdsSize() {
         return htod.getDepIdsSize();
     }
 
     /**
      * Call this method to get the number of the templates in the disk.
-     * 
+     *
      * @return int - the size
      */
+    @Override
     public int getTemplatesSize() {
         return htod.getTemplatesSize();
     }
 
     /**
      * Call this method to get the total number of cache entries size in the disk.
-     * 
+     *
      * @return long - the size
      */
+    @Override
     public long getCacheSizeInBytes() {
         return this.currentCacheSizeInBytes;
     }
 
+    @Override
     public int getDiskCacheSizeLimit() { // 3821 NK begin
         return this.diskCacheSizeInfo.diskCacheSizeLimit;
     }
 
+    @Override
     public int getDiskCacheSizeHighLimit() { // 3821 NK begin
         return this.diskCacheSizeInfo.diskCacheSizeHighLimit;
     }
@@ -1477,18 +1508,22 @@ public class CacheOnDisk implements DynacacheOnDisk {
         return this.diskCacheSizeInfo.diskCacheSizeLowLimit;
     }
 
+    @Override
     public int getDiskCacheSizeInGBLimit() {
         return this.diskCacheSizeInfo.diskCacheSizeInGBLimit;
     }
 
+    @Override
     public long getDiskCacheEntrySizeInBytesLimit() {
         return this.diskCacheSizeInfo.diskCacheEntrySizeInBytesLimit;
     }
 
+    @Override
     public long getDiskCacheSizeInBytesLimit() {
         return this.diskCacheSizeInfo.getDiskCacheSizeInBytesLimit();
     }
 
+    @Override
     public long getDiskCacheSizeInBytesHighLimit() {
         return this.diskCacheSizeInfo.getDiskCacheSizeInBytesHighLimit();
     }
@@ -1497,18 +1532,20 @@ public class CacheOnDisk implements DynacacheOnDisk {
         return this.diskCacheSizeInfo.getDiskCacheSizeInBytesLowLimit();
     }
 
+    @Override
     public int getEvictionPolicy() {
         return this.evictionPolicy;
     } // 3821 NK end
 
     /**
      * Call this method to delete a cache id from a specified dependency in the disk.
-     * 
+     *
      * @param id
      *            - dependency id.
      * @param entry
      *            - cache id.
      */
+    @Override
     public void delDependencyEntry(Object id, Object entry) { // SKS-O
         if (htod.delDependencyEntry(id, entry) == HTODDynacache.DISK_EXCEPTION) {
             stopOnError(this.htod.diskCacheException);
@@ -1517,12 +1554,13 @@ public class CacheOnDisk implements DynacacheOnDisk {
 
     /**
      * Call this method to delete a cache id from a specified template in the disk.
-     * 
+     *
      * @param template
      *            - template id.
      * @param entry
      *            - cache id.
      */
+    @Override
     public void delTemplateEntry(String template, Object entry) {
         if (htod.delTemplateEntry(template, entry) == HTODDynacache.DISK_EXCEPTION) {
             stopOnError(this.htod.diskCacheException);
@@ -1531,10 +1569,11 @@ public class CacheOnDisk implements DynacacheOnDisk {
 
     /**
      * Call this method to delete speciifed dependency id from the disk.
-     * 
+     *
      * @param id
      *            - dependency id.
      */
+    @Override
     public void delDependency(Object id) { // SKS-O
         if (htod.delDependency(id) == HTODDynacache.DISK_EXCEPTION) {
             stopOnError(this.htod.diskCacheException);
@@ -1543,10 +1582,11 @@ public class CacheOnDisk implements DynacacheOnDisk {
 
     /**
      * Call this method to delete speciifed template from the disk.
-     * 
+     *
      * @param id
      *            - template id.
      */
+    @Override
     public void delTemplate(String template) {
         if (htod.delTemplate(template) == HTODDynacache.DISK_EXCEPTION) {
             stopOnError(this.htod.diskCacheException);
@@ -1555,12 +1595,13 @@ public class CacheOnDisk implements DynacacheOnDisk {
 
     /**
      * Call this method to write a dependency id with a collection of cache ids to the disk.
-     * 
+     *
      * @param id
      *            - dependency id.
      * @param vs
      *            - a collection of cache ids.
      */
+    @Override
     public int writeDependency(Object id, ValueSet vs) { // SKS-O
         int returnCode = htod.writeDependency(id, vs);
         if (returnCode == HTODDynacache.DISK_EXCEPTION) {
@@ -1571,12 +1612,13 @@ public class CacheOnDisk implements DynacacheOnDisk {
 
     /**
      * Call this method to write a template with a collection of cache ids to the disk.
-     * 
+     *
      * @param template
      *            - template id.
      * @param vs
      *            - a collection of cache ids.
      */
+    @Override
     public int writeTemplate(String template, ValueSet vs) {
         int returnCode = htod.writeTemplate(template, vs);
         if (returnCode == HTODDynacache.DISK_EXCEPTION) {
@@ -1587,12 +1629,13 @@ public class CacheOnDisk implements DynacacheOnDisk {
 
     /**
      * Call this method to add a cache id for a specified dependency id to the disk.
-     * 
+     *
      * @param id
      *            - dependency id.
      * @param entry
      *            - cache id.
      */
+    @Override
     public int writeDependencyEntry(Object id, Object entry) { // SKS-O
         int returnCode = htod.writeDependencyEntry(id, entry);
         if (returnCode == HTODDynacache.DISK_EXCEPTION) {
@@ -1603,12 +1646,13 @@ public class CacheOnDisk implements DynacacheOnDisk {
 
     /**
      * Call this method to add a cache id for a specified template to the disk.
-     * 
+     *
      * @param template
      *            - template id.
      * @param entry
      *            - cache id.
      */
+    @Override
     public int writeTemplateEntry(String template, Object entry) {
         int returnCode = htod.writeTemplateEntry(template, entry);
         if (returnCode == HTODDynacache.DISK_EXCEPTION) {
@@ -1619,20 +1663,22 @@ public class CacheOnDisk implements DynacacheOnDisk {
 
     /**
      * This method returns true if disk cache contains a mapping for the specified key.
-     * 
+     *
      * @param key
      *            - key is to be tested.
      * @return true if disk cache contains a mapping for the specified key.
      */
+    @Override
     public boolean containsKey(Object key) {
         return htod.containsKey(key);
     }
 
     /**
      * This method gets the start state of HTOD which is used in the Cache.start() method
-     * 
+     *
      * @return startState START_NONE, START_LPBT_SCAN, START_LPBT_REMOVE
      */
+    @Override
     public int getStartState() {
         return this.startState;
     }
@@ -1640,6 +1686,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
     /**
      * This method returns true if EvictionTable needs to be populated on server restart
      **/
+    @Override
     public boolean shouldPopulateEvictionTable() {
         return this.populateEvictionTable;
     }
@@ -1647,6 +1694,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
     /**
      * This method gets the current pending removal size in the disk invalidation buffers.
      */
+    @Override
     public int getPendingRemovalSize() {
         return htod.getPendingRemovalSize();
     }
@@ -1654,6 +1702,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
     /**
      * This method gets the current size of dependency id buckets in the memory table for the disk.
      */
+    @Override
     public int getDepIdsBufferedSize() {
         return htod.getDepIdsBufferedSize();
     }
@@ -1661,6 +1710,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
     /**
      * This method gets the current size of template buckets in the memory table for the disk.
      */
+    @Override
     public int getTemplatesBufferedSize() {
         return htod.getTemplatesBufferedSize();
     }
@@ -1685,6 +1735,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
     /**
      * This method checks whether the disk cleanup is running or not
      */
+    @Override
     public boolean isCleanupRunning() {
         return this.htod.invalidationBuffer.isBackgroundInvalidationInProgress();
     }
@@ -1692,6 +1743,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
     /**
      * This method clears invalidaiton buffers in HTODDynacache
      */
+    @Override
     public void clearInvalidationBuffers() {
         this.htod.invalidationBuffer.clear(HTODInvalidationBuffer.EXPLICIT_BUFFER); // 3821 NK begin
         this.htod.invalidationBuffer.clear(HTODInvalidationBuffer.SCAN_BUFFER);
@@ -1703,6 +1755,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
     /**
      * This method checks whether invalidaiton buffers in HTODDynacache is full or not
      */
+    @Override
     @Trivial
     public boolean isInvalidationBuffersFull() {
         return this.htod.invalidationBuffer.isFull();
@@ -1711,13 +1764,14 @@ public class CacheOnDisk implements DynacacheOnDisk {
     /**
      * This method releases unused pools which is over its life time.
      */
+    @Override
     public void releaseUnusedPools() {
         this.htod.releaseUnusedPools();
     }
 
     /**
      * This method find the hashcode based on index and length.
-     * 
+     *
      * @param index
      *            If index = 0, it starts the beginning. If index = 1, it means "next". If Index = -1, it means
      *            "previous".
@@ -1728,6 +1782,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
      * @param useValue
      *            true to calculate hashcode including value
      */
+    @Override
     public Result readHashcodeByRange(int index, int length, boolean debug, boolean useValue) { // LI4337-17
         Result result = this.htod.readHashcodeByRange(index, length, debug, useValue);
         if (result.returnCode == HTODDynacache.DISK_EXCEPTION) {
@@ -1739,6 +1794,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
     /**
      * This method is used to update expiration times in GC and disk emtry header
      */
+    @Override
     public int updateExpirationTime(Object id, long oldExpirationTime, int size, long newExpirationTime, long newValidatorExpirationTime) {
         int returnCode = this.htod.updateExpirationTime(id, oldExpirationTime, size, newExpirationTime, newValidatorExpirationTime);
         if (returnCode == HTODDynacache.DISK_EXCEPTION) {
@@ -1747,10 +1803,12 @@ public class CacheOnDisk implements DynacacheOnDisk {
         return returnCode;
     }
 
+    @Override
     public Exception getDiskCacheException() {
         return htod.diskCacheException;
     }
 
+    @Override
     public void waitForCleanupComplete() {
         final String methodName = "waitForCleanupComplete()";
         if (this.diskCleanupThread != null) {
@@ -1833,7 +1891,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
 
     /**
      * Check the location whether it is writable or not
-     * 
+     *
      * @param location
      * @return int 0 = OK 1 = LOCATION_NOT_DEFINED 2 = INVALID_LOCATION 3 = LOCATION_NOT_DIRECTORY 4 =
      *         LOCATION_NOT_WRITABLE 5 = LOCATION_CANNOT_MAKE_DIR
@@ -1871,6 +1929,7 @@ public class CacheOnDisk implements DynacacheOnDisk {
     /**
      * Return a boolean to indicate whether the specified cache id exists in the aux dependency table
      */
+    @Override
     public boolean isCacheIdInAuxDepIdTable(Object id) {
         return this.htod.isCacheIdInAuxDepIdTable(id);
     }

--- a/dev/com.ibm.ws.dynamic.bundle/src/com/ibm/ws/dynamic/bundle/BundleFactory.java
+++ b/dev/com.ibm.ws.dynamic.bundle/src/com/ibm/ws/dynamic/bundle/BundleFactory.java
@@ -14,7 +14,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -48,8 +48,8 @@ public class BundleFactory extends ManifestFactory {
     private String metatypeXML = null;
     private final List<ServiceComponentDeclaration> components = new ArrayList<ServiceComponentDeclaration>();
 
-    // Leaving this commented out main method in the code 
-    // to serve as an example of how to use this factory 
+    // Leaving this commented out main method in the code
+    // to serve as an example of how to use this factory
     // with a service component declaration.
     //    public static void main(String[] args) throws IOException {
     //        final ServiceComponentDeclaration scd = new ServiceComponentDeclaration()
@@ -189,18 +189,16 @@ public class BundleFactory extends ManifestFactory {
         try {
             MessageDigest shaDigest = MessageDigest.getInstance(SHA_ALGORITHM);
             for (ServiceComponentDeclaration component : components) {
-                shaDigest.update(component.toString().getBytes("UTF-8"));
+                shaDigest.update(component.toString().getBytes(StandardCharsets.UTF_8));
             }
             if (defaultInstance != null) {
-                shaDigest.update(defaultInstance.getBytes("UTF-8"));
+                shaDigest.update(defaultInstance.getBytes(StandardCharsets.UTF_8));
             }
             if (metatypeXML != null) {
-                shaDigest.update(metatypeXML.getBytes("UTF-8"));
+                shaDigest.update(metatypeXML.getBytes(StandardCharsets.UTF_8));
             }
             addAttributeValues(EXTRAS_SHA_HEADER, getHexSHA(shaDigest));
         } catch (NoSuchAlgorithmException e) {
-            // auto FFDC
-        } catch (UnsupportedEncodingException e) {
             // auto FFDC
         }
     }
@@ -241,19 +239,19 @@ public class BundleFactory extends ManifestFactory {
             // write each component
             for (ServiceComponentDeclaration component : components) {
                 jarOut.putNextEntry(new JarEntry(component.getFileName()));
-                jarOut.write(component.toString().getBytes("UTF-8"));
+                jarOut.write(component.toString().getBytes(StandardCharsets.UTF_8));
                 jarOut.closeEntry();
             }
 
             if (defaultInstance != null) {
                 jarOut.putNextEntry(new JarEntry("OSGI-INF/wlp/defaultInstances.xml"));
-                jarOut.write(defaultInstance.getBytes("UTF-8"));
+                jarOut.write(defaultInstance.getBytes(StandardCharsets.UTF_8));
                 jarOut.closeEntry();
             }
 
             if (metatypeXML != null) {
                 jarOut.putNextEntry(new JarEntry("OSGI-INF/metatype/metatype.xml"));
-                jarOut.write(metatypeXML.getBytes("UTF-8"));
+                jarOut.write(metatypeXML.getBytes(StandardCharsets.UTF_8));
                 jarOut.closeEntry();
             }
 

--- a/dev/com.ibm.ws.jaxrs.2.0.client/src/com/ibm/ws/jaxrs20/client/security/saml/PropagationHandler.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client/src/com/ibm/ws/jaxrs20/client/security/saml/PropagationHandler.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.jaxrs20.client.security.saml;
 
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +32,7 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.jaxrs20.client.JAXRSClientConstants;
 
 /**
- * 
+ *
  */
 public class PropagationHandler extends AbstractPhaseInterceptor<Message> {
     private static final TraceComponent tc = Tr.register(PropagationHandler.class, JAXRSClientConstants.TR_GROUP, JAXRSClientConstants.TR_RESOURCE_BUNDLE);
@@ -78,7 +78,7 @@ public class PropagationHandler extends AbstractPhaseInterceptor<Message> {
                 Tr.debug(tc, "About to get a SAML authentication token from the runAs Subject");
             }
 
-            // retrieve the saml token from the runAs Subject in current thread 
+            // retrieve the saml token from the runAs Subject in current thread
             try {
                 saml = getEncodedSaml20Token();
 
@@ -86,7 +86,7 @@ public class PropagationHandler extends AbstractPhaseInterceptor<Message> {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                         Tr.debug(tc, "Retrieved the encoded SAML token. About to set it on the request Header " + saml);
                     }
-                    //Authorization=[saml="<SAML_HERE>"] 
+                    //Authorization=[saml="<SAML_HERE>"]
                     @SuppressWarnings("unchecked")
                     Map<String, List<String>> headers = (Map<String, List<String>>) message
                                     .get(Message.PROTOCOL_HEADERS);
@@ -133,14 +133,7 @@ public class PropagationHandler extends AbstractPhaseInterceptor<Message> {
             Tr.warning(tc, "failed_to_extract_saml_token_from_subject", e.getLocalizedMessage());
         }
         if (samlString != null) {
-            byte output[] = null;
-            try {
-                output = samlString.getBytes("UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                // This should not happen.
-                // If it happens, it would be some runtime or operating system issue, so just give up and return null.
-                // ffdc data will be logged automatically.
-            }
+            byte output[] = samlString.getBytes(StandardCharsets.UTF_8);
             if (output != null) {
                 base64Saml = Base64Coder.base64EncodeToString(output);
             } else {

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/utils/UriEncoder.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/com/ibm/ws/jaxrs20/utils/UriEncoder.java
@@ -13,6 +13,7 @@ package com.ibm.ws.jaxrs20.utils;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 /**
@@ -20,7 +21,7 @@ import java.util.Arrays;
  */
 public final class UriEncoder {
 
-    private static final Charset CHARSET_UTF_8 = Charset.forName("UTF-8"); //$NON-NLS-1$
+    private static final Charset CHARSET_UTF_8 = StandardCharsets.UTF_8;
 
     private UriEncoder() {
         // no instances

--- a/dev/com.ibm.ws.jbatch.jms/src/com/ibm/ws/jbatch/jms/internal/dispatcher/BatchJmsDispatcher.java
+++ b/dev/com.ibm.ws.jbatch.jms/src/com/ibm/ws/jbatch/jms/internal/dispatcher/BatchJmsDispatcher.java
@@ -12,6 +12,7 @@ package com.ibm.ws.jbatch.jms.internal.dispatcher;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -875,11 +876,7 @@ public class BatchJmsDispatcher implements BatchDispatcher {
      * @return a J2EEName for the given app / module / comp.
      */
     protected J2EEName createJ2EEName(String j2eeName) {
-        try {
-            return j2eeNameFactory.create( j2eeName.getBytes("UTF-8") );
-        } catch (UnsupportedEncodingException uee) {
-            throw new JobStartException("Failed to parse J2EEName from app name: " + j2eeName, uee);
-        }
+        return j2eeNameFactory.create( j2eeName.getBytes(StandardCharsets.UTF_8) );
     }
 
 

--- a/dev/com.ibm.ws.jbatch.rest/src/com/ibm/ws/jbatch/rest/bridge/BatchInternalDispatcherImpl.java
+++ b/dev/com.ibm.ws.jbatch.rest/src/com/ibm/ws/jbatch/rest/bridge/BatchInternalDispatcherImpl.java
@@ -11,6 +11,7 @@
 package com.ibm.ws.jbatch.rest.bridge;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -149,11 +150,7 @@ public class BatchInternalDispatcherImpl implements BatchInternalDispatcher {
 	 * @return a J2EEName for the given app / module / comp.
 	 */
 	protected J2EEName createJ2EEName(String j2eeName) {
-		try {
-			return j2eeNameFactory.create( j2eeName.getBytes("UTF-8") );
-		} catch (UnsupportedEncodingException uee) {
-			throw new JobStartException("Failed to parse J2EEName from app name: " + j2eeName, uee);
-		}
+		return j2eeNameFactory.create( j2eeName.getBytes(StandardCharsets.UTF_8) );
 	}
 
 	/**

--- a/dev/com.ibm.ws.jbatch.rest/src/com/ibm/ws/jbatch/rest/internal/ZipHelper.java
+++ b/dev/com.ibm.ws.jbatch.rest/src/com/ibm/ws/jbatch/rest/internal/ZipHelper.java
@@ -16,6 +16,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.zip.ZipEntry;
@@ -124,9 +125,9 @@ public class ZipHelper {
                                               OutputStream outputStream) throws IOException {
         
         for (File file : files) {
-            outputStream.write( buildAggregateHeader(file, rootDirs).getBytes("UTF-8") );
+            outputStream.write( buildAggregateHeader(file, rootDirs).getBytes(StandardCharsets.UTF_8) );
             copyStream( new FileInputStream(file), outputStream );
-            outputStream.write( buildAggregateFooter(file, rootDirs).getBytes("UTF-8") );
+            outputStream.write( buildAggregateFooter(file, rootDirs).getBytes(StandardCharsets.UTF_8) );
         }
 
     }

--- a/dev/com.ibm.ws.jbatch.rest/src/com/ibm/ws/jbatch/rest/internal/resources/JobInstances.java
+++ b/dev/com.ibm.ws.jbatch.rest/src/com/ibm/ws/jbatch/rest/internal/resources/JobInstances.java
@@ -18,6 +18,7 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -636,7 +637,7 @@ public class JobInstances implements RESTHandler {
             if (jslInput != null) {
                 // Defaulting to UTF-8
                 BufferedReader br = new BufferedReader(new InputStreamReader(
-                                jslInput, "UTF-8"));
+                                jslInput, StandardCharsets.UTF_8));
                 String jslBody = IOUtils.toString(br);
 
                 jobInstance = batchManager.start(

--- a/dev/com.ibm.ws.jbatch.utility/src/com/ibm/ws/jbatch/utility/http/StringEntityReader.java
+++ b/dev/com.ibm.ws.jbatch.utility/src/com/ibm/ws/jbatch/utility/http/StringEntityReader.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,7 +34,7 @@ public class StringEntityReader implements EntityReader<List<String>> {
         }
         
         String line;
-        BufferedReader br = new BufferedReader(new InputStreamReader(entityStream, Charset.forName("UTF-8")));
+        BufferedReader br = new BufferedReader(new InputStreamReader(entityStream, StandardCharsets.UTF_8));
         while ( (line = br.readLine()) != null ) {
             retMe.add(line);
         }

--- a/dev/com.ibm.ws.jmx.connector.local/src/com/ibm/ws/jmx/connector/local/LocalConnectorActivator.java
+++ b/dev/com.ibm.ws.jmx.connector.local/src/com/ibm/ws/jmx/connector/local/LocalConnectorActivator.java
@@ -13,6 +13,7 @@ package com.ibm.ws.jmx.connector.local;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Properties;
@@ -221,7 +222,7 @@ public final class LocalConnectorActivator {
                     resource.create();
                 }
                 OutputStream os = resource.putStream();
-                os.write(connectorAddress.getBytes("UTF-8"));
+                os.write(connectorAddress.getBytes(StandardCharsets.UTF_8));
                 os.flush();
                 os.close();
 

--- a/dev/com.ibm.ws.jndi.iiop/src/com/ibm/ws/jndi/iiop/CorbanameUrlContextFactory.java
+++ b/dev/com.ibm.ws.jndi.iiop/src/com/ibm/ws/jndi/iiop/CorbanameUrlContextFactory.java
@@ -13,6 +13,7 @@ package com.ibm.ws.jndi.iiop;
 import static org.osgi.service.component.annotations.ConfigurationPolicy.IGNORE;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.BitSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -103,7 +104,7 @@ public class CorbanameUrlContextFactory extends UrlContextFactory implements Obj
             // * any of these: ; / : ? @ & = + $ , - _ . ! ~ * ’ ( )
             StringBuilder escaped = new StringBuilder(twoParts[0]).append("#");
             // since we must use an octet-based representation to URI-encode, convert the string into its UTF-8 bytes
-            for (byte b : sn.toString().getBytes(Charset.forName("UTF-8"))) {
+            for (byte b : sn.toString().getBytes(StandardCharsets.UTF_8)) {
                 if (ESCAPE_NOT_NEEDED.get(b)) {
                     escaped.append((char) b);
                 } else {

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/BootstrapConfig.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/BootstrapConfig.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.lang.instrument.Instrumentation;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.text.MessageFormat;
@@ -242,7 +243,7 @@ public class BootstrapConfig {
      *
      * Swiped from PathUtils, which isn't currently exposed to BootstrapConfig
      *
-     * @param file       file to check if is a symbolic link
+     * @param file file to check if is a symbolic link
      * @param parentFile parent of the file to check
      * @return whether the given file refers to a symbolic link
      *
@@ -285,11 +286,11 @@ public class BootstrapConfig {
      * than the Launcher.
      *
      * @param initProps
-     *                           Initial set of properties we're working with, contains some
-     *                           properties populated by command line parser
+     *            Initial set of properties we're working with, contains some
+     *            properties populated by command line parser
      * @param instanceDirStr Value of WLP_USER_DIR environment variable
-     * @param outputDirStr   Value of WLP_OUTPUT_DIR environment variable
-     * @param logDirStr      Value of X_LOG_DIR or LOG_DIR environment variable
+     * @param outputDirStr Value of WLP_OUTPUT_DIR environment variable
+     * @param logDirStr Value of X_LOG_DIR or LOG_DIR environment variable
      *
      * @throws LocationException
      */
@@ -366,12 +367,12 @@ public class BootstrapConfig {
      * or exists as a directory.
      *
      * @param dirName
-     *                    Name/path to directory
+     *            Name/path to directory
      * @param locName
-     *                    Symbol/location associated with directory
+     *            Symbol/location associated with directory
      * @return File for directory location
      * @throws LocationException
-     *                               if dirName references an existing File (isFile).
+     *             if dirName references an existing File (isFile).
      */
     protected File assertDirectory(String dirName, String locName) {
         File d = new File(dirName);
@@ -443,7 +444,7 @@ public class BootstrapConfig {
      * properties.
      *
      * @param key
-     *                Property key
+     *            Property key
      * @return Object value, or null if not found.
      */
     public String get(final String key) {
@@ -471,9 +472,9 @@ public class BootstrapConfig {
      * null) if key is null.
      *
      * @param key
-     *                  Property key string
+     *            Property key string
      * @param value
-     *                  Property value object
+     *            Property value object
      * @return current/replaced value
      */
     public String put(final String key, String value) {
@@ -487,7 +488,7 @@ public class BootstrapConfig {
      * Set a new property into the set of initial properties only if the
      * key does not already have an existing value.
      *
-     * @param key   the key to set
+     * @param key the key to set
      * @param value the value to set
      * @return the previous value associated with the specified key, or
      *         {@code null} if there was no mapping for the key.
@@ -504,7 +505,7 @@ public class BootstrapConfig {
      * Clear property
      *
      * @param key
-     *                Key of property to clear
+     *            Key of property to clear
      * @return current/removed value
      */
     public String remove(final String key) {
@@ -516,9 +517,9 @@ public class BootstrapConfig {
 
     /**
      * @param useLineBreaks
-     *                          If true, line breaks will be used when displaying
-     *                          configured locations; locations will otherwise be separated by
-     *                          commas.
+     *            If true, line breaks will be used when displaying
+     *            configured locations; locations will otherwise be separated by
+     *            commas.
      * @return Display string describing configured bootstrap locations.
      */
     public String printLocations(boolean formatOutput) {
@@ -610,7 +611,7 @@ public class BootstrapConfig {
      * WLP_OUTPUT_DIR/relativePath
      *
      * @param relativePath
-     *                         relative path of file to create in the WLP_OUTPUT_DIR directory
+     *            relative path of file to create in the WLP_OUTPUT_DIR directory
      * @return File object for relative path, or for the WLP_OUTPUT_DIR directory itself
      *         if the relative path argument is null
      */
@@ -626,7 +627,7 @@ public class BootstrapConfig {
      * usr/servers/serverName/relativeServerPath
      *
      * @param relativeServerPath
-     *                               relative path of file to create in the server directory
+     *            relative path of file to create in the server directory
      * @return File object for relative path, or for the server directory itself
      *         if the relative path argument is null
      */
@@ -642,7 +643,7 @@ public class BootstrapConfig {
      * server-data/serverName/relativeServerPath
      *
      * @param relativeServerPath
-     *                               relative path of file to create in the server directory
+     *            relative path of file to create in the server directory
      * @return File object for relative path, or for the server directory itself
      *         if the relative path argument is null
      */
@@ -658,7 +659,7 @@ public class BootstrapConfig {
      * usr/servers/serverName/workarea/relativeServerWorkareaPath
      *
      * @param relativeServerWorkareaPath
-     *                                       relative path of file to create in the server's workarea
+     *            relative path of file to create in the server's workarea
      * @return File object for relative path, or for the server workarea itself if
      *         the relative path argument is null
      */
@@ -675,14 +676,14 @@ public class BootstrapConfig {
      * baseURL, in the case of relative paths) into the target map.
      *
      * @param target
-     *                    Target map to populate with new properties
+     *            Target map to populate with new properties
      * @param baseURL
-     *                    Base location used for resolving relative paths
+     *            Base location used for resolving relative paths
      * @param urlStr
-     *                    URL string describing the properties resource to load
+     *            URL string describing the properties resource to load
      * @param recurse
-     *                    Whether or not to follow any included bootstrap resources
-     *                    (bootstrap.includes).
+     *            Whether or not to follow any included bootstrap resources
+     *            (bootstrap.includes).
      */
     protected void mergeProperties(Map<String, String> target, URL baseURL, String urlStr) {
         String includes = null;
@@ -791,7 +792,7 @@ public class BootstrapConfig {
      * symbol with the initial property value.
      *
      * @param str
-     *                String to evaluate for symbols
+     *            String to evaluate for symbols
      * @return String with known symbols replaced by the associated values.
      * @see #get(String)
      */
@@ -819,13 +820,13 @@ public class BootstrapConfig {
      * created unless the files to use were specified explicitly on the command line.
      *
      * @param verifyServerString
-     *                               A value from the {@link BootstrapConstants.VerifyServer} enum: describes
-     *                               whether or not a server should be created if it does not exist.
+     *            A value from the {@link BootstrapConstants.VerifyServer} enum: describes
+     *            whether or not a server should be created if it does not exist.
      * @param createOptions
-     *                               Other launch arguments, namely template options for use with create
+     *            Other launch arguments, namely template options for use with create
      * @throws LaunchException
-     *                             If server does not exist and --create was not specified and
-     *                             it is not the defaultServer.
+     *             If server does not exist and --create was not specified and
+     *             it is not the defaultServer.
      */
     void verifyProcess(VerifyServer verifyServer, LaunchArguments createOptions) throws LaunchException {
         if (verifyServer == null || verifyServer == VerifyServer.SKIP) {
@@ -1015,7 +1016,7 @@ public class BootstrapConfig {
 
     /**
      * @param cmdArgs
-     *                    command line arguments (post-parse)
+     *            command line arguments (post-parse)
      */
     public void setCmdArgs(List<String> cmdArgs) {
         this.cmdArgs = cmdArgs;
@@ -1030,7 +1031,7 @@ public class BootstrapConfig {
 
     /**
      * @param frameworkLaunchClassloader
-     *                                       the frameworkLaunchClassloader to set
+     *            the frameworkLaunchClassloader to set
      */
     public void setFrameworkClassloader(ClassLoader frameworkLaunchClassloader) {
         this.frameworkLaunchClassloader = frameworkLaunchClassloader;
@@ -1177,9 +1178,9 @@ public class BootstrapConfig {
             }
 
             if (serverEnvContents == null)
-                FileUtils.createFile(serverEnv, new ByteArrayInputStream(toWrite.getBytes("UTF-8")));
+                FileUtils.createFile(serverEnv, new ByteArrayInputStream(toWrite.getBytes(StandardCharsets.UTF_8)));
             else
-                FileUtils.appendFile(serverEnv, new ByteArrayInputStream(toWrite.getBytes("UTF-8")));
+                FileUtils.appendFile(serverEnv, new ByteArrayInputStream(toWrite.getBytes(StandardCharsets.UTF_8)));
 
         } catch (IOException ex) {
             throw new LaunchException("Failed to create/update the server.env file for this server", MessageFormat.format(BootstrapConstants.messages.getString("error.create.java8serverenv"),

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/KernelResolver.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/KernelResolver.java
@@ -20,6 +20,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -141,38 +142,38 @@ public class KernelResolver {
 
             // Make sure we can find the log provider
             if (logProviderName == null || logProviderName.trim().length() == 0)
-                logThrowLaunchException(new LaunchException("Log provider definition not found (Tr/FFDC)",
-                                BootstrapConstants.messages.getString("error.rasProvider")));
+                logThrowLaunchException(new LaunchException("Log provider definition not found (Tr/FFDC)", BootstrapConstants.messages.getString("error.rasProvider")));
 
             logProviderMf = new File(platformDir, logProviderName + ".mf");
             if (!logProviderMf.exists())
-                logThrowLaunchException(new LaunchException("Kernel definition could not be found: " + logProviderMf.getAbsolutePath(),
-                                MessageFormat.format(BootstrapConstants.messages.getString("error.kernelDefFile"), logProviderName)));
+                logThrowLaunchException(new LaunchException("Kernel definition could not be found: "
+                                                            + logProviderMf.getAbsolutePath(), MessageFormat.format(BootstrapConstants.messages.getString("error.kernelDefFile"),
+                                                                                                                    logProviderName)));
 
             // The log provider also most specify the class we should be creating so we have logging!
             ManifestCacheElement entry = cache.checkEntry(logProviderMf, true, repo);
             logProviderClass = entry.getLogProviderClass();
             if (logProviderClass == null)
-                logThrowLaunchException(new LaunchException("A log provider implementation was not defined",
-                                BootstrapConstants.messages.getString("error.rasProvider")));
+                logThrowLaunchException(new LaunchException("A log provider implementation was not defined", BootstrapConstants.messages.getString("error.rasProvider")));
 
             // Make sure we can find the kernel definition
             if (kernelDefName == null || kernelDefName.trim().length() == 0)
-                logThrowLaunchException(new LaunchException("Could not find kernel definition",
-                                BootstrapConstants.messages.getString("error.kernelDef")));
+                logThrowLaunchException(new LaunchException("Could not find kernel definition", BootstrapConstants.messages.getString("error.kernelDef")));
 
             kernelMf = new File(platformDir, kernelDefName + ".mf");
             if (!kernelMf.exists())
-                logThrowLaunchException(new LaunchException("Kernel definition could not be found: " + kernelMf.getAbsolutePath(),
-                                MessageFormat.format(BootstrapConstants.messages.getString("error.kernelDefFile"), kernelDefName)));
+                logThrowLaunchException(new LaunchException("Kernel definition could not be found: "
+                                                            + kernelMf.getAbsolutePath(), MessageFormat.format(BootstrapConstants.messages.getString("error.kernelDefFile"),
+                                                                                                               kernelDefName)));
             cache.checkEntry(kernelMf, false, repo);
 
             // If we have an os extension to work with, make sure we can find it, too
             if (osExtensionName != null) {
                 osExtensionMf = new File(platformDir, osExtensionName + ".mf");
                 if (!osExtensionMf.exists())
-                    logThrowLaunchException(new LaunchException("Kernel definition could not be found: " + osExtensionMf.getAbsolutePath(),
-                                    MessageFormat.format(BootstrapConstants.messages.getString("error.kernelDefFile"), osExtensionName)));
+                    logThrowLaunchException(new LaunchException("Kernel definition could not be found: "
+                                                                + osExtensionMf.getAbsolutePath(), MessageFormat.format(BootstrapConstants.messages.getString("error.kernelDefFile"),
+                                                                                                                        osExtensionName)));
 
                 cache.checkEntry(osExtensionMf, true, repo);
             } else {
@@ -346,8 +347,9 @@ public class KernelResolver {
                     packages = (packages == null) ? mPackages : packages + "," + mPackages;
                 }
             } catch (IOException e) {
-                throw new LaunchException("Exception loading log provider jar " + (jarFile != null ? jarFile.getName() : "null") + ", " + e,
-                                MessageFormat.format(BootstrapConstants.messages.getString("error.rasProviderResolve"), (jarFile != null ? jarFile.getName() : "null")), e);
+                throw new LaunchException("Exception loading log provider jar " + (jarFile != null ? jarFile.getName() : "null") + ", "
+                                          + e, MessageFormat.format(BootstrapConstants.messages.getString("error.rasProviderResolve"),
+                                                                    (jarFile != null ? jarFile.getName() : "null")), e);
             } finally {
                 Utils.tryToClose(jarFile);
             }
@@ -412,7 +414,7 @@ public class KernelResolver {
                     //   kernelManifest-1.0=kernel;manifest;information
                     //   --|kernelManifest-1.0|bundle.symbolic.name....
                     // It is expected that the manifest line will precede the lines with the bundle..
-                    reader = new BufferedReader(new InputStreamReader(new FileInputStream(cacheFile), "UTF-8"));
+                    reader = new BufferedReader(new InputStreamReader(new FileInputStream(cacheFile), StandardCharsets.UTF_8));
                     while ((line = reader.readLine()) != null) {
                         if (line.startsWith(BUNDLE_LINE)) {
                             // If line starts with --|, this is a line describing a kernel bundle
@@ -468,7 +470,7 @@ public class KernelResolver {
                     if (!parentExists)
                         throw new IOException("Unable to create parent(s) of file " + cacheFile.getAbsolutePath());
 
-                    writer = new PrintWriter(new OutputStreamWriter(new FileOutputStream(cacheFile), "UTF-8"));
+                    writer = new PrintWriter(new OutputStreamWriter(new FileOutputStream(cacheFile), StandardCharsets.UTF_8));
                     for (ManifestCacheElement entry : cacheEntries.values()) {
                         entry.write(writer);
                         writer.write(NL);
@@ -591,8 +593,8 @@ public class KernelResolver {
                                     File bestMatchFile = repo.selectBundle(element.symbolicName,
                                                                            VersionUtility.stringToVersionRange(element.vrangeString));
                                     if (bestMatchFile == null) {
-                                        throw new LaunchException("Could not find bundle for " + element + ".",
-                                                        BootstrapConstants.messages.getString("error.missingBundleException"));
+                                        throw new LaunchException("Could not find bundle for " + element
+                                                                  + ".", BootstrapConstants.messages.getString("error.missingBundleException"));
                                     } else {
                                         // Add to the list of boot jars...
                                         jarList.add(bestMatchFile);
@@ -643,8 +645,8 @@ public class KernelResolver {
                     cacheEntries.put(mfFile.getName(), entry);
                     return entry;
                 } catch (IOException e) {
-                    throw new LaunchException("Kernel definition could not be read: " + mfFile.getAbsolutePath(),
-                                    MessageFormat.format(BootstrapConstants.messages.getString("error.unknownException"), e));
+                    throw new LaunchException("Kernel definition could not be read: "
+                                              + mfFile.getAbsolutePath(), MessageFormat.format(BootstrapConstants.messages.getString("error.unknownException"), e));
                 } finally {
                     Utils.tryToClose(reader);
                 }

--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/ServerCommand.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/ServerCommand.java
@@ -15,9 +15,9 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.channels.SocketChannel;
-import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
+import java.nio.charset.StandardCharsets;
 
 import com.ibm.ws.kernel.boot.BootstrapConfig;
 
@@ -34,10 +34,8 @@ public abstract class ServerCommand {
     protected static final String PAUSE_COMMAND = "pause";
     protected static final String RESUME_COMMAND = "resume";
 
-    protected static final Charset charset = Charset.forName("ISO-8859-1");
-
-    private final CharsetDecoder decoder = charset.newDecoder();
-    private final CharsetEncoder encoder = charset.newEncoder();
+    private final CharsetDecoder decoder = StandardCharsets.ISO_8859_1.newDecoder();
+    private final CharsetEncoder encoder = StandardCharsets.ISO_8859_1.newEncoder();
 
     private final ByteBuffer buffer = ByteBuffer.allocate(256);
     private final CharBuffer charBuffer = CharBuffer.allocate(256);

--- a/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkConfigurator.java
+++ b/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkConfigurator.java
@@ -14,6 +14,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
 import java.lang.reflect.Constructor;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
@@ -40,8 +41,8 @@ public class FrameworkConfigurator {
      * allow sub-classes to further massage framework initialization properties.
      *
      * @param config
-     *                   BootstrapConfig object containing the active set of properties
-     *                   that will be used to initialize the framework.
+     *            BootstrapConfig object containing the active set of properties
+     *            that will be used to initialize the framework.
      */
     public static void configure(BootstrapConfig config) {
         extraBootDelegationPackages(config);
@@ -220,7 +221,7 @@ public class FrameworkConfigurator {
      *
      * @return non-null instance of the framework factory.
      * @throws LaunchException
-     *                             if Factory can not be found or instantiated.
+     *             if Factory can not be found or instantiated.
      * @see {@link KernelUtils#getServiceClass(BufferedReader)}
      */
     public static FrameworkFactory getFrameworkFactory(ClassLoader loader) {
@@ -237,7 +238,7 @@ public class FrameworkConfigurator {
 
         BufferedReader bufferedreader;
         try {
-            bufferedreader = new BufferedReader(new InputStreamReader(inputstream, "UTF-8"));
+            bufferedreader = new BufferedReader(new InputStreamReader(inputstream, StandardCharsets.UTF_8));
 
             factoryClassName = KernelUtils.getServiceClass(bufferedreader);
             bufferedreader.close();

--- a/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/boot/internal/commands/ServerCommandClientTest.java
+++ b/dev/com.ibm.ws.kernel.boot_test/test/com/ibm/ws/kernel/boot/internal/commands/ServerCommandClientTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.nio.CharBuffer;
 import java.nio.channels.SocketChannel;
 import java.nio.charset.CharsetEncoder;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -65,7 +66,7 @@ public class ServerCommandClientTest {
 
     private class TestServerCommandListener extends ServerCommandListener {
 
-        private final CharsetEncoder encoder = charset.newEncoder();
+        private final CharsetEncoder encoder = StandardCharsets.ISO_8859_1.newEncoder();
         private TestType test;
         private boolean challengeWritten = false;
 

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureRepository.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureRepository.java
@@ -17,6 +17,7 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -430,7 +431,7 @@ public final class FeatureRepository implements FeatureResolver.Repository {
             // this is a long string
             byte[] data = new byte[in.readInt()];
             in.readFully(data);
-            return new String(data, "UTF-8");
+            return new String(data, StandardCharsets.UTF_8);
         } else {
             // normal string
             return in.readUTF();

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/location/internal/WsLocationAdminImpl.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/location/internal/WsLocationAdminImpl.java
@@ -22,6 +22,7 @@ import java.io.OutputStreamWriter;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
@@ -217,12 +218,12 @@ public class WsLocationAdminImpl implements WsLocationAdmin {
      * includes some set in response to command line argument parsing).
      *
      * @param config
-     *                   Map containing location service configuration information
+     *            Map containing location service configuration information
      * @throws IllegalArgumentException
-     *                                      if serverName, instanceRootStr, or bootstrapLibStr are empty or
-     *                                      null
+     *             if serverName, instanceRootStr, or bootstrapLibStr are empty or
+     *             null
      * @throws IllegalStateException
-     *                                      if bootstrap library location or instance root don't exist.
+     *             if bootstrap library location or instance root don't exist.
      */
     protected WsLocationAdminImpl(Map<String, Object> config) {
         String userRootStr = (String) config.get(WsLocationConstants.LOC_USER_DIR);
@@ -455,7 +456,7 @@ public class WsLocationAdminImpl implements WsLocationAdmin {
             UUID result = null;
             BufferedReader in = null;
             try {
-                in = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"));
+                in = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
                 String id = in.readLine();
                 if (id != null) {
                     result = UUID.fromString(id);
@@ -478,7 +479,7 @@ public class WsLocationAdminImpl implements WsLocationAdmin {
                 if (!FileUtils.ensureDirExists(file.getParentFile())) {
                     return;
                 }
-                out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file, false), "UTF-8"));
+                out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file, false), StandardCharsets.UTF_8));
                 out.write(idString);
             } catch (IOException e) {
                 // failed to write the id to the file ... log FFDC

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/CpuInfo.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/CpuInfo.java
@@ -19,6 +19,7 @@ import java.io.InputStreamReader;
 import java.lang.management.ManagementFactory;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.nio.charset.StandardCharsets;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -199,7 +200,7 @@ public class CpuInfo {
 
     private static String readFile(File file) throws IOException {
         InputStream is = new FileInputStream(file);
-        BufferedReader buf = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+        BufferedReader buf = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
         String line = buf.readLine();
         StringBuilder sb = new StringBuilder();
         while (line != null) {

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/wsspi/kernel/service/utils/LDAPUtils.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/wsspi/kernel/service/utils/LDAPUtils.java
@@ -11,7 +11,7 @@
 package com.ibm.wsspi.kernel.service.utils;
 
 import java.io.CharConversionException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -21,7 +21,7 @@ public class LDAPUtils {
 
     /**
      * Escape a term for use in an LDAP filter.
-     * 
+     *
      * @param term
      * @return
      */
@@ -58,7 +58,7 @@ public class LDAPUtils {
      * Java char values. This routine <em>will</em> work with any
      * Java chars from any human language string expressible in
      * Java (at least in Java version 7.0).
-     * 
+     *
      * @param ch the character (or high/low surrogate) to be escaped
      * @return the escaped form of the character
      */
@@ -75,7 +75,7 @@ public class LDAPUtils {
             default:
                 // must be a character > 128, so process it as UTF-8 bytes
                 try {
-                    byte[] bytes = Character.toString(ch).getBytes("UTF-8");
+                    byte[] bytes = Character.toString(ch).getBytes(StandardCharsets.UTF_8);
                     switch (bytes.length) {
                         case 1:
                             return String.format("\\%02x", bytes[0]);
@@ -86,9 +86,6 @@ public class LDAPUtils {
                         default:
                             throw new CharConversionException("No character should map to more than three UTF-8 bytes");
                     }
-                } catch (UnsupportedEncodingException e) {
-                    //auto-FFDC: Every Java platform should support the UTF-8 encoding
-                    return "";
                 } catch (CharConversionException e) {
                     // auto-FFDC
                     return "";

--- a/dev/com.ibm.ws.messaging.common/src/com/ibm/ws/sib/mfp/util/Utf8Codec.java
+++ b/dev/com.ibm.ws.messaging.common/src/com/ibm/ws/sib/mfp/util/Utf8Codec.java
@@ -12,6 +12,7 @@
 package com.ibm.ws.sib.mfp.util;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Static class providing methods for encoding and decoding Unicode Strings and chars to
@@ -20,15 +21,6 @@ import java.nio.charset.Charset;
 public enum Utf8Codec {
     ;
 
-    private static final Charset UTF_8;
-
-    static {
-        try {
-            UTF_8 = Charset.forName("UTF-8");
-        } catch (Exception e) {
-            throw new RuntimeException("UTF-8 unexpectedly unsupported", e);
-        }
-    }
 
     /**
      * Calculate the number of bytes needed to UTF8 encode a String
@@ -86,14 +78,14 @@ public enum Utf8Codec {
      * @return byte[] The UTF8 encoding of the given String
      */
     public static byte[] encode(String s) {
-        return s.getBytes(UTF_8);
+        return s.getBytes(StandardCharsets.UTF_8);
     }
 
     /**
      * Decodes UTF8 to a String
      */
     public static String decode(byte[] ba, int offset, int length) {
-        return new String(ba, offset, length, UTF_8);
+        return new String(ba, offset, length, StandardCharsets.UTF_8);
     }
 
     /**

--- a/dev/com.ibm.ws.messaging.common/src/com/ibm/ws/sib/trm/topology/LinkCellule.java
+++ b/dev/com.ibm.ws.messaging.common/src/com/ibm/ws/sib/trm/topology/LinkCellule.java
@@ -17,6 +17,7 @@ import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.sib.trm.TrmConstants;
 import com.ibm.ws.sib.utils.ras.SibTr;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * This class represents a LinkCellule. A LinkCellule is constructed from the
@@ -79,12 +80,7 @@ public final class LinkCellule extends Cellule {
 
     if (b[0] == Cellule.LINKCELLULE) {
 
-      String cellule = null;
-      try {
-        cellule = new String(b, 1, b.length-1, "UTF-8");
-      } catch (UnsupportedEncodingException e) {
-        FFDCFilter.processException(e, className + ".<init>", "1", this);
-      }
+      String cellule = new String(b, 1, b.length-1, StandardCharsets.UTF_8);
 
       // Locate the delimiter character and separate out the two subnet names
 
@@ -122,12 +118,7 @@ public final class LinkCellule extends Cellule {
   public byte[] getBytes() {
     if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) SibTr.entry(tc, "getBytes");
 
-    byte[] b = null;
-    try {
-      b = string().getBytes("UTF-8");
-    } catch (UnsupportedEncodingException e) {
-      FFDCFilter.processException(e, className + ".getBytes", "2", this);
-    }
+    byte[] b = string().getBytes(StandardCharsets.UTF_8);
 
     byte[] c = new byte[b.length+1];
 

--- a/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/comms/common/CommsByteBuffer.java
+++ b/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/comms/common/CommsByteBuffer.java
@@ -12,6 +12,7 @@ package com.ibm.ws.sib.comms.common;
 
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -109,9 +110,6 @@ public class CommsByteBuffer extends JFapByteBuffer
                                                            CommsConstants.MSG_GROUP,
                                                            CommsConstants.MSG_BUNDLE);
 
-   /** The encoding to use for Strings */
-   private static final String stringEncoding = "UTF-8";
-
    /** The poolManager the byte buffer was allocated from */
    private CommsByteBufferPool poolManager = null;
 
@@ -172,27 +170,10 @@ public class CommsByteBuffer extends JFapByteBuffer
       }
       else
       {
-         try
-         {
-            byte[] stringAsBytes = item.getBytes(stringEncoding);
-            WsByteBuffer currentBuffer = getCurrentByteBuffer(2 + stringAsBytes.length);
-            currentBuffer.putShort((short) stringAsBytes.length);
-            currentBuffer.put(stringAsBytes);
-         }
-         catch (UnsupportedEncodingException e)
-         {
-            FFDCFilter.processException(e, CLASS_NAME + ".putString",
-                                        CommsConstants.COMMSBYTEBUFFER_PUTSTRING_01,
-                                        this);
-
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) SibTr.debug(tc, "Unable to encode String: ", e);
-
-            SibTr.error(tc, "UNSUPPORTED_STRING_ENCODING_SICO8005", new Object[] {stringEncoding, e});
-
-            throw new SIErrorException(
-               TraceNLS.getFormattedMessage(CommsConstants.MSG_BUNDLE, "UNSUPPORTED_STRING_ENCODING_SICO8005", new Object[] {stringEncoding, e}, null)
-            );
-         }
+         byte[] stringAsBytes = item.getBytes(StandardCharsets.UTF_8);
+         WsByteBuffer currentBuffer = getCurrentByteBuffer(2 + stringAsBytes.length);
+         currentBuffer.putShort((short) stringAsBytes.length);
+         currentBuffer.put(stringAsBytes);
       }
 
       if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) SibTr.exit(this, tc, "putString");
@@ -741,28 +722,7 @@ public class CommsByteBuffer extends JFapByteBuffer
       }
       else
       {
-         try
-         {
-            returningString = new String(stringBytes, stringEncoding);
-         }
-         catch (UnsupportedEncodingException e)
-         {
-            FFDCFilter.processException(e, CLASS_NAME + ".getString",
-                                        CommsConstants.COMMSBYTEBUFFER_GETSTRING_01,
-                                        this);
-
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-            {
-               SibTr.debug(tc, "Unable to encode String: ", e);
-               SibTr.exception(tc, e);
-            }
-
-            SibTr.error(tc, "UNSUPPORTED_STRING_ENCODING_SICO8005", new Object[] {stringEncoding, e});
-
-            throw new SIErrorException(
-               TraceNLS.getFormattedMessage(CommsConstants.MSG_BUNDLE, "UNSUPPORTED_STRING_ENCODING_SICO8005", new Object[] {stringEncoding, e}, null)
-            );
-         }
+         returningString = new String(stringBytes, StandardCharsets.UTF_8);
       }
 
       return returningString;
@@ -2128,23 +2088,8 @@ public class CommsByteBuffer extends JFapByteBuffer
       }
       else
       {
-         try
-         {
-            final byte[] stringAsBytes = s.getBytes(stringEncoding);
-            length = stringAsBytes.length + 2;
-         }
-         catch (UnsupportedEncodingException e)
-         {
-            FFDCFilter.processException(e, CLASS_NAME + ".calculateEncodedStringLength", CommsConstants.COMMSBYTEBUFFER_CALC_ENC_STRLEN_01);
-
-            if(TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) SibTr.debug(tc, "Unable to encode String: ", e);
-
-            SibTr.error(tc, "UNSUPPORTED_STRING_ENCODING_SICO8023", new Object[] {stringEncoding, e});
-
-            throw new SIErrorException(
-               TraceNLS.getFormattedMessage(CommsConstants.MSG_BUNDLE, "UNSUPPORTED_STRING_ENCODING_SICO8023", new Object[] {stringEncoding, e}, null)
-            );
-         }
+         final byte[] stringAsBytes = s.getBytes(StandardCharsets.UTF_8);
+         length = stringAsBytes.length + 2;
       }
 
       if(TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) SibTr.exit(tc, "calculateEncodedStringLength", Integer.valueOf(length));

--- a/dev/com.ibm.ws.messaging.jms.common/src/com/ibm/ws/sib/jms/util/Utf8Codec.java
+++ b/dev/com.ibm.ws.messaging.jms.common/src/com/ibm/ws/sib/jms/util/Utf8Codec.java
@@ -12,6 +12,7 @@
 package com.ibm.ws.sib.jms.util;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Static class providing methods for encoding and decoding Unicode Strings and chars to
@@ -19,16 +20,6 @@ import java.nio.charset.Charset;
  */
 public enum Utf8Codec {
     ;
-
-    private static final Charset UTF_8;
-
-    static {
-        try {
-            UTF_8 = Charset.forName("UTF-8");
-        } catch (Exception e) {
-            throw new RuntimeException("UTF-8 unexpectedly unsupported", e);
-        }
-    }
 
     /**
      * Calculate the number of bytes needed to UTF8 encode a String
@@ -86,14 +77,14 @@ public enum Utf8Codec {
      * @return byte[] The UTF8 encoding of the given String
      */
     public static byte[] encode(String s) {
-        return s.getBytes(UTF_8);
+        return s.getBytes(StandardCharsets.UTF_8);
     }
 
     /**
      * Decodes UTF8 to a String
      */
     public static String decode(byte[] ba, int offset, int length) {
-        return new String(ba, offset, length, UTF_8);
+        return new String(ba, offset, length, StandardCharsets.UTF_8);
     }
 
     /**

--- a/dev/com.ibm.ws.microprofile.metrics.2.0/src/com/ibm/ws/microprofile/metrics/impl/WeightedSnapshot.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0/src/com/ibm/ws/microprofile/metrics/impl/WeightedSnapshot.java
@@ -26,7 +26,7 @@ package com.ibm.ws.microprofile.metrics.impl;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
@@ -50,8 +50,6 @@ public class WeightedSnapshot extends Snapshot {
             this.weight = weight;
         }
     }
-
-    private static final Charset UTF_8 = Charset.forName("UTF-8");
 
     private final long[] values;
     private final double[] normWeights;
@@ -221,7 +219,7 @@ public class WeightedSnapshot extends Snapshot {
      */
     @Override
     public void dump(OutputStream output) {
-        final PrintWriter out = new PrintWriter(new OutputStreamWriter(output, UTF_8));
+        final PrintWriter out = new PrintWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8));
         try {
             for (long value : values) {
                 out.printf("%d%n", value);

--- a/dev/com.ibm.ws.microprofile.metrics/src/com/ibm/ws/microprofile/metrics/impl/WeightedSnapshot.java
+++ b/dev/com.ibm.ws.microprofile.metrics/src/com/ibm/ws/microprofile/metrics/impl/WeightedSnapshot.java
@@ -26,7 +26,7 @@ package com.ibm.ws.microprofile.metrics.impl;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
@@ -50,8 +50,6 @@ public class WeightedSnapshot extends Snapshot {
             this.weight = weight;
         }
     }
-
-    private static final Charset UTF_8 = Charset.forName("UTF-8");
 
     private final long[] values;
     private final double[] normWeights;
@@ -221,7 +219,7 @@ public class WeightedSnapshot extends Snapshot {
      */
     @Override
     public void dump(OutputStream output) {
-        final PrintWriter out = new PrintWriter(new OutputStreamWriter(output, UTF_8));
+        final PrintWriter out = new PrintWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8));
         try {
             for (long value : values) {
                 out.printf("%d%n", value);

--- a/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/StaticFileProcessor.java
+++ b/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/StaticFileProcessor.java
@@ -12,6 +12,7 @@ package com.ibm.ws.microprofile.openapi;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 
@@ -56,7 +57,7 @@ public class StaticFileProcessor {
         }
 
         try {
-            result = IOUtils.toString(is, "UTF-8");
+            result = IOUtils.toString(is, StandardCharsets.UTF_8);
         } catch (IOException e) {
             if (OpenAPIUtils.isEventEnabled(tc)) {
                 Tr.event(tc, "Unable to read openapi file into a string");

--- a/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/impl/CustomCSSProcessor.java
+++ b/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/impl/CustomCSSProcessor.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Dictionary;
@@ -269,7 +270,7 @@ public final class CustomCSSProcessor implements FileMonitor, ServerQuiesceListe
     private String getContent(InputStream is) throws IOException {
         Reader reader = null;
         try {
-            reader = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+            reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
             final StringBuilder builder = new StringBuilder();
             int c;
             while ((c = reader.read()) != -1) {

--- a/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/impl/OpenAPIUIBundlesUpdater.java
+++ b/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/impl/OpenAPIUIBundlesUpdater.java
@@ -19,6 +19,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -228,7 +229,7 @@ public class OpenAPIUIBundlesUpdater {
     private static void processResource(String resourcePath, Object resourceContents, ZipOutputStream zos) throws UnsupportedEncodingException, IOException {
         if (resourceContents != null) {
             if (resourceContents instanceof String) {
-                zos.write(((String) resourceContents).getBytes("UTF-8"));
+                zos.write(((String) resourceContents).getBytes(StandardCharsets.UTF_8));
                 if (OpenAPIUtils.isDebugEnabled(tc)) {
                     Tr.debug(tc, "Processed (String) resource at " + resourcePath);
                 }
@@ -273,7 +274,7 @@ public class OpenAPIUIBundlesUpdater {
         if (bundleResource != null) {
             BufferedReader br = null;
             try { // read the requested resource from the bundle
-                br = new BufferedReader(new InputStreamReader(bundleResource.openConnection().getInputStream(), "UTF-8"));
+                br = new BufferedReader(new InputStreamReader(bundleResource.openConnection().getInputStream(), StandardCharsets.UTF_8));
                 while (br.ready()) {
                     responseString.append(br.readLine());
                 }

--- a/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/impl/parser/OpenAPIV3Parser.java
+++ b/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/impl/parser/OpenAPIV3Parser.java
@@ -12,6 +12,7 @@
 package com.ibm.ws.microprofile.openapi.impl.parser;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -137,7 +138,7 @@ public class OpenAPIV3Parser implements SwaggerParserExtension {
                     path = Paths.get(location);
                 }
                 if (Files.exists(path)) {
-                    data = FileUtils.readFileToString(path.toFile(), "UTF-8");
+                    data = FileUtils.readFileToString(path.toFile(), StandardCharsets.UTF_8);
                 } else {
                     data = ClasspathHelper.loadFileFromClasspath(location);
                 }

--- a/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/impl/parser/util/RefUtils.java
+++ b/dev/com.ibm.ws.microprofile.openapi/src/com/ibm/ws/microprofile/openapi/impl/parser/util/RefUtils.java
@@ -13,17 +13,18 @@
 
 package com.ibm.ws.microprofile.openapi.impl.parser.util;
 
+import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.ibm.ws.microprofile.openapi.impl.parser.core.models.AuthorizationValue;
 import com.ibm.ws.microprofile.openapi.impl.parser.models.RefFormat;
-
-import java.io.FileInputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.Set;
 
 public class RefUtils {
 
@@ -159,7 +160,7 @@ public class RefUtils {
                 final Path pathToUse = parentDirectory.resolve(file).normalize();
 
                 if (Files.exists(pathToUse)) {
-                    result = IOUtils.toString(new FileInputStream(pathToUse.toFile()), "UTF-8");
+                    result = IOUtils.toString(new FileInputStream(pathToUse.toFile()), StandardCharsets.UTF_8);
                 } else {
                     result = ClasspathHelper.loadFileFromClasspath(file);
                 }

--- a/dev/com.ibm.ws.openapi.3.1/src/com/ibm/ws/openapi31/OpenAPIUtils.java
+++ b/dev/com.ibm.ws.openapi.3.1/src/com/ibm/ws/openapi31/OpenAPIUtils.java
@@ -12,6 +12,7 @@ package com.ibm.ws.openapi31;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -202,7 +203,7 @@ public class OpenAPIUtils {
     @FFDCIgnore({ IOException.class })
     public static String getAPIDocFromFile(File file) {
         try {
-            return FileUtils.readFileToString(file, "UTF-8"); //YAML document's format has to be preserved
+            return FileUtils.readFileToString(file, StandardCharsets.UTF_8); //YAML document's format has to be preserved
         } catch (IOException ioe) {
             if (isEventEnabled(tc)) {
                 Tr.event(tc, "Exception when reading: " + ioe.getMessage());

--- a/dev/com.ibm.ws.openapi.3.1/src/com/ibm/ws/openapi31/customization/CustomCSSProcessor.java
+++ b/dev/com.ibm.ws.openapi.3.1/src/com/ibm/ws/openapi31/customization/CustomCSSProcessor.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Dictionary;
@@ -264,7 +265,7 @@ public final class CustomCSSProcessor implements FileMonitor {
     private String getContent(InputStream is) throws IOException {
         Reader reader = null;
         try {
-            reader = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+            reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
             final StringBuilder builder = new StringBuilder();
             int c;
             while ((c = reader.read()) != -1) {
@@ -306,7 +307,8 @@ public final class CustomCSSProcessor implements FileMonitor {
     //
 
     @Override
-    public void onBaseline(Collection<File> baseline) {}
+    public void onBaseline(Collection<File> baseline) {
+    }
 
     @Override
     public void onChange(Collection<File> createdFiles, Collection<File> modifiedFiles, Collection<File> deletedFiles) {

--- a/dev/com.ibm.ws.openapi.3.1/src/com/ibm/ws/openapi31/customization/OpenAPIUIBundlesUpdater.java
+++ b/dev/com.ibm.ws.openapi.3.1/src/com/ibm/ws/openapi31/customization/OpenAPIUIBundlesUpdater.java
@@ -19,6 +19,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -225,7 +226,7 @@ public class OpenAPIUIBundlesUpdater {
     private static void processResource(String resourcePath, Object resourceContents, ZipOutputStream zos) throws UnsupportedEncodingException, IOException {
         if (resourceContents != null) {
             if (resourceContents instanceof String) {
-                zos.write(((String) resourceContents).getBytes("UTF-8"));
+                zos.write(((String) resourceContents).getBytes(StandardCharsets.UTF_8));
                 if (OpenAPIUtils.isDebugEnabled(tc)) {
                     Tr.debug(tc, "Processed (String) resource at " + resourcePath);
                 }
@@ -270,7 +271,7 @@ public class OpenAPIUIBundlesUpdater {
         if (bundleResource != null) {
             BufferedReader br = null;
             try { // read the requested resource from the bundle
-                br = new BufferedReader(new InputStreamReader(bundleResource.openConnection().getInputStream(), "UTF-8"));
+                br = new BufferedReader(new InputStreamReader(bundleResource.openConnection().getInputStream(), StandardCharsets.UTF_8));
                 while (br.ready()) {
                     responseString.append(br.readLine());
                 }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpBaseMessageImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpBaseMessageImpl.java
@@ -15,6 +15,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -666,7 +667,7 @@ public abstract class HttpBaseMessageImpl extends GenericMessageImpl implements 
      *
      * @param version
      * @throws NullPointerException
-     *                                  if the input version is null
+     *             if the input version is null
      */
     @Override
     public void setVersion(VersionValues version) {
@@ -688,7 +689,7 @@ public abstract class HttpBaseMessageImpl extends GenericMessageImpl implements 
      * @param version
      * @throws UnsupportedProtocolVersionException
      * @throws NullPointerException
-     *                                                 if input version is null
+     *             if input version is null
      */
     @Override
     public void setVersion(String version) throws UnsupportedProtocolVersionException {
@@ -709,7 +710,7 @@ public abstract class HttpBaseMessageImpl extends GenericMessageImpl implements 
      * @param version
      * @throws UnsupportedProtocolVersionException
      * @throws NullPointerException
-     *                                                 if input version is null
+     *             if input version is null
      */
     @Override
     public void setVersion(byte[] version) throws UnsupportedProtocolVersionException {
@@ -741,7 +742,7 @@ public abstract class HttpBaseMessageImpl extends GenericMessageImpl implements 
      *
      * @param length
      * @throws IllegalArgumentException
-     *                                      if input length is invalid
+     *             if input length is invalid
      */
     @Override
     public void setContentLength(long length) {
@@ -1836,7 +1837,7 @@ public abstract class HttpBaseMessageImpl extends GenericMessageImpl implements 
      *
      * @param type
      * @throws NullPointerException
-     *                                  if input string is null
+     *             if input string is null
      */
     @Override
     public void setMIMEType(String type) {
@@ -1888,7 +1889,7 @@ public abstract class HttpBaseMessageImpl extends GenericMessageImpl implements 
         }
         if (null == DEF_CHARSET) {
             // lazily instantiate the default charset if need be
-            DEF_CHARSET = AccessController.doPrivileged(new privCharsetLookup("ISO-8859-1"));
+            DEF_CHARSET = StandardCharsets.ISO_8859_1;
         }
         return DEF_CHARSET;
     }
@@ -1898,7 +1899,7 @@ public abstract class HttpBaseMessageImpl extends GenericMessageImpl implements 
      * If the content type is null, or there is no explicit character encoding, <code>null</code> is returned.
      *
      * @param contentType
-     *                        a content type header.
+     *            a content type header.
      * @return Returns the character encoding for this flow, or null if the given
      *         content-type header is null or if no character enoding is present
      *         in the content-type header.
@@ -1935,7 +1936,7 @@ public abstract class HttpBaseMessageImpl extends GenericMessageImpl implements 
      *
      * @param set
      * @throws NullPointerException
-     *                                  if the input Charset is null
+     *             if the input Charset is null
      */
     @Override
     public void setCharset(Charset set) {
@@ -2680,7 +2681,7 @@ public abstract class HttpBaseMessageImpl extends GenericMessageImpl implements 
      * operation. This is allowed on an outgoing message only.
      *
      * @param cookie
-     *                       the <code>HttpCookie</code> to add.
+     *            the <code>HttpCookie</code> to add.
      * @param cookieType
      * @return TRUE if the cookie was set successfully otherwise returns FALSE.
      *         if setcookie constraints are violated.
@@ -2739,7 +2740,7 @@ public abstract class HttpBaseMessageImpl extends GenericMessageImpl implements 
      * @param header
      * @return the caching data for the particular set of Cookies.
      * @throws IllegalArgumentException
-     *                                      if the header is not a cookie header
+     *             if the header is not a cookie header
      */
     private CookieCacheData getCookieCache(HttpHeaderKeys header) {
         // 347066 - removed sync because we only allow 1 thread to be working
@@ -2839,9 +2840,9 @@ public abstract class HttpBaseMessageImpl extends GenericMessageImpl implements 
      * Marshall the list of Cookies into the base header storage area.
      *
      * @param list
-     *                   the list of new cookies.
+     *            the list of new cookies.
      * @param header
-     *                   the type of header the new cookies are intended for.
+     *            the type of header the new cookies are intended for.
      */
     private void marshallCookies(List<HttpCookie> list, HeaderKeys header) {
 

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/filter/FilterListFastStr.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/filter/FilterListFastStr.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.http.channel.internal.filter;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -94,7 +94,7 @@ public class FilterListFastStr implements FilterListStr {
      * Add a new address to the address tree
      *
      * @param newAddress
-     *                       address to add
+     *            address to add
      */
     private boolean addAddressToList(String newAddress) {
         return putInList(convertToEntries(newAddress));
@@ -105,7 +105,7 @@ public class FilterListFastStr implements FilterListStr {
      * tree
      *
      * @param oEntry
-     *                   Entry object for the address to look for
+     *            Entry object for the address to look for
      * @return true if this address is found in the address tree, false if
      *         it is not.
      */
@@ -124,14 +124,14 @@ public class FilterListFastStr implements FilterListStr {
      * the address is found in the tree.
      *
      * @param hashcodes
-     *                      - array of hashcodes of the substrings of the address to find
+     *            - array of hashcodes of the substrings of the address to find
      * @param lengths
-     *                      - array of lengths of the substrings of the address to find
+     *            - array of lengths of the substrings of the address to find
      * @param cell
-     *                      - the current cell that is being traversed in the address tree
+     *            - the current cell that is being traversed in the address tree
      * @param index
-     *                      - the next index into the arrays that is to be matched against the
-     *                      tree
+     *            - the next index into the arrays that is to be matched against the
+     *            tree
      * @return true if this address is found in the address tree, false if
      *         it is not.
      */
@@ -210,7 +210,7 @@ public class FilterListFastStr implements FilterListStr {
      * address
      *
      * @param newAddress
-     *                       address to convert
+     *            address to convert
      * @return the Entry object created from this address.
      */
     private Entry convertToEntries(String newAddress) {
@@ -220,15 +220,7 @@ public class FilterListFastStr implements FilterListStr {
             Tr.entry(tc, "convertToEntries");
         }
 
-        try {
-            ba = newAddress.getBytes("ISO-8859-1");
-        } catch (UnsupportedEncodingException x) {
-            // should never happen, log a message and use default encoding
-            if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
-                Tr.event(tc, "ISO-8859-1 encoding not supported.  Exception: " + x);
-            }
-            ba = newAddress.getBytes();
-        }
+        ba = newAddress.getBytes(StandardCharsets.ISO_8859_1);
         int baLength = ba.length;
         int hashValue = 0;
         int hashLength = 0;
@@ -354,9 +346,9 @@ public class FilterListFastStr implements FilterListStr {
          * the substrings that represent this entry
          *
          * @param hashcode
-         *                     hashcode to add
+         *            hashcode to add
          * @param length
-         *                     length to add
+         *            length to add
          */
         public void addEntry(int hashcode, int length) {
             if (iSwitch == 1) {

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/genericbnf/GenericKeys.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/genericbnf/GenericKeys.java
@@ -10,15 +10,13 @@
  *******************************************************************************/
 package com.ibm.wsspi.genericbnf;
 
-import java.io.UnsupportedEncodingException;
-
 /**
  * Generic abstract class for the various enumerated classes in the
  * Channel. Each basic key has a String name and an int ordinal to
  * match. The extended classes are responsible for maintaining the
  * static list of all the keys in the enum, along with anything extra
  * they may require.
- * 
+ *
  * @ibm-private-in-use
  */
 public abstract class GenericKeys implements Comparable<GenericKeys> {
@@ -34,26 +32,20 @@ public abstract class GenericKeys implements Comparable<GenericKeys> {
 
     /**
      * Constructor is limited to the subclasses.
-     * 
+     *
      * @param inputName
      * @param inputOrdinal
      */
     protected GenericKeys(String inputName, int inputOrdinal) {
         this.name = inputName;
-        try {
-            this.byteArray = inputName.getBytes(HeaderStorage.ENGLISH_CHARSET);
-        } catch (UnsupportedEncodingException uee) {
-            // no FFDC required
-            // Invalid key name
-            throw new IllegalArgumentException("Unsupported non-English name: " + inputName);
-        }
+        this.byteArray = inputName.getBytes(HeaderStorage.ENGLISH_CHARSET);
         this.ordinal = inputOrdinal;
         this.hashcode = inputOrdinal + inputName.hashCode();
     }
 
     /**
      * Query the name of this key as a byte[].
-     * 
+     *
      * @return byte[]
      */
     final public byte[] getByteArray() {
@@ -62,7 +54,7 @@ public abstract class GenericKeys implements Comparable<GenericKeys> {
 
     /**
      * Query the ordinal number for this header.
-     * 
+     *
      * @return int
      */
     final public int getOrdinal() {
@@ -71,27 +63,22 @@ public abstract class GenericKeys implements Comparable<GenericKeys> {
 
     /**
      * Query the name for this key as a String.
-     * 
+     *
      * @return String
      */
     public String getName() {
         if (null == this.name && null != this.byteArray) {
-            try {
-                this.name = new String(this.byteArray, HeaderStorage.ENGLISH_CHARSET);
-            } catch (UnsupportedEncodingException uee) {
-                // no FFDC required
-                // Invalid key name
-                throw new IllegalArgumentException("Unsupported non-English name: " + new String(this.byteArray));
-            }
+            this.name = new String(this.byteArray, HeaderStorage.ENGLISH_CHARSET);
         }
         return this.name;
     }
 
     /**
      * For debugging purposes, convert this object to a String.
-     * 
+     *
      * @return String
      */
+    @Override
     public String toString() {
         return "Key: " + getName() + " Ordinal: " + getOrdinal();
     }
@@ -100,20 +87,22 @@ public abstract class GenericKeys implements Comparable<GenericKeys> {
      * Compare this key against the given value. Returns a negative integer,
      * zero, or a positive integer as this object is less than, equal to, or
      * greater than the specified GenericKeys object.
-     * 
+     *
      * @param inKey
      * @return int
      */
+    @Override
     public int compareTo(GenericKeys inKey) {
         return (null == inKey) ? -1 : (getOrdinal() - inKey.getOrdinal());
     }
 
     /**
      * Check whether this object equals another.
-     * 
+     *
      * @param val
      * @return boolean
      */
+    @Override
     public boolean equals(Object val) {
 
         if (this == val) {
@@ -128,7 +117,7 @@ public abstract class GenericKeys implements Comparable<GenericKeys> {
 
     /**
      * Allow an equality check against another enum object.
-     * 
+     *
      * @param val
      * @return boolean (true if ordinals match)
      */
@@ -138,9 +127,10 @@ public abstract class GenericKeys implements Comparable<GenericKeys> {
 
     /**
      * Hash code of this object.
-     * 
+     *
      * @return int
      */
+    @Override
     public int hashCode() {
         return this.hashcode;
     }

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/genericbnf/HeaderStorage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/wsspi/genericbnf/HeaderStorage.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.wsspi.genericbnf;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
@@ -17,7 +19,7 @@ import java.util.List;
  * format, which looks like "Name: value". This provides the various methods
  * for interacting with the headers in storage, adding, removing, comparing,
  * etc.
- * 
+ *
  * @ibm-private-in-use
  */
 public interface HeaderStorage {
@@ -26,12 +28,12 @@ public interface HeaderStorage {
     int NOTSET = -1;
 
     /** English charset for various String conversions */
-    String ENGLISH_CHARSET = "iso-8859-1";
+    Charset ENGLISH_CHARSET = StandardCharsets.ISO_8859_1;
 
     /**
      * Allow the debug context object to be set to the input Object for more
      * specialized debugging. A null input object will be ignored.
-     * 
+     *
      * @param o
      */
     void setDebugContext(Object o);
@@ -39,7 +41,7 @@ public interface HeaderStorage {
     /**
      * Access the first instance, if multiple exist, of the header. If the
      * header does not exist, then an empty header field is returned.
-     * 
+     *
      * @param name
      * @return HeaderField
      */
@@ -48,7 +50,7 @@ public interface HeaderStorage {
     /**
      * Access the first instance, if multiple exist, of the header. If the
      * header does not exist, then an empty header field is returned.
-     * 
+     *
      * @param name
      * @return HeaderField
      */
@@ -57,7 +59,7 @@ public interface HeaderStorage {
     /**
      * Access the first instance, if multiple exist, of the header. If the
      * header does not exist, then an empty header field is returned.
-     * 
+     *
      * @param name
      * @return HeaderField
      */
@@ -66,7 +68,7 @@ public interface HeaderStorage {
     /**
      * Access a list of all instances that exist of the input header. This
      * list is never null but may be empty.
-     * 
+     *
      * @param name
      * @return List<HeaderField>
      */
@@ -75,7 +77,7 @@ public interface HeaderStorage {
     /**
      * Access a list of all instances that exist of the input header. This
      * list is never null but may be empty.
-     * 
+     *
      * @param name
      * @return List<HeaderField>
      */
@@ -84,7 +86,7 @@ public interface HeaderStorage {
     /**
      * Access a list of all instances that exist of the input header. This
      * list is never null but may be empty.
-     * 
+     *
      * @param name
      * @return List<HeaderField>
      */
@@ -95,7 +97,7 @@ public interface HeaderStorage {
      * individual
      * header name exists multiple times, it will appear on this list for each
      * instance. This list is never null but may be empty.
-     * 
+     *
      * @return List<HeaderField>
      */
     List<HeaderField> getAllHeaders();
@@ -104,7 +106,7 @@ public interface HeaderStorage {
      * Query a list of all the unique header names found in this particular
      * message.
      * This list is never null but may be empty.
-     * 
+     *
      * @return List<String>
      */
     List<String> getAllHeaderNames();
@@ -116,7 +118,7 @@ public interface HeaderStorage {
      * <p>
      * Any String encoding or decoding on the value will be performed with the
      * ISO-8859-1 charset.
-     * 
+     *
      * @param header
      * @param value
      * @throws IllegalArgumentException
@@ -128,7 +130,7 @@ public interface HeaderStorage {
      * Create a new instance of this header with the given value. The value is
      * only a subset of the input array, specified by the offset into the array
      * and the length from that point.
-     * 
+     *
      * @param header
      * @param value
      * @param offset
@@ -146,7 +148,7 @@ public interface HeaderStorage {
      * <p>
      * Any String encoding or decoding on the value will be performed with the
      * ISO-8859-1 charset.
-     * 
+     *
      * @param header
      * @param value
      * @throws IllegalArgumentException
@@ -161,7 +163,7 @@ public interface HeaderStorage {
      * <p>
      * Any String encoding or decoding on the value will be performed with the
      * ISO-8859-1 charset.
-     * 
+     *
      * @param header
      * @param value
      * @throws IllegalArgumentException
@@ -173,7 +175,7 @@ public interface HeaderStorage {
      * Create a new instance of this header with the given value. The value is
      * only a subset of the input array, specified by the offset into the array
      * and the length from that point.
-     * 
+     *
      * @param header
      * @param value
      * @param offset
@@ -191,7 +193,7 @@ public interface HeaderStorage {
      * <p>
      * Any String encoding or decoding on the value will be performed with the
      * ISO-8859-1 charset.
-     * 
+     *
      * @param header
      * @param value
      * @throws IllegalArgumentException
@@ -206,7 +208,7 @@ public interface HeaderStorage {
      * <p>
      * Any String encoding or decoding on the value will be performed with the
      * ISO-8859-1 charset.
-     * 
+     *
      * @param header
      * @param value
      * @throws IllegalArgumentException
@@ -218,7 +220,7 @@ public interface HeaderStorage {
      * Create a new instance of this header with the given value. The value is
      * only a subset of the input array, specified by the offset into the array
      * and the length from that point.
-     * 
+     *
      * @param header
      * @param value
      * @param offset
@@ -236,7 +238,7 @@ public interface HeaderStorage {
      * <p>
      * Any String encoding or decoding on the value will be performed with the
      * ISO-8859-1 charset.
-     * 
+     *
      * @param header
      * @param value
      * @throws IllegalArgumentException
@@ -247,7 +249,7 @@ public interface HeaderStorage {
     /**
      * Query how many instances of the target header are currently stored in
      * this message.
-     * 
+     *
      * @param header
      * @return int (0 if none)
      */
@@ -255,7 +257,7 @@ public interface HeaderStorage {
 
     /**
      * Query whether a header is present in storage.
-     * 
+     *
      * @param header
      * @return boolean
      * @throws IllegalArgumentException
@@ -265,7 +267,7 @@ public interface HeaderStorage {
 
     /**
      * Query whether a header is present in storage.
-     * 
+     *
      * @param header
      * @return boolean
      * @throws IllegalArgumentException
@@ -275,7 +277,7 @@ public interface HeaderStorage {
 
     /**
      * Query whether a header is present in storage.
-     * 
+     *
      * @param header
      * @return boolean
      * @throws IllegalArgumentException
@@ -286,7 +288,7 @@ public interface HeaderStorage {
     /**
      * Query how many instances of the target header are currently stored in
      * this message.
-     * 
+     *
      * @param header
      * @return int (0 if none)
      */
@@ -295,7 +297,7 @@ public interface HeaderStorage {
     /**
      * Query how many instances of the target header are currently stored in
      * this message.
-     * 
+     *
      * @param header
      * @return int (0 if none)
      */
@@ -303,7 +305,7 @@ public interface HeaderStorage {
 
     /**
      * Remove all instances of this header from storage.
-     * 
+     *
      * @param header
      * @throws IllegalArgumentException
      *             if input is invalid
@@ -312,7 +314,7 @@ public interface HeaderStorage {
 
     /**
      * Remove a specific instance of this header from storage.
-     * 
+     *
      * @param header
      * @param instance
      * @throws IllegalArgumentException
@@ -322,7 +324,7 @@ public interface HeaderStorage {
 
     /**
      * Remove all instances of a particular header from storage
-     * 
+     *
      * @param header
      * @throws IllegalArgumentException
      *             if input is invalid
@@ -331,7 +333,7 @@ public interface HeaderStorage {
 
     /**
      * Remove a specific instance of a header from storage.
-     * 
+     *
      * @param header
      * @param instance
      * @throws IllegalArgumentException
@@ -341,7 +343,7 @@ public interface HeaderStorage {
 
     /**
      * Remove all instances of this header from storage.
-     * 
+     *
      * @param header
      * @throws IllegalArgumentException
      *             if input is invalid
@@ -350,7 +352,7 @@ public interface HeaderStorage {
 
     /**
      * Remove a specific instance of this header from storage.
-     * 
+     *
      * @param header
      * @param instance
      * @throws IllegalArgumentException
@@ -360,7 +362,7 @@ public interface HeaderStorage {
 
     /**
      * Remove all of the headers from storage, cleaning up the memory
-     * 
+     *
      */
     void removeAllHeaders();
 
@@ -369,7 +371,7 @@ public interface HeaderStorage {
      * <p>
      * Any String encoding or decoding on the value will be performed with the
      * ISO-8859-1 charset.
-     * 
+     *
      * @param header
      * @param value
      * @throws IllegalArgumentException
@@ -381,7 +383,7 @@ public interface HeaderStorage {
      * Set the header to the input value, erasing any existing values. The value
      * is only a subset of the input array, specified by the offset into the array
      * and the length from that point.
-     * 
+     *
      * @param header
      * @param value
      * @param offset
@@ -397,7 +399,7 @@ public interface HeaderStorage {
      * <p>
      * Any String encoding or decoding on the value will be performed with the
      * ISO-8859-1 charset.
-     * 
+     *
      * @param header
      * @param value
      * @throws IllegalArgumentException
@@ -410,7 +412,7 @@ public interface HeaderStorage {
      * <p>
      * Any String encoding or decoding on the value will be performed with the
      * ISO-8859-1 charset.
-     * 
+     *
      * @param header
      * @param value
      * @throws IllegalArgumentException
@@ -422,7 +424,7 @@ public interface HeaderStorage {
      * Set the header to the input value, erasing any existing values. The value
      * is only a subset of the input array, specified by the offset into the array
      * and the length from that point.
-     * 
+     *
      * @param header
      * @param value
      * @param offset
@@ -438,7 +440,7 @@ public interface HeaderStorage {
      * <p>
      * Any String encoding or decoding on the value will be performed with the
      * ISO-8859-1 charset.
-     * 
+     *
      * @param header
      * @param value
      * @throws IllegalArgumentException
@@ -451,7 +453,7 @@ public interface HeaderStorage {
      * <p>
      * Any String encoding or decoding on the value will be performed with the
      * ISO-8859-1 charset.
-     * 
+     *
      * @param header
      * @param value
      * @throws IllegalArgumentException
@@ -463,7 +465,7 @@ public interface HeaderStorage {
      * Set the header to the input value, erasing any existing values. The value
      * is only a subset of the input array, specified by the offset into the array
      * and the length from that point.
-     * 
+     *
      * @param header
      * @param value
      * @param offset
@@ -479,7 +481,7 @@ public interface HeaderStorage {
      * <p>
      * Any String encoding or decoding on the value will be performed with the
      * ISO-8859-1 charset.
-     * 
+     *
      * @param header
      * @param value
      * @throws IllegalArgumentException
@@ -489,7 +491,7 @@ public interface HeaderStorage {
 
     /**
      * Set the limit on the number of headers allowed to be set on this message.
-     * 
+     *
      * @param number
      * @throws IllegalArgumentException
      *             if number is negative or zero
@@ -498,7 +500,7 @@ public interface HeaderStorage {
 
     /**
      * Query the current limit on number of headers allowed in the message.
-     * 
+     *
      * @return int
      */
     int getLimitOnNumberOfHeaders();
@@ -506,7 +508,7 @@ public interface HeaderStorage {
     /**
      * Set the limit on the size of individual protocol tokens, ie. header names
      * or header values, etc, when parsing inbound messages.
-     * 
+     *
      * @param size
      * @throws IllegalArgumentException
      *             if size is negative or zero
@@ -515,7 +517,7 @@ public interface HeaderStorage {
 
     /**
      * Query the current limit on the size of protocol tokens.
-     * 
+     *
      * @return int
      */
     int getLimitOfTokenSize();

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/extension/DefaultExtensionProcessor.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/extension/DefaultExtensionProcessor.java
@@ -15,6 +15,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.text.MessageFormat;
@@ -1125,14 +1126,7 @@ private ICollaboratorHelper collabHelper;
 		String scheme = req.getScheme();
 		int port = req.getServerPort();
 		String urlPath = null;
-		try
-		{
-			urlPath = new String(req.getRequestURI().getBytes("utf-8"), "iso-8859-1");
-		}
-		catch (UnsupportedEncodingException e)
-		{
-			urlPath = req.getRequestURI();
-		}
+		urlPath = new String(req.getRequestURI().getBytes(StandardCharsets.UTF_8), StandardCharsets.ISO_8859_1);
 		url.append(scheme);
 		url.append("://");
 		url.append(req.getServerName());

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
@@ -21,6 +21,7 @@ import java.io.OutputStreamWriter;
 import java.io.StringReader;
 import java.net.UnknownHostException;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.security.AccessController;
@@ -809,7 +810,7 @@ public class PluginGenerator {
                 try {
                     if (!cachedFile.exists() || writeFile) {
                         fOutputStream = new FileOutputStream(cachedFile);
-                        pluginCfgWriter = new BufferedWriter(new OutputStreamWriter(fOutputStream, "ISO-8859-1"));
+                        pluginCfgWriter = new BufferedWriter(new OutputStreamWriter(fOutputStream, StandardCharsets.ISO_8859_1));
 
                         // Write the plugin config file
                         // Create a style sheet to indent the output

--- a/dev/com.ibm.ws.wsoc/src/com/ibm/ws/wsoc/util/Utils.java
+++ b/dev/com.ibm.ws.wsoc/src/com/ibm/ws/wsoc/util/Utils.java
@@ -19,6 +19,7 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -38,7 +39,7 @@ import com.ibm.wsspi.bytebuffer.WsByteBuffer;
 
 public class Utils {
 
-    public static final Charset UTF8_CHARSET = Charset.forName("UTF-8");
+    public static final Charset UTF8_CHARSET = StandardCharsets.UTF_8;
 
     private static final TraceComponent tc = Tr.register(Utils.class);
 
@@ -465,7 +466,7 @@ public class Utils {
         String inputKey = key + Constants.GUID;
 
         MessageDigest md = MessageDigest.getInstance("SHA-1");
-        byte[] arrayKey = inputKey.getBytes("iso-8859-1");
+        byte[] arrayKey = inputKey.getBytes(StandardCharsets.ISO_8859_1);
         // Question: should it be:  "utf-8" above?
         md.update(arrayKey, 0, arrayKey.length);
         byte[] sha1hash = md.digest();


### PR DESCRIPTION
- Instead of looking up the UTF-8 and ISO-8859-1 charsets, use the built-in Constants class provided by the JDK.
- This is applying the work that was done with PR #15997 to other code where the lookup happens.
