### PR TITLE
Workaround for Java 2 security issue in servlet-5.0 API

### DIFF
--- a/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/wlp/defaultInstances.xml
+++ b/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/wlp/defaultInstances.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017, 2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -11,6 +11,12 @@
 <server>
 
   <webContainer/>
+
+  <!-- this is a workaround for issue https://github.com/eclipse-ee4j/servlet-api/issues/389 -->
+  <javaPermission id="org.glassfish.web.rfc2109_cookie_names_enforced" 
+                  className="java.util.PropertyPermission" 
+                  name="org.glassfish.web.rfc2109_cookie_names_enforced"
+                  actions="read"/>
 
 <!--  apparently the link extension factory is never used??? -->
   <!--com.ibm.wsspi.webcontainer.extension.ExtensionFactory type="Link"/-->


### PR DESCRIPTION
This change works around a Java 2 Security issue in the Servlet 5.0 API reported at https://github.com/eclipse-ee4j/servlet-api/issues/389 - once this is fixed in the API and the update pulled in, we can revert this change.