### PR TITLE
Add option to allow the build to specify complete feature list

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -105,6 +105,7 @@ File mavenDir = new File(project.buildDir, 'maven')
 
 class PackageLibertyWithFeatures extends DefaultTask {
     Closure withFeatures
+    Boolean completeFeatureList
     File outputTo
 
     @TaskAction
@@ -134,7 +135,12 @@ class PackageLibertyWithFeatures extends DefaultTask {
             project.delete archive
             project.exec {
                 workingDir project.file('wlp/bin')
-                def args = ["package", "packageOpenLiberty", "--archive=${archive}", "--include=minify", "-Dinternal.minify.ignore.singleton=true"]
+                def args = ["package", "packageOpenLiberty", "--archive=${archive}", "--include=minify"]
+                if (completeFeatureList) { 
+                    args.add("-Dinternal.minify.feature.list.complete=true") 
+                } else {
+                    args.add("-Dinternal.minify.ignore.singleton=true") 
+                }
                 if (OperatingSystem.current().windows) {
                     commandLine = ["cmd", "/c", "server"] + args
                 } else {
@@ -211,7 +217,7 @@ def allFeatures() {
 
 def gaPublicFeatures() {
     String features = ""
-    gaFeatures(true).each {
+    gaFeatures(false).each {
         features += '<feature>' + it + '</feature>\n'
     }
     features
@@ -219,10 +225,24 @@ def gaPublicFeatures() {
 
 def gaAndBetaPublicFeatures() {
     String features = ""
-    gaFeatures(true).each {
+    gaFeatures(false).each {
         features += '<feature>' + it + '</feature>\n'
     }
     betaFeatures().each {
+        features += '<feature>' + it + '</feature>\n'
+    }
+    features
+}
+
+def gaAndBetaAndNoShipPublicFeatures() {
+    String features = ""
+    gaFeatures(false).each {
+        features += '<feature>' + it + '</feature>\n'
+    }
+    betaFeatures().each {
+        features += '<feature>' + it + '</feature>\n'
+    }
+    noShipFeatures().each {
         features += '<feature>' + it + '</feature>\n'
     }
     features
@@ -303,28 +323,18 @@ def replaceBetaVersionAndEdition(String pathname, String release, String beta) {
 
 if (isAutomatedBuild && !isIFIXBuild) {
     task packageOpenLibertyAll(type: PackageLibertyWithFeatures) {
-        def excludedFeatures = []
-        doFirst {
-            excludedFeatures.addAll(testFeatures())
-            excludedFeatures.each {
-                this.&removeFeature("${it}")
-            }
-        }
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
-        withFeatures this.&allFeatures
+        withFeatures this.&gaAndBetaAndNoShipPublicFeatures
+        completeFeatureList = true
         outputTo packageDir
-        doLast {
-            excludedFeatures.each {
-                this.&restoreFeature("${it}")
-            }
-        }
     }
 
     task packageOpenLiberty(type: PackageLibertyWithFeatures) {
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
         withFeatures this.&gaPublicFeatures
+        completeFeatureList = true
         outputTo packageDir
     }
 
@@ -333,6 +343,7 @@ if (isAutomatedBuild && !isIFIXBuild) {
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
         withFeatures this.&gaAndBetaPublicFeatures
+        completeFeatureList = true
         outputTo packageDir
         doLast {
             ["$packageDir/wlp/NOTICES", "$packageDir/wlp/README.TXT", "$packageDir/wlp/lib/versions/openliberty.properties"].each { path ->

--- a/dev/com.ibm.websphere.appserver.features/build.gradle
+++ b/dev/com.ibm.websphere.appserver.features/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@
 
 def featurePropertiesMap
 def gaFeatures
+def noShipFeatures
 def betaFeatures
 def gaPublicFeatures
 def getFeatureMap = {
@@ -18,6 +19,7 @@ def getFeatureMap = {
         Map<String,Properties> map = new TreeMap()
         Set<String> featuresGa = new TreeSet()
         Set<String> featuresBeta = new TreeSet()
+        Set<String> featuresNoShip = new TreeSet()
         Set<String> publicFeatures = new TreeSet()
         project(':com.ibm.websphere.appserver.features').fileTree(dir: '.', include: 'visibility/**/*.feature').each { featureFile ->
             Properties featureProps = new Properties()
@@ -30,11 +32,14 @@ def getFeatureMap = {
                 }
             } else if ('beta'.equals(featureProps['kind'])) {
                 featuresBeta.add(featureProps['symbolicName'])
+            } else if ('noship'.equals(featureProps['kind'])) {
+                featuresNoShip.add(featureProps['symbolicName'])
             }
         }
         featurePropertiesMap = map
         gaFeatures = featuresGa
         betaFeatures = featuresBeta
+        noShipFeatures = featuresNoShip
         gaPublicFeatures = publicFeatures
     }
     featurePropertiesMap
@@ -65,6 +70,13 @@ rootProject.ext.betaFeatures = {
         getFeatureMap()
     }
     betaFeatures
+}
+
+rootProject.ext.noShipFeatures = {
+    if (noShipFeatures == null) {
+        getFeatureMap()
+    }
+    noShipFeatures
 }
 
 copyPiiFiles {

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2020 IBM Corporation and others.
+ * Copyright (c) 2009, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,6 +31,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -203,10 +204,15 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
             featureBundlesResolved = runtimeUpdateManager.createNotification(RuntimeUpdateNotification.FEATURE_BUNDLES_RESOLVED);
         }
 
-        Set<String> getFeaturesWithLowerCaseName() {
+        Set<String> getFeaturesWithLowerCaseName(FeatureRepository featureRepo) {
             Set<String> lcnFeatures = new HashSet<String>();
             for (String feature : features) {
-                lcnFeatures.add(FeatureRepository.lowerFeature(feature));
+                ProvisioningFeatureDefinition f = featureRepo.getFeature(feature);
+                if (f == null || f.getVisibility() == Visibility.PUBLIC) {
+                    lcnFeatures.add(FeatureRepository.lowerFeature(feature));
+                } else {
+                    lcnFeatures.add(feature);
+                }
             }
 
             return lcnFeatures;
@@ -1209,7 +1215,7 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
     private Result resolveFeatures(FeatureChange featureChange) {
         // In 850 we were not case sensitive so we need to stay that way.
         // Use a set to eliminate duplicates.
-        Set<String> newConfiguredFeatures = featureChange.getFeaturesWithLowerCaseName();
+        Set<String> newConfiguredFeatures = featureChange.getFeaturesWithLowerCaseName(featureRepository);
 
         return resolveFeatures(newConfiguredFeatures, new ArrayList<String>(), featureChange.provisioningMode);
     }
@@ -1222,10 +1228,17 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
         Repository restrictedRespository;
         Collection<String> restrictedRepoAccessAttempts = new ArrayList<String>();
         boolean allowMultipleVersions = false;
+        boolean featureListIsComplete = false;
         if (ProvisioningMode.CONTENT_REQUEST == mode || ProvisioningMode.FEATURES_REQUEST == mode) {
             // allow multiple versions if in minify (TODO strange since we are minifying!)
             // For feature request using the minified approach but that could cause additional singletons to be provisioned.
             allowMultipleVersions = Boolean.getBoolean("internal.minify.ignore.singleton");
+            // For packaging purposes; have an option that just blindly takes
+            // the feature list and uses it without using the resolver.
+            // This feature list may include public, protected, private and auto-features.
+            // No additional feature resolution will be done to pull in additional required features.
+            // The feature list is expected to be complete.
+            featureListIsComplete = Boolean.getBoolean("internal.minify.feature.list.complete");
             // do not restrict any features
             restrictedRespository = featureRepository;
         } else {
@@ -1249,6 +1262,19 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
                 restrictedRespository = temp;
             }
         }
+        Result result;
+        if (featureListIsComplete) {
+            result = createResultFromCompleteList(restrictedRespository, rootFeatures);
+        } else {
+            result = callFeatureResolver(restrictedRespository, kernelFeaturesHolder.getKernelFeatures(), rootFeatures, allowMultipleVersions);
+        }
+        restrictedAccessAttempts.addAll(restrictedRepoAccessAttempts);
+        return result;
+    }
+
+    private Result callFeatureResolver(Repository restrictedRespository, Collection<ProvisioningFeatureDefinition> kernelFeatures, Set<String> rootFeatures,
+                                       boolean allowMultipleVersions) {
+
         // resolve the features
         // TODO Note that we are just supporting all types at runtime right now.  In the future this may be restricted by the actual running process type
         Result result = featureResolver.resolveFeatures(restrictedRespository, kernelFeaturesHolder.getKernelFeatures(), rootFeatures, Collections.<String> emptySet(),
@@ -1258,9 +1284,55 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
                 result = featureResolver.resolveFeatures(restrictedRespository, kernelFeaturesHolder.getKernelFeatures(), rootFeatures, Collections.<String> emptySet(), true);
             }
         }
-        restrictedAccessAttempts.addAll(restrictedRepoAccessAttempts);
 
         return result;
+    }
+
+    private Result createResultFromCompleteList(Repository repository, Set<String> rootFeatures) {
+        final Set<String> missing = new HashSet<>();
+        final Set<String> resolved = new LinkedHashSet<>();
+
+        for (String featureName : rootFeatures) {
+            ProvisioningFeatureDefinition feature = repository.getFeature(featureName);
+            if (feature == null) {
+                missing.add(featureName);
+            } else {
+                resolved.add(feature.getFeatureName());
+            }
+        }
+
+        return new Result() {
+
+            @Override
+            public boolean hasErrors() {
+                return !getMissing().isEmpty();
+            }
+
+            @Override
+            public Map<String, Chain> getWrongProcessTypes() {
+                return Collections.emptyMap();
+            }
+
+            @Override
+            public Set<String> getResolvedFeatures() {
+                return resolved;
+            }
+
+            @Override
+            public Set<String> getNonPublicRoots() {
+                return Collections.emptySet();
+            }
+
+            @Override
+            public Set<String> getMissing() {
+                return missing;
+            }
+
+            @Override
+            public Map<String, Collection<Chain>> getConflicts() {
+                return Collections.emptyMap();
+            }
+        };
     }
 
     /**
@@ -1284,7 +1356,7 @@ public class FeatureManager implements FeatureProvisioner, FrameworkReady, Manag
 
         // In 850 we were not case sensitive so we need to stay that way.
         // Use a set to eliminate duplicates.
-        Set<String> newConfiguredFeatures = featureChange.getFeaturesWithLowerCaseName();
+        Set<String> newConfiguredFeatures = featureChange.getFeaturesWithLowerCaseName(featureRepository);
 
         if (newConfiguredFeatures.isEmpty() && featureRepository.emptyFeatures()) {
 


### PR DESCRIPTION
For packaging a mode is added to minify that blindly takes the feature
list as-is with no feature resolution or checking and packages its
content.  No additional feature dependencies are pulled in during this
process.
