### PR TITLE
Fix compile failure in MP metrics internal 3.0 monitor

### DIFF
--- a/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/bnd.bnd
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/bnd.bnd
@@ -49,5 +49,5 @@ Service-Component: \
 	com.ibm.ws.anno;version=latest, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest, \
 	com.ibm.ws.jaxrs.defaultexceptionmapper;version=latest, \
-	com.ibm.websphere.javaee.jaxrs.2.0;version=latest\
+	com.ibm.websphere.javaee.jaxrs.2.0;version=latest,\
 	com.ibm.ws.kernel.boot.core;version=latest


### PR DESCRIPTION
fixes a syntax error in the bnd file that is causing one of the dependencies to be ignored, leading to the compile failure

```
/Users/njr/lgit/open-liberty/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/MappingTable.java:20: error: package com.ibm.ws.kernel.productinfo does not exist
import com.ibm.ws.kernel.productinfo.ProductInfo;
                                    ^
/Users/njr/lgit/open-liberty/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/MappingTable.java:171: error: cannot find symbol
            if (ProductInfo.getBetaEdition() && !isBeta) {
                ^
  symbol:   variable ProductInfo
  location: class MappingTable
Note: /Users/njr/lgit/open-liberty/dev/io.openliberty.microprofile.metrics.internal.3.0.monitor/src/io/openliberty/microprofile/metrics/internal/monitor/MonitorGauge.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
2 errors
```