### PR TITLE
Stage 1 of refactoring ApacheDSandKDC, move out variables

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/FATSuite.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/FATSuite.java
@@ -44,11 +44,11 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
                  */
 
 })
-public class FATSuite extends ApacheDSandKDC {
+public class FATSuite extends LdapApacheDSandKDC {
     /*
      * The ApacheDS Directory Service, Ldap and KDC are started globally in ApacheDSandKDC (beforeClass and afterClass).
      *
-     * ApacheDS trace will appear in output.txt. To enable more ApacheDS trace, see the setup method in ApacheDSandKDC.
+     * ApacheDS trace will appear in output.txt. To enable more ApacheDS trace, see the setupService method in ApacheDSandKDC.
      *
      */
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/LdapApacheDSandKDC.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/LdapApacheDSandKDC.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.wim.adapter.ldap.fat.krb5;
+
+import org.apache.directory.api.ldap.model.entry.Entry;
+import org.apache.directory.api.ldap.model.name.Dn;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.log.Log;
+import com.ibm.ws.security.wim.adapter.ldap.fat.krb5.utils.LdapKerberosUtils;
+
+import componenttest.custom.junit.runner.FATRunner;
+
+@RunWith(FATRunner.class)
+public class LdapApacheDSandKDC extends ApacheDSandKDC {
+
+    private static final Class<?> c = LdapApacheDSandKDC.class;
+
+    // regular user/group
+    protected static final String vmmUser1 = "user1";
+    protected static final String vmmUser1DN = "uid=vmmUser1," + BASE_DN;
+    protected static final String vmmUser1pwd = "password";
+    protected static final String vmmGroup1 = "vmmGroup1";
+    protected static final String vmmGroup1DN = "cn=" + vmmGroup1 + "," + BASE_DN;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+
+        BASE_DN = LdapKerberosUtils.BASE_DN;
+
+        DOMAIN = LdapKerberosUtils.DOMAIN;
+
+        bindPassword = LdapKerberosUtils.BIND_PASSWORD;
+
+        bindUserName = LdapKerberosUtils.BIND_USER;
+
+        bindPrincipalName = LdapKerberosUtils.BIND_PRINCIPAL_NAME;
+
+        ldapUser = "ldap";
+
+        krbtgtUser = "krbtgt";
+
+        setupService();
+
+        addBasicUserAndGroup();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        tearDownService();
+    }
+
+    /**
+     * Add a starter user and group for general servlet login and searches
+     *
+     */
+    public static void addBasicUserAndGroup() throws Exception {
+        Log.info(c, "addBasicUserAndGroup", "Adding basic user and group");
+        Entry entry = directoryService.newEntry(new Dn(vmmUser1DN));
+        entry.add("objectclass", "inetorgperson");
+        entry.add("uid", vmmUser1);
+        entry.add("sn", "user1");
+        entry.add("cn", "user1");
+        entry.add("userPassword", vmmUser1pwd);
+        session.add(entry);
+
+        entry = directoryService.newEntry(new Dn(vmmGroup1DN));
+        entry.add("objectclass", "groupOfNames");
+        entry.add("member", vmmUser1DN);
+        session.add(entry);
+        Log.info(c, "addBasicUserAndGroup", "Adding basic user and group");
+    }
+
+}

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBindLongRunTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBindLongRunTest.java
@@ -94,7 +94,7 @@ public class TicketCacheBindLongRunTest extends CommonBindTest {
      * @throws Exception
      */
     @Test
-    @CheckForLeakedPasswords({ LdapKerberosUtils.BIND_PASSWORD, ApacheDSandKDC.vmmUser1pwd })
+    @CheckForLeakedPasswords({ LdapKerberosUtils.BIND_PASSWORD, LdapApacheDSandKDC.vmmUser1pwd })
     public void dynamimcUpdateLoop() throws Exception {
         int numUpdates = 30;
 
@@ -120,7 +120,7 @@ public class TicketCacheBindLongRunTest extends CommonBindTest {
      * @throws Exception
      */
     @Test
-    @CheckForLeakedPasswords({ LdapKerberosUtils.BIND_PASSWORD, ApacheDSandKDC.vmmUser1pwd })
+    @CheckForLeakedPasswords({ LdapKerberosUtils.BIND_PASSWORD, LdapApacheDSandKDC.vmmUser1pwd })
     public void serverRestartLoop() throws Exception {
         int numUpdates = 5;
 


### PR DESCRIPTION
Stage 1 of splitting off some of the Ldap Kerberos specific bits to starting an ApacheDS KDC.

I moved the `@BeforeClass` and `@AfterClass` to the extending class so consumers can start `ApacheDSandKDC` how they want.

I did not move it out of the `ldap_fat.krb5` yet. 