### PR TITLE
Issue  17230: Add back remote mongoDB for all

### DIFF
--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonTest.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonTest.java
@@ -23,6 +23,7 @@ import java.net.InetAddress;
 import java.net.Socket;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.security.KeyStore;
@@ -1812,7 +1813,7 @@ public class CommonTest extends com.ibm.ws.security.fat.common.CommonTest {
                 Log.info(thisClass, "mongoDBTeardownCleanup", "Exception removing MONGO_PROPS_FILE. If this is a Derby test, ignore this message." + e);
             }
 
-            MongoDBUtils.stopMongoDB();
+            MongoDBUtils.stopMongoDB(server.getHttpString(), server.getHttpDefaultPort());
 
             return true;
 
@@ -3214,9 +3215,17 @@ public class CommonTest extends com.ibm.ws.security.fat.common.CommonTest {
     private static void setupMongoDBConfig(TestServer aTestServer, String httpString, Integer defaultPort) {
         String methodName = "setupMongoDBConfig";
         Log.info(thisClass, methodName, "Setup for mongoDB");
+        String mongoTableUid = "defaultUID";
         try {
-            MongoDBUtils.startMongoDB(aTestServer.getServer(), MONGO_PROPS_FILE);
-            MongoDBUtils.setupMongoDBEntries(httpString, defaultPort);
+            mongoTableUid = "_" + InetAddress.getLocalHost().getHostName() + "_" + new Random(System.currentTimeMillis()).nextLong();
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+            mongoTableUid = "localhost-" + System.nanoTime();
+        }
+
+        try {
+            MongoDBUtils.startMongoDB(aTestServer.getServer(), MONGO_PROPS_FILE, mongoTableUid);
+            MongoDBUtils.setupMongoDBEntries(httpString, defaultPort, mongoTableUid);
         } catch (Exception e) {
             Log.error(thisClass, methodName, e, "Exception setting up MongoDB, CustomStore tests may fail.");
 

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/MongoDBUtils.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/MongoDBUtils.java
@@ -18,14 +18,22 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import org.slf4j.LoggerFactory;
 
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.CommonMessageTools;
 import com.ibm.ws.security.fat.common.utils.AutomationTools;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoCredential;
+import com.mongodb.ServerAddress;
 
 import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.ExternalTestService;
 import de.flapdoodle.embed.mongo.Command;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodStarter;
@@ -47,7 +55,8 @@ public class MongoDBUtils {
     final static String DB_NAME = "dbName";
     final static String DB_HOST = "dbHost";
     final static String DB_PORT = "dbPort";
-
+    final static String DB_PWD = "dbPwd";
+    final static String DB_USER = "dbUser";
     static String dbInfo = "";
 
     private static final String TEST_DATABASE = "oauthMongoDB";
@@ -55,19 +64,52 @@ public class MongoDBUtils {
     private static String dbHost = "localhost";
     private static int dbPort = -1;
 
+    // from MongoServerSelector
+    private static final String TEST_USERNAME = "user";
+    private static final String TEST_DATABASE_REMOTE = "default";
+    private static final String MONGODB_SERVICE = "mongo-auth";
+
+    private static String dbName = "not set";
+    private static String dbPwd = "not set";
+    private static String dbUser = TEST_USERNAME;
+
+    private static String mongoTableUid = "not set";
+
     public static String MONGO_PROPS_FILE = "not set"; // this name needs to match the one used in CustomStoreSample
 
     private static MongodExecutable mongodExecutable = null;
+
+    private static boolean runRemote = true;
+
+    static {
+        /*
+         * Local mongoDB does not run on z/OS and some other OS, use remote for now
+         */
+        //isZOS = LibertyServerUtils.isZOS();
+        if (runRemote) {
+            Log.info(thisClass, "staticSetup", "Running remote, will connect to remote mongoDB server.");
+            dbName = TEST_DATABASE_REMOTE;
+        } else {
+            Log.info(thisClass, "staticSetup", "Running local mongoDB server.");
+            dbName = TEST_DATABASE;
+
+        }
+    }
 
     /**
      * Stop the embedded mongoDB server
      *
      * @throws Exception
      */
-    public static void stopMongoDB() throws Exception {
-        Log.info(thisClass, "stopMongoDB", "Stopping the embedded MongoDB.");
-        mongodExecutable.stop();
-        Log.info(thisClass, "stopMongoDB", "Stopped the embedded MongoDB.");
+    public static void stopMongoDB(String httpString, Integer httpPort) throws Exception {
+        if (runRemote) {
+            Log.info(thisClass, "mongoDBTeardownCleanup", "cleanupMongoDBEntries");
+            MongoDBUtils.cleanupMongoDBEntries(httpString, httpPort);
+        } else {
+            Log.info(thisClass, "stopMongoDB", "Stopping the embedded MongoDB.");
+            mongodExecutable.stop();
+            Log.info(thisClass, "stopMongoDB", "Stopped the embedded MongoDB.");
+        }
     }
 
     /**
@@ -78,7 +120,11 @@ public class MongoDBUtils {
      * @param propsFile
      * @throws Exception
      */
-    public static void startMongoDB(LibertyServer server, String propsFile) throws Exception {
+    public static void startMongoDB(LibertyServer server, String propsFile, String uid) throws Exception {
+        if (runRemote) {
+            startMongoDBRemoteOnly(server, propsFile, uid);
+            return;
+        }
         String method = "startMongoDB";
         MONGO_PROPS_FILE = propsFile;
 
@@ -91,7 +137,7 @@ public class MongoDBUtils {
         try {
             BufferedWriter out = new BufferedWriter(new FileWriter(tmpFile));
             try {
-                out.write("DBNAME:" + TEST_DATABASE);
+                out.write("DBNAME:" + dbName);
                 out.write("\nHOST:" + dbHost);
                 out.write("\nPORT:" + dbPort);
             } finally {
@@ -124,9 +170,142 @@ public class MongoDBUtils {
         Log.info(thisClass, method, "Started embedded mongoDB server.");
 
         // build variables to send to the setup servlet
-        dbInfo = "&" + DB_NAME + "=" + TEST_DATABASE + "&" + DB_HOST + "=" + dbHost + "&" + DB_PORT + "=" + dbPort;
+        dbInfo = "&" + DB_NAME + "=" + dbName + "&" + DB_HOST + "=" + dbHost + "&" + DB_PORT + "=" + dbPort;
 
         Log.info(thisClass, method, "MongoDB servlet props are " + dbInfo);
+    }
+
+    /**
+     * Added back in to support running on z/OS only
+     *
+     * @param server
+     * @param propsFile
+     * @param uid
+     * @throws Exception
+     */
+    public static void startMongoDBRemoteOnly(LibertyServer server, String propsFile, String uid) throws Exception {
+        String method = "startMongoDBRemoteOnly";
+        MONGO_PROPS_FILE = propsFile;
+        mongoTableUid = uid;
+
+        Log.info(thisClass, method, "Running get service for " + MONGODB_SERVICE);
+        getAvailableMongoServer(MONGODB_SERVICE);
+
+        Log.info(thisClass, method, "Populate mongo db props file for CustomStoreSample use.");
+        File tmpFile = new File("lib/LibertyFATTestFiles/", MONGO_PROPS_FILE);
+        tmpFile.getParentFile().mkdirs();
+        try {
+            BufferedWriter out = new BufferedWriter(new FileWriter(tmpFile));
+            try {
+                out.write("DBNAME:" + dbName);
+                out.write("\nHOST:" + dbHost);
+                out.write("\nPWD:" + dbPwd);
+                out.write("\nPORT:" + dbPort);
+                out.write("\nUSER:" + dbUser);
+                out.write("\nUID:" + mongoTableUid);
+            } finally {
+                out.close();
+            }
+
+            server.copyFileToLibertyServerRoot(MONGO_PROPS_FILE);
+        } catch (IllegalStateException e) {
+            Log.info(thisClass, method, "Failed to create props file " + MONGO_PROPS_FILE);
+            e.printStackTrace();
+            throw new Exception("Could not set up " + MONGO_PROPS_FILE + ". The CustomStoreSample will likely fail to connect to the database.");
+        } finally {
+            tmpFile.delete();
+        }
+
+        // build variables to send to the setup servlet
+        dbInfo = "&" + DB_NAME + "=" + dbName + "&" + DB_HOST + "=" + dbHost + "&" + DB_PWD + "=" + dbPwd + "&" + DB_PORT + "=" + dbPort + "&" + DB_USER + "=" + dbUser + "&uid="
+                 + uid;
+
+        Log.info(thisClass, method, "MongoDB props are " + dbInfo);
+    }
+
+    private static ExternalTestService getAvailableMongoServer(String serverPlaceholder) {
+        String method = "getAvailableMongoServer";
+
+        Exception failure = null;
+        ExternalTestService mongoService = null;
+
+        for (int i = 1; i < 4; i++) {
+            Log.info(thisClass, method, "Request for mongoDB service, attempt #" + i);
+            try {
+                while (true) {
+                    mongoService = ExternalTestService.getService(serverPlaceholder);
+                    Log.info(thisClass, method, "Found service, testing if valid");
+                    if (validateMongoConnectionAndSetConfig(mongoService)) {
+                        Log.info(thisClass, method, "Found service, ping successful");
+                        return mongoService;
+                    }
+                }
+            } catch (Exception e) {
+                Log.error(thisClass, method, e, "Exeption trying to get MongoDB service.");
+                failure = e;
+                if (i < 3) {
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException e1) {
+                        // fine
+                    }
+                }
+            }
+        }
+
+        if (failure != null) {
+            // Thrown when there are no more services to try
+            Log.warning(thisClass, method + " Despite a retry, could not get requested MongoDB server");
+            throw new RuntimeException(failure);
+        }
+
+        return mongoService;
+    }
+
+    private static boolean validateMongoConnectionAndSetConfig(ExternalTestService mongoService) {
+        String method = "validateMongoConnectionAndSetConfig";
+        MongoClient mongoClient = null;
+
+        dbHost = mongoService.getAddress();
+        int port = mongoService.getPort();
+        dbPort = port;
+
+        File trustStore = null;
+
+        MongoClientOptions.Builder optionsBuilder = new MongoClientOptions.Builder().connectTimeout(30000);
+        try {
+            trustStore = File.createTempFile("mongoTrustStore", "jks");
+            Map<String, String> serviceProperties = mongoService.getProperties();
+
+            String password = serviceProperties.get(TEST_USERNAME + "_password"); // will be null if there's no auth for this server
+
+            MongoClientOptions clientOptions = optionsBuilder.build();
+            List<MongoCredential> credentials = Collections.emptyList();
+            if (password != null) {
+                MongoCredential credential = MongoCredential.createCredential(TEST_USERNAME, TEST_DATABASE_REMOTE, password.toCharArray());
+                credentials = Collections.singletonList(credential);
+                dbPwd = password;
+            }
+
+            Log.info(thisClass, method,
+                     "Attempting to contact server " + dbHost + ":" + port + " with password " + (password != null ? "set" : "not set") + " and truststore "
+                                        + "not set");
+            mongoClient = new MongoClient(new ServerAddress(dbHost, port), credentials, clientOptions);
+            mongoClient.getDB(TEST_DATABASE_REMOTE).getCollectionNames();
+            dbName = TEST_DATABASE_REMOTE;
+            mongoClient.close();
+        } catch (Exception e) {
+            // "Timed out" is checked in the output.txt and can cause a spurious failure
+            String exceptionMsg = e.toString().replaceAll("Timed out", "Took too long");
+            Log.info(thisClass, method, "Couldn't create a connection to " + mongoService.getServiceName() + " on " + mongoService.getAddress() + ". " + exceptionMsg);
+            mongoService.reportUnhealthy("Couldn't connect to server. Exception: " + exceptionMsg);
+            return false;
+        } finally {
+            if (trustStore != null) {
+                trustStore.delete();
+            }
+        }
+        return true;
     }
 
     /**
@@ -136,7 +315,7 @@ public class MongoDBUtils {
      * @param defaultPort
      * @throws Exception
      */
-    public static void setupMongoDBEntries(String httpString, Integer defaultPort) throws Exception {
+    public static void setupMongoDBEntries(String httpString, Integer defaultPort, String uid) throws Exception {
         String method = "setupMongoDBEntries";
 
         HttpURLConnection con = null;
@@ -145,7 +324,7 @@ public class MongoDBUtils {
             msgUtils.printMethodName(method);
             Log.info(thisClass, method, "Create DataBases through the server");
             URL setupURL = AutomationTools.getNewUrl(httpString + "/oAuth20MongoSetup?port=" + defaultPort
-                                                     + "&schemaName=OAuthDBSchema" + dbInfo);
+                                                     + "&schemaName=OAuthDBSchema" + "&uid=" + uid + dbInfo);
             Log.info(thisClass, method, "setupURL: " + setupURL);
             con = (HttpURLConnection) setupURL.openConnection();
             con.setDoInput(true);
@@ -368,6 +547,48 @@ public class MongoDBUtils {
         }
 
         return msg;
+
+    }
+
+    public static void cleanupMongoDBEntries(String httpString, Integer defaultPort) throws Exception {
+
+        HttpURLConnection con = null;
+        try {
+            msgUtils.printMethodName("cleanupMongoDBEntries");
+            Log.info(thisClass, "cleanupMongoDBEntries", "Drop DataBases through the server");
+            URL setupURL = AutomationTools
+                            .getNewUrl(httpString + "/oAuth20MongoSetup?port=" + defaultPort + "&dropDB=true" + dbInfo);
+            Log.info(thisClass, "cleanupMongoDBEntries", "cleanupURL: " + setupURL);
+            con = (HttpURLConnection) setupURL.openConnection();
+            con.setDoInput(true);
+            con.setDoOutput(true);
+            con.setUseCaches(false);
+            con.setRequestMethod("GET");
+            InputStream is = con.getInputStream();
+            InputStreamReader isr = new InputStreamReader(is);
+            BufferedReader br = new BufferedReader(isr);
+
+            String sep = System.getProperty("line.separator");
+            StringBuilder lines = new StringBuilder();
+
+            // Send output from servlet to console output
+            for (String line = br.readLine(); line != null; line = br.readLine()) {
+                lines.append(line).append(sep);
+                Log.info(thisClass, "cleanupMongoDBEntries", line);
+            }
+
+            con.disconnect();
+
+        } catch (Exception e) {
+
+            Log.info(thisClass, "cleanupMongoDBEntries", "Exception occurred: " + e.toString());
+            Log.error(thisClass, "cleanupMongoDBEntries", e, "Exception occurred");
+            System.err.println("Exception: " + e);
+            if (con != null) {
+                con.disconnect();
+            }
+            // throw e;
+        }
 
     }
 

--- a/dev/com.ibm.ws.security.oauth_fat/bnd.bnd
+++ b/dev/com.ibm.ws.security.oauth_fat/bnd.bnd
@@ -30,6 +30,7 @@ fat.project: true
     com.ibm.ws.webcontainer.security;version=latest,\
     com.ibm.ws.security.oauth.oidc_fat.common;version=latest,\
     com.ibm.websphere.javaee.jsonp.1.0;version=latest,\
+    com.ibm.ws.mongo_fat;version=latest,\
     com.ibm.ws.security.fat.common;version=latest, \
     org.apache.httpcomponents:httpclient;version=4.5.7, \
     org.apache.httpcomponents:httpcore;version=4.4.13, \

--- a/dev/com.ibm.ws.security.oauth_fat/build.gradle
+++ b/dev/com.ibm.ws.security.oauth_fat/build.gradle
@@ -36,6 +36,7 @@ dependencies {
                   project(':com.ibm.ws.com.meterware.httpunit.1.6.2'),     // 1.7 causes refresh token failures
                   files('lib/jsse.jar'),
                   'rhino:js:1.6R5',
+                  project(':com.ibm.ws.mongo_fat'),
                   'de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.0.0',
                   'de.flapdoodle.embed:de.flapdoodle.embed.process:3.0.1',
                   'org.apache.commons:commons-compress:1.20'

--- a/dev/com.ibm.ws.security.oauth_fat/fat/src/com/ibm/ws/security/oauth20/fat/OAuth20TestCommon.java
+++ b/dev/com.ibm.ws.security.oauth_fat/fat/src/com/ibm/ws/security/oauth20/fat/OAuth20TestCommon.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.security.oauth20.fat;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.BufferedReader;
@@ -19,9 +20,12 @@ import java.io.FileWriter;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
 import java.net.URL;
+import java.net.UnknownHostException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.Random;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
@@ -37,7 +41,9 @@ import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.slf4j.LoggerFactory;
 
+import com.ibm.websphere.simplicity.config.MongoDBElement;
 import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.mongo.fat.MongoServerSelector;
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.Constants;
 import com.meterware.httpunit.HttpUnitOptions;
 import com.meterware.httpunit.WebConversation;
@@ -78,14 +84,26 @@ public class OAuth20TestCommon {
     private static final Class<?> thisClass = OAuth20TestCommon.class;
 
     public static String MONGO_PROPS_FILE = "mongoDB.props"; // this name needs to match the one used in CustomStoreSample
+    public static String mongoTableUid = "defaultUID";
     public boolean isRunningCustomStore = false;
     // These should match the strings used in the oAuth20MongoSetup servlet
     final static String DB_NAME = "dbName";
     final static String DB_HOST = "dbHost";
     final static String DB_PORT = "dbPort";
+    final static String DB_PWD = "dbPwd";
+    final static String DB_USER = "dbUser";
     static String dbInfo = "";
 
     private static MongodExecutable mongodExecutable = null;
+
+    static {
+        try {
+            mongoTableUid = "_" + InetAddress.getLocalHost().getHostName() + "_" + new Random(System.currentTimeMillis()).nextLong();
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+            mongoTableUid = "localhost-" + System.nanoTime();
+        }
+    }
 
     protected static TrustManager tm = null;
 
@@ -143,6 +161,20 @@ public class OAuth20TestCommon {
     public String refreshToken = "Refresh Token: ";
 
     private static String[] expectedMessages;
+
+    private static boolean runRemote = true;
+
+    static {
+        /*
+         * Local mongoDB does not run on z/OS, use remote
+         */
+        //isZOS = LibertyServerUtils.isZOS();
+        if (runRemote) {
+            Log.info(thisClass, "staticSetup", "Will connect to remote mongoDB server.");
+        } else {
+            Log.info(thisClass, "staticSetup", "Will start local mongoDB server.");
+        }
+    }
 
     @Before
     public void beforeTest() {
@@ -204,11 +236,11 @@ public class OAuth20TestCommon {
             isRunningCustomStore = true;
             server.installUserBundle("security.custom.store_1.0");
             server.installUserFeature("customStoreSample-1.0");
-            setupRemoteMongoDBConfig(server);
+            setupMongoDBConfig(server);
         } else if (_server.equals(MONGO_STORE_BELL_SERVER) || _server.equals(MONGO_STORE_BELL_SERVER2) || _server.equals(MONGO_STORE_BELL_SERVER3)) {
             Log.info(thisClass, thisMethod, "Add CustomStore Bell");
             isRunningCustomStore = true;
-            setupRemoteMongoDBConfig(server);
+            setupMongoDBConfig(server);
         }
 
         // start the test server and wait for it to complete starting
@@ -246,7 +278,13 @@ public class OAuth20TestCommon {
         return;
     }
 
-    private void setupRemoteMongoDBConfig(LibertyServer server) throws Exception {
+    private void setupMongoDBConfig(LibertyServer server) throws Exception {
+        String methodName = "setupMongoDBConfig";
+        if (runRemote) {
+            setupRemoteMongoDBConfig(server);
+            return;
+        }
+
         /*
          * Get the MongoDB connection properties. These are read in from the
          * mongoDB.props file.
@@ -255,7 +293,7 @@ public class OAuth20TestCommon {
         String mongodbHost = "localHost";
         int mongodbPort = Network.getFreeServerPort();
 
-        Log.info(thisClass, "setupRemoteMongoDBConfig", "Populate mongo db props file for CustomStoreSample use.");
+        Log.info(thisClass, methodName, "Populate mongo db props file for CustomStoreSample use.");
         File tmpFile = new File("lib/LibertyFATTestFiles/", MONGO_PROPS_FILE);
         tmpFile.getParentFile().mkdirs();
         try {
@@ -270,7 +308,7 @@ public class OAuth20TestCommon {
 
             server.copyFileToLibertyServerRoot(MONGO_PROPS_FILE);
         } catch (IllegalStateException e) {
-            Log.info(thisClass, "setupRemoteMongoDBConfig", "Failed to create props file " + MONGO_PROPS_FILE);
+            Log.info(thisClass, methodName, "Failed to create props file " + MONGO_PROPS_FILE);
             e.printStackTrace();
         } finally {
             tmpFile.delete();
@@ -279,7 +317,7 @@ public class OAuth20TestCommon {
         /*
          * Startup a MondoDB instance.
          */
-        Log.info(thisClass, "setupRemoteMongoDBConfig", "Start embedded mongoDB server.");
+        Log.info(thisClass, methodName, "Start embedded mongoDB server.");
         RuntimeConfig runtimeConfig = Defaults.runtimeConfigFor(Command.MongoD, LoggerFactory.getLogger(thisClass.getName()))
                         .build();
         MongodStarter starter = MongodStarter.getInstance(runtimeConfig);
@@ -294,6 +332,46 @@ public class OAuth20TestCommon {
         dbInfo = "&" + DB_NAME + "=" + mongodbName + "&" + DB_HOST + "=" + mongodbHost + "&" + DB_PORT + "=" + mongodbPort;
     }
 
+    private void setupRemoteMongoDBConfig(LibertyServer server) throws Exception {
+        Log.info(thisClass, "setupRemoteMongoDBConfig", "Adding MongoDB info to server.xml");
+        // gets a remote host we can use
+        MongoServerSelector.assignMongoServers(server);
+
+        assertEquals("Should have 1 mongoDB ref defined in server config", 1, server.getServerConfiguration().getMongoDBs().size());
+
+        // now populate a properties file for the CustomStoreSample to use
+        MongoDBElement mongoConfig = server.getServerConfiguration().getMongoDBs().get(0);
+
+        Log.info(thisClass, "setupRemoteMongoDBConfig", "Populate mongo db props file for CustomStoreSample use.");
+        File tmpFile = new File("lib/LibertyFATTestFiles/", MONGO_PROPS_FILE);
+        tmpFile.getParentFile().mkdirs();
+        try {
+            BufferedWriter out = new BufferedWriter(new FileWriter(tmpFile));
+            try {
+                out.write("DBNAME:" + mongoConfig.getDatabaseName());
+                out.write("\nHOST:" + mongoConfig.getMongo().getHostNames());
+                out.write("\nPWD:" + mongoConfig.getMongo().getPassword());
+                out.write("\nPORT:" + mongoConfig.getMongo().getPortList()[0]);
+                out.write("\nUSER:" + mongoConfig.getMongo().getUser());
+                out.write("\nUID:" + mongoTableUid);
+            } finally {
+                out.close();
+            }
+
+            server.copyFileToLibertyServerRoot(MONGO_PROPS_FILE);
+        } catch (IllegalStateException e) {
+            Log.info(thisClass, "setupRemoteMongoDBConfig", "Failed to create props file " + MONGO_PROPS_FILE);
+            e.printStackTrace();
+        } finally {
+            tmpFile.delete();
+        }
+
+        // build variables to send to the setup servlet
+        dbInfo = "&" + DB_NAME + "=" + mongoConfig.getDatabaseName() + "&" + DB_HOST + "=" + mongoConfig.getMongo().getHostNames() + "&" + DB_PWD + "="
+                 + mongoConfig.getMongo().getPassword() + "&" + DB_PORT + "=" + mongoConfig.getMongo().getPortList()[0] + "&" + DB_USER + "=" + mongoConfig.getMongo().getUser()
+                 + "&uid=" + mongoTableUid;
+    }
+
     @After
     public void testTearDown() throws Exception {
         printTestEnd();
@@ -301,6 +379,40 @@ public class OAuth20TestCommon {
 
     @AfterClass
     public static void tearDown() throws Exception {
+        if (runRemote) {
+            try {
+                /**
+                 * Clean up the remote mongoDB database.
+                 */
+                String urlString = httpStart + "/oAuth20MongoSetup?port=" + new Integer(server.getHttpDefaultPort());
+
+                urlString = urlString + "&dropDB=true" + dbInfo;
+                URL setupURL = new URL(urlString);
+                Log.info(thisClass, "tearDown", "dropURL: " + setupURL);
+                HttpURLConnection con = (HttpURLConnection) setupURL.openConnection();
+                con.setDoInput(true);
+                con.setDoOutput(true);
+                con.setUseCaches(false);
+                con.setRequestMethod("GET");
+                InputStream is = con.getInputStream();
+                InputStreamReader isr = new InputStreamReader(is);
+                BufferedReader br = new BufferedReader(isr);
+
+                String sep = System.getProperty("line.separator");
+                StringBuilder lines = new StringBuilder();
+
+                // Send output from servlet to console output
+                for (String line = br.readLine(); line != null; line = br.readLine()) {
+                    lines.append(line).append(sep);
+                    Log.info(thisClass, "tearDown", line);
+                }
+
+                con.disconnect();
+            } catch (Throwable e) {
+                Log.info(thisClass, "tearDown", "Exception calling dropDB for mongoDB. If this is a Derby test, ignore this message." + e);
+            }
+        }
+
         try {
             server.deleteFileFromLibertyServerRoot(MONGO_PROPS_FILE);
         } catch (Exception e) {

--- a/dev/com.ibm.ws.security.oauth_fat/publish/servers/com.ibm.ws.security.oauth-2.0.customstore.bell.fat/server.xml
+++ b/dev/com.ibm.ws.security.oauth_fat/publish/servers/com.ibm.ws.security.oauth-2.0.customstore.bell.fat/server.xml
@@ -96,6 +96,8 @@
 
 	<javaPermission codebase="${wlp.user.dir}/shared/security.custom.store_1.0.jar"
 		className="java.security.AllPermission" />
-		
+    <javaPermission
+		codebase="${server.config.dir}/apps/oAuth20MongoSetup.war"
+		className="java.security.AllPermission" />	
 
 </server>

--- a/dev/com.ibm.ws.security.oauth_fat/publish/servers/com.ibm.ws.security.oauth-2.0.customstore.fat/server.xml
+++ b/dev/com.ibm.ws.security.oauth_fat/publish/servers/com.ibm.ws.security.oauth-2.0.customstore.fat/server.xml
@@ -92,5 +92,12 @@
 	<javaPermission
 		codebase="${server.config.dir}/mongoDB/mongo-java-driver.jar"
 		className="java.security.AllPermission" />
+		
+	<javaPermission
+		codebase="${server.config.dir}/publish/bundles/security.custom.store_1.0.jar"
+		className="java.security.AllPermission" />
+    <javaPermission
+		codebase="${server.config.dir}/apps/oAuth20MongoSetup.war"
+		className="java.security.AllPermission" />	
 
 </server>

--- a/dev/com.ibm.ws.security.oauth_fat/publish/servers/com.ibm.ws.security.oauth-2.0.customstore.xor.fat/server.xml
+++ b/dev/com.ibm.ws.security.oauth_fat/publish/servers/com.ibm.ws.security.oauth-2.0.customstore.xor.fat/server.xml
@@ -92,5 +92,8 @@
 	<javaPermission
 		codebase="${server.config.dir}/mongoDB/mongo-java-driver.jar"
 		className="java.security.AllPermission" />
+    <javaPermission
+		codebase="${server.config.dir}/apps/oAuth20MongoSetup.war"
+		className="java.security.AllPermission" />
 
 </server>

--- a/dev/com.ibm.ws.security.oauth_fat/publish/servers/com.ibm.ws.security.oauth-2.0.customstore2.bell.fat/server.xml
+++ b/dev/com.ibm.ws.security.oauth_fat/publish/servers/com.ibm.ws.security.oauth-2.0.customstore2.bell.fat/server.xml
@@ -96,6 +96,8 @@
 
 	<javaPermission codebase="${wlp.user.dir}/shared/security.custom.store_1.0.jar"
 		className="java.security.AllPermission" />
-		
+	<javaPermission
+		codebase="${server.config.dir}/apps/oAuth20MongoSetup.war"
+		className="java.security.AllPermission" />	
 
 </server>

--- a/dev/com.ibm.ws.security.oauth_fat/publish/servers/com.ibm.ws.security.oauth-2.0.customstore2.fat/server.xml
+++ b/dev/com.ibm.ws.security.oauth_fat/publish/servers/com.ibm.ws.security.oauth-2.0.customstore2.fat/server.xml
@@ -91,5 +91,8 @@
 	<javaPermission
 		codebase="${server.config.dir}/mongoDB/mongo-java-driver.jar"
 		className="java.security.AllPermission" />
+    <javaPermission
+		codebase="${server.config.dir}/apps/oAuth20MongoSetup.war"
+		className="java.security.AllPermission" />
 
 </server>

--- a/dev/com.ibm.ws.security.oauth_fat/publish/servers/com.ibm.ws.security.oauth-2.0.customstore3.bell.fat/server.xml
+++ b/dev/com.ibm.ws.security.oauth_fat/publish/servers/com.ibm.ws.security.oauth-2.0.customstore3.bell.fat/server.xml
@@ -94,6 +94,7 @@
 		className="java.security.AllPermission" />
 	<javaPermission codebase="${wlp.user.dir}/shared/security.custom.store_1.0.jar"
 		className="java.security.AllPermission" />
-
-
+    <javaPermission
+		codebase="${server.config.dir}/apps/oAuth20MongoSetup.war"
+		className="java.security.AllPermission" />
 </server>

--- a/dev/com.ibm.ws.security.oauth_fat/publish/servers/com.ibm.ws.security.oauth-2.0.customstore3.fat/server.xml
+++ b/dev/com.ibm.ws.security.oauth_fat/publish/servers/com.ibm.ws.security.oauth-2.0.customstore3.fat/server.xml
@@ -91,5 +91,8 @@
 	<javaPermission
 		codebase="${server.config.dir}/mongoDB/mongo-java-driver.jar"
 		className="java.security.AllPermission" />
+    <javaPermission
+		codebase="${server.config.dir}/apps/oAuth20MongoSetup.war"
+		className="java.security.AllPermission" />
 
 </server>


### PR DESCRIPTION
Fixes #17230

RTC 283942

The new local mongoDB doesn't work on z/OS and some other OS. Adding back in accessing the Consul remote mongoDB to run remote again until we can determine what OSs are supported and/or make updates to the local MongoDB and/or swap in a new one.

Also added additional permissions for `com.ibm.ws.security.oauth_fat` tests as I noticed the mongoDB tests were causing Java 2 failures.

Rather than doing a full revert of #16775, this adds in either remote or local with it defaulted to remote.