### PR TITLE
Issue 17188: Add test features for bnd on SPNEGO fat

### DIFF
--- a/dev/com.ibm.ws.security.spnego_fat.1/bnd.bnd
+++ b/dev/com.ibm.ws.security.spnego_fat.1/bnd.bnd
@@ -16,7 +16,7 @@ src: \
 
 fat.project: true
 
-tested.features: pages-3.0
+tested.features: pages-3.0, appsecurity-4.0, cdi-3.0
 
 -buildpath: \
     fattest.simplicity;version=latest,\


### PR DESCRIPTION
Fixes #17188 

For RTC 283934

```
testS4U2ProxyFromSubjectNotPassClientGssCredTest_spnegoToken_EE9_FEATURES:junit.framework.AssertionFailedError: 2021-04-24-03:31:11:694 Exception was thrown: Installed feature(s) [appsecurity-4.0, cdi-3.0] were not defined in the autoFVT/fat-metadata.json file! To correct this, add [appsecurity-4.0, cdi-3.0] to the 'tested.features' property in the bnd.bnd or build-test.xml file for this FAT so that an accurate test depdendency graph can be generated in the future.
```