### PR TITLE
Enable default SSL configuration if none is selected by user

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLDefaultTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLDefaultTest.java
@@ -26,11 +26,9 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
-@SkipForRepeat("EE9_FEATURES") // Continue to skip this test for EE9 as Default SSL is not supported yet
 @RunWith(FATRunner.class)
 public class JAXRSClientSSLDefaultTest extends AbstractTest {
 
@@ -81,24 +79,10 @@ public class JAXRSClientSSLDefaultTest extends AbstractTest {
     }
 
     @Test
-    public void testClientBasicSSLDefault_ClientBuilder() throws Exception {
+    public void testClientBasicSSLDefault() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         p.put("param", "alex");
-        this.runTestOnServer(target, "testClientBasicSSLDefault_ClientBuilder", p, "[Basic Resource]:alex");
-    }
-
-    @Test
-    public void testClientBasicSSLDefault_Client() throws Exception {
-        Map<String, String> p = new HashMap<String, String>();
-        p.put("param", "alex");
-        this.runTestOnServer(target, "testClientBasicSSLDefault_Client", p, "[Basic Resource]:alex");
-    }
-
-    @Test
-    public void testClientBasicSSLDefault_WebTarget() throws Exception {
-        Map<String, String> p = new HashMap<String, String>();
-        p.put("param", "alex");
-        this.runTestOnServer(target, "testClientBasicSSLDefault_WebTarget", p, "[Basic Resource]:alex");
+        this.runTestOnServer(target, "testClientBasicSSLDefault", p, "[Basic Resource]:alex");
     }
 
 //    @Test

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLFiltersTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLFiltersTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -81,24 +81,10 @@ public class JAXRSClientSSLFiltersTest extends AbstractTest {
     }
 
     @Test
-    public void testClientBasicSSLFilters_ClientBuilder() throws Exception {
+    public void testClientBasicSSLDefaultFilters() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         p.put("param", "alex");
-        this.runTestOnServer(target, "testClientBasicSSLDefault_ClientBuilder", p, "[Basic Resource]:alex");
-    }
-
-    @Test
-    public void testClientBasicSSLFilters_Client() throws Exception {
-        Map<String, String> p = new HashMap<String, String>();
-        p.put("param", "alex");
-        this.runTestOnServer(target, "testClientBasicSSLDefault_Client", p, "[Basic Resource]:alex");
-    }
-
-    @Test
-    public void testClientBasicSSLFilters_WebTarget() throws Exception {
-        Map<String, String> p = new HashMap<String, String>();
-        p.put("param", "alex");
-        this.runTestOnServer(target, "testClientBasicSSLDefault_WebTarget", p, "[Basic Resource]:alex");
+        this.runTestOnServer(target, "testClientBasicSSLDefault", p, "[Basic Resource]:alex");
     }
 
 //    @Test

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLTestNoLibertySSLCfg.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLTestNoLibertySSLCfg.java
@@ -36,12 +36,10 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 
-@SkipForRepeat("EE9_FEATURES") // Continue to skip this test for EE9 as Default SSL is not supported yet
 @RunWith(FATRunner.class)
 public class JAXRSClientSSLTestNoLibertySSLCfg extends AbstractTest {
 
@@ -51,7 +49,7 @@ public class JAXRSClientSSLTestNoLibertySSLCfg extends AbstractTest {
     @Server("jaxrs20.client.JAXRSClientSSLTest")
     public static LibertyServer server;
 
-    private final static String appname = "jaxrsclientssl";
+    protected final static String appname = "jaxrsclientssl";
     protected final static String target = appname + "/ClientTestServlet";
 
     @BeforeClass
@@ -111,21 +109,7 @@ public class JAXRSClientSSLTestNoLibertySSLCfg extends AbstractTest {
     public void testClientNoLibertySSL_ClientBuilder() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         p.put("param", "alex");
-        runTestOnServer(target, "testClientBasicSSLDefault_ClientBuilder", p, "[Basic Resource]:alex");
-    }
-
-    @Test
-    public void testClientNoLibertySSL_Client() throws Exception {
-        Map<String, String> p = new HashMap<String, String>();
-        p.put("param", "alex");
-        runTestOnServer(target, "testClientBasicSSLDefault_Client", p, "[Basic Resource]:alex");
-    }
-
-    @Test
-    public void testClientNoLibertySSL_WebTarget() throws Exception {
-        Map<String, String> p = new HashMap<String, String>();
-        p.put("param", "alex");
-        runTestOnServer(target, "testClientBasicSSLDefault_WebTarget", p, "[Basic Resource]:alex");
+        runTestOnServer(target, "testClientBasicSSLDefault", p, "[Basic Resource]:alex");
     }
 
     @Test

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLTestNoLibertySSLFeature.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLTestNoLibertySSLFeature.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,20 +10,29 @@
  *******************************************************************************/
 package com.ibm.ws.jaxrs20.client.fat.test;
 
+
+import static org.junit.Assert.assertNotNull;
+
 import java.util.Arrays;
 
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
-import componenttest.annotation.SkipForRepeat;
-import componenttest.custom.junit.runner.FATRunner;
+import com.ibm.websphere.simplicity.ShrinkHelper;
 
-@SkipForRepeat("EE9_FEATURES") // Continue to skip this test for EE9 as Default SSL is not supported yet
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.JakartaEE9Action;
+
 @RunWith(FATRunner.class)
 public class JAXRSClientSSLTestNoLibertySSLFeature extends JAXRSClientSSLTestNoLibertySSLCfg {
 
     @BeforeClass
     public static void setup() throws Exception {
+        WebArchive app = ShrinkHelper.defaultDropinApp(server, appname,
+                                                       "com.ibm.ws.jaxrs20.client.JAXRSClientSSL.client",
+                                                       "com.ibm.ws.jaxrs20.client.JAXRSClientSSL.service");
 
         // Make sure we don't fail because we try to start an
         // already started server
@@ -32,12 +41,33 @@ public class JAXRSClientSSLTestNoLibertySSLFeature extends JAXRSClientSSLTestNoL
         } catch (Exception e) {
             System.out.println(e.toString());
         }
-        serverNoSSL.changeFeatures(Arrays.asList("jaxrs-2.0", "ssl-1.0"));
+        if (JakartaEE9Action.isActive()) {
+            serverNoSSL.changeFeatures(Arrays.asList("restfulWS-3.0", "ssl-1.0"));
+        } else {
+            serverNoSSL.changeFeatures(Arrays.asList("jaxrs-2.0", "ssl-1.0"));
+        }
 
         try {
             server.startServer(true);
         } catch (Exception e) {
             System.out.println(e.toString());
         }
+
+        // Pause for the smarter planet message
+        assertNotNull("The smarter planet message did not get printed on serverNoSSL",
+                      serverNoSSL.waitForStringInLog("CWWKF0011I"));
+        
+        // Pause for the smarter planet message
+        assertNotNull("The smarter planet message did not get printed on server",
+                      server.waitForStringInLog("CWWKF0011I"));
+
+        // wait for LTPA key to be available to avoid CWWKS4000E
+        assertNotNull("CWWKS4105I.* not received on server",
+                      server.waitForStringInLog("CWWKS4105I.*"));
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        JAXRSClientSSLTestNoLibertySSLCfg.tearDown();
     }
 }

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/test-applications/jaxrsclientssl/src/com/ibm/ws/jaxrs20/client/JAXRSClientSSL/client/ClientTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/test-applications/jaxrsclientssl/src/com/ibm/ws/jaxrs20/client/JAXRSClientSSL/client/ClientTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -94,16 +94,20 @@ public class ClientTestServlet extends HttpServlet {
         ret.append(res);
     }
 
-    public void testClientBasicSSLDefault_ClientBuilder(Map<String, String> param, StringBuilder ret) {
+    public void testClientBasicSSLDefault(Map<String, String> param, StringBuilder ret) {
         String serverIP = param.get("hostname");
         String serverPort = param.get("secport");
 
         ClientBuilder cb = ClientBuilder.newBuilder();
         Client c = cb.build();
-        String res = c.target("https://" + serverIP + ":" + serverPort + "/" + moduleName
+        try {
+            String res = c.target("https://" + serverIP + ":" + serverPort + "/" + moduleName
                               + "/Test/BasicResource").path("echo").path(param.get("param")).request().get(String.class);
-        c.close();
-        ret.append(res);
+            c.close();
+            ret.append(res);
+        } finally {
+            c.close();
+        }
     }
 
     public void testClientBasicSSL_Client(Map<String, String> param, StringBuilder ret) {
@@ -120,19 +124,6 @@ public class ClientTestServlet extends HttpServlet {
         ret.append(res);
     }
 
-    public void testClientBasicSSLDefault_Client(Map<String, String> param, StringBuilder ret) {
-        String serverIP = param.get("hostname");
-        String serverPort = param.get("secport");
-
-        ClientBuilder cb = ClientBuilder.newBuilder();
-
-        Client c = cb.build();
-        String res = c.target("https://" + serverIP + ":" + serverPort + "/" + moduleName
-                              + "/Test/BasicResource").path("echo").path(param.get("param")).request().get(String.class);
-        c.close();
-        ret.append(res);
-    }
-
     public void testClientBasicSSL_WebTarget(Map<String, String> param, StringBuilder ret) {
         String serverIP = param.get("hostname");
         String serverPort = param.get("secport");
@@ -143,21 +134,6 @@ public class ClientTestServlet extends HttpServlet {
 
         WebTarget wt = c.target("https://" + serverIP + ":" + serverPort + "/" + moduleName + "/Test/BasicResource");
         wt.property("com.ibm.ws.jaxrs.client.ssl.config", "mySSLConfig");
-
-        String res = wt.path("echo").path(param.get("param")).request().get(String.class);
-        c.close();
-        ret.append(res);
-    }
-
-    public void testClientBasicSSLDefault_WebTarget(Map<String, String> param, StringBuilder ret) {
-        String serverIP = param.get("hostname");
-        String serverPort = param.get("secport");
-
-        ClientBuilder cb = ClientBuilder.newBuilder();
-
-        Client c = cb.build();
-
-        WebTarget wt = c.target("https://" + serverIP + ":" + serverPort + "/" + moduleName + "/Test/BasicResource");
 
         String res = wt.path("echo").path(param.get("param")).request().get(String.class);
         c.close();

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientSSLTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientSSLTest.java
@@ -31,7 +31,6 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-//@SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
 public class JAXRS21ClientSSLTest extends JAXRS21AbstractTest {
     @Server("jaxrs21.client.JAXRS21ClientSSLTest")
     public static LibertyServer server;

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/PatchTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/PatchTest.java
@@ -18,16 +18,13 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import jaxrs21.fat.patch.PatchTestServlet;
 
-@SkipForRepeat(JakartaEE9Action.ID) // requires SSL client enablement
 @RunWith(FATRunner.class)
 public class PatchTest extends FATServletClient {
 

--- a/dev/io.openliberty.restfulWS.3.0.client_fat/fat/src/io/openliberty/restfulWS30/client/fat/ssl/SslTestServlet.java
+++ b/dev/io.openliberty.restfulWS.3.0.client_fat/fat/src/io/openliberty/restfulWS30/client/fat/ssl/SslTestServlet.java
@@ -20,7 +20,6 @@ import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
 
-
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
@@ -48,24 +47,14 @@ public class SslTestServlet extends FATServlet {
     }
 
     @Test
-    public void testSSLRequestFailsWhenNoContextSpecified() throws Exception {
+    public void testUsesDefaultSSLConfigWhenNoContextSpecified() throws Exception {
         ClientBuilder builder = ClientBuilder.newBuilder();
         Client client = builder.build();
         WebTarget target = client.target("https://localhost:" + PORT + "/ssl/hello/secure");
         try {
-            target.request().get();
-            fail("Did not throw expected SSL Exception");
-        } catch (final Throwable t) {
-            Throwable t2 = t;
-            while (t2 != null) {
-                t2.printStackTrace();
-                if (t2.getClass().getName().contains("ssl")) {
-                    return;
-                }
-                t2 = t2.getCause();
-            }
-            //t2.printStackTrace();
-            fail("Threw an exception, but not related to SSL");
+            Response response = target.request().get();
+            assertEquals(200, response.getStatus());
+            assertEquals("Hello secure world!", response.readEntity(String.class));
         } finally {
             client.close();
         }

--- a/dev/io.openliberty.restfulWS.internal.ssl/src/io/openliberty/restfulWS/internal/ssl/component/SslClientBuilderListener.java
+++ b/dev/io.openliberty.restfulWS.internal.ssl/src/io/openliberty/restfulWS/internal/ssl/component/SslClientBuilderListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -57,12 +57,11 @@ public class SslClientBuilderListener implements ClientBuilderListener {
     @Override
     public void building(ClientBuilder clientBuilder) {
         Object sslRef = clientBuilder.getConfiguration().getProperty(SSL_REFKEY);
-        if (sslRef != null) {
-            try {
-                clientBuilder.sslContext(getSSLContext(toString(sslRef)));
-            } catch (SSLException ex) {
-                throw new IllegalStateException(ex);
-            }
+        try {
+            SSLContext sslContext = getSSLContext(toString(sslRef));
+            clientBuilder.sslContext( sslContext );
+        } catch (SSLException ex) {
+            throw new IllegalStateException(ex);
         }
     }
 
@@ -85,7 +84,7 @@ public class SslClientBuilderListener implements ClientBuilderListener {
             if (cause instanceof Error) {
                 throw (Error) cause;
             }
-            throw new SSLException((Exception)cause);
+            throw new SSLException((Exception) cause);
         }
     }
 
@@ -96,6 +95,6 @@ public class SslClientBuilderListener implements ClientBuilderListener {
         if (o instanceof String) {
             return (String) o;
         }
-        return o == null ? "null" : o.toString();
+        return o == null ? null : o.toString();
     }
 }


### PR DESCRIPTION
Part of JAX-RS 3.0 - ensuring that the default SSL configuration (from Liberty config) is used if no SSL config was specified by the user.