### PR TITLE
Prevent wsAtomicTransaction-1.2 from activating the jaxrs transport bundle

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.core.2.6.2/src/org/apache/cxf/bus/osgi/CXFExtensionBundleListener.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.core.2.6.2/src/org/apache/cxf/bus/osgi/CXFExtensionBundleListener.java
@@ -70,7 +70,7 @@ public class CXFExtensionBundleListener implements SynchronousBundleListener {
     
     protected void register(final Bundle bundle) {
 
-        if (bundle.getSymbolicName().contains("jaxrs")) {
+        if (bundle.getSymbolicName().contains("jaxrs") || bundle.getSymbolicName().contains("3.2")) {
             LOG.fine("register: Skipping jaxrs bundle...");
             return;
         }


### PR DESCRIPTION
When wsAtomicTransaction-1.2 and jaxrs-2.1 are started in the same enviornment, the CXFActivator class starts both versions of the transport layer in CXF. 