### PR TITLE
SQLServer reset transaction timeout

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/test-applications/sqlserverfat/src/web/SQLServerTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/test-applications/sqlserverfat/src/web/SQLServerTestServlet.java
@@ -265,6 +265,9 @@ public class SQLServerTestServlet extends FATServlet {
             } catch (RollbackException x) {
                 System.out.println("tran.commit() threw a RollbackException as expected.");
                 x.printStackTrace(System.out);
+            } finally {
+                //Restore default transaction timeout
+                tran.setTransactionTimeout(0);
             }
         }
 


### PR DESCRIPTION
The test `testTransactionTimeout` sets a timeout of 8 seconds. 
However, this timeout is set on a UserTransaction and therefore will affect all subsequent tests. 
It is possible on a slow system that one of the other tests could throw a Rollback Exception if this timeout is reached due to a slow test. 

Therefore, re-set this timeout to 0 (disabled) after `testTransactionTimeout` is finished. 