### PR TITLE
Issue 12778: Fix JWK cache issue in JwKRetriever

### DIFF
--- a/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JwKRetriever.java
+++ b/dev/com.ibm.ws.security.common.jsonwebkey/src/com/ibm/ws/security/common/jwk/impl/JwKRetriever.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 IBM Corporation and others.
+ * Copyright (c) 2016, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -210,6 +210,7 @@ public class JwKRetriever {
 
     @Sensitive
     private Key getJwkFromJWKSet(@Sensitive String setId, String kid, String x5t, String use, @Sensitive String keyText, JwkKeyType keyType) {
+        boolean isKeyIdentifierUsed = (kid != null || x5t != null || use != null);
         Key key = null;
         if (kid != null) {
             key = jwkSet.getKeyBySetIdAndKid(setId, kid, keyType);
@@ -224,7 +225,7 @@ public class JwKRetriever {
         if (keyText != null) {
             key = jwkSet.getKeyBySetIdAndKeyText(setId, keyText, keyType);
         }
-        if (key == null) {
+        if (key == null && !isKeyIdentifierUsed) {
             key = jwkSet.getKeyBySetId(setId, keyType);
         }
         return key;

--- a/dev/com.ibm.ws.security.fat.common.jwt/src/com/ibm/ws/security/fat/common/jwt/JwtConstants.java
+++ b/dev/com.ibm.ws.security.fat.common.jwt/src/com/ibm/ws/security/fat/common/jwt/JwtConstants.java
@@ -48,4 +48,7 @@ public class JwtConstants extends Constants {
 
     public static final String BOOTSTRAP_PROP_ENCRYPTION_SETTING = "fat.server.encryption.setting";
 
+    public static final String JWT_SIMPLE_BUILDER_SERVLET = "jwtbuilder";
+    public static final String JWT_SIMPLE_BUILDER_ENDPOINT = JWT_SIMPLE_BUILDER_SERVLET + "/build";
+
 }

--- a/dev/com.ibm.ws.security.fat.common.jwt/src/com/ibm/ws/security/fat/common/jwt/actions/JwtTokenActions.java
+++ b/dev/com.ibm.ws.security.fat.common.jwt/src/com/ibm/ws/security/fat/common/jwt/actions/JwtTokenActions.java
@@ -29,7 +29,7 @@ public class JwtTokenActions extends TestActions {
     // anyone calling this method needs to add upn to the extraClaims that it passes in (if they need it)
     public String getJwtTokenUsingBuilder(String testName, LibertyServer server, String builderId, List<NameValuePair> extraClaims) throws Exception {
 
-        String jwtBuilderUrl = SecurityFatHttpUtils.getServerUrlBase(server) + "/jwtbuilder/build";
+        String jwtBuilderUrl = SecurityFatHttpUtils.getServerUrlBase(server) + JwtConstants.JWT_SIMPLE_BUILDER_ENDPOINT;
 
         List<NameValuePair> requestParams = setRequestParms(builderId, extraClaims);
 

--- a/dev/com.ibm.ws.security.fat.common.mp.jwt/fat/src/com/ibm/ws/security/fat/common/mp/jwt/sharedTests/MPJwtMPConfigTests.java
+++ b/dev/com.ibm.ws.security.fat.common.mp.jwt/fat/src/com/ibm/ws/security/fat/common/mp/jwt/sharedTests/MPJwtMPConfigTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -140,7 +140,11 @@ public class MPJwtMPConfigTests extends CommonMpJwtFat {
      * @throws Exception
      */
     protected static void setUpAndStartRSServerForApiTests(LibertyServer rs_server, LibertyServer builderServer, String configFile, boolean jwkEnabled) throws Exception {
-        setupBootstrapPropertiesForMPTests(rs_server, "\"" + SecurityFatHttpUtils.getServerSecureUrlBase(builderServer) + "jwt/ibm/api/defaultJWT/jwk\"", jwkEnabled);
+        setUpAndStartRSServerForApiTests(rs_server, builderServer, configFile, jwkEnabled, "defaultJWT");
+    }
+
+    protected static void setUpAndStartRSServerForApiTests(LibertyServer rs_server, LibertyServer builderServer, String configFile, boolean jwkEnabled, String builderId) throws Exception {
+        setupBootstrapPropertiesForMPTests(rs_server, "\"" + SecurityFatHttpUtils.getServerSecureUrlBase(builderServer) + "jwt/ibm/api/" + builderId + "/jwk\"", jwkEnabled);
 
         bootstrapUtils.writeBootstrapProperty(rs_server, "mpJwt_authHeaderPrefix", MPJwt11FatConstants.TOKEN_TYPE_BEARER + " ");
 

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -95,10 +95,12 @@ import componenttest.rules.repeater.RepeatTests;
                 MPJwtGoodMPConfigAsEnvVars_NoPublicKey_UseKeyLoc.class,
                 MPJwtGoodMPConfigAsEnvVars_NoPublicKey_UseJwksUri_X509.class,
                 MPJwtGoodMPConfigAsEnvVars_NoPublicKey_UseJwksUri_JWK.class,
-                MPJwtBadMPConfigAsEnvVars.class
+                MPJwtBadMPConfigAsEnvVars.class,
 
-                // the mpJwt-1.2 project contains tests that validate the behavior of 1.2
-                // it will run these same tests, but enable the 1.2 feature instead of the 1.1 feature
+                MPJwtJwkTokenCacheTests.class
+
+// the mpJwt-1.2 project contains tests that validate the behavior of 1.2
+// it will run these same tests, but enable the 1.2 feature instead of the 1.1 feature
 })
 
 public class FATSuite {

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/MPJwtJwkTokenCacheTests.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/fat/src/com/ibm/ws/security/mp/jwt11/fat/MPJwtJwkTokenCacheTests.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.mp.jwt11.fat;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.ibm.ws.security.fat.common.expectations.Expectations;
+import com.ibm.ws.security.fat.common.jwt.JwtTokenForTest;
+import com.ibm.ws.security.fat.common.mp.jwt.MPJwtFatConstants;
+import com.ibm.ws.security.fat.common.mp.jwt.sharedTests.MPJwt11MPConfigTests;
+import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * This is the test class that will run tests validate the correct behavior with unique jwk cache conditions.
+ * <OL>
+ * <LI>Setup 2 servers - one to act as the jwtBuilder and another to consume the tokens using mpJwt.
+ * <OL>
+ * <LI>
+ *
+ **/
+
+@Mode(TestMode.FULL)
+@RunWith(FATRunner.class)
+public class MPJwtJwkTokenCacheTests extends MPJwt11MPConfigTests {
+
+    protected static Class<?> thisClass = MPJwtBasicTests.class;
+
+    @Server("com.ibm.ws.security.mp.jwt.1.1.fat")
+    public static LibertyServer resourceServer;
+
+    @Server("com.ibm.ws.security.mp.jwt.1.1.fat.builder")
+    public static LibertyServer jwtBuilderServer;
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.withoutModification();
+
+    private final TestValidationUtils validationUtils = new TestValidationUtils();
+
+    /**
+     * Startup the builder and resource servers
+     * Set flag to tell the code that runs between tests NOT to restore the server config between tests
+     * (very few of the tests use the config that the server starts with - this setting will save run time)
+     * Build the list of app urls and class names that each test will use
+     *
+     * @throws Exception
+     */
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        setUpAndStartBuilderServer(jwtBuilderServer, "server_jwkCacheTests_1.xml", true, true);
+
+        setUpAndStartRSServerForApiTests(resourceServer, jwtBuilderServer, "rs_server_orig_withAudience.xml", true, "defaultJWT_withAudience");
+
+        skipRestoreServerTracker.addServer(resourceServer);
+
+    }
+
+    /**
+     *
+     * Test that we can consume a jwt token when we only have one entry in the jwk cache.
+     * We ran into a case where we were creating a jwt and when we tried to consume it, we received a signature validation failure.
+     * When the token was consumed, the jwk token cache was populated with 1 entry and then further along, we to process a second
+     * token. We don't find an entry matching the second kid in the cache and other values to check against are not set, so
+     * we ended up falling into getKeyBySetId which will return the 1 and only cache entry - which in this case is not
+     * correct.
+     * To reproduce the problem:
+     * This test will start up a server with a jwtBuilder that has jwkEnabled=false. It will create a jwt token (using the key to generate
+     * the kid) and then use that token in another server with mpJwt configured (referencing the jwksUri of the builder).
+     * It then reconfigures the builder setting jwkEnabled=true. It will create another token (this time using the jwk to generate the kid).
+     * When we try to consume this token, we need to show that we don't end up using the 1 cached value - which would result in a
+     * signature validation failure.
+     * We should be able to successfully access the protected app.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void MPJwtJwkTokenCacheTests_OnlyOneEntryInCache() throws Exception {
+
+        WebClient webClient = actions.createWebClient();
+
+        MPJwtJwkTokenCacheTests_common(webClient);
+
+        // reconfigure the server to use the "same builder", but this time set jwkEnabled to true to force a new kid value
+        jwtBuilderServer.reconfigureServerUsingExpandedConfiguration(_testName, "server_jwkCacheTests_2.xml");
+
+        MPJwtJwkTokenCacheTests_common(webClient);
+
+        actions.destroyWebClient(webClient);
+
+    }
+
+    public void MPJwtJwkTokenCacheTests_common(WebClient webClient) throws Exception {
+
+        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer);
+
+        JwtTokenForTest jwtTokenTools = new JwtTokenForTest(builtToken);
+
+        String url = buildAppUrl(resourceServer, MPJwtFatConstants.MICROPROFILE_SERVLET, MPJwtFatConstants.MPJWT_APP_SEC_CONTEXT_REQUEST_SCOPE);
+
+        Expectations expectations = goodTestExpectations(jwtTokenTools, url, MPJwtFatConstants.MPJWT_APP_CLASS_SEC_CONTEXT_REQUEST_SCOPE);
+
+        Page response = actions.invokeUrlWithBearerToken(_testName, webClient, url, builtToken);
+        validationUtils.validateResult(response, expectations);
+
+    }
+
+}

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/publish/servers/com.ibm.ws.security.mp.jwt.1.1.fat.builder/configs/server_jwkCacheTests_1.xml
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/publish/servers/com.ibm.ws.security.mp.jwt.1.1.fat.builder/configs/server_jwkCacheTests_1.xml
@@ -1,0 +1,33 @@
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+    <include location="${shared.config.dir}/jwtBuilderFeatures.xml" />
+
+    <include location="${shared.config.dir}/goodBasicRegistry.xml" />
+
+    <include location="${shared.config.dir}/goodSSLSettings.xml" />
+
+    <include location="${shared.config.dir}/builder_fatTestPorts.xml" />
+
+    <include location="${shared.config.dir}/jwtbuilderApp.xml" />
+
+    <include location="${shared.config.dir}/builderAppJava2Settings.xml"/>
+
+    <jwtBuilder id="defaultJWT_withAudience"
+                issuer="testIssuer"
+                keyStoreRef="rsa_key"
+                keyAlias="rsacert"
+                signatureAlgorithm="RS256"
+                audiences="client01, client02"
+                />
+
+</server>

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat/publish/servers/com.ibm.ws.security.mp.jwt.1.1.fat.builder/configs/server_jwkCacheTests_2.xml
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat/publish/servers/com.ibm.ws.security.mp.jwt.1.1.fat.builder/configs/server_jwkCacheTests_2.xml
@@ -1,0 +1,34 @@
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+    <include location="${shared.config.dir}/jwtBuilderFeatures.xml" />
+
+    <include location="${shared.config.dir}/goodBasicRegistry.xml" />
+
+    <include location="${shared.config.dir}/goodSSLSettings.xml" />
+
+    <include location="${shared.config.dir}/builder_fatTestPorts.xml" />
+
+    <include location="${shared.config.dir}/jwtbuilderApp.xml" />
+
+    <include location="${shared.config.dir}/builderAppJava2Settings.xml"/>
+
+    <jwtBuilder id="defaultJWT_withAudience"
+                issuer="testIssuer"
+                jwkEnabled="${oidcJWKEnabled}"
+                keyStoreRef="rsa_key"
+                keyAlias="rsacert"
+                signatureAlgorithm="RS256"
+                audiences="client01, client02"
+                />
+
+</server>


### PR DESCRIPTION
Resolves #12778

The `JwKRetriever` class has a cache for JWKs that have already been retrieved or otherwise obtained. There's a bug in the cache retrieval code that would return an incorrect cached JWK.

**Scenario:**

1. A JWT with a `kid` value of `"JWK1"` and signed with JWK1 is received by the JWT consumer.
2. When no keys have been cached yet and the JWT consumer uses JWKs, the JWT consumer will fetch the JWK document from the JWKS URI that's configured in the JWT consumer.
3. Assuming that JWK1 is included in the JWK document with the `kid` value `"JWK1"`, that JWK will be matched as the key to use to verify the signature of the JWT. That JWK is cached in a collection associated with a "set ID". The "set ID" is the JWKS URI string. (e.g. `"https://.../jwks":[JWK1]`)
4. Since the correct JWK was used, the JWT signature is considered valid.
5. A new JWT with a `kid` value of `"JWK2"` and signed with JWK2 is received by the JWT consumer.
6. The `JwKRetriever` code will fail to find a key in the cache that has a `kid` of `"JWK2"`. It will fall back to seeing if there's only one key in the cached collection associated with the same "set ID". Again, the "set ID" is the JWKS URI and currently looks like `"https://.../jwks":[JWK1]`. In this case, we did already cache JWK1 in that collection. Since JWK1 is the only key in that collection, the `JwKRetriever` code will return that key. This is despite JWK1 having a `kid` value that doesn't match the `kid` value we're supposed to match against.
7. Validation of the new JWT will fail because the wrong key is used to verify the signature.