### PR TITLE
Exclude unreliable mpConfig TCK tests

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.1_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -8,21 +8,32 @@
 -->
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
-<suite name="microprofile-config-1.1-tck" verbose="2"
-    configfailurepolicy="continue">
+<suite name="microprofile-config-1.1-tck" verbose="2" configfailurepolicy="continue">
     <test name="tck-package-org.eclipse.microprofile.config.tck">
         <method-selectors>
             <method-selector>
                 <script language="beanshell">
                     <![CDATA[
-                        !method.getName().contains("testEnvironmentConfigSource")
+                    // org.eclipse.microprofile.config.tck.ConverterTest
+                    if(method.getName().startsWith("testURLConverter")){
+                        // Test unreliable in 1.x TCK due to URL.equals() performing DNS resolution. See: https://github.com/eclipse/microprofile-config/issues/549
+                        return false;
+                    }
+                    
+                    // org.eclipse.microprofile.config.tck.ConfigProviderTest
+                    String os = System.getProperty("os.name");
+                    if (os.contains("Windows") && method.getName().startsWith("testEnvironmentConfigSource")){
+                        // Test unreliable in 1.x TCK on Windows due to inconsistent path variable name. See https://github.com/eclipse/microprofile-config/issues/664
+                        return false;
+                    }
+                    
+                    return true;
                     ]]>
                 </script>
             </method-selector>
         </method-selectors>
         <packages>
-            <package
-                name="org.eclipse.microprofile.config.tck.*"></package>
+            <package name="org.eclipse.microprofile.config.tck.*"></package>
         </packages>
     </test>
 </suite>

--- a/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -8,9 +8,35 @@
 -->
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
-<suite name="microprofile-config-1.2-tck" verbose="2"
-    configfailurepolicy="continue">
+<suite name="microprofile-config-1.2-tck" verbose="2" configfailurepolicy="continue">
     <test name="tck-package-org.eclipse.microprofile.config12.tck">
+        <method-selectors>
+            <method-selector>
+                <script language="beanshell">
+                    <![CDATA[
+                    // org.eclipse.microprofile.config.tck.ConverterTest and ArrayConverterTest
+                    if(method.getName().startsWith("testURLConverter") ||
+                       method.getName().startsWith("testUrlLookupProgrammatically") ||
+                       method.getName().startsWith("testUrlArrayInjection") ||
+                       method.getName().startsWith("testURLListInjection") ||
+                       method.getName().startsWith("testURLSetInjection")
+                       ){
+                        // Tests unreliable in 1.x TCK due to URL.equals() performing DNS resolution. See: https://github.com/eclipse/microprofile-config/issues/549
+                        return false;
+                    }
+                    
+                    // org.eclipse.microprofile.config.tck.ConfigProviderTest
+                    String os = System.getProperty("os.name");
+                    if (os.contains("Windows") && method.getName().startsWith("testEnvironmentConfigSource")){
+                        // Test unreliable in 1.x TCK on Windows due to inconsistent path variable name. See https://github.com/eclipse/microprofile-config/issues/664
+                        return false;
+                    }
+                    
+                    return true;
+                    ]]>
+                </script>
+            </method-selector>
+        </method-selectors>
         <packages>
             <package name="org.eclipse.microprofile.config.tck.*"></package>
         </packages>

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -8,9 +8,35 @@
 -->
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
-<suite name="microprofile-config-1.3-tck" verbose="2"
-    configfailurepolicy="continue">
+<suite name="microprofile-config-1.3-tck" verbose="2" configfailurepolicy="continue">
     <test name="tck-package-org.eclipse.microprofile.config13.tck">
+        <method-selectors>
+            <method-selector>
+                <script language="beanshell">
+                    <![CDATA[
+                    // org.eclipse.microprofile.config.tck.ConverterTest and ArrayConverterTest
+                    if(method.getName().startsWith("testURLConverter") ||
+                       method.getName().startsWith("testUrlLookupProgrammatically") ||
+                       method.getName().startsWith("testUrlArrayInjection") ||
+                       method.getName().startsWith("testURLListInjection") ||
+                       method.getName().startsWith("testURLSetInjection")
+                       ){
+                        // Tests unreliable in 1.x TCK due to URL.equals() performing DNS resolution. See: https://github.com/eclipse/microprofile-config/issues/549
+                        return false;
+                    }
+                    
+                    // org.eclipse.microprofile.config.tck.ConfigProviderTest
+                    String os = System.getProperty("os.name");
+                    if (os.contains("Windows") && method.getName().startsWith("testEnvironmentConfigSource")){
+                        // Test unreliable in 1.x TCK on Windows due to inconsistent path variable name. See https://github.com/eclipse/microprofile-config/issues/664
+                        return false;
+                    }
+                    
+                    return true;
+                    ]]>
+                </script>
+            </method-selector>
+        </method-selectors>
         <packages>
             <package name="org.eclipse.microprofile.config.tck.*"></package>
         </packages>

--- a/dev/com.ibm.ws.microprofile.config.1.4_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.4_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -8,9 +8,36 @@
 -->
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
-<suite name="microprofile-config-1.4-tck" verbose="2"
-    configfailurepolicy="continue">
+<suite name="microprofile-config-1.4-tck" verbose="2" configfailurepolicy="continue">
     <test name="tck-package-org.eclipse.microprofile.config14.tck">
+        <method-selectors>
+            <method-selector>
+                <script language="beanshell">
+                    <![CDATA[
+                    // org.eclipse.microprofile.config.tck.ConverterTest and ArrayConverterTest
+                    if(method.getName().startsWith("testURLConverter") ||
+                       method.getName().startsWith("testUrlLookupProgrammatically") ||
+                       method.getName().startsWith("testOptionalUrlLookupProgrammatically") ||
+                       method.getName().startsWith("testUrlArrayInjection") ||
+                       method.getName().startsWith("testURLListInjection") ||
+                       method.getName().startsWith("testURLSetInjection")
+                       ){
+                        // Tests unreliable in 1.x TCK due to URL.equals() performing DNS resolution. See: https://github.com/eclipse/microprofile-config/issues/549
+                        return false;
+                    }
+                    
+                    // org.eclipse.microprofile.config.tck.ConfigProviderTest
+                    String os = System.getProperty("os.name");
+                    if (os.contains("Windows") && method.getName().startsWith("testEnvironmentConfigSource")){
+                        // Test unreliable in 1.x TCK on Windows due to inconsistent path variable name. See https://github.com/eclipse/microprofile-config/issues/664
+                        return false;
+                    }
+                    
+                    return true;
+                    ]]>
+                </script>
+            </method-selector>
+        </method-selectors>
         <packages>
             <package name="org.eclipse.microprofile.config.tck.*"></package>
         </packages>

--- a/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -8,28 +8,31 @@
 -->
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
-<suite name="microprofile-config-2.0-tck" verbose="2"
-    configfailurepolicy="continue">
+<suite name="microprofile-config-2.0-tck" verbose="2" configfailurepolicy="continue">
     <test name="tck-package-org.eclipse.microprofile.config20.tck">
-		<method-selectors>
-			<method-selector>
-				<script language="beanshell">
-					<!-- ConfigProviderTest.testEnvironmentConfigSource() looks for a Config Property called "path". -->
-					<!-- On some Windows machines, the Property can be called "Path", and hence the value isn't found. -->
-					<!-- Therefore this test is skipped on Windows machines. -->
-					<!-- Relates to: https://github.com/eclipse/microprofile-config/issues/664 -->
-					<![CDATA[
-					String os = System.getProperty("os.name");
-					if (os.contains("Windows")){
-					    return !method.getName().startsWith("testEnvironmentConfigSource");
-					}else{
-					    return true;
-					}
-					]]>
-				</script>
-			</method-selector>
-		</method-selectors>
-		
+        <method-selectors>
+            <method-selector>
+                <script language="beanshell">
+                    <![CDATA[
+                    // org.eclipse.microprofile.config.tck.ConverterTest
+                    if(method.getName().startsWith("testURLConverter") ||
+                       method.getName().startsWith("testGetURLConverter")){
+                        // Tests unreliable in 2.0 TCK due to URL.equals() performing DNS resolution. See: https://github.com/eclipse/microprofile-config/issues/695
+                        return false;
+                    }
+                    
+                    // org.eclipse.microprofile.config.tck.ConfigProviderTest
+                    String os = System.getProperty("os.name");
+                    if (os.contains("Windows") && method.getName().startsWith("testEnvironmentConfigSource")){
+                        // Test unreliable in 2.0 TCK on Windows due to inconsistent path variable name. See https://github.com/eclipse/microprofile-config/issues/664
+                        return false;
+                    }
+                    
+                    return true;
+                    ]]>
+                </script>
+            </method-selector>
+        </method-selectors>
         <packages>
             <package name="org.eclipse.microprofile.config.tck.*"></package>
         </packages>


### PR DESCRIPTION
Resolves defect 283716. 

Relates to https://github.com/eclipse/microprofile-config/issues/549 which was fixed for the MicroProfile Config 2.0 TCK but not back ported.