### PR TITLE
Fix test failure for RTC 282681. The test was calling the SSL endpoin…

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/AutoApplySessionTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/AutoApplySessionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -72,6 +72,11 @@ public class AutoApplySessionTest extends JavaEESecTestBase {
 
         urlBase = "http://" + myServer.getHostname() + ":" + myServer.getHttpDefaultPort();
         urlHttps = "https://" + myServer.getHostname() + ":" + myServer.getHttpDefaultSecurePort();
+
+        /*
+         * Wait for the SSL endpoint to start.
+         */
+        myServer.waitForStringInLog("CWWKO0219I");
     }
 
     @AfterClass


### PR DESCRIPTION
…t before it was available.
