### PR TITLE
Ensure MP Config properties from the application are visible when mpOpenApi-2.0 runs filters

### DIFF
--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.microprofile.openapi.fat.filter.FilterConfigTest;
 import com.ibm.ws.microprofile.openapi.validation.fat.OpenAPIValidationTestFive;
 import com.ibm.ws.microprofile.openapi.validation.fat.OpenAPIValidationTestFour;
 import com.ibm.ws.microprofile.openapi.validation.fat.OpenAPIValidationTestOne;
@@ -34,6 +35,7 @@ import componenttest.rules.repeater.RepeatTests;
                 OpenAPIValidationTestFour.class,
                 OpenAPIValidationTestFive.class,
                 OpenAPIValidationTestSix.class,
+                FilterConfigTest.class,
                 ProxySupportTest.class,
                 EndpointAvailabilityTest.class,
                 UICustomizationTest.class

--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/filter/FilterConfigTest.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/filter/FilterConfigTest.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.openapi.fat.filter;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.info.Info;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.PropertiesAsset;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+import com.ibm.ws.microprofile.openapi.fat.utils.OpenAPIConnection;
+import com.ibm.ws.microprofile.openapi.fat.utils.OpenAPITestUtil;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.HttpUtils;
+
+/**
+ * Checks that a filter can be defined and called and can use values from MP
+ * Config
+ */
+@RunWith(FATRunner.class)
+public class FilterConfigTest {
+
+    private static final String TITLE_VALUE = "title from config";
+    private static final String DESC_VALUE = "description from config";
+
+    @Server("FilterServer")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUpTest() throws Exception {
+        HttpUtils.trustAllCertificates();
+        OpenAPITestUtil.changeServerPorts(server, server.getHttpDefaultPort(), server.getHttpDefaultSecurePort());
+
+        server.addEnvVar("filter_title", TITLE_VALUE);
+
+        PropertiesAsset config = new PropertiesAsset()
+            .addProperty("filter.description", DESC_VALUE)
+            .addProperty("mp.openapi.filter", MyTestFilter.class.getName());
+
+        WebArchive war = ShrinkWrap.create(WebArchive.class)
+            .addClasses(FilterTestApp.class, FilterTestResource.class, MyTestFilter.class)
+            .addAsResource(config, "META-INF/microprofile-config.properties");
+
+        ShrinkHelper.exportDropinAppToServer(server, war, DeployOptions.SERVER_ONLY);
+
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+
+    @Test
+    public void testFilterConfig() throws Exception {
+        OpenAPI model = OpenAPIConnection.openAPIDocsConnection(server, false).downloadModel();
+        Info info = model.getInfo();
+        assertEquals(TITLE_VALUE, info.getTitle());
+        assertEquals(DESC_VALUE, info.getDescription());
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/filter/FilterTestApp.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/filter/FilterTestApp.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,9 +8,12 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+package com.ibm.ws.microprofile.openapi.fat.filter;
 
-dependencies {
-  requiredLibs project(':io.openliberty.com.fasterxml.jackson')
-  requiredLibs project(path: ':com.ibm.websphere.org.eclipse.microprofile', configuration: 'openapi10')
-  requiredLibs project(':com.ibm.ws.microprofile.openapi')
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class FilterTestApp extends Application {
+
 }

--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/filter/FilterTestResource.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/filter/FilterTestResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 IBM Corporation and others.
+ * Copyright (c) 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,9 +8,19 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+package com.ibm.ws.microprofile.openapi.fat.filter;
 
-dependencies {
-  requiredLibs project(':io.openliberty.com.fasterxml.jackson')
-  requiredLibs project(path: ':com.ibm.websphere.org.eclipse.microprofile', configuration: 'openapi10')
-  requiredLibs project(':com.ibm.ws.microprofile.openapi')
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * Basic resource, just so there's an endpoint to document in the app
+ */
+@Path("/")
+public class FilterTestResource {
+
+    @GET
+    public String get() {
+        return "OK";
+    }
 }

--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/filter/MyTestFilter.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/filter/MyTestFilter.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.openapi.fat.filter;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.info.Info;
+
+/**
+ * Reads values from config and adds them to the Info block
+ */
+public class MyTestFilter implements OASFilter {
+
+    @Override
+    public void filterOpenAPI(
+        OpenAPI openAPI) {
+
+        Info info = OASFactory.createObject(Info.class);
+
+        Config config = ConfigProvider.getConfig();
+
+        // Read from META-INF/microprofile-config.properties
+        String description = config.getOptionalValue("filter.description", String.class)
+            .orElse("value missing");
+        info.setDescription(description);
+
+        // Read from environment variables
+        String title = config.getOptionalValue("filter_title", String.class)
+            .orElse("value missing");
+        info.setTitle(title);
+
+        info.setVersion("1.0");
+
+        openAPI.setInfo(info);
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.openapi_fat/publish/servers/FilterServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/publish/servers/FilterServer/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2018, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all=enabled:mpOpenAPI=debug=enabled

--- a/dev/com.ibm.ws.microprofile.openapi_fat/publish/servers/FilterServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/publish/servers/FilterServer/server.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2018, 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+  <!-- Note that fatTestPorts.xml is not included because we control creation of all ports in fats -->
+  <include location="../fatTestCommon.xml" />
+
+  <featureManager>
+    <feature>componenttest-1.0</feature>
+    <feature>ssl-1.0</feature>
+    <feature>mpOpenAPI-1.0</feature>
+  </featureManager>
+
+  <keyStore id="defaultKeyStore" password="password" />
+
+</server>

--- a/dev/io.openliberty.io.smallrye.openapi.core/bnd.bnd
+++ b/dev/io.openliberty.io.smallrye.openapi.core/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,9 +20,6 @@ src: src
 
 -dsannotations-inherit: true
 
-Include-Resource: \
-    META-INF/services=resources/META-INF/services
-
 Import-Package: \
     io.smallrye.openapi.jaxrs,\
     *
@@ -30,13 +27,6 @@ Import-Package: \
 Export-Package: \
     io.smallrye.openapi.*;version=2.0.0
 
-Service-Component: \
-    io.smallrye.openapi.runtime.scanner.spi.AnnotationScanner; \
-    implementation:=com.ibm.wsspi.classloading.ResourceProvider; \
-    provide:=com.ibm.wsspi.classloading.ResourceProvider; \
-    configuration-policy:=optional; \
-    properties:="resources=META-INF/services/io.smallrye.openapi.runtime.scanner.spi.AnnotationScanner"
-  
 -buildpath: \
     io.smallrye:smallrye-open-api-core;version=latest,\
     io.openliberty.org.eclipse.microprofile.openapi.2.0;version=latest,\

--- a/dev/io.openliberty.io.smallrye.openapi.core/resources/META-INF/services/io.smallrye.openapi.runtime.scanner.spi.AnnotationScanner
+++ b/dev/io.openliberty.io.smallrye.openapi.core/resources/META-INF/services/io.smallrye.openapi.runtime.scanner.spi.AnnotationScanner
@@ -1,1 +1,0 @@
-io.smallrye.openapi.jaxrs.JaxRsAnnotationScanner

--- a/dev/io.openliberty.io.smallrye.openapi.jaxrs/bnd.bnd
+++ b/dev/io.openliberty.io.smallrye.openapi.jaxrs/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,11 +20,21 @@ src: src
 
 -dsannotations-inherit: true
 
+Include-Resource: \
+    @${repo;io.smallrye:smallrye-open-api-jaxrs}!/META-INF/services/*
+
+Service-Component: \
+    io.smallrye.openapi.runtime.scanner.spi.AnnotationScanner; \
+    implementation:=com.ibm.wsspi.classloading.ResourceProvider; \
+    provide:=com.ibm.wsspi.classloading.ResourceProvider; \
+    configuration-policy:=optional; \
+    properties:="resources=META-INF/services/io.smallrye.openapi.runtime.scanner.spi.AnnotationScanner"
+
 Import-Package: \
    *
 
 Export-Package: \
-    io.smallrye.openapi.jaxrs;version=2.0.0
+    io.smallrye.openapi.jaxrs;version=2.0.0;thread-context=true
 
 -buildpath: \
     io.smallrye:smallrye-open-api-jaxrs;version=latest,\

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -42,6 +42,8 @@ Include-Resource: \
 
 -dsannotations-inherit: true
 -dsannotations: io.openliberty.microprofile.openapi20.ApplicationListener,\
+    io.openliberty.microprofile.openapi20.ApplicationRegistry,\
+    io.openliberty.microprofile.openapi20.ApplicationProcessor,\
     io.openliberty.microprofile.openapi20.OLOASFactoryResolverImpl,\
     io.openliberty.microprofile.openapi20.css.CustomCSSProcessor,\
     io.openliberty.microprofile.openapi20.DefaultHostListener
@@ -71,7 +73,9 @@ WS-TraceGroup: MPOPENAPI
     com.ibm.ws.webcontainer;version=latest,\
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
     io.openliberty.com.fasterxml.jackson;version=latest,\
-    io.openliberty.microprofile.openapi.internal.common;version=latest
+    io.openliberty.microprofile.openapi.internal.common;version=latest,\
+    com.ibm.ws.classloading;version=latest
+
 
 -testpath: \
     ../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/ApplicationListener.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/ApplicationListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@ package io.openliberty.microprofile.openapi20;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -29,6 +30,9 @@ import io.openliberty.microprofile.openapi20.utils.LoggingUtils;
 public class ApplicationListener implements ApplicationStateListener {
 
     private static final TraceComponent tc = Tr.register(ApplicationListener.class);
+    
+    @Reference
+    private ApplicationRegistry appRegistry;
 
     /** {@inheritDoc} */
     @Override

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/ApplicationListener.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/ApplicationListener.java
@@ -42,7 +42,7 @@ public class ApplicationListener implements ApplicationStateListener {
                 Tr.event(tc, "Application starting process started: " + appInfo);
             }
             
-            ApplicationRegistry.getInstance().addApplication(appInfo);
+            appRegistry.addApplication(appInfo);
             
             if (LoggingUtils.isEventEnabled(tc)) {
                 Tr.event(tc, "Application starting process ended: " + appInfo);
@@ -62,7 +62,7 @@ public class ApplicationListener implements ApplicationStateListener {
     @Override
     public void applicationStopping(ApplicationInfo appInfo) {
         try {
-            ApplicationRegistry.getInstance().removeApplication(appInfo);
+            appRegistry.removeApplication(appInfo);
         } catch (Throwable e) {
             if (LoggingUtils.isEventEnabled(tc)) {
                 Tr.event(tc, "Failed to remove application: " + e.getMessage());

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/ApplicationRegistry.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/ApplicationRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,12 @@ package io.openliberty.microprofile.openapi20;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -31,11 +37,15 @@ import io.openliberty.microprofile.openapi20.utils.LoggingUtils;
  *       deployed that contains multiple web modules, an OpenAPI document will only be generated for the first Web
  *       Module that generates an OpenAPI document.
  */
+@Component(configurationPolicy = ConfigurationPolicy.IGNORE, service = ApplicationRegistry.class)
 public class ApplicationRegistry {
 
     private static final TraceComponent tc = Tr.register(ApplicationRegistry.class);
     
-    private static final ApplicationRegistry INSTANCE = new ApplicationRegistry();
+    @Reference
+    private ApplicationProcessor applicationProcessor;
+    
+    private static ApplicationRegistry INSTANCE;
     private Map<String, ApplicationInfo> applications = Collections.synchronizedMap(new HashMap<>());
     private ApplicationInfo currentApp = null;
     private OpenAPIProvider currentProvider = null;
@@ -49,7 +59,19 @@ public class ApplicationRegistry {
     public static ApplicationRegistry getInstance() {
         return INSTANCE;
     }
-
+    
+    @Activate
+    protected void activate() {
+        INSTANCE = this;
+    }
+    
+    @Deactivate
+    protected void deactivate() {
+        if (INSTANCE == this) {
+            INSTANCE = null;
+        }
+    }
+    
     /**
      * The addApplication method is invoked by the {@link ApplicationListener} when it is notified that an application
      * is starting. It only needs to process the application if we have not already found an application that implements
@@ -132,14 +154,11 @@ public class ApplicationRegistry {
     private void processApplication(ApplicationInfo appInfo) {
         // Only scan the application if we do not have a current application
         if (currentApp == null) {
-            currentProvider = ApplicationProcessor.processApplication(appInfo);
+            currentProvider = applicationProcessor.processApplication(appInfo);
             if (currentProvider != null) {
                 currentApp = appInfo;
             }
         }
     }
 
-    private ApplicationRegistry() {
-        // This class is not meant to be instantiated.
-    }
 }

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/ApplicationRegistry.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/ApplicationRegistry.java
@@ -14,10 +14,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 import com.ibm.websphere.ras.Tr;
@@ -50,28 +48,6 @@ public class ApplicationRegistry {
     private ApplicationInfo currentApp = null;
     private OpenAPIProvider currentProvider = null;
 
-    /**
-     * The getInstance method returns the singleton instance of the ApplicationRegistry
-     * 
-     * @return ApplicationRegistry
-     *             The singleton instance
-     */
-    public static ApplicationRegistry getInstance() {
-        return INSTANCE;
-    }
-    
-    @Activate
-    protected void activate() {
-        INSTANCE = this;
-    }
-    
-    @Deactivate
-    protected void deactivate() {
-        if (INSTANCE == this) {
-            INSTANCE = null;
-        }
-    }
-    
     /**
      * The addApplication method is invoked by the {@link ApplicationListener} when it is notified that an application
      * is starting. It only needs to process the application if we have not already found an application that implements


### PR DESCRIPTION
Main changes:
* Ensure that both the service loader file and the implementation class for the Smallrye OpenAPI jaxrs extension are both available on the thread context class loader.
* Set the TCCL correctly during mpOpenAPI-2.0 setup (which is when filters are run)
* Add test using MP Config in MP OpenAPI filter

Fixes #16661