### PR TITLE
Issue 16604: Swap CustomStoreSample to embedded MongoDB

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -432,6 +432,16 @@
       <version>3.6</version>
     </dependency>
     <dependency>
+      <groupId>de.flapdoodle.embed</groupId>
+      <artifactId>de.flapdoodle.embed.mongo</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>de.flapdoodle.embed</groupId>
+      <artifactId>de.flapdoodle.embed.process</artifactId>
+      <version>3.0.1</version>
+    </dependency>
+    <dependency>
       <groupId>httpunit</groupId>
       <artifactId>httpunit</artifactId>
       <version>1.5.4</version>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -82,6 +82,8 @@ commons-logging:commons-logging:1.1.1
 commons-logging:commons-logging:1.1.3
 commons-logging:commons-logging:1.2
 commons-net:commons-net:3.6
+de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.0.0
+de.flapdoodle.embed:de.flapdoodle.embed.process:3.0.1
 httpunit:httpunit:1.5.4
 httpunit:httpunit:1.6.2
 httpunit:httpunit:1.7

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/bnd.bnd
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/bnd.bnd
@@ -72,8 +72,12 @@ test.project: true
 	net.sourceforge.htmlunit:htmlunit;version='2.44.0',\
 	com.ibm.ws.security.jwt;version=latest,\
 	org.apache.commons.io;version='2.6.0',\
-	javax.ws.rs:javax.ws.rs-api;version=2.0
-	
+	javax.ws.rs:javax.ws.rs-api;version='2.0',\
+	de.flapdoodle.embed.mongo;version='3.0.0',\
+	de.flapdoodle.embed.process;version='3.0.1',\
+	org.slf4j:slf4j-jdk14;version=latest,\
+	com.ibm.ws.org.slf4j.api.1.7.7
+    
 -testpath: \
     cglib:cglib-nodep;version=3.3.0, \
     com.ibm.websphere.javaee.jsonp.1.1;version=latest, \

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/build.gradle
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/build.gradle
@@ -22,6 +22,8 @@ dependencies {
      * for eash of retrieval by other projects.
      */
     collectedDeps 'org.mongodb:mongo-java-driver:2.13.3',
+                  'de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.0.0',
+                  'org.apache.commons:commons-compress:1.20',
                   project(':io.openliberty.org.apache.commons.codec'),
                   project(':io.openliberty.org.apache.commons.logging'),
                   project(':com.ibm.json4j'),

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/MongoDBUtils.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/MongoDBUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,20 +18,24 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+
+import org.slf4j.LoggerFactory;
 
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.CommonMessageTools;
 import com.ibm.ws.security.fat.common.utils.AutomationTools;
-import com.mongodb.MongoClient;
-import com.mongodb.MongoClientOptions;
-import com.mongodb.MongoCredential;
-import com.mongodb.ServerAddress;
 
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.utils.ExternalTestService;
+import de.flapdoodle.embed.mongo.Command;
+import de.flapdoodle.embed.mongo.MongodExecutable;
+import de.flapdoodle.embed.mongo.MongodStarter;
+import de.flapdoodle.embed.mongo.config.Defaults;
+import de.flapdoodle.embed.mongo.config.MongodConfig;
+import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.config.Timeout;
+import de.flapdoodle.embed.mongo.distribution.Version;
+import de.flapdoodle.embed.process.config.RuntimeConfig;
+import de.flapdoodle.embed.process.runtime.Network;
 
 public class MongoDBUtils {
 
@@ -43,158 +47,106 @@ public class MongoDBUtils {
     final static String DB_NAME = "dbName";
     final static String DB_HOST = "dbHost";
     final static String DB_PORT = "dbPort";
-    final static String DB_PWD = "dbPwd";
-    final static String DB_USER = "dbUser";
+
     static String dbInfo = "";
 
-    // from MongoServerSelector
-    private static final String TEST_USERNAME = "user";
-    private static final String TEST_DATABASE = "default";
-    private static final String MONGODB_SERVICE = "mongo-auth";
+    private static final String TEST_DATABASE = "oauthMongoDB";
 
-    private static String dbName = TEST_DATABASE;
-    private static String dbHost = "not set";
-    private static String dbPort = "not set";
-    private static String dbPwd = "not set";
-    private static String dbUser = TEST_USERNAME;
-
-    private static String mongoTableUid = "not set";
+    private static String dbHost = "localhost";
+    private static int dbPort = -1;
 
     public static String MONGO_PROPS_FILE = "not set"; // this name needs to match the one used in CustomStoreSample
 
-    public static void startMongoDB(LibertyServer server, String propsFile, String uid) throws Exception {
+    private static MongodExecutable mongodExecutable = null;
+
+    /**
+     * Stop the embedded mongoDB server
+     *
+     * @throws Exception
+     */
+    public static void stopMongoDB() throws Exception {
+        Log.info(thisClass, "stopMongoDB", "Stopping the embedded MongoDB.");
+        mongodExecutable.stop();
+        Log.info(thisClass, "stopMongoDB", "Stopped the embedded MongoDB.");
+    }
+
+    /**
+     * Start the embedded MongoDB server. Will construct the mongoDB URL string to use while connecting to the
+     * mongoDB helper servlet -- oAuth20MongoSetup.
+     *
+     * @param server
+     * @param propsFile
+     * @throws Exception
+     */
+    public static void startMongoDB(LibertyServer server, String propsFile) throws Exception {
         String method = "startMongoDB";
         MONGO_PROPS_FILE = propsFile;
-        mongoTableUid = uid;
 
-        Log.info(thisClass, method, "Running get service for " + MONGODB_SERVICE);
-        getAvailableMongoServer(MONGODB_SERVICE);
+        Log.info(thisClass, method, "Get free port for MongoDB embedded database.");
+        dbPort = Network.getFreeServerPort();
 
-        Log.info(thisClass, method, "Populate mongo db props file for CustomStoreSample use.");
+        Log.info(thisClass, method, "Populate mongo db props file for CustomStoreSample use. Port is " + dbPort);
         File tmpFile = new File("lib/LibertyFATTestFiles/", MONGO_PROPS_FILE);
         tmpFile.getParentFile().mkdirs();
         try {
             BufferedWriter out = new BufferedWriter(new FileWriter(tmpFile));
             try {
-                out.write("DBNAME:" + dbName);
+                out.write("DBNAME:" + TEST_DATABASE);
                 out.write("\nHOST:" + dbHost);
-                out.write("\nPWD:" + dbPwd);
                 out.write("\nPORT:" + dbPort);
-                out.write("\nUSER:" + dbUser);
-                out.write("\nUID:" + mongoTableUid);
             } finally {
                 out.close();
             }
 
             server.copyFileToLibertyServerRoot(MONGO_PROPS_FILE);
         } catch (IllegalStateException e) {
-            Log.info(thisClass, method, "Failed to create props file " + MONGO_PROPS_FILE);
+            Log.info(thisClass, method, "Failed to create props file, mongoDB related tests will fail. " + MONGO_PROPS_FILE);
             e.printStackTrace();
-            throw new Exception("Could not set up " + MONGO_PROPS_FILE + ". The CustomStoreSample will likely fail to connect to the database.");
         } finally {
             tmpFile.delete();
         }
 
+        /*
+         * Startup a MondoDB instance.
+         */
+
+        Log.info(thisClass, method, "Start embedded mongoDB server.");
+        RuntimeConfig runtimeConfig = Defaults.runtimeConfigFor(Command.MongoD, LoggerFactory.getLogger(thisClass.getName()))
+                        .build();
+        MongodStarter starter = MongodStarter.getInstance(runtimeConfig);
+        MongodConfig builder = MongodConfig.builder()
+                        .version(Version.Main.PRODUCTION)
+                        .net(new Net(dbHost, dbPort, Network.localhostIsIPv6()))
+                        .timeout(new Timeout(30000))
+                        .build();
+        mongodExecutable = starter.prepare(builder);
+        mongodExecutable.start();
+        Log.info(thisClass, method, "Started embedded mongoDB server.");
+
         // build variables to send to the setup servlet
-        dbInfo = "&" + DB_NAME + "=" + dbName + "&" + DB_HOST + "=" + dbHost + "&" + DB_PWD + "=" + dbPwd + "&" + DB_PORT + "=" + dbPort + "&" + DB_USER + "=" + dbUser;
+        dbInfo = "&" + DB_NAME + "=" + TEST_DATABASE + "&" + DB_HOST + "=" + dbHost + "&" + DB_PORT + "=" + dbPort;
 
-        Log.info(thisClass, method, "MongoDB props are " + dbInfo);
+        Log.info(thisClass, method, "MongoDB servlet props are " + dbInfo);
     }
 
-    private static ExternalTestService getAvailableMongoServer(String serverPlaceholder) {
-        String method = "getAvailableMongoServer";
-
-        Exception failure = null;
-        ExternalTestService mongoService = null;
-
-        for (int i = 1; i < 4; i++) {
-            Log.info(thisClass, method, "Request for mongoDB service, attempt #" + i);
-            try {
-                while (true) {
-                    mongoService = ExternalTestService.getService(serverPlaceholder);
-                    Log.info(thisClass, method, "Found service, testing if valid");
-                    if (validateMongoConnectionAndSetConfig(mongoService)) {
-                        Log.info(thisClass, method, "Found service, ping successful");
-                        return mongoService;
-                    }
-                }
-            } catch (Exception e) {
-                Log.error(thisClass, method, e, "Exeption trying to get MongoDB service.");
-                failure = e;
-                if (i < 3) {
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException e1) {
-                        // fine
-                    }
-                }
-            }
-        }
-
-        if (failure != null) {
-            // Thrown when there are no more services to try
-            Log.warning(thisClass, method + " Despite a retry, could not get requested MongoDB server");
-            throw new RuntimeException(failure);
-        }
-
-        return mongoService;
-    }
-
-    private static boolean validateMongoConnectionAndSetConfig(ExternalTestService mongoService) {
-        String method = "validateMongoConnectionAndSetConfig";
-        MongoClient mongoClient = null;
-
-        dbHost = mongoService.getAddress();
-        int port = mongoService.getPort();
-        dbPort = String.valueOf(port);
-
-        File trustStore = null;
-
-        MongoClientOptions.Builder optionsBuilder = new MongoClientOptions.Builder().connectTimeout(30000);
-        try {
-            trustStore = File.createTempFile("mongoTrustStore", "jks");
-            Map<String, String> serviceProperties = mongoService.getProperties();
-
-            String password = serviceProperties.get(TEST_USERNAME + "_password"); // will be null if there's no auth for this server
-
-            MongoClientOptions clientOptions = optionsBuilder.build();
-            List<MongoCredential> credentials = Collections.emptyList();
-            if (password != null) {
-                MongoCredential credential = MongoCredential.createCredential(TEST_USERNAME, TEST_DATABASE, password.toCharArray());
-                credentials = Collections.singletonList(credential);
-                dbPwd = password;
-            }
-
-            Log.info(thisClass, method,
-                     "Attempting to contact server " + dbHost + ":" + port + " with password " + (password != null ? "set" : "not set") + " and truststore "
-                                        + "not set");
-            mongoClient = new MongoClient(new ServerAddress(dbHost, port), credentials, clientOptions);
-            mongoClient.getDB(TEST_DATABASE).getCollectionNames();
-            dbName = TEST_DATABASE;
-            mongoClient.close();
-        } catch (Exception e) {
-            // "Timed out" is checked in the output.txt and can cause a spurious failure
-            String exceptionMsg = e.toString().replaceAll("Timed out", "Took too long");
-            Log.info(thisClass, method, "Couldn't create a connection to " + mongoService.getServiceName() + " on " + mongoService.getAddress() + ". " + exceptionMsg);
-            mongoService.reportUnhealthy("Couldn't connect to server. Exception: " + exceptionMsg);
-            return false;
-        } finally {
-            if (trustStore != null) {
-                trustStore.delete();
-            }
-        }
-        return true;
-    }
-
-    public static void setupMongoDBEntries(String httpString, Integer defaultPort, String uid) throws Exception {
+    /**
+     * Prepopulate the mongoDB database with some users for later testing.
+     *
+     * @param httpString
+     * @param defaultPort
+     * @throws Exception
+     */
+    public static void setupMongoDBEntries(String httpString, Integer defaultPort) throws Exception {
+        String method = "setupMongoDBEntries";
 
         HttpURLConnection con = null;
+
         try {
-            msgUtils.printMethodName("setupMongoDBEntries");
-            Log.info(thisClass, "setupMongoDBEntries", "Create DataBases through the server");
+            msgUtils.printMethodName(method);
+            Log.info(thisClass, method, "Create DataBases through the server");
             URL setupURL = AutomationTools.getNewUrl(httpString + "/oAuth20MongoSetup?port=" + defaultPort
-                                                     + "&schemaName=OAuthDBSchema" + "&uid=" + uid + dbInfo);
-            Log.info(thisClass, "setupMongoDBEntries", "setupURL: " + setupURL);
+                                                     + "&schemaName=OAuthDBSchema" + dbInfo);
+            Log.info(thisClass, method, "setupURL: " + setupURL);
             con = (HttpURLConnection) setupURL.openConnection();
             con.setDoInput(true);
             con.setDoOutput(true);
@@ -210,15 +162,11 @@ public class MongoDBUtils {
             // Send output from servlet to console output
             for (String line = br.readLine(); line != null; line = br.readLine()) {
                 lines.append(line).append(sep);
-                Log.info(thisClass, "setupMongoDBEntries", line);
+                Log.info(thisClass, method, line);
             }
 
-            con.disconnect();
-
         } catch (Exception e) {
-
-            Log.info(thisClass, "setupMongoDBEntries", "Exception occurred: " + e.toString());
-            Log.error(thisClass, "setupMongoDBEntries", e, "Exception occurred");
+            Log.error(thisClass, method, e, "Exception occurred while pre-populating up the mongoDB database.");
             System.err.println("Exception: " + e);
             if (con != null) {
                 con.disconnect();
@@ -228,12 +176,34 @@ public class MongoDBUtils {
 
     }
 
+    /**
+     * Add the requested client to the mongoDB database
+     *
+     * @param httpString
+     * @param defaultPort
+     * @param clientID
+     * @param secret
+     * @param compID
+     * @throws Exception
+     */
     public static void addMongoDBEntry(String httpString, Integer defaultPort, String clientID, String secret,
                                        String compID) throws Exception {
         addMongoDBEntry(httpString, defaultPort, clientID, secret, compID, null, null);
 
     }
 
+    /**
+     * Add the requested client to the mongoDB database
+     *
+     * @param httpString
+     * @param defaultPort
+     * @param clientID
+     * @param secret
+     * @param compID
+     * @param salt
+     * @param alg
+     * @throws Exception
+     */
     public static void addMongoDBEntry(String httpString, Integer defaultPort, String clientID, String secret,
                                        String compID, String salt, String alg) throws Exception {
         String METHOD = "addMongoDBEntry";
@@ -281,22 +251,73 @@ public class MongoDBUtils {
 
     }
 
+    /**
+     * Get the type of secret stored in the database (hashed, xor, ext) for the supplied clientID.
+     *
+     * @param httpString
+     * @param defaultPort
+     * @param clientID
+     * @param compID
+     * @return
+     * @throws Exception
+     */
     public static String checkSecretType(String httpString, Integer defaultPort, String clientID, String compID) throws Exception {
         return checkEntry(httpString, defaultPort, clientID, compID, "checkSecret");
     }
 
+    /**
+     * Get the salt value for the supplied clientID
+     *
+     * @param httpString
+     * @param defaultPort
+     * @param clientID
+     * @param compID
+     * @return
+     * @throws Exception
+     */
     public static String checkSalt(String httpString, Integer defaultPort, String clientID, String compID) throws Exception {
         return checkEntry(httpString, defaultPort, clientID, compID, "checkSalt");
     }
 
+    /**
+     * Get the algorithm type for the supplied clientID
+     *
+     * @param httpString
+     * @param defaultPort
+     * @param clientID
+     * @param compID
+     * @return
+     * @throws Exception
+     */
     public static String checkAlgorithm(String httpString, Integer defaultPort, String clientID, String compID) throws Exception {
         return checkEntry(httpString, defaultPort, clientID, compID, "checkAlgorithm");
     }
 
+    /**
+     * Get the iteration value for the supplied clientID
+     *
+     * @param httpString
+     * @param defaultPort
+     * @param clientID
+     * @param compID
+     * @return
+     * @throws Exception
+     */
     public static String checkIteration(String httpString, Integer defaultPort, String clientID, String compID) throws Exception {
         return checkEntry(httpString, defaultPort, clientID, compID, "checkIteration");
     }
 
+    /**
+     * Get the requested value specified by checkType for the supplied clientID.
+     *
+     * @param httpString
+     * @param defaultPort
+     * @param clientID
+     * @param compID
+     * @param checkType
+     * @return
+     * @throws Exception
+     */
     public static String checkEntry(String httpString, Integer defaultPort, String clientID, String compID,
                                     String checkType) throws Exception {
 
@@ -350,48 +371,13 @@ public class MongoDBUtils {
 
     }
 
-    public static void cleanupMongoDBEntries(String httpString, Integer defaultPort) throws Exception {
-
-        HttpURLConnection con = null;
-        try {
-            msgUtils.printMethodName("cleanupMongoDBEntries");
-            Log.info(thisClass, "cleanupMongoDBEntries", "Drop DataBases through the server");
-            URL setupURL = AutomationTools
-                            .getNewUrl(httpString + "/oAuth20MongoSetup?port=" + defaultPort + "&dropDB=true" + dbInfo);
-            Log.info(thisClass, "cleanupMongoDBEntries", "cleanupURL: " + setupURL);
-            con = (HttpURLConnection) setupURL.openConnection();
-            con.setDoInput(true);
-            con.setDoOutput(true);
-            con.setUseCaches(false);
-            con.setRequestMethod("GET");
-            InputStream is = con.getInputStream();
-            InputStreamReader isr = new InputStreamReader(is);
-            BufferedReader br = new BufferedReader(isr);
-
-            String sep = System.getProperty("line.separator");
-            StringBuilder lines = new StringBuilder();
-
-            // Send output from servlet to console output
-            for (String line = br.readLine(); line != null; line = br.readLine()) {
-                lines.append(line).append(sep);
-                Log.info(thisClass, "cleanupMongoDBEntries", line);
-            }
-
-            con.disconnect();
-
-        } catch (Exception e) {
-
-            Log.info(thisClass, "cleanupMongoDBEntries", "Exception occurred: " + e.toString());
-            Log.error(thisClass, "cleanupMongoDBEntries", e, "Exception occurred");
-            System.err.println("Exception: " + e);
-            if (con != null) {
-                con.disconnect();
-            }
-            // throw e;
-        }
-
-    }
-
+    /**
+     * Remove existing clients from the database and recreate the default clients.
+     *
+     * @param httpString
+     * @param defaultPort
+     * @throws Exception
+     */
     public static void clearClientEntries(String httpString, Integer defaultPort) throws Exception {
         String METHOD = "clearClientEntries";
         HttpURLConnection con = null;

--- a/dev/com.ibm.ws.security.oauth_fat/bnd.bnd
+++ b/dev/com.ibm.ws.security.oauth_fat/bnd.bnd
@@ -30,7 +30,6 @@ fat.project: true
     com.ibm.ws.webcontainer.security;version=latest,\
     com.ibm.ws.security.oauth.oidc_fat.common;version=latest,\
     com.ibm.websphere.javaee.jsonp.1.0;version=latest,\
-    com.ibm.ws.mongo_fat;version=latest,\
     com.ibm.ws.security.fat.common;version=latest, \
     org.apache.httpcomponents:httpclient;version=4.5.7, \
     org.apache.httpcomponents:httpcore;version=4.4.13, \
@@ -42,4 +41,8 @@ fat.project: true
     com.ibm.ws.security.oauth.oidc_fat.common;version=latest, \
     com.ibm.ws.security.oauth_test.servlets;version=latest, \
     net.sf.jtidy:jtidy;version=9.3.8, \
-    com.ibm.ws.com.meterware.httpunit.1.6.2;version=latest
+    com.ibm.ws.com.meterware.httpunit.1.6.2;version=latest,\
+    de.flapdoodle.embed.mongo;version='3.0.0',\
+	de.flapdoodle.embed.process;version='3.0.1',\
+	org.slf4j:slf4j-jdk14;version=latest,\
+	com.ibm.ws.org.slf4j.api.1.7.7

--- a/dev/com.ibm.ws.security.oauth_fat/build.gradle
+++ b/dev/com.ibm.ws.security.oauth_fat/build.gradle
@@ -36,7 +36,9 @@ dependencies {
                   project(':com.ibm.ws.com.meterware.httpunit.1.6.2'),     // 1.7 causes refresh token failures
                   files('lib/jsse.jar'),
                   'rhino:js:1.6R5',
-                  project(':com.ibm.ws.mongo_fat')
+                  'de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.0.0',
+                  'de.flapdoodle.embed:de.flapdoodle.embed.process:3.0.1',
+                  'org.apache.commons:commons-compress:1.20'
 }
 
 addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/com.ibm.ws.security.oauth_test.custom_store/src/security/custom/store/CustomStoreSample.java
+++ b/dev/com.ibm.ws.security.oauth_test.custom_store/src/security/custom/store/CustomStoreSample.java
@@ -19,9 +19,7 @@ import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 
 import com.ibm.websphere.security.oauth20.store.OAuthClient;
 import com.ibm.websphere.security.oauth20.store.OAuthConsent;
@@ -35,7 +33,6 @@ import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
-import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
 import com.mongodb.WriteResult;
 
@@ -53,7 +50,6 @@ public class CustomStoreSample implements OAuthStore {
     private String dbUser = "user";
     private String dbPwd = "password";
     private int dbPort = 27017;
-    String uid = "defaultUID";
 
     private DB db = null;
     private DBCollection clientCollection = null;
@@ -110,21 +106,15 @@ public class CustomStoreSample implements OAuthStore {
             MongoClient mongoClient = null;
             try {
                 System.out.println("CustomStoreSample connecting to the " + dbName + " database at " + dbHost + ":"
-                                   + dbPort + " using table modifier " + uid);
-                List<MongoCredential> credentials = Collections.emptyList();
-                MongoCredential credential = MongoCredential.createCredential(dbUser, dbName, dbPwd.toCharArray());
-                credentials = Collections.singletonList(credential);
+                                   + dbPort);
                 MongoClientOptions.Builder optionsBuilder = new MongoClientOptions.Builder().connectTimeout(30000);
                 optionsBuilder.socketTimeout(10000);
                 optionsBuilder.socketKeepAlive(true);
                 optionsBuilder.maxWaitTime(30000);
                 MongoClientOptions clientOptions = optionsBuilder.build();
-                mongoClient = new MongoClient(new ServerAddress(dbHost, dbPort), credentials, clientOptions);
+                mongoClient = new MongoClient(new ServerAddress(dbHost, dbPort), null, clientOptions);
                 db = mongoClient.getDB(dbName);
                 System.out.println("CustomStoreSample connected to the database");
-                OAUTHCLIENT = OAUTHCLIENT + uid;
-                OAUTHTOKEN = OAUTHTOKEN + uid;
-                OAUTHCONSENT = OAUTHCONSENT + uid;
 
                 // for test purposes, double check the starting state of the database
                 DBCollection col = getClientCollection();
@@ -214,15 +204,13 @@ public class CustomStoreSample implements OAuthStore {
                             dbPort = Integer.parseInt(prop[1]);
                         } else if (prop[0].equals("USER")) {
                             dbUser = prop[1];
-                        } else if (prop[0].equals("UID")) {
-                            uid = prop[1];
                         } else {
                             System.out.println("CustomStoreSample Unexpected property in " + MONGO_PROPS_FILE + ": " + prop[0]);
                         }
                     }
                 }
 
-                System.out.println("CustomStoreSample Table mod is " + uid);
+                System.out.println("CustomStoreSample Config fetched");
             } finally {
                 br.close();
             }

--- a/dev/com.ibm.ws.security.oidc.server_fat.oidc/bnd.bnd
+++ b/dev/com.ibm.ws.security.oidc.server_fat.oidc/bnd.bnd
@@ -29,5 +29,7 @@ tested.features: oidctai-2.0, appsecurity-4.0, expressionlanguage-4.0, cdi-3.0, 
     com.ibm.ws.org.joda.time.1.6.2;version=latest,\
     io.openliberty.org.apache.commons.codec;version=latest,\
     io.openliberty.org.apache.commons.logging;version=latest,\
-    net.sourceforge.htmlunit:htmlunit;version=2.44.0
+    net.sourceforge.htmlunit:htmlunit;version=2.44.0,\
+    de.flapdoodle.embed.mongo;version=3.0.0,\
+    de.flapdoodle.embed.process;version=3.0.1
 

--- a/dev/com.ibm.ws.security.oidc.server_fat.oidc/build.gradle
+++ b/dev/com.ibm.ws.security.oidc.server_fat.oidc/build.gradle
@@ -34,7 +34,9 @@ dependencies {
                 project(':com.ibm.ws.crypto.passwordutil'),
                 fileTree("${project(':com.ibm.ws.security.oauth.oidc_fat.common').buildDir}/collectedJars") { include '*.jar' },
                 'jtidy:jtidy:4aug2000r7-dev',
-                'rhino:js:1.6R5'
+                'rhino:js:1.6R5',
+                'de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.0.0',
+                'org.apache.commons:commons-compress:1.20'
                 
   /*
    * Previously we had an uber jar named htmlunit-2.20-OSGi.jar. It appears to have contained all of


### PR DESCRIPTION
Fixes #16604 

- Added the opensource project `de.flapdoodle.embed` so we can start a local mongoDB.
- Removed the code to fetch the consul based MongoDB (also no longer need the user/pwd for the DB)
- Removed the `uid` references since we're no longer sharing a remote mongoDB. Each FAT run will have its own temporary mongoDB.
- There is some historical duplication of mongoDB access code in with `com.ibm.ws.security.oauth_fat` and `com.ibm.ws.security.oauth.oidc_fat.common`. As more CustomStore related fats suites are moved, I do not anticipate having to make more additions to the mongoDB customStore support.