### PR TITLE
Break apart JPA github test-categories into smaller groups.

### DIFF
--- a/.github/test-categories/JPA_1A
+++ b/.github/test-categories/JPA_1A
@@ -2,5 +2,3 @@ com.ibm.ws.jpa.container.ormdiagnostics_fat
 com.ibm.ws.jpa.container.ormdiagnostics_3.0_fat
 com.ibm.ws.jpa_22_fat
 com.ibm.ws.jpa_30_fat
-com.ibm.ws.jpa_eclipselink_fat
-com.ibm.ws.jpa_ol_fat

--- a/.github/test-categories/JPA_1B
+++ b/.github/test-categories/JPA_1B
@@ -1,0 +1,2 @@
+com.ibm.ws.jpa_eclipselink_fat
+com.ibm.ws.jpa_ol_fat

--- a/.github/test-categories/JPA_2A
+++ b/.github/test-categories/JPA_2A
@@ -1,0 +1,4 @@
+com.ibm.ws.jpa_spec10_query_fat
+com.ibm.ws.jpa_spec20_fat
+com.ibm.ws.jpa.tests.spec20.lock_fat
+com.ibm.ws.persistence_fat

--- a/.github/test-categories/JPA_2B
+++ b/.github/test-categories/JPA_2B
@@ -1,7 +1,3 @@
-com.ibm.ws.jpa_spec10_query_fat
-com.ibm.ws.jpa_spec20_fat
-com.ibm.ws.jpa.tests.spec20.lock_fat
 com.ibm.ws.jpa.tests.spec21.cdi_fat
 com.ibm.ws.jpa.tests.spec21.issues_fat
 com.ibm.ws.jpa.tests.spec21.txsynchronization_fat
-com.ibm.ws.persistence_fat

--- a/.github/test-categories/JPA_3A
+++ b/.github/test-categories/JPA_3A
@@ -1,0 +1,5 @@
+com.ibm.ws.jpa.tests.spec10.callback_fat
+com.ibm.ws.jpa.tests.spec10.entitymanager_fat
+com.ibm.ws.jpa.tests.spec10.inheritance_fat
+com.ibm.ws.jpa.tests.spec10.issues_fat
+

--- a/.github/test-categories/JPA_3B
+++ b/.github/test-categories/JPA_3B
@@ -1,9 +1,4 @@
-com.ibm.ws.jpa.tests.spec10.callback_fat
-com.ibm.ws.jpa.tests.spec10.entitymanager_fat
-com.ibm.ws.jpa.tests.spec10.inheritance_fat
 com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_fat
 com.ibm.ws.jpa.tests.spec10.relationships.manyXone_fat
 com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_fat
 com.ibm.ws.jpa.tests.spec10.relationships.oneXone_fat
-com.ibm.ws.jpa.tests.spec10.issues_fat
-

--- a/.github/test-categories/JPA_4A
+++ b/.github/test-categories/JPA_4A
@@ -1,0 +1,4 @@
+com.ibm.ws.jpa.tests.spec10.injection.dfi_fat
+com.ibm.ws.jpa.tests.spec10.injection.dmi_fat
+com.ibm.ws.jpa.tests.spec10.injection.jndi_fat
+

--- a/.github/test-categories/JPA_4B
+++ b/.github/test-categories/JPA_4B
@@ -1,6 +1,3 @@
-com.ibm.ws.jpa.tests.spec10.injection.dfi_fat
-com.ibm.ws.jpa.tests.spec10.injection.dmi_fat
-com.ibm.ws.jpa.tests.spec10.injection.jndi_fat
 com.ibm.ws.jpa.tests.spec10.injection.mdb_fat
 com.ibm.ws.jpa.tests.spec10.injection.ejbinwar_fat
 com.ibm.ws.jpa.tests.spec10.injection.defaultPersistenceUnit_fat


### PR DESCRIPTION
The github test-categories for JPA might have grown too large to run under the allowed execution times, and need to be broken into smaller blocks.