### PR TITLE
fix rtc defects in wsscxf fat

### DIFF
--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_orig.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/publish/servers/com.ibm.ws.wssecurity_fat.sha2sig/server_orig.xml
@@ -2,7 +2,7 @@
 	<featureManager>
 		<feature>ssl-1.0</feature>
 		<feature>usr:wsseccbh-1.0</feature>
-		<feature>servlet-3.0</feature>
+		<feature>servlet-3.1</feature>
 		<feature>appSecurity-2.0</feature>
 		<feature>jsp-2.2</feature>
 		<feature>jaxws-2.2</feature>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/publish/servers/com.ibm.ws.wssecurity_fat.x509enc/server_orig.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/publish/servers/com.ibm.ws.wssecurity_fat.x509enc/server_orig.xml
@@ -2,7 +2,7 @@
 	<featureManager>
 		<feature>ssl-1.0</feature>
 		<feature>usr:wsseccbh-1.0</feature>
-		<feature>servlet-3.0</feature>
+		<feature>servlet-3.1</feature>
 		<feature>appSecurity-2.0</feature>
 		<feature>jsp-2.2</feature>
 		<feature>jaxws-2.2</feature>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/publish/servers/com.ibm.ws.wssecurity_fat.x509enc/server_wrongEnc.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/publish/servers/com.ibm.ws.wssecurity_fat.x509enc/server_wrongEnc.xml
@@ -2,7 +2,7 @@
 	<featureManager>
 		<feature>ssl-1.0</feature>
 		<feature>usr:wsseccbh-1.0</feature>
-		<feature>servlet-3.0</feature>
+		<feature>servlet-3.1</feature>
 		<feature>appSecurity-2.0</feature>
 		<feature>jsp-2.2</feature>
 		<feature>jaxws-2.2</feature>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf/test-applications/x509client/src/com/ibm/ws/wssecurity/fat/x509client/CxfX509SvcClient.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf/test-applications/x509client/src/com/ibm/ws/wssecurity/fat/x509client/CxfX509SvcClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -95,6 +95,7 @@ public class CxfX509SvcClient extends HttpServlet {
             servicePort = new QName(SERVICE_NS, request.getParameter("servicePort"));
             if (httpSecurePortNum == null || httpSecurePortNum.length() == 0) {
                 thePort = httpPortNum;
+                httpProtocal = "http:";
             } else {
                 thePort = httpSecurePortNum;
                 httpProtocal = "https:";


### PR DESCRIPTION
* update servlet version from 3.0 to 3.1 in com.ibm.ws.wssecurity_fat.wsscxf server configs (rtc281447)
* set http protocol correctly in com.ibm.ws.wssecurity_fat.wsscxf x509client (rtc282101)