### PR TITLE
clean up jaxrs test by removing unused SSL context that can be confusing

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/test-applications/complexclient/src/com/ibm/ws/jaxrs20/client/ComplexClientTest/client/ClientTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/test-applications/complexclient/src/com/ibm/ws/jaxrs20/client/ComplexClientTest/client/ClientTestServlet.java
@@ -193,7 +193,6 @@ public class ClientTestServlet extends HttpServlet {
     }
 
     public void testNewClientSslContext(Map<String, String> param, StringBuilder ret) throws NoSuchAlgorithmException {
-        SSLContext.getInstance("SSL");
         SSLContext ssl = SSLContext.getDefault();
         ClientBuilder cb = ClientBuilder.newBuilder().sslContext(ssl);
         Client c = cb.build();


### PR DESCRIPTION
A user was confused by this unused line in our FAT tests, so I'm removing to avoid future confusion.