### PR TITLE
Only run original and latest MP versions in LITE mode; all else in FULL

### DIFF
--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/FATSuite.java
@@ -82,6 +82,13 @@ public class FATSuite {
             }
         }
         action = action.removeFeatures(featuresToRemove);
+        if (!isLatest(featureName, version)) {
+            action.fullFATOnly();
+        }
         return action;
+    }
+
+    private static boolean isLatest(String featureName, String version) {
+        return "mpRestClient".equals(featureName) && "2.0".equals(version);
     }
 }


### PR DESCRIPTION
Trim down FAT run time for `com.ibm.ws.microprofile.rest.client_fat` by only running the original version of the test and the latest version (currently 2.0) in LITE mode.  All other versions will now only run in FULL mode.