### PR TITLE
spnego fat temporary quarentine to refactor

### DIFF
--- a/dev/com.ibm.ws.security.spnego_fat.1/fat/src/com/ibm/ws/security/spnego/fat/DynamicSpnegoConfigTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat.1/fat/src/com/ibm/ws/security/spnego/fat/DynamicSpnegoConfigTest.java
@@ -34,7 +34,8 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+//@Mode(TestMode.FULL)
+@Mode(TestMode.QUARANTINE)
 @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 public class DynamicSpnegoConfigTest extends CommonTest {
 

--- a/dev/com.ibm.ws.security.spnego_fat.1/fat/src/com/ibm/ws/security/spnego/fat/S4U2ProxyTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat.1/fat/src/com/ibm/ws/security/spnego/fat/S4U2ProxyTest.java
@@ -47,7 +47,8 @@ import componenttest.topology.impl.LibertyServerFactory;
  *
  */
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+//@Mode(TestMode.FULL)
+@Mode(TestMode.QUARANTINE)
 @MinimumJavaLevel(javaLevel = 8)
 public class S4U2ProxyTest extends CommonTest {
 

--- a/dev/com.ibm.ws.security.spnego_fat.2/fat/src/com/ibm/ws/security/spnego/fat/AuthFilterElementTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat.2/fat/src/com/ibm/ws/security/spnego/fat/AuthFilterElementTest.java
@@ -37,7 +37,8 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+//@Mode(TestMode.FULL)
+@Mode(TestMode.QUARANTINE)
 public class AuthFilterElementTest extends CommonTest {
 
     private static final Class<?> c = AuthFilterElementTest.class;

--- a/dev/com.ibm.ws.security.spnego_fat.2/fat/src/com/ibm/ws/security/spnego/fat/DynamicAuthFilterTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat.2/fat/src/com/ibm/ws/security/spnego/fat/DynamicAuthFilterTest.java
@@ -31,7 +31,8 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+//@Mode(TestMode.FULL)
+@Mode(TestMode.QUARANTINE)
 public class DynamicAuthFilterTest extends CommonTest {
 
     private static final Class<?> c = DynamicAuthFilterTest.class;

--- a/dev/com.ibm.ws.security.spnego_fat.2/fat/src/com/ibm/ws/security/spnego/fat/InvokeAfterSSOTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat.2/fat/src/com/ibm/ws/security/spnego/fat/InvokeAfterSSOTest.java
@@ -35,7 +35,8 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+//@Mode(TestMode.FULL)
+@Mode(TestMode.QUARANTINE)
 public class InvokeAfterSSOTest extends CommonTest {
 
     private static final Class<?> c = InvokeAfterSSOTest.class;

--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/BasicAuthTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/BasicAuthTest.java
@@ -40,7 +40,8 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+//@Mode(TestMode.FULL)
+@Mode(TestMode.QUARANTINE)
 @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 public class BasicAuthTest extends CommonTest {
 

--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/CanonicalHostNameTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/CanonicalHostNameTest.java
@@ -30,7 +30,8 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+//@Mode(TestMode.FULL)
+@Mode(TestMode.QUARANTINE)
 @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 public class CanonicalHostNameTest extends CommonTest {
 

--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/IncludeClientGSSCredentialInSubjectTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/IncludeClientGSSCredentialInSubjectTest.java
@@ -33,7 +33,8 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+//@Mode(TestMode.FULL)
+@Mode(TestMode.QUARANTINE)
 @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 public class IncludeClientGSSCredentialInSubjectTest extends CommonTest {
 

--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/IncludeCustomCacheKeyTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/IncludeCustomCacheKeyTest.java
@@ -26,7 +26,8 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+//@Mode(TestMode.FULL)
+@Mode(TestMode.QUARANTINE)
 @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 public class IncludeCustomCacheKeyTest extends CommonTest {
 

--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/Krb5ConfigTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/Krb5ConfigTest.java
@@ -30,7 +30,8 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+//@Mode(TestMode.FULL)
+@Mode(TestMode.QUARANTINE)
 @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 public class Krb5ConfigTest extends CommonTest {
 

--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/ServicePrincipalNamesTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/ServicePrincipalNamesTest.java
@@ -38,7 +38,8 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+//@Mode(TestMode.FULL)
+@Mode(TestMode.QUARANTINE)
 public class ServicePrincipalNamesTest extends CommonTest {
 
     private static final Class<?> c = ServicePrincipalNamesTest.class;

--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/SpnegoTokenHelperApiTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/SpnegoTokenHelperApiTest.java
@@ -33,7 +33,8 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+//@Mode(TestMode.FULL)
+@Mode(TestMode.QUARANTINE)
 @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 public class SpnegoTokenHelperApiTest extends CommonTest {
 

--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/TrustedActiveDirectoryDomainsTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/TrustedActiveDirectoryDomainsTest.java
@@ -36,7 +36,8 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServerFactory;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+//@Mode(TestMode.FULL)
+@Mode(TestMode.QUARANTINE)
 @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 public class TrustedActiveDirectoryDomainsTest extends CommonTest {
 


### PR DESCRIPTION
Temporarily quarantine the spnego fat while refactoring to move away from using remote KDC machines which have been having connection issues.
Refactoring work will be tracked in: https://github.com/OpenLiberty/open-liberty/issues/17102