### PR TITLE
Update jaxrs21 FAT for Java 16

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/PatchTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/PatchTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,12 +15,14 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import jaxrs21.fat.patch.PatchTestServlet;
@@ -29,6 +31,7 @@ import jaxrs21.fat.patch.PatchTestServlet;
 @RunWith(FATRunner.class)
 public class PatchTest extends FATServletClient {
 
+    private static final Class<?> c = PatchTest.class;
     private static final String appName = "patchapp";
 
     @Server("jaxrs21.fat.patch")
@@ -37,6 +40,12 @@ public class PatchTest extends FATServletClient {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        JavaInfo java = JavaInfo.forCurrentVM();
+        int javaVersion = java.majorVersion();
+        if (javaVersion > 8) {
+            Log.info(c, "setup()", "Detected Java version (" + javaVersion + ") is 9 or higher, adding additional jvm.options file to compensate for strong encapsulation");
+            server.copyFileToLibertyServerRoot("patch_java9_jvm/jvm.options");
+        }
         ShrinkHelper.defaultDropinApp(server, appName, "jaxrs21.fat.patch");
         server.startServer();
     }

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/files/patch_java9_jvm/jvm.options
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/publish/files/patch_java9_jvm/jvm.options
@@ -1,0 +1,3 @@
+# for patch test
+--add-opens
+java.base/sun.net.www.protocol.https=ALL-UNNAMED


### PR DESCRIPTION
Fixes an illegal access problem in the com.ibm.ws.jaxrs.2.1_fat_extended FAT when running in Java 16.

```
testSubResourcePatch:junit.framework.AssertionFailedError: 2021-03-06-03:31:42:264 The response did not contain "[SUCCESS]".  Full output is:"
ERROR: Caught exception attempting to call test method testSubResourcePatch on servlet jaxrs21.fat.patch.PatchTestServlet
	at jaxrs21.fat.patch.PatchTestServlet.testSubResourcePatch(PatchTestServlet.java:86)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at componenttest.app.FATServlet.doGet(FATServlet.java:67)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:686)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:791)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.service(ServletWrapper.java:1257)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:745)
	at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:442)
	at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1226)
	at com.ibm.ws.webcontainer.webapp.WebApp.handleRequest(WebApp.java:5057)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.handleRequest(DynamicVirtualHost.java:314)
	at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:1006)
	at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:279)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1146)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:427)
	at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:386)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:566)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:500)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:360)
	at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.ready(HttpInboundLink.java:327)
	at com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.sendToDiscriminators(NewConnectionInitialReadCallback.java:167)
	at com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.complete(NewConnectionInitialReadCallback.java:75)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:504)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:574)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:958)
	at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1047)
	at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:238)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:831)
". expected:<0> but was:<1>
	at componenttest.topology.utils.HttpUtils.findStringInHttpConnection(HttpUtils.java:537)
	at componenttest.topology.utils.HttpUtils.findStringInHttpConnection(HttpUtils.java:495)
	at componenttest.topology.utils.HttpUtils.findStringInUrl(HttpUtils.java:472)
	at componenttest.topology.utils.HttpUtils.findStringInReadyUrl(HttpUtils.java:444)
	at componenttest.topology.utils.HttpUtils.findStringInReadyUrl(HttpUtils.java:414)
	at componenttest.topology.utils.FATServletClient.runTest(FATServletClient.java:83)
	at componenttest.custom.junit.runner.SyntheticServletTest.invokeExplosively(SyntheticServletTest.java:40)
	at componenttest.custom.junit.runner.FATRunner$1.evaluate(FATRunner.java:197)
	at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:318)
	at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:171)
	at componenttest.rules.repeater.RepeatTests$CompositeRepeatTestActionStatement.evaluate(RepeatTests.java:115)
```
