### PR TITLE
PR for Issue 15023: Fix WASReqURLOidc encoding problem

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/web/OidcRedirectServlet.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/web/OidcRedirectServlet.java
@@ -42,7 +42,6 @@ import com.ibm.ws.security.openidconnect.clients.common.HashUtils;
 import com.ibm.ws.security.openidconnect.clients.common.OidcClientUtil;
 import com.ibm.ws.security.openidconnect.clients.common.OidcUtil;
 import com.ibm.ws.security.openidconnect.common.Constants;
-import com.ibm.ws.webcontainer.security.CookieHelper;
 import com.ibm.ws.webcontainer.security.openidconnect.OidcClient;
 
 /**
@@ -66,8 +65,8 @@ public class OidcRedirectServlet extends HttpServlet {
 
     /**
      * @param activatedOidcClientImpl
-     *                                    the activatedOidcClientImpl to set
-     *                                    (called by the oidcClientImpl on activation)
+     *            the activatedOidcClientImpl to set
+     *            (called by the oidcClientImpl on activation)
      */
     public static void setActivatedOidcClientImpl(OidcClientImpl activatedOidcClientImpl) {
         OidcRedirectServlet.activatedOidcClientImpl = activatedOidcClientImpl;
@@ -129,8 +128,7 @@ public class OidcRedirectServlet extends HttpServlet {
         //  this cookie was set to hold the original URL.
         //  Now it's time to get it back.
         String cookieName = ClientConstants.WAS_REQ_URL_OIDC + HashUtils.getStrHashCode(state);
-        Cookie[] cookies = request.getCookies();
-        String requestUrl = CookieHelper.getCookieValue(cookies, cookieName);
+        String requestUrl = OidcClientUtil.getReferrerURLCookieHandler().getReferrerURLFromCookies(request, cookieName);
         // 240540
         //CookieHelper.clearCookie(request, response, cookieName, cookies); //clear the WAS_REQ_URL_OIDC cookie
         OidcClientUtil.invalidateReferrerURLCookie(request, response, cookieName);

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OIDCClientAuthenticatorUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -629,21 +629,30 @@ public class OIDCClientAuthenticatorUtil {
 
         StringBuffer reqURL = req.getRequestURL();
         if (rewritePort) {
-            reqURL = new StringBuffer();
-            reqURL.append(req.getScheme());
-            reqURL.append("://");
-            reqURL.append(req.getServerName());
-            reqURL.append(":");
-            reqURL.append(realPort);
-            reqURL.append(req.getRequestURI());
-            //reqURL = new StringBuffer(com.ibm.ws.security.common.web.WebUtils.rewriteURL(reqURL.toString(), null, realport.toString()));
+            reqURL = rewritePortInRequestUrl(req, realPort);
         }
+        reqURL = appendQueryString(req, reqURL);
+        return reqURL.toString();
+    }
+
+    StringBuffer rewritePortInRequestUrl(HttpServletRequest req, int realPort) {
+        StringBuffer reqURL = new StringBuffer();
+        reqURL.append(req.getScheme());
+        reqURL.append("://");
+        reqURL.append(req.getServerName());
+        reqURL.append(":");
+        reqURL.append(realPort);
+        reqURL.append(req.getRequestURI());
+        return reqURL;
+    }
+
+    StringBuffer appendQueryString(HttpServletRequest req, StringBuffer reqURL) {
         String queryString = req.getQueryString();
         if (queryString != null) {
             reqURL.append("?");
-            reqURL.append(OidcUtil.encodeQuery(queryString));
+            reqURL.append(queryString);
         }
-        return reqURL.toString();
+        return reqURL;
     }
 
     /**


### PR DESCRIPTION
Fixes #15023

Instead of encoding the query string in the original request URL, we'll leave it as-is. That should ensure we ultimately use the "real" value of the query string. During the creation of the WASReqURLOidc cookie, the cookie value is encoded anyway to mitigate against malformed and potentially malicious cookie values. The `OidcRedirectServlet` code is also updated to use slightly different code to read the cookie so that the respective decoding is done.