### PR TITLE
Fix throughput performance problem in new cxf version

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.frontend.jaxrs.3.2/src/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
@@ -2175,7 +2175,7 @@ public final class JAXRSUtils {
             return parent;
         } else if (parent.endsWith("/")) {
             // Remove only last slash
-            return parent.replaceAll("/$", "") + child;
+            return parent.substring(0, parent.length() - 1) + child; //Liberty change
         } else {
             return parent + child;
         }


### PR DESCRIPTION
This fixes a 2% throughput drop due to the addition of org.apache.cxf.jaxrs.utils.JAXRSUtils.combineUriTemplates(String,String). The logic can be changed to eliminate the throughput regression by changing the String.replaceAll to String.substring since we are only removing the last character of the uri.