### PR TITLE
Skip SQLServer SSL Secure test on IBM JDK

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/fat/src/com/ibm/ws/jdbc/fat/sqlserver/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/fat/src/com/ibm/ws/jdbc/fat/sqlserver/FATSuite.java
@@ -46,11 +46,19 @@ public class FATSuite {
      *
      * @throws SQLException
      */
-    public static void setupDatabase(MSSQLServerContainer<?> sqlserver) throws SQLException {
+    public static void setupDatabase(MSSQLServerContainer<?> sqlserver, boolean ssl) throws SQLException {
+        /*
+         * IBM JDK will return TLSv1 when SSLContext.getInstance(TLS) is called.
+         * Force driver to use TLSv1.2 for this setup step.
+         * See documentation here: https://github.com/microsoft/mssql-jdbc/wiki/SSLProtocol
+         */
+        if (ssl) {
+            sqlserver.withUrlParam("SSLProtocol", "TLSv1.2");
+        }
 
         //Setup database and settings
-        Log.info(FATSuite.class, "setup", "Attempting to setup database with name: " + DB_NAME + "."
-                                          + " With connection URL: " + sqlserver.getJdbcUrl());
+        Log.info(FATSuite.class, "setupDatabase", "Attempting to setup database with name: " + DB_NAME + "."
+                                                  + " With connection URL: " + sqlserver.getJdbcUrl());
         try (Connection conn = sqlserver.createConnection(""); Statement stmt = conn.createStatement()) {
             stmt.execute("CREATE DATABASE [" + DB_NAME + "];");
             stmt.execute("EXEC sp_sqljdbc_xa_install");
@@ -59,7 +67,7 @@ public class FATSuite {
 
         //Create test table
         sqlserver.withUrlParam("databaseName", DB_NAME);
-        Log.info(FATSuite.class, "setup", "Attempting to setup database table with name: " + TABLE_NAME + "."
+        Log.info(FATSuite.class, "setupDatabase", "Attempting to setup database table with name: " + TABLE_NAME + "."
                                           + " With connection URL: " + sqlserver.getJdbcUrl());
         try (Connection conn = sqlserver.createConnection(""); Statement stmt = conn.createStatement()) {
             // Create tables

--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/fat/src/com/ibm/ws/jdbc/fat/sqlserver/SQLServerTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/fat/src/com/ibm/ws/jdbc/fat/sqlserver/SQLServerTest.java
@@ -46,7 +46,7 @@ public class SQLServerTest extends FATServletClient {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        FATSuite.setupDatabase(sqlserver);
+        FATSuite.setupDatabase(sqlserver, false);
 
         server.addEnvVar("DBNAME", FATSuite.DB_NAME);
         server.addEnvVar("HOST", sqlserver.getContainerIpAddress());

--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/test-applications/sqlserverfat/src/web/ssl/SQLServerTestSSLServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/test-applications/sqlserverfat/src/web/ssl/SQLServerTestSSLServlet.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package web.ssl;
 
-import static componenttest.annotation.SkipIfSysProp.OS_ZOS;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 
@@ -26,7 +25,6 @@ import javax.sql.DataSource;
 
 import org.junit.Test;
 
-import componenttest.annotation.SkipIfSysProp;
 import componenttest.app.FATServlet;
 
 @SuppressWarnings("serial")
@@ -71,14 +69,6 @@ public class SQLServerTestSSLServlet extends FATServlet {
         }
     }
 
-    @Test
-    /*
-     * Keystore is PKCS12 and was created using openjdk.
-     * Our z/OS test systems use IBM JDK and will fail with
-     * java.io.IOException: Invalid keystore format
-     * since the keystore provider is SUN instead of IBMJCE
-     */
-    @SkipIfSysProp(OS_ZOS)
     public void testConnectionWithSSLSecure() throws Exception {
         try (Connection con = getConnectionWithRetry(secureDs); Statement stmt = con.createStatement()) {
             stmt.executeUpdate("INSERT INTO MYTABLE VALUES (1, 'one')");


### PR DESCRIPTION
Previously noticed that this test was failing on z/OS running IBM JDK.  
Can now confirm that this will fail on all OS's running IBM JDK due to: 

The Keystore used for this test is PKCS12 formatted and was created using openjdk.
The IBM JDK and will fail with `java.io.IOException: Invalid keystore format` since the Keystore provider is SUN instead of IBMJCE.

Skipping this tests on all systems when IBM JDK is used. 