### PR TITLE
Fixing SessionCacheConfigUpdateTest cases

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheConfigUpdateTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheConfigUpdateTest.java
@@ -67,8 +67,8 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         server.setMarkToEndOfLog();
         server.updateServerConfiguration(savedConfig);
 
-        Log.info(SessionCacheConfigUpdateTest.class, "cleanUpPerTest", "wait 2 seconds");
-        TimeUnit.SECONDS.sleep(2);
+        Log.info(SessionCacheConfigUpdateTest.class, "cleanUpPerTest", "wait 5 seconds");
+        TimeUnit.SECONDS.sleep(5);
         server.waitForConfigUpdateInLogUsingMark(APP_NAMES, cleanupList);
         cleanupList = EMPTY_RECYCLE_LIST;
 

--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheConfigUpdateTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheConfigUpdateTest.java
@@ -66,6 +66,9 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
     public void cleanUpPerTest() throws Exception {
         server.setMarkToEndOfLog();
         server.updateServerConfiguration(savedConfig);
+
+        Log.info(SessionCacheConfigUpdateTest.class, "cleanUpPerTest", "wait 2 seconds");
+        TimeUnit.SECONDS.sleep(2);
         server.waitForConfigUpdateInLogUsingMark(APP_NAMES, cleanupList);
         cleanupList = EMPTY_RECYCLE_LIST;
 
@@ -205,6 +208,9 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         server.setMarkToEndOfLog(); // Only marks messages.log, does not mark the trace file
         server.setTraceMarkToEndOfDefaultTrace();
         server.updateServerConfiguration(config);
+
+        Log.info(SessionCacheConfigUpdateTest.class, "testScheduleInvalidation", "wait 2 seconds");
+        TimeUnit.SECONDS.sleep(2);
         server.waitForConfigUpdateInLogUsingMark(APP_NAMES, EMPTY_RECYCLE_LIST);
         String messageToCheckFor = "doScheduledInvalidation scheduled hours are " + Integer.toString(hour1) + " and " + Integer.toString(hour2);
 
@@ -247,7 +253,11 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         httpSessionCache.setWriteContents("GET_AND_SET_ATTRIBUTES");
         server.setMarkToEndOfLog();
         server.updateServerConfiguration(config);
-        server.waitForConfigUpdateInLogUsingMark(APP_NAMES, EMPTY_RECYCLE_LIST);
+
+        Log.info(SessionCacheConfigUpdateTest.class, "testWriteContents", "wait 2 seconds");
+        TimeUnit.SECONDS.sleep(2);
+        Log.info(SessionCacheConfigUpdateTest.class, "testWriteContents",
+                 server.waitForConfigUpdateInLogUsingMark(APP_NAMES, EMPTY_RECYCLE_LIST).toString());
 
         run("testWriteContents_GET_AND_SET_ATTRIBUTES", new ArrayList<>());
 
@@ -255,7 +265,11 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         httpSessionCache.setWriteContents("ALL_SESSION_ATTRIBUTES");
         server.setMarkToEndOfLog();
         server.updateServerConfiguration(config);
-        server.waitForConfigUpdateInLogUsingMark(APP_NAMES, EMPTY_RECYCLE_LIST);
+
+        Log.info(SessionCacheConfigUpdateTest.class, "testWriteContents", "wait 2 seconds");
+        TimeUnit.SECONDS.sleep(2);
+        Log.info(SessionCacheConfigUpdateTest.class, "testWriteContents",
+                 server.waitForConfigUpdateInLogUsingMark(APP_NAMES, EMPTY_RECYCLE_LIST).toString());
 
         run("testWriteContents_ALL_SESSION_ATTRIBUTES", new ArrayList<>());
     }
@@ -278,6 +292,9 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         httpSessionCache.setWriteFrequency("MANUAL_UPDATE");
         server.setMarkToEndOfLog();
         server.updateServerConfiguration(config);
+
+        Log.info(SessionCacheConfigUpdateTest.class, "testWriteFrequency", "wait 2 seconds");
+        TimeUnit.SECONDS.sleep(2);
         server.waitForConfigUpdateInLogUsingMark(APP_NAMES, EMPTY_RECYCLE_LIST);
 
         // Set a new attribute value without performing a manual sync, the value in the cache should not be updated
@@ -306,6 +323,9 @@ public class SessionCacheConfigUpdateTest extends FATServletClient {
         httpSessionCache.setWriteInterval("5s");
         server.setMarkToEndOfLog();
         server.updateServerConfiguration(config);
+
+        Log.info(SessionCacheConfigUpdateTest.class, "testWriteInterval", "wait 2 seconds");
+        TimeUnit.SECONDS.sleep(2);
         server.waitForConfigUpdateInLogUsingMark(APP_NAMES, EMPTY_RECYCLE_LIST);
 
         // Set a new attribute value and verify that it does not get persisted upon the end of the servlet request.

--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheConfigUpdateTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheConfigUpdateTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
Between server configuration update and completion, it needs time.

        server.updateServerConfiguration(config);

        server.waitForConfigUpdateInLogUsingMark(APP_NAMES, EMPTY_RECYCLE_LIST);

