### PR TITLE
Debug Websocket Test -- testSinglePublisherMultipleReciverTextSuccess

### DIFF
--- a/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/all/TraceEnabledTest.java
+++ b/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/all/TraceEnabledTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2015 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -51,6 +51,7 @@ public class TraceEnabledTest {
 
         for (WsocTestContext wtc : mctr.getReceivers()) {
             wtc.reThrowException();
+            LOG.log(Level.INFO, "Actual message array", wtc.getMessage().toArray());
             Assert.assertArrayEquals(data, wtc.getMessage().toArray());
         }
     }

--- a/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/util/wsoc/WsocTestContext.java
+++ b/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/util/wsoc/WsocTestContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/util/wsoc/WsocTestContext.java
+++ b/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/util/wsoc/WsocTestContext.java
@@ -99,8 +99,8 @@ public class WsocTestContext {
     public synchronized void addMessage(Object msg) {
 
         _curMessage++;
-        // log the first five messages of each test, for better debugging
-        if (_curMessage <= 5) {
+        // log the six messages of each test, for better debugging
+        if (_curMessage <= 6) {
             LOG.info("Adding message to test results, message #: " + _curMessage + " " + msg);
         }
         if (!_messageCountOnly) {
@@ -117,7 +117,7 @@ public class WsocTestContext {
 
         if (_numMsgsExpected > 0) {
             if (_curMessage >= _numMsgsExpected) {
-
+                LOG.info(this.toString() + " --  Message Total: " + this._messages.toString());
                 _limitReached = true;
 
             }


### PR DESCRIPTION
For defect [282392]( https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=282392)

testSinglePublisherMultipleReciverTextSuccess_EE9_FEATURES:junit.framework.AssertionFailedError: 2021-03-06-10:15:00:347 array lengths differed, expected.length=6 actual.length=5
at io.openliberty.wsoc.tests.all.TraceEnabledTest.testSinglePublisherMultipleReciverTextSuccess(TraceEnabledTest.java:194)

Test fails because not all messages are supposedly received.  Logging the message array after the last message to confirm. 

Could be some networking/infrastructure issue perhaps? Otherwise, it could indicate a test bug. 


