### PR TITLE
optionally exclude @HandlesTypes parameter class

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.servlet-servletSpi1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.servlet-servletSpi1.0.feature
@@ -3,7 +3,7 @@ symbolicName=com.ibm.websphere.appserver.servlet-servletSpi1.0
 WLP-DisableAllFeatures-OnConflict: false
 visibility=private
 -jars=com.ibm.websphere.appserver.spi.servlet; location:=dev/spi/ibm/
--files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.servlet_2.8-javadoc.zip
+-files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.servlet_2.9-javadoc.zip
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.spi.servlet/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.servlet/bnd.bnd
@@ -9,7 +9,7 @@
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
-bVersion: 2.8
+bVersion: 2.9
 
 Bundle-Name: WebSphere WebContainer Servlet SPI
 Bundle-Description: WebSphere WebContainer Servlet SPI, version ${bVersion}

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2020 IBM Corporation and others.
+# Copyright (c) 2017, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -26,7 +26,8 @@ src: \
     test-applications/SCIFilterServletNameMapping.jar/src,\
     test-applications/SameSiteTest.war/src,\
     test-applications/SameSiteSecurityTest.war/src,\
-    test-applications/Servlet5TestApp.war/src
+    test-applications/Servlet5TestApp.war/src,\
+    test-applications/TestHandlesTypesClasses.war/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/FATSuite.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/FATSuite.java
@@ -26,6 +26,7 @@ import com.ibm.ws.fat.wc.tests.WCEncodingTest;
 import com.ibm.ws.fat.wc.tests.WCGetMappingSlashStarTest;
 import com.ibm.ws.fat.wc.tests.WCGetMappingTest;
 import com.ibm.ws.fat.wc.tests.WCPushBuilderTest;
+import com.ibm.ws.fat.wc.tests.WCSCIHandlesTypesTest;
 import com.ibm.ws.fat.wc.tests.WCSameSiteCookieAttributeTests;
 import com.ibm.ws.fat.wc.tests.WCSendRedirectRelativeURLDefault;
 import com.ibm.ws.fat.wc.tests.WCSendRedirectRelativeURLTrue;
@@ -85,7 +86,8 @@ import componenttest.rules.repeater.RepeatTests;
                 WCGetMappingSlashStarTest.class,
                 WCSendRedirectRelativeURLTrue.class,
                 WCSendRedirectRelativeURLDefault.class,
-                WC5GetContextPath.class
+                WC5GetContextPath.class,
+                WCSCIHandlesTypesTest.class
 })
 
 public class FATSuite {

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCSCIHandlesTypesTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCSCIHandlesTypesTest.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.fat.wc.tests;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.logging.Logger;
+
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.ws.fat.wc.WCApplicationHelper;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * This tests the functionality of the 
+ * ServletContainerInitializer.onStartup(Set<Class<?>> c, ServletContext ctx) API.
+ *
+ * @See https://github.com/OpenLiberty/open-liberty/issues/16598
+ *
+ */
+@RunWith(FATRunner.class)
+public class WCSCIHandlesTypesTest {
+
+    private static final Logger LOG = Logger.getLogger(WCServerTest.class.getName());
+
+    private static final String APP_NAME = "TestHandlesTypesClasses";
+
+    @Server("servlet40_excludeAllHandledTypesClasses")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        LOG.info("Setup : add TestHandlesTypesClasses to the server if not already present.");
+
+        WCApplicationHelper.addWarToServerDropins(server, APP_NAME + ".war", true,
+            "testhandlestypesclasses.war.examples", "testhandlestypesclasses.war.servlets");
+
+        // Start the server and use the class name so we can find logs easily.
+        server.startServer(WCSCIHandlesTypesTest.class.getSimpleName() + ".log");
+        WCApplicationHelper.waitForAppStart(APP_NAME, WCEncodingTest.class.getName(), server);
+        LOG.info("Setup : complete, ready for Tests");
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        // Stop the server
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+    /**
+     * Test to verify that the correct set of Classes is passed via 
+     * ServletContainerInitializer.onStartup(Set<Class<?>> c, ServletContext ctx)
+     * 
+     * @throws Exception
+     */
+    @Test
+    @Mode(TestMode.FULL)
+    public void test_ServletContainerInitializer_HandlesTypes_Classes() throws Exception {
+        String url = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/" + APP_NAME 
+            + "/GetMappingTestServletSlashStar";
+        LOG.info("url: " + url);
+        HttpGet getMethod = new HttpGet(url);
+
+        try (final CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            try (final CloseableHttpResponse response = client.execute(getMethod)) {
+                String responseText = EntityUtils.toString(response.getEntity());
+                LOG.info("\n" + "Response Text:");
+                LOG.info("\n" + responseText);
+                assertTrue("The response did not contain \"PASS\"", responseText.contains("PASS"));
+            }
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet40_excludeAllHandledTypesClasses/.gitignore
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet40_excludeAllHandledTypesClasses/.gitignore
@@ -1,0 +1,2 @@
+/apps
+/dropins

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet40_excludeAllHandledTypesClasses/bootstrap.properties
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet40_excludeAllHandledTypesClasses/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+osgi.console=7777
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.webcontainer*=all:com.ibm.wsspi.webcontainer*=all
+com.ibm.ws.classloading.tcclLockWaitTimeMillis=60000

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet40_excludeAllHandledTypesClasses/server.xml
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet40_excludeAllHandledTypesClasses/server.xml
@@ -1,0 +1,10 @@
+<server description="Server for testing excludeAllHandledTypesClasses=true">
+
+  <include location="../fatTestPorts.xml"/>
+
+  <featureManager>
+    <feature>servlet-4.0</feature>
+  </featureManager>
+
+  <webContainer excludeAllHandledTypesClasses="true"/>
+</server>

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestHandlesTypesClasses.war/resources/META-INF/services/javax.servlet.ServletContainerInitializer
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestHandlesTypesClasses.war/resources/META-INF/services/javax.servlet.ServletContainerInitializer
@@ -1,0 +1,1 @@
+testhandlestypesclasses.war.examples.TestServletContainerInitializer

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestHandlesTypesClasses.war/src/testhandlestypesclasses/war/examples/AbstractClass.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestHandlesTypesClasses.war/src/testhandlestypesclasses/war/examples/AbstractClass.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package testhandlestypesclasses.war.examples;
+
+public abstract class AbstractClass {
+}

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestHandlesTypesClasses.war/src/testhandlestypesclasses/war/examples/MyAbstractClass.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestHandlesTypesClasses.war/src/testhandlestypesclasses/war/examples/MyAbstractClass.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package testhandlestypesclasses.war.examples;
+
+public abstract class MyAbstractClass extends AbstractClass {
+}

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestHandlesTypesClasses.war/src/testhandlestypesclasses/war/examples/MyImpl.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestHandlesTypesClasses.war/src/testhandlestypesclasses/war/examples/MyImpl.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package testhandlestypesclasses.war.examples;
+
+public class MyImpl implements MyInterface {
+}

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestHandlesTypesClasses.war/src/testhandlestypesclasses/war/examples/MyInterface.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestHandlesTypesClasses.war/src/testhandlestypesclasses/war/examples/MyInterface.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package testhandlestypesclasses.war.examples;
+
+public interface MyInterface {
+}

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestHandlesTypesClasses.war/src/testhandlestypesclasses/war/examples/SubMyInterface.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestHandlesTypesClasses.war/src/testhandlestypesclasses/war/examples/SubMyInterface.java
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package testhandlestypesclasses.war.examples;
+
+public interface SubMyInterface extends MyInterface {
+}

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestHandlesTypesClasses.war/src/testhandlestypesclasses/war/examples/TestServletContainerInitializer.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestHandlesTypesClasses.war/src/testhandlestypesclasses/war/examples/TestServletContainerInitializer.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package testhandlestypesclasses.war.examples;
+
+import java.util.Set;
+
+import javax.servlet.ServletContainerInitializer;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.HandlesTypes;
+
+@HandlesTypes({MyInterface.class, AbstractClass.class})
+public class TestServletContainerInitializer implements ServletContainerInitializer {
+
+  public static final String ON_STARTUP_SET_KEY = "onStartupSet";
+
+  @Override
+  public void onStartup(Set<Class<?>> c, ServletContext ctx) throws ServletException {
+    ctx.setAttribute(ON_STARTUP_SET_KEY, String.valueOf(c));
+    System.out.println("Set: " + String.valueOf(c));
+  }
+}

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestHandlesTypesClasses.war/src/testhandlestypesclasses/war/servlets/GetHandlesTypesClassesServlet.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/test-applications/TestHandlesTypesClasses.war/src/testhandlestypesclasses/war/servlets/GetHandlesTypesClassesServlet.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package testhandlestypesclasses.war.servlets;
+
+import java.io.IOException;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import testhandlestypesclasses.war.examples.TestServletContainerInitializer;
+
+/**
+ * This tests the functionality of the 
+ * ServletContainerInitializer.onStartup(Set<Class<?>> c, ServletContext ctx) API.
+ *
+ * This test expects a SCI "TestServletContainerInitializer" to be registered, which 
+ * will set an attribute under "ON_STARTUP_SET_KEY" containing a string representation
+ * of the Set of classes passed to it during onStartup(). That set of classes should 
+ * not contain the classes which were specified as @HandlesTypes parameters; if only 
+ * "MyImpl", "MyAbstractClass", and "SubMyInterface" are rerturned then this servlet 
+ * will print "PASS", and otherwise it will print "FAIL".
+ * 
+ * @See https://github.com/OpenLiberty/open-liberty/issues/16598
+ *
+ */
+@WebServlet(urlPatterns = "/*", name = "GetHandlesTypesClassesServlet")
+public class GetHandlesTypesClassesServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
+        System.out.println("++++++++ Enter GetHandlesTypesClassesServlet");
+
+        ServletContext context = request.getSession().getServletContext();
+        String onStartupSet = (String) context.getAttribute(TestServletContainerInitializer.ON_STARTUP_SET_KEY);
+        System.out.println("++++++++ classes passed to onStartup(): [ " + onStartupSet + " ]");
+
+        if (onStartupSet != null && !onStartupSet.isEmpty() && onStartupSet.contains("testhandlestypesclasses.war.examples.MyImpl") 
+                && onStartupSet.contains("testhandlestypesclasses.war.examples.MyAbstractClass") && onStartupSet.contains("testhandlestypesclasses.war.examples.SubMyInterface") 
+                && !!!onStartupSet.contains("testhandlestypesclasses.war.examples.MyInterface") && !!!onStartupSet.contains("testhandlestypesclasses.war.examples.AbstractClass")) {
+            response.getWriter().append("PASS: TestServletContainerInitializer.onStartup() was passed the correct set of @HandlesTypes implementation classes");
+        } else {
+            response.getWriter().append("FAIL: TestServletContainerInitializer.onStartup() was passed unexpected classes:\n" + onStartupSet);
+        }
+
+        System.out.println("-------- Exit GetHandlesTypesClassesServlet");
+    }
+
+}

--- a/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype.properties
@@ -187,5 +187,5 @@ allowQueryParamWithNoEqual.desc=When this property is set to true, if the query 
 setHtmlContentTypeOnError.name=Disable text/html content type on error responses
 setHtmlContentTypeOnError.desc=When this property is false, the webcontainer will not set the response's content type header during the error handling process. An application is responsible to set the response's content type. The default value (true) sets the content type to "text/html".
 
-excludeAllHandledTypesClasses.name=Disable the return of HandlesTypes parameter classes
-excludeAllHandledTypesClasses.desc=When this property is true, ServletContainerInitializer implementors using the HandlesTypes annotation will not receive those classes directly specified as HandlesTypes parameters during startup. For servlet-5.0 and newer Servlet features, the default value is true.
+excludeAllHandledTypesClasses.name=Disable returning handlesTypes parameters
+excludeAllHandledTypesClasses.desc=When this property is true, ServletContainerInitializer implementors using the HandlesTypes annotation will not receive those classes which are specified as HandlesTypes parameters during startup. For servlet-5.0 and newer servlet features, the default value is true.

--- a/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype.properties
@@ -188,4 +188,4 @@ setHtmlContentTypeOnError.name=Disable text/html content type on error responses
 setHtmlContentTypeOnError.desc=When this property is false, the webcontainer will not set the response's content type header during the error handling process. An application is responsible to set the response's content type. The default value (true) sets the content type to "text/html".
 
 excludeAllHandledTypesClasses.name=Disable returning handlesTypes parameters
-excludeAllHandledTypesClasses.desc=When this property is true, ServletContainerInitializer implementors using the HandlesTypes annotation will not receive those classes which are specified as HandlesTypes parameters during startup. For servlet-5.0 and newer servlet features, the default value is true.
+excludeAllHandledTypesClasses.desc=When this property is set to true, during startup, ServletContainerInitializer implementors that use the HandlesTypes annotation do not receive classes that are specified as HandlesTypes parameters.

--- a/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype.properties
@@ -186,3 +186,6 @@ allowQueryParamWithNoEqual.desc=When this property is set to true, if the query 
 
 setHtmlContentTypeOnError.name=Disable text/html content type on error responses
 setHtmlContentTypeOnError.desc=When this property is false, the webcontainer will not set the response's content type header during the error handling process. An application is responsible to set the response's content type. The default value (true) sets the content type to "text/html".
+
+excludeAllHandledTypesClasses.name=Disable the return of HandlesTypes parameter classes
+excludeAllHandledTypesClasses.desc=When this property is true, ServletContainerInitializer implementors using the HandlesTypes annotation will not receive those classes directly specified as HandlesTypes parameters during startup. For servlet-5.0 and newer Servlet features, the default value is true.

--- a/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/metatype/metatype.xml
@@ -337,12 +337,18 @@
             name="%allowQueryParamWithNoEqual.name"
             description="%allowQueryParamWithNoEqual.desc"
             required="false" type="Boolean" />
-        
+
         <!--com.ibm.ws.webcontainer.-->
         <AD id="setHtmlContentTypeOnError"
             name="%setHtmlContentTypeOnError.name"
             description="%setHtmlContentTypeOnError.desc"
             required="false" type="Boolean" default="true" />
+
+        <!--com.ibm.ws.webcontainer.-->
+        <AD id="excludeAllHandledTypesClasses"
+            name="%excludeAllHandledTypesClasses.name"
+            description="%excludeAllHandledTypesClasses.desc"
+            required="false" type="Boolean" default="false" />
 
         <AD name="internal" description="internal use only"
             id="extensionFactory" required="true" type="String" cardinality="100"

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/webapp/WebApp.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/webapp/WebApp.java
@@ -1019,19 +1019,24 @@ public class WebApp extends com.ibm.ws.webcontainer.webapp.WebApp implements Com
                           logger.logp(Level.FINE, CLASS_NAME, methodName, "Selection Type: [ {0} ]", handledType.getName() );
                       }
 
-                      String actualClassReason = "Selection of handlesType class [ " + handledTypeName + " ]";
-                      addClassToHandlesTypesStartupSet(handledTypeName, startupTypes, actualClassReason);
-
-                      String classesReason = "Selection on sub-classes of [ " + handledTypeName + " ]";
-                      for ( String targetClassName : annoTargets.getSubclassNames(handledTypeName)) {
-                          addClassToHandlesTypesStartupSet(targetClassName, startupTypes, classesReason);
+                      // add the @HandlesTypes param class for init if setHandledTypesClasses=false
+                      if (!WCCustomProperties.SET_HANDLED_TYPES_CLASSES) {
+                          String actualClassReason = "Selection of handlesType class [ " + handledTypeName + " ]";
+                          addClassToHandlesTypesStartupSet(handledTypeName, startupTypes, actualClassReason);
                       }
-
-                      String interfaceReason = "Selection on interface [ " + handledTypeName + " ]";
-                      Set<String> implementerClassNames = annoTargets.getAllImplementorsOf(handledTypeName);   
-                      for ( String implementerClassName : implementerClassNames ) {
-                          addClassToHandlesTypesStartupSet(implementerClassName, startupTypes, interfaceReason);
-                      }                  
+                      // if @HandlesTypes param is an interface look for implementors, otherwise look for subclasses
+                      if ( ((com.ibm.wsspi.annocache.targets.AnnotationTargets_Targets) annoTargets).isInterface(handledTypeName) ) {
+                          String interfaceReason = "Selection on interface [ " + handledTypeName + " ]";
+                          Set<String> implementerClassNames = annoTargets.getAllImplementorsOf(handledTypeName);
+                          for ( String implementerClassName : implementerClassNames ) {
+                              addClassToHandlesTypesStartupSet(implementerClassName, startupTypes, interfaceReason);
+                          }
+                      } else {
+                          String classesReason = "Selection on sub-classes of [ " + handledTypeName + " ]";
+                          for ( String targetClassName : annoTargets.getSubclassNames(handledTypeName)) {
+                              addClassToHandlesTypesStartupSet(targetClassName, startupTypes, classesReason);
+                          }
+                      }
                   }
               }
           }
@@ -1140,7 +1145,6 @@ public class WebApp extends com.ibm.ws.webcontainer.webapp.WebApp implements Com
               }
           } else {
               handlesTypesOnStartupSet.add(targetInitializerClass);
-          
               if ( enableTrace ) { 
                   logger.logp(Level.FINE, CLASS_NAME, methodName,
                               "Adding initializer [ {0} ] to [ {1} ] [ {2} ]",

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/webapp/WebApp.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/webapp/WebApp.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2020 IBM Corporation and others.
+ * Copyright (c) 2010, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1019,8 +1019,8 @@ public class WebApp extends com.ibm.ws.webcontainer.webapp.WebApp implements Com
                           logger.logp(Level.FINE, CLASS_NAME, methodName, "Selection Type: [ {0} ]", handledType.getName() );
                       }
 
-                      // add the @HandlesTypes param class for init if setHandledTypesClasses=false
-                      if (!WCCustomProperties.SET_HANDLED_TYPES_CLASSES) {
+                      // add the @HandlesTypes param class for init only if excludeAllHandledTypesClasses=false
+                      if (!WCCustomProperties.EXCLUDE_ALL_HANDLED_TYPES_CLASSES) {
                           String actualClassReason = "Selection of handlesType class [ " + handledTypeName + " ]";
                           addClassToHandlesTypesStartupSet(handledTypeName, startupTypes, actualClassReason);
                       }

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/WCCustomProperties.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/WCCustomProperties.java
@@ -322,6 +322,9 @@ public class WCCustomProperties {
     //21.0.0.4
     public static boolean SET_HTML_CONTENT_TYPE_ON_ERROR; 
 
+    //21.0.0.X
+    public static boolean SET_HANDLED_TYPES_CLASSES;
+
     static {
         setCustomPropertyVariables(); //initializes all the variables
     }
@@ -415,6 +418,7 @@ public class WCCustomProperties {
         WCCustomProperties.FullyQualifiedPropertiesMap.put("getrealpathreturnsqualifiedPath", "com.ibm.ws.webcontainer.getrealpathreturnsqualifiedPath");
         WCCustomProperties.FullyQualifiedPropertiesMap.put("redirecttorelativeurl", "com.ibm.ws.webcontainer.redirecttorelativeurl");
         WCCustomProperties.FullyQualifiedPropertiesMap.put("sethtmlcontenttypeonerror", "com.ibm.ws.webcontainer.sethtmlcontenttypeonerror"); //PH34054
+        WCCustomProperties.FullyQualifiedPropertiesMap.put("sethandledtypesclasses", "com.ibm.ws.webcontainer.setHandledTypesClasses");
     }
 
     //some properties require "com.ibm.ws.webcontainer." on the front
@@ -811,11 +815,17 @@ public class WCCustomProperties {
             STOP_APP_STARTUP_ON_LISTENER_EXCEPTION = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.stopappstartuponlistenerexception" , "true")).booleanValue();
             DECODE_URL_PLUS_SIGN = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.decodeurlplussign", "false")).booleanValue(); 
             ALLOW_QUERY_PARAM_WITH_NO_EQUAL = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.allowqueryparamwithnoequal", "true")).booleanValue();
+            //21.0.0.X
+            SET_HANDLED_TYPES_CLASSES = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.sethandledtypesclasses", "true")).booleanValue();
+
         } else {
             DISABLE_X_POWERED_BY = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.disablexpoweredby","false")).booleanValue();
             STOP_APP_STARTUP_ON_LISTENER_EXCEPTION = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.stopappstartuponlistenerexception" , "false")).booleanValue();
             DECODE_URL_PLUS_SIGN = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.decodeurlplussign", "true")).booleanValue();
             ALLOW_QUERY_PARAM_WITH_NO_EQUAL = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.allowqueryparamwithnoequal", "false")).booleanValue();
+            //21.0.0.X
+            SET_HANDLED_TYPES_CLASSES = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.sethandledtypesclasses", "false")).booleanValue();
+
         }
         
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/WCCustomProperties.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/WCCustomProperties.java
@@ -322,8 +322,8 @@ public class WCCustomProperties {
     //21.0.0.4
     public static boolean SET_HTML_CONTENT_TYPE_ON_ERROR; 
 
-    //21.0.0.X
-    public static boolean SET_HANDLED_TYPES_CLASSES;
+    //21.0.0.6
+    public static boolean EXCLUDE_ALL_HANDLED_TYPES_CLASSES;
 
     static {
         setCustomPropertyVariables(); //initializes all the variables
@@ -418,7 +418,7 @@ public class WCCustomProperties {
         WCCustomProperties.FullyQualifiedPropertiesMap.put("getrealpathreturnsqualifiedPath", "com.ibm.ws.webcontainer.getrealpathreturnsqualifiedPath");
         WCCustomProperties.FullyQualifiedPropertiesMap.put("redirecttorelativeurl", "com.ibm.ws.webcontainer.redirecttorelativeurl");
         WCCustomProperties.FullyQualifiedPropertiesMap.put("sethtmlcontenttypeonerror", "com.ibm.ws.webcontainer.sethtmlcontenttypeonerror"); //PH34054
-        WCCustomProperties.FullyQualifiedPropertiesMap.put("sethandledtypesclasses", "com.ibm.ws.webcontainer.setHandledTypesClasses");
+        WCCustomProperties.FullyQualifiedPropertiesMap.put("excludeallhandledtypesclasses", "com.ibm.ws.webcontainer.excludeallhandledtypesclasses");
     }
 
     //some properties require "com.ibm.ws.webcontainer." on the front
@@ -815,16 +815,16 @@ public class WCCustomProperties {
             STOP_APP_STARTUP_ON_LISTENER_EXCEPTION = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.stopappstartuponlistenerexception" , "true")).booleanValue();
             DECODE_URL_PLUS_SIGN = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.decodeurlplussign", "false")).booleanValue(); 
             ALLOW_QUERY_PARAM_WITH_NO_EQUAL = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.allowqueryparamwithnoequal", "true")).booleanValue();
-            //21.0.0.X
-            SET_HANDLED_TYPES_CLASSES = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.sethandledtypesclasses", "true")).booleanValue();
+            //21.0.0.6
+            EXCLUDE_ALL_HANDLED_TYPES_CLASSES = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.excludeallhandledtypesclasses", "true")).booleanValue();
 
         } else {
             DISABLE_X_POWERED_BY = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.disablexpoweredby","false")).booleanValue();
             STOP_APP_STARTUP_ON_LISTENER_EXCEPTION = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.stopappstartuponlistenerexception" , "false")).booleanValue();
             DECODE_URL_PLUS_SIGN = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.decodeurlplussign", "true")).booleanValue();
             ALLOW_QUERY_PARAM_WITH_NO_EQUAL = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.allowqueryparamwithnoequal", "false")).booleanValue();
-            //21.0.0.X
-            SET_HANDLED_TYPES_CLASSES = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.sethandledtypesclasses", "false")).booleanValue();
+            //21.0.0.6
+            EXCLUDE_ALL_HANDLED_TYPES_CLASSES = Boolean.valueOf(WebContainer.getWebContainerProperties().getProperty("com.ibm.ws.webcontainer.excludeallhandledtypesclasses", "false")).booleanValue();
 
         }
         

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/package-info.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/wsspi/webcontainer/package-info.java
@@ -10,7 +10,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 /**
- * @version 1.9.0
+ * @version 1.10.0
  */
-@org.osgi.annotation.versioning.Version("1.9.0")
+@org.osgi.annotation.versioning.Version("1.10.0")
 package com.ibm.wsspi.webcontainer;


### PR DESCRIPTION
fixes #16598

* add new custom property `com.ibm.ws.webcontainer.excludeAllHandledTypesClasses` which will prevent `@HandleTypes` parameter classes from being passed to the relevant `ServletContainerInitializer` implementations during startup
* disable this new behavior by default, unless `servlet-5.0` or newer is enabled