### PR TITLE
Update non Jakarta 9 features to have eeCompatible

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.optional.jaxb-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.optional.jaxb-2.2.feature
@@ -9,7 +9,8 @@ IBM-Process-Types: client, \
  server
 Subsystem-Name: Java XML Bindings 2.2 for Java 9 and above
 -features=\
-  com.ibm.websphere.appserver.classloading-1.0
+  com.ibm.websphere.appserver.classloading-1.0, \
+  com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0, 8.0"
 -bundles=\
   com.ibm.websphere.javaee.activation.1.1; require-java:="9"; location:="dev/api/spec/,lib/"; apiJar=false, \
   com.ibm.websphere.javaee.jaxb.2.2; require-java:="9"; location:="dev/api/spec/,lib/"; apiJar=false, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.optional.jaxb-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.optional.jaxb-2.3.feature
@@ -8,7 +8,8 @@ IBM-Process-Types: client, \
  server
 Subsystem-Name: Java XML Bindings 2.3 for all Java versions
 -features=\
-  com.ibm.websphere.appserver.classloading-1.0
+  com.ibm.websphere.appserver.classloading-1.0, \
+  com.ibm.websphere.appserver.eeCompatible-6.0; ibm.tolerates:="7.0, 8.0"
 -bundles=\
   com.ibm.websphere.javaee.activation.1.1; require-java:="9" ;location:="dev/api/spec/,lib/"; apiJar=false, \
   com.ibm.websphere.javaee.jaxb.2.3; location:="dev/api/spec/,lib/"; apiJar=false, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.wimcore-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.wimcore-1.0.feature
@@ -1,7 +1,7 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=com.ibm.websphere.appserver.wimcore-1.0
 WLP-DisableAllFeatures-OnConflict: false
--features=com.ibm.websphere.appserver.internal.optional.jaxb-2.2; ibm.tolerates:="2.3", \
+-features=\
   com.ibm.websphere.appserver.classloading-1.0, \
   com.ibm.websphere.appserver.ssl-1.0, \
   io.openliberty.wimcore.internal.ee-6.0; ibm.tolerates:=9.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jsonp-1.0/com.ibm.websphere.appserver.jsonp-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jsonp-1.0/com.ibm.websphere.appserver.jsonp-1.0.feature
@@ -8,7 +8,8 @@ IBM-API-Package: javax.json; type="spec", \
  javax.json.spi; type="spec"
 IBM-ShortName: jsonp-1.0
 Subsystem-Name: JavaScript Object Notation Processing 1.0
--features=com.ibm.websphere.appserver.jsonpImpl-1.0.0
+-features=com.ibm.websphere.appserver.jsonpImpl-1.0.0, \
+  com.ibm.websphere.appserver.eeCompatible-7.0; ibm.tolerates:="8.0, 6.0"
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/springBoot-1.5/com.ibm.websphere.appserver.springBoot-1.5.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/springBoot-1.5/com.ibm.websphere.appserver.springBoot-1.5.feature
@@ -6,6 +6,7 @@ singleton=true
 IBM-ShortName: springBoot-1.5
 IBM-Process-Types: server
 Subsystem-Name: Spring Boot Support 1.5
--features=com.ibm.websphere.appserver.springBootHandler-1.0
+-features=com.ibm.websphere.appserver.springBootHandler-1.0, \
+  com.ibm.websphere.appserver.eeCompatible-7.0; ibm.tolerates:="8.0, 6.0"
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/springBoot-2.0/com.ibm.websphere.appserver.springBoot-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/springBoot-2.0/com.ibm.websphere.appserver.springBoot-2.0.feature
@@ -6,6 +6,7 @@ singleton=true
 IBM-ShortName: springBoot-2.0
 IBM-Process-Types: server
 Subsystem-Name: Spring Boot Support 2.0
--features=com.ibm.websphere.appserver.springBootHandler-1.0
+-features=com.ibm.websphere.appserver.springBootHandler-1.0, \
+  com.ibm.websphere.appserver.eeCompatible-7.0; ibm.tolerates:="8.0, 6.0"
 kind=ga
 edition=core


### PR DESCRIPTION
- Update jsonp-1.0, jaxb-2.x, and springBoot-x.y features to have eeCompatible so that they do not try to start with EE 9 features.
