### PR TITLE
Make `@ApplicationPath` a CDI bean-defining annotation

### DIFF
--- a/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/component/LibertyResteasyCdiExtension.java
+++ b/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/component/LibertyResteasyCdiExtension.java
@@ -22,6 +22,7 @@ import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.Extension;
 import javax.enterprise.inject.spi.ProcessAnnotatedType;
 import javax.enterprise.inject.spi.WithAnnotations;
+import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.ext.Provider;
@@ -48,6 +49,7 @@ import io.openliberty.org.jboss.resteasy.common.cdi.LibertyCdiInjectorFactory;
              "bean.defining.annotations=" +
                 "jakarta.ws.rs.Path;" +
                 "jakarta.ws.rs.core.Application;" +
+                "jakarta.ws.rs.ApplicationPath;" +
                 "jakarta.ws.rs.ext.Provider;" +
                 "jakarta.annotation.ManagedBean",
              "service.vendor=IBM" })

--- a/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/component/ResteasyCDIExtensionMetadata.java
+++ b/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/component/ResteasyCDIExtensionMetadata.java
@@ -32,6 +32,7 @@ import io.openliberty.cdi.spi.CDIExtensionMetadata;
                  "bean.defining.annotations=" +
                     "javax.ws.rs.Path;" +
                     "javax.ws.rs.core.Application;" +
+                    "javax.ws.rs.ApplicationPath;" +
                     "javax.ws.rs.ext.Provider",
                  "service.vendor=IBM" })
 public class ResteasyCDIExtensionMetadata implements CDIExtensionMetadata {

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/CDIInjectIntoAppTest.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/CDIInjectIntoAppTest.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS30.fat;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.restfulWS30.fat.appandresource.AppAndResourceTestServlet;
+import io.openliberty.restfulWS30.fat.cdiInjectIntoApp.CDIInjectIntoAppTestServlet;
+
+@RunWith(FATRunner.class)
+public class CDIInjectIntoAppTest extends FATServletClient {
+
+    public static final String APP_NAME = "cdiinjectintoapp";
+    public static final String SERVER_NAME = APP_NAME;
+
+    @Server(SERVER_NAME)
+    @TestServlet(servlet = CDIInjectIntoAppTestServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addPackages(true, CDIInjectIntoAppTestServlet.class.getPackage());
+
+        ShrinkHelper.exportDropinAppToServer(server, war, DeployOptions.SERVER_ONLY);
+
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/FATSuite.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/FATSuite.java
@@ -18,6 +18,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({
                 AppAndResourceTest.class,
                 AppAndResourceCDIBeanDiscoveryModeDisabledTest.class,
+                CDIInjectIntoAppTest.class,
                 ExceptionTest.class,
                 InjectAppTest.class,
                 JsonbTest.class,

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/cdiInjectIntoApp/CDIInjectIntoAppTestServlet.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/cdiInjectIntoApp/CDIInjectIntoAppTestServlet.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS30.fat.cdiInjectIntoApp;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import jakarta.servlet.annotation.WebServlet;
+
+@SuppressWarnings("serial")
+@WebServlet("/CDIInjectIntoAppTestServlet")
+public class CDIInjectIntoAppTestServlet extends FATServlet {
+
+    @Test
+    public void testCanInjectIntoAppAndAppIntoResource() throws Exception {
+        assertEquals("SUCCESS", testResource("checkAppInjection"));
+    }
+
+    @Test
+    public void testInjectedBeansHaveCorrectScopes() throws Exception {
+        assertEquals("1 - 1", testResource("1"));
+        assertEquals("2 - 2", testResource("1"));
+        assertEquals("1 - 3", testResource("2"));
+        assertEquals("3 - 4", testResource("1"));
+        assertEquals("2 - 5", testResource("2"));
+    }
+
+    private String testResource(String resourcePath) throws Exception {
+        URI uri = URI.create("http://localhost:" + System.getProperty("bvt.prop.HTTP_default") + "/cdiinjectintoapp/app/resource/" + resourcePath);
+        HttpURLConnection conn = (HttpURLConnection) uri.toURL().openConnection();
+        assertEquals(200, conn.getResponseCode());
+        return readEntity(conn.getInputStream());
+    }
+
+    private String readEntity(InputStream is) throws Exception {
+        StringBuilder sb = new StringBuilder();
+        byte[] b = new byte[256];
+        int i = is.read(b);
+        while (i > 0) {
+            sb.append(new String(b, 0, i));
+            i = is.read(b);
+        }
+        return sb.toString().trim();
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/cdiInjectIntoApp/InvocationCounter.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/cdiInjectIntoApp/InvocationCounter.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS30.fat.cdiInjectIntoApp;
+
+public interface InvocationCounter {
+
+    int invoke();
+
+    int getInvocations();
+}

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/cdiInjectIntoApp/InvocationCounterImpl.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/cdiInjectIntoApp/InvocationCounterImpl.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS30.fat.cdiInjectIntoApp;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class InvocationCounterImpl implements InvocationCounter {
+
+    AtomicInteger count = new AtomicInteger(0);
+
+    @Override
+    public int invoke() {
+        return count.incrementAndGet();
+    }
+
+    @Override
+    public int getInvocations() {
+        return count.get();
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/cdiInjectIntoApp/MyApplication.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/cdiInjectIntoApp/MyApplication.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS30.fat.cdiInjectIntoApp;
+
+import java.util.Collections;
+import java.util.Map;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/app")
+public class MyApplication extends Application {
+
+    @Inject
+    InvocationCounter counter;
+
+    @Override
+    public Map<String, Object> getProperties() {
+        return Collections.singletonMap("counter", counter);
+    }
+
+    InvocationCounter getCounter() {
+        return counter;
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/cdiInjectIntoApp/MyResource.java
+++ b/dev/io.openliberty.restfulWS.3.0_fat/fat/src/io/openliberty/restfulWS30/fat/cdiInjectIntoApp/MyResource.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS30.fat.cdiInjectIntoApp;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Context;
+
+@Path("/resource")
+public class MyResource {
+
+    static Map<String,AtomicInteger> resourceCounterMap = new HashMap<>();
+
+    static {
+        resourceCounterMap.put("1", new AtomicInteger(0));
+        resourceCounterMap.put("2", new AtomicInteger(0));
+    }
+
+    @Context
+    Application app;
+
+    @GET
+    @Path("checkAppInjection")
+    public String checkAppInjectionNotNull() {
+        // Do not update any counters for this method.
+        if (app == null) {
+            return "Failed to inject app into MyResource";
+        }
+        Map<String, Object> props = app.getProperties();
+        if (props == null) {
+            return "Application#getProperties is null";
+        }
+        Object counter = props.get("counter");
+        if (counter == null) {
+            return "Counter that is supposed to be injected into MyApplication is null";
+        }
+        return "SUCCESS";
+    }
+
+    @GET
+    @Path("1")
+    public String one() {
+        int resourceCount = resourceCounterMap.get("1").incrementAndGet();
+        int appCount = ((InvocationCounter) app.getProperties().get("counter")).invoke();
+        return "" + resourceCount + " - " + appCount;
+    }
+
+    @GET
+    @Path("2")
+    public String two() {
+        int resourceCount = resourceCounterMap.get("2").incrementAndGet();
+        int appCount = ((InvocationCounter) app.getProperties().get("counter")).invoke();
+        return "" + resourceCount + " - " + appCount;
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/cdiinjectintoapp/bootstrap.properties
+++ b/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/cdiinjectintoapp/bootstrap.properties
@@ -1,0 +1,3 @@
+bootstrap.include=../testports.properties
+#com.ibm.ws.logging.max.files=1
+#com.ibm.ws.logging.trace.specification=LogService=all:RESTfulWS=all

--- a/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/cdiinjectintoapp/server.xml
+++ b/dev/io.openliberty.restfulWS.3.0_fat/publish/servers/cdiinjectintoapp/server.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<server>
+    <featureManager>
+        <feature>componenttest-2.0</feature>
+        <feature>restfulWS-3.0</feature>
+    </featureManager>
+    <include location="../fatTestPorts.xml"/>
+    
+    <javaPermission className="java.util.PropertyPermission"  name="*" actions="read" />
+    <javaPermission className="java.net.URLPermission" name="http://localhost:8010/cdiinjectintoapp/app/-" actions="GET:"/>
+    <javaPermission className="java.net.SocketPermission" name="*" actions="connect,resolve"/>
+</server>


### PR DESCRIPTION
This should enable injection into `Application` subclasses so long as they are annotated with `@ApplicationPath`