### PR TITLE
WS-AT Conduit Initiator conflict with JAX-RS

### DIFF
--- a/dev/com.ibm.ws.wsat.common/bnd.bnd
+++ b/dev/com.ibm.ws.wsat.common/bnd.bnd
@@ -10,7 +10,8 @@ IBM-Default-Config: OSGI-INF/wlp/defaultInstances.xml
 WS-TraceGroup: WSAT
 
 Import-Package: \
-  javax.xml.ws.*;version=!,\
+  javax.xml.ws.*;version="[2.2,3)", \
+  org.apache.cxf.*;version="[2.6.2,2.6.3)", \
   *
 
 Export-Package: \


### PR DESCRIPTION
This fix limits the CXF version the `com.ibm.ws.wsat.common` bundle can use to match what is currently in use by jaxws-2.2. 