### PR TITLE
Add selenium testcontainer and cleanup testcontainer projects

### DIFF
--- a/dev/build.example.testcontainers_fat/build.gradle
+++ b/dev/build.example.testcontainers_fat/build.gradle
@@ -10,27 +10,15 @@
  *******************************************************************************/
  apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
  
- addRequiredLibraries.dependsOn addJakartaTransformer
- 
- // If you need certain pre-configured testcontainers from the org.testcontainers 
- // project you will want to declare those dependencies here.
- // Use ${testcontainersVersion} to make it easier to upgrade testcontainer versions.
+ // Add budle io.openliberty.org.testcontainers to list of required
+ // libraries.  This bundle is needed both for compile time and runtime.
  dependencies {
-  requiredLibs "org.testcontainers:database-commons:${testcontainersVersion}",
-               "org.testcontainers:db2:${testcontainersVersion}",
-               "org.testcontainers:jdbc:${testcontainersVersion}"
+  requiredLibs project(':io.openliberty.org.testcontainers')
  }
-
- addRequiredLibraries {  
-//CHOOSE ONE (from wlp-gradle/subprojects/fat.gradle): 
-  
-  //addTestcontainers - adds general TestContainer dependencies
-  dependsOn addTestcontainers
-  
-// -- OR --
-  //copyDatabaseRotationDrivers - adds general TestContainer dependencies and 
-  //  database specific TestContainer dependencies
-  dependsOn copyDatabaseRotationDrivers
-  //copyJdbcDrivers - Copies all common JDBC drivers used to database rotation
-  dependsOn copyJdbcDrivers
-}
+ 
+ // If you are preforming database testing use the copyJdbcDrivers
+ // task to copy the common JDBC drivers into the
+ // publish/shared/resources/jdbc directory 
+ addRequiredLibraries.dependsOn copyJdbcDrivers
+ 
+ addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -68,6 +68,11 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.12.3</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>2.11.2</version>
     </dependency>
@@ -905,6 +910,11 @@
       <groupId>jtidy</groupId>
       <artifactId>jtidy</artifactId>
       <version>4aug2000r7-dev</version>
+    </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <version>5.8.0</version>
     </dependency>
     <dependency>
       <groupId>net.minidev</groupId>
@@ -2857,6 +2867,11 @@
       <version>1.0.8</version>
     </dependency>
     <dependency>
+      <groupId>org.rnorth.visible-assertions</groupId>
+      <artifactId>visible-assertions</artifactId>
+      <version>2.1.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.seleniumhq.webdriver</groupId>
       <artifactId>webdriver-common</artifactId>
       <version>0.9.7376</version>
@@ -3194,6 +3209,11 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
+      <version>1.15.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>selenium</artifactId>
       <version>1.15.3</version>
     </dependency>
     <dependency>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -9,6 +9,7 @@ com.cloudant:cloudant-http:2.16.0
 com.cloudant:cloudant-http:2.8.0
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
 com.fasterxml.jackson.core:jackson-annotations:2.11.2
+com.fasterxml.jackson.core:jackson-annotations:2.12.3
 com.fasterxml.jackson.core:jackson-core:2.11.2
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.11.2
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.2
@@ -177,6 +178,7 @@ javax:javaee-api:7.0
 joda-time:joda-time:1.6.2
 joda-time:joda-time:2.9.9
 jtidy:jtidy:4aug2000r7-dev
+net.java.dev.jna:jna:5.8.0
 net.minidev:json-smart:1.3.1
 net.sf.ehcache:ehcache-core:2.5.2
 net.shibboleth.utilities:java-support:7.5.1
@@ -567,6 +569,7 @@ org.reactivestreams:reactive-streams-examples:1.0.3
 org.reactivestreams:reactive-streams-tck:1.0.3
 org.reactivestreams:reactive-streams:1.0.3
 org.rnorth.duct-tape:duct-tape:1.0.8
+org.rnorth.visible-assertions:visible-assertions:2.1.2
 org.seleniumhq.webdriver:webdriver-common:0.9.7376
 org.slf4j:slf4j-api:1.7.30
 org.slf4j:slf4j-simple:1.7.30
@@ -635,6 +638,7 @@ org.testcontainers:kafka:1.15.3
 org.testcontainers:mssqlserver:1.15.3
 org.testcontainers:oracle-xe:1.15.3
 org.testcontainers:postgresql:1.15.3
+org.testcontainers:selenium:1.15.3
 org.testcontainers:testcontainers:1.15.3
 org.testng:testng:6.14.3
 org.yaml:snakeyaml:1.27

--- a/dev/com.ibm.ws.cloudant_fat/build.gradle
+++ b/dev/com.ibm.ws.cloudant_fat/build.gradle
@@ -19,6 +19,7 @@ dependencies {
            project(':io.openliberty.org.apache.commons.codec'),
            project(':com.ibm.ws.org.apache.commons.io'),
            'com.google.code.gson:gson:2.2.4'
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task copyCloudant(type: Copy) {
@@ -28,4 +29,3 @@ task copyCloudant(type: Copy) {
 }
 
 addRequiredLibraries.dependsOn copyCloudant
-addRequiredLibraries.dependsOn addTestcontainers

--- a/dev/com.ibm.ws.concurrent.persistent_fat/build.gradle
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/build.gradle
@@ -9,6 +9,10 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
+ dependencies {
+  requiredLibs project(':io.openliberty.org.testcontainers')
+ }
+ 
 task copyFeatureBundle(type: Copy) {
   from buildDir
   into new File(autoFvtDir, 'lib/LibertyFATTestFiles/bundles')
@@ -21,6 +25,5 @@ autoFVT {
 
 addRequiredLibraries {
 	dependsOn copyJdbcDrivers
-	dependsOn copyDatabaseRotationDrivers
 	dependsOn addJakartaTransformer
 }

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/build.gradle
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/build.gradle
@@ -9,8 +9,9 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-addRequiredLibraries {
-	dependsOn copyJdbcDrivers
-	dependsOn copyDatabaseRotationDrivers
-}
+ dependencies {
+  requiredLibs project(':io.openliberty.org.testcontainers')
+ }
+
+addRequiredLibraries.dependsOn copyJdbcDrivers
 

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/build.gradle
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/build.gradle
@@ -11,10 +11,10 @@
 
 dependencies {
   requiredLibs 'org.apache.derby:derbynet:10.11.1.1'
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 addRequiredLibraries {
 	dependsOn addJakartaTransformer
 	dependsOn copyJdbcDrivers
-	dependsOn copyDatabaseRotationDrivers
 }

--- a/dev/com.ibm.ws.concurrent.persistent_fat_locking/build.gradle
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_locking/build.gradle
@@ -9,7 +9,9 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-addRequiredLibraries {
-	dependsOn copyJdbcDrivers
-	dependsOn copyDatabaseRotationDrivers
-}
+ dependencies {
+  requiredLibs project(':io.openliberty.org.testcontainers')
+ }
+ 
+addRequiredLibraries.dependsOn copyJdbcDrivers
+

--- a/dev/com.ibm.ws.concurrent.persistent_fat_multiple/build.gradle
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_multiple/build.gradle
@@ -9,7 +9,9 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-addRequiredLibraries {
-	dependsOn copyJdbcDrivers
-	dependsOn copyDatabaseRotationDrivers
-}
+ dependencies {
+  requiredLibs project(':io.openliberty.org.testcontainers')
+ }
+ 
+addRequiredLibraries.dependsOn copyJdbcDrivers
+

--- a/dev/com.ibm.ws.concurrent.persistent_fat_timers/build.gradle
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_timers/build.gradle
@@ -9,7 +9,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-addRequiredLibraries {
-	dependsOn copyJdbcDrivers
-	dependsOn copyDatabaseRotationDrivers
-}
+ dependencies {
+  requiredLibs project(':io.openliberty.org.testcontainers')
+ }
+ 
+addRequiredLibraries.dependsOn copyJdbcDrivers

--- a/dev/com.ibm.ws.couchdb_fat/build.gradle
+++ b/dev/com.ibm.ws.couchdb_fat/build.gradle
@@ -23,6 +23,8 @@ dependencies {
           'org.ektorp:org.ektorp:1.5.0',
           'org.slf4j:slf4j-api:1.7.7',
           'org.slf4j:slf4j-jdk14:1.7.7'
+          
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task copyCouchDB(type: Copy) {
@@ -32,4 +34,3 @@ task copyCouchDB(type: Copy) {
 }
 
  addRequiredLibraries.dependsOn copyCouchDB
- addRequiredLibraries.dependsOn addTestcontainers

--- a/dev/com.ibm.ws.jdbc_fat/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   db2 'com.ibm.db2:jcc:11.1.4.4'
   derbyClient 'org.apache.derby:derbyclient:10.11.1.1'
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
  
 //Anonymous drivers
@@ -54,6 +55,4 @@ task copyDB2(type: Copy) {
   dependsOn copyAutomaticDerby
   dependsOn copyDB2
   dependsOn copyJdbcDrivers
-  //Database Rotation
-  dependsOn copyDatabaseRotationDrivers
 }

--- a/dev/com.ibm.ws.jdbc_fat_db2/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_db2/build.gradle
@@ -15,9 +15,7 @@ configurations {
 }
 
 dependencies {
-  requiredLibs "org.testcontainers:database-commons:${testcontainersVersion}",
-               "org.testcontainers:db2:${testcontainersVersion}",
-               "org.testcontainers:jdbc:${testcontainersVersion}"
+  requiredLibs project(':io.openliberty.org.testcontainers')
   db2 'com.ibm.db2:jcc:11.1.4.4'
 }
 
@@ -28,7 +26,6 @@ task copyDB2(type: Copy) {
 }
 
 addRequiredLibraries.dependsOn copyDB2
-addRequiredLibraries.dependsOn addTestcontainers
 
 // This is the equivalent ant code that needs to be invoked in order to transform the SQLJProcedure.sqlj
 // file into a .java file. Since the SQLJ customizer code library is not publicly available, and the

--- a/dev/com.ibm.ws.jdbc_fat_krb5/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/build.gradle
@@ -11,15 +11,10 @@
 apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
 
 dependencies {
-  requiredLibs "org.testcontainers:database-commons:${testcontainersVersion}",
-               "org.testcontainers:db2:${testcontainersVersion}",
-               "org.testcontainers:oracle-xe:${testcontainersVersion}",
-               "org.testcontainers:postgresql:${testcontainersVersion}",
-               "org.testcontainers:jdbc:${testcontainersVersion}"
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
   dependsOn addJakartaTransformer
-  dependsOn addTestcontainers
 }

--- a/dev/com.ibm.ws.jdbc_fat_oracle/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/build.gradle
@@ -19,9 +19,7 @@ configurations {
 }
 
 dependencies {
-  requiredLibs 	"org.testcontainers:database-commons:${testcontainersVersion}",
-               	"org.testcontainers:oracle-xe:${testcontainersVersion}",
-               	"org.testcontainers:jdbc:${testcontainersVersion}"
+  requiredLibs project(':io.openliberty.org.testcontainers')
   oracle        "com.oracle.database.jdbc.debug:ojdbc8_g:${oracleVersion}"
   oraclessl     "com.oracle.database.jdbc.debug:ojdbc8_g:${oracleVersion}",
                	"com.oracle.database.security:oraclepki:${oracleVersion}",
@@ -66,5 +64,4 @@ addRequiredLibraries {
   dependsOn copySharedUCP
   dependsOn copyAnonymousOracle
   dependsOn copySharedOracleSSL
-  dependsOn addTestcontainers
 }

--- a/dev/com.ibm.ws.jdbc_fat_postgresql/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_postgresql/build.gradle
@@ -15,9 +15,7 @@ configurations {
 }
 
 dependencies {
-  requiredLibs "org.testcontainers:database-commons:${testcontainersVersion}",
-       "org.testcontainers:jdbc:${testcontainersVersion}",
-       "org.testcontainers:postgresql:${testcontainersVersion}"
+  requiredLibs project(':io.openliberty.org.testcontainers')
   postgres 'org.postgresql:postgresql:42.2.5'
 }
 
@@ -37,4 +35,3 @@ task copyAnonymousPostgres(type: Copy) {
 
 addRequiredLibraries.dependsOn copySharedPostgres
 addRequiredLibraries.dependsOn copyAnonymousPostgres
-addRequiredLibraries.dependsOn addTestcontainers

--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/build.gradle
@@ -15,9 +15,7 @@ configurations {
 }
 
 dependencies {
-  requiredLibs "org.testcontainers:database-commons:${testcontainersVersion}",
-               "org.testcontainers:jdbc:${testcontainersVersion}",
-               "org.testcontainers:mssqlserver:${testcontainersVersion}"
+  requiredLibs project(':io.openliberty.org.testcontainers')
   sqlserver 'com.microsoft.sqlserver:mssql-jdbc:9.2.1.jre8'
 }
 
@@ -37,4 +35,3 @@ task copySharedSQLServer(type: Copy) {
 
 addRequiredLibraries.dependsOn copySharedSQLServer
 addRequiredLibraries.dependsOn copySharedSqlServerAnon
-addRequiredLibraries.dependsOn addTestcontainers

--- a/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_2.0_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.callback")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_2.1_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_2.1_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.callback")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_2.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_2.2_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.callback")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_3.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_3.0_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.callback")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/build.gradle
@@ -15,6 +15,7 @@ configurations {
 
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -27,7 +28,6 @@ task addJPAFATTools (type: Copy) {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_2.0_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.entitymanager")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_2.1_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_2.1_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.entitymanager")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_2.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_2.2_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.entitymanager")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_3.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_3.0_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.entitymanager")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_2.0_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.inheritance")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_2.1_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_2.1_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.inheritance")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_2.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_2.2_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.inheritance")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_3.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_3.0_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.inheritance")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.defaultPersistenceUnit_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.defaultPersistenceUnit_fat/build.gradle
@@ -28,6 +28,8 @@ dependencies {
   hibernateJPA22 'org.hibernate.common:hibernate-commons-annotations:5.1.0.Final'
   
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
+  
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addhibernateJPA22(type: Copy) {
@@ -54,7 +56,6 @@ task addJPAFATTools (type: Copy) {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addhibernateJPA22
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.dfi_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.dfi_fat/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.injection.common")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addhibernateJPA22(type: Copy) {
@@ -88,7 +89,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addhibernateJPA22
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.dmi_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.dmi_fat/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.injection.common")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addhibernateJPA22(type: Copy) {
@@ -88,7 +89,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addhibernateJPA22
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.ejbinwar_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.ejbinwar_fat/build.gradle
@@ -28,6 +28,7 @@ dependencies {
   hibernateJPA22 'org.hibernate.common:hibernate-commons-annotations:5.1.0.Final'
   
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addhibernateJPA22(type: Copy) {
@@ -54,7 +55,6 @@ task addJPAFATTools (type: Copy) {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addhibernateJPA22
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.jndi_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.jndi_fat/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.injection.common")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addhibernateJPA22(type: Copy) {
@@ -88,7 +89,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addhibernateJPA22
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.mdb_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.mdb_fat/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.injection.common")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addhibernateJPA22(type: Copy) {
@@ -88,7 +89,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addhibernateJPA22
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools

--- a/dev/com.ibm.ws.jpa.tests.spec10.issues_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.issues_fat/build.gradle
@@ -15,6 +15,7 @@ configurations {
 
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -27,7 +28,6 @@ task addJPAFATTools (type: Copy) {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.0_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.query")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.1_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.1_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.query")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.2_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.query")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.0_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.query")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.0_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.manyXmany")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.1_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.1_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.manyXmany")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.2_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.manyXmany")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_3.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_3.0_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.manyXmany")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.0_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.manyXone")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.1_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.1_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.manyXone")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.2_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.manyXone")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_3.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_3.0_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.manyXone")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.0_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.oneXmany")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.1_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.1_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.oneXmany")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.2_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.oneXmany")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_3.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_3.0_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.oneXmany")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.0_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.oneXone")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.1_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.1_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.oneXone")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.2_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.oneXone")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_3.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_3.0_fat/build.gradle
@@ -16,6 +16,7 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.oneXone")
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -57,7 +58,6 @@ task copyCommonFiles {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT

--- a/dev/com.ibm.ws.jpa.tests.spec20.lock_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec20.lock_fat/build.gradle
@@ -15,6 +15,7 @@ configurations {
 
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -27,7 +28,6 @@ task addJPAFATTools (type: Copy) {
 
 addRequiredLibraries {
     dependsOn copyJdbcDrivers
-    dependsOn copyDatabaseRotationDrivers
     dependsOn addJakartaTransformer
     dependsOn addJPAFATTools
 }

--- a/dev/com.ibm.ws.jpa_eclipselink_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa_eclipselink_fat/build.gradle
@@ -15,6 +15,7 @@ configurations {
 
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -27,7 +28,6 @@ task addJPAFATTools (type: Copy) {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
 }

--- a/dev/com.ibm.ws.jpa_ol_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa_ol_fat/build.gradle
@@ -15,6 +15,7 @@ configurations {
 
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -27,7 +28,6 @@ task addJPAFATTools (type: Copy) {
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
-  dependsOn copyDatabaseRotationDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
 }

--- a/dev/com.ibm.ws.logstash.collector_fat/build.gradle
+++ b/dev/com.ibm.ws.logstash.collector_fat/build.gradle
@@ -8,8 +8,8 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-addRequiredLibraries.dependsOn addTestcontainers
 
 dependencies {
   requiredLibs 'org.json:json:20080701' 
+  requiredLibs project(':io.openliberty.org.testcontainers')
 } 

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   kafkaClient 'org.xerial.snappy:snappy-java:1.1.7.2'
   kafkaClient 'org.slf4j:slf4j-api:1.7.7'
   kafkaClient 'org.slf4j:slf4j-jdk14:1.7.7'
-  requiredLibs "org.testcontainers:kafka:${testcontainersVersion}"
+  requiredLibs project(':io.openliberty.org.testcontainers')
   requiredLibs 'org.testng:testng:6.14.3'
   requiredLibs project(':com.ibm.websphere.org.reactivestreams.reactive-streams.1.0')
   requiredLibs project(':com.ibm.ws.microprofile.reactive.messaging.kafka')
@@ -41,4 +41,3 @@ task addKafkaClientLibs (type: Copy) {
 }
 
 zipAutoFVT.dependsOn addKafkaClientLibs
-addRequiredLibraries.dependsOn addTestcontainers

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/build.gradle
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     kafkaClient 'org.xerial.snappy:snappy-java:1.1.7.2'
     kafkaClient 'org.slf4j:slf4j-api:1.7.7'
     kafkaClient 'org.slf4j:slf4j-jdk14:1.7.7'
-    requiredLibs "org.testcontainers:kafka:${testcontainersVersion}"
+    requiredLibs project(':io.openliberty.org.testcontainers')
     requiredLibs 'org.testng:testng:6.14.3'
     requiredLibs 'org.reactivestreams:reactive-streams-tck:1.0.3'
     requiredLibs project(':com.ibm.websphere.org.reactivestreams.reactive-streams.1.0')
@@ -30,4 +30,3 @@ task addKafkaClientLibs (type: Copy) {
 }
 
 zipAutoFVT.dependsOn addKafkaClientLibs
-addRequiredLibraries.dependsOn addTestcontainers

--- a/dev/com.ibm.ws.rest.handler.validator.cloudant_fat/build.gradle
+++ b/dev/com.ibm.ws.rest.handler.validator.cloudant_fat/build.gradle
@@ -22,6 +22,7 @@ dependencies {
                           'com.cloudant:cloudant-http:2.8.0'
       cloudantCommonDeps  project(':com.ibm.ws.org.apache.commons.io'),
       					  'com.google.code.gson:gson:2.8.0'
+      requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task copyCloudant(type: Copy) {
@@ -41,4 +42,3 @@ addRequiredLibraries.dependsOn copyCloudant
 addRequiredLibraries.dependsOn copyCloudantOld
 
 addRequiredLibraries.dependsOn addJakartaTransformer
-addRequiredLibraries.dependsOn addTestcontainers

--- a/dev/com.ibm.ws.security.acme_fat/build.gradle
+++ b/dev/com.ibm.ws.security.acme_fat/build.gradle
@@ -10,8 +10,8 @@
  *******************************************************************************/
 
 configurations {
-    runPebble  { extendsFrom testcontainers }
-    runBoulder { extendsFrom testcontainers }
+    runPebble
+    runBoulder
 }
 
 dependencies {
@@ -20,7 +20,8 @@ dependencies {
                'org.shredzone.acme4j:acme4j-client:2.7',
                'org.shredzone.acme4j:acme4j-utils:2.7',
                project(':com.ibm.ws.security.acme'),
-               project(':com.ibm.ws.crypto.certificateutil')
+               project(':com.ibm.ws.crypto.certificateutil'),
+               project(':io.openliberty.org.testcontainers')
                
   runPebble    project(':io.openliberty.org.apache.commons.logging')
                
@@ -28,7 +29,6 @@ dependencies {
   
 }
 
-addRequiredLibraries.dependsOn addTestcontainers
 addRequiredLibraries.dependsOn addJakartaTransformer
 
 autoFVT.doLast {

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/build.gradle
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/build.gradle
@@ -20,6 +20,7 @@ configurations {
 
 // Define G:A:V coordinates of each dependency
 dependencies {
+requiredLibs project(':io.openliberty.org.testcontainers')
 infinispanClient 'com.github.ben-manes.caffeine:caffeine:2.8.0',
                  'org.infinispan:infinispan-client-hotrod:10.0.0.Final',
                  'org.infinispan:infinispan-commons:10.0.0.Final',
@@ -47,5 +48,4 @@ addRequiredLibraries {
   dependsOn addDerby
   dependsOn addInfinispanClientLibs
   dependsOn addJakartaTransformer
-  dependsOn addTestcontainers
 }

--- a/dev/com.ibm.ws.transaction.DB2HADB_fat/build.gradle
+++ b/dev/com.ibm.ws.transaction.DB2HADB_fat/build.gradle
@@ -13,7 +13,8 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.DerbyHADB_fat"),
-               project(':io.openliberty.org.apache.commons.logging')
+               project(':io.openliberty.org.apache.commons.logging'),
+               project(':io.openliberty.org.testcontainers')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -70,7 +71,6 @@ addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
 addRequiredLibraries.dependsOn copyTxJdbcDrivers
-addRequiredLibraries.dependsOn copyDatabaseRotationDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
 
 clean.doLast {

--- a/dev/com.ibm.ws.transaction.DerbyHADB_fat/build.gradle
+++ b/dev/com.ibm.ws.transaction.DerbyHADB_fat/build.gradle
@@ -12,7 +12,8 @@
 // Define G:A:V coordinates of each dependency
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
-               project(':io.openliberty.org.apache.commons.logging')
+               project(':io.openliberty.org.apache.commons.logging'),
+               project(':io.openliberty.org.testcontainers')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -34,7 +35,6 @@ autoFVT.dependsOn copyFeatureBundle
 
 addRequiredLibraries.dependsOn copyJdbcDrivers
 addRequiredLibraries.dependsOn copyTxJdbcDrivers
-addRequiredLibraries.dependsOn copyDatabaseRotationDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
 
 clean.doLast {

--- a/dev/com.ibm.ws.transaction.OracleHADB_fat/build.gradle
+++ b/dev/com.ibm.ws.transaction.OracleHADB_fat/build.gradle
@@ -13,7 +13,8 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.DerbyHADB_fat"),
-               project(':io.openliberty.org.apache.commons.logging')
+               project(':io.openliberty.org.apache.commons.logging'),
+               project(':io.openliberty.org.testcontainers')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -70,7 +71,6 @@ addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
 addRequiredLibraries.dependsOn copyTxJdbcDrivers
-addRequiredLibraries.dependsOn copyDatabaseRotationDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
 
 clean.doLast {

--- a/dev/com.ibm.ws.transaction.PostgresqlHADB_fat/build.gradle
+++ b/dev/com.ibm.ws.transaction.PostgresqlHADB_fat/build.gradle
@@ -13,7 +13,8 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.DerbyHADB_fat"),
-               project(':io.openliberty.org.apache.commons.logging')
+               project(':io.openliberty.org.apache.commons.logging'),
+               project(':io.openliberty.org.testcontainers')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -70,7 +71,6 @@ addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
 addRequiredLibraries.dependsOn copyTxJdbcDrivers
-addRequiredLibraries.dependsOn copyDatabaseRotationDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
 
 clean.doLast {

--- a/dev/com.ibm.ws.transaction.SQLServerHADB_fat/build.gradle
+++ b/dev/com.ibm.ws.transaction.SQLServerHADB_fat/build.gradle
@@ -13,7 +13,8 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.DerbyHADB_fat"),
-               project(':io.openliberty.org.apache.commons.logging')
+               project(':io.openliberty.org.apache.commons.logging'),
+               project(':io.openliberty.org.testcontainers')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -70,7 +71,6 @@ addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
 addRequiredLibraries.dependsOn copyTxJdbcDrivers
-addRequiredLibraries.dependsOn copyDatabaseRotationDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
 
 clean.doLast {

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/build.gradle
@@ -12,6 +12,7 @@
 // Define G:A:V coordinates of each dependency
 dependencies {
   requiredLibs project(':io.openliberty.org.apache.commons.logging')
+  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -24,5 +25,4 @@ task addDerbyToSharedDir(type: Copy) {
 
 addRequiredLibraries.dependsOn addDerbyToSharedDir
 addRequiredLibraries.dependsOn copyJdbcDrivers
-addRequiredLibraries.dependsOn copyDatabaseRotationDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/com.ibm.ws.transaction.cloud_fat.db2.1/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloud_fat.db2.1/build.gradle
@@ -13,7 +13,8 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.cloud_fat.base"),
-               project(':io.openliberty.org.apache.commons.logging')
+               project(':io.openliberty.org.apache.commons.logging'),
+               project(':io.openliberty.org.testcontainers')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -55,7 +56,6 @@ task copyCommonFiles {
 addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
-addRequiredLibraries.dependsOn copyDatabaseRotationDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
 
 jar {

--- a/dev/com.ibm.ws.transaction.cloud_fat.db2.2/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloud_fat.db2.2/build.gradle
@@ -13,7 +13,8 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.cloud_fat.base"),
-               project(':io.openliberty.org.apache.commons.logging')
+               project(':io.openliberty.org.apache.commons.logging'),
+               project(':io.openliberty.org.testcontainers')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -55,7 +56,6 @@ task copyCommonFiles {
 addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
-addRequiredLibraries.dependsOn copyDatabaseRotationDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
 
 jar {

--- a/dev/com.ibm.ws.transaction.cloud_fat.derby.1/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloud_fat.derby.1/build.gradle
@@ -13,7 +13,8 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.cloud_fat.base"),
-               project(':io.openliberty.org.apache.commons.logging')
+               project(':io.openliberty.org.apache.commons.logging'),
+               project(':io.openliberty.org.testcontainers')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -55,7 +56,6 @@ task copyCommonFiles {
 addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
-addRequiredLibraries.dependsOn copyDatabaseRotationDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
 
 jar {

--- a/dev/com.ibm.ws.transaction.cloud_fat.derby.2/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloud_fat.derby.2/build.gradle
@@ -13,7 +13,8 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.cloud_fat.base"),
-               project(':io.openliberty.org.apache.commons.logging')
+               project(':io.openliberty.org.apache.commons.logging'),
+               project(':io.openliberty.org.testcontainers')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -55,7 +56,6 @@ task copyCommonFiles {
 addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
-addRequiredLibraries.dependsOn copyDatabaseRotationDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
 
 jar {

--- a/dev/com.ibm.ws.transaction.cloud_fat.oracle.1/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloud_fat.oracle.1/build.gradle
@@ -13,7 +13,8 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.cloud_fat.base"),
-               project(':io.openliberty.org.apache.commons.logging')
+               project(':io.openliberty.org.apache.commons.logging'),
+               project(':io.openliberty.org.testcontainers')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -55,7 +56,6 @@ task copyCommonFiles {
 addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
-addRequiredLibraries.dependsOn copyDatabaseRotationDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
 
 jar {

--- a/dev/com.ibm.ws.transaction.cloud_fat.oracle.2/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloud_fat.oracle.2/build.gradle
@@ -13,7 +13,8 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.cloud_fat.base"),
-               project(':io.openliberty.org.apache.commons.logging')
+               project(':io.openliberty.org.apache.commons.logging'),
+               project(':io.openliberty.org.testcontainers')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -55,7 +56,6 @@ task copyCommonFiles {
 addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
-addRequiredLibraries.dependsOn copyDatabaseRotationDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
 
 jar {

--- a/dev/com.ibm.ws.transaction.cloud_fat.postgresql.1/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloud_fat.postgresql.1/build.gradle
@@ -12,7 +12,8 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.cloud_fat.base"),
-               project(':io.openliberty.org.apache.commons.logging')
+               project(':io.openliberty.org.apache.commons.logging'),
+               project(':io.openliberty.org.testcontainers')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -54,7 +55,6 @@ task copyCommonFiles {
 addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
-addRequiredLibraries.dependsOn copyDatabaseRotationDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
 
 jar {

--- a/dev/com.ibm.ws.transaction.cloud_fat.postgresql.2/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloud_fat.postgresql.2/build.gradle
@@ -12,7 +12,8 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.cloud_fat.base"),
-               project(':io.openliberty.org.apache.commons.logging')
+               project(':io.openliberty.org.apache.commons.logging'),
+               project(':io.openliberty.org.testcontainers')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -54,7 +55,6 @@ task copyCommonFiles {
 addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
-addRequiredLibraries.dependsOn copyDatabaseRotationDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
 
 jar {

--- a/dev/com.ibm.ws.transaction.cloud_fat.sqlserver.1/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloud_fat.sqlserver.1/build.gradle
@@ -13,7 +13,8 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.cloud_fat.base"),
-               project(':io.openliberty.org.apache.commons.logging')
+               project(':io.openliberty.org.apache.commons.logging'),
+               project(':io.openliberty.org.testcontainers')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -55,7 +56,6 @@ task copyCommonFiles {
 addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
-addRequiredLibraries.dependsOn copyDatabaseRotationDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
 
 jar {

--- a/dev/com.ibm.ws.transaction.cloud_fat.sqlserver.2/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloud_fat.sqlserver.2/build.gradle
@@ -13,7 +13,8 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.cloud_fat.base"),
-               project(':io.openliberty.org.apache.commons.logging')
+               project(':io.openliberty.org.apache.commons.logging'),
+               project(':io.openliberty.org.testcontainers')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -55,7 +56,6 @@ task copyCommonFiles {
 addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
-addRequiredLibraries.dependsOn copyDatabaseRotationDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
 
 jar {

--- a/dev/com.ibm.ws.transaction.db_fat/build.gradle
+++ b/dev/com.ibm.ws.transaction.db_fat/build.gradle
@@ -15,9 +15,7 @@ configurations {
 }
 
 dependencies {
-  requiredLibs "org.testcontainers:database-commons:${testcontainersVersion}",
-               "org.testcontainers:jdbc:${testcontainersVersion}",
-               "org.testcontainers:postgresql:${testcontainersVersion}"
+  requiredLibs project(':io.openliberty.org.testcontainers')
   postgres 'org.postgresql:postgresql:42.2.5'
 }
 
@@ -37,4 +35,3 @@ task copyAnonymousPostgres(type: Copy) {
 
 addRequiredLibraries.dependsOn copySharedPostgres
 addRequiredLibraries.dependsOn copyAnonymousPostgres
-addRequiredLibraries.dependsOn addTestcontainers

--- a/dev/io.openliberty.org.testcontainers/bnd.bnd
+++ b/dev/io.openliberty.org.testcontainers/bnd.bnd
@@ -15,15 +15,34 @@ Bundle-Name: FAT Testcontainer Bundle
 Bundle-SymbolicName: io.openliberty.org.testcontainers
 Bundle-Description: FAT Testcontainer Bundle; version=${bVersion}
 
+#Notice: com.sun.jna.*;version="5.8.0"
+# Will cause many bnd build warnings as many of it's packages contain
+# binary files instead of class files. This is expected and necessary
+
 Export-Package: \
-	org.testcontainers.*;version="1.15.3",\
 	com.github.*;version="3.2.8",\
+	com.sun.jna.*;version="5.8.0",\
+	org.apache.commons.*;version="1.20",\
+	org.testcontainers.*;version="1.15.3";-split-package:=merge-last,\
 	org.rnorth.*;version="1.0.8",\
 	org.slf4j.*;version="1.7.30"
 
 test.project: true
+generate.replacement: true
+
+#Notice: com.github.docker-java:docker-java-api has a runtime dependency on 
+# com.fasterxml.jackson.core:jackson-annotations;version=2.12.3
+# It is not included in the build path or export-package because all FATs already include jackson-annotations.
+# Currently, the version included in each FAT is 2.11.2. If Testcontainers ever depends on a version of
+# jackson-annotations that is not backwards compatible with 2.11.2 then we will need to upgrade 
+# the version we include in FATs by updating /cnf/build.gradle configurations binaries.
+
 
 -buildpath: \
+	com.github.docker-java:docker-java-api;version=3.2.8,\
+	com.github.docker-java:docker-java-transport;version=3.2.8,\
+	com.github.docker-java:docker-java-transport-zerodep;version=3.2.8,\
+	org.apache.commons:commons-compress;version=1.20,\
 	org.testcontainers:testcontainers;version=1.15.3,\
 	org.testcontainers:database-commons;version=1.15.3,\
 	org.testcontainers:jdbc;version=1.15.3,\
@@ -32,12 +51,9 @@ test.project: true
 	org.testcontainers:mssqlserver;version=1.15.3,\
 	org.testcontainers:oracle-xe;version=1.15.3,\
 	org.testcontainers:postgresql;version=1.15.3,\
-	com.github.docker-java:docker-java-api;version=3.2.8,\
-	com.github.docker-java:docker-java-transport;version=3.2.8,\
-	com.github.docker-java:docker-java-transport-zerodep;version=3.2.8,\
+	org.testcontainers:selenium;version=1.15.3,\
 	org.rnorth.duct-tape:duct-tape;version=1.0.8,\
+	org.rnorth.visible-assertions:visible-assertions;version=2.1.2,\
 	org.slf4j:slf4j-api;version=1.7.30,\
-	org.slf4j:slf4j-simple;version=1.7.30
-	
-	
-
+	org.slf4j:slf4j-simple;version=1.7.30,\
+	net.java.dev.jna:jna;version=5.8.0

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -41,10 +41,8 @@ task cleanBeforeRun(type: Delete) {
 configurations {
   requiredLibs
   jdbcDrivers { transitive = false; }
-  databaseRotationDrivers
   derby
   jakartaTransformer
-  testcontainers
 }
 
 dependencies {
@@ -57,14 +55,6 @@ dependencies {
 		'org.apache.derby:derby:10.11.1.1',
 		'com.oracle.database.jdbc.debug:ojdbc8_g:21.1.0.0'
 
-  // this will inherit from the 'testcontainers' config
-  databaseRotationDrivers "org.testcontainers:database-commons:${testcontainersVersion}",
-       "org.testcontainers:jdbc:${testcontainersVersion}",
-       "org.testcontainers:oracle-xe:${testcontainersVersion}",
-       "org.testcontainers:mssqlserver:${testcontainersVersion}",
-       "org.testcontainers:postgresql:${testcontainersVersion}",
-       "org.testcontainers:db2:${testcontainersVersion}"
-
   jakartaTransformer 'biz.aQute.bnd:biz.aQute.bnd.transform:5.3.0',
        'commons-cli:commons-cli:1.4',
        'org.slf4j:slf4j-simple:1.7.30',
@@ -72,23 +62,6 @@ dependencies {
        'org.eclipse.transformer:org.eclipse.transformer:0.2.0',
        'org.eclipse.transformer:org.eclipse.transformer.cli:0.2.0'
 
-  testcontainers "org.testcontainers:testcontainers:${testcontainersVersion}",
-       'com.fasterxml.jackson.core:jackson-annotations:2.10.3',
-       'com.github.docker-java:docker-java-api:3.2.8',
-       'com.github.docker-java:docker-java-transport:3.2.8',
-       'com.github.docker-java:docker-java-transport-zerodep:3.2.8',
-       'net.java.dev.jna:jna:5.8.0',
-       'org.apache.commons:commons-compress:1.20',
-       'org.rnorth.duct-tape:duct-tape:1.0.8',
-       'org.rnorth.visible-assertions:visible-assertions:2.1.2',
-       'org.slf4j:slf4j-api:1.7.30',
-       'org.slf4j:slf4j-jdk14:1.7.30'
-}
-
-task addTestcontainers(type: Copy) {
-  mustRunAfter jar
-  from configurations.testcontainers
-  into new File(autoFvtDir, 'lib')
 }
 
 task addRequiredLibraries(type: Copy) {
@@ -130,13 +103,6 @@ task copyJdbcDrivers(type: Copy) {
   rename 'ojdbc8_g.*.jar', 'ojdbc8_g.jar'
   rename 'postgresql.*.jar', 'postgresql.jar'
   rename 'mssql-jdbc.*.jar', 'mssql-jdbc.jar'
-}
-
-task copyDatabaseRotationDrivers(type: Copy) {
-  mustRunAfter jar
-  dependsOn addTestcontainers
-  from configurations.databaseRotationDrivers
-  into new File(autoFvtDir, 'lib')
 }
 
 task copyFeatureBundles {


### PR DESCRIPTION
Add selenium test container to `io.openliberty.org.testcontainers` bundle. 
Change test container projects to have runtime dependency on said bundle.
Add `generate.replacement: true` to bundle so the bundle is accessible in the WL repo.
