### PR TITLE
Add EJB client tests with escape in JNDI

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteClientWeb.war/src/com/ibm/ws/ejbcontainer/remote/client/web/RemoteTxAttrServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/RemoteClientWeb.war/src/com/ibm/ws/ejbcontainer/remote/client/web/RemoteTxAttrServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -81,6 +81,10 @@ public class RemoteTxAttrServlet extends FATServlet {
     private static final String TestRemoteSingletonJndi = "ejb/global/" + App + "/" + Module + "/" + TestRemoteSingleton;
     private static final String TestRemoteStatefulJndi = "ejb/global/" + App + "/" + Module + "/" + TestRemoteStateful;
     private static final String TestRemoteStatelessJndi = "ejb/global/" + App + "/" + Module + "/" + TestRemoteStateless;
+
+    private static final String TxAttrRemote_Escape_5c = "com%5c.ibm%5c.ws%5c.ejbcontainer%5c.remote%5c.server%5c.shared%5c.TxAttrRemote";
+    private static final String TxAttrRemote_Escape_5C = "com%5C.ibm%5C.ws%5C.ejbcontainer%5C.remote%5C.server%5C.shared%5C.TxAttrRemote";
+    private static final String TxAttrRemote_Escape_Slash = "com\\.ibm\\.ws\\.ejbcontainer\\.remote\\.server\\.shared\\.TxAttrRemote";
 
     private TxAttrRemote txAttrBean;
 
@@ -175,6 +179,24 @@ public class RemoteTxAttrServlet extends FATServlet {
         // verify the bean works
         boolean global = bean.txRequired();
         assertTrue("Container did not begin global transaction for TX REQUIRED", global);
+
+        // lookup the bean using default context with corbaname using %5c escape
+        jndiName = CorbaName + "#" + TxAttrBeanJndi + "!" + TxAttrRemote_Escape_5c;
+        bean = lookupRemoteBean(getDefaultContext(), jndiName, TxAttrRemote.class);
+        assertNotNull("Remote bean is null", bean);
+        assertTrue("Container did not begin global transaction for TX REQUIRED", bean.txRequired());
+
+        // lookup the bean using default context with corbaname using %5C escape
+        jndiName = CorbaName + "#" + TxAttrBeanJndi + "!" + TxAttrRemote_Escape_5C;
+        bean = lookupRemoteBean(getDefaultContext(), jndiName, TxAttrRemote.class);
+        assertNotNull("Remote bean is null", bean);
+        assertTrue("Container did not begin global transaction for TX REQUIRED", bean.txRequired());
+
+        // lookup the bean using default context with corbaname using \\ escape
+        jndiName = CorbaName + "#" + TxAttrBeanJndi + "!" + TxAttrRemote_Escape_Slash;
+        bean = lookupRemoteBean(getDefaultContext(), jndiName, TxAttrRemote.class);
+        assertNotNull("Remote bean is null", bean);
+        assertTrue("Container did not begin global transaction for TX REQUIRED", bean.txRequired());
     }
 
     /**


### PR DESCRIPTION
Add tests for escape characters in JNDI lookup strings