### PR TITLE
Allow unit tests to fall back to default ports when the portSelector task fails

### DIFF
--- a/dev/wlp-gradle/subprojects/tasks.gradle
+++ b/dev/wlp-gradle/subprojects/tasks.gradle
@@ -345,6 +345,10 @@ test {
     def propertiesFile = new File(compileTestJava.destinationDir, 'unittestports.properties')
     portSelectorTaskdef(ant)
     ant.portSelector(engineName: "${bnd.buildEngineName}", location: propertiesFile, jvmarg: 'jvmargPorts')
+    if (null.equals(ant.properties['jvmargPorts'])) {
+      logger.error( 'Error: PortSelector task failed to set ports; unittestports JVM props will not be set' )
+      return
+    }
     jvmArgs ant.jvmargPorts.tokenize()
   }
 


### PR DESCRIPTION
We've had issues with unit test failures caused by the legacy ant task [PortSelector](https://github.ibm.com/websphere/infrastructure/blob/master/dev/infra.buildtasks-core/src/com/ibm/aries/buildtasks/PortSelector.java#L97). That task uses `netstat` to detect port conflict, and passes what it determines to be good ports to the unit test via JVM props. Currently, when `PortSelector` hits an issue, it causes the underlying unit test suite to fail. These proposed changes will allow the affected unit test suite to attempt to continue, which testing has shown will generally not be an issue.

In Open Liberty this task is only used by the unit tests in `com.ibm.ws.channelfw`; we'll need to continue monitoring the results from that bucket.