### PR TITLE
Keep separate track of prime (root) feature conflicts

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/FeatureResolverImpl.java
@@ -162,8 +162,8 @@ public class FeatureResolverImpl implements FeatureResolver {
             }
             resolved = doResolveFeatures(rootFeatures, preResolved, selectionContext);
         } while (!!!(autoFeaturesToInstall = processAutoFeatures(kernelFeatures, resolved, seenAutoFeatures, selectionContext)).isEmpty());
-        // Finally return the selected result
-        return selectionContext.getResult();
+        // Finalize the result and finally return the selected result
+        return selectionContext.finalizeResult();
     }
 
     private List<String> checkRootsAreAccessibleAndSetFullName(List<String> rootFeatures, SelectionContext selectionContext, Set<String> preResolved) {
@@ -611,6 +611,7 @@ public class FeatureResolverImpl implements FeatureResolver {
         private final AtomicInteger _initialBlockedCount = new AtomicInteger(-1);
         private final Map<String, Collection<Chain>> _preResolveConflicts = new HashMap<String, Collection<Chain>>();
         private Permutation _current = _permutations.getFirst();
+        private final Map<String, Collection<Chain>> _primeConflicts = new HashMap<String, Collection<Chain>>();
 
         SelectionContext(FeatureResolver.Repository repository, boolean allowMultipleVersions, EnumSet<ProcessType> supportedProcessTypes) {
             this._repository = repository;
@@ -820,7 +821,7 @@ public class FeatureResolverImpl implements FeatureResolver {
                         if (features.contains(selectedFeature)) {
                             Chain conflictedFeatureChain = new Chain(Collections.<String> emptyList(), Collections.singletonList(featureSymbolicName), preferredVersion,
                                                                      featureSymbolicName);
-                            addConflict(base, new ArrayList<Chain>(Arrays.asList(selectedChain, conflictedFeatureChain)));
+                            addPrimeConflict(base, new ArrayList<Chain>(Arrays.asList(selectedChain, conflictedFeatureChain)));
                             conflicts.put(selectedFeature, base);
                         }
                     } else {
@@ -853,6 +854,23 @@ public class FeatureResolverImpl implements FeatureResolver {
         void addConflict(String baseFeatureName, List<Chain> conflicts) {
             _current._blockedFeatures.add(baseFeatureName);
             _current._result.addConflict0(baseFeatureName, conflicts);
+        }
+
+        void addPrimeConflict(String baseFeatureName, List<Chain> conflicts) {
+            trace("Found a conflict for root (prime) feature: \"" + baseFeatureName + "\" with conficts: " + conflicts);
+            _primeConflicts.put(baseFeatureName, conflicts);
+        }
+
+        Result finalizeResult() {
+            // be sure there is at least one conflict reported conflicts of the prime (root) features
+            Map<String, Collection<Chain>> conflicts = _current._result.getConflicts();
+            for (Map.Entry<String, Collection<Chain>> primeConflict : _primeConflicts.entrySet()) {
+                if (!conflicts.containsKey(primeConflict.getKey())) {
+                    conflicts.put(primeConflict.getKey(), primeConflict.getValue());
+
+                }
+            }
+            return _current._result;
         }
     }
 

--- a/dev/com.ibm.ws.kernel.feature/test/com/ibm/ws/kernel/feature/internal/FeatureResolverTest.java
+++ b/dev/com.ibm.ws.kernel.feature/test/com/ibm/ws/kernel/feature/internal/FeatureResolverTest.java
@@ -221,7 +221,7 @@ public class FeatureResolverTest {
     @Test
     public void testRootConflictWithOtherFeature() {
         Result result = resolver.resolveFeatures(repository, noKernelFeatures, Arrays.asList("t1.a-1.0", "t1.a-1.1", "t1.b-1.0"), Collections.<String> emptySet(), false);
-        Set<String> expected = new HashSet<String>(Arrays.asList("t1.b-1.0"));
+        Set<String> expected = new HashSet<String>(Arrays.asList("t1.a-1.0", "t1.b-1.0"));
         Assert.assertEquals("Wrong results found.", new TreeSet<String>(expected), new TreeSet<String>(result.getResolvedFeatures()));
         Assert.assertEquals("Unexpected missing.", Collections.emptySet(), result.getMissing());
         checkConflict(result.getConflicts(), "t1.a");
@@ -398,6 +398,20 @@ public class FeatureResolverTest {
         Assert.assertEquals("Unexpected missing.", Collections.emptySet(), result.getMissing());
         checkConflict(result.getConflicts(), "t7.h", ROOT, "t7.l-1.0");
         checkConflict(result.getConflicts(), "t7.i", "t7.c-1.0", "t7.m-1.0");
+    }
+
+    @Test
+    public void testComplicatedPreferenceWithHardConflictAndRootConflict() {
+        Result result = resolver.resolveFeatures(repository, noKernelFeatures, Arrays.asList("t7.a-1.0", "t7.b-1.0", "t7.h-1.0", "t7.p-1.0", "t7.p-2.0"),
+                                                 Collections.<String> emptySet(),
+                                                 false);
+        Set<String> expected = new HashSet<String>(Arrays.asList("t7.a-1.0", "t7.b-1.0", "t7.c-1.0", "t7.d-2.0", "t7.f-1.0", "t7.g-1.0",
+                                                                 "t7.j-2.0", "t7.k-2.0", "t7.l-1.0", "t7.m-1.0", "t7.n-1.0", "t7.o-1.0"));
+        Assert.assertEquals("Wrong results found.", new TreeSet<String>(expected), new TreeSet<String>(result.getResolvedFeatures()));
+        Assert.assertEquals("Unexpected missing.", Collections.emptySet(), result.getMissing());
+        checkConflict(result.getConflicts(), "t7.h", ROOT, "t7.l-1.0");
+        checkConflict(result.getConflicts(), "t7.i", "t7.c-1.0", "t7.m-1.0");
+        checkConflict(result.getConflicts(), "t7.p");
     }
 
     @Test

--- a/dev/com.ibm.ws.kernel.feature/test/resolverData/lib/features/t7.p-2.0.mf
+++ b/dev/com.ibm.ws.kernel.feature/test/resolverData/lib/features/t7.p-2.0.mf
@@ -1,0 +1,3 @@
+Subsystem-SymbolicName: t7.p-2.0; visibility:=public; singleton:=true
+Subsystem-Version: 1.0
+Subsystem-Type: osgi.subsystem.feature


### PR DESCRIPTION
Prime conflicts are ones that are direct conflicts from the initial set
of root features.  The resolver has always removed such conflicts from
the initial set of root features but would also block the feature from
resolving if it was pulled in from a transitive dependency.

This causes a miscalculation in the initial blocked features from the
first pass over the configured features.  The blocked prime features
added to the initial count which then later would cause a miscalculation
for what additional permutations to try.  This ultimately causes what
appears to be an endless retry of new permutations.

The solution is to instead track the prime conflicts separately.  There
is no choice that can be made that would solve these types of conflicts
so they should not contribute to the initial block count that we use as
the bar for letting in new permutations to try.
