### PR TITLE
Issue 16703: Add permissions for CustomStoreSample

### DIFF
--- a/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/MongoDBServlet.xml
+++ b/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/MongoDBServlet.xml
@@ -21,4 +21,17 @@
 	<javaPermission
 		codebase="${server.config.dir}/mongoDB/mongo-java-driver.jar"
 		className="java.security.AllPermission" />
+    <javaPermission
+		codebase="${wlp.user.dir}/shared/mongo-java-driver.jar"
+		className="java.security.AllPermission" />
+	<javaPermission
+		codebase="${wlp.user.dir}/shared/security.custom.store_1.0.jar"
+		className="java.security.AllPermission" />
+	<javaPermission
+		codebase="${server.config.dir}/publish/bundles/security.custom.store_1.0.jar"
+		className="java.security.AllPermission" />
+    <javaPermission
+		codebase="${server.config.dir}/test-apps/oAuth20MongoSetup.war"
+		className="java.security.AllPermission" />		
+		
 </server>


### PR DESCRIPTION
Fixes #16703 
Fixes RTC 283138

Accessing mongoDB and the mongoDB test properties file, causes java2 security failures.

Add permission to the CustomStoreSample jar and the mongoDB servlet.