### PR TITLE
Remove --illegal-access=permit refs

### DIFF
--- a/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
@@ -102,10 +102,10 @@
 		<!-- In Java 16, the default enforcement of strong encapsulation (part of JPMS, which was introduced in Java 9) has changed from 
 		     illegal-access=permit to illegal-access=deny.  This causes many of our FATs that use reflection to fail.  
 		     This change sets up a gated property (illegal.access.permit) so that any builds that take place on Java 15+ use 
-		     illegal-access=permit, but older versions will be skipped -->
-		<condition property="illegal.access.permit" value="--illegal-access=permit">
+		     illegal-access=permit, but older versions will be skipped 
+		<condition property="illegal.access.permit" value="-illegal-access=permit">
 			<istrue value="${is.java15.orHigher}"/>
-		</condition>
+		</condition> -->
 		<property name="illegal.access.permit" value=""/>
 		
 		<tstamp>

--- a/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
@@ -100,9 +100,9 @@
 		</condition>
 
 		<!-- In Java 16, the default enforcement of strong encapsulation (part of JPMS, which was introduced in Java 9) has changed from 
-		     illegal-access=permit to illegal-access=deny.  This causes many of our FATs that use reflection to fail.  
-		     This change sets up a gated property (illegal.access.permit) so that any builds that take place on Java 15+ use 
-		     illegal-access=permit, but older versions will be skipped --> 
+			 <dash><dash>"illegal-access=permit" to <dash><dash>"illegal-access=deny".  This causes many of our FATs that use reflection to fail.  
+			 Setting up a gated property (illegal.access.permit) so that any builds that take place on Java 15+ use the JVM override 
+			 <dash><dash>"add-opens java.base/java.lang=ALL-UNNAMED" which is needed for many of our FATs, but older versions will be skipped -->
 		<condition property="illegal.access.permit" value="--add-opens java.base/java.lang=ALL-UNNAMED">
 			<istrue value="${is.java15.orHigher}"/>
 		</condition>

--- a/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/com.ibm.ws.componenttest/autoFVT-defaults/src/ant/launch.xml
@@ -102,10 +102,10 @@
 		<!-- In Java 16, the default enforcement of strong encapsulation (part of JPMS, which was introduced in Java 9) has changed from 
 		     illegal-access=permit to illegal-access=deny.  This causes many of our FATs that use reflection to fail.  
 		     This change sets up a gated property (illegal.access.permit) so that any builds that take place on Java 15+ use 
-		     illegal-access=permit, but older versions will be skipped 
-		<condition property="illegal.access.permit" value="-illegal-access=permit">
+		     illegal-access=permit, but older versions will be skipped --> 
+		<condition property="illegal.access.permit" value="--add-opens java.base/java.lang=ALL-UNNAMED">
 			<istrue value="${is.java15.orHigher}"/>
-		</condition> -->
+		</condition>
 		<property name="illegal.access.permit" value=""/>
 		
 		<tstamp>

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/DB2KerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/DB2KerberosTest.java
@@ -41,7 +41,6 @@ import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import jdbc.krb5.db2.web.DB2KerberosTestServlet;
@@ -85,9 +84,9 @@ public class DB2KerberosTest extends FATServletClient {
         jvmOpts.add("-Dsun.security.krb5.debug=true"); // Hotspot/OpenJ9
         jvmOpts.add("-Dcom.ibm.security.krb5.krb5Debug=true"); // IBM JDK
 
-        if (JavaInfo.JAVA_VERSION >= 9) {
-            jvmOpts.add("--illegal-access=permit"); // Java 16 JEPS 396
-        }
+//        if (JavaInfo.JAVA_VERSION >= 9) {
+//            jvmOpts.add("--illegal-access=permit"); // Java 16 JEPS 396
+//        }
         server.setJvmOptions(jvmOpts);
 
         server.startServer();

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/DB2KerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/DB2KerberosTest.java
@@ -84,9 +84,6 @@ public class DB2KerberosTest extends FATServletClient {
         jvmOpts.add("-Dsun.security.krb5.debug=true"); // Hotspot/OpenJ9
         jvmOpts.add("-Dcom.ibm.security.krb5.krb5Debug=true"); // IBM JDK
 
-//        if (JavaInfo.JAVA_VERSION >= 9) {
-//            jvmOpts.add("--illegal-access=permit"); // Java 16 JEPS 396
-//        }
         server.setJvmOptions(jvmOpts);
 
         server.startServer();

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/ErrorPathTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/ErrorPathTest.java
@@ -35,7 +35,6 @@ import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
@@ -77,9 +76,9 @@ public class ErrorPathTest extends FATServletClient {
         jvmOpts.add("-Dsun.security.krb5.debug=true"); // Hotspot/OpenJ9
         jvmOpts.add("-Dcom.ibm.security.krb5.krb5Debug=true"); // IBM JDK
 
-        if (JavaInfo.JAVA_VERSION >= 9) {
-            jvmOpts.add("--illegal-access=permit"); // Java 16 JEPS 396
-        }
+//        if (JavaInfo.JAVA_VERSION >= 9) {
+//            jvmOpts.add("--illegal-access=permit"); // Java 16 JEPS 396
+//        }
         server.setJvmOptions(jvmOpts);
 
         server.startServer();

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/ErrorPathTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/ErrorPathTest.java
@@ -76,9 +76,6 @@ public class ErrorPathTest extends FATServletClient {
         jvmOpts.add("-Dsun.security.krb5.debug=true"); // Hotspot/OpenJ9
         jvmOpts.add("-Dcom.ibm.security.krb5.krb5Debug=true"); // IBM JDK
 
-//        if (JavaInfo.JAVA_VERSION >= 9) {
-//            jvmOpts.add("--illegal-access=permit"); // Java 16 JEPS 396
-//        }
         server.setJvmOptions(jvmOpts);
 
         server.startServer();

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/OracleKerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/OracleKerberosTest.java
@@ -84,9 +84,9 @@ public class OracleKerberosTest extends FATServletClient {
         jvmOpts.add("-Dsun.security.jgss.debug=true");
         jvmOpts.add("-Dcom.ibm.security.krb5.krb5Debug=true"); // IBM JDK
 
-        if (JavaInfo.JAVA_VERSION >= 9) {
-            jvmOpts.add("--illegal-access=permit"); // Java 16 JEPS 396
-        }
+//        if (JavaInfo.JAVA_VERSION >= 9) {
+//            jvmOpts.add("--illegal-access=permit"); // Java 16 JEPS 396
+//        }
         server.setJvmOptions(jvmOpts);
 
         server.startServer();

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/OracleKerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/OracleKerberosTest.java
@@ -84,9 +84,6 @@ public class OracleKerberosTest extends FATServletClient {
         jvmOpts.add("-Dsun.security.jgss.debug=true");
         jvmOpts.add("-Dcom.ibm.security.krb5.krb5Debug=true"); // IBM JDK
 
-//        if (JavaInfo.JAVA_VERSION >= 9) {
-//            jvmOpts.add("--illegal-access=permit"); // Java 16 JEPS 396
-//        }
         server.setJvmOptions(jvmOpts);
 
         server.startServer();

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/PostgresKerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/PostgresKerberosTest.java
@@ -30,7 +30,6 @@ import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import jdbc.krb5.pg.web.PgKerberosTestServlet;
@@ -78,9 +77,9 @@ public class PostgresKerberosTest extends FATServletClient {
         jvmOpts.add("-Dsun.security.krb5.debug=true"); // Hotspot/OpenJ9
         jvmOpts.add("-Dcom.ibm.security.krb5.krb5Debug=true"); // IBM JDK
 
-        if (JavaInfo.JAVA_VERSION >= 9) {
-            jvmOpts.add("--illegal-access=permit"); // Java 16 JEPS 396
-        }
+//        if (JavaInfo.JAVA_VERSION >= 9) {
+//            jvmOpts.add("--illegal-access=permit"); // Java 16 JEPS 396
+//        }
         server.setJvmOptions(jvmOpts);
 
         server.startServer();

--- a/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/PostgresKerberosTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/fat/src/com/ibm/ws/jdbc/fat/krb5/PostgresKerberosTest.java
@@ -77,9 +77,6 @@ public class PostgresKerberosTest extends FATServletClient {
         jvmOpts.add("-Dsun.security.krb5.debug=true"); // Hotspot/OpenJ9
         jvmOpts.add("-Dcom.ibm.security.krb5.krb5Debug=true"); // IBM JDK
 
-//        if (JavaInfo.JAVA_VERSION >= 9) {
-//            jvmOpts.add("--illegal-access=permit"); // Java 16 JEPS 396
-//        }
         server.setJvmOptions(jvmOpts);
 
         server.startServer();

--- a/dev/com.ibm.ws.kernel.boot/publish/platform/java/java9.options
+++ b/dev/com.ibm.ws.kernel.boot/publish/platform/java/java9.options
@@ -7,6 +7,9 @@ java.base/sun.security.action=ALL-UNNAMED
 java.naming/com.sun.jndi.ldap=ALL-UNNAMED
 --add-exports
 java.naming/com.sun.jndi.url.ldap=ALL-UNNAMED
+# for Oracle Kerberos
+--add-exports
+java.security.jgss/sun.security.krb5.internal=ALL-UNNAMED
 ### Opens
 --add-opens
 java.base/java.util=ALL-UNNAMED
@@ -46,5 +49,3 @@ java.base/java.security=ALL-UNNAMED
 # for java -jar execution on command line (java.net.URLClassLoader)
 --add-opens
 java.base/java.net=ALL-UNNAMED
-# for testing only to focus on FAT tests
---illegal-access=permit

--- a/dev/com.ibm.ws.kernel.boot/publish/platform/java/java9.options
+++ b/dev/com.ibm.ws.kernel.boot/publish/platform/java/java9.options
@@ -46,4 +46,5 @@ java.base/java.security=ALL-UNNAMED
 # for java -jar execution on command line (java.net.URLClassLoader)
 --add-opens
 java.base/java.net=ALL-UNNAMED
-
+# for testing only to focus on FAT tests
+--illegal-access=permit

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandport/ServerCommandPortTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandport/ServerCommandPortTest.java
@@ -61,9 +61,9 @@ public class ServerCommandPortTest {
     public void testServerCommandPortDisabled() throws Exception {
         LibertyServer server = commandPortDisabledServer;
         JavaInfo java = JavaInfo.forCurrentVM();
-        if (java.majorVersion() != 8) {
-            server.copyFileToLibertyServerRoot("illegalAccess/jvm.options");
-        }
+//        if (java.majorVersion() != 8) {
+//            server.copyFileToLibertyServerRoot("illegalAccess/jvm.options");
+//        }
 
         // server should start, but with a warning message that we can't actually tell if it completed starting
         // because the command port is disabled
@@ -141,9 +141,9 @@ public class ServerCommandPortTest {
         LibertyServer server = commandPortEnabledServer;
 
         JavaInfo java = JavaInfo.forCurrentVM();
-        if (java.majorVersion() != 8) {
-            server.copyFileToLibertyServerRoot("illegalAccess/jvm.options");
-        }
+//        if (java.majorVersion() != 8) {
+//            server.copyFileToLibertyServerRoot("illegalAccess/jvm.options");
+//        }
 
         String output = server.startServer().getStdout();
         assertTrue(output.contains("Server " + server.getServerName() + " started"));

--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandport/ServerCommandPortTest.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/ws/kernel/boot/commandport/ServerCommandPortTest.java
@@ -25,7 +25,6 @@ import com.ibm.websphere.simplicity.RemoteFile;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
-import componenttest.topology.impl.JavaInfo;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.HttpUtils;
@@ -60,10 +59,6 @@ public class ServerCommandPortTest {
      */
     public void testServerCommandPortDisabled() throws Exception {
         LibertyServer server = commandPortDisabledServer;
-        JavaInfo java = JavaInfo.forCurrentVM();
-//        if (java.majorVersion() != 8) {
-//            server.copyFileToLibertyServerRoot("illegalAccess/jvm.options");
-//        }
 
         // server should start, but with a warning message that we can't actually tell if it completed starting
         // because the command port is disabled
@@ -139,11 +134,6 @@ public class ServerCommandPortTest {
      */
     public void testServerCommandPortEnabled() throws Exception {
         LibertyServer server = commandPortEnabledServer;
-
-        JavaInfo java = JavaInfo.forCurrentVM();
-//        if (java.majorVersion() != 8) {
-//            server.copyFileToLibertyServerRoot("illegalAccess/jvm.options");
-//        }
 
         String output = server.startServer().getStdout();
         assertTrue(output.contains("Server " + server.getServerName() + " started"));

--- a/dev/com.ibm.ws.kernel.boot_fat/publish/files/illegalAccess/jvm.options
+++ b/dev/com.ibm.ws.kernel.boot_fat/publish/files/illegalAccess/jvm.options
@@ -1,1 +1,1 @@
---illegal-access=permit
+# Here is where we can add the necessary JPMS permissions for this FAT to successfully complete

--- a/dev/com.ibm.ws.kernel.boot_fat/publish/files/illegalAccess/jvm.options
+++ b/dev/com.ibm.ws.kernel.boot_fat/publish/files/illegalAccess/jvm.options
@@ -1,1 +1,0 @@
-# Here is where we can add the necessary JPMS permissions for this FAT to successfully complete

--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -197,10 +197,10 @@
 		<!-- In Java 16, the default enforcement of strong encapsulation (part of JPMS, which was introduced in Java 9) has changed from 
 			     illegal-access=permit to illegal-access=deny.  This causes many of our FATs that use reflection to fail.  
 			     This change sets up a gated property (illegal.access.permit) so that any builds that take place on Java 15+ use 
-			     illegal-access=permit, but older versions will be skipped -->
-		<condition property="illegal.access.permit" value="--illegal-access=permit">
+			     illegal-access=permit, but older versions will be skipped 
+		<condition property="illegal.access.permit" value="-illegal-access=permit">
 			<istrue value="${is.java15.orHigher}"/>
-		</condition>
+		</condition> -->
 		<property name="illegal.access.permit" value=""/>
 		
 		<!-- Replace LDAP ports of all 3 Apache DS instance in configuration with updated ports from port selector and kill any apache ds related processes -->

--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -195,9 +195,9 @@
 		</condition>
 		
 		<!-- In Java 16, the default enforcement of strong encapsulation (part of JPMS, which was introduced in Java 9) has changed from 
-			     illegal-access=permit to illegal-access=deny.  This causes many of our FATs that use reflection to fail.  
-			     This change sets up a gated property (illegal.access.permit) so that any builds that take place on Java 15+ use 
-			     illegal-access=permit, but older versions will be skipped -->
+			 <dash><dash>"illegal-access=permit" to <dash><dash>"illegal-access=deny".  This causes many of our FATs that use reflection to fail.  
+			 Setting up a gated property (illegal.access.permit) so that any builds that take place on Java 15+ use the JVM override 
+			 <dash><dash>"add-opens java.base/java.lang=ALL-UNNAMED" which is needed for many of our FATs, but older versions will be skipped -->
 		<condition property="illegal.access.permit" value="--add-opens java.base/java.lang=ALL-UNNAMED">
 			<istrue value="${is.java15.orHigher}"/>
 		</condition>

--- a/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
+++ b/dev/fattest.simplicity/autoFVT-defaults/src/ant/launch.xml
@@ -197,10 +197,10 @@
 		<!-- In Java 16, the default enforcement of strong encapsulation (part of JPMS, which was introduced in Java 9) has changed from 
 			     illegal-access=permit to illegal-access=deny.  This causes many of our FATs that use reflection to fail.  
 			     This change sets up a gated property (illegal.access.permit) so that any builds that take place on Java 15+ use 
-			     illegal-access=permit, but older versions will be skipped 
-		<condition property="illegal.access.permit" value="-illegal-access=permit">
+			     illegal-access=permit, but older versions will be skipped -->
+		<condition property="illegal.access.permit" value="--add-opens java.base/java.lang=ALL-UNNAMED">
 			<istrue value="${is.java15.orHigher}"/>
-		</condition> -->
+		</condition>
 		<property name="illegal.access.permit" value=""/>
 		
 		<!-- Replace LDAP ports of all 3 Apache DS instance in configuration with updated ports from port selector and kill any apache ds related processes -->


### PR DESCRIPTION
Replace generic `--illegal-access=permit` JVM argument for testing with explicit `--add-opens` or `--add-exports` instead.