### PR TITLE
Fix up eclipse / github actions builds

### DIFF
--- a/.github/test-categories/MP_HEALTH
+++ b/.github/test-categories/MP_HEALTH
@@ -6,3 +6,4 @@ com.ibm.ws.microprofile.health.2.2_fat_tck
 com.ibm.ws.microprofile.health_fat
 io.openliberty.microprofile.health.3.0.internal_fat
 io.openliberty.microprofile.health.3.0.internal_fat_tck
+io.openliberty.microprofile.health.3.1.internal_fat_tck

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLProxyAuthTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLProxyAuthTest.java
@@ -17,7 +17,7 @@ import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 import static org.mockserver.model.NottableString.not;
 import static org.mockserver.model.NottableString.string;
-import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;;
+import static componenttest.annotation.SkipForRepeat.NO_MODIFICATION;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/dev/io.openliberty.microprofile.health.3.1.internal/.classpath
+++ b/dev/io.openliberty.microprofile.health.3.1.internal/.classpath
@@ -5,6 +5,5 @@
 	<classpathentry kind="src" output="bin_test" path="test/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="src" path="/io.openliberty.microprofile.health.3.1.internal"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/io.openliberty.microprofile.health.internal.common/.classpath
+++ b/dev/io.openliberty.microprofile.health.internal.common/.classpath
@@ -2,7 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="resources"/>
-	<classpathentry kind="src" output="bin_test" path="test/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>


### PR DESCRIPTION
- Clean up errors in mp health 3.1 .classpath files
- Add new mp health fat to the github actions test categories
- Remove extra semicolon which causes a build failure in eclipse
