### PR TITLE
Mark SPI update as beta

### DIFF
--- a/dev/com.ibm.ws.cdi.extension_fat/publish/servers/cdi12SPIConstructorExceptionExtensionServer/jvm.options
+++ b/dev/com.ibm.ws.cdi.extension_fat/publish/servers/cdi12SPIConstructorExceptionExtensionServer/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/com.ibm.ws.cdi.extension_fat/publish/servers/cdi12SPIExtensionServer/jvm.options
+++ b/dev/com.ibm.ws.cdi.extension_fat/publish/servers/cdi12SPIExtensionServer/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/com.ibm.ws.cdi.interfaces/src/io/openliberty/cdi/spi/CDIExtensionMetadata.java
+++ b/dev/com.ibm.ws.cdi.interfaces/src/io/openliberty/cdi/spi/CDIExtensionMetadata.java
@@ -76,6 +76,7 @@ public interface CDIExtensionMetadata {
      * performs annotation scanning during application startup.
      * All classes must be in the same archive as your CDIExtensionMetadata.
      */
+    @Deprecated//This method is currently beta, if you override this default you must include beta guards
     default public Set<Class<? extends Annotation>> getBeanDefiningAnnotationClasses() {
         return Collections.emptySet();
     }

--- a/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/CDIContainerImpl.java
+++ b/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/CDIContainerImpl.java
@@ -628,6 +628,8 @@ public class CDIContainerImpl implements CDIContainer, InjectionMetaDataListener
         return this.probeExtensionArchive;
     }
 
+    private static boolean issuedBetaMessage = false;
+
     private ExtensionArchive newSPIExtensionArchive(ServiceReference<CDIExtensionMetadata> sr,
                                                     CDIExtensionMetadata webSphereCDIExtensionMetaData, WebSphereCDIDeployment applicationContext) throws CDIException {
         Bundle bundle = sr.getBundle();
@@ -635,6 +637,15 @@ public class CDIContainerImpl implements CDIContainer, InjectionMetaDataListener
         Set<Class<? extends Extension>> extensionClasses = webSphereCDIExtensionMetaData.getExtensions();
         Set<Class<?>> beanClasses = webSphereCDIExtensionMetaData.getBeanClasses();
         Set<Class<? extends Annotation>> beanDefiningAnnotationClasses = webSphereCDIExtensionMetaData.getBeanDefiningAnnotationClasses();
+
+        if (! beanDefiningAnnotationClasses.isEmpty()) {
+            if (! com.ibm.ws.kernel.productinfo.ProductInfo.getBetaEdition()) {
+                throw new UnsupportedOperationException("This method is beta and is not available.");
+            } else if (!issuedBetaMessage) {
+                Tr.info(tc, "BETA: A beta method getBeanDefiningAnnotationClasses has been invoked for the class " + this.getClass().getName() + " for the first time.");
+                issuedBetaMessage = true;
+            }
+        }
 
         for (Iterator<Class<? extends Extension>> i = extensionClasses.iterator(); i.hasNext();) {
             Class extensionClass = i.next();
@@ -656,6 +667,7 @@ public class CDIContainerImpl implements CDIContainer, InjectionMetaDataListener
 
         Set<String> extra_classes = beanClasses.stream().map(clazz -> clazz.getCanonicalName()).collect(Collectors.toSet());
         Set<String> extraAnnotations = beanDefiningAnnotationClasses.stream().map(clazz -> clazz.getCanonicalName()).collect(Collectors.toSet());
+
         //The simpler SPI does not offer these properties.
         boolean applicationBDAsVisible = false;
         boolean extClassesOnly = false;


### PR DESCRIPTION
Marks the new SPI method for bean defining annotations as beta as more FAT tests are needed. 