### PR TITLE
omit unused Informix property

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DatabaseHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/DatabaseHelper.java
@@ -211,9 +211,6 @@ public class DatabaseHelper {
         if ((value = config.vendorProps.get("informixAllowNewLine")) != null)
             helperProps.put("informixAllowNewLine", value.toString());
 
-        if ((value = config.vendorProps.get("informixLockModeWait")) != null)
-            helperProps.put("informixLockModeWait", value.toString());
-
         if ((value = config.vendorProps.get("longDataCacheSize")) != null)
             helperProps.put("longDataCacheSize", value.toString());
 


### PR DESCRIPTION
Omit informixLockModeWait from data store helper properties.  Liberty doesn't have a property by that name, and the data store helper doesn't need it because existing vendor property ifxIFX_LOCK_MODE_WAIT already covers the function.