### PR TITLE
transition from inheritance model to direct use of legacy datastorehelper

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/AdapterUtil.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/AdapterUtil.java
@@ -1192,7 +1192,7 @@ public class AdapterUtil {
         }
         else
         {
-            if (mcf.dataStoreHelper == null) {
+            if (iHelper.dataStoreHelper == null) {
                 mappedX = sqlX;
                 mapsToStaleConnection = iHelper.isConnectionError(sqlX);
             } else {
@@ -1210,7 +1210,7 @@ public class AdapterUtil {
 
             // Check for stale statement
 
-            if (mcf.dataStoreHelper == null)
+            if (iHelper.dataStoreHelper == null)
                 isStaleStatement = iHelper.isStaleStatement(sqlX);
             else if (isLegacyException(mappedX, IdentifyExceptionAs.StaleStatement.legacyClassName))
                 try {

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/AdapterUtil.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/AdapterUtil.java
@@ -1196,7 +1196,7 @@ public class AdapterUtil {
                 mappedX = sqlX;
                 mapsToStaleConnection = iHelper.isConnectionError(sqlX);
             } else {
-                mappedX = mcf.dataStoreHelper.mapException(sqlX);
+                mappedX = iHelper.mapException(sqlX);
                 mapsToStaleConnection = isLegacyException(mappedX, IdentifyExceptionAs.StaleConnection.legacyClassName);
                 if (tc.isDebugEnabled())
                     Tr.debug(tc, mappedX == sqlX ? "not replaced" : ("mapped to " + mappedX.getClass().getName()));

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2Helper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2Helper.java
@@ -120,6 +120,11 @@ public class DB2Helper extends DatabaseHelper {
      */
     @Override
     public void doConnectionSetup(Connection conn) throws SQLException {
+        if (dataStoreHelper != null) {
+            doConnectionSetupLegacy(conn);
+            return;
+        }
+
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
 
         if (isTraceOn && tc.isEntryEnabled()) 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2JCCHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2JCCHelper.java
@@ -238,6 +238,11 @@ public class DB2JCCHelper extends DB2Helper {
 
     @Override
     public void doStatementCleanup(PreparedStatement stmt) throws SQLException {
+        if (dataStoreHelper != null) {
+            doStatementCleanupLegacy(stmt);
+            return;
+        }
+
         try {
             stmt.setCursorName(null);
         } catch (NullPointerException npe) {

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2JCCHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2JCCHelper.java
@@ -121,7 +121,7 @@ public class DB2JCCHelper extends DB2Helper {
 
         boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
 
-        dataStoreHelper = "com.ibm.websphere.rsadapter.DB2UniversalDataStoreHelper";
+        dataStoreHelperClassName = "com.ibm.websphere.rsadapter.DB2UniversalDataStoreHelper";
 
         configuredTraceLevel = 0; // value of DB2BaseDataSource.TRACE_NONE
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iNativeHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iNativeHelper.java
@@ -100,6 +100,9 @@ public class DB2iNativeHelper extends DB2Helper {
 
     @Override
     public boolean doConnectionCleanup(java.sql.Connection conn) throws SQLException {
+        if (dataStoreHelper != null)
+            return doConnectionCleanupLegacy(conn);
+
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
             Tr.entry(this, tc, "doConnectionCleanup");
 
@@ -124,6 +127,11 @@ public class DB2iNativeHelper extends DB2Helper {
 
     @Override
     public void doStatementCleanup(PreparedStatement stmt) throws SQLException {
+        if (dataStoreHelper != null) {
+            doStatementCleanupLegacy(stmt);
+            return;
+        }
+
         stmt.setCursorName(null);
         stmt.setFetchDirection(ResultSet.FETCH_FORWARD);
         stmt.setMaxFieldSize(0);

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iNativeHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iNativeHelper.java
@@ -61,7 +61,7 @@ public class DB2iNativeHelper extends DB2Helper {
     DB2iNativeHelper(WSManagedConnectionFactoryImpl mcf) throws Exception {
         super(mcf);
 
-        dataStoreHelper = "com.ibm.websphere.rsadapter.DB2AS400DataStoreHelper";
+        dataStoreHelperClassName = "com.ibm.websphere.rsadapter.DB2AS400DataStoreHelper";
 
         // For the Native driver (unlike the Toolbox driver) the custom property isolationLevelSwitchingSupport is
         // optional and really is only needed if the target database is a remote one.  If this property is not set

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iToolboxHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iToolboxHelper.java
@@ -103,6 +103,9 @@ public class DB2iToolboxHelper extends DB2Helper {
 
     @Override
     public boolean doConnectionCleanup(java.sql.Connection conn) throws SQLException {
+        if (dataStoreHelper != null)
+            return doConnectionCleanupLegacy(conn);
+
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
             Tr.entry(this, tc, "doConnectionCleanup");
 
@@ -127,6 +130,11 @@ public class DB2iToolboxHelper extends DB2Helper {
 
     @Override
     public void doStatementCleanup(PreparedStatement stmt) throws SQLException {
+        if (dataStoreHelper != null) {
+            doStatementCleanupLegacy(stmt);
+            return;
+        }
+
         stmt.setCursorName(null);
         stmt.setFetchDirection(ResultSet.FETCH_FORWARD);
         stmt.setMaxFieldSize(0);

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iToolboxHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DB2iToolboxHelper.java
@@ -60,7 +60,7 @@ public class DB2iToolboxHelper extends DB2Helper {
     DB2iToolboxHelper(WSManagedConnectionFactoryImpl mcf) throws Exception {
         super(mcf);
 
-        dataStoreHelper = "com.ibm.websphere.rsadapter.DB2AS400DataStoreHelper";
+        dataStoreHelperClassName = "com.ibm.websphere.rsadapter.DB2AS400DataStoreHelper";
 
         localZOS = false;
         isRRSTransaction = false;

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DataDirectConnectSQLServerHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DataDirectConnectSQLServerHelper.java
@@ -13,6 +13,9 @@ package com.ibm.ws.rsadapter.impl;
 import java.io.PrintWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 import java.sql.Connection;
 import java.sql.SQLException; 
 import java.sql.SQLFeatureNotSupportedException;
@@ -153,6 +156,9 @@ public class DataDirectConnectSQLServerHelper extends DatabaseHelper {
 
     @Override
     public boolean doConnectionCleanup(Connection conn) throws  SQLException {
+        if (dataStoreHelper != null)
+            return doConnectionCleanupLegacy(conn);
+
         final boolean trace = TraceComponent.isAnyTracingEnabled(); 
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "doConnectionCleanup", AdapterUtil.toString(conn));
@@ -220,6 +226,11 @@ public class DataDirectConnectSQLServerHelper extends DatabaseHelper {
     @Override
     public void doStatementCleanup(java.sql.PreparedStatement stmt) throws SQLException
     {
+       if (dataStoreHelper != null) {
+           doStatementCleanupLegacy(stmt);
+           return;
+       }
+
        if (TraceComponent.isAnyTracingEnabled() &&  tc.isEntryEnabled()) 
            Tr.entry(this, tc, "doStatementCleanup", AdapterUtil.toString(stmt));  
 
@@ -352,6 +363,21 @@ public class DataDirectConnectSQLServerHelper extends DatabaseHelper {
 
         if (isTraceOn && tc.isEntryEnabled())
             Tr.entry(this, tc, "isConnectionError", ex);
+
+        // Use the equivalent method on DataStoreHelper if possible.
+        if (dataStoreHelper != null)
+            try {
+                boolean stale = AccessController.doPrivileged((PrivilegedExceptionAction<Boolean>) () -> {
+                    return (Boolean) dataStoreHelper.getClass()
+                                    .getMethod("isConnectionError", SQLException.class)
+                                    .invoke(dataStoreHelper, ex);
+                });
+                if (isTraceOn && tc.isEntryEnabled())
+                    Tr.exit(this, tc, "isConnectionError", stale);
+                return stale;
+            } catch (PrivilegedActionException x) {
+                FFDCFilter.processException(x, getClass().getName(), "673", this);
+            }
 
         DSConfig config = mcf.dsConfig.get();
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DataDirectConnectSQLServerHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DataDirectConnectSQLServerHelper.java
@@ -101,7 +101,7 @@ public class DataDirectConnectSQLServerHelper extends DatabaseHelper {
     DataDirectConnectSQLServerHelper(WSManagedConnectionFactoryImpl mcf) {
         super(mcf);
 
-        dataStoreHelper = "com.ibm.websphere.rsadapter.ConnectJDBCDataStoreHelper";
+        dataStoreHelperClassName = "com.ibm.websphere.rsadapter.ConnectJDBCDataStoreHelper";
 
         mcf.defaultIsolationLevel = Connection.TRANSACTION_REPEATABLE_READ;
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DerbyHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DerbyHelper.java
@@ -41,7 +41,7 @@ public class DerbyHelper extends DatabaseHelper {
     DerbyHelper(WSManagedConnectionFactoryImpl mcf) {
         super(mcf);
 
-        dataStoreHelper = "com.ibm.websphere.rsadapter.DerbyDataStoreHelper";
+        dataStoreHelperClassName = "com.ibm.websphere.rsadapter.DerbyDataStoreHelper";
 
         mcf.defaultIsolationLevel = Connection.TRANSACTION_REPEATABLE_READ;
         mcf.supportsGetTypeMap = false;

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DerbyHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DerbyHelper.java
@@ -57,6 +57,11 @@ public class DerbyHelper extends DatabaseHelper {
 
     @Override
     public void doStatementCleanup(PreparedStatement stmt) throws SQLException {
+        if (dataStoreHelper != null) {
+            doStatementCleanupLegacy(stmt);
+            return;
+        }
+
         stmt.setCursorName(null);
         stmt.setFetchDirection(ResultSet.FETCH_FORWARD);
         stmt.setMaxFieldSize(0);

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DerbyNetworkClientHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DerbyNetworkClientHelper.java
@@ -117,6 +117,11 @@ public class DerbyNetworkClientHelper extends DerbyHelper {
 
     @Override
     public void doStatementCleanup(PreparedStatement stmt) throws SQLException {
+        if (dataStoreHelper != null) {
+            doStatementCleanupLegacy(stmt);
+            return;
+        }
+
         // setCursorName not supported in network server
         stmt.setFetchDirection(ResultSet.FETCH_FORWARD);
         stmt.setMaxFieldSize(0);

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DerbyNetworkClientHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DerbyNetworkClientHelper.java
@@ -53,7 +53,7 @@ public class DerbyNetworkClientHelper extends DerbyHelper {
     DerbyNetworkClientHelper(WSManagedConnectionFactoryImpl mcf) {
         super(mcf);
 
-        dataStoreHelper = "com.ibm.websphere.rsadapter.DerbyNetworkServerDataStoreHelper";
+        dataStoreHelperClassName = "com.ibm.websphere.rsadapter.DerbyNetworkServerDataStoreHelper";
 
         mcf.doesStatementCacheIsoLevel = true;
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/InformixHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/InformixHelper.java
@@ -61,6 +61,11 @@ public class InformixHelper extends DatabaseHelper {
 
     @Override
     public void doStatementCleanup(PreparedStatement stmt) throws SQLException {
+        if (dataStoreHelper != null) {
+            doStatementCleanupLegacy(stmt);
+            return;
+        }
+
         // Informix doesn't support cursorName
         stmt.setFetchDirection(ResultSet.FETCH_FORWARD);
         stmt.setMaxFieldSize(0);

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/InformixHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/InformixHelper.java
@@ -42,7 +42,7 @@ public class InformixHelper extends DatabaseHelper {
     InformixHelper(WSManagedConnectionFactoryImpl mcf) {
         super(mcf);
 
-        dataStoreHelper = "com.ibm.websphere.rsadapter.InformixDataStoreHelper";
+        dataStoreHelperClassName = "com.ibm.websphere.rsadapter.InformixDataStoreHelper";
 
         mcf.defaultIsolationLevel = Connection.TRANSACTION_REPEATABLE_READ;
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/InformixJCCHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/InformixJCCHelper.java
@@ -74,11 +74,20 @@ public class InformixJCCHelper extends InformixHelper {
     }
 
     public void doConnectionSetup(Connection conn) throws SQLException {
-        // don't inherit from Informix helper because external Informix JCC helper didn't either 
+        // don't inherit from Informix helper because external Informix JCC helper didn't either
+        if (dataStoreHelper != null) {
+            doConnectionSetupLegacy(conn);
+            return;
+        }
     }
 
     @Override
     public void doStatementCleanup(PreparedStatement stmt) throws SQLException {
+        if (dataStoreHelper != null) {
+            doStatementCleanupLegacy(stmt);
+            return;
+        }
+
         try {
             stmt.setCursorName(null);
         } catch (NullPointerException npe) {

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/InformixJCCHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/InformixJCCHelper.java
@@ -62,7 +62,7 @@ public class InformixJCCHelper extends InformixHelper {
     InformixJCCHelper(WSManagedConnectionFactoryImpl mcf) throws Exception {
         super(mcf);
 
-        dataStoreHelper = "com.ibm.websphere.rsadapter.InformixJccDataStoreHelper";
+        dataStoreHelperClassName = "com.ibm.websphere.rsadapter.InformixJccDataStoreHelper";
 
         mcf.doesStatementCacheIsoLevel = true;
         mcf.supportsGetTypeMap = false;

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/MicrosoftSQLServerHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/MicrosoftSQLServerHelper.java
@@ -60,7 +60,7 @@ public class MicrosoftSQLServerHelper extends DatabaseHelper {
     MicrosoftSQLServerHelper(WSManagedConnectionFactoryImpl mcf) {
         super(mcf);
 
-        dataStoreHelper = "com.ibm.websphere.rsadapter.MicrosoftSQLServerDataStoreHelper";
+        dataStoreHelperClassName = "com.ibm.websphere.rsadapter.MicrosoftSQLServerDataStoreHelper";
 
         mcf.defaultIsolationLevel = Connection.TRANSACTION_REPEATABLE_READ;
         mcf.supportsGetTypeMap = false;

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/MicrosoftSQLServerHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/MicrosoftSQLServerHelper.java
@@ -107,6 +107,11 @@ public class MicrosoftSQLServerHelper extends DatabaseHelper {
 
     @Override
     public void doStatementCleanup(PreparedStatement stmt) throws SQLException {
+        if (dataStoreHelper != null) {
+            doStatementCleanupLegacy(stmt);
+            return;
+        }
+
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
             Tr.entry(this, tc, "doStatementCleanup", AdapterUtil.toString(stmt));
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
@@ -295,10 +295,10 @@ public class OracleHelper extends DatabaseHelper {
             return super.branchCouplingSupported(couplingType);
 
         if (couplingType == ResourceRefInfo.BRANCH_COUPLING_LOOSE)
-            if (mcf.dataStoreHelper == null)
+            if (dataStoreHelper == null)
                 return 0x10000; // value of oracle.jdbc.xa.OracleXAResource.ORATRANSLOOSE
             else
-                return mcf.dataStoreHelper.modifyXAFlag(XAResource.TMNOFLAGS);
+                return modifyXAFlag(XAResource.TMNOFLAGS);
 
         // Tight branch coupling is default for Oracle
         return XAResource.TMNOFLAGS;

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
@@ -131,7 +131,7 @@ public class OracleHelper extends DatabaseHelper {
     OracleHelper(WSManagedConnectionFactoryImpl mcf) throws Exception {
         super(mcf);
 
-        dataStoreHelper = "com.ibm.websphere.rsadapter.Oracle11gDataStoreHelper";
+        dataStoreHelperClassName = "com.ibm.websphere.rsadapter.Oracle11gDataStoreHelper";
 
         mcf.supportsIsReadOnly = false;
         xaEndResetsAutoCommit = true;

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/SybaseHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/SybaseHelper.java
@@ -45,7 +45,7 @@ public class SybaseHelper extends DatabaseHelper
     SybaseHelper(WSManagedConnectionFactoryImpl mcf) {
         super(mcf);
 
-        dataStoreHelper = "com.ibm.websphere.rsadapter.Sybase11DataStoreHelper";
+        dataStoreHelperClassName = "com.ibm.websphere.rsadapter.Sybase11DataStoreHelper";
 
         mcf.defaultIsolationLevel = Connection.TRANSACTION_REPEATABLE_READ;
         mcf.supportsGetTypeMap = false;

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/SybaseHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/SybaseHelper.java
@@ -57,6 +57,9 @@ public class SybaseHelper extends DatabaseHelper
 
     @Override
     public boolean doConnectionCleanup(Connection conn) throws SQLException {
+        if (dataStoreHelper != null)
+            return doConnectionCleanupLegacy(conn);
+
         boolean standardPropModified = false;
 
         if (XADataSource.class.isAssignableFrom(mcf.vendorImplClass)) {
@@ -95,6 +98,11 @@ public class SybaseHelper extends DatabaseHelper
      */
     @Override
     public void doConnectionSetup(Connection conn) throws SQLException {
+        if (dataStoreHelper != null) {
+            doConnectionSetupLegacy(conn);
+            return;
+        }
+
         SQLWarning warn = conn.getWarnings();
 
         if (warn != null) {
@@ -123,6 +131,11 @@ public class SybaseHelper extends DatabaseHelper
 
     @Override
     public void doStatementCleanup(PreparedStatement stmt) throws SQLException {
+        if (dataStoreHelper != null) {
+            doStatementCleanupLegacy(stmt);
+            return;
+        }
+
         // Sybase doesn't support cursor name. Cursor name will
         // be reset when the result set is closed.
 
@@ -201,7 +214,7 @@ public class SybaseHelper extends DatabaseHelper
             super.gatherAndDisplayMetaDataInfo(conn, mcf);                 
         } catch (SQLException x)
         {
-            if (mcf.dataStoreHelper == null ? isConnectionError(x) : mcf.dataStoreHelper.isConnectionError(x))
+            if (isConnectionError(x))
                 throw x;
 
             Tr.info(tc, "META_DATA_EXCEPTION", x.getMessage());

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
@@ -1348,8 +1348,8 @@ public class WSManagedConnectionFactoryImpl extends WSManagedConnectionFactory i
             helper.gatherAndDisplayMetaDataInfo(conn, this);
 
             // If a legacy data store helper is used, allow it to determine the unit-of-work detection support:
-            if (dataStoreHelper != null)
-                supportsUOWDetection = dataStoreHelper.getMetaData().supportsUOWDetection();
+            if (helper.dataStoreHelper != null)
+                helper.initUOWDetection();
 
             wasUsedToGetAConnection = true;
         }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
@@ -2355,7 +2355,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                 (stateMgr.getState() == WSStateManager.RRS_GLOBAL_TRANSACTION_ACTIVE 
                 && !rrsGlobalTransactionReallyActive)) 
             {
-                if (mcf.dataStoreHelper != null) {
+                if (helper.dataStoreHelper != null) {
                     if (doConnectionSetupPerTranProps == null) {
                         doConnectionSetupPerTranProps = new Properties();
                         doConnectionSetupPerTranProps.setProperty("FIRST_TIME_CALLED", "true");
@@ -2421,7 +2421,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
         if (isTraceOn && tc.isDebugEnabled())
             Tr.debug(this, tc, "numHandlesInUse", numHandlesInUse);
 
-        if (mcf.isCustomHelper && numHandlesInUse == 1) {
+        if (helper.isCustomHelper && numHandlesInUse == 1) {
             helper.doConnectionSetupPerGetConnection(sqlConn, subject);
             // indicate that we need to undo in case cleanup is called before close
             perCloseCleanupNeeded = true;
@@ -2831,9 +2831,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                 helper.resetClientInformation(this);
             }
 
-            modifiedByCleanup = mcf.dataStoreHelper == null
-                              ? helper.doConnectionCleanup(sqlConn)
-                              : mcf.dataStoreHelper.doConnectionCleanup((Connection) WSJdbcTracer.getImpl(sqlConn));
+            modifiedByCleanup = helper.doConnectionCleanup(sqlConn);
 
             if (!connectionErrorDetected) 
             {
@@ -4264,10 +4262,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
             }
 
             // Clean up the connection.
-            if (mcf.dataStoreHelper == null)
-                helper.doConnectionCleanup(sqlConn);
-            else
-                mcf.dataStoreHelper.doConnectionCleanup((Connection) WSJdbcTracer.getImpl(sqlConn));
+            helper.doConnectionCleanup(sqlConn);
 
             // Clear the warning.
             sqlConn.clearWarnings();
@@ -4284,7 +4279,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
             if (isTraceOn && tc.isDebugEnabled()) 
                 Tr.debug(this, tc, "validate", AdapterUtil.getStackTraceWithState(sqle));
 
-            if (mcf.dataStoreHelper == null ? helper.isConnectionError(sqle) : mcf.dataStoreHelper.isConnectionError(sqle)) {
+            if (helper.isConnectionError(sqle)) {
                 // Don't do any cleanup
                 if (isTraceOn && tc.isEntryEnabled())
                     Tr.exit(this, tc, "validate", false);
@@ -4303,7 +4298,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
 
                         // There is a possibility that now the connection is stale.
 
-                        if (mcf.dataStoreHelper == null ? helper.isConnectionError(rollbackEx) : mcf.dataStoreHelper.isConnectionError(rollbackEx)) {
+                        if (helper.isConnectionError(rollbackEx)) {
                             if (isTraceOn && tc.isEntryEnabled())
                                 Tr.exit(this, tc, "validate", AdapterUtil.getStackTraceWithState(rollbackEx));
                             return false;
@@ -4312,16 +4307,13 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                 }
 
                 try {
-                    if (mcf.dataStoreHelper == null)
-                        helper.doConnectionCleanup(sqlConn);
-                    else
-                        mcf.dataStoreHelper.doConnectionCleanup((Connection) WSJdbcTracer.getImpl(sqlConn));
+                    helper.doConnectionCleanup(sqlConn);
                 } catch (SQLException cleanEx) {
                     // No FFDC coded needed
 
                     // There is a possibility that now the connection is stale.
 
-                    if (mcf.dataStoreHelper == null ? helper.isConnectionError(cleanEx) : mcf.dataStoreHelper.isConnectionError(cleanEx)) {
+                    if (helper.isConnectionError(cleanEx)) {
                         if (isTraceOn && tc.isEntryEnabled())
                             Tr.exit(this, tc, "validate", AdapterUtil.getStackTraceWithState(cleanEx));
                         return false;
@@ -4335,7 +4327,7 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
 
                     // There is a possibility that now the connection is stale.
 
-                    if (mcf.dataStoreHelper == null ? helper.isConnectionError(cleanEx) : mcf.dataStoreHelper.isConnectionError(cleanEx)) {
+                    if (helper.isConnectionError(cleanEx)) {
                         if (isTraceOn && tc.isEntryEnabled())
                             Tr.exit(this, tc, "validate", AdapterUtil.getStackTraceWithState(cleanEx));
                         return false;

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbManagedConnectionImpl.java
@@ -21,7 +21,6 @@ import java.sql.Driver;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
@@ -2356,32 +2355,18 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
                 (stateMgr.getState() == WSStateManager.RRS_GLOBAL_TRANSACTION_ACTIVE 
                 && !rrsGlobalTransactionReallyActive)) 
             {
-                if (mcf.dataStoreHelper != null)
-                    try
-                    {
-                        if (doConnectionSetupPerTranProps == null) {
-                            doConnectionSetupPerTranProps = new Properties();
-                            doConnectionSetupPerTranProps.setProperty("FIRST_TIME_CALLED", "true");
-                        } else {
-                            doConnectionSetupPerTranProps.setProperty("FIRST_TIME_CALLED", "false");
-                        }
-
-                        // Remove the wrapper for supplemental trace before invoking a custom helper
-                        // because the java.sql.Connection wrapper prevents access to vendor APIs
-                        // that might be used by the custom helper.
-                        Connection conn = mcf.isCustomHelper ?
-                            (Connection) WSJdbcTracer.getImpl(sqlConn) : sqlConn;
-
-                        // if we have a subject, it will take precedence
-                        mcf.dataStoreHelper.doConnectionSetupPerTransaction(subject,
-                           (subject == null ? newCRI.ivUserName : null),
-                            conn, _claimedVictim, doConnectionSetupPerTranProps);
+                if (mcf.dataStoreHelper != null) {
+                    if (doConnectionSetupPerTranProps == null) {
+                        doConnectionSetupPerTranProps = new Properties();
+                        doConnectionSetupPerTranProps.setProperty("FIRST_TIME_CALLED", "true");
+                    } else {
+                        doConnectionSetupPerTranProps.setProperty("FIRST_TIME_CALLED", "false");
                     }
-                    catch (SQLException sqe)
-                    {
-                        FFDCFilter.processException(sqe, getClass().getName(), "2294", this);
-                        throw new DataStoreAdapterException("DSA_ERROR", sqe, getClass());
-                    }
+
+                    // if we have a subject, it will take precedence
+                    helper.doConnectionSetupPerTransaction(subject, (subject == null ? newCRI.ivUserName : null),
+                                                           sqlConn, _claimedVictim, doConnectionSetupPerTranProps);
+                }
 
                 // setting the new subject in the managed connection, this may be the same
                 // as the existing one, however, in the claimedVictim path it won't. Setting it all the time.
@@ -2436,32 +2421,11 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
         if (isTraceOn && tc.isDebugEnabled())
             Tr.debug(this, tc, "numHandlesInUse", numHandlesInUse);
 
-        if (mcf.isCustomHelper && numHandlesInUse == 1)
-            try
-            {
-                Map<String, Object> props = new HashMap<String, Object>();
-                props.put("SUBJECT", subject);
-
-                // Remove the wrapper for supplemental trace before invoking a custom helper
-                // because the java.sql.Connection wrapper prevents access to vendor APIs
-                // that might be used by the custom helper.
-                Connection conn = mcf.isCustomHelper ?
-                    (Connection) WSJdbcTracer.getImpl(sqlConn) : sqlConn;
-
-                boolean conSetupPerformed = mcf.dataStoreHelper.doConnectionSetupPerGetConnection(conn, false, props);
-                if (isTraceOn && tc.isDebugEnabled())
-                    Tr.debug(this, tc, "doConnectionSetupPerGetConnection", mcf.dataStoreHelper, this, sqlConn, conSetupPerformed);
-
-                // indicate that we need to undo in case cleanup is called before close
-                perCloseCleanupNeeded = true;
-            }
-            catch (Throwable t)
-            {
-                FFDCFilter.processException(t, getClass().getName(), "2849", this);
-                if (t instanceof SQLException)
-                    t = AdapterUtil.mapSQLException((SQLException) t, this);
-                throw new DataStoreAdapterException("DSA_ERROR", t, getClass());
-            }
+        if (mcf.isCustomHelper && numHandlesInUse == 1) {
+            helper.doConnectionSetupPerGetConnection(sqlConn, subject);
+            // indicate that we need to undo in case cleanup is called before close
+            perCloseCleanupNeeded = true;
+        }
 
         // Record the number of fatal connection errors found on connections created by the
         // parent ManagedConnectionFactory at the time the last handle was created for this
@@ -2804,25 +2768,12 @@ public class WSRdbManagedConnectionImpl extends WSManagedConnection implements
             throw x;
         }
 
-        if (perCloseCleanupNeeded)
-            try {
-                perCloseCleanupNeeded = false;
-
-                Connection conn = mcf.isCustomHelper ?
-                    (Connection) WSJdbcTracer.getImpl(sqlConn) : sqlConn;
-
-                boolean conCleanupPerformed = mcf.dataStoreHelper.doConnectionCleanupPerCloseConnection(conn, false, null);
-
-                if (isTraceOn && tc.isDebugEnabled())
-                    Tr.debug(this, tc, "doConnectionCleanupPerCloseConnection", mcf.dataStoreHelper, sqlConn, conCleanupPerformed);
-            }
-            catch (Throwable x) {
-                if (isTraceOn && tc.isDebugEnabled())
-                    Tr.debug(this, tc, "doConnectionCleanupPerCloseConnection", x);
-                SQLException sqlx = x instanceof SQLException ? (SQLException) x
-                                : new SQLException(x.getMessage(), null, 999999); // 999999 matches legacy behavior
-                throw AdapterUtil.translateSQLException(sqlx, this, false, getClass());
-            }
+        if (perCloseCleanupNeeded) {
+            perCloseCleanupNeeded = false;
+            SQLException failure = helper.doConnectionCleanupPerCloseConnection(sqlConn);
+            if (failure != null)
+                throw AdapterUtil.translateSQLException(failure, this, false, getClass());
+        }
 
         // Reset to null so that it gets refreshed on next use.
         transactional = null; 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbXaResourceImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSRdbXaResourceImpl.java
@@ -247,9 +247,7 @@ public class WSRdbXaResourceImpl implements WSXAResource, FFDCSelfIntrospectable
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                     Tr.debug(this, tc,
                              "XA resource got XAER_NOTA (" + XAException.XAER_NOTA + ") during recovery. This happens when the XA resource previously committed successfully.",
-                             ivManagedConnection.mcf.dataStoreHelper == null
-                                             ? ivManagedConnection.helper.getXAExceptionContents(xae)
-                                             : ivManagedConnection.mcf.dataStoreHelper.getXAExceptionContents(xae));
+                             ivManagedConnection.helper.getXAExceptionContents(xae));
             } else {
                 FFDCFilter.processException(xae, "com.ibm.ws.rsadapter.spi.WSRdbXaResourceImpl.commit", "126", this);
                 traceXAException(xae, currClass);
@@ -1151,9 +1149,7 @@ public class WSRdbXaResourceImpl implements WSXAResource, FFDCSelfIntrospectable
      */
     public final XAException traceXAException(XAException xae, Class<?> callerClass) { 
 
-        String detailedMessage = ivManagedConnection.mcf.dataStoreHelper == null
-                        ? ivManagedConnection.helper.getXAExceptionContents(xae)
-                        : ivManagedConnection.mcf.dataStoreHelper.getXAExceptionContents(xae);
+        String detailedMessage = ivManagedConnection.helper.getXAExceptionContents(xae);
         Tr.error(tc, "DISPLAY_XAEX_CONTENT", detailedMessage);
 
         Tr.error(tc, "THROW_XAEXCEPTION", new Object[]
@@ -1201,9 +1197,7 @@ public class WSRdbXaResourceImpl implements WSXAResource, FFDCSelfIntrospectable
                 {
                     Tr.debug(this, tc, "Authorization Exception is chanined to the XAException");
                 }
-            } else if (ivManagedConnection.mcf.dataStoreHelper == null
-                       ? ivManagedConnection.helper.isConnectionError(cause)
-                       : ivManagedConnection.mcf.dataStoreHelper.isConnectionError(cause)) {
+            } else if (ivManagedConnection.helper.isConnectionError(cause)) {
                 connError = true;
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) 
                 {

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcConnection.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcConnection.java
@@ -497,32 +497,9 @@ public class WSJdbcConnection extends WSJdbcObject implements Connection {
         // Looking for the public close method?  Try WSJdbcObject.
         SQLException sqlX = null;
 
-        if (mcf.isCustomHelper && managedConn != null && managedConn.getHandleCount() == 1)
-            try
-            {
-                // Remove the wrapper for supplemental trace before invoking a custom helper
-                // because the java.sql.Connection wrapper prevents access to vendor APIs
-                // that might be used by the custom helper.
-                Connection conn =
-                    mcf.isCustomHelper ? (Connection) WSJdbcTracer.getImpl(connImpl) : connImpl;
-
-                boolean conCleanupPerformed = mcf.dataStoreHelper.doConnectionCleanupPerCloseConnection(conn, false, null);
-
-                if (isTraceOn && tc.isDebugEnabled())
-                    Tr.debug(tc, "doConnectionCleanupPerCloseConnection", mcf.dataStoreHelper, managedConn, connImpl, conCleanupPerformed);
-
-                managedConn.perCloseCleanupNeeded = false;
-            }
-            catch (Throwable x)
-            {
-                if (isTraceOn && tc.isDebugEnabled())
-                    Tr.debug(tc, "doConnectionCleanupPerCloseConnection", x);
-
-                if (x instanceof SQLException)
-                    sqlX =  WSJdbcUtil.mapException(this, (SQLException) x);
-                else
-                    sqlX = new SQLException(x.getMessage(), null, 999999); // 999999 matches legacy behavior
-            }
+        if (mcf.isCustomHelper && managedConn != null && managedConn.getHandleCount() == 1
+         && null == (sqlX = mcf.getHelper().doConnectionCleanupPerCloseConnection(connImpl)))
+            managedConn.perCloseCleanupNeeded = false;
 
         // Send a Connection Closed Event to notify the Managed Connection of the close -- if
         // we are associated with a ManagedConnection to notify.

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcConnection.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcConnection.java
@@ -492,12 +492,10 @@ public class WSJdbcConnection extends WSJdbcObject implements Connection {
      */
     protected SQLException closeWrapper(boolean closeWrapperOnly) 
     {
-        final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
-
         // Looking for the public close method?  Try WSJdbcObject.
         SQLException sqlX = null;
 
-        if (mcf.isCustomHelper && managedConn != null && managedConn.getHandleCount() == 1
+        if (mcf.getHelper().isCustomHelper && managedConn != null && managedConn.getHandleCount() == 1
          && null == (sqlX = mcf.getHelper().doConnectionCleanupPerCloseConnection(connImpl)))
             managedConn.perCloseCleanupNeeded = false;
 
@@ -2542,14 +2540,7 @@ public class WSJdbcConnection extends WSJdbcObject implements Connection {
     {
         // - in order to free up memory, parameters are cleared before caching instead of after
         if (managedConn.resetStmtsInCacheOnRemove)
-        {
-            if (mcf.dataStoreHelper == null)
-                mcf.getHelper().doStatementCleanup(cstmt);
-            else
-                mcf.dataStoreHelper.doStatementCleanup(mcf.isCustomHelper ?
-                                (CallableStatement) WSJdbcTracer.getImpl(cstmt) :
-                                cstmt);
-        }
+            mcf.getHelper().doStatementCleanup(cstmt);
         return cstmt;
     }
 
@@ -2568,14 +2559,7 @@ public class WSJdbcConnection extends WSJdbcObject implements Connection {
     {
         // - in order to free up memory, parameters are cleared before caching instead of after
         if (managedConn.resetStmtsInCacheOnRemove)
-        {
-            if (mcf.dataStoreHelper == null)
-                mcf.getHelper().doStatementCleanup(pstmt);
-            else
-                mcf.dataStoreHelper.doStatementCleanup(mcf.isCustomHelper ?
-                                (PreparedStatement) WSJdbcTracer.getImpl(pstmt) :
-                                pstmt);
-        }
+            mcf.getHelper().doStatementCleanup(pstmt);
 
         return pstmt;
     }

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcPreparedStatement.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcPreparedStatement.java
@@ -308,12 +308,7 @@ public class WSJdbcPreparedStatement extends WSJdbcStatement implements Prepared
                     if (haveStatementPropertiesChanged) {
                         if (isTraceOn && tc.isDebugEnabled())
                             Tr.debug(this, tc, "Cleaning up Statement");
-                        if (mcf.dataStoreHelper == null)
-                            mcf.getHelper().doStatementCleanup(pstmtImpl);
-                        else
-                            mcf.dataStoreHelper.doStatementCleanup(mcf.isCustomHelper ?
-                                            (PreparedStatement) WSJdbcTracer.getImpl(pstmtImpl) :
-                                            pstmtImpl);
+                        mcf.getHelper().doStatementCleanup(pstmtImpl);
                         haveStatementPropertiesChanged = false;
                     }
 

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcStatement.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcStatement.java
@@ -512,7 +512,7 @@ public class WSJdbcStatement extends WSJdbcObject implements Statement {
             try {
                 WSJdbcConnection connWrapper = (WSJdbcConnection) parentWrapper;
 
-                if (mcf.dataStoreHelper == null ? mcf.getHelper().isConnectionError(batchX) : mcf.dataStoreHelper.isConnectionError(batchX)) {
+                if (mcf.getHelper().isConnectionError(batchX)) {
                     if (tc.isEventEnabled())
                         Tr.event(this, tc,
                                  "Encountered a Stale Connection: ", connWrapper);

--- a/dev/com.ibm.ws.jdbc_fat_heritageinterop/jdbcHeritage.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_heritageinterop/jdbcHeritage.bnd
@@ -22,6 +22,7 @@ IBM-Default-Config: OSGI-INF/wlp/defaultInstances.xml
 WS-TraceGroup: jdbcHeritage
 
 Export-Package:\
+ com.ibm.websphere.appprofile.accessintent,\
  com.ibm.websphere.ce.cm,\
  com.ibm.websphere.rsadapter
 

--- a/dev/com.ibm.ws.jdbc_fat_heritageinterop/publish/files/features/jdbcHeritage-1.0.mf
+++ b/dev/com.ibm.ws.jdbc_fat_heritageinterop/publish/files/features/jdbcHeritage-1.0.mf
@@ -4,6 +4,7 @@ Subsystem-SymbolicName: ShortName:jdbcHeritage-1.0;visibility:=public
 Subsystem-Version: 1.0.0
 Subsystem-Content: jdbcHeritage; version="[1,1.0.100)"
 Subsystem-Type: osgi.subsystem.feature
-IBM-API-Package: com.ibm.websphere.ce.cm; type="ibm-api",
+IBM-API-Package: com.ibm.websphere.appprofile.accessintent; type="ibm-api",
+ com.ibm.websphere.ce.cm; type="ibm-api",
  com.ibm.websphere.rsadapter; type="ibm-api"
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HDConnection.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HDConnection.java
@@ -93,7 +93,7 @@ public class HDConnection implements Connection, HeritageDBConnection, XAConnect
     /**
      * Counts the number of times that doConnectionSetupPerTransaction is invoked for this connection.
      */
-    public final AtomicInteger transactionCount = new AtomicInteger(-1);
+    public final AtomicInteger transactionCount = new AtomicInteger(Integer.MIN_VALUE); // make it obvious if it never gets initialized to 1
 
     /**
      * Xid of transaction that we are pretending to participate in.

--- a/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-applications/heritageDriver/src/test/jdbc/heritage/driver/helper/HDDataStoreHelper.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-applications/heritageDriver/src/test/jdbc/heritage/driver/helper/HDDataStoreHelper.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.security.auth.Subject;
 import javax.transaction.xa.XAException;
 
+import com.ibm.websphere.appprofile.accessintent.AccessIntent;
 import com.ibm.websphere.ce.cm.DuplicateKeyException;
 import com.ibm.websphere.ce.cm.StaleConnectionException;
 import com.ibm.websphere.ce.cm.StaleStatementException;
@@ -153,8 +154,14 @@ public class HDDataStoreHelper extends GenericDataStoreHelper {
         stmt.setQueryTimeout(queryTimeout);
     }
 
+    // TODO remove
     @Override
     public int getIsolationLevel() {
+        return getIsolationLevel(null);
+    }
+
+    // TODO @Override
+    public int getIsolationLevel(AccessIntent unused) {
         return Connection.TRANSACTION_SERIALIZABLE;
     }
 

--- a/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-bundles/jdbcHeritage/src/com/ibm/websphere/appprofile/accessintent/AccessIntent.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-bundles/jdbcHeritage/src/com/ibm/websphere/appprofile/accessintent/AccessIntent.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.appprofile.accessintent;
+
+/**
+ * No-op version of legacy interface for testing.
+ */
+public interface AccessIntent {
+}

--- a/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-bundles/jdbcHeritage/src/com/ibm/websphere/appprofile/accessintent/package-info.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-bundles/jdbcHeritage/src/com/ibm/websphere/appprofile/accessintent/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0.0
+ */
+@org.osgi.annotation.versioning.Version("1.0.0")
+package com.ibm.websphere.appprofile.accessintent;

--- a/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-bundles/jdbcHeritage/src/com/ibm/websphere/rsadapter/GenericDataStoreHelper.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-bundles/jdbcHeritage/src/com/ibm/websphere/rsadapter/GenericDataStoreHelper.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.security.auth.Subject;
 import javax.transaction.xa.XAException;
 
+import com.ibm.websphere.appprofile.accessintent.AccessIntent;
 import com.ibm.websphere.ce.cm.DuplicateKeyException;
 import com.ibm.websphere.ce.cm.StaleConnectionException;
 import com.ibm.ws.jdbc.heritage.DataStoreHelperMetaData;
@@ -104,8 +105,14 @@ public class GenericDataStoreHelper extends com.ibm.ws.jdbc.heritage.GenericData
         stmt.setQueryTimeout(queryTimeout);
     }
 
+    // TODO remove
     @Override
     public int getIsolationLevel() {
+        return getIsolationLevel(null);
+    }
+
+    // TODO @Override
+    public int getIsolationLevel(AccessIntent unused) {
         return Connection.TRANSACTION_READ_COMMITTED;
     }
 


### PR DESCRIPTION
Switch to direct usage (via reflection) of the legacy DataStoreHelper, instead of through an intermediate interface which caused problems.