### PR TITLE
Add new packaging flag for passing complete feature list

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -105,6 +105,7 @@ File mavenDir = new File(project.buildDir, 'maven')
 
 class PackageLibertyWithFeatures extends DefaultTask {
     Closure withFeatures
+    Boolean completeFeatureList
     File outputTo
 
     @TaskAction
@@ -134,7 +135,10 @@ class PackageLibertyWithFeatures extends DefaultTask {
             project.delete archive
             project.exec {
                 workingDir project.file('wlp/bin')
-                def args = ["package", "packageOpenLiberty", "--archive=${archive}", "--include=minify", "-Dinternal.minify.ignore.singleton=true"]
+                def args = ["package", "packageOpenLiberty", "--archive=${archive}", "--include=minify"]
+                if (completeFeatureList) { 
+                    args.add("-Dinternel.minify.feature.list.complete=true") 
+                }
                 if (OperatingSystem.current().windows) {
                     commandLine = ["cmd", "/c", "server"] + args
                 } else {
@@ -211,7 +215,7 @@ def allFeatures() {
 
 def gaPublicFeatures() {
     String features = ""
-    gaFeatures(true).each {
+    gaFeatures(false).each {
         features += '<feature>' + it + '</feature>\n'
     }
     features
@@ -219,10 +223,24 @@ def gaPublicFeatures() {
 
 def gaAndBetaPublicFeatures() {
     String features = ""
-    gaFeatures(true).each {
+    gaFeatures(false).each {
         features += '<feature>' + it + '</feature>\n'
     }
     betaFeatures().each {
+        features += '<feature>' + it + '</feature>\n'
+    }
+    features
+}
+
+def gaAndBetaAndNoShipPublicFeatures() {
+    String features = ""
+    gaFeatures(false).each {
+        features += '<feature>' + it + '</feature>\n'
+    }
+    betaFeatures().each {
+        features += '<feature>' + it + '</feature>\n'
+    }
+    noShipFeatures().each {
         features += '<feature>' + it + '</feature>\n'
     }
     features
@@ -303,28 +321,18 @@ def replaceBetaVersionAndEdition(String pathname, String release, String beta) {
 
 if (isAutomatedBuild && !isIFIXBuild) {
     task packageOpenLibertyAll(type: PackageLibertyWithFeatures) {
-        def excludedFeatures = []
-        doFirst {
-            excludedFeatures.addAll(testFeatures())
-            excludedFeatures.each {
-                this.&removeFeature("${it}")
-            }
-        }
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
-        withFeatures this.&allFeatures
+        withFeatures this.&gaAndBetaAndNoShipPublicFeatures
+        completeFeatureList = true
         outputTo packageDir
-        doLast {
-            excludedFeatures.each {
-                this.&restoreFeature("${it}")
-            }
-        }
     }
 
     task packageOpenLiberty(type: PackageLibertyWithFeatures) {
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
         withFeatures this.&gaPublicFeatures
+        completeFeatureList = true
         outputTo packageDir
     }
 
@@ -333,6 +341,7 @@ if (isAutomatedBuild && !isIFIXBuild) {
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
         withFeatures this.&gaAndBetaPublicFeatures
+        completeFeatureList = true
         outputTo packageDir
         doLast {
             ["$packageDir/wlp/NOTICES", "$packageDir/wlp/README.TXT", "$packageDir/wlp/lib/versions/openliberty.properties"].each { path ->

--- a/dev/com.ibm.websphere.appserver.features/build.gradle
+++ b/dev/com.ibm.websphere.appserver.features/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@
 
 def featurePropertiesMap
 def gaFeatures
+def noShipFeatures
 def betaFeatures
 def gaPublicFeatures
 def getFeatureMap = {
@@ -18,6 +19,7 @@ def getFeatureMap = {
         Map<String,Properties> map = new TreeMap()
         Set<String> featuresGa = new TreeSet()
         Set<String> featuresBeta = new TreeSet()
+        Set<String> featuresNoShip = new TreeSet()
         Set<String> publicFeatures = new TreeSet()
         project(':com.ibm.websphere.appserver.features').fileTree(dir: '.', include: 'visibility/**/*.feature').each { featureFile ->
             Properties featureProps = new Properties()
@@ -30,11 +32,14 @@ def getFeatureMap = {
                 }
             } else if ('beta'.equals(featureProps['kind'])) {
                 featuresBeta.add(featureProps['symbolicName'])
+            } else if ('noship'.equals(featureProps['kind'])) {
+                featuresNoShip.add(featureProps['symbolicName'])
             }
         }
         featurePropertiesMap = map
         gaFeatures = featuresGa
         betaFeatures = featuresBeta
+        noShipFeatures = featuresNoShip
         gaPublicFeatures = publicFeatures
     }
     featurePropertiesMap
@@ -65,6 +70,13 @@ rootProject.ext.betaFeatures = {
         getFeatureMap()
     }
     betaFeatures
+}
+
+rootProject.ext.noShipFeatures = {
+    if (noShipFeatures == null) {
+        getFeatureMap()
+    }
+    noShipFeatures
 }
 
 copyPiiFiles {


### PR DESCRIPTION
Adding new -Dinternel.minify.feature.list.complete flag to skip the feature resolver portion of the packager - and rely on passing complete feature lists for the various "all" packages.