### PR TITLE
Issue 17121: Fix primary and failover LDAP host groupings on FATs

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertComplexFilter.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertComplexFilter.xml
@@ -35,7 +35,6 @@
 		searchTimeout="8m">
 		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
-		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
         </failoverServers>	
 	</ldapRegistry>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertComplexFilter1.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertComplexFilter1.xml
@@ -35,7 +35,6 @@
 		searchTimeout="8m">
 		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
-		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
         </failoverServers>	
 	</ldapRegistry>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertExactDN.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertExactDN.xml
@@ -34,7 +34,6 @@
 		searchTimeout="8m">
 		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
-		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
         </failoverServers>	
 	</ldapRegistry>		

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertInvalidFilter.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertInvalidFilter.xml
@@ -35,7 +35,6 @@
 		searchTimeout="8m">
 		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
-		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
         </failoverServers>	
 	</ldapRegistry>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertInvalidFilter1.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertInvalidFilter1.xml
@@ -35,7 +35,6 @@
 		searchTimeout="8m">
 		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
-		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
         </failoverServers>	
 	</ldapRegistry>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertInvalidFilter2.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertInvalidFilter2.xml
@@ -35,7 +35,6 @@
 		searchTimeout="8m">
 		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
-		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
         </failoverServers>	
 	</ldapRegistry>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertMultipleLDAP.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertMultipleLDAP.xml
@@ -35,7 +35,6 @@
 		searchTimeout="8m">
 		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
-		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
         </failoverServers>	
 	</ldapRegistry>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertNonMatchingFilter.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientCertNonMatchingFilter.xml
@@ -35,7 +35,6 @@
 		searchTimeout="8m">
 		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
-		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
         </failoverServers>	
 	</ldapRegistry>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientcert.server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/clientcert.server.xml
@@ -36,7 +36,6 @@
 		searchTimeout="8m">
 		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
-		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
         </failoverServers>	
 	</ldapRegistry>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/dynamicUpdate/server_invalidSearchBase.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/dynamicUpdate/server_invalidSearchBase.xml
@@ -59,8 +59,7 @@
         <searchResultsCache size="2000" timeout="600ms" enabled="true" resultsSizeLimit="1000"/>
       </ldapCache>
       <failoverServers name="failoverLdapServers">
-      	<server host="${ldap.server.1.name}" port="${ldap.server.1.port}"/>
-		<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
+      	<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        </failoverServers>
 	</ldapRegistry> 
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/dynamicUpdate/server_multipleSearchBase.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/dynamicUpdate/server_multipleSearchBase.xml
@@ -59,8 +59,7 @@
         <searchResultsCache size="2000" timeout="600ms" enabled="true" resultsSizeLimit="1000"/>
       </ldapCache>
       <failoverServers name="failoverLdapServers">
-      	<server host="${ldap.server.1.name}" port="${ldap.server.1.port}"/>
-		<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
+		<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        </failoverServers>
 	</ldapRegistry> 
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/dynamicUpdate/server_validSearchBase.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/dynamicUpdate/server_validSearchBase.xml
@@ -59,8 +59,7 @@
         <searchResultsCache size="2000" timeout="600ms" enabled="true" resultsSizeLimit="1000"/>
       </ldapCache>
       <failoverServers name="failoverLdapServers">
-      	<server host="${ldap.server.1.name}" port="${ldap.server.1.port}"/>
-		<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
+		<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        </failoverServers>
 	</ldapRegistry> 
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/fedclientCertComplexFilter.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/fedclientCertComplexFilter.xml
@@ -36,7 +36,6 @@
 		searchTimeout="8m">
 		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
-		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
         </failoverServers>	
 	</ldapRegistry>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/fedclientCertExactDN.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/fedclientCertExactDN.xml
@@ -35,7 +35,6 @@
 		searchTimeout="8m">
 		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
-		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
         </failoverServers>	
 	</ldapRegistry>		

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/fedclientCertInvalidFilter.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/fedclientCertInvalidFilter.xml
@@ -36,7 +36,6 @@
 		searchTimeout="8m">
 		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
-		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
         </failoverServers>	
 	</ldapRegistry>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/fedclientCertNonMatchingFilter.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/fedclientCertNonMatchingFilter.xml
@@ -36,7 +36,6 @@
 		searchTimeout="8m">
 		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
-		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
         </failoverServers>	
 	</ldapRegistry>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/fedclientcert.server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/fedclientcert.server.xml
@@ -37,7 +37,6 @@
 		searchTimeout="8m">
 		<loginProperty name = "cn"/>
 		<failoverServers name="failoverLdapServers">
-		   <server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
         </failoverServers>	
 	</ldapRegistry>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/reuseConnectionOn.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/files/reuseConnectionOn.xml
@@ -29,8 +29,8 @@
 			groupIdMap="*:cn"
 			groupMemberIdMap="ibm-allGroups:member;ibm-allGroups:uniqueMember;groupOfNames:member;groupOfUniqueNames:uniqueMember" />
 		<failoverServers name="failoverLdapServers">
-		   <server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
-           <server host="${ldap.server.1.name}" port="${ldap.server.1.port}"/>
+		   <server host="${ldap.server.7.name}" port="${ldap.server.7.port}"/>
+           <server host="${ldap.server.8.name}" port="${ldap.server.8.port}"/>
         </failoverServers>	
 	</ldapRegistry> 
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.custom/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.custom/server.xml
@@ -57,7 +57,6 @@
         <searchResultsCache size="2000" timeout="600ms" enabled="true" resultsSizeLimit="1000"/>
       </ldapCache>
       <failoverServers name="failoverLdapServers">
-      	<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 		<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        </failoverServers>
 	</ldapRegistry>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.attrMappingVar1/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.attrMappingVar1/server.xml
@@ -56,7 +56,6 @@
         <searchResultsCache size="2000" timeout="600ms" enabled="true" resultsSizeLimit="1000"/>
       </ldapCache>
       <failoverServers name="failoverLdapServers">
-      		<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        </failoverServers>
 	</ldapRegistry>

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.attrMappingVar2/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.attrMappingVar2/server.xml
@@ -56,7 +56,6 @@
         <searchResultsCache size="2000" timeout="600ms" enabled="true" resultsSizeLimit="1000"/>
       </ldapCache>
       <failoverServers name="failoverLdapServers">
-      		<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
 			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        </failoverServers>
 	</ldapRegistry> 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.attrMappingVar3/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.attrMappingVar3/server.xml
@@ -58,8 +58,8 @@
         <searchResultsCache size="2000" timeout="600ms" enabled="true" resultsSizeLimit="1000"/>
       </ldapCache>
       <failoverServers name="failoverLdapServers">
-      	<server host="${ldap.server.1.name}" port="${ldap.server.1.port}"/>
-		<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
+      	<server host="${ldap.server.7.name}" port="${ldap.server.7.port}"/>
+		<server host="${ldap.server.8.name}" port="${ldap.server.8.port}"/>
        </failoverServers>
 	</ldapRegistry> 
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.failover/server.xml
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/publish/servers/com.ibm.ws.security.wim.adapter.ldap.fat.tds.failover/server.xml
@@ -56,7 +56,7 @@
       </ldapCache>
       <failoverServers name="failoverLdapServers">
       	<server host="${ldap.server.1.name}" port="${ldap.server.1.port}"/>
-		<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
+		<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        </failoverServers>
 	</ldapRegistry>
 

--- a/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/master_server.xml
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/master_server.xml
@@ -12,7 +12,7 @@
 		ldapType="IBM Tivoli Directory Server"
 		searchTimeout="8m">
 		<failoverServers name="failoverLdapServers">
-			<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
+			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        	</failoverServers>
 	</ldapRegistry>
     

--- a/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/multiple_ldaps_and_multiple_realms.xml
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/multiple_ldaps_and_multiple_realms.xml
@@ -12,7 +12,7 @@
 		ldapType="IBM Tivoli Directory Server"
 		searchTimeout="8m">
 		<failoverServers name="failoverLdapServers">
-			<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
+			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        	</failoverServers>
 	</ldapRegistry>
 	

--- a/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/multiple_ldaps_and_multiple_under_realm.xml
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/multiple_ldaps_and_multiple_under_realm.xml
@@ -12,7 +12,7 @@
 		ldapType="IBM Tivoli Directory Server"
 		searchTimeout="8m">
 		<failoverServers name="failoverLdapServers">
-			<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
+			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        	</failoverServers>
 	</ldapRegistry>
 	

--- a/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/multiple_ldaps_and_single_under_realm.xml
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/multiple_ldaps_and_single_under_realm.xml
@@ -12,7 +12,7 @@
 		ldapType="IBM Tivoli Directory Server"
 		searchTimeout="8m">
 		<failoverServers name="failoverLdapServers">
-			<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
+			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        	</failoverServers>
 	</ldapRegistry>
 	

--- a/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/with_UR_mapping.xml
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/with_UR_mapping.xml
@@ -12,7 +12,7 @@
 		ldapType="IBM Tivoli Directory Server"
 		searchTimeout="8m">
 		<failoverServers name="failoverLdapServers">
-			<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
+			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        	</failoverServers>
 	</ldapRegistry>
     

--- a/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/without_primary_realm.xml
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/without_primary_realm.xml
@@ -12,7 +12,7 @@
 		ldapType="IBM Tivoli Directory Server"
 		searchTimeout="8m">
 		<failoverServers name="failoverLdapServers">
-			<server host="${ldap.server.4.name}" port="${ldap.server.4.port}"/>
+			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
       	</failoverServers>
 	</ldapRegistry>
    		


### PR DESCRIPTION
Fixes #17121 

Fixes RTC 283841

Correctly match TDS servers to their correct groups (1 and 5 vs 4,7 and 8).