### PR TITLE
Issue 17199: Add retry on token create for CustomStoreSample

### DIFF
--- a/dev/com.ibm.ws.security.oauth_test.custom_store/src/security/custom/store/CustomStoreSample.java
+++ b/dev/com.ibm.ws.security.oauth_test.custom_store/src/security/custom/store/CustomStoreSample.java
@@ -233,6 +233,7 @@ public class CustomStoreSample implements OAuthStore {
 
     @Override
     public void create(OAuthClient oauthClient) throws OAuthStoreException {
+        System.out.println("CustomStoreSample entering create on OauthClient for " + oauthClient.getClientId());
         for (int i = 0; i < RETRY_COUNT; i++) {
             try {
                 DBCollection col = getClientCollection();
@@ -263,13 +264,23 @@ public class CustomStoreSample implements OAuthStore {
 
     @Override
     public void create(OAuthToken oauthToken) throws OAuthStoreException {
-        try {
-            DBCollection col = getTokenCollection();
-            col.insert(createTokenDBObjectHelper(oauthToken));
+        System.out.println("CustomStoreSample entering create on OauthToken for " + oauthToken.getClientId());
+        for (int i = 0; i < RETRY_COUNT; i++) {
+            try {
+                DBCollection col = getTokenCollection();
+                col.insert(createTokenDBObjectHelper(oauthToken));
 
-            System.out.println("CustomStoreSample create Token " + oauthToken.getTokenString());
-        } catch (Exception e) {
-            throw new OAuthStoreException("Failed to process create on OAuthToken " + oauthToken.getClientId(), e);
+                System.out.println("CustomStoreSample create Token " + oauthToken.getTokenString());
+            } catch (Exception e) {
+                if (i < RETRY_COUNT && isNetworkFailure(e)) {
+                    try {
+                        Thread.sleep(5000);
+                    } catch (InterruptedException e1) {
+                    }
+                } else {
+                    throw new OAuthStoreException("Failed to process create on OAuthToken " + oauthToken.getClientId(), e);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #17199 

For RTC 283337

CustomStoreSample has a retry on creating a client, but not a token.

```
Exception = com.ibm.websphere.security.oauth20.store.OAuthStoreException
Source = com.ibm.ws.security.oauth20.plugins.custom.OauthTokenStore
probeid = 121
Stack Dump = com.ibm.websphere.security.oauth20.store.OAuthStoreException: Failed to process create on OAuthToken dclient01
at security.custom.store.CustomStoreSample.create(CustomStoreSample.java:260)
at com.ibm.ws.security.oauth20.plugins.custom.OauthTokenStore.add(OauthTokenStore.java:120)
```