### PR TITLE
Update getErrorsFromMvnOutput() to check whole line for [ERROR]

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/utils/MvnUtils.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/utils/MvnUtils.java
@@ -194,7 +194,7 @@ public class MvnUtils {
             try (Scanner s = new Scanner(installOutput)) {
                 while (s.hasNextLine() && sb.length() < 20000) {
                     String line = s.nextLine();
-                    if (line.startsWith("[ERROR]"))
+                    if (line.contains("[ERROR]"))
                         sb.append(line).append("\n");
                 }
             } catch (FileNotFoundException e) {
@@ -207,7 +207,7 @@ public class MvnUtils {
             try (Scanner s = new Scanner(testOutput)) {
                 while (s.hasNextLine() && sb.length() < 20000) {
                     String line = s.nextLine();
-                    if (line.startsWith("[ERROR]"))
+                    if (line.contains("[ERROR]"))
                         sb.append(line).append("\n");
                 }
             } catch (FileNotFoundException e) {


### PR DESCRIPTION
Resolves #16753

PR https://github.com/OpenLiberty/open-liberty/pull/15723 added timestamps to the mvnOutput files, meaning the `line.startsWith("[ERROR]")` checks were no longer valid.

#build
#spawn.fullfat.buckets=io.openliberty.microprofile.config.2.0.internal_fat_tck,com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck

(tests a random pair of TCK buckets)