### PR TITLE
Address Illegal Access issues on Java 16

### DIFF
--- a/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/RequestTimingEventTest.java
+++ b/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/RequestTimingEventTest.java
@@ -42,6 +42,7 @@ import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 
 /**
@@ -120,6 +121,13 @@ public class RequestTimingEventTest {
     @BeforeClass
     public static void setUp() throws Exception {
         ShrinkHelper.defaultApp(server, "RequestTimingWebApp", "com.ibm.ws.request.timing.app");
+
+        JavaInfo java = JavaInfo.forCurrentVM();
+        int javaMajorVersion = java.majorVersion();
+        if (javaMajorVersion != 8) {
+            Log.info(c, "setUp", " Java version = " + javaMajorVersion + " - It is higher than 8, adding --add-exports...");
+            server.copyFileToLibertyServerRoot("add-exports/jvm.options");
+        }
         server.startServer();
         setupTables();
     }

--- a/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/RequestTimingMbeanTest.java
+++ b/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/RequestTimingMbeanTest.java
@@ -90,10 +90,11 @@ public class RequestTimingMbeanTest {
     public static void setUp() throws Exception {
         ShrinkHelper.defaultDropinApp(server, "RequestTimingWebApp", "com.ibm.ws.request.timing.app");
 
-        // Fix for Java 16 Hotspot exception during java dump
         JavaInfo java = JavaInfo.forCurrentVM();
-        if (java.majorVersion() != 8) {
-            server.copyFileToLibertyServerRoot("illegalAccess/jvm.options");
+        int javaMajorVersion = java.majorVersion();
+        if (javaMajorVersion != 8) {
+            Log.info(c, "setUp", " Java version = " + javaMajorVersion + " - It is higher than 8, adding --add-exports...");
+            server.copyFileToLibertyServerRoot("add-exports/jvm.options");
         }
 
         server.startServer();
@@ -540,7 +541,7 @@ public class RequestTimingMbeanTest {
      * allow a test to finish
      *
      * @param countToWaitFor
-     *            Value looked for in CountDownLatch
+     *                           Value looked for in CountDownLatch
      * @throws Exception
      */
     private void waitInServletForCountDownLatch(int countToWaitFor) throws Exception {
@@ -614,13 +615,13 @@ public class RequestTimingMbeanTest {
      * test
      *
      * @param th
-     *            -- array of threads
+     *                            -- array of threads
      * @param numReqs
-     *            -- number of requests is the number of threads needed
+     *                            -- number of requests is the number of threads needed
      * @param servletTestName
-     *            -- Used for request to servlet
+     *                            -- Used for request to servlet
      * @param testMethodName
-     *            -- Used for printing to logs
+     *                            -- Used for printing to logs
      */
     private void createRequestThreads(Thread[] th, int numReqs) {
         // Send N servlet requests to server, last request used to terminate

--- a/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/RequestTimingMetricsTest.java
+++ b/dev/com.ibm.ws.request.timing.monitor_fat/fat/src/com/ibm/ws/request/timing/monitor/fat/RequestTimingMetricsTest.java
@@ -32,6 +32,7 @@ import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 
 /**
@@ -70,6 +71,14 @@ public class RequestTimingMetricsTest {
         ShrinkHelper.defaultDropinApp(server, "RequestTimingWebApp", "com.ibm.ws.request.timing.app");
         totalRequestCount = new AtomicInteger();
         activeServletRequest = 1;
+
+        JavaInfo java = JavaInfo.forCurrentVM();
+        int javaMajorVersion = java.majorVersion();
+        if (javaMajorVersion != 8) {
+            Log.info(c, "setUp", " Java version = " + javaMajorVersion + " - It is higher than 8, adding --add-exports...");
+            server.copyFileToLibertyServerRoot("add-exports/jvm.options");
+        }
+
         server.startServer();
 
         //Wait until server has started

--- a/dev/com.ibm.ws.request.timing.monitor_fat/publish/files/add-exports/jvm.options
+++ b/dev/com.ibm.ws.request.timing.monitor_fat/publish/files/add-exports/jvm.options
@@ -1,0 +1,5 @@
+# Temporary - Currently still in BETA. If we copy over, we'll override existing jvm.options which has the beta flag.
+-Dcom.ibm.ws.beta.edition=true
+# for dump action: com.ibm.ws.kernel.boot.internal.commands.HotSpotJavaDumperImpl$VirtualMachine.remoteDataDump(HotSpotJavaDumperImpl.java:342)
+--add-exports
+jdk.attach/sun.tools.attach=ALL-UNNAMED

--- a/dev/com.ibm.ws.request.timing.monitor_fat/publish/files/illegalAccess/jvm.options
+++ b/dev/com.ibm.ws.request.timing.monitor_fat/publish/files/illegalAccess/jvm.options
@@ -1,1 +1,0 @@
---illegal-access=permit


### PR DESCRIPTION
Fixes #17037 
The existing `dev/com.ibm.ws.request.timing.monitor_fat/publish/files/illegalAccess/jvm.options` which was only applicable to a single serve was removed in favour of the _add-exports_  strategy `dev/com.ibm.ws.request.timing.monitor_fat/publish/files/add-exports/jvm.options`. The original illegal access strategy would not be applicable in java 17 and up.
#build