### PR TITLE
Add --add-opens for JDBC DB2 FAT for Java 16

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/SQLJTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_db2/fat/src/com/ibm/ws/jdbc/fat/db2/SQLJTest.java
@@ -378,6 +378,7 @@ public class SQLJTest extends FATServletClient {
             args.add("--add-opens=java.base/java.util.jar=ALL-UNNAMED");
             args.add("--add-opens=java.base/jdk.internal.util.jar=ALL-UNNAMED");
             args.add("--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED");
+            args.add("--add-opens=java.base/java.security=ALL-UNNAMED");
         }
         args.add("com.ibm.db2.jcc.sqlj.Customizer");
         args.add("-url");


### PR DESCRIPTION
Fixes a Java 16 permissions error by adding `--add-opens` to the needed package.