### PR TITLE
add diagnostic message for excessive hostname lookup time

### DIFF
--- a/dev/com.ibm.ws.channelfw/src/com/ibm/wsspi/channelfw/utils/HostNameUtils.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/wsspi/channelfw/utils/HostNameUtils.java
@@ -49,7 +49,7 @@ public class HostNameUtils {
 
     private static final boolean PREFER_IPV6 = Boolean.getBoolean("java.net.preferIPv6Addresses");
 
-    private static final int HOSTNAME_LOOKUP_TIMEOUT_WARNING_MS = 5000;
+    protected static final int HOSTNAME_LOOKUP_TIMEOUT_WARNING_MS = 5000;
 
     /**
      * Try to determine the hostname of this server, one that is suitable for use in
@@ -327,7 +327,7 @@ public class HostNameUtils {
      * @param runnable PrivilegedAction<T>
      * @return T the result of the PrivilegedAction<T>, or null if the runnable could not complete
      */
-    private static <T> T doPrivilegedWithTimeoutWarning(PrivilegedAction<T> runnable) {
+    protected static <T> T doPrivilegedWithTimeoutWarning(PrivilegedAction<T> runnable) {
         Callable<T> doPrivCall = new Callable<T>() {
             @Override
             public T call() throws Exception {
@@ -344,7 +344,7 @@ public class HostNameUtils {
                 } catch (TimeoutException tex) {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                         Tr.debug(tc, "hostname lookup has taken longer than " + HOSTNAME_LOOKUP_TIMEOUT_WARNING_MS
-                                    + " - something might be wrong with the network configuration. Continuing to wait.");
+                                    + " ms - something might be wrong with the network configuration. Continuing to wait.");
                     }
                 } catch (InterruptedException iex) {
                     // interrupted; log a message but continue waiting for lookup completion

--- a/dev/com.ibm.ws.channelfw/src/com/ibm/wsspi/channelfw/utils/HostNameUtils.java
+++ b/dev/com.ibm.ws.channelfw/src/com/ibm/wsspi/channelfw/utils/HostNameUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,7 +22,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
+import com.ibm.websphere.channelfw.osgi.CHFWBundle;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
@@ -41,6 +48,8 @@ public class HostNameUtils {
     public static final String WILDCARD = "*";
 
     private static final boolean PREFER_IPV6 = Boolean.getBoolean("java.net.preferIPv6Addresses");
+
+    private static final int HOSTNAME_LOOKUP_TIMEOUT_WARNING_MS = 5000;
 
     /**
      * Try to determine the hostname of this server, one that is suitable for use in
@@ -83,7 +92,7 @@ public class HostNameUtils {
             Tr.debug(tc, "Trying to resolve hostname : " + nameToResolve + ", prefer IPv6 : " + preferIPv6);
         }
 
-        return AccessController.doPrivileged(new PrivilegedAction<String>() {
+        PrivilegedAction<String> action = new PrivilegedAction<String>() {
             @Override
             @FFDCIgnore({ SocketException.class, UnknownHostException.class })
             public String run() {
@@ -217,7 +226,8 @@ public class HostNameUtils {
                 }
                 return false;
             }
-        });
+        };
+        return doPrivilegedWithTimeoutWarning(action);
     }
 
     /**
@@ -261,14 +271,14 @@ public class HostNameUtils {
      *         is a loopback address or is associated with a {@link NetworkInterface} on this machine.
      */
     private static InetAddress findLocalHostAddress(final String nameToResolve, final boolean preferIPv6) {
-        return AccessController.doPrivileged(new PrivilegedAction<InetAddress>() {
+        PrivilegedAction<InetAddress> action = new PrivilegedAction<InetAddress>() {
             @Override
             @FFDCIgnore({ SocketException.class, UnknownHostException.class })
             public InetAddress run() {
                 InetAddressResult result = new InetAddressResult(preferIPv6);
                 try {
-                    // We are checking a configured hostname or IP address. This could be a shortname, like "bob", 
-                    // or could be a qualified name like 'was.pok.ibm.com'. If it is "bob", 
+                    // We are checking a configured hostname or IP address. This could be a shortname, like "bob",
+                    // or could be a qualified name like 'was.pok.ibm.com'. If it is "bob",
                     // there is a possibility of getting something else's ip address back
                     // with a blind getAllByName.
                     InetAddress[] addrs = InetAddress.getAllByName(nameToResolve);
@@ -278,8 +288,8 @@ public class HostNameUtils {
                         // to a nic on this machine... we don't care why or how (ipv4 vs. ipv6)...
                         for (InetAddress addr : addrs) {
                             if (addr.isLoopbackAddress()) {
-                                // On z/OS, 127.0.0.1 is not correctly matched to the loopback 
-                                // network interface (the call below returns null, see RTC Java Defect 125337). 
+                                // On z/OS, 127.0.0.1 is not correctly matched to the loopback
+                                // network interface (the call below returns null, see RTC Java Defect 125337).
                                 // If the addr is a loopback, we know that it is an address local
                                 // to this machine, so we can answer appropriately.
                                 // Try to preserve the IP address preference, for getCanonicalHostName behavior.
@@ -303,7 +313,63 @@ public class HostNameUtils {
 
                 return result.getAddress();
             }
-        });
+        };
+        // might be null
+        return doPrivilegedWithTimeoutWarning(action);
+    }
+
+    /**
+     * Execute a PrivilegedAction using the Channel Framework's ExecutorService. If the runnable does not complete
+     * within a reasonable time - HOSTNAME_LOOKUP_TIMEOUT_WARNING_MS - then a message will be logged indicating
+     * some slowness. Note the runnable will not be canceled after HOSTNAME_LOOKUP_TIMEOUT_WARNING_MS elapses;
+     * it will continue until completion or cancellation.
+     *
+     * @param runnable PrivilegedAction<T>
+     * @return T the result of the PrivilegedAction<T>, or null if the runnable could not complete
+     */
+    private static <T> T doPrivilegedWithTimeoutWarning(PrivilegedAction<T> runnable) {
+        Callable<T> doPrivCall = new Callable<T>() {
+            @Override
+            public T call() throws Exception {
+                return AccessController.doPrivileged(runnable);
+            }
+        };
+        ExecutorService e = CHFWBundle.getExecutorService();
+        if (e != null && !e.isShutdown()) {
+            Future<T> future = e.submit(doPrivCall);
+            T response = null;
+            do {
+                try {
+                    response = future.get(HOSTNAME_LOOKUP_TIMEOUT_WARNING_MS, TimeUnit.MILLISECONDS);
+                } catch (TimeoutException tex) {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "hostname lookup has taken longer than " + HOSTNAME_LOOKUP_TIMEOUT_WARNING_MS
+                                    + " - something might be wrong with the network configuration. Continuing to wait.");
+                    }
+                } catch (InterruptedException iex) {
+                    // interrupted; log a message but continue waiting for lookup completion
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "hostname lookup task was interrupted: " + iex);
+                    }
+                } catch (ExecutionException eex) {
+                    // the task was aborted; log a message and break out of the while
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "hostname lookup task was aborted: " + eex);
+                    }
+                    break;
+                }
+            } while (response == null && !future.isDone());
+            return response;
+        } else {
+            try {
+                return doPrivCall.call();
+            } catch (Exception ex) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "hostname runnable invocation failed: " + ex);
+                }
+            }
+        }
+        return null;
     }
 
     private static class InetAddressResult {

--- a/dev/com.ibm.ws.channelfw/test/com/ibm/wsspi/utils/HostNameUtilsTest.java
+++ b/dev/com.ibm.ws.channelfw/test/com/ibm/wsspi/utils/HostNameUtilsTest.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.wsspi.channelfw.utils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.security.PrivilegedAction;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
+
+import com.ibm.websphere.channelfw.osgi.CHFWBundle;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.wsspi.channelfw.utils.HostNameUtils;
+
+import junit.framework.Assert;
+import test.common.SharedOutputManager;
+
+/**
+ * Unit tests for HostNameUtils
+ */
+public class HostNameUtilsTest {
+
+    private final Mockery mock = new JUnit4Mockery();
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("*=info=enabled:ChannelFramework=all");
+
+    private final ComponentContext componentContext = mock.mock(ComponentContext.class, "componentContext");
+
+    private CHFWBundle bundle;
+    @Rule
+    public TestRule managerRule = outputMgr;
+
+    @Before
+    public void initialize() {
+        // Instantiate CHFWBundle and mock OSGi environment
+        // Inspiration taken from com.ibm.ws.event.internal.EventEngineImplTest
+        bundle = new CHFWBundle();
+        final BundleContext bundleContext = mock.mock(BundleContext.class, "bundleContext");
+
+        // BundleContext accessed through ComponentContext
+        mock.checking(new Expectations() {
+            {
+                ignoring(bundleContext);
+            }
+        });
+
+        // ComponentContext used on activate/deactivate
+        mock.checking(new Expectations() {
+            {
+                allowing(componentContext).getProperties();
+                will(returnValue(new Hashtable<String, Object>()));
+                allowing(componentContext).getBundleContext();
+                will(returnValue(bundleContext));
+            }
+        });
+        try {
+            // invoke the protected activate method
+            Method activateMethod = bundle.getClass().getDeclaredMethod("activate", ComponentContext.class, Map.class);
+            activateMethod.setAccessible(true);
+            activateMethod.invoke(bundle, componentContext, new HashMap<String, Object>());
+
+            // invoke the protected setExecutorService method
+            Method setExecutorServiceMethod = bundle.getClass().getDeclaredMethod("setExecutorService", ExecutorService.class);
+            setExecutorServiceMethod.setAccessible(true);
+            setExecutorServiceMethod.invoke(bundle, Executors.newSingleThreadExecutor());
+        } catch (Exception e) {
+            outputMgr.failWithThrowable("HostNameUtilsTest", e);
+        }
+
+    }
+
+    /**
+     * Verify for doPrivilegedWithTimeoutWarning():
+     * 1. a runnable taking more than HOSTNAME_LOOKUP_TIMEOUT_WARNING_MS will cause a debug message
+     * 2. that runnable will still complete successfully despite the timeout
+     */
+    @Test
+    public void testDoPriviledWithTimeoutWarning() {
+        try {
+            PrivilegedAction<Boolean> action = new PrivilegedAction<Boolean>() {
+                @Override
+                @FFDCIgnore({ SocketException.class, UnknownHostException.class })
+                public Boolean run() {
+                    try {
+                        // sleep for a few ms longer than the timeout
+                        Thread.sleep(HostNameUtils.HOSTNAME_LOOKUP_TIMEOUT_WARNING_MS + 100);
+                    } catch (InterruptedException e) {
+                        outputMgr.failWithThrowable("testDoPriviledWithTimeoutWarning", e);
+                    }
+                    return true;
+                }
+            };
+            boolean result = HostNameUtils.doPrivilegedWithTimeoutWarning(action);
+
+            Assert.assertTrue("the runnable did not complete correctly", result);
+            Assert.assertTrue("timeout string not found",
+                              outputMgr.checkForTrace("hostname lookup has taken longer than " 
+                              + HostNameUtils.HOSTNAME_LOOKUP_TIMEOUT_WARNING_MS + " ms"));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable("testDoPriviledWithTimeoutWarning", t);
+        }
+    }
+
+}


### PR DESCRIPTION
These changes will allow the channel framework `HostNameUtils` to execute its expensive network operations on a new thread via an executor service. For now we'll use the future we get back to detect and log (debug) excessive lookup times; in the future, if needed, we'll have the option of adding user-visible logging, or even aborting the task altogether.

fixes #17441