### PR TITLE
Allow deleted PIDs to be processed by the ApplicationPrereq component

### DIFF
--- a/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/lifecycle/ApplicationPrereqMonitor.java
+++ b/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/lifecycle/ApplicationPrereqMonitor.java
@@ -91,8 +91,11 @@ public class ApplicationPrereqMonitor implements ConfigurationListener {
         try {
             configs = this.configurationAdmin.listConfigurations("(" + Constants.SERVICE_PID + "=" + servicePid + ")");
 
-            if (configs == null)
-                throw new IllegalStateException("No configs found matching servicePid=" + servicePid);
+            if (configs == null) {
+                // This is not strictly an error given that we may be processing a pid from a deleted application
+                Tr.debug(tc, "No configs found matching servicePid=" + servicePid);
+                return "PID not found: " + servicePid;
+            }
             if (configs.length > 1)
                 throw new IllegalStateException("Non unique servicePid=" + servicePid + " matched configs=" + Arrays.toString(configs));
 

--- a/dev/com.ibm.ws.junit.extensions/src/com/ibm/websphere/ras/CapturedOutputHolder.java
+++ b/dev/com.ibm.ws.junit.extensions/src/com/ibm/websphere/ras/CapturedOutputHolder.java
@@ -77,7 +77,8 @@ public class CapturedOutputHolder extends BaseTraceService {
         PrintStream trSysErr = systemErr.getOriginalStream();
 
         if (sysOut != trSysOut) {
-            throw new ConcurrentModificationException("Someone else has reset or cached System.out");
+            throw new ConcurrentModificationException("Someone else has reset or cached System.out. Current System.out value: " + System.out + " and current original stream: "
+                                                      + systemOut.getOriginalStream());
         }
         if (sysErr != trSysErr) {
             throw new ConcurrentModificationException("Someone else has reset or cached System.err");
@@ -184,8 +185,8 @@ public class CapturedOutputHolder extends BaseTraceService {
      * If there is an exception writing to the stream, return null to disable subsequent
      * writes.
      *
-     * @param holder LogHolder : system err or system out
-     * @param txt Text to be logged
+     * @param holder         LogHolder : system err or system out
+     * @param txt            Text to be logged
      * @param capturedStream stream holding captured data
      * @return capturedStream if all is well, null if an exception occurred writing to the stream
      */


### PR DESCRIPTION
A missing PID is not necessarily an error as it may have been deleted as a result of removing an application. 