### PR TITLE
recreate datastorehelper when identifyException changes

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
@@ -17,8 +17,8 @@ import java.sql.Driver;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLNonTransientException;
-import java.util.AbstractMap;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
@@ -749,7 +749,8 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
                     || !match(newProperties.get(DSConfig.HELPER_CLASS), properties.get(DSConfig.HELPER_CLASS))
                     || !match(newProperties.get(DSConfig.JDBC_DRIVER_REF), properties.get(DSConfig.JDBC_DRIVER_REF))
                     || !match(newProperties.get(DSConfig.ON_CONNECT), properties.get(DSConfig.ON_CONNECT))
-                    || !match(newProperties.get(DataSourceDef.transactional.name()), properties.get(DataSourceDef.transactional.name()))) {
+                    || !match(newProperties.get(DataSourceDef.transactional.name()), properties.get(DataSourceDef.transactional.name()))
+                    || connectorSvc.isHeritageEnabled() && !config.identifyExceptions.equals(wProps.get(DSConfig.IDENTIFY_EXCEPTION))) {
                     // Destroy everything, and allow lazy initialization to recreate
                     destroyConnectionFactories(true);
                 } else if (!AdapterUtil.match(vProps, config.vendorProps)
@@ -882,8 +883,7 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
                 identifications.put(new SQLStateAndCode(sqlState, errorCode), as);
             }
         }
-        if (identifications != null)
-            wProps.put(DSConfig.IDENTIFY_EXCEPTION, identifications);
+        wProps.put(DSConfig.IDENTIFY_EXCEPTION, identifications == null ? Collections.EMPTY_MAP : identifications);
 
         //Don't send out auth alias recommendation message with UCP since it may be required to set the 
         //user and password as ds props

--- a/dev/com.ibm.ws.jdbc_fat_v41/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_v41/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2020 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,12 @@ task addDerbyToErrorMapServer(type: Copy) {
   rename 'derby-.*.jar', 'derby.jar'
 }
 
+task addDerbyToErrorMapConfigUpdateServer(type: Copy) {
+  from configurations.derby
+  into file("$autoFvtDir/publish/servers/com.ibm.ws.jdbc.fat.v41.errorMapConfigUpdate/derby")
+  rename 'derby-.*.jar', 'derby.jar'
+}
+
 task addDerbyToServerDir(type: Copy) {
   from configurations.derby
   into new File(serverDir, 'derby')
@@ -42,5 +48,6 @@ addRequiredLibraries {
   dependsOn addDerbyToServerDir
   dependsOn addDerby40ToServerDir
   dependsOn addDerbyToErrorMapServer
+  dependsOn addDerbyToErrorMapConfigUpdateServer
   dependsOn addJakartaTransformer
 }

--- a/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/ErrorMappingConfigUpdateTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/ErrorMappingConfigUpdateTest.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2020,2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jdbc.fat.v41;
+
+import java.util.Collections;
+
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.DataSource;
+import com.ibm.websphere.simplicity.config.IdentifyException;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+@AllowedFFDC("java.sql.SQLException") // simulated exceptions forced by test case
+@RunWith(FATRunner.class)
+@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
+public class ErrorMappingConfigUpdateTest extends FATServletClient {
+
+    static final String APP_NAME = "errorMappingApp";
+
+    @Server("com.ibm.ws.jdbc.fat.v41.errorMapConfigUpdate")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        JavaArchive errorDriver = ShrinkHelper.buildJavaArchive("errorMappingDriver.jar", "jdbc.fat.v41.errormap.driver");
+        ShrinkHelper.exportToServer(server, "derby", errorDriver);
+
+        ShrinkHelper.defaultApp(server, APP_NAME, "jdbc.fat.v41.errormap.web");
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+
+    /**
+     * Verify configuration updates that add, remove, and modify identifyException elements.
+     */
+    @Test
+    public void testConfigUpdateIdentifyException() throws Exception {
+        // confirm the behavior with the original configuration
+        runTest(server, APP_NAME + "/ErrorMappingTestServlet", "testIdentify1234Stale");
+        runTest(server, APP_NAME + "/ErrorMappingTestServlet", "testIdentify08888NotStale");
+
+        // add: identifyException sqlState="08888" as="StaleConnection"
+        ServerConfiguration config = server.getServerConfiguration();
+
+        IdentifyException identify08888 = new IdentifyException();
+        identify08888.setSqlState("08888");
+        identify08888.setAs("StaleConnection");
+        DataSource errorMapDS = config.getDataSources().getById("errorMapDS");
+        errorMapDS.getIdentifyExceptions().add(identify08888);
+
+        server.setMarkToEndOfLog();
+        server.updateServerConfiguration(config);
+        server.waitForConfigUpdateInLogUsingMark(Collections.singleton(APP_NAME));
+
+        runTest(server, APP_NAME + "/ErrorMappingTestServlet", "testIdentify1234Stale");
+        runTest(server, APP_NAME + "/ErrorMappingTestServlet", "testIdentify08888Stale");
+
+        // modify: identifyException errorCode="1234" as="StaleConnection"
+        //    -->  identifyException errorCode="1234" as="Unsupported"
+
+        IdentifyException identify1234 = errorMapDS.getIdentifyExceptions().getBy("errorCode", "1234");
+        identify1234.setAs("Unsupported");
+
+        server.setMarkToEndOfLog();
+        server.updateServerConfiguration(config);
+        server.waitForConfigUpdateInLogUsingMark(Collections.singleton(APP_NAME));
+
+        runTest(server, APP_NAME + "/ErrorMappingTestServlet", "testIdentify1234NotStale");
+        runTest(server, APP_NAME + "/ErrorMappingTestServlet", "testIdentify08888Stale");
+
+        // remove: identifyException sqlState="08888" as="StaleConnection"
+        errorMapDS.getIdentifyExceptions().remove(identify08888);
+
+        server.setMarkToEndOfLog();
+        server.updateServerConfiguration(config);
+        server.waitForConfigUpdateInLogUsingMark(Collections.singleton(APP_NAME));
+
+        runTest(server, APP_NAME + "/ErrorMappingTestServlet", "testIdentify1234NotStale");
+        runTest(server, APP_NAME + "/ErrorMappingTestServlet", "testIdentify08888NotStale");
+
+        // restore: identifyException errorCode="1234" as="Unsupported"
+        //     -->  identifyException errorCode="1234" as="StaleConnection"
+        identify1234.setAs("StaleConnection");
+
+        server.setMarkToEndOfLog();
+        server.updateServerConfiguration(config);
+        server.waitForConfigUpdateInLogUsingMark(Collections.singleton(APP_NAME));
+
+        runTest(server, APP_NAME + "/ErrorMappingTestServlet", "testIdentify1234Stale");
+        runTest(server, APP_NAME + "/ErrorMappingTestServlet", "testIdentify08888NotStale");
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2020 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,7 +28,8 @@ import componenttest.topology.impl.LibertyServerFactory;
 @SuiteClasses({
                 JDBC41UpgradeTest.class,
                 JDBC41Test.class,
-                ErrorMappingTest.class
+                ErrorMappingTest.class,
+                ErrorMappingConfigUpdateTest.class
 })
 public class FATSuite {
     public static final String appName = "basicfat";

--- a/dev/com.ibm.ws.jdbc_fat_v41/publish/servers/com.ibm.ws.jdbc.fat.v41.errorMapConfigUpdate/bootstrap.properties
+++ b/dev/com.ibm.ws.jdbc_fat_v41/publish/servers/com.ibm.ws.jdbc.fat.v41.errorMapConfigUpdate/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+com.ibm.ws.logging.trace.specification=*=info=enabled:RRA=all
+com.ibm.ws.logging.max.file.size=0
+osgi.console=5678
+bootstrap.include=../testports.properties

--- a/dev/com.ibm.ws.jdbc_fat_v41/publish/servers/com.ibm.ws.jdbc.fat.v41.errorMapConfigUpdate/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_v41/publish/servers/com.ibm.ws.jdbc.fat.v41.errorMapConfigUpdate/server.xml
@@ -1,0 +1,47 @@
+<!--
+    Copyright (c) 2020,2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+    <featureManager>
+        <feature>componenttest-1.0</feature>
+        <feature>servlet-4.0</feature>
+        <feature>jdbc-4.1</feature>
+        <feature>jndi-1.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+
+    <application location="errorMappingApp.war" >
+        <classloader commonLibraryRef="CustomDriverLib"/>
+    </application>
+    
+    <library id="CustomDriverLib">
+        <fileset dir="${server.config.dir}/derby" includes="derby.jar,errorMappingDriver.jar"/>
+    </library>
+    
+    <jdbcDriver id="CustomDriver" libraryRef="CustomDriverLib" javax.sql.DataSource="jdbc.fat.v41.errormap.driver.ErrorMapDataSourceImpl"/>
+    
+    <dataSource id="errorMapDS" jndiName="jdbc/errorMap" type="javax.sql.DataSource" jdbcDriverRef="CustomDriver">
+        <properties.derby.embedded databaseName="memory:ds1" createDatabase="create"/>
+        <identifyException errorCode="1234" as="StaleConnection"/>
+    </dataSource>
+    
+    <javaPermission codebase="${server.config.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${server.config.dir}/apps/errorMappingApp.war" className="java.sql.SQLPermission" name="callAbort"/>
+    <javaPermission codebase="${server.config.dir}/apps/errorMappingApp.war" className="java.lang.RuntimePermission" name="accessDeclaredMembers"/>
+    <javaPermission codebase="${server.config.dir}/apps/errorMappingApp.war" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codebase="${server.config.dir}/apps/errorMappingApp.war" className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
+
+    <!--  Permissions for application to access mbeans -->
+    <javaPermission codebase="${server.config.dir}/apps/errorMappingApp.war" className="javax.management.MBeanPermission" actions="queryNames"/>
+    <javaPermission codebase="${server.config.dir}/apps/errorMappingApp.war" className="javax.management.MBeanServerPermission" name="createMBeanServer"/>
+    
+    <variable name="onError" value="FAIL"/>
+</server>

--- a/dev/com.ibm.ws.jdbc_fat_v41/test-applications/errorMappingApp/src/jdbc/fat/v41/errormap/web/ErrorMappingTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_v41/test-applications/errorMappingApp/src/jdbc/fat/v41/errormap/web/ErrorMappingTestServlet.java
@@ -43,27 +43,33 @@ public class ErrorMappingTestServlet extends FATServlet {
     @Resource
     UserTransaction tx;
 
-    @Resource(lookup = "jdbc/errorMap")
-    DataSource ds;
+    /**
+     * Verifies that SQL state 08888 does not indicate StaleConnection (for config update tests)
+     */
+    public void testIdentify08888NotStale() throws Exception {
+        assertNotStale("jdbc/errorMap", "08888", null);
+    }
 
-    @Resource(lookup = "jdbc/removeMapping")
-    DataSource removeMapping;
+    /**
+     * Verifies that SQL state 08888 indicates StaleConnection (for config update tests)
+     */
+    public void testIdentify08888Stale() throws Exception {
+        assertStale("jdbc/errorMap", "08888", null);
+    }
 
-    @Resource(lookup = "jdbc/noMappings")
-    DataSource noMappings;
-
-    @Resource(lookup = "jdbc/manyMappings")
-    DataSource manyMappings;
-
-    @Resource(lookup = "jdbc/stateAndCode")
-    DataSource stateAndCode;
+    /**
+     * Verifies that error code 1234 does not indicate StaleConnection (for config update tests)
+     */
+    public void testIdentify1234NotStale() throws Exception {
+        assertNotStale("jdbc/errorMap", null, 1234);
+    }
 
     /**
      * Verify that once a connection goes stale (as indicated by server.xml config)
      * it is removed from the connection pool.
      */
     @Test
-    public void testStaleConnection() throws Exception {
+    public void testIdentify1234Stale() throws Exception {
         assertStale("jdbc/errorMap", null, 1234);
     }
 


### PR DESCRIPTION
Added a test case of adding/removing/modifying identifyException elements of a dataSource while the server is running.
This works well, except when a legacy DataStoreHelper is involved, which receives the identifyException information on initialization.  This pull adds code to ensure that the DataStoreHelper gets re-initialized when there is a change to the identifyException config.