### PR TITLE
Issue 17142: Reduce connectTimeout in DynamicUpdateTest

### DIFF
--- a/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/master_server.xml
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/master_server.xml
@@ -10,7 +10,7 @@
 	<ldapRegistry id="LDAP" realm="SampleLdapIDSRealm" host="${ldap.server.1.name}" port="${ldap.server.1.port}" ignoreCase="true"
 		baseDN="o=ibm,c=us"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m">
+		searchTimeout="8m" connectTimeout="30s">
 		<failoverServers name="failoverLdapServers">
 			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        	</failoverServers>

--- a/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/multiple_ldaps_and_multiple_realms.xml
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/multiple_ldaps_and_multiple_realms.xml
@@ -10,7 +10,7 @@
 	<ldapRegistry id="TDS_LDAP" realm="SampleLdapIDSRealm" host="${ldap.server.1.name}" port="${ldap.server.1.port}" ignoreCase="true"
 		baseDN="o=ibm,c=us"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m">
+		searchTimeout="8m" connectTimeout="30s">
 		<failoverServers name="failoverLdapServers">
 			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        	</failoverServers>
@@ -20,7 +20,7 @@
 		bindDN="cn=testuser,cn=users,dc=secfvt2,dc=austin,dc=ibm,dc=com"
 		bindPassword="testuserpwd"
 		ldapType="Microsoft Active Directory"
-		searchTimeout="8m" >
+		searchTimeout="8m" connectTimeout="30s">
 		<failoverServers name="failoverLdapServers">
       		<server host="${ldap.server.6.name}" port="${ldap.server.6.port}"/>
        	</failoverServers>

--- a/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/multiple_ldaps_and_multiple_under_realm.xml
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/multiple_ldaps_and_multiple_under_realm.xml
@@ -10,7 +10,7 @@
 	<ldapRegistry id="TDS_LDAP" realm="SampleLdapIDSRealm" host="${ldap.server.1.name}" port="${ldap.server.1.port}" ignoreCase="true"
 		baseDN="o=ibm,c=us"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m">
+		searchTimeout="8m" connectTimeout="30s">
 		<failoverServers name="failoverLdapServers">
 			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        	</failoverServers>
@@ -20,7 +20,7 @@
 		bindDN="cn=testuser,cn=users,dc=secfvt2,dc=austin,dc=ibm,dc=com"
 		bindPassword="testuserpwd"
 		ldapType="Microsoft Active Directory"
-		searchTimeout="8m" >
+		searchTimeout="8m" connectTimeout="30s">
 		<failoverServers name="failoverLdapServers">
       		<server host="${ldap.server.6.name}" port="${ldap.server.6.port}"/>
        	</failoverServers>

--- a/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/multiple_ldaps_and_single_under_realm.xml
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/multiple_ldaps_and_single_under_realm.xml
@@ -10,7 +10,7 @@
 	<ldapRegistry id="TDS_LDAP" realm="SampleLdapIDSRealm" host="${ldap.server.1.name}" port="${ldap.server.1.port}" ignoreCase="true"
 		baseDN="o=ibm,c=us"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m">
+		searchTimeout="8m" connectTimeout="30s">
 		<failoverServers name="failoverLdapServers">
 			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        	</failoverServers>
@@ -20,7 +20,7 @@
 		bindDN="cn=testuser,cn=users,dc=secfvt2,dc=austin,dc=ibm,dc=com"
 		bindPassword="testuserpwd"
 		ldapType="Microsoft Active Directory"
-		searchTimeout="8m" >
+		searchTimeout="8m" connectTimeout="30s">
 		<failoverServers name="failoverLdapServers">
       		<server host="${ldap.server.6.name}" port="${ldap.server.6.port}"/>
        	</failoverServers>

--- a/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/with_UR_mapping.xml
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/with_UR_mapping.xml
@@ -10,7 +10,7 @@
 	<ldapRegistry id="LDAP" realm="SampleLdapIDSRealm" host="${ldap.server.1.name}" port="${ldap.server.1.port}" ignoreCase="true"
 		baseDN="o=ibm,c=us"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m">
+		searchTimeout="8m" connectTimeout="30s">
 		<failoverServers name="failoverLdapServers">
 			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        	</failoverServers>

--- a/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/without_primary_realm.xml
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/files/dynamicUpdate/without_primary_realm.xml
@@ -10,7 +10,7 @@
 	<ldapRegistry id="LDAP" realm="SampleLdapIDSRealm" host="${ldap.server.1.name}" port="${ldap.server.1.port}" ignoreCase="true"
 		baseDN="o=ibm,c=us"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m">
+		searchTimeout="8m" connectTimeout="30s">
 		<failoverServers name="failoverLdapServers">
 			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
       	</failoverServers>

--- a/dev/com.ibm.ws.security.wim.core_fat/publish/servers/com.ibm.ws.security.wim.core.fat.dynamic/server.xml
+++ b/dev/com.ibm.ws.security.wim.core_fat/publish/servers/com.ibm.ws.security.wim.core.fat.dynamic/server.xml
@@ -10,7 +10,7 @@
 	<ldapRegistry id="LDAP" realm="SampleLdapIDSRealm" host="${ldap.server.1.name}" port="${ldap.server.1.port}" ignoreCase="true"
 		baseDN="o=ibm,c=us"
 		ldapType="IBM Tivoli Directory Server"
-		searchTimeout="8m">
+		searchTimeout="8m" connectTimeout="30s">
 		<failoverServers name="failoverLdapServers">
 			<server host="${ldap.server.5.name}" port="${ldap.server.5.port}"/>
        	</failoverServers>


### PR DESCRIPTION
Fixes #17142 
Fixes RTC 283835

Add `connectTimeout="30s"` to server configs used by `DynamicUpdateTest` to work around issues if one of the LDAPs is down and connecting to it times out instead of a fast Connection Refused. We were hitting Config Update timeouts and/or FAT suite timeouts waiting for the default 60s timeout. Updating this one FAT as an experiment.