### PR TITLE
Issue 16705: Move from consul Oracle server to unboundID for Ldap FATs

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_SUNLDAPTest_URAttrMappingVar4.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_SUNLDAPTest_URAttrMappingVar4.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2013 IBM Corporation and others.
+ * Copyright (c) 2012, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.websphere.simplicity.config.wim.LdapRegistry;
 import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.com.unboundid.InMemorySunLDAPServer;
 import com.ibm.ws.security.registry.SearchResult;
 import com.ibm.ws.security.registry.test.UserRegistryServletConnection;
 
@@ -32,7 +35,6 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
-import componenttest.topology.utils.LDAPUtils;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
@@ -41,17 +43,40 @@ public class URAPIs_SUNLDAPTest_URAttrMappingVar4 {
     private static final Class<?> c = URAPIs_SUNLDAPTest_URAttrMappingVar4.class;
     private static UserRegistryServletConnection servlet;
 
+    private static InMemorySunLDAPServer ldapServer;
+
     /**
      * Updates the sample, which is expected to be at the hard-coded path.
      * If this test is failing, check this path is correct.
      */
     @BeforeClass
     public static void setUp() throws Exception {
-        // Add LDAP variables to bootstrap properties file
-        LDAPUtils.addLDAPVariables(server);
+        setupLdapServer();
+        setupLibertyServer();
+    }
+
+    /**
+     * Setup the Liberty server. This server will start with very basic configuration. The tests
+     * will configure the server dynamically.
+     *
+     * @throws Exception If there was an issue setting up the Liberty server.
+     */
+    public static void setupLibertyServer() throws Exception {
         Log.info(c, "setUp", "Starting the server... (will wait for userRegistry servlet to start)");
         server.copyFileToLibertyInstallRoot("lib/features", "internalfeatures/securitylibertyinternals-1.0.mf");
         server.addInstalledAppForValidation("userRegistry");
+
+        /*
+         * Update LDAP configuration with In-Memory Server
+         */
+        ServerConfiguration serverConfig = server.getServerConfiguration();
+        LdapRegistry ldap = serverConfig.getLdapRegistries().get(0);
+        ldap.setHost("localhost");
+        ldap.setPort(String.valueOf(ldapServer.getLdapPort()));
+        ldap.setBindDN(InMemorySunLDAPServer.getBindDN());
+        ldap.setBindPassword(InMemorySunLDAPServer.getBindPassword());
+        server.updateServerConfiguration(serverConfig);
+
         server.startServer(c.getName() + ".log");
 
         //Make sure the application has come up before proceeding
@@ -71,12 +96,31 @@ public class URAPIs_SUNLDAPTest_URAttrMappingVar4 {
         }
     }
 
+    /**
+     * Configure the embedded LDAP server.
+     *
+     * @throws Exception If the server failed to start for some reason.
+     */
+    private static void setupLdapServer() throws Exception {
+        ldapServer = new InMemorySunLDAPServer();
+    }
+
     @AfterClass
     public static void tearDown() throws Exception {
         Log.info(c, "tearDown", "Stopping the server...");
         try {
-            server.stopServer();
+            if (server != null) {
+                server.stopServer();
+            }
         } finally {
+            try {
+                if (ldapServer != null) {
+                    ldapServer.shutDown(true);
+                }
+            } catch (Exception e) {
+                Log.error(c, "teardown", e, "LDAP server threw error while shutting down. " + e.getMessage());
+            }
+
             server.deleteFileFromLibertyInstallRoot("lib/features/internalfeatures/securitylibertyinternals-1.0.mf");
         }
     }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_SUNLDAP_DefaultConfigTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/URAPIs_SUNLDAP_DefaultConfigTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,7 +27,10 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.websphere.simplicity.config.wim.LdapRegistry;
 import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.com.unboundid.InMemorySunLDAPServer;
 import com.ibm.ws.security.registry.EntryNotFoundException;
 import com.ibm.ws.security.registry.SearchResult;
 import com.ibm.ws.security.registry.test.UserRegistryServletConnection;
@@ -37,7 +40,6 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
-import componenttest.topology.utils.LDAPUtils;
 import componenttest.vulnerability.LeakedPasswordChecker;
 
 @RunWith(FATRunner.class)
@@ -52,17 +54,40 @@ public class URAPIs_SUNLDAP_DefaultConfigTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
+    private static InMemorySunLDAPServer ldapServer;
+
     /**
      * Updates the sample, which is expected to be at the hard-coded path.
      * If this test is failing, check this path is correct.
      */
     @BeforeClass
     public static void setUp() throws Exception {
-        // Add LDAP variables to bootstrap properties file
-        LDAPUtils.addLDAPVariables(server);
+        setupLdapServer();
+        setupLibertyServer();
+    }
+
+    /**
+     * Setup the Liberty server. This server will start with very basic configuration. The tests
+     * will configure the server dynamically.
+     *
+     * @throws Exception If there was an issue setting up the Liberty server.
+     */
+    public static void setupLibertyServer() throws Exception {
         Log.info(c, "setUp", "Starting the server... (will wait for userRegistry servlet to start)");
         server.copyFileToLibertyInstallRoot("lib/features", "internalfeatures/securitylibertyinternals-1.0.mf");
         server.addInstalledAppForValidation("userRegistry");
+
+        /*
+         * Update LDAP configuration with In-Memory Server
+         */
+        ServerConfiguration serverConfig = server.getServerConfiguration();
+        LdapRegistry ldap = serverConfig.getLdapRegistries().get(0);
+        ldap.setHost("localhost");
+        ldap.setPort(String.valueOf(ldapServer.getLdapPort()));
+        ldap.setBindDN(InMemorySunLDAPServer.getBindDN());
+        ldap.setBindPassword(InMemorySunLDAPServer.getBindPassword());
+        server.updateServerConfiguration(serverConfig);
+
         server.startServer(c.getName() + ".log");
 
         //Make sure the application has come up before proceeding
@@ -82,12 +107,30 @@ public class URAPIs_SUNLDAP_DefaultConfigTest {
         }
     }
 
+    /**
+     * Configure the embedded LDAP server.
+     *
+     * @throws Exception If the server failed to start for some reason.
+     */
+    private static void setupLdapServer() throws Exception {
+        ldapServer = new InMemorySunLDAPServer();
+    }
+
     @AfterClass
     public static void tearDown() throws Exception {
         Log.info(c, "tearDown", "Stopping the server...");
         try {
-            server.stopServer("CWIML4529E", "CWIML4537E");
+            if (server != null) {
+                server.stopServer("CWIML4529E", "CWIML4537E");
+            }
         } finally {
+            try {
+                if (ldapServer != null) {
+                    ldapServer.shutDown(true);
+                }
+            } catch (Exception e) {
+                Log.error(c, "teardown", e, "LDAP server threw error while shutting down. " + e.getMessage());
+            }
             server.deleteFileFromLibertyInstallRoot("lib/features/internalfeatures/securitylibertyinternals-1.0.mf");
         }
     }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.multipleldaps/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.multipleldaps/server.xml
@@ -32,9 +32,6 @@
 		baseDN="dc=rtp,dc=raleigh,dc=ibm,dc=com"
 		ldapType="Sun Java System Directory Server"
 		searchTimeout="8m">
-		<failoverServers name="failoverLdapServers">
-		   <server host="${ldap.server.3.name}" port="${ldap.server.3.port}"/>
-        </failoverServers>
 	</ldapRegistry>
 		
 	<ldapRegistry id="TDS" realm="SampleLdapIDSRealm" host="${ldap.server.1.name}" port="${ldap.server.1.port}" ignoreCase="true"

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.sun.attrMappingVar4/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.sun.attrMappingVar4/server.xml
@@ -58,9 +58,6 @@
         <attributesCache size="4000" timeout="1200ms" enabled="true" sizeLimit="2000"/>
         <searchResultsCache size="2000" timeout="600ms" enabled="true" resultsSizeLimit="1000"/>
       </ldapCache>
-      <failoverServers name="failoverLdapServers">
-      	<server host="${ldap.server.3.name}" port="${ldap.server.3.port}"/>
-       </failoverServers>
 	</ldapRegistry> 
 
     <federatedRepository>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.sun.default/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.sun.default/server.xml
@@ -22,9 +22,7 @@
 		baseDN="dc=rtp,dc=raleigh,dc=ibm,dc=com"
 		ldapType="Sun Java System Directory Server"
 		searchTimeout="8m">
-		<failoverServers name="failoverLdapServers">
-      	<server host="${ldap.server.3.name}" port="${ldap.server.3.port}"/>
-       </failoverServers>
+
 	</ldapRegistry> 
 
     <federatedRepository>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.sun/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.sun/server.xml
@@ -58,9 +58,6 @@
         <attributesCache size="4000" timeout="1200ms" enabled="true" sizeLimit="2000"/>
         <searchResultsCache size="2000" timeout="600ms" enabled="true" resultsSizeLimit="1000"/>
       </ldapCache>
-      <failoverServers name="failoverLdapServers">
-      	<server host="${ldap.server.3.name}" port="${ldap.server.3.port}"/>
-       </failoverServers>
 	</ldapRegistry> 
 
     <federatedRepository>

--- a/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/DefaultWIMRealmMultipleReposTest.java
+++ b/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/DefaultWIMRealmMultipleReposTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,7 +25,10 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.websphere.simplicity.config.wim.LdapRegistry;
 import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.com.unboundid.InMemorySunLDAPServer;
 import com.ibm.ws.security.registry.EntryNotFoundException;
 import com.ibm.ws.security.registry.RegistryException;
 import com.ibm.ws.security.registry.SearchResult;
@@ -48,12 +51,39 @@ public class DefaultWIMRealmMultipleReposTest {
     private static final Class<?> c = DefaultWIMRealmMultipleReposTest.class;
     private static UserRegistryServletConnection servlet;
 
+    private static InMemorySunLDAPServer sunLdapServer;
+
+    /**
+     * Configure the embedded LDAP server.
+     *
+     * @throws Exception If the server failed to start for some reason.
+     */
+    private static void setupLdapServer() throws Exception {
+        sunLdapServer = new InMemorySunLDAPServer();
+    }
+
     /**
      * Updates the sample, which is expected to be at the hard-coded path.
      * If this test is failing, check this path is correct.
      */
     @BeforeClass
     public static void setUp() throws Exception {
+        setupLdapServer();
+        /*
+         * Update LDAP configuration with In-Memory Server
+         */
+        ServerConfiguration serverConfig = server.getServerConfiguration();
+        for (LdapRegistry ldap : serverConfig.getLdapRegistries()) {
+            if (ldap.getRealm().equals("SUN_LDAP")) {
+                ldap.setHost("localhost");
+                ldap.setPort(String.valueOf(sunLdapServer.getLdapPort()));
+                ldap.setBindDN(InMemorySunLDAPServer.getBindDN());
+                ldap.setBindPassword(InMemorySunLDAPServer.getBindPassword());
+                server.updateServerConfiguration(serverConfig);
+                break;
+            }
+        }
+
         // Add LDAP variables to bootstrap properties file
         LDAPUtils.addLDAPVariables(server);
         Log.info(c, "setUp", "Starting the server... (will wait for userRegistry servlet to start)");
@@ -84,8 +114,18 @@ public class DefaultWIMRealmMultipleReposTest {
     public static void tearDown() throws Exception {
         Log.info(c, "tearDown", "Stopping the server...");
         try {
-            server.stopServer("CWIML4538E");
+            if (server != null) {
+                server.stopServer("CWIML4538E");
+            }
         } finally {
+            try {
+                if (sunLdapServer != null) {
+                    sunLdapServer.shutDown(true);
+                }
+            } catch (Exception e) {
+                Log.error(c, "teardown", e, "LDAP server threw error while shutting down. " + e.getMessage());
+            }
+
             server.deleteFileFromLibertyInstallRoot("lib/features/testfileadapter-1.0.mf");
         }
     }

--- a/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/DefaultWIMRealmTest.java
+++ b/dev/com.ibm.ws.security.wim.registry_fat/fat/src/com/ibm/ws/security/wim/registry/fat/DefaultWIMRealmTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+import com.ibm.websphere.simplicity.config.wim.LdapRegistry;
 import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.com.unboundid.InMemorySunLDAPServer;
 import com.ibm.ws.security.registry.EntryNotFoundException;
 import com.ibm.ws.security.registry.RegistryException;
 import com.ibm.ws.security.registry.SearchResult;
@@ -36,7 +39,6 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.utils.LDAPUtils;
 
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
@@ -48,19 +50,40 @@ public class DefaultWIMRealmTest {
     private static final Class<?> c = DefaultWIMRealmTest.class;
     private static UserRegistryServletConnection servlet;
 
+    private static InMemorySunLDAPServer ldapServer;
+
     /**
      * Updates the sample, which is expected to be at the hard-coded path.
      * If this test is failing, check this path is correct.
      */
     @BeforeClass
     public static void setUp() throws Exception {
-        // Add LDAP variables to bootstrap properties file
-        LDAPUtils.addLDAPVariables(server);
-        Log.info(c, "setUp", "Starting the server... (will wait for userRegistry servlet to start)");
-        // install our user feature
+        setupLdapServer();
+        setupLibertyServer();
+    }
 
+    /**
+     * Setup the Liberty server. This server will start with very basic configuration. The tests
+     * will configure the server dynamically.
+     *
+     * @throws Exception If there was an issue setting up the Liberty server.
+     */
+    public static void setupLibertyServer() throws Exception {
+        Log.info(c, "setUp", "Starting the server... (will wait for userRegistry servlet to start)");
         server.copyFileToLibertyInstallRoot("lib/features", "internalfeatures/securitylibertyinternals-1.0.mf");
         server.addInstalledAppForValidation("userRegistry");
+
+        /*
+         * Update LDAP configuration with In-Memory Server
+         */
+        ServerConfiguration serverConfig = server.getServerConfiguration();
+        LdapRegistry ldap = serverConfig.getLdapRegistries().get(0);
+        ldap.setHost("localhost");
+        ldap.setPort(String.valueOf(ldapServer.getLdapPort()));
+        ldap.setBindDN(InMemorySunLDAPServer.getBindDN());
+        ldap.setBindPassword(InMemorySunLDAPServer.getBindPassword());
+        server.updateServerConfiguration(serverConfig);
+
         server.startServer(c.getName() + ".log");
         //Make sure the application has come up before proceeding
         assertNotNull("Application userRegistry does not appear to have started.",
@@ -79,12 +102,31 @@ public class DefaultWIMRealmTest {
         }
     }
 
+    /**
+     * Configure the embedded LDAP server.
+     *
+     * @throws Exception If the server failed to start for some reason.
+     */
+    private static void setupLdapServer() throws Exception {
+        ldapServer = new InMemorySunLDAPServer();
+    }
+
     @AfterClass
     public static void tearDown() throws Exception {
         Log.info(c, "tearDown", "Stopping the server...");
         try {
-            server.stopServer("CWIML4537E");
+            if (server != null) {
+                server.stopServer("CWIML4537E");
+            }
         } finally {
+            try {
+                if (ldapServer != null) {
+                    ldapServer.shutDown(true);
+                }
+            } catch (Exception e) {
+                Log.error(c, "teardown", e, "LDAP server threw error while shutting down. " + e.getMessage());
+            }
+
             server.deleteFileFromLibertyInstallRoot("lib/features/testfileadapter-1.0.mf");
         }
     }

--- a/dev/com.ibm.ws.security.wim.registry_fat/publish/servers/com.ibm.ws.security.wim.registry.fat.DefaultWIMRealm/server.xml
+++ b/dev/com.ibm.ws.security.wim.registry_fat/publish/servers/com.ibm.ws.security.wim.registry.fat.DefaultWIMRealm/server.xml
@@ -10,9 +10,6 @@
 		baseDN="dc=rtp,dc=raleigh,dc=ibm,dc=com"
 		ldapType="Sun Java System Directory Server"
 		searchTimeout="8m">
-		<failoverServers name="failoverLdapServers">
-      		<server host="${ldap.server.3.name}" port="${ldap.server.3.port}"/>
-       </failoverServers>
 	</ldapRegistry>
 
     <federatedRepository>

--- a/dev/com.ibm.ws.security.wim.registry_fat/publish/servers/com.ibm.ws.security.wim.registry.fat.DefaultWIMRealmMultipleRepos/server.xml
+++ b/dev/com.ibm.ws.security.wim.registry_fat/publish/servers/com.ibm.ws.security.wim.registry.fat.DefaultWIMRealmMultipleRepos/server.xml
@@ -9,9 +9,6 @@
 	<ldapRegistry id="SUN_LDAP" realm="SampleLdapSUNRealm" host="${ldap.server.13.name}" port="${ldap.server.13.port}"
 		baseDN="dc=rtp,dc=raleigh,dc=ibm,dc=com"
 		ldapType="Sun Java System Directory Server">
-		<failoverServers name="failoverLdapServers">
-      		<server host="${ldap.server.3.name}" port="${ldap.server.3.port}"/>
-       </failoverServers>
 	</ldapRegistry>
    	
    	<ldapRegistry id="AD_LDAP" realm="SampleLdapADRealm" host="${ldap.server.2.name}" port="${ldap.server.2.port}"


### PR DESCRIPTION
Fixes #16705 

As we  need to decommission the Oracle ldap server, move to our Oracle edition of UnboundId Ldap, for a local more stable Ldap server. Also need to remove the failover server because we can't set it to a duplicate host/port.

In a future issue, remove calling the oracle service -- #16707