### PR TITLE
remove references to GenericDataStoreHelper that were missed

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DatabaseHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DatabaseHelper.java
@@ -53,7 +53,6 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.jca.adapter.WSConnectionManager;
 import com.ibm.ws.jca.cm.AbstractConnectionFactoryService;
-import com.ibm.ws.jdbc.heritage.GenericDataStoreHelper;
 import com.ibm.ws.resource.ResourceRefInfo;
 import com.ibm.ws.rsadapter.AdapterUtil;
 import com.ibm.ws.rsadapter.DSConfig;
@@ -192,12 +191,11 @@ public class DatabaseHelper {
     /**
      * Creates a legacy DataStoreHelper and populates or overrides some default values from it.
      *
-     * @return legacy DataStoreHelper.
      * @throws PrivilegedActionException if an error occurs.
      * @throws ResourceException if an error occurs.
      * @throws ClassNotFoundException if unable to load a data store helper class.
      */
-    GenericDataStoreHelper createDataStoreHelper() throws PrivilegedActionException, ResourceException, ClassNotFoundException {
+    final void createDataStoreHelper() throws PrivilegedActionException, ResourceException, ClassNotFoundException {
         DSConfig config = mcf.dsConfig.get();
         Properties helperProps = new Properties();
         Object value;
@@ -317,8 +315,6 @@ public class DatabaseHelper {
 
             return h;
         });
-
-        return (GenericDataStoreHelper) dataStoreHelper;
     }
 
     /**


### PR DESCRIPTION
Missed a couple of references to GenericDataStoreHelper which still need to be removed in order to get the legacy code path to build cleanly.  The classes in the heritage package themselves will need to be removed as well, but in a later phase.