### PR TITLE
Adjusting default to max amount of requests on persist connections

### DIFF
--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2019 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -898,7 +898,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertEquals(err, "defaultHttpOptions", httpOptionsRef.getString("uid"));
         assertEquals(err, "defaultHttpOptions", httpOptionsRef.getString("id"));
         assertTrue(err, httpOptionsRef.getBoolean("keepAliveEnabled"));
-        assertEquals(err, 100, httpOptionsRef.getInt("maxKeepAliveRequests"));
+        assertEquals(err, -1, httpOptionsRef.getInt("maxKeepAliveRequests"));
         assertEquals(err, 30, httpOptionsRef.getInt("persistTimeout"));
         assertEquals(err, 60, httpOptionsRef.getInt("readTimeout"));
         assertFalse(err, httpOptionsRef.getBoolean("removeServerHeader"));

--- a/dev/com.ibm.ws.transport.http/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.transport.http/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 IBM Corporation and others.
+    Copyright (c) 2011, 2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -161,7 +161,7 @@
             id="keepAliveEnabled" required="false" type="Boolean" default="true" />
 
         <AD name="%http.maxKeepAliveRequests" description="%http.maxKeepAliveRequests.desc"
-            id="maxKeepAliveRequests" required="false" type="Integer" default="100" min="-1" />
+            id="maxKeepAliveRequests" required="false" type="Integer" default="-1" min="-1" />
 
         <AD name="%http.persistTimeout" description="%http.persistTimeout.desc"
             id="persistTimeout" required="false" type="String" ibm:type="duration(s)" min="0" default="30s" />

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpChannelConfig.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpChannelConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2020 IBM Corporation and others.
+ * Copyright (c) 2004, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -53,7 +53,7 @@ public class HttpChannelConfig {
     private static final int TIMEOUT_MODIFIER = 1000;
 
     /** Maximum persistent requests to allow on a single socket */
-    private int maxPersistRequest = 100;
+    private int maxPersistRequest = -1;
     /** Default HTTP version to put into an outgoing HTTP message */
     private VersionValues outgoingHttpVersion = VersionValues.V11;
     /** Flag on whether to allocate direct or indirect byte buffers. */


### PR DESCRIPTION
The current default for how many requests are allowed on a single persistent connection is 100 requests. The new default will be set to -1, which represents unlimited. 

Fixes #17040 