### PR TITLE
http2_fat: remove unnecessary commons dependencies

### DIFF
--- a/dev/com.ibm.ws.transport.http2_fat/build.gradle
+++ b/dev/com.ibm.ws.transport.http2_fat/build.gradle
@@ -13,7 +13,5 @@
 dependencies {
   requiredLibs  'org.apache.httpcomponents.client5:httpclient5:5.0.2',
     'org.apache.httpcomponents.core5:httpcore5:5.0.2',
-    'org.apache.httpcomponents.core5:httpcore5-h2:5.0.2',
-    project(':io.openliberty.org.apache.commons.logging'),
-    project(':io.openliberty.org.apache.commons.codec')
+    'org.apache.httpcomponents.core5:httpcore5-h2:5.0.2'
 }


### PR DESCRIPTION
Running `com.ibm.ws.transport.http2_fat` locally is broken, due to a combination of extraneous dependency declarations and #16620. 