### PR TITLE
Revert "Adjust error text."

### DIFF
--- a/dev/com.ibm.ws.container.service.compat/src/com/ibm/ws/util/WSUtil.java
+++ b/dev/com.ibm.ws.container.service.compat/src/com/ibm/ws/util/WSUtil.java
@@ -13,15 +13,8 @@ package com.ibm.ws.util;
 import java.util.ArrayList;
 import java.util.StringTokenizer;
 
-import com.ibm.ejs.ras.Tr;
-import com.ibm.ejs.ras.TraceComponent;
-
 public class WSUtil {
-    // Using the same trace style as used by
-    // com.ibm.ws.util.ThreadPool
-    private static TraceComponent tc =
-        Tr.register(WSUtil.class, "Runtime", "com.ibm.ws.runtime.runtime");
-    
+
     @SuppressWarnings("unchecked")
     public static String resolveURI(String uriToResolve) { // rewrote method to improve perf (251221)
 
@@ -98,7 +91,6 @@ public class WSUtil {
 
         StringTokenizer uriParser = new StringTokenizer(uriToResolve, "/", false);
         String currentElement = null;
-        @SuppressWarnings("rawtypes")
         ArrayList uriElements = new ArrayList();
 
         while (uriParser.hasMoreTokens() == true) {
@@ -112,27 +104,8 @@ public class WSUtil {
             if (currentElement.equals("..") == true) {
                 if (uriElements.size() < 1) {
                     // URI is outside the current context
-
-                    // Start: Issue 17123:
-                    // "UPDATE ERROR OUTPUT TO MEET THE MESSAGING STANDARD" 
-                    //
-                    // Per the issue, the current text is to be changed to a
-                    // generic message, and error details are to be written
-                    // to server logs.
-                    
-                    // throw new java.lang.IllegalArgumentException(
-                    //     "The specified URI, " + uriToResolve + ", is invalid because" +
-                    //     " it contains more references to parent directories (\"..\")" +
-                    //     " than is possible.");
-
-                    if ( TraceComponent.isAnyTracingEnabled() && tc.isErrorEnabled() ) {
-                        Tr.error(tc,
-                            "Non-valid URI [ " + uriToResolve + " ]:" +
-                            " The URI contains too many parent directory elements (\"..\")."); 
-                    }
-                    throw new IllegalArgumentException("Non-valid URI.");
-
-                    // End: Issue 17123
+                    throw new java.lang.IllegalArgumentException("The specified URI, " + uriToResolve
+                                                                 + ", is invalid because it contains more references to parent directories (\"..\") than is possible.");
                 }
 
                 uriElements.remove(uriElements.size() - 1);


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#17124

A test was not properly fixed and the PB did not run properly.
```
resolveURI_invalidArgument_tooManyParents:java.lang.AssertionError: Did not contain expected exception text indicating more parents than directory depth
    at org.junit.Assert.fail(Assert.java:93)
    at org.junit.Assert.assertTrue(Assert.java:43)
    at com.ibm.ws.util.WSUtilTest.resolveURI_invalidArgument_tooManyParents(WSUtilTest.java:35)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
```