### PR TITLE
Add null check to LTPA filter check in SSOAuthFilterImpl

### DIFF
--- a/dev/com.ibm.ws.security.sso/src/com/ibm/ws/security/sso/SSOAuthFilterImpl.java
+++ b/dev/com.ibm.ws.security.sso/src/com/ibm/ws/security/sso/SSOAuthFilterImpl.java
@@ -126,9 +126,11 @@ public class SSOAuthFilterImpl implements com.ibm.ws.webcontainer.security.util.
         AuthenticationFilter authFilter = null;
         if (ltpaConfigurationRef != null) {
             ltpaConfig = ltpaConfigurationRef.getService();
-            String pid = ltpaConfig.getAuthFilterRef();
-            if (pid != null && pid.length() > 0) {
-                authFilter = getAuthFilterService(pid);
+            if (ltpaConfig != null) {
+                String pid = ltpaConfig.getAuthFilterRef();
+                if (pid != null && pid.length() > 0) {
+                    authFilter = getAuthFilterService(pid);
+                }
             }
         }
         return authFilter;


### PR DESCRIPTION
Makes sure there's a non-null `LTPAConfiguration` object before using it.