### PR TITLE
Fix #2 for test failure in RTC 282932. Unconditionally reset the serv…

### DIFF
--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/CommonTest.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/CommonTest.java
@@ -313,14 +313,15 @@ public class CommonTest {
             Log.info(c, thisMethod, "Using initial config: " + config);
         }
 
+        if (getKdcHelper() == null) {
+            setKdcHelper(getKdcHelper(getMyServer()));
+        } else {
+            createKrbConf(getKdcHelper().server);
+        }
+
         if (createSpnAndKeytab) {
             try {
                 Log.info(c, thisMethod, "Creating SPN and keytab");
-                if (getKdcHelper() == null) {
-                    setKdcHelper(getKdcHelper(getMyServer()));
-                } else {
-                    createKrbConf(getKdcHelper().server);
-                }
                 getKdcHelper().createSpnAndKeytab(spnRealm, useCanonicalHostName, SPNEGOConstants.DEFAULT_CMD_ARGS);
             } catch (Exception e) {
                 Log.info(c, thisMethod, "Got unexpected exception; no tests will be run: " + CommonTest.maskHostnameAndPassword(e.getMessage()));


### PR DESCRIPTION
…er in KdcHelper in test setup.

