### PR TITLE
add escape characters so '+' can appear in doc

### DIFF
--- a/dev/com.ibm.ws.classloading/resources/OSGI-INF/l10n/classloader.properties
+++ b/dev/com.ibm.ws.classloading/resources/OSGI-INF/l10n/classloader.properties
@@ -26,21 +26,21 @@ parentLast=Parent last
 # libraryRefs
 classloader.library.ref=Library
 classloader.library.ref$Ref=Library references
-classloader.library.ref.desc=List of library references. Library class instances are unique to this classloader, independent of class instances from other classloaders. 
+classloader.library.ref.desc=List of library references. Library class instances are unique to this classloader, independent of class instances from other classloaders.
 
 classloader.common.library.ref=Shared Library
 classloader.common.library.ref$Ref=Shared library references
-classloader.common.library.ref.desc=List of library references. Library class instances are shared with other classloaders.  
+classloader.common.library.ref.desc=List of library references. Library class instances are shared with other classloaders.
 # allowed api types
 classloader.apis=Allowed API types
-classloader.apis.desc=The types of API packages that this class loader supports. This value is a comma-separated list of any combination of the following API packages: spec, ibm-api, api, stable, third-party.  If a prefix of + or - is added to API types, those API types are added or removed, respectively, from the default set of API types. Common usage for the prefix, +third-party, results in "spec, ibm-api, api, stable, third-party". The prefix, -api, results in "spec, ibm-api, stable". 
+classloader.apis.desc=The types of API packages that this class loader supports. This value is a comma-separated list of any combination of the following API packages: spec, ibm-api, api, stable, third-party.  If a prefix of \+ or - is added to API types, those API types are added or removed, respectively, from the default set of API types. Common usage for the prefix, \+third-party, results in "spec, ibm-api, api, stable, third-party". The prefix, -api, results in "spec, ibm-api, stable". 
 classloader.api.spec=Spec interfaces
-classloader.api.spec.desc=Interfaces from formal specifications implemented or supported by the runtime, e.g. Java EE. 
+classloader.api.spec.desc=Interfaces from formal specifications implemented or supported by the runtime, e.g. Java EE.
 classloader.api.ibmapi=IBM APIs
 classloader.api.ibmapi.desc=Application programming interfaces defined by IBM.
 classloader.api.user=APIs
 classloader.api.user.desc=Application programming interfaces defined by features.
-classloader.api.thirdparty=Third party interfaces 
+classloader.api.thirdparty=Third party interfaces
 classloader.api.thirdparty.desc=Interfaces defined by third party vendors.
 
 # classProviderRef


### PR DESCRIPTION
per https://github.com/OpenLiberty/docs/issues/3058 

The plus symbol (+) is in the file at https://github.com/OpenLiberty/open-liberty/blob/integration/dev/com.ibm.ws.classloading/resources/OSGI-INF/l10n/classloader.properties for the description of `apiTypeVisibility` but it does not render to the built docs site- added a `\` before it as an escape character so the plus will display.
