### PR TITLE
Add runtime trace to websocket traceTestServer

### DIFF
--- a/dev/io.openliberty.wsoc.internal_fat/publish/servers/traceTestServer/server.xml
+++ b/dev/io.openliberty.wsoc.internal_fat/publish/servers/traceTestServer/server.xml
@@ -31,7 +31,7 @@
     </featureManager>
    
     
- <logging maxFileSize="50" maxFiles="3" traceFileName="wsocTrace.log" traceSpecification="*=info:com.ibm.ws.webcontainer.*=all:com.ibm.wsspi.webcontainer.*=all:com.ibm.ws.webcontainer31.*=all:ChannelFramework=all:HTTPChannel=all:TCPChannel=all:websockets=all"/> 
+ <logging maxFileSize="50" maxFiles="3" traceFileName="wsocTrace.log" traceSpecification="*=info:com.ibm.ws.webcontainer.*=all:com.ibm.wsspi.webcontainer.*=all:com.ibm.ws.webcontainer31.*=all:ChannelFramework=all:HTTPChannel=all:TCPChannel=all:websockets=all:com.ibm.ws.runtime.update.*=all"/> 
       
     <javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
     <javaPermission className="java.lang.RuntimePermission" name="modifyThread"/>  


### PR DESCRIPTION
For defect [276206](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=276206)

` Errors/warnings  were found in server traceTestServer logs: 
[4/17/21, 8:33:13:758 PDT] 00000035  com.ibm.ws.runtime.update.internal.RuntimeUpdateManagerImpl  W  CWWKE1102W: The quiesce operation did not complete. The server will now  stop. 
[4/17/21, 8:33:13:758 PDT] 00000035  com.ibm.ws.runtime.update.internal.RuntimeUpdateManagerImpl  W  CWWKE1106W: 1 shutdown operations did not complete during the quiesce  period.`

Hoping this will help provide more information on what's occurring here. 

This issue could also apply to #16645 -- another pr where debug statements were added. 