### PR TITLE
add entry and exit trace to H2WriteTree queue runnable

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/H2WriteTree.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/h2internal/H2WriteTree.java
@@ -356,6 +356,9 @@ public class H2WriteTree implements H2WorkQInterface {
 
         @Override
         public void run() {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
+                Tr.entry(tc, "Write Q run entry, qStatus: " + qStatus + " qSync: " + qSync);
+            }
 
             try {
                 while (true) {
@@ -415,6 +418,10 @@ public class H2WriteTree implements H2WorkQInterface {
                 // add debug
                 // something went really wrong, log and leave
                 qStatus = Q_STATUS.FINISHED;
+            } finally {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
+                    Tr.exit(tc, "Write Q run exit, qStatus: " + qStatus + " qSync: " + qSync);
+                }
             }
         }
     }


### PR DESCRIPTION
It will be helpful to have entry and exit trace for the H2WriteTree's queue, to help keep track of the state of the lock object used by that queue