### PR TITLE
JAX-RS Client Proxy and Proxy Authentication for EE9

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/ProxyClientTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/ProxyClientTest.java
@@ -24,13 +24,11 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jaxrs20.client.fat.proxy.HttpProxyServer;
 
-import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
-@SkipForRepeat("EE9_FEATURES") // Continue to skip this test for EE9 as com.ibm.ws.jaxrs.client.proxy.* properties are not supported yet
 @RunWith(FATRunner.class)
 public class ProxyClientTest extends AbstractTest {
 
@@ -61,7 +59,7 @@ public class ProxyClientTest extends AbstractTest {
     @AfterClass
     public static void tearDown() throws Exception {
         if (server != null) {
-            server.stopServer("CWWKW0702E", "CWWKW0701E");
+            server.stopServer("CWWKW0702E", "CWWKW0701E", "CWWKW1303W");
         }
         HttpProxyServer.stopHttpProxyServer(Integer.valueOf(proxyPort));//
         System.out.println("End!");
@@ -114,11 +112,13 @@ public class ProxyClientTest extends AbstractTest {
         p.put("proxyhost", serverRef.getHostname());
         p.put("proxyport", "8889");
         p.put("proxytype", "HTTP");
-        this.runTestOnServer(target, "testProxy", p, "[Proxy Error]:javax.ws.rs.ProcessingException: java.net.ConnectException: ConnectException");
+        this.runTestOnServer(target, "testProxy", p, 
+                             "[Proxy Error]:javax.ws.rs.ProcessingException: java.net.ConnectException: ConnectException", // <= EE8
+                             "[Proxy Error]:jakarta.ws.rs.ProcessingException: RESTEASY004655: Unable to invoke request"); // EE9
     }
 
     @Test
-    @ExpectedFFDC("java.lang.NumberFormatException")
+    @AllowedFFDC("java.lang.NumberFormatException")
     public void testProxyNotWork_InvalidPort() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         p.put("param", "testProxyNotWork_InvalidPort");
@@ -149,13 +149,14 @@ public class ProxyClientTest extends AbstractTest {
     }
 
     @Test
-    @ExpectedFFDC("java.lang.IllegalArgumentException")
+    @AllowedFFDC("java.lang.IllegalArgumentException")
     public void testProxyWork_InvalidType() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         p.put("param", "testProxyWork_InvalidType");
         p.put("proxyhost", serverRef.getHostname());
         p.put("proxyport", proxyPort);
         p.put("proxytype", "invalidType"); //JaxRS-2.0 Client set the proxy type to default HTTP
-        this.runTestOnServer(target, "testProxy", p, "[Basic Resource]:testProxyWork_InvalidType");
+        this.runTestOnServer(target, "testProxy", p, "[Basic Resource]:testProxyWork_InvalidType", // <= EE8
+                                                     "[Proxy Error]:jakarta.ws.rs.ProcessingException: RESTEASY004655: Unable to invoke request"); //EE9
     }
 }

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/jaxrs20.client.ProxyAuthTest/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/publish/servers/jaxrs20.client.ProxyAuthTest/server.xml
@@ -15,6 +15,8 @@
      <keyStore id="clientKeyStore" location="key.jks" type="JKS" password="passw0rd" /> 
      <keyStore id="clientTrustStore" location="trust.jks" type="JKS" password="passw0rd" /> 
 
+    <logging traceSpecification="org.apache.http.*=all" maxFiles="1"/>
+
   	<include location="../fatTestPorts.xml"/>
   	<javaPermission className="org.osgi.framework.AdminPermission" name="*" actions="*"/>
   	<javaPermission className="org.osgi.framework.ServicePermission" name="*" actions="get"/>

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/test-applications/jaxrsclientproxy/src/com/ibm/ws/jaxrs20/client/jaxrsclientproxy/client/ClientTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/test-applications/jaxrsclientproxy/src/com/ibm/ws/jaxrs20/client/jaxrsclientproxy/client/ClientTestServlet.java
@@ -101,6 +101,7 @@ public class ClientTestServlet extends HttpServlet {
                             .get(String.class);
         } catch (Exception e) {
             res = "[Proxy Error]:" + e.toString();
+            e.printStackTrace();
         } finally {
             c.close();
             ret.append(res);

--- a/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/client/JAXRSClientConstants.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/client/JAXRSClientConstants.java
@@ -10,6 +10,13 @@
  *******************************************************************************/
 package io.openliberty.org.jboss.resteasy.common.client;
 
+import java.util.Map;
+
+import javax.ws.rs.core.Configuration;
+
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;
+
 public class JAXRSClientConstants {
 
     public final static String TR_GROUP = "com.ibm.ws.jaxrs20.client";
@@ -21,6 +28,7 @@ public class JAXRSClientConstants {
     public final static String PROXY_HOST = "com.ibm.ws.jaxrs.client.proxy.host";
     public final static String PROXY_PORT = "com.ibm.ws.jaxrs.client.proxy.port";
     public final static String PROXY_TYPE = "com.ibm.ws.jaxrs.client.proxy.type";
+    public final static String PROXY_SCHEME = "com.ibm.ws.jaxrs.client.proxy.scheme";
     public final static String PROXY_AUTH_TYPE = "com.ibm.ws.jaxrs.client.proxy.authType";
     public final static String PROXY_AUTH_TYPE_DEFAULT = "Basic";
     public final static String PROXY_USERNAME = "com.ibm.ws.jaxrs.client.proxy.username";
@@ -33,4 +41,17 @@ public class JAXRSClientConstants {
     public static final String DISABLE_CN_CHECK = "com.ibm.ws.jaxrs.client.disableCNCheck";
     public final static String SAML_HANDLER = "com.ibm.ws.jaxrs.client.saml.sendToken";
 
+    public static void mapProperties(ClientConfiguration c) {
+        Map<String,Object> props = c.getMutableProperties();
+        map(props, PROXY_HOST, ResteasyClientBuilder.PROPERTY_PROXY_HOST);
+        map(props, PROXY_PORT, ResteasyClientBuilder.PROPERTY_PROXY_PORT);
+        map(props, PROXY_SCHEME, ResteasyClientBuilder.PROPERTY_PROXY_SCHEME);
+    }
+
+    private static void map(Map<String, Object> props, String origKey, String newKey) {
+        Object o = props.get(origKey);
+        if (o != null) {
+            props.put(newKey, o);
+        }
+    }
 }

--- a/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/client/LibertyClientHttpEngineBuilder43.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/client/LibertyClientHttpEngineBuilder43.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.org.jboss.resteasy.common.client;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.jboss.resteasy.client.jaxrs.ClientHttpEngine;
+import org.jboss.resteasy.client.jaxrs.ClientHttpEngineBuilder;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient43Engine;
+import org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43;
+
+/**
+ * This is primarily taken from org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43,
+ * but modified to include proxy authentication support - changes noted with {@code //Liberty...}
+ * comments.
+ */
+public class LibertyClientHttpEngineBuilder43 extends ClientHttpEngineBuilder43 {
+
+    private ResteasyClientBuilder that;
+
+    @Override
+    public ClientHttpEngineBuilder resteasyClientBuilder(ResteasyClientBuilder resteasyClientBuilder) {
+        that = resteasyClientBuilder;
+        return super.resteasyClientBuilder(resteasyClientBuilder);
+    }
+
+    @Override
+    protected ClientHttpEngine createEngine(final HttpClientConnectionManager cm, final RequestConfig.Builder rcBuilder,
+                                            final HttpHost defaultProxy, final int responseBufferSize, final HostnameVerifier verifier, final SSLContext theContext) {
+        final HttpClient httpClient;
+        rcBuilder.setProxy(defaultProxy);
+        if (System.getSecurityManager() == null) {
+            httpClient = buildHttpClient(cm, rcBuilder, defaultProxy);
+        } else {
+            httpClient = AccessController.doPrivileged((PrivilegedAction<HttpClient>)() -> buildHttpClient(cm, rcBuilder, defaultProxy));
+        }
+
+        ApacheHttpClient43Engine engine = new ApacheHttpClient43Engine(httpClient, true);
+        engine.setResponseBufferSize(responseBufferSize);
+        engine.setHostnameVerifier(verifier);
+        // this may be null.  We can't really support this with Apache Client.
+        engine.setSslContext(theContext);
+        engine.setFollowRedirects(that.isFollowRedirects());
+        return engine;
+    }
+
+    private HttpClient buildHttpClient(final HttpClientConnectionManager cm, final RequestConfig.Builder rcBuilder, HttpHost defaultProxy) {
+        HttpClientBuilder httpClientBuilder= HttpClientBuilder.create()
+                        .setConnectionManager(cm)
+                        .setDefaultRequestConfig(rcBuilder.build())
+                        .disableContentCompression();
+        if (!that.isCookieManagementEnabled()) {
+            httpClientBuilder.disableCookieManagement();
+        }
+        if (that.isDisableAutomaticRetries()) {
+            httpClientBuilder.disableAutomaticRetries();
+        }
+        if (defaultProxy != null) {
+            Object proxyUser = that.getConfiguration().getProperty(JAXRSClientConstants.PROXY_USERNAME);
+            if (proxyUser != null) {
+                Object proxyPass = that.getConfiguration().getProperty(JAXRSClientConstants.PROXY_PASSWORD);
+                CredentialsProvider credsProvider = new BasicCredentialsProvider();
+                credsProvider.setCredentials(new AuthScope(defaultProxy),
+                                             new UsernamePasswordCredentials(str(proxyUser), str(proxyPass)));
+                httpClientBuilder.setDefaultCredentialsProvider(credsProvider);
+            }
+        }
+        return httpClientBuilder.build();
+    }
+
+    private static String str(Object o) {
+        if (o instanceof String) {
+            return (String) o;
+        }
+        return o.toString();
+    }
+}

--- a/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/client/LibertyClientWebTarget.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/client/LibertyClientWebTarget.java
@@ -14,8 +14,6 @@ import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
 
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
@@ -76,6 +74,8 @@ public class LibertyClientWebTarget extends ClientWebTarget {
             // incomplete url encountered from uriBuilder.build, we can't act on it
         }
 
+        JAXRSClientConstants.mapProperties(configuration);
+        
         // for timeouts and proxy settings, update ClientBuilder
         Long timeout = toLong(configuration, JAXRSClientConstants.CONNECTION_TIMEOUT);
         if (timeout != null) {

--- a/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/client/LibertyResteasyClientBuilderImpl.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/client/LibertyResteasyClientBuilderImpl.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import org.jboss.resteasy.client.jaxrs.ClientHttpEngine;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
-import org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43;
 import org.jboss.resteasy.client.jaxrs.i18n.LogMessages;
 import org.jboss.resteasy.client.jaxrs.i18n.Messages;
 import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;
@@ -91,7 +90,7 @@ public class LibertyResteasyClientBuilderImpl extends ResteasyClientBuilderImpl 
     @Override
     protected ResteasyClient createResteasyClient(ClientHttpEngine engine,ExecutorService executor, boolean cleanupExecutor, ScheduledExecutorService scheduledExecutorService, ClientConfiguration config ) {
 
-        return new LibertyResteasyClientImpl(() -> new ClientHttpEngineBuilder43().resteasyClientBuilder(this).build(), executor, cleanupExecutor, scheduledExecutorService, config, this);
+        return new LibertyResteasyClientImpl(() -> new LibertyClientHttpEngineBuilder43().resteasyClientBuilder(this).build(), executor, cleanupExecutor, scheduledExecutorService, config, this);
     }
 
     private BundleContext getBundleContext() {

--- a/dev/io.openliberty.restfulWS.internal.ssl/src/io/openliberty/restfulWS/internal/ssl/component/SslClientBuilderListener.java
+++ b/dev/io.openliberty.restfulWS.internal.ssl/src/io/openliberty/restfulWS/internal/ssl/component/SslClientBuilderListener.java
@@ -31,11 +31,11 @@ import com.ibm.websphere.ssl.JSSEHelper;
 import com.ibm.websphere.ssl.SSLException;
 import com.ibm.wsspi.ssl.SSLSupport;
 
+import io.openliberty.org.jboss.resteasy.common.client.JAXRSClientConstants;
 import io.openliberty.restfulWS.client.ClientBuilderListener;
 
 @Component(property = { "service.vendor=IBM" })
 public class SslClientBuilderListener implements ClientBuilderListener {
-    private final static String SSL_REFKEY = "com.ibm.ws.jaxrs.client.ssl.config";
 
     private JSSEHelper jsseHelper;
 
@@ -57,7 +57,7 @@ public class SslClientBuilderListener implements ClientBuilderListener {
 
     @Override
     public void building(ClientBuilder clientBuilder) {
-        Object sslRef = clientBuilder.getConfiguration().getProperty(SSL_REFKEY);
+        Object sslRef = clientBuilder.getConfiguration().getProperty(JAXRSClientConstants.SSL_REFKEY);
         try {
             getSSLContext(toString(sslRef)).ifPresent(clientBuilder::sslContext);
         } catch (SSLException ex) {


### PR DESCRIPTION
- also refactored to clean test cases
- HTTPS test case was not working as intended - now fixed
- proxy settings now required to be specified on the ClientBuilder
- note that JAX-RS 2.0 does not support HTTPS-based proxy auth
