### PR TITLE
Fix up io.openliberty.org.testcontainers component

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.defaultPersistenceUnit_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.defaultPersistenceUnit_fat/bnd.bnd
@@ -41,6 +41,4 @@ fat.bucket.db.type: Derby
     com.ibm.websphere.javaee.transaction.1.2;version=latest,\
     com.ibm.websphere.javaee.validation.2.0;version=latest,\
     io.openliberty.jakarta.persistence.3.0;version=latest,\
-    io.openliberty.org.testcontainers;version=latest,\
-    org.rnorth.duct-tape:duct-tape;version=latest,\
-    org.slf4j:slf4j-api;version=latest
+    io.openliberty.org.testcontainers;version=latest

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.ejbinwar_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.ejbinwar_fat/bnd.bnd
@@ -29,7 +29,6 @@ fat.bucket.db.type: Derby
 -buildpath: \
     com.ibm.ws.jpa_testframework;version=latest,\
     fattest.simplicity;version=latest,\
-    com.github.docker-java:docker-java-api;version=latest,\
     com.ibm.websphere.javaee.annotation.1.1;version=latest,\
     com.ibm.websphere.javaee.cdi.2.0;version=latest,\
     com.ibm.websphere.javaee.ejb.3.2;version=latest,\
@@ -39,8 +38,4 @@ fat.bucket.db.type: Derby
     com.ibm.websphere.javaee.transaction.1.2;version=latest,\
     com.ibm.websphere.javaee.validation.2.0;version=latest,\
     io.openliberty.jakarta.persistence.3.0;version=latest,\
-    org.testcontainers:database-commons;version=latest,\
-    org.testcontainers:jdbc;version=latest,\
-    org.testcontainers:testcontainers;version=latest,\
-    org.rnorth.duct-tape:duct-tape;version=latest,\
-    org.slf4j:slf4j-api;version=latest
+    io.openliberty.org.testcontainers;version=latest

--- a/dev/io.openliberty.org.testcontainers/.classpath
+++ b/dev/io.openliberty.org.testcontainers/.classpath
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
-		<attributes>
-			<attribute name="module" value="true"/>
-		</attributes>
-	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
-	<classpathentry kind="src" output="bin" path="src"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/io.openliberty.org.testcontainers/.settings/bndtools.core.prefs
+++ b/dev/io.openliberty.org.testcontainers/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/io.openliberty.org.testcontainers/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/io.openliberty.org.testcontainers/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
@@ -11,4 +11,4 @@ org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=1.8

--- a/dev/io.openliberty.org.testcontainers/bnd.bnd
+++ b/dev/io.openliberty.org.testcontainers/bnd.bnd
@@ -18,7 +18,7 @@ Bundle-Description: FAT Testcontainer Bundle; version=${bVersion}
 Export-Package: \
 	org.testcontainers.*;version="1.15.3",\
 	com.github.*;version="3.2.8",\
-	org.rnoth.*;version="1.0.8",\
+	org.rnorth.*;version="1.0.8",\
 	org.slf4j.*;version="1.7.30"
 
 test.project: true


### PR DESCRIPTION
- Update to use Java 8 settings
- Update export path for typo which prevented things from being found in eclipse.
- Update two jpa projects that still had some of the old buildpath settings for test containers