### PR TITLE
Resolve startup checks of the RequestTimingMetricsTest FAT

### DIFF
--- a/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/RequestTimingMetricsTest.java
+++ b/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/RequestTimingMetricsTest.java
@@ -96,19 +96,23 @@ public class RequestTimingMetricsTest {
         String testName = "testBasic";
         Log.info(c, testName, "Entry");
 
-        //Metrics Monitor Bundle has started - using default timeout
-        String logMsg = server.waitForStringInLogUsingMark("CWPMI2003I");
-        Log.info(c, testName, logMsg);
-        Assert.assertNotNull("No CWPMI2003I was found.", logMsg);
-
         //Wait until server has started
-        logMsg = server.waitForStringInLogUsingMark("CWWKF0011I");
-        Log.info(c, testName, logMsg);
-        Assert.assertNotNull("No CWWKF0011I was found.", logMsg);
+        String logMsg = server.waitForStringInLogUsingMark("CWWKF0011I");
 
-        //Validate that we have registered the RequestTiming MBean
-        Assert.assertNotNull("RequestTiming Mbean not registered",
-                             server.waitForStringInTraceUsingMark("Monitoring MXBean WebSphere:type=RequestTimingStats"));
+        /*
+         * Run the following block only if we found a server start message
+         * If it is null then that indicates that the tests are running out of order.
+         * If the other tests have already executed, then the server would have
+         * already started ;)
+         */
+        if (logMsg != null) {
+            Log.info(c, testName, logMsg);
+            Assert.assertNotNull("No CWWKF0011I was found.", logMsg);
+
+            //Validate that we have registered the RequestTiming MBean
+            Assert.assertNotNull("RequestTiming Mbean not registered",
+                                 server.waitForStringInTraceUsingMark("Monitoring MXBean WebSphere:type=RequestTimingStats"));
+        }
 
         /*
          * The call to /metrics counts as an active request. And the total is 1.

--- a/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/RequestTimingMetricsTest.java
+++ b/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/RequestTimingMetricsTest.java
@@ -71,6 +71,16 @@ public class RequestTimingMetricsTest {
         totalRequestCount = new AtomicInteger();
         activeServletRequest = 1;
         server.startServer();
+
+        //Wait until server has started
+        String logMsg = server.waitForStringInLogUsingMark("CWWKF0011I");
+
+        Log.info(c, "setUp", logMsg);
+        Assert.assertNotNull("No CWWKF0011I was found.", logMsg);
+
+        //Validate that we have registered the RequestTiming MBean
+        Assert.assertNotNull("RequestTiming Mbean not registered",
+                             server.waitForStringInTraceUsingMark("Monitoring MXBean WebSphere:type=RequestTimingStats"));
     }
 
     /**
@@ -95,24 +105,6 @@ public class RequestTimingMetricsTest {
     public void testBasic() throws Exception {
         String testName = "testBasic";
         Log.info(c, testName, "Entry");
-
-        //Wait until server has started
-        String logMsg = server.waitForStringInLogUsingMark("CWWKF0011I");
-
-        /*
-         * Run the following block only if we found a server start message
-         * If it is null then that indicates that the tests are running out of order.
-         * If the other tests have already executed, then the server would have
-         * already started ;)
-         */
-        if (logMsg != null) {
-            Log.info(c, testName, logMsg);
-            Assert.assertNotNull("No CWWKF0011I was found.", logMsg);
-
-            //Validate that we have registered the RequestTiming MBean
-            Assert.assertNotNull("RequestTiming Mbean not registered",
-                                 server.waitForStringInTraceUsingMark("Monitoring MXBean WebSphere:type=RequestTimingStats"));
-        }
 
         /*
          * The call to /metrics counts as an active request. And the total is 1.


### PR DESCRIPTION
fixes #16763

Remove the check for the message emitted from the metric monitor bundle (i.e. `CWWKF0011I`) . We check for a server start after which implies all necessary bundles have started.
Also, if the test is executed out of order, the server has already started. Disable any other _startup_ checks if that is the case.