### PR TITLE
update the restfulWS-3.0 feature to use the CDIExtensionMetadata to enable CDI

### DIFF
--- a/dev/io.openliberty.org.jboss.resteasy.server/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.server/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -20,7 +20,7 @@ src: src, resources
 -cdiannotations:
 
 -dsannotations: \
-  io.openliberty.org.jboss.resteasy.common.component.LibertyResteasyCdiExtension, \
+  io.openliberty.org.jboss.resteasy.common.component.ResteasyCDIExtensionMetadata, \
   io.openliberty.org.jboss.resteasy.common.component.ResteasyInjectionClassListCollaborator
 -dsannotations-inherit: true
 
@@ -110,7 +110,6 @@ Include-Resource:\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	io.openliberty.org.jboss.resteasy.common,\
 	javax.activation:activation;version=1.1,\
-	
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file,\

--- a/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/component/LibertyResteasyCdiExtension.java
+++ b/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/component/LibertyResteasyCdiExtension.java
@@ -22,7 +22,6 @@ import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.Extension;
 import javax.enterprise.inject.spi.ProcessAnnotatedType;
 import javax.enterprise.inject.spi.WithAnnotations;
-import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.ext.Provider;
@@ -30,31 +29,8 @@ import javax.ws.rs.ext.Provider;
 import org.jboss.resteasy.cdi.ResteasyCdiExtension;
 import org.jboss.resteasy.cdi.i18n.LogMessages;
 import org.jboss.resteasy.cdi.i18n.Messages;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
-import org.osgi.service.component.annotations.Reference;
 
-import com.ibm.ws.cdi.CDIService;
-import com.ibm.ws.cdi.extension.WebSphereCDIExtension;
-
-import io.openliberty.org.jboss.resteasy.common.cdi.LibertyCdiInjectorFactory;
-
-@Component(service = WebSphereCDIExtension.class,
-    configurationPolicy = ConfigurationPolicy.IGNORE,
-    immediate = true,
-    property = { "api.classes=" +
-                "jakarta.ws.rs.Path;" +
-                "jakarta.ws.rs.core.Application;" +
-                "jakarta.ws.rs.ext.Provider",
-             "bean.defining.annotations=" +
-                "jakarta.ws.rs.Path;" +
-                "jakarta.ws.rs.core.Application;" +
-                "jakarta.ws.rs.ApplicationPath;" +
-                "jakarta.ws.rs.ext.Provider;" +
-                "jakarta.annotation.ManagedBean",
-             "service.vendor=IBM" })
-
-public class LibertyResteasyCdiExtension extends ResteasyCdiExtension implements Extension, WebSphereCDIExtension {
+public class LibertyResteasyCdiExtension extends ResteasyCdiExtension implements Extension {
 
     private static final String JAVAX_EJB_STATELESS = "javax.ejb.Stateless";
     private static final String JAVAX_EJB_SINGLETON = "javax.ejb.Singleton";
@@ -161,14 +137,5 @@ public class LibertyResteasyCdiExtension extends ResteasyCdiExtension implements
           return true;
        }
        return Modifier.isPrivate(constructor.getModifiers());
-    }
-
-    @Reference
-    protected void setCdiService(CDIService cdiService) {
-        LibertyCdiInjectorFactory.cdiService = cdiService;
-    }
-
-    protected void unsetCdiService(CDIService cdiService) {
-        LibertyCdiInjectorFactory.cdiService = null;
     }
 }

--- a/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/component/ResteasyCDIExtensionMetadata.java
+++ b/dev/io.openliberty.org.jboss.resteasy.server/src/io/openliberty/org/jboss/resteasy/common/component/ResteasyCDIExtensionMetadata.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,44 +10,57 @@
  *******************************************************************************/
 package io.openliberty.org.jboss.resteasy.common.component;
 
+import java.lang.annotation.Annotation;
 import java.util.HashSet;
 import java.util.Set;
 
 import javax.enterprise.inject.spi.Extension;
 
-import org.jboss.resteasy.cdi.ResteasyCdiExtension;
-
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+
+import com.ibm.ws.cdi.CDIService;
 
 import io.openliberty.cdi.spi.CDIExtensionMetadata;
+import io.openliberty.org.jboss.resteasy.common.cdi.LibertyCdiInjectorFactory;
 
 @Component(service = CDIExtensionMetadata.class,
     configurationPolicy = ConfigurationPolicy.IGNORE,
     immediate = true,
-    property = { "api.classes=" +
-                    "javax.ws.rs.Path;" +
-                    "javax.ws.rs.core.Application;" +
-                    "javax.ws.rs.ext.Provider",
-                 "bean.defining.annotations=" +
-                    "javax.ws.rs.Path;" +
-                    "javax.ws.rs.core.Application;" +
-                    "javax.ws.rs.ApplicationPath;" +
-                    "javax.ws.rs.ext.Provider",
-                 "service.vendor=IBM" })
+    property = { "service.vendor=IBM" })
 public class ResteasyCDIExtensionMetadata implements CDIExtensionMetadata {
-    
-    // TODO
-    // This class is currently "unhooked", meaning that it is not listed in -dsannotations in the bnd file.
-    // This is because the CDIExtensionMetadata SPI doesn't currently support bean.defining.annotations.
-    // Until bean.defining.annotations is supported, we have to use the "old" WebSphereCDIExtension API.
-    // When bean.defining.annotations is suppoerted, we will need to delete LibertyResteasyCdiExtension
-    // and replace it's -dsannotations with this class in the bnd file (and delete this comment).
-    
+
+    @Override
+    public Set<Class<?>> getBeanClasses() {
+        Set<Class<?>> classes = new HashSet<Class<?>>();
+        classes.add(javax.ws.rs.core.Application.class);
+        return classes;
+    }
+
+    @Override
+    public Set<Class<? extends Annotation>> getBeanDefiningAnnotationClasses() {
+        Set<Class<? extends Annotation>> classes = new HashSet<Class<? extends Annotation>>();
+        classes.add(javax.ws.rs.ApplicationPath.class);
+        classes.add(javax.ws.rs.Path.class);
+        classes.add(javax.ws.rs.ext.Provider.class);
+        classes.add(javax.annotation.ManagedBean.class);
+        return classes;
+    }
+
     @Override
     public Set<Class<? extends Extension>> getExtensions() {
         Set<Class<? extends Extension>> extensions = new HashSet<Class<? extends Extension>>();
-        extensions.add(ResteasyCdiExtension.class);
+        extensions.add(LibertyResteasyCdiExtension.class);
         return extensions;
+    }
+
+    @Reference
+    protected void setCdiService(CDIService cdiService) {
+        LibertyCdiInjectorFactory.cdiService = cdiService;
+    }
+
+    protected void unsetCdiService(CDIService cdiService) {
+        LibertyCdiInjectorFactory.cdiService = null;
     }
 }


### PR DESCRIPTION
I'm switching the `restfulWS-3.0` feature from using the old `WebSphereCDIExtension` SPI to the new `CDIExtensionMetadata` SPI to integrate with CDI.