### PR TITLE
Skip SQLServer secure ssl test on z/os

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/test-applications/sqlserverfat/src/web/ssl/SQLServerTestSSLServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/test-applications/sqlserverfat/src/web/ssl/SQLServerTestSSLServlet.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package web.ssl;
 
+import static componenttest.annotation.SkipIfSysProp.OS_ZOS;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 
@@ -25,6 +26,7 @@ import javax.sql.DataSource;
 
 import org.junit.Test;
 
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.app.FATServlet;
 
 @SuppressWarnings("serial")
@@ -70,6 +72,13 @@ public class SQLServerTestSSLServlet extends FATServlet {
     }
 
     @Test
+    /*
+     * Keystore is PKCS12 and was created using openjdk.
+     * Our z/OS test systems use IBM JDK and will fail with
+     * java.io.IOException: Invalid keystore format
+     * since the keystore provider is SUN instead of IBMJCE
+     */
+    @SkipIfSysProp(OS_ZOS)
     public void testConnectionWithSSLSecure() throws Exception {
         try (Connection con = getConnectionWithRetry(secureDs); Statement stmt = con.createStatement()) {
             stmt.executeUpdate("INSERT INTO MYTABLE VALUES (1, 'one')");

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/internal/commands/PackageCommandTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/internal/commands/PackageCommandTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.kernel.boot.internal.commands;
 
+import static componenttest.annotation.SkipIfSysProp.OS_ZOS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -145,7 +146,7 @@ public class PackageCommandTest {
      * Packages --include=minify,runnable jar and verifies correct content.
      */
     @Test
-    @SkipIfSysProp("os.name=z/OS") // Jar not supported on Z/OS
+    @SkipIfSysProp(OS_ZOS) // Jar not supported on Z/OS
     public void testRunnable() throws Exception {
         String serverName = bootstrapFatServerName;
         LibertyServer server = bootstrapFatServer;
@@ -192,7 +193,7 @@ public class PackageCommandTest {
 //     * the resulting jar files does NOT contain the self-extract files.
 //     */
 //    @Test
-//    @SkipIfSysProp("os.name=z/OS") // Jar not supported on Z/OS
+//    @SkipIfSysProp(OS_ZOS) // Jar not supported on Z/OS
 //    public void testPackageJarArchiveWithIncludeEqualsUsr() throws Exception {
 //        LibertyServer server = bootstrapFatServer;
 //
@@ -484,7 +485,7 @@ public class PackageCommandTest {
      * that a .jar archive is created by default.
      */
     @Test
-    @SkipIfSysProp("os.name=z/OS") // Jar not supported on Z/OS
+    @SkipIfSysProp(OS_ZOS) // Jar not supported on Z/OS
     public void testRunnable_DefaultToJar() throws Exception {
         LibertyServer server = rootFatServer;
 
@@ -553,7 +554,7 @@ public class PackageCommandTest {
      * error is returned.
      */
     @Test
-    @SkipIfSysProp("os.name=z/OS") // Jar not supported on Z/OS
+    @SkipIfSysProp(OS_ZOS) // Jar not supported on Z/OS
     public void testUsr_Error_Jar() throws Exception {
         LibertyServer server = rootFatServer;
 

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/internal/commands/PackageLooseContentsTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/internal/commands/PackageLooseContentsTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.kernel.boot.internal.commands;
 
+import static componenttest.annotation.SkipIfSysProp.OS_ZOS;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -118,7 +119,7 @@ public class PackageLooseContentsTest extends AbstractLooseConfigTest {
     //
 
     @Test
-    @SkipIfSysProp("os.name=z/OS") // ZipFile verifyContents code cant open pax on Z/OS
+    @SkipIfSysProp(OS_ZOS) // ZipFile verifyContents code cant open pax on Z/OS
     public void testUsr() throws Exception {
         String[] packageCmd = new String[] {
                                              "--archive=" + SERVER_NAME,

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/internal/commands/PackageLooseContentsTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/internal/commands/PackageLooseContentsTest.java
@@ -39,6 +39,13 @@ import componenttest.annotation.SkipIfSysProp;
 import componenttest.topology.impl.LibertyServerFactory;
 
 @RunWith(Parameterized.class)
+/*
+ * ZipFile verifyContents code cant open pax on Z/OS
+ * Need to skip test class as @SkipIfSysProp will target the
+ * method name, but the parameterized runner will spawn tests
+ * with names such as testUsr[1] therefore the test will run.
+ */
+@SkipIfSysProp(OS_ZOS)
 public class PackageLooseContentsTest extends AbstractLooseConfigTest {
 
     // The full list of available configurations is:
@@ -119,7 +126,6 @@ public class PackageLooseContentsTest extends AbstractLooseConfigTest {
     //
 
     @Test
-    @SkipIfSysProp(OS_ZOS) // ZipFile verifyContents code cant open pax on Z/OS
     public void testUsr() throws Exception {
         String[] packageCmd = new String[] {
                                              "--archive=" + SERVER_NAME,

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/internal/commands/PackageLooseRunnableTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/internal/commands/PackageLooseRunnableTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.kernel.boot.internal.commands;
 
+import static componenttest.annotation.SkipIfSysProp.OS_ZOS;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -29,7 +31,7 @@ import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.FileUtils;
 
 @RunWith(Parameterized.class)
-@SkipIfSysProp("os.name=z/OS") // Jar not supported on Z/OS
+@SkipIfSysProp(OS_ZOS) // Jar not supported on Z/OS
 public class PackageLooseRunnableTest extends AbstractLooseConfigTest {
     private static final String MODULE_NAME = "DefaultArchive.war";
     private static final String MODULE_NAME_LOOSE = "DefaultArchive.war.xml";

--- a/dev/fattest.simplicity/src/componenttest/annotation/SkipIfSysProp.java
+++ b/dev/fattest.simplicity/src/componenttest/annotation/SkipIfSysProp.java
@@ -68,6 +68,9 @@ public @interface SkipIfSysProp {
     public static final String DB_SQLServer = "fat.bucket.db.type=SQLServer";
     public static final String DB_Sybase = "fat.bucket.db.type=Sybase";
 
+    // OS system properties
+    public static final String OS_ZOS = "os.name=z/OS";
+
     String[] value();
 
 }


### PR DESCRIPTION
The Keystore used for this test is PKCS12 formatted and was created using openjdk.
Our z/OS test systems use IBM JDK and will fail with `java.io.IOException: Invalid keystore format` since the Keystore provider is SUN instead of IBMJCE.

Skipping this test on z/OS as we have another proof of concept test `testConnectionWithSSLUnsecure` that does work on z/OS.

