### PR TITLE
Issue #17320: NPE in EJBServantLocator for Jakarta

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/EJBRuntimeImpl.java
+++ b/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/EJBRuntimeImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corporation and others.
+ * Copyright (c) 2012, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -514,7 +514,8 @@ public class EJBRuntimeImpl extends AbstractEJBRuntime implements ApplicationSta
         this.j2eeNameFactory = ref;
     }
 
-    protected void unsetJ2EENameFactory(J2EENameFactory ref) {}
+    protected void unsetJ2EENameFactory(J2EENameFactory ref) {
+    }
 
     @Reference
     protected void setMetaDataService(MetaDataService ref) {
@@ -1357,9 +1358,11 @@ public class EJBRuntimeImpl extends AbstractEJBRuntime implements ApplicationSta
                         "(containerToType=com.ibm.ws.javaee.dd.ejbbnd.EJBJarBnd)" +
                         "(containerToType=com.ibm.ws.javaee.dd.managedbean.ManagedBeanBnd)" +
                         ")")
-    protected void setAdapterFactoryDependency(AdapterFactoryService afs) {}
+    protected void setAdapterFactoryDependency(AdapterFactoryService afs) {
+    }
 
-    protected void unsetAdapterFactoryDependency(AdapterFactoryService afs) {}
+    protected void unsetAdapterFactoryDependency(AdapterFactoryService afs) {
+    }
 
     @Override
     public boolean isRemoteUsingPortableServer() {
@@ -1661,7 +1664,7 @@ public class EJBRuntimeImpl extends AbstractEJBRuntime implements ApplicationSta
         // then create a latch to support a pause in starting remote EJBs.
         if (remoteFeatureLatch == null && ejbRemoteRuntimeServiceRef.getReference() == null) {
             String featureName = (String) feature.getProperty("ibm.featureName");
-            if (featureName != null && featureName.startsWith("ejbRemote")) {
+            if (featureName != null && (featureName.startsWith("enterpriseBeansRemote") || featureName.startsWith("ejbRemote"))) {
                 remoteFeatureLatch = new CountDownLatch(1);
             }
         }
@@ -1673,7 +1676,7 @@ public class EJBRuntimeImpl extends AbstractEJBRuntime implements ApplicationSta
         CountDownLatch remoteLatch = remoteFeatureLatch;
         if (remoteLatch != null) {
             String featureName = (String) feature.getProperty("ibm.featureName");
-            if (featureName != null && featureName.startsWith("ejbRemote")) {
+            if (featureName != null && (featureName.startsWith("enterpriseBeansRemote") || featureName.startsWith("ejbRemote"))) {
                 remoteFeatureLatch = null;
                 remoteLatch.countDown();
             }

--- a/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/SystemNameSpaceBinderImpl.java
+++ b/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/SystemNameSpaceBinderImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ import java.rmi.RemoteException;
 import java.util.List;
 
 import javax.ejb.CreateException;
+import javax.ejb.EJB;
 import javax.naming.NamingException;
 
 import com.ibm.ejs.container.HomeRecord;
@@ -29,7 +30,8 @@ public class SystemNameSpaceBinderImpl implements NameSpaceBinder<String> {
     }
 
     @Override
-    public void beginBind() throws NamingException {}
+    public void beginBind() throws NamingException {
+    }
 
     @Override
     public String createBindingObject(HomeRecord hr,
@@ -52,13 +54,16 @@ public class SystemNameSpaceBinderImpl implements NameSpaceBinder<String> {
     }
 
     @Override
-    public void bindJavaGlobal(String name, String bindingObject) throws NamingException {}
+    public void bindJavaGlobal(String name, String bindingObject) throws NamingException {
+    }
 
     @Override
-    public void bindJavaApp(String name, String bindingObject) throws NamingException {}
+    public void bindJavaApp(String name, String bindingObject) throws NamingException {
+    }
 
     @Override
-    public void bindJavaModule(String name, String bindingObject) throws NamingException {}
+    public void bindJavaModule(String name, String bindingObject) throws NamingException {
+    }
 
     @Override
     public void bindBindings(String homeBindingName,
@@ -69,8 +74,10 @@ public class SystemNameSpaceBinderImpl implements NameSpaceBinder<String> {
                              String interfaceName,
                              boolean local,
                              boolean deferred) throws NamingException {
-        if (remoteRuntime == null)
-            throw new NamingException("Unable to bind system module. Ensure the ejbRemote feature is installed.");
+        if (remoteRuntime == null) {
+            String remoteFeatureName = EJB.class.getName().startsWith("jakarta") ? "enterpriseBeansRemote" : "ejbRemote";
+            throw new NamingException("Unable to bind system module. Ensure the " + remoteFeatureName + " feature is installed.");
+        }
 
         HomeRecordImpl hrImpl = HomeRecordImpl.cast(hr);
         if (hrImpl.remoteBindingData == null) {
@@ -79,16 +86,20 @@ public class SystemNameSpaceBinderImpl implements NameSpaceBinder<String> {
     }
 
     @Override
-    public void bindEJBFactory() throws NamingException {}
+    public void bindEJBFactory() throws NamingException {
+    }
 
     @Override
-    public void beginUnbind(boolean error) throws NamingException {}
+    public void beginUnbind(boolean error) throws NamingException {
+    }
 
     @Override
-    public void unbindJavaGlobal(List<String> names) throws NamingException {}
+    public void unbindJavaGlobal(List<String> names) throws NamingException {
+    }
 
     @Override
-    public void unbindJavaApp(List<String> names) throws NamingException {}
+    public void unbindJavaApp(List<String> names) throws NamingException {
+    }
 
     @Override
     public void unbindBindings(HomeRecord hr) throws NamingException {
@@ -102,32 +113,42 @@ public class SystemNameSpaceBinderImpl implements NameSpaceBinder<String> {
     }
 
     @Override
-    public void unbindEJBFactory() throws NamingException {}
+    public void unbindEJBFactory() throws NamingException {
+    }
 
     @Override
-    public void end() throws NamingException {}
+    public void end() throws NamingException {
+    }
 
     @Override
-    public void bindDefaultEJBLocal(String bindingObject, HomeRecord hr) {}
+    public void bindDefaultEJBLocal(String bindingObject, HomeRecord hr) {
+    }
 
     @Override
-    public void bindDefaultEJBRemote(String bindingObject, HomeRecord hr) {}
+    public void bindDefaultEJBRemote(String bindingObject, HomeRecord hr) {
+    }
 
     @Override
-    public void unbindEJBLocal(List<String> names) throws NamingException {}
+    public void unbindEJBLocal(List<String> names) throws NamingException {
+    }
 
     @Override
-    public void bindSimpleBindingName(String bindingObject, HomeRecord hr, boolean local, boolean generateDisambiguatedSimpleBindingNames) {}
+    public void bindSimpleBindingName(String bindingObject, HomeRecord hr, boolean local, boolean generateDisambiguatedSimpleBindingNames) {
+    }
 
     @Override
-    public void bindLocalHomeBindingName(String bindingObject, HomeRecord hr) {}
+    public void bindLocalHomeBindingName(String bindingObject, HomeRecord hr) {
+    }
 
     @Override
-    public void bindLocalBusinessInterface(String bindingObject, HomeRecord hr) {}
+    public void bindLocalBusinessInterface(String bindingObject, HomeRecord hr) {
+    }
 
     @Override
-    public void unbindLocalColonEJB(List<String> names) throws NamingException {}
+    public void unbindLocalColonEJB(List<String> names) throws NamingException {
+    }
 
     @Override
-    public void unbindRemote(List<String> names) {}
+    public void unbindRemote(List<String> names) {
+    }
 }


### PR DESCRIPTION
EJB Container may fail to generate Tie classes for remote interfaces because
it is looking for the "ejbRemote" feature; however for Jakarta 9, the feature
name is now "enterpriseBeansRemote".

Update code to look for either EJB remote feature name.

fixes #17320 