### PR TITLE
15540 bda spi 3

### DIFF
--- a/dev/com.ibm.ws.cdi.extension_fat/.classpath
+++ b/dev/com.ibm.ws.cdi.extension_fat/.classpath
@@ -6,6 +6,7 @@
 	<classpathentry kind="src" path="test-bundles/cdi.spi.extension/src"/>
 	<classpathentry kind="src" path="test-bundles/cdi.spi.constructor.fail.extension/src"/>
 	<classpathentry kind="src" path="test-bundles/cdi.helloworld.extension/src"/>
+        <classpathentry kind="src" path="test-bundles/cdi.misplaced.extension/src"/>
 	<classpathentry kind="src" path="test-applications/applicationExtension.jar/src"/>
 	<classpathentry kind="src" path="test-applications/dynamicallyAddedBeans.jar/src"/>
 	<classpathentry kind="src" path="test-applications/helloWorldExtensionTest.war/src"/>

--- a/dev/com.ibm.ws.cdi.extension_fat/bnd.bnd
+++ b/dev/com.ibm.ws.cdi.extension_fat/bnd.bnd
@@ -26,6 +26,7 @@ src: \
 	test-applications/multipleWarEmbeddedJar.jar/src,\
 	test-applications/multipleWarNoBeans.war/src,\
 	test-bundles/cdi.helloworld.extension/src, \
+	test-bundles/cdi.spi.misplaced/src, \
 	test-bundles/cdi.spi.extension/src, \
 	test-bundles/cdi.spi.constructor.fail.extension/src, \
 	test-applications/observeProcessProducerMethod.war/src, \

--- a/dev/com.ibm.ws.cdi.extension_fat/cdi_misplaced_extension.bnd
+++ b/dev/com.ibm.ws.cdi.extension_fat/cdi_misplaced_extension.bnd
@@ -1,0 +1,28 @@
+#*******************************************************************************
+# Copyright (c) 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0.0
+
+Bundle-Name:  Misplaced Beans To Test CDI SPI 
+Bundle-SymbolicName: cdi.spi.misplaced
+Bundle-Description: This bundle has extra beans to test the cdi extension spi; version=${bVersion}
+
+Import-Package: \
+  javax.enterprise.*; version="[1.1.0,2.1.0)",\
+  javax.validation.*; version="[1.1.0,2.1.0)",\
+  *
+
+Export-Package: \
+  com.ibm.ws.cdi.misplaced.spi.test.bundle.annotations;version=1.0.0,\
+  com.ibm.ws.cdi.misplaced.spi.test.bundle.extension;version=1.0.0,\
+  com.ibm.ws.cdi.misplaced.spi.test.bundle.getclass.beaninjection;version=1.0.0,\
+  com.ibm.ws.cdi.misplaced.spi.test.bundle.getclass.interceptor;version=1.0.0,\
+  com.ibm.ws.cdi.misplaced.spi.test.bundle.getclass.producer;version=1.0.0

--- a/dev/com.ibm.ws.cdi.extension_fat/cdi_spi_extension.bnd
+++ b/dev/com.ibm.ws.cdi.extension_fat/cdi_spi_extension.bnd
@@ -13,7 +13,7 @@ bVersion=1.0.0
 
 Bundle-Name:  Extension To Test CDI SPI 
 Bundle-SymbolicName: cdi.spi.extension
-Bundle-Description: This bundle tests cdi runtime extension; version=${bVersion}
+Bundle-Description: This bundle tests the cdi runtime spi; version=${bVersion}
 
 Import-Package: \
   javax.enterprise.*; version="[1.1.0,2.1.0)",\

--- a/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi12/suite/FATSuite.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi12/suite/FATSuite.java
@@ -50,7 +50,8 @@ public class FATSuite {
     private static final String[] PATHS_TO_BUNDLES = {
         "publish/bundles/cdi.helloworld.extension.jar", 
         "publish/bundles/cdi.spi.constructor.fail.extension.jar", 
-        "publish/bundles/cdi.spi.extension.jar" 
+        "publish/bundles/cdi.spi.extension.jar", 
+        "publish/bundles/cdi.spi.misplaced.jar" 
     };
 
     @ClassRule

--- a/dev/com.ibm.ws.cdi.extension_fat/publish/features/cdi.spi.extension-1.0.mf
+++ b/dev/com.ibm.ws.cdi.extension_fat/publish/features/cdi.spi.extension-1.0.mf
@@ -4,11 +4,16 @@ Subsystem-SymbolicName: cdi.spi.extension-1.0;visibility:=public
 Subsystem-Version: 1.0.0
 Subsystem-Content: 
   cdi.spi.extension; version="[1.0,1.100)",
+  cdi.spi.misplaced; version="[1.0,1.100)",
   com.ibm.websphere.appserver.cdi-1.2; ibm.tolerates:="2.0"; type="osgi.subsystem.feature"
 Subsystem-Type: osgi.subsystem.feature
 IBM-API-Package: com.ibm.ws.cdi.extension.spi.test.bundle,
   com.ibm.ws.cdi.extension.spi.test.bundle.getclass.beaninjection,
   com.ibm.ws.cdi.extension.spi.test.bundle.getclass.interceptor,
   com.ibm.ws.cdi.extension.spi.test.bundle.getclass.producer,
-  com.ibm.ws.cdi.extension.spi.test.bundle.extension
+  com.ibm.ws.cdi.extension.spi.test.bundle.extension,
+  com.ibm.ws.cdi.misplaced.spi.test.bundle.getclass.beaninjection,
+  com.ibm.ws.cdi.misplaced.spi.test.bundle.getclass.interceptor,
+  com.ibm.ws.cdi.misplaced.spi.test.bundle.getclass.producer,
+  com.ibm.ws.cdi.misplaced.spi.test.bundle.extension
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.cdi.extension_fat/publish/features/cdi.spi.extension-3.0.mf
+++ b/dev/com.ibm.ws.cdi.extension_fat/publish/features/cdi.spi.extension-3.0.mf
@@ -4,11 +4,16 @@ Subsystem-SymbolicName: cdi.spi.extension;visibility-3.0;visibility:=public
 Subsystem-Version: 1.0.0
 Subsystem-Content: 
   cdi.spi.extension.jakarta; version="[1.0,1.100)",
+  cdi.spi.misplaced.jakarta; version="[1.0,1.100)",
   io.openliberty.cdi-3.0; type="osgi.subsystem.feature"
 Subsystem-Type: osgi.subsystem.feature
 IBM-API-Package: com.ibm.ws.cdi.extension.spi.test.bundle,
   com.ibm.ws.cdi.extension.spi.test.bundle.getclass.beaninjection,
   com.ibm.ws.cdi.extension.spi.test.bundle.getclass.interceptor,
   com.ibm.ws.cdi.extension.spi.test.bundle.getclass.producer,
-  com.ibm.ws.cdi.extension.spi.test.bundle.extension
+  com.ibm.ws.cdi.extension.spi.test.bundle.extension,
+  com.ibm.ws.cdi.misplaced.spi.test.bundle.getclass.beaninjection,
+  com.ibm.ws.cdi.misplaced.spi.test.bundle.getclass.interceptor,
+  com.ibm.ws.cdi.misplaced.spi.test.bundle.getclass.producer,
+  com.ibm.ws.cdi.misplaced.spi.test.bundle.extension
 IBM-Feature-Version: 2

--- a/dev/com.ibm.ws.cdi.extension_fat/test-applications/SPIExtension.war/src/com/ibm/ws/cdi/extension/spi/test/app/CrossWireTestServlet.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-applications/SPIExtension.war/src/com/ibm/ws/cdi/extension/spi/test/app/CrossWireTestServlet.java
@@ -26,45 +26,20 @@ import com.ibm.ws.cdi.extension.spi.test.bundle.extension.MyExtensionString;
 import com.ibm.ws.cdi.extension.spi.test.bundle.getclass.beaninjection.MyBeanInjectionString;
 import com.ibm.ws.cdi.extension.spi.test.bundle.getclass.producer.MyProducedString;
 
-@WebServlet("/")
-public class TestServlet extends HttpServlet {
+@WebServlet("/CrossWire")
+public class CrossWireTestServlet extends HttpServlet {
 
     @Inject
-    MyExtensionString extensionString;
-
-    @Inject
-    MyProducedString classString;
-
-    @Inject
-    MyBeanInjectionString beanInjectedString;
-
-    @Inject
-    AppBean appBean;
-
-    @Inject
-    CustomBDABean customBDABean;
+    OuterBean outerBean;
 
     private static final long serialVersionUID = 1L;
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
 
-        String unregString = "";
-        try {
-            UnregisteredBean ub = javax.enterprise.inject.spi.CDI.current().select(UnregisteredBean.class).get();
-            unregString = "Found unregistered bean";
-        } catch (UnsatisfiedResolutionException e) {
-            unregString = "Could not find unregistered bean";
-        }
-
         PrintWriter pw = response.getWriter();
         pw.println("Test Results:");
-        pw.println(extensionString.toString());
-        pw.println(beanInjectedString.toString());
-        pw.println(classString.toString());
-        pw.println(unregString);
-        pw.println(appBean.toString());
-        pw.println(customBDABean.toString());
+        pw.println(outerBean.toString());
 
     }
 }

--- a/dev/com.ibm.ws.cdi.extension_fat/test-applications/SPIExtension.war/src/com/ibm/ws/cdi/extension/spi/test/app/MisplacedTestServlet.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-applications/SPIExtension.war/src/com/ibm/ws/cdi/extension/spi/test/app/MisplacedTestServlet.java
@@ -21,16 +21,12 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.ibm.ws.cdi.extension.spi.test.bundle.UnregisteredBean;
-import com.ibm.ws.cdi.extension.spi.test.bundle.extension.MyExtensionString;
-import com.ibm.ws.cdi.extension.spi.test.bundle.getclass.beaninjection.MyBeanInjectionString;
-import com.ibm.ws.cdi.extension.spi.test.bundle.getclass.producer.MyProducedString;
+import com.ibm.ws.cdi.misplaced.spi.test.bundle.extension.MyExtensionString;
+import com.ibm.ws.cdi.misplaced.spi.test.bundle.getclass.beaninjection.MyBeanInjectionString;
+import com.ibm.ws.cdi.misplaced.spi.test.bundle.getclass.producer.MyProducedString;
 
-@WebServlet("/")
-public class TestServlet extends HttpServlet {
-
-    @Inject
-    MyExtensionString extensionString;
+@WebServlet("/misplaced")
+public class MisplacedTestServlet extends HttpServlet {
 
     @Inject
     MyProducedString classString;
@@ -51,18 +47,18 @@ public class TestServlet extends HttpServlet {
 
         String unregString = "";
         try {
-            UnregisteredBean ub = javax.enterprise.inject.spi.CDI.current().select(UnregisteredBean.class).get();
-            unregString = "Found unregistered bean";
+            //This will fail because while the extension will run as expected and add MyExtensionString to the BDA, it will be filtered out later because it cannot be found in the bundle.
+            MyExtensionString ub = javax.enterprise.inject.spi.CDI.current().select(MyExtensionString.class).get();
+            unregString = "Bean registered via an extension when both the bean and the extension are in a different bundle to the SPI impl class. This is unexpected";
         } catch (UnsatisfiedResolutionException e) {
-            unregString = "Could not find unregistered bean";
+            unregString = "Could not find bean registered via an extension when both the bean and the extension are in a different bundle to the SPI impl class";
         }
 
         PrintWriter pw = response.getWriter();
         pw.println("Test Results:");
-        pw.println(extensionString.toString());
+        pw.println(unregString);
         pw.println(beanInjectedString.toString());
         pw.println(classString.toString());
-        pw.println(unregString);
         pw.println(appBean.toString());
         pw.println(customBDABean.toString());
 

--- a/dev/com.ibm.ws.cdi.extension_fat/test-applications/SPIExtension.war/src/com/ibm/ws/cdi/extension/spi/test/app/crosswire/MissPlacedBean.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-applications/SPIExtension.war/src/com/ibm/ws/cdi/extension/spi/test/app/crosswire/MissPlacedBean.java
@@ -10,13 +10,15 @@
  *******************************************************************************/
 package com.ibm.ws.cdi.extension.spi.test.app;
 
-import com.ibm.ws.cdi.extension.spi.test.bundle.annotations.NewBDATwo;
+import javax.inject.Inject;
 
-@NewBDATwo
-public class CustomBDABeanTwo {
+import com.ibm.ws.cdi.misplaced.spi.test.bundle.annotations.NewBDA;
+
+@NewBDA
+public class MissPlacedBean {
 
     public String toString() {
-        return "A Bean with an annotation registered via getBeanDefiningAnnotationClasses was successfully injected into a different bean with an annotation registered via getBeanDefiningAnnotationClasses";
+        return "A bean created by an annotation defined by the SPI in a different bundle, injected into a bean created by an annotation defined by the spi in the same bundle, intercepted by two interceptors defined by the SPI one from each bundle";
     }
 
 }

--- a/dev/com.ibm.ws.cdi.extension_fat/test-applications/SPIExtension.war/src/com/ibm/ws/cdi/extension/spi/test/app/crosswire/OuterBean.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-applications/SPIExtension.war/src/com/ibm/ws/cdi/extension/spi/test/app/crosswire/OuterBean.java
@@ -10,13 +10,19 @@
  *******************************************************************************/
 package com.ibm.ws.cdi.extension.spi.test.app;
 
-import com.ibm.ws.cdi.extension.spi.test.bundle.annotations.NewBDATwo;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
 
-@NewBDATwo
-public class CustomBDABeanTwo {
+@RequestScoped
+@com.ibm.ws.cdi.extension.spi.test.bundle.getclass.interceptor.Intercept
+@com.ibm.ws.cdi.misplaced.spi.test.bundle.getclass.interceptor.Intercept
+public class OuterBean {
+
+    @Inject
+    WellPlacedBean bean;
 
     public String toString() {
-        return "A Bean with an annotation registered via getBeanDefiningAnnotationClasses was successfully injected into a different bean with an annotation registered via getBeanDefiningAnnotationClasses";
+        return bean.toString();
     }
 
 }

--- a/dev/com.ibm.ws.cdi.extension_fat/test-applications/SPIExtension.war/src/com/ibm/ws/cdi/extension/spi/test/app/crosswire/WellPlacedBean.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-applications/SPIExtension.war/src/com/ibm/ws/cdi/extension/spi/test/app/crosswire/WellPlacedBean.java
@@ -10,13 +10,18 @@
  *******************************************************************************/
 package com.ibm.ws.cdi.extension.spi.test.app;
 
-import com.ibm.ws.cdi.extension.spi.test.bundle.annotations.NewBDATwo;
+import javax.inject.Inject;
 
-@NewBDATwo
-public class CustomBDABeanTwo {
+import com.ibm.ws.cdi.extension.spi.test.bundle.annotations.NewBDA;
+
+@NewBDA
+public class WellPlacedBean {
+
+    @Inject
+    MissPlacedBean two;
 
     public String toString() {
-        return "A Bean with an annotation registered via getBeanDefiningAnnotationClasses was successfully injected into a different bean with an annotation registered via getBeanDefiningAnnotationClasses";
+        return two.toString();
     }
 
 }

--- a/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.extension/src/com/ibm/ws/cdi/extension/spi/test/bundle/SPIMetaData.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.extension/src/com/ibm/ws/cdi/extension/spi/test/bundle/SPIMetaData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020. 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -43,6 +43,12 @@ public class SPIMetaData implements CDIExtensionMetadata {
 
         //This will register an intercepter that can be applied to other beans.
         beans.add(ClassSPIInterceptor.class);
+
+        //Now repeat the whole thing with duplicate classes from another bundle.
+        beans.add(com.ibm.ws.cdi.misplaced.spi.test.bundle.getclass.producer.ClassSPIRegisteredProducer.class);
+        beans.add(com.ibm.ws.cdi.misplaced.spi.test.bundle.getclass.beaninjection.MyBeanInjectionString.class);
+        beans.add(com.ibm.ws.cdi.misplaced.spi.test.bundle.getclass.interceptor.ClassSPIInterceptor.class);
+
         return beans;
     }
 
@@ -50,6 +56,11 @@ public class SPIMetaData implements CDIExtensionMetadata {
         Set<Class<? extends Annotation>> BDAs = new HashSet<Class<? extends Annotation>>();
         BDAs.add(NewBDA.class);
         BDAs.add(NewBDATwo.class);
+
+        //Now repeat the whole thing with duplicate classes from another bundle.
+        BDAs.add(com.ibm.ws.cdi.misplaced.spi.test.bundle.annotations.NewBDA.class);
+        BDAs.add(com.ibm.ws.cdi.misplaced.spi.test.bundle.annotations.NewBDATwo.class);
+
         return BDAs;
     }
 
@@ -57,6 +68,10 @@ public class SPIMetaData implements CDIExtensionMetadata {
     public Set<Class<? extends Extension>> getExtensions() {
         Set<Class<? extends Extension>> extensions = new HashSet<Class<? extends Extension>>();
         extensions.add(MyExtension.class);
+
+        //Now repeat the whole thing with duplicate classes from another bundle.
+        extensions.add(com.ibm.ws.cdi.misplaced.spi.test.bundle.extension.MyExtension.class);
+
         return extensions;
     }
 

--- a/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.extension/src/com/ibm/ws/cdi/extension/spi/test/bundle/extension/ExtensionSPIRegisteredProducer.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.extension/src/com/ibm/ws/cdi/extension/spi/test/bundle/extension/ExtensionSPIRegisteredProducer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,6 @@ public class ExtensionSPIRegisteredProducer {
 
     @Produces
     public MyExtensionString createMyString() {
-        return new MyExtensionString("Extension injection");
+        return new MyExtensionString("Injection from a producer registered in a CDI extension that was registered through the SPI");
     }
 }

--- a/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.extension/src/com/ibm/ws/cdi/extension/spi/test/bundle/getclass/beaninjection/MyBeanInjectionString.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.extension/src/com/ibm/ws/cdi/extension/spi/test/bundle/getclass/beaninjection/MyBeanInjectionString.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,7 @@ import com.ibm.ws.cdi.extension.spi.test.bundle.getclass.interceptor.Intercept;
 @RequestScoped
 public class MyBeanInjectionString {
 
-    String s = "bean injection";
+    String s = "Injection of a normal scoped class that was registered via getBeanClasses";
 
     @Override
     @Intercept

--- a/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.misplaced/src/com/ibm/ws/cdi/misplaced/spi/test/bundle/annotations/NewBDA.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.misplaced/src/com/ibm/ws/cdi/misplaced/spi/test/bundle/annotations/NewBDA.java
@@ -8,15 +8,16 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.cdi.extension.spi.test.app;
+package com.ibm.ws.cdi.misplaced.spi.test.bundle.annotations;
 
-import com.ibm.ws.cdi.extension.spi.test.bundle.annotations.NewBDATwo;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-@NewBDATwo
-public class CustomBDABeanTwo {
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
-    public String toString() {
-        return "A Bean with an annotation registered via getBeanDefiningAnnotationClasses was successfully injected into a different bean with an annotation registered via getBeanDefiningAnnotationClasses";
-    }
-
+@Target({ METHOD, TYPE })
+@Retention(RUNTIME)
+public @interface NewBDA {
 }

--- a/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.misplaced/src/com/ibm/ws/cdi/misplaced/spi/test/bundle/annotations/NewBDATwo.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.misplaced/src/com/ibm/ws/cdi/misplaced/spi/test/bundle/annotations/NewBDATwo.java
@@ -8,15 +8,16 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.cdi.extension.spi.test.app;
+package com.ibm.ws.cdi.misplaced.spi.test.bundle.annotations;
 
-import com.ibm.ws.cdi.extension.spi.test.bundle.annotations.NewBDATwo;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-@NewBDATwo
-public class CustomBDABeanTwo {
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
-    public String toString() {
-        return "A Bean with an annotation registered via getBeanDefiningAnnotationClasses was successfully injected into a different bean with an annotation registered via getBeanDefiningAnnotationClasses";
-    }
-
+@Target({ METHOD, TYPE })
+@Retention(RUNTIME)
+public @interface NewBDATwo {
 }

--- a/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.misplaced/src/com/ibm/ws/cdi/misplaced/spi/test/bundle/extension/ExtensionSPIRegisteredProducer.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.misplaced/src/com/ibm/ws/cdi/misplaced/spi/test/bundle/extension/ExtensionSPIRegisteredProducer.java
@@ -8,15 +8,14 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.cdi.extension.spi.test.app;
+package com.ibm.ws.cdi.misplaced.spi.test.bundle.extension;
 
-import com.ibm.ws.cdi.extension.spi.test.bundle.annotations.NewBDATwo;
+import javax.enterprise.inject.Produces;
 
-@NewBDATwo
-public class CustomBDABeanTwo {
+public class ExtensionSPIRegisteredProducer {
 
-    public String toString() {
-        return "A Bean with an annotation registered via getBeanDefiningAnnotationClasses was successfully injected into a different bean with an annotation registered via getBeanDefiningAnnotationClasses";
+    @Produces
+    public MyExtensionString createMyString() {
+        return new MyExtensionString("Injection from a producer registered in a CDI misplaced that was registered through the SPI");
     }
-
 }

--- a/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.misplaced/src/com/ibm/ws/cdi/misplaced/spi/test/bundle/extension/MyExtension.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.misplaced/src/com/ibm/ws/cdi/misplaced/spi/test/bundle/extension/MyExtension.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.misplaced.spi.test.bundle.extension;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.BeforeBeanDiscovery;
+import javax.enterprise.inject.spi.Extension;
+
+public class MyExtension implements Extension {
+
+    public void beforeBeanDiscovery(@Observes BeforeBeanDiscovery beforeBeanDiscovery, BeanManager beanManager) {
+        System.out.println("MISPLACED SPI registered extention beforeBeanDiscovery has been fired");
+        AnnotatedType<ExtensionSPIRegisteredProducer> producerType = beanManager.createAnnotatedType(ExtensionSPIRegisteredProducer.class);
+        beforeBeanDiscovery.addAnnotatedType(producerType, "my misplaced unique identifier");
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.misplaced/src/com/ibm/ws/cdi/misplaced/spi/test/bundle/extension/MyExtensionString.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.misplaced/src/com/ibm/ws/cdi/misplaced/spi/test/bundle/extension/MyExtensionString.java
@@ -8,15 +8,18 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.cdi.extension.spi.test.app;
+package com.ibm.ws.cdi.misplaced.spi.test.bundle.extension;
 
-import com.ibm.ws.cdi.extension.spi.test.bundle.annotations.NewBDATwo;
+public class MyExtensionString {
 
-@NewBDATwo
-public class CustomBDABeanTwo {
+    String s;
 
-    public String toString() {
-        return "A Bean with an annotation registered via getBeanDefiningAnnotationClasses was successfully injected into a different bean with an annotation registered via getBeanDefiningAnnotationClasses";
+    public MyExtensionString(String s) {
+        this.s = s;
     }
 
+    @Override
+    public String toString() {
+        return s;
+    }
 }

--- a/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.misplaced/src/com/ibm/ws/cdi/misplaced/spi/test/bundle/getclass/beaninjection/MyBeanInjectionString.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.misplaced/src/com/ibm/ws/cdi/misplaced/spi/test/bundle/getclass/beaninjection/MyBeanInjectionString.java
@@ -8,15 +8,20 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.cdi.extension.spi.test.app;
+package com.ibm.ws.cdi.misplaced.spi.test.bundle.getclass.beaninjection;
 
-import com.ibm.ws.cdi.extension.spi.test.bundle.annotations.NewBDATwo;
+import javax.enterprise.context.RequestScoped;
 
-@NewBDATwo
-public class CustomBDABeanTwo {
+import com.ibm.ws.cdi.misplaced.spi.test.bundle.getclass.interceptor.Intercept;
 
+@RequestScoped
+public class MyBeanInjectionString {
+
+    String s = "Injection of a normal scoped class that was registered via getBeanClasses";
+
+    @Override
+    @Intercept
     public String toString() {
-        return "A Bean with an annotation registered via getBeanDefiningAnnotationClasses was successfully injected into a different bean with an annotation registered via getBeanDefiningAnnotationClasses";
+        return s;
     }
-
 }

--- a/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.misplaced/src/com/ibm/ws/cdi/misplaced/spi/test/bundle/getclass/interceptor/ClassSPIInterceptor.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.misplaced/src/com/ibm/ws/cdi/misplaced/spi/test/bundle/getclass/interceptor/ClassSPIInterceptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,14 +8,14 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.cdi.extension.spi.test.bundle.getclass.interceptor;
+package com.ibm.ws.cdi.misplaced.spi.test.bundle.getclass.interceptor;
 
 import javax.annotation.Priority;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 
-import com.ibm.ws.cdi.extension.spi.test.bundle.getclass.beaninjection.MyBeanInjectionString;
+import com.ibm.ws.cdi.misplaced.spi.test.bundle.getclass.beaninjection.MyBeanInjectionString;
 
 @Interceptor
 @Intercept
@@ -31,7 +31,7 @@ public class ClassSPIInterceptor {
         } else if (interceptedString.equals("application bean")) {
             return "An Interceptor registered via getBeanClasses in the SPI intercepted a normal scoped class in the application WAR";
         } else if (interceptedString.contains("A bean created by an annotation defined by the SPI in a different bundle, injected into a bean created by an annotation defined by the spi in the same bundle, intercepted by two interceptors defined by the SPI one from each bundle")) {
-            return "WELL PLACED INTERCEPTOR " + interceptedString;
+            return "MISSPLACED INTERCEPTOR " + interceptedString;
         }
 
         throw new IllegalArgumentException("unrecogniesd intercepted string");

--- a/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.misplaced/src/com/ibm/ws/cdi/misplaced/spi/test/bundle/getclass/interceptor/Intercept.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.misplaced/src/com/ibm/ws/cdi/misplaced/spi/test/bundle/getclass/interceptor/Intercept.java
@@ -8,15 +8,19 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.cdi.extension.spi.test.app;
+package com.ibm.ws.cdi.misplaced.spi.test.bundle.getclass.interceptor;
 
-import com.ibm.ws.cdi.extension.spi.test.bundle.annotations.NewBDATwo;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-@NewBDATwo
-public class CustomBDABeanTwo {
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
-    public String toString() {
-        return "A Bean with an annotation registered via getBeanDefiningAnnotationClasses was successfully injected into a different bean with an annotation registered via getBeanDefiningAnnotationClasses";
-    }
+import javax.interceptor.InterceptorBinding;
 
+@InterceptorBinding
+@Target({ METHOD, TYPE })
+@Retention(RUNTIME)
+public @interface Intercept {
 }

--- a/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.misplaced/src/com/ibm/ws/cdi/misplaced/spi/test/bundle/getclass/producer/ClassSPIRegisteredProducer.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.misplaced/src/com/ibm/ws/cdi/misplaced/spi/test/bundle/getclass/producer/ClassSPIRegisteredProducer.java
@@ -8,15 +8,16 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.cdi.extension.spi.test.app;
+package com.ibm.ws.cdi.misplaced.spi.test.bundle.getclass.producer;
 
-import com.ibm.ws.cdi.extension.spi.test.bundle.annotations.NewBDATwo;
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.Produces;
 
-@NewBDATwo
-public class CustomBDABeanTwo {
+@RequestScoped
+public class ClassSPIRegisteredProducer {
 
-    public String toString() {
-        return "A Bean with an annotation registered via getBeanDefiningAnnotationClasses was successfully injected into a different bean with an annotation registered via getBeanDefiningAnnotationClasses";
+    @Produces
+    public MyProducedString createMyString() {
+        return new MyProducedString("Produced injection");
     }
-
 }

--- a/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.misplaced/src/com/ibm/ws/cdi/misplaced/spi/test/bundle/getclass/producer/MyProducedString.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.misplaced/src/com/ibm/ws/cdi/misplaced/spi/test/bundle/getclass/producer/MyProducedString.java
@@ -8,15 +8,18 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.cdi.extension.spi.test.app;
+package com.ibm.ws.cdi.misplaced.spi.test.bundle.getclass.producer;
 
-import com.ibm.ws.cdi.extension.spi.test.bundle.annotations.NewBDATwo;
+public class MyProducedString {
 
-@NewBDATwo
-public class CustomBDABeanTwo {
+    String s;
 
-    public String toString() {
-        return "A Bean with an annotation registered via getBeanDefiningAnnotationClasses was successfully injected into a different bean with an annotation registered via getBeanDefiningAnnotationClasses";
+    public MyProducedString(String s) {
+        this.s = s;
     }
 
+    @Override
+    public String toString() {
+        return s;
+    }
 }

--- a/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/CDIContainerImpl.java
+++ b/dev/com.ibm.ws.cdi.weld/src/com/ibm/ws/cdi/impl/CDIContainerImpl.java
@@ -636,22 +636,6 @@ public class CDIContainerImpl implements CDIContainer, InjectionMetaDataListener
         Set<Class<?>> beanClasses = webSphereCDIExtensionMetaData.getBeanClasses();
         Set<Class<? extends Annotation>> beanDefiningAnnotationClasses = webSphereCDIExtensionMetaData.getBeanDefiningAnnotationClasses();
 
-        for (Iterator<Class<? extends Extension>> i = extensionClasses.iterator(); i.hasNext();) {
-            Class extensionClass = i.next();
-            if (extensionClass.getClassLoader() != webSphereCDIExtensionMetaData.getClass().getClassLoader()) {
-                i.remove();
-                Tr.error(tc, "spi.extension.class.in.different.bundle.CWOWB1011E", extensionClass.getCanonicalName());
-            }
-        }
-
-        for (Iterator<Class<?>> i = beanClasses.iterator(); i.hasNext();) {
-            Class beanClass = i.next();
-            if (beanClass.getClassLoader() != webSphereCDIExtensionMetaData.getClass().getClassLoader()) {
-                i.remove();
-                Tr.error(tc, "spi.extension.class.in.different.bundle.CWOWB1011E", beanClass.getCanonicalName());
-            }
-        }
-
         Set<String> extensionClassNames = extensionClasses.stream().map(clazz -> clazz.getCanonicalName()).collect(Collectors.toSet());
 
         Set<String> extra_classes = beanClasses.stream().map(clazz -> clazz.getCanonicalName()).collect(Collectors.toSet());


### PR DESCRIPTION
This is part of #15540 and removes the guard that prevents you from registering classes from a separate archive in the bundle. This is needed in order to register javax/jakarta classes. 