### PR TITLE
Issue 17050: Updates for Ldap Kerberos Tests

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/SimpleBindTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/SimpleBindTest.java
@@ -123,6 +123,8 @@ public class SimpleBindTest extends CommonBindTest {
 
             ServerConfiguration newServer = emptyConfiguration.clone();
             LdapRegistry ldap = getLdapRegistryWithSimpleBind();
+            ldap.setBindDN(null);
+            ldap.setBindPassword(null);
             ldap.setBindAuthMechanism(ConfigConstants.CONFIG_AUTHENTICATION_TYPE_NONE);
             newServer.getLdapRegistries().add(ldap);
             updateConfigDynamically(server, newServer);
@@ -139,7 +141,7 @@ public class SimpleBindTest extends CommonBindTest {
     }
 
     /**
-     * Regression test. Do not set bindAuthMech and run tests with DirectoryService allowing anonymous bind.
+     * Regression test. Do not set bindAuthMech and run tests with/without DirectoryService allowing anonymous bind.
      *
      * @throws Exception
      */
@@ -156,7 +158,9 @@ public class SimpleBindTest extends CommonBindTest {
 
             ServerConfiguration newServer = emptyConfiguration.clone();
             LdapRegistry ldap = getLdapRegistryWithSimpleBind();
-            ldap.setBindAuthMechanism(ConfigConstants.CONFIG_AUTHENTICATION_TYPE_NONE);
+            ldap.setBindDN(null);
+            ldap.setBindPassword(null);
+            ldap.setBindAuthMechanism(null);
             newServer.getLdapRegistries().add(ldap);
             updateConfigDynamically(server, newServer);
 
@@ -167,6 +171,8 @@ public class SimpleBindTest extends CommonBindTest {
             ds.setAllowAnonymousAccess(false);
         }
 
+        Log.info(c, testName.getMethodName(), "Basic logins should fail with bindAuth=none, blocked by DirectoryService.");
+        loginUserShouldFail();
     }
 
     /**

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBindTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBindTest.java
@@ -259,7 +259,7 @@ public class TicketCacheBindTest extends CommonBindTest {
         newServer.getLdapRegistries().add(ldap);
         updateConfigDynamically(server, newServer);
 
-        bodySwapToKeytab(ldap, kerb);
+        bodySwapToKeytab(ldap, kerb, newServer);
     }
 
     /**
@@ -281,7 +281,7 @@ public class TicketCacheBindTest extends CommonBindTest {
         newServer.getLdapRegistries().add(ldap);
         updateConfigDynamically(server, newServer);
 
-        bodySwapToKeytab(ldap, kerb);
+        bodySwapToKeytab(ldap, kerb, newServer);
     }
 
     /**
@@ -291,21 +291,24 @@ public class TicketCacheBindTest extends CommonBindTest {
      * @param kerb
      * @throws Exception
      */
-    private void bodySwapToKeytab(LdapRegistry ldap, Kerberos kerb) throws Exception {
+    private void bodySwapToKeytab(LdapRegistry ldap, Kerberos kerb, ServerConfiguration newServer) throws Exception {
         loginUser();
 
         Log.info(c, testName.getMethodName(), "Add valid keytab, should be successful");
         kerb.keytab = keytabFile;
+        updateConfigDynamically(server, newServer);
 
         loginUser();
 
         Log.info(c, testName.getMethodName(), "Change the ticketCache to a bad config, login should be successful because we'll use the keytab");
         ldap.setKrb5TicketCache("badCache.cc");
+        updateConfigDynamically(server, newServer);
 
         loginUser();
 
         Log.info(c, testName.getMethodName(), "Remove the bad ticketCache, login should be successful because we'll use the keytab");
         ldap.setKrb5TicketCache(null);
+        updateConfigDynamically(server, newServer);
 
         loginUser();
     }


### PR DESCRIPTION
Fixes #17050 

Some SimpleBindTest weren't doing the correct bind config settings to match the test intention.

TicketCacheBindTest was missing some server updates after the config was changed.