### PR TITLE
Add commons codec to buildpath

### DIFF
--- a/dev/com.ibm.ws.springboot.support_fat/bnd.bnd
+++ b/dev/com.ibm.ws.springboot.support_fat/bnd.bnd
@@ -46,6 +46,7 @@ tested.features: \
     com.ibm.ws.springboot.support.version22.test.app;version=latest,\
     com.ibm.ws.springboot.support.version23.test.app;version=latest,\
 	io.openliberty.org.apache.commons.logging;version=latest,\
+	io.openliberty.org.apache.commons.codec;version=latest,\
 	net.sourceforge.htmlunit:htmlunit;version=2.44.0,\
 	net.sourceforge.htmlunit:neko-htmlunit;strategy=exact;version=2.44.0,\
 	net.sourceforge.htmlunit:webdriver;version=2.6,\


### PR DESCRIPTION
No idea why this didn't fail in previous builds ... but locally it does appear to be a hard break. It is a low risk change so merging without PB.