### PR TITLE
Add HttpTransport=all to WSOC Servers & Some Debug Lines

### DIFF
--- a/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/endpoints/client/basic/ProgrammaticClientEP.java
+++ b/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/endpoints/client/basic/ProgrammaticClientEP.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -78,6 +78,7 @@ public abstract class ProgrammaticClientEP extends Endpoint implements TestHelpe
                     else {
                         try {
                             String s = _data[_counter++];
+                            LOG.info("Sending message: " + s);
                             sess.getBasicRemote().sendText(s);
                         } catch (Exception e) {
                             _wtr.addExceptionAndTerminate("Error publishing msg", e);

--- a/dev/io.openliberty.wsoc.internal_fat/publish/servers/basicTestServer/server.xml
+++ b/dev/io.openliberty.wsoc.internal_fat/publish/servers/basicTestServer/server.xml
@@ -40,7 +40,6 @@
     
     <webContainer deferServletLoad="false"/>
 
-    <logging maxFileSize="50" maxFiles="3" traceFileName="wsocTrace.log" traceSpecification="*=info:com.ibm.ws.webcontainer.*=all:com.ibm.wsspi.webcontainer.*=all:com.ibm.ws.webcontainer31.*=all:ChannelFramework=all:HTTPChannel=all:TCPChannel=all:websockets=all"/> 
-  
+    <logging maxFileSize="50" maxFiles="3" traceFileName="wsocTrace.log" traceSpecification="*=info:com.ibm.ws.webcontainer.*=all:com.ibm.wsspi.webcontainer.*=all:com.ibm.ws.webcontainer31.*=all:ChannelFramework=all:HTTPChannel=all:TCPChannel=all:HttpTransport=all:websockets=all:com.ibm.ws.runtime.update.*=all"/> 
     
 </server>

--- a/dev/io.openliberty.wsoc.internal_fat/publish/servers/cdi12TestServer/server.xml
+++ b/dev/io.openliberty.wsoc.internal_fat/publish/servers/cdi12TestServer/server.xml
@@ -133,6 +133,6 @@
     
     <webContainer deferServletLoad="false"/>
 
-	<logging maxFileSize="50" maxFiles="3" traceFileName="wsocTrace.log" traceSpecification="*=info:com.ibm.ws.webcontainer.*=all:com.ibm.wsspi.webcontainer.*=all:com.ibm.ws.webcontainer31.*=all:ChannelFramework=all:HTTPChannel=all:TCPChannel=all:websockets=all"/> 
-  
+<logging maxFileSize="50" maxFiles="3" traceFileName="wsocTrace.log" traceSpecification="*=info:com.ibm.ws.webcontainer.*=all:com.ibm.wsspi.webcontainer.*=all:com.ibm.ws.webcontainer31.*=all:ChannelFramework=all:HTTPChannel=all:TCPChannel=all:HttpTransport=all:websockets=all:com.ibm.ws.runtime.update.*=all"/> 
+ 
 </server>

--- a/dev/io.openliberty.wsoc.internal_fat/publish/servers/secureTestServer/server.xml
+++ b/dev/io.openliberty.wsoc.internal_fat/publish/servers/secureTestServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2013 IBM Corporation and others.
+    Copyright (c) 2013, 2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -40,5 +40,7 @@
     <javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
     
     <webContainer deferServletLoad="false"/>
+
+    <logging maxFileSize="50" maxFiles="3" traceFileName="wsocTrace.log" traceSpecification="*=info:com.ibm.ws.webcontainer.*=all:com.ibm.wsspi.webcontainer.*=all:com.ibm.ws.webcontainer31.*=all:ChannelFramework=all:HTTPChannel=all:TCPChannel=all:HttpTransport=all:websockets=all:com.ibm.ws.runtime.update.*=all"/> 
     
 </server>

--- a/dev/io.openliberty.wsoc.internal_fat/publish/servers/traceTestServer/server.xml
+++ b/dev/io.openliberty.wsoc.internal_fat/publish/servers/traceTestServer/server.xml
@@ -31,7 +31,7 @@
     </featureManager>
    
     
- <logging maxFileSize="50" maxFiles="3" traceFileName="wsocTrace.log" traceSpecification="*=info:com.ibm.ws.webcontainer.*=all:com.ibm.wsspi.webcontainer.*=all:com.ibm.ws.webcontainer31.*=all:ChannelFramework=all:HTTPChannel=all:TCPChannel=all:websockets=all:com.ibm.ws.runtime.update.*=all"/> 
+ <logging maxFileSize="50" maxFiles="3" traceFileName="wsocTrace.log" traceSpecification="*=info:com.ibm.ws.webcontainer.*=all:com.ibm.wsspi.webcontainer.*=all:com.ibm.ws.webcontainer31.*=all:ChannelFramework=all:HTTPChannel=all:TCPChannel=all:HttpTransport=all:websockets=all:com.ibm.ws.runtime.update.*=all"/> 
       
     <javaPermission className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
     <javaPermission className="java.lang.RuntimePermission" name="modifyThread"/>  

--- a/dev/io.openliberty.wsoc.internal_fat/test-applications/cdi.war/src/cdi/war/ProgrammaticExtendCDIServerCDI12EP.java
+++ b/dev/io.openliberty.wsoc.internal_fat/test-applications/cdi.war/src/cdi/war/ProgrammaticExtendCDIServerCDI12EP.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -40,7 +40,7 @@ public class ProgrammaticExtendCDIServerCDI12EP extends Endpoint implements
 
     @Override
     public void onMessage(String msg) {
-
+        Logger.getLogger(ProgrammaticExtendCDIServerCDI12EP.class.getName()).log(Level.INFO, "recieved msg", msg);
         String responseMessage = "Nothing yet";
         try {
             int depCount = depScopedCounter.getNext();
@@ -58,6 +58,7 @@ public class ProgrammaticExtendCDIServerCDI12EP extends Endpoint implements
             responseMessage = ex.toString();
         }
         try {
+            Logger.getLogger(ProgrammaticExtendCDIServerCDI12EP.class.getName()).log(Level.INFO, "Sending responseMessage", responseMessage);
             this.session.getBasicRemote().sendText(responseMessage);
         } catch (Exception ex) {
             Logger.getLogger(ProgrammaticExtendCDIServerCDI12EP.class.getName()).log(Level.SEVERE, null, ex);


### PR DESCRIPTION
Previous tracing indicates that an extended wait may be occurring in the HttpTransport code, but the previous logging doesn't cover it. Adding it now. 

Debug lines are for [Defect 283549 ](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=283549)