### PR TITLE
Update webCache to work with Jakarta EE 9

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.webCache1.0.javaee.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.webCache1.0.javaee.feature
@@ -1,0 +1,12 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName = io.openliberty.webCache1.0.javaee
+visibility = private
+IBM-Provision-Capability:\
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.webCache-1.0))",\
+  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.servlet-3.0)(osgi.identity=com.ibm.websphere.appserver.servlet-3.1)(osgi.identity=com.ibm.websphere.appserver.servlet-4.0)))"
+IBM-Install-Policy: when-satisfied
+-features=\
+  com.ibm.websphere.appserver.jsp-2.2; ibm.tolerates:="2.3", \
+  com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0"
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webCache1.0.internal.ee-6.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webCache1.0.internal.ee-6.0.feature
@@ -1,0 +1,10 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.webCache1.0.internal.ee-6.0
+singleton=true
+WLP-DisableAllFeatures-OnConflict: false
+visibility=private
+-features=com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1, 4.0"
+-bundles=\
+  com.ibm.ws.dynacache.web
+kind=ga
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webCache1.0.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.webCache1.0.internal.ee-9.0.feature
@@ -1,0 +1,10 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.webCache1.0.internal.ee-9.0
+singleton=true
+visibility=private
+-features=\
+  com.ibm.websphere.appserver.servlet-5.0, \
+  io.openliberty.pages-3.0
+-bundles=com.ibm.ws.dynacache.web.jakarta
+kind=noship
+edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/webCache-1.0/com.ibm.websphere.appserver.webCache-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/webCache-1.0/com.ibm.websphere.appserver.webCache-1.0.feature
@@ -13,10 +13,10 @@ IBM-API-Package: com.ibm.websphere.servlet.cache; type="ibm-api", \
 IBM-ShortName: webCache-1.0
 IBM-SPI-Package: com.ibm.wsspi.cache.web
 Subsystem-Name: Web Response Cache 1.0
--features=com.ibm.websphere.appserver.jsp-2.2; ibm.tolerates:="2.3", \
-  com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0", \
-  com.ibm.websphere.appserver.distributedMap-1.0
--bundles=com.ibm.ws.dynacache.web
+-features=\
+  com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0,5.0", \
+  com.ibm.websphere.appserver.distributedMap-1.0, \
+  io.openliberty.webCache1.0.internal.ee-6.0; ibm.tolerates:="9.0"
 -jars=com.ibm.websphere.appserver.spi.webCache; location:=dev/spi/ibm/, \
  com.ibm.websphere.appserver.api.webCache; location:=dev/api/ibm/
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.webCache_1.0-javadoc.zip, \

--- a/dev/com.ibm.ws.dynacache.web/bnd.bnd
+++ b/dev/com.ibm.ws.dynacache.web/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019,2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -19,6 +19,8 @@ Bundle-Name: dynacache web
 Bundle-SymbolicName: com.ibm.ws.dynacache.web
 Bundle-Description: Dynacache Web cache capability in Liberty
     
+jakartaeeMe: true
+
 Include-Resource: \
     META-INF/cachespec.dtd=resources/cachespec.dtd
 

--- a/dev/wlp-jakartaee-transform/rules/jakarta-xml-master.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-xml-master.properties
@@ -87,3 +87,6 @@ com.ibm.ws.jbatch.cdi.BatchCDIInjectionExtension.xml=jakarta-batch.properties
 
 #Rest Handler validator FAT
 validatorCustomLoginModuleServer.xml=jakarta-metatype.properties
+
+#webCache
+com.ibm.ws.cache.servlet.xml=jakarta-xml-servletContainerInitializer.properties


### PR DESCRIPTION
- Use the transformer for the com.ibm.ws.dynacache.web bundle
- Update to use auto features for tolerated Java EE features where the feature names don't match for Jakarta EE 9
- Use internal private features to enable the right bundle / features with Jakarta EE 9.
