### PR TITLE
fix jsfContainer_fat_2.3 local builds

### DIFF
--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/bnd.bnd
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2020 IBM Corporation and others.
+# Copyright (c) 2018, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -51,5 +51,7 @@ fat.project: true
 	com.ibm.websphere.javaee.jsf.2.3;version=latest,\
 	com.ibm.websphere.javaee.servlet.4.0;version=latest,\
 	com.ibm.websphere.javaee.validation.2.0;version=latest,\
+	io.openliberty.org.apache.commons.logging;version=latest,\
+	io.openliberty.org.apache.commons.codec;version=latest,\
 	net.sourceforge.htmlunit:htmlunit;version=2.20,\
 	xml-apis:xml-apis;version=1.4.01


### PR DESCRIPTION
This fixes a similar problem as #17258 - due to the changes made in #16620, local gradle builds of `com.ibm.ws.jsfContainer_fat_2.3` were broken. In this case, the fix is to add the new `io.openliberty.org.apache.commons.*` projects to the project bnd.