### PR TITLE
Use original feature name and rename file to satisfy feature verifica…

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.autoTimingMonitor-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.autoTimingMonitor-1.0.feature
@@ -1,5 +1,5 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.autoRequestTimingMonitor-1.0
+symbolicName=com.ibm.websphere.appserver.autoTimingMonitor-1.0
 IBM-App-ForceRestart: uninstall
 Manifest-Version: 1.0
 IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.monitor-1.0))", \


### PR DESCRIPTION
#build

First PR which moved Request Timing Monitor bundles over: https://github.com/OpenLiberty/open-liberty/pull/16550

The file being moved over was:
`com.ibm.websphere.appserver.autoRequestTimingMonitor-1.0.feature`

This failed OL feature checkers due to the mismatched names. The file was `autoRequestTimingMonitor-1.0` but the symbolic name  was  `com.ibm.websphere.appserver.autoTimingMonitor-1.0`. As a result, the symbolic name was changed to  `com.ibm.websphere.appserver.autoRequestTimingMonitor-1.0` with #16550

However, this causes issues when removing the _original_ feature file from WS-CD as it is expecting `com.ibm.websphere.appserver.autoTimingMonitor-1.0` but it is now _deleted_.

To fix this, this PR will rename the feature file in OL to `com.ibm.websphere.appserver.autoTimingMonitor-1.0.feature` so we can keep the original symbolic name and avoid failures with WS-CD.
