### PR TITLE
Add new featureManager attr package.server.conflict

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -106,6 +106,7 @@ File mavenDir = new File(project.buildDir, 'maven')
 class PackageLibertyWithFeatures extends DefaultTask {
     Closure withFeatures
     Boolean completeFeatureList
+    Boolean packageServerConflict
     File outputTo
 
     @TaskAction
@@ -126,7 +127,7 @@ class PackageLibertyWithFeatures extends DefaultTask {
             def serverXml = project.file("wlp/usr/servers/packageOpenLiberty/server.xml")
             serverXml.text = """<?xml version="1.0" encoding="UTF-8"?>
 <server description="new server">
-    <featureManager>${withFeatures()}
+    <featureManager package.server.conflict="${packageServerConflict}">${withFeatures()}
     </featureManager>
 </server>
 """
@@ -138,8 +139,6 @@ class PackageLibertyWithFeatures extends DefaultTask {
                 def args = ["package", "packageOpenLiberty", "--archive=${archive}", "--include=minify"]
                 if (completeFeatureList) { 
                     args.add("-Dinternal.minify.feature.list.complete=true") 
-                } else {
-                    args.add("-Dinternal.minify.ignore.singleton=true") 
                 }
                 if (OperatingSystem.current().windows) {
                     commandLine = ["cmd", "/c", "server"] + args
@@ -368,6 +367,7 @@ if (isAutomatedBuild && !isIFIXBuild) {
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
         withFeatures this.&webProfile8Features
+        packageServerConflict = true
         outputTo packageDir
         doLast {
             copy {
@@ -394,6 +394,7 @@ if (isAutomatedBuild && !isIFIXBuild) {
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
         withFeatures this.&javaee8Features
+        packageServerConflict = true
         outputTo packageDir
         doLast {
             copy {
@@ -439,6 +440,7 @@ if (isAutomatedBuild && !isIFIXBuild) {
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
         withFeatures this.&microProfile3Features
+        packageServerConflict = true
         outputTo packageDir
         doLast {
             copy {

--- a/dev/com.ibm.ws.kernel.feature/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.kernel.feature/resources/OSGI-INF/metatype/metatype.xml
@@ -20,6 +20,8 @@
 			<Option	label="%onError.ignore" value="IGNORE"/>   
 		</AD> 
         <AD id="feature" name="%feature.name" description="%feature.desc" required="false" type="String" cardinality="2147483647"/>
+        <AD id="package.server.conflict" name="internal" description="internal use only" 
+            type="Boolean" default="false" required="false"/>
     </OCD>
   
     <Designate pid="com.ibm.ws.kernel.feature">


### PR DESCRIPTION
The package.server.conflict attribute is internal.  It is
intended to be used to produce the packages during the build.
In some cases the packages are built using a service
configuration that we know has conflicts on purpose.
For example, if the package is meant to include multiple
versions of a singleton feature.  The package.server.conflict
attribute is used doing the package optioneration.
When set to true the package operation will ignore
singlton rules for feature resolution while building
the server package
