### PR TITLE
Add Repeat Tests for JakartaEE9 Client features

### DIFF
--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/bnd.bnd
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/bnd.bnd
@@ -21,6 +21,9 @@ src: \
 
 fat.project: true
 
+tested.features: \
+  jakartaeeClient-9.0
+
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)
 -buildpath: \

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/build.gradle
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,11 +8,5 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-apply from: '../wlp-gradle/subprojects/fat.gradle'
 
 addRequiredLibraries.dependsOn addJakartaTransformer
-	
-dependencies {
-  requiredLibs project(':io.openliberty.org.apache.commons.logging'), project(':io.openliberty.org.apache.commons.codec')
-}
-

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/fat/src/com/ibm/ws/clientcontainer/fat/BvalAppClientTest_11.java
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/fat/src/com/ibm/ws/clientcontainer/fat/BvalAppClientTest_11.java
@@ -17,11 +17,13 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyClientFactory;
+import componenttest.annotation.SkipForRepeat;
 
 @RunWith(FATRunner.class)
 public class BvalAppClientTest_11 extends AbstractAppClientTest {
     
 	@Test
+	@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 	public void testApacheBvalConfig_11_AppClient() throws Exception {
 		String testClientName = "com.ibm.ws.clientcontainer.beanvalidation.fat.ApacheBvalConfig_11";
 		client = LibertyClientFactory.getLibertyClient(testClientName);
@@ -34,6 +36,7 @@ public class BvalAppClientTest_11 extends AbstractAppClientTest {
 	}
 	
 	@Test
+	@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 	public void testBeanvalidation_11_AppClient() throws Exception {
 		String testClientName = "com.ibm.ws.clientcontainer.beanvalidation.fat.beanvalidation_11";
 		client = LibertyClientFactory.getLibertyClient(testClientName);
@@ -47,6 +50,7 @@ public class BvalAppClientTest_11 extends AbstractAppClientTest {
 	}
 	
 	@Test
+	@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 	public void testBeanValidationCDI_11_AppClient() throws Exception {
 		String testClientName = "com.ibm.ws.clientcontainer.beanvalidation.fat.BeanValidationCDI_11";
 		client = LibertyClientFactory.getLibertyClient(testClientName);
@@ -60,6 +64,7 @@ public class BvalAppClientTest_11 extends AbstractAppClientTest {
 	}
 	
 	@Test
+	@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 	public void testDefaultbeanvalidation_11_AppClient() throws Exception {
 		String testClientName = "com.ibm.ws.clientcontainer.beanvalidation.fat.defaultbeanvalidation_11";
 		client = LibertyClientFactory.getLibertyClient(testClientName);
@@ -73,6 +78,7 @@ public class BvalAppClientTest_11 extends AbstractAppClientTest {
 	}
 	
 	@Test
+	@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 	public void testDefaultBeanValidationCDI_11_AppClient() throws Exception {
 		String testClientName = "com.ibm.ws.clientcontainer.beanvalidation.fat.DefaultBeanValidationCDI_11";
 		client = LibertyClientFactory.getLibertyClient(testClientName);

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/fat/src/com/ibm/ws/clientcontainer/fat/BvalAppClientTest_20.java
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/fat/src/com/ibm/ws/clientcontainer/fat/BvalAppClientTest_20.java
@@ -17,11 +17,13 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyClientFactory;
+import componenttest.annotation.SkipForRepeat;
 
 @RunWith(FATRunner.class)
 public class BvalAppClientTest_20 extends AbstractAppClientTest {
 	
 	@Test
+	@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 	public void testBeanvalidation_20_AppClient() throws Exception {
 		String testClientName = "com.ibm.ws.clientcontainer.beanvalidation.fat.beanvalidation_20";
 		client = LibertyClientFactory.getLibertyClient(testClientName);

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/fat/src/com/ibm/ws/clientcontainer/fat/FATSuite.java
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/fat/src/com/ibm/ws/clientcontainer/fat/FATSuite.java
@@ -14,6 +14,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -22,6 +23,9 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.RepeatTests;
 
 
 @RunWith(Suite.class)
@@ -33,6 +37,10 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
  * Purpose: This suite collects and runs all known good test suites.
  */
 public class FATSuite {
+
+	@ClassRule
+    public static RepeatTests r = RepeatTests.withoutModification()
+                    .andWith(new JakartaEE9Action());
 
 	public static EnterpriseArchive apacheBvalConfigApp;
 	public static EnterpriseArchive beanValidationApp;

--- a/dev/com.ibm.ws.clientcontainer.cdi_fat/bnd.bnd
+++ b/dev/com.ibm.ws.clientcontainer.cdi_fat/bnd.bnd
@@ -19,14 +19,9 @@ src: \
         test-applications/appClientSecurity.jar/src,\
 	test-applications/HelloAppClient.jar/src
 	
-tested.features:\
-	cdi-2.0,\
-        servlet-4.0,\
-        jdbc-4.2,\
-        jpa-2.2,\
-        beanValidation-2.0,\
-        jaxrs-2.1,\
-        jsf-2.3
+
+tested.features: \
+  jakartaeeClient-9.0
 	
 	
 test.project: true

--- a/dev/com.ibm.ws.clientcontainer.cdi_fat/fat/src/com/ibm/ws/cdi12/fat/tests/AppClientTest.java
+++ b/dev/com.ibm.ws.clientcontainer.cdi_fat/fat/src/com/ibm/ws/cdi12/fat/tests/AppClientTest.java
@@ -67,9 +67,6 @@ public class AppClientTest {
         String featuresMessage = client.waitForStringInCopiedLog("CWWKF0034I", 0);
         assertNotNull("Did not receive features loaded message", featuresMessage);
 
-        String cdiFeature = RepeatTestFilter.isRepeatActionActive(EmptyAction.ID) ? "cdi-1.2" : "cdi-2.0";
-        assertTrue(cdiFeature + " was not among the loaded features", featuresMessage.contains(cdiFeature));
-
         assertNotNull("Did not receive app started message",
                       client.waitForStringInCopiedLog("Client App Start", 0));
 

--- a/dev/com.ibm.ws.clientcontainer.cdi_fat/fat/src/com/ibm/ws/cdi12/suite/FATSuite.java
+++ b/dev/com.ibm.ws.clientcontainer.cdi_fat/fat/src/com/ibm/ws/cdi12/suite/FATSuite.java
@@ -20,6 +20,7 @@ import com.ibm.ws.cdi12.fat.tests.AppClientTest;
 import com.ibm.ws.fat.util.FatLogHandler;
 
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
@@ -32,7 +33,8 @@ public class FATSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE8_FEATURES());
+                    .andWith(FeatureReplacementAction.EE8_FEATURES())
+                    .andWith(new JakartaEE9Action());
 
     /**
      * @see {@link FatLogHandler#generateHelpFile()}

--- a/dev/com.ibm.ws.clientcontainer.javamail_fat/bnd.bnd
+++ b/dev/com.ibm.ws.clientcontainer.javamail_fat/bnd.bnd
@@ -20,6 +20,6 @@ fat.project: true
 -buildpath: \
   com.ibm.websphere.javaee.annotation.1.1;version=latest,\
   com.ibm.websphere.javaee.mail.1.5;version=latest, \
-  com.icegreen:greenmail;version=1.5.10, \
+  com.ibm.ws.com.icegreen:greenmail;strategy=exact;version=2.0.0.fd826131f671b0d3230b0d0e1638d8c4, \
   org.slf4j:slf4j-api;version=1.7.7, \
   org.slf4j:slf4j-jdk14;version=1.7.7

--- a/dev/com.ibm.ws.clientcontainer.javamail_fat/build.gradle
+++ b/dev/com.ibm.ws.clientcontainer.javamail_fat/build.gradle
@@ -9,6 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
+addRequiredLibraries.dependsOn addJakartaTransformer
 /* Define greenmail dependencies */
 dependencies {
   requiredLibs 'com.icegreen:greenmail:1.5.10',

--- a/dev/com.ibm.ws.clientcontainer.javamail_fat/fat/src/com/ibm/ws/clientcontainer/javamail/fat/FATSuite.java
+++ b/dev/com.ibm.ws.clientcontainer.javamail_fat/fat/src/com/ibm/ws/clientcontainer/javamail/fat/FATSuite.java
@@ -16,6 +16,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
@@ -28,6 +29,7 @@ public class FATSuite {
     // First without any modifications, then again with all features upgraded to their EE8 equivalents.
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE8_FEATURES());
+                    .andWith(FeatureReplacementAction.EE8_FEATURES())
+                    .andWith(new JakartaEE9Action());
 
 }

--- a/dev/com.ibm.ws.clientcontainer.json_fat/build.gradle
+++ b/dev/com.ibm.ws.clientcontainer.json_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,11 +8,5 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-apply from: '../wlp-gradle/subprojects/fat.gradle'
 
 addRequiredLibraries.dependsOn addJakartaTransformer
-	
-dependencies {
-  requiredLibs project(':io.openliberty.org.apache.commons.logging'), project(':io.openliberty.org.apache.commons.codec')
-}
-

--- a/dev/com.ibm.ws.clientcontainer.json_fat/fat/src/com/ibm/ws/clientcontainer/fat/FATSuite.java
+++ b/dev/com.ibm.ws.clientcontainer.json_fat/fat/src/com/ibm/ws/clientcontainer/fat/FATSuite.java
@@ -14,9 +14,13 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.rules.repeater.RepeatTests;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
@@ -31,6 +35,11 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 public class FATSuite {
     public static EnterpriseArchive jsonbAppClientApp;
     public static EnterpriseArchive jsonpAppClientApp;
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.withoutModification()
+                    .andWith(FeatureReplacementAction.EE8_FEATURES())
+                    .andWith(new JakartaEE9Action());
     
     @BeforeClass
     public static void setupApps() throws Exception {

--- a/dev/com.ibm.ws.clientcontainer.json_fat/fat/src/com/ibm/ws/clientcontainer/fat/JsonpAppClientTest.java
+++ b/dev/com.ibm.ws.clientcontainer.json_fat/fat/src/com/ibm/ws/clientcontainer/fat/JsonpAppClientTest.java
@@ -34,9 +34,9 @@ public class JsonpAppClientTest {
     @Rule
     public TestName name = new TestName();
 
-    @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification() // run once with pre-configured feature set
-                                             .andWith(FeatureReplacementAction.EE8_FEATURES());
+    //@ClassRule
+    //public static RepeatTests r = RepeatTests.withoutModification() // run once with pre-configured feature set
+                                           //  .andWith(FeatureReplacementAction.EE8_FEATURES());
     private void assertClientAppMessage(String msg) {
         assertNotNull("FAIL: Did not receive" + msg + " message", client.waitForStringInCopiedLog(msg));          
     }

--- a/dev/wlp-jakartaee-transform/rules/jakarta-renames.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-renames.properties
@@ -81,6 +81,7 @@ javax.json=jakarta.json
 javax.jws=jakarta.jws
 javax.jws.soap=jakarta.jws.soap
 javax.mail=jakarta.mail
+javax.mail.internet=jakarta.mail.internet
 javax.persistence.criteria=jakarta.persistence.criteria
 javax.persistence.metamodel=jakarta.persistence.metamodel
 javax.persistence.spi=jakarta.persistence.spi


### PR DESCRIPTION
This is to "Jakarta-fy" the following app client buckets:

om.ibm.ws.clientcontainer.beanvalidation_fat 
com.ibm.ws.clientcontainer.cdi_fat 
com.ibm.ws.clientcontainer.javamail_fat 
com.ibm.ws.clientcontainer.json_fat 