### PR TITLE
grpc_fat: correctly wait for channel termination

### DIFF
--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/ClientInterceptorTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/ClientInterceptorTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -107,7 +107,7 @@ public class ClientInterceptorTests extends FATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         Exception excep = null;
-        worldChannel.shutdownNow();
+        GrpcTestUtils.stopGrpcService(worldChannel);
 
         try {
             if (grpcClient != null && grpcClient.isStarted()) {

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/ServiceConfigTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/ServiceConfigTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -101,7 +101,7 @@ public class ServiceConfigTests extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        worldChannel.shutdownNow();
+        GrpcTestUtils.stopGrpcService(worldChannel);
         // The testInvalidMaxInboundMessageSize() test generates this log message, don't flag it as an error
         // CWWKT0203E: The maxInboundMessageSize -1 is not valid. Sizes must greater than 0.
         grpcServer.stopServer("CWWKT0203E");
@@ -296,7 +296,7 @@ public class ServiceConfigTests extends FATServletClient {
         }
 
         // Stop only the FavoriteBeerService grpc application
-        beerChannel.shutdownNow();
+        GrpcTestUtils.stopGrpcService(beerChannel);
         LOG.info("ServiceConfigTests : testSingleWarWithGrpcService() : Stop the FavoriteBeerService application and remove it from dropins.");
         grpcServer.removeAndStopDropinsApplications("FavoriteBeerService.war");
 
@@ -395,7 +395,7 @@ public class ServiceConfigTests extends FATServletClient {
         assertTrue(test1Passed && rsp.getDone());
 
         // Stop only the FavoriteBeerService grpc application and remove the app from dropins
-        beerChannel.shutdownNow();
+        GrpcTestUtils.stopGrpcService(beerChannel);
         grpcServer.removeAndStopDropinsApplications("FavoriteBeerService.war");
         // removeAndStop above actually just renames the file, so really delete so the next tests have a clean slate
         grpcServer.deleteFileFromLibertyServerRoot("/FavoriteBeerService");

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/ServiceInterceptorTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/ServiceInterceptorTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -90,7 +90,7 @@ public class ServiceInterceptorTests extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        worldChannel.shutdownNow();
+        GrpcTestUtils.stopGrpcService(worldChannel);
         grpcServer.stopServer("CWWKT0202W");
     }
 

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/ServiceSupportTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/ServiceSupportTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ package com.ibm.ws.fat.grpc;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -90,10 +91,6 @@ public class ServiceSupportTests extends FATServletClient {
         beerServiceBlockingStub = BeerServiceGrpc.newBlockingStub(beerChannel);
     }
 
-    private void stopGrpcService(ManagedChannel channel) {
-        channel.shutdownNow();
-    }
-
     private void startHelloWorldService(String address, int port) {
         LOG.info("startHelloWorldService() : Connecting to helloWorld gRPC service at " + address + ":" + port);
         worldChannel = ManagedChannelBuilder.forAddress(address, port).usePlaintext().build();
@@ -167,7 +164,7 @@ public class ServiceSupportTests extends FATServletClient {
         LOG.info("testSingleWarWithGrpcService() : Stopping the beer service.");
 
         // Stop the grpc service
-        stopGrpcService(beerChannel);
+        GrpcTestUtils.stopGrpcService(beerChannel);
 
         // Stop the grpc application
         LOG.info("testSingleWarWithGrpcService() : Stop the FavoriteBeerService application and remove it from dropins.");
@@ -242,8 +239,8 @@ public class ServiceSupportTests extends FATServletClient {
         assertTrue(greeting.getMessage().contains("Scarlett"));
 
         // Stop the grpc services
-        stopGrpcService(beerChannel);
-        stopGrpcService(worldChannel);
+        GrpcTestUtils.stopGrpcService(beerChannel);
+        GrpcTestUtils.stopGrpcService(worldChannel);
 
         // Stop the grpc applications
         LOG.info("testMultipleGrpcServiceWars() : Stop the FavoriteBeerService and HelloworldService applications and remove them from dropins.");
@@ -316,8 +313,7 @@ public class ServiceSupportTests extends FATServletClient {
         BeerResponse rsp2 = beerServiceBlockingStub.addBeer(newBeer2);
 
         assertTrue(rsp2.getDone());
-
-        stopGrpcService(beerChannel);
+        GrpcTestUtils.stopGrpcService(beerChannel);
 
         // Stop the grpc application
         LOG.info("testSingleWarUpdate() : Stop the FavoriteBeerService application and remove it from dropins.");
@@ -378,7 +374,7 @@ public class ServiceSupportTests extends FATServletClient {
         assertTrue(grpcExcep);
 
         LOG.info("testInvalidService() : Stop service.");
-        stopGrpcService(beerChannel);
+        GrpcTestUtils.stopGrpcService(beerChannel);
 
         assertTrue(grpcServer.removeAndStopDropinsApplications(is));
 
@@ -440,8 +436,7 @@ public class ServiceSupportTests extends FATServletClient {
         BeerResponse rsp = beerServiceBlockingStub.addBeer(newBeer);
 
         assertTrue(rsp.getDone());
-
-        stopGrpcService(beerChannel);
+        GrpcTestUtils.stopGrpcService(beerChannel);
 
         // Stop the grpc applications
         LOG.info("testDuplicateService() : Stop the FavoriteBeerService application and remove it from dropins.");

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StreamingTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StreamingTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -76,7 +76,7 @@ public class StreamingTests extends FATServletClient {
     }
 
     private void stopStreamingService() {
-        streamingChannel.shutdownNow();
+        GrpcTestUtils.stopGrpcService(streamingChannel);
     }
 
     public String replyAfterClientStream = "Null";


### PR DESCRIPTION
The grpc_fat test code needs to use `ManagedChannel.awaitTermination()` to be sure that channels are actually terminated