### PR TITLE
Add another failover ldap server to ldap registry config

### DIFF
--- a/dev/com.ibm.ws.security.jwt_fat.builder/publish/shared/config/LDAPRegistry_customClaims.xml
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/publish/shared/config/LDAPRegistry_customClaims.xml
@@ -1,3 +1,13 @@
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
 <server>
 
 	<ldapRegistry
@@ -33,6 +43,9 @@
 			<server
 				host="${ldap.server.8.name}"
 				port="${ldap.server.8.port}" />
+			<server
+				host="${ldap.server.7.name}"
+				port="${ldap.server.7.port}" />
 		</failoverServers>
 	</ldapRegistry>
 -->

--- a/dev/com.ibm.ws.security.oidc.client_fat/publish/files/serversettings/goodLDAPRegistry.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat/publish/files/serversettings/goodLDAPRegistry.xml
@@ -29,6 +29,9 @@
 			<server
 				host="${ldap.server.4.name}"
 				port="${ldap.server.4.port}" />
+			<server
+				host="${ldap.server.7.name}"
+				port="${ldap.server.7.port}" />
 		</failoverServers>
 	</ldapRegistry>
 </server>

--- a/dev/com.ibm.ws.security.oidc.client_fat/publish/files/serversettings/goodOPLDAPRegistry.xml
+++ b/dev/com.ibm.ws.security.oidc.client_fat/publish/files/serversettings/goodOPLDAPRegistry.xml
@@ -29,6 +29,9 @@
 			<server
 				host="${ldap.server.4.name}"
 				port="${ldap.server.4.port}" />
+			<server
+				host="${ldap.server.7.name}"
+				port="${ldap.server.7.port}" />
 		</failoverServers>
 	</ldapRegistry>
 </server>

--- a/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/LDAPRegistry.xml
+++ b/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/LDAPRegistry.xml
@@ -29,6 +29,9 @@
 			<server
 				host="${ldap.server.4.name}"
 				port="${ldap.server.4.ssl.port}" />
+			<server
+				host="${ldap.server.7.name}"
+				port="${ldap.server.7.ssl.port}" />
 		</failoverServers>
 	</ldapRegistry>
 

--- a/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/LDAPRegistry_auth_roles_all_auth.xml
+++ b/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/LDAPRegistry_auth_roles_all_auth.xml
@@ -29,6 +29,9 @@
 			<server
 				host="${ldap.server.4.name}"
 				port="${ldap.server.4.ssl.port}" />
+			<server
+				host="${ldap.server.7.name}"
+				port="${ldap.server.7.ssl.port}" />
 		</failoverServers>
 	</ldapRegistry>
 

--- a/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/LDAPRegistry_oauth_and_auth_roles_all_auth.xml
+++ b/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/LDAPRegistry_oauth_and_auth_roles_all_auth.xml
@@ -29,6 +29,9 @@
 			<server
 				host="${ldap.server.4.name}"
 				port="${ldap.server.4.ssl.port}" />
+			<server
+				host="${ldap.server.7.name}"
+				port="${ldap.server.7.ssl.port}" />
 		</failoverServers>
 	</ldapRegistry>
 

--- a/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/LDAPRegistry_oauth_roles_all_auth.xml
+++ b/dev/com.ibm.ws.security.oidc.server_fat/publish/files/serversettings/LDAPRegistry_oauth_roles_all_auth.xml
@@ -29,6 +29,9 @@
 			<server
 				host="${ldap.server.4.name}"
 				port="${ldap.server.4.ssl.port}" />
+			<server
+				host="${ldap.server.7.name}"
+				port="${ldap.server.7.ssl.port}" />
 		</failoverServers>
 	</ldapRegistry>
 

--- a/dev/com.ibm.ws.security.oidc.server_fat/publish/servers/com.ibm.ws.security.openidconnect.server-1.0_fat/configs/server_introspect_oauth_derby.xml
+++ b/dev/com.ibm.ws.security.oidc.server_fat/publish/servers/com.ibm.ws.security.openidconnect.server-1.0_fat/configs/server_introspect_oauth_derby.xml
@@ -38,6 +38,9 @@
 			<server
 				host="${ldap.server.4.name}"
 				port="${ldap.server.4.ssl.port}" />
+			<server
+				host="${ldap.server.7.name}"
+				port="${ldap.server.7.ssl.port}" />
 		</failoverServers>
 	</ldapRegistry>
 

--- a/dev/com.ibm.ws.security.oidc.server_fat/publish/servers/com.ibm.ws.security.openidconnect.server-1.0_fat/configs/server_introspect_oidc_derby.xml
+++ b/dev/com.ibm.ws.security.oidc.server_fat/publish/servers/com.ibm.ws.security.openidconnect.server-1.0_fat/configs/server_introspect_oidc_derby.xml
@@ -39,6 +39,9 @@
 			<server
 				host="${ldap.server.4.name}"
 				port="${ldap.server.4.ssl.port}" />
+			<server
+				host="${ldap.server.7.name}"
+				port="${ldap.server.7.ssl.port}" />
 		</failoverServers>
 	</ldapRegistry>
 

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.shibboleth/configs/server_orig.xml
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.shibboleth/configs/server_orig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -43,6 +43,9 @@
 			<server
 				host="${ldap.server.4.name}"
 				port="${ldap.server.4.port}" />
+			<server
+				host="${ldap.server.7.name}"
+				port="${ldap.server.7.port}" />
 		</failoverServers>
 	</ldapRegistry>
 

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.shibboleth/configs/server_samesite.xml
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.shibboleth/configs/server_samesite.xml
@@ -43,6 +43,9 @@
 			<server
 				host="${ldap.server.4.name}"
 				port="${ldap.server.4.port}" />
+			<server
+				host="${ldap.server.7.name}"
+				port="${ldap.server.7.port}" />
 		</failoverServers>
 	</ldapRegistry>
 


### PR DESCRIPTION
We've seen some communication issues using ldap4 and ldap8 during testing.  In the latest case (at least), ldap4 and ldap8 were set to the same ldap server.  This doesn't do much for failover.  I'm looking into how many ldap servers of this type we have, but, so far, it looks like only 2.  ldap4 and ldap8 are getting set to the same server, while ldap7 is set to another server.
I'm going to add ldap7 to the list of failover servers, so, this should give us a better chance of failing over.