### PR TITLE
Add call to setMarkToEndOfLogs at start of config update 

### DIFF
--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/SameSiteTestTools.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/SameSiteTestTools.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -90,6 +90,12 @@ public class SameSiteTestTools {
     public void updateServerSettings(TestServer server, Map<String, String> valuesToSet) throws Exception {
 
         String thisMethod = "updateServerSettings";
+
+        // update the mark so that we look for the config update message only in the latest log entries
+        // we had cases where we were finding the config update complete message from the previous config
+        // we made requests using the old config (the new one wasn't ready) and were getting bad results.
+        server.setMarkToEndOfLogs();
+
         ServerConfiguration config = server.getServer().getServerConfiguration();
         ConfigElementList<Variable> configVars = config.getVariables();
 


### PR DESCRIPTION
The samesite tests use combinations of multiple settings.  Each test sets some primary config attributes and then will run a bunch of "sub" tests that reconfig other attrs and make requests.
We recently hit an issue where occasionally the wait for the "config update completed" found the message from the previous reconfig instead of the message for the just requested reconfig.  Because of this, the test made it's next request before the config that it was expecting to use was in place.  The test didn't get the behavior that it expected and the case fails.
I'm adding a call to server.setMarkToEndOfLogs() to move the mark to the end of each log.  That causes waitForConfigUpdateInLogUsingMark to search for the "config update completed" starting at point in the log right before the latest reconfig.  We'll only find the final update message.
