### PR TITLE
Correcting IBM JDK LoginModule behavior plus minor fixes

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/OracleHelper.java
@@ -835,10 +835,8 @@ public class OracleHelper extends DatabaseHelper {
             if (connProps == null)
                 connProps = new Properties();
             
-            if (!connProps.containsKey("oracle.net.authentication_services") &&
-                !connProps.containsKey("oracle.net.kerberos5_mutual_authentication")) {
+            if (!connProps.containsKey("oracle.net.authentication_services")) {
                 connProps.put("oracle.net.authentication_services", "( KERBEROS5 )");
-                connProps.put("oracle.net.kerberos5_mutual_authentications", "true");
                 
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                     Tr.debug(tc, "Automatically setting kerberos connectionProperties for Oracle: ", connProps);

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/DB2KerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/DB2KerberosTest.java
@@ -35,6 +35,7 @@ import com.ibm.ws.jdbc.fat.krb5.containers.DB2KerberosContainer;
 import com.ibm.ws.jdbc.fat.krb5.containers.KerberosContainer;
 import com.ibm.ws.jdbc.fat.krb5.containers.KerberosPlatformRule;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
@@ -126,7 +127,41 @@ public class DB2KerberosTest extends FATServletClient {
     public void testTicketCache() throws Exception {
         String ccPath = Paths.get(server.getServerRoot(), "security", "krb5TicketCache_" + KRB5_USER).toAbsolutePath().toString();
         try {
-            generateTicketCache(ccPath);
+            generateTicketCache(ccPath, false);
+        } catch (UnsupportedOperationException e) {
+            Log.info(c, testName.getMethodName(), "Skipping test because OS does not support 'kinit'");
+            return;
+        }
+
+        ServerConfiguration config = server.getServerConfiguration();
+        final String originalKeytab = config.getKerberos().keytab;
+        try {
+            Log.info(c, testName.getMethodName(), "Changing config to use 'krb5TicketCache' instead of 'keytab'");
+            AuthData krb5Auth = config.getAuthDataElements().getById("krb5Auth");
+            krb5Auth.krb5TicketCache = ccPath;
+            Kerberos kerberos = config.getKerberos();
+            kerberos.keytab = null;
+            updateConfigAndWait(config);
+
+            FATServletClient.runTest(server, APP_NAME + "/DB2KerberosTestServlet", testName);
+        } finally {
+            Log.info(c, testName.getMethodName(), "Restoring original config");
+            config.getKerberos().keytab = originalKeytab;
+            config.getAuthDataElements().getById("krb5Auth").krb5TicketCache = null;
+            updateConfigAndWait(config);
+        }
+    }
+
+    /**
+     * Mimics testTicketCache, but using an expired cache to ensure a LoginException is thrown.
+     */
+    @Test
+    @Mode(TestMode.FULL)
+    @AllowedFFDC({ "javax.resource.ResourceException", "javax.security.auth.login.LoginException" })
+    public void testTicketCacheExpired() throws Exception {
+        String ccPath = Paths.get(server.getServerRoot(), "security", "krb5TicketCacheExpired_" + KRB5_USER).toAbsolutePath().toString();
+        try {
+            generateTicketCache(ccPath, true);
         } catch (UnsupportedOperationException e) {
             Log.info(c, testName.getMethodName(), "Skipping test because OS does not support 'kinit'");
             return;
@@ -174,12 +209,20 @@ public class DB2KerberosTest extends FATServletClient {
         }
     }
 
-    private static void generateTicketCache(String ccPath) throws Exception {
+    /**
+     * Generates a ccache using kinit on the local system.
+     *
+     * @param ccPath  - Location to create the ccache
+     * @param expired - creates the ccache with expired credentials
+     * @throws Exception
+     */
+    private static void generateTicketCache(String ccPath, boolean expired) throws Exception {
         final String m = "generateTicketCache";
         String keytabPath = Paths.get("publish", "servers", "com.ibm.ws.jdbc.fat.krb5", "security", "krb5.keytab").toAbsolutePath().toString();
 
         ProcessBuilder pb = new ProcessBuilder("kinit", "-k", "-t", keytabPath, //
                         "-c", "FILE:" + ccPath, //Some linux kinit installs require FILE:
+                        "-l", expired ? "1" : "604800", //Ticket lifetime, if expired set the minimum of 1s, otherwise 7 days.
                         KRB5_USER + "@" + KerberosContainer.KRB5_REALM);
         pb.environment().put("KRB5_CONFIG", Paths.get(server.getServerRoot(), "security", "krb5.conf").toAbsolutePath().toString());
         pb.redirectErrorStream(true);
@@ -194,8 +237,10 @@ public class DB2KerberosTest extends FATServletClient {
         boolean success = p.waitFor(2, TimeUnit.MINUTES);
         String kinitResult = readInputStream(p.getInputStream());
         Log.info(c, m, "Output from creating ccache with kinit:\n" + kinitResult);
-        if (success) {
+        if (success && kinitResult.length() == 0) { //kinit should return silently if successful
             Log.info(c, m, "Successfully generated a ccache at: " + ccPath);
+            if (expired)
+                TimeUnit.SECONDS.sleep(1); //Wait 1s to ensure ccache credentials are expired
         } else {
             Log.info(c, m, "FAILED to create ccache");
             throw new Exception("Failed to create Kerberos ticket cache. Kinit output was: " + kinitResult);

--- a/dev/com.ibm.ws.jdbc_fat_krb5/test-applications/krb5-db2-app/src/jdbc/krb5/db2/web/DB2KerberosTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/test-applications/krb5-db2-app/src/jdbc/krb5/db2/web/DB2KerberosTestServlet.java
@@ -105,6 +105,22 @@ public class DB2KerberosTestServlet extends FATServlet {
         }
     }
 
+    public void testTicketCacheExpired() throws Exception {
+        try (Connection con = krb5DataSource.getConnection()) {
+            fail("The expired ticket should result in a LoginException");
+        } catch (SQLException expected) {
+            Throwable cause1 = expected.getCause();
+            if (cause1.getClass().getCanonicalName().contains("ResourceException")) { // javax.resource.ResourceException is not on the cp
+                Throwable cause2 = cause1.getCause();
+                if (cause2 instanceof LoginException) {
+                    System.out.println("Caught expected SQLException with nested LoginException");
+                    return;
+                }
+            }
+            throw expected;
+        }
+    }
+
     public void testTicketCacheInvalid() throws Exception {
         try (Connection con = krb5DataSource.getConnection()) {
             fail("Should not be able to get a connection with invalid krb5TicketCache");

--- a/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/Krb5LoginModuleWrapper.java
+++ b/dev/com.ibm.ws.security.kerberos.auth/src/com/ibm/ws/security/kerberos/auth/Krb5LoginModuleWrapper.java
@@ -172,18 +172,31 @@ public class Krb5LoginModuleWrapper implements LoginModule {
         krb5loginModule.initialize(subject, callbackHandler, sharedState, options);
     }
 
+    /**
+     * If the login module returns false, throws a LoginException. This is to make the IBM Krb5LoginModule behavior
+     * match the Sun Krb5LoginModule.<br><br>
+     *
+     * {@inheritDoc}
+     */
     @Override
     public boolean login() throws LoginException {
-        krb5loginModule.login();
+        if (!krb5loginModule.login())
+            throw new LoginException("Kerberos login failed");
         login_called = true;
         return true;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * If the login module returns false, throws a LoginException. This is to make the IBM Krb5LoginModule behavior
+     * match the Sun Krb5LoginModule.<br><br>
+     *
+     * {@inheritDoc}
+     */
     @Override
     public boolean commit() throws LoginException {
         if (login_called)
-            krb5loginModule.commit();
+            if (!krb5loginModule.commit())
+                throw new LoginException("Kerberos login failed (commit)");
         return true;
     }
 


### PR DESCRIPTION
fixes #16946
- Catches the IBM Krb5LoginModule returning false and throws a LoginException to match the Sun Krb5LoginModule
- Adds test for Expired Credentials in the ccache
- Stops adding the invalid "oracle.net.kerberos5_mutual_authentications" property.
