### PR TITLE
Add --illegal-access=permit for JDBC Kerberos FAT for Java 16

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/DB2KerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/DB2KerberosTest.java
@@ -40,6 +40,7 @@ import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import jdbc.krb5.db2.web.DB2KerberosTestServlet;
@@ -82,6 +83,10 @@ public class DB2KerberosTest extends FATServletClient {
         List<String> jvmOpts = new ArrayList<>();
         jvmOpts.add("-Dsun.security.krb5.debug=true"); // Hotspot/OpenJ9
         jvmOpts.add("-Dcom.ibm.security.krb5.krb5Debug=true"); // IBM JDK
+
+        if (JavaInfo.JAVA_VERSION >= 9) {
+            jvmOpts.add("--illegal-access=permit"); // Java 16 JEPS 396
+        }
         server.setJvmOptions(jvmOpts);
 
         server.startServer();

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/ErrorPathTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/ErrorPathTest.java
@@ -35,6 +35,7 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
@@ -75,6 +76,10 @@ public class ErrorPathTest extends FATServletClient {
         List<String> jvmOpts = new ArrayList<>();
         jvmOpts.add("-Dsun.security.krb5.debug=true"); // Hotspot/OpenJ9
         jvmOpts.add("-Dcom.ibm.security.krb5.krb5Debug=true"); // IBM JDK
+
+        if (JavaInfo.JAVA_VERSION >= 9) {
+            jvmOpts.add("--illegal-access=permit"); // Java 16 JEPS 396
+        }
         server.setJvmOptions(jvmOpts);
 
         server.startServer();

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/OracleKerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/OracleKerberosTest.java
@@ -83,6 +83,10 @@ public class OracleKerberosTest extends FATServletClient {
         jvmOpts.add("-Dsun.security.krb5.debug=true"); // Hotspot/OpenJ9
         jvmOpts.add("-Dsun.security.jgss.debug=true");
         jvmOpts.add("-Dcom.ibm.security.krb5.krb5Debug=true"); // IBM JDK
+
+        if (JavaInfo.JAVA_VERSION >= 9) {
+            jvmOpts.add("--illegal-access=permit"); // Java 16 JEPS 396
+        }
         server.setJvmOptions(jvmOpts);
 
         server.startServer();

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/PostgresKerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/PostgresKerberosTest.java
@@ -30,6 +30,7 @@ import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import jdbc.krb5.pg.web.PgKerberosTestServlet;
@@ -76,6 +77,10 @@ public class PostgresKerberosTest extends FATServletClient {
         List<String> jvmOpts = new ArrayList<>();
         jvmOpts.add("-Dsun.security.krb5.debug=true"); // Hotspot/OpenJ9
         jvmOpts.add("-Dcom.ibm.security.krb5.krb5Debug=true"); // IBM JDK
+
+        if (JavaInfo.JAVA_VERSION >= 9) {
+            jvmOpts.add("--illegal-access=permit"); // Java 16 JEPS 396
+        }
         server.setJvmOptions(jvmOpts);
 
         server.startServer();


### PR DESCRIPTION
Fixes Java 16 permission errors by adding `--illegal-access=permit` to the needed package.