### PR TITLE
Update adminCenter to work with Jakarta EE 9

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.adminCenter1.0.javaee.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.adminCenter1.0.javaee.feature
@@ -1,0 +1,14 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName = io.openliberty.adminCenter1.0.javaee
+visibility = private
+IBM-Provision-Capability:\
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.adminCenter-1.0))",\
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.servlet-3.0)(osgi.identity=com.ibm.websphere.appserver.servlet-3.1)(osgi.identity=com.ibm.websphere.appserver.servlet-4.0)))"
+IBM-Install-Policy: when-satisfied
+-features=\
+  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0", \
+  com.ibm.websphere.appserver.jta-1.1; ibm.tolerates:="1.2", \
+  com.ibm.websphere.appserver.jsp-2.2; ibm.tolerates:="2.3", \
+  com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0"
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.adminCenter1.0.internal.ee-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.adminCenter1.0.internal.ee-6.0.feature
@@ -1,0 +1,12 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.adminCenter1.0.internal.ee-6.0
+WLP-DisableAllFeatures-OnConflict: false
+visibility=private
+singleton=true
+-features=\
+  com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0"
+-bundles=\
+  com.ibm.ws.ui, \
+  com.ibm.ws.org.owasp.esapi.2.1.0
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.adminCenter1.0.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.adminCenter1.0.internal.ee-9.0.feature
@@ -1,0 +1,14 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.adminCenter1.0.internal.ee-9.0
+visibility=private
+singleton=true
+-features=\
+  com.ibm.websphere.appserver.servlet-5.0, \
+  com.ibm.websphere.appserver.restConnector-2.0, \
+  io.openliberty.jta-2.0, \
+  io.openliberty.pages-3.0
+-bundles=\
+  com.ibm.ws.ui.jakarta, \
+  com.ibm.ws.org.owasp.esapi.2.1.0.jakarta
+kind=noship
+edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/adminCenter-1.0/com.ibm.websphere.appserver.adminCenter-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/adminCenter-1.0/com.ibm.websphere.appserver.adminCenter-1.0.feature
@@ -6,17 +6,13 @@ IBM-ShortName: adminCenter-1.0
 Subsystem-Name: Admin Center
 Subsystem-Icon: OSGI-INF/admincenter_200x200.png,OSGI-INF/admincenter_200x200.png;size=200
 -features=com.ibm.websphere.appserver.restHandler-1.0, \
-  com.ibm.websphere.appserver.restConnector-1.0; ibm.tolerates:="2.0", \
-  com.ibm.websphere.appserver.jta-1.1; ibm.tolerates:="1.2", \
   com.ibm.wsspi.appserver.webBundle-1.0, \
-  com.ibm.websphere.appserver.jsp-2.2; ibm.tolerates:="2.3", \
-  com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0", \
+  com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0", \
   com.ibm.websphere.appserver.adminCenter.tool.explore-1.0, \
-  com.ibm.websphere.appserver.adminCenter.tool.serverConfig-1.0
+  com.ibm.websphere.appserver.adminCenter.tool.serverConfig-1.0, \
+  io.openliberty.adminCenter1.0.internal.ee-6.0; ibm.tolerates:="9.0"
 -bundles=\
     com.ibm.websphere.jsonsupport,\
-    com.ibm.ws.ui,\
-    com.ibm.ws.org.owasp.esapi.2.1.0,\
     com.ibm.ws.org.joda.time.1.6.2
 kind=ga
 edition=core

--- a/dev/com.ibm.ws.org.owasp.esapi/bnd.bnd
+++ b/dev/com.ibm.ws.org.owasp.esapi/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019,2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@ allow.bundle-version.override=true
 Bundle-Name: owasp.esapi
 Bundle-Description: owasp.esapi
 Bundle-SymbolicName: com.ibm.ws.org.owasp.esapi.2.1.0
+
+jakartaeeMe: true
 
 WS-TraceGroup: UI
 

--- a/dev/com.ibm.ws.ui/bnd.bnd
+++ b/dev/com.ibm.ws.ui/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2016, 2020 IBM Corporation and others.
+# Copyright (c) 2016, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -23,6 +23,8 @@ OL-VirtualHost: ${admin.virtual.host}
 IBM-Authorization-Roles: com.ibm.ws.management
 
 instrument.disabled: true
+
+jakartaeeMe: true
 
 Export-Package: \
   com.ibm.ws.ui.persistence,\


### PR DESCRIPTION
- Use the transformer for the com.ibm.ws.ui bundle
- Update to use auto features for tolerated Java EE features where the feature names don't match for Jakarta EE 9
- Use internal private features to enable the right bundle / features with Jakarta EE 9.