### PR TITLE
WSConnectionSpec MatchCurrentState tests

### DIFF
--- a/dev/com.ibm.ws.jdbc/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc/bnd.bnd
@@ -28,7 +28,8 @@ Export-Package: \
     com.ibm.ws.rsadapter, \
     com.ibm.ws.rsadapter.jdbc, \
     com.ibm.ws.rsadapter.impl, \
-    com.ibm.websphere.ce.cm
+    com.ibm.websphere.ce.cm, \
+    com.ibm.websphere.rsadapter
 
 Import-Package: \
     com.ibm.ws.jca.adapter, \

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/websphere/rsadapter/JDBCConnectionSpec.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/websphere/rsadapter/JDBCConnectionSpec.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.rsadapter;
+
+// This is provided as legacy function. Do not use.
+/**
+* <p>An interface provided for JDBC users to specify additional Connection
+* properties on getConnection.</p>
+*
+* <p>To make use of this functionality, the JDBC application must cast to WSDataSource as
+* follows,</p>
+*
+* <p><code>Connection conn = ((WSDataSource) ds).getConnection(jdbcConnectionSpec);</code></p>
+*/
+public interface JDBCConnectionSpec extends WSConnectionSpec {
+    /**
+     * Get the transaction isolation level.
+     *
+     * @return the java.sql.Connection transaction isolation constant for the isolation level.
+     */
+    int getTransactionIsolation();
+
+    /**
+     * <p>Set the transaction isolation level. Any isolation level constant from the
+     * java.sql.Connection interface can be used, provided the backend supports it.</p>
+     *
+     * <p>A value of TRANSACTION_NONE indicates unspecified, in which case the
+     * isolation level is determined as usual.</p>
+     *
+     * @param isolationLevel the isolation level.
+     */
+    void setTransactionIsolation(int isolationLevel);
+}

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/websphere/rsadapter/WSConnectionSpec.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/websphere/rsadapter/WSConnectionSpec.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2002, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.rsadapter;
+
+import java.util.Map;
+
+// This is provided as legacy function. Do not use.
+/**
+ * <p>Enables connections to be requested and matched based on additional attributes.</p>
+ */
+public interface WSConnectionSpec {
+  /**
+   * Get the catalog name.
+   *
+   * @return the catalog name.
+   */
+  String getCatalog();
+
+  /**
+   * Get the password.
+   *
+   * @return the password.
+   */
+  String getPassword();
+
+  /**
+   * Get the type map, which is used for the custom mapping of SQL structured types and
+   * distinct types.
+   *
+   * @return the type map.
+   */
+  @SuppressWarnings("rawtypes")
+  Map getTypeMap();
+
+  /**
+   * <p>Get the cursor holdability value. If the JDBC driver doesn't support cursor holdability 
+   * feature, 0 is returned.</p>
+   * 
+   * @return the cursor holdability. 0 If the JDBC driver doesn't support cursor holdability 
+   * feature.
+   */
+  int getHoldability();
+
+  /**
+   * Get the user name.
+   * @return the user name.
+   */
+  String getUserName();
+
+  /**
+  * Get the read-only indicator for the database.
+  * @return true if the connection is read only; otherwise false. Value will be null if the
+  *         readOnly property was never set, which means the database default will be used.
+  */
+  Boolean isReadOnly();
+
+  /**
+   * Gets the requested schema.
+   *
+   * @return the schema.
+   */
+  String getSchema();
+
+  /**
+   * Gets the requested network timeout.
+   *
+   * @return the network timeout.
+   */
+  int getNetworkTimeout();
+
+  /**
+   * Set the catalog name. A value of null indicates to use the database default.
+   *
+   * @param catalog the catalog name.
+   */
+  void setCatalog(String catalog);
+
+  /**
+   * Set the password.
+   *
+   * @param pwd the password.
+   */
+  void setPassword(String pwd);
+
+  /**
+   * Indicate whether the connection is read only. A value of null indicates to use the
+   * database default.
+   *
+   * @param readOnly a flag indicating whether the connection is read only.
+   */
+  void setReadOnly(Boolean readOnly);
+
+  /**
+   * Set the type map for this connection. The type map is used for the custom mapping of SQL
+   * structured types and distinct types.  A value of null indicates to use the database
+   * default.
+   *
+   * @param typeMap the type map.
+   */
+  void setTypeMap(@SuppressWarnings("rawtypes") Map map);
+
+  /**
+   * Set the user name.
+   *
+   * @param userName the user name.
+   */
+  void setUserName(String userName);
+
+  /**
+   * Set the cursor holdability value. A value of 0 indicates to use the database default. 
+   * If the JDBC driver doesn't support cursor holdability feature, you can set the holdability 
+   * value to 0.
+   *
+   * @param holdability the cursor holdability
+   */
+  void setHoldability(int holdability);
+
+  /**
+   * Sets the requested schema.
+   *
+   * @param schema the schema.
+   */
+  void setSchema(String schema);
+
+  /**
+   * Sets the requested network timeout.
+   *
+   * @param networkTimeout the network timeout.
+   */
+  void setNetworkTimeout(int networkTimeout);
+}

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/websphere/rsadapter/WSConnectionSpec.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/websphere/rsadapter/WSConnectionSpec.java
@@ -41,11 +41,9 @@ public interface WSConnectionSpec {
   Map getTypeMap();
 
   /**
-   * <p>Get the cursor holdability value. If the JDBC driver doesn't support cursor holdability 
-   * feature, 0 is returned.</p>
+   * <p>Get the cursor holdability value. 0 indicates to use the JDBC driver's default.</p>
    * 
-   * @return the cursor holdability. 0 If the JDBC driver doesn't support cursor holdability 
-   * feature.
+   * @return the cursor holdability.
    */
   int getHoldability();
 
@@ -115,9 +113,9 @@ public interface WSConnectionSpec {
   void setUserName(String userName);
 
   /**
-   * Set the cursor holdability value. A value of 0 indicates to use the database default. 
-   * If the JDBC driver doesn't support cursor holdability feature, you can set the holdability 
-   * value to 0.
+   * Sets the cursor holdability value. A value of 0 indicates to use the JDBC driver's default.
+   * If the JDBC driver doesn't support setting the cursor holdability via the JDBC
+   * spec-defined mechanism, you can set the holdability value to 0.
    *
    * @param holdability the cursor holdability
    */

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/websphere/rsadapter/WSDataSource.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/websphere/rsadapter/WSDataSource.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2001, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.rsadapter;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+// This is provided as legacy function. Do not use.
+/**
+* This interface enables an application to provide additional parameters when requesting a
+* Connection.  These parameters are provided in a ConnectionSpec object.
+*/
+public interface WSDataSource extends DataSource {
+    /**
+     * Error code for SQLException that indicates that the connection pool is paused.
+     */
+    public static final int ERROR_CONNECTION_POOL_IS_PAUSED = 2147117569;
+
+    /**
+     *  With the NORMAL_PURGE option, the purged pool will behave as follows after the purge call:
+     * <OL>
+     * <LI> Existing in-flight transactions will be allowed to continue work </LI>
+     * <LI> Shared connection requests will be honored</LI>
+     * <LI> Free connections are cleanup and destroyed</LI>
+     * <LI> In use connection (i.e. connections in transactions) are cleanup and destroyed when returned to the 
+     * connection pool</LI>
+     * <LI> </LI>
+     * <LI> <CODE> close() </CODE> calls issued on any connections obtained prior to the <code>purgePool</code> call will 
+     * be done synchronously (i.e. wait for the JDBC driver to come back before proceeding) </LI>
+     * <LI> Requests for new connections (not handles to existing old connections) will be honored.</LI>
+     * </OL>
+     */
+    public static final String NORMAL_PURGE = "normal";
+    
+    /**
+     *  With the IMMEDIATE_PURGE option, the purged pool will behave as follows after the purge call:
+     * <OL>
+     * <LI> No new transactions will be allowed to start on any connections obtained prior to the <code>purgePoolContents()</code> call.  Instead,
+     *      a StaleConnectionException is thrown </LI>
+     * <LI> No new handles are allowed to be handed out on any connections obtained prior to the <code>purgePoolContents()</code> call.  Instead,
+     *      a StaleConnectionException is thrown</LI>
+     * <LI> Existing in-flight transactions will be allowed to continue work, any new activities on the purgedConnection will cause a StaleConnectionException
+     * or an XAER_FAIL exception </LI>
+     * <LI> <CODE> close() </CODE> calls issued on any connections obtained prior to the <code>purgePoolContents()</code> call will be
+     *      done asynchronously (i.e. no wait time) </LI>
+     * <LI> Requests for new connections (i.e. not handles to existing old connections) will be honored.</LI>
+     * <LI> Number of connections will be decremented immediately.  This may cause the total number of connections in Liberty
+     * to be, temporarily, out of sync with the database total number of connections</LI>
+     * </OL>
+     */
+    public static final String IMMEDIATE_PURGE = "immediate";
+
+    /**
+     * Requests a connection that matches the information provided in the JDBCConnectionSpec.
+     * The application can specify the catalog, cursor holdability, isReadOnly,
+     * network timeout, schema, transaction isolation level, and typeMap attributes,
+     * allowing for the underlying Connection to be shared based on the above criteria.
+     *
+     * @param connSpec information used to establish the Connection, such as user name,
+     *        password, and type map.  This value should never be null.
+     * @return the Connection
+     * @throws SQLException if an error occurs while obtaining a Connection.
+     */
+    Connection getConnection(JDBCConnectionSpec connSpec) throws SQLException;
+
+    /**
+     * Indicates whether or not the underlying data source is an XADataSource, capable of
+     * two phase commit.
+     *
+     * @return true if the underlying data source is an XADataSource, capable of two
+     *         phase commit, otherwise false.
+     */
+    boolean isXADataSource();
+}

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/websphere/rsadapter/package-info.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/websphere/rsadapter/package-info.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+/**
+ * @version 1.0
+ */
+@org.osgi.annotation.versioning.Version("1.0")
+package com.ibm.websphere.rsadapter;

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/WSManagedConnectionFactoryImpl.java
@@ -131,7 +131,7 @@ public class WSManagedConnectionFactoryImpl extends WSManagedConnectionFactory i
     /**
      * The type of data source (for example, javax.sql.XADataSource) or java.sql.Driver that this managed connection factory uses to establish connections.
      */
-    final Class<?> type;
+    public final Class<?> type;
 
     /**
      * Helps cope with differences between databases/JDBC drivers.

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcDataSource.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/jdbc/WSJdbcDataSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2020 IBM Corporation and others.
+ * Copyright (c) 1997, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,14 +21,15 @@ import java.util.logging.Logger;
 import javax.resource.ResourceException;
 import javax.resource.spi.ConnectionRequestInfo;
 import javax.sql.DataSource;
+import javax.sql.XADataSource;
 
 import com.ibm.websphere.csi.J2EEName;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.rsadapter.JDBCConnectionSpec;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.ffdc.FFDCSelfIntrospectable;
 import com.ibm.ws.jca.adapter.WSConnectionManager;
-import com.ibm.ws.jdbc.WSDataSource;
 import com.ibm.ws.resource.ResourceRefConfig;
 import com.ibm.ws.resource.ResourceRefConfigFactory;
 import com.ibm.ws.resource.ResourceRefInfo;
@@ -44,7 +45,9 @@ import com.ibm.wsspi.resource.ResourceFactory;
 /**
  * This class wraps a JDBC DataSource. It is used as a Connection Factory.
  */
-public class WSJdbcDataSource extends WSJdbcWrapper implements DataSource, FFDCSelfIntrospectable, WSDataSource {
+public class WSJdbcDataSource extends WSJdbcWrapper implements DataSource,
+    FFDCSelfIntrospectable, com.ibm.ws.jdbc.WSDataSource, com.ibm.websphere.rsadapter.WSDataSource {
+
     private static final TraceComponent tc =
                     Tr.register(
                                 WSJdbcDataSource.class,
@@ -171,6 +174,46 @@ public class WSJdbcDataSource extends WSJdbcWrapper implements DataSource, FFDCS
         if (isTraceOn && tc.isEntryEnabled()) 
             Tr.exit(this, tc, "getConnection", c);
         return c;
+    }
+
+    /**
+     * Requests a connection that matches the JDBCConnectionSpec.
+     *
+     * @param connSpec requested connection attributes.
+     * @return the Connection
+     * @throws SQLException if an error occurs while obtaining a Connection.
+     */
+    public Connection getConnection(JDBCConnectionSpec connSpec) throws SQLException {
+        final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
+
+        if (isTraceOn && tc.isDebugEnabled())
+            Tr.debug(this, tc, "getConnection", connSpec);
+
+        // Get the isolation level from the resource reference, or if that is not specified, use the
+        // configured isolationLevel value, otherwise use a default that we choose for the database.
+        int isolationLevelForCRI = connSpec.getTransactionIsolation();
+        if (isolationLevelForCRI == Connection.TRANSACTION_NONE)
+            isolationLevelForCRI = getDefaultIsolationLevel();
+
+        @SuppressWarnings("unchecked")
+        WSConnectionRequestInfoImpl _connInf = new WSConnectionRequestInfoImpl(
+                        connSpec.getUserName(),
+                        connSpec.getPassword(),
+                        isolationLevelForCRI,
+                        connSpec.getCatalog(),
+                        connSpec.isReadOnly(),
+                        null, // sharding key
+                        null, // super sharding key
+                        connSpec.getTypeMap(),
+                        connSpec.getHoldability(),
+                        connSpec.getSchema(),
+                        connSpec.getNetworkTimeout(),
+                        mcf.instanceID,
+                        mcf.getHelper().isIsolationLevelSwitchingSupport());
+
+        _connInf.markAsChangable();
+
+        return getConnection(_connInf);
     }
 
     public final Connection getConnection(String user, String pwd)
@@ -330,6 +373,16 @@ public class WSJdbcDataSource extends WSJdbcWrapper implements DataSource, FFDCS
         if (isTraceOn && tc.isEntryEnabled())
             Tr.exit(this, tc, "invokeOperation: " + method.getName(), result); 
         return result;
+    }
+
+    /**
+     * Legacy operation that indicates if the underlying data source is an XADataSource,
+     * capable of two phase commit.
+     *
+     * @return true if an XADataSource, otherwise false.
+     */
+    public final boolean isXADataSource() {
+        return XADataSource.class.equals(mcf.type);
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc_fat_heritageinterop/fat/src/test/jdbc/heritage/HeritageJDBCTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritageinterop/fat/src/test/jdbc/heritage/HeritageJDBCTest.java
@@ -64,7 +64,9 @@ public class HeritageJDBCTest extends FATServletClient {
             List<String> found = server.findStringsInLogs(".*==> Connection.*.prepareStatement\\(\"VALUES \\('testDefaultQueryTimeout', SQRT\\(196\\)\\)\", 1003, 1007\\).*");
             assertTrue(found.toString(), found.size() == 1);
         } finally {
-            server.stopServer();
+            server.stopServer("J2CA0030E", // test attempts to enlist multiple one-phase resources to prove that sharing does not occur
+                              "WTRN0062E" // test attempts to enlist multiple one-phase resources to prove that sharing does not occur
+            );
         }
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_heritageinterop/jdbcHeritageApi.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_heritageinterop/jdbcHeritageApi.bnd
@@ -22,10 +22,10 @@ WS-TraceGroup: jdbcHeritage
 Fragment-Host: com.ibm.ws.jdbc
 
 Export-Package:\
- com.ibm.websphere.appprofile.accessintent,\
- com.ibm.websphere.rsadapter
+ com.ibm.websphere.appprofile.accessintent
 
 Import-Package: *
 
 Private-Package:\
- com.ibm.websphere.ce.cm
+ com.ibm.websphere.ce.cm,\
+ com.ibm.websphere.rsadapter

--- a/dev/com.ibm.ws.jdbc_fat_heritageinterop/publish/servers/com.ibm.ws.jdbc.heritage/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_heritageinterop/publish/servers/com.ibm.ws.jdbc.heritage/server.xml
@@ -51,6 +51,7 @@
   </dataSource>
 
   <dataSource jndiName="jdbc/helperDefaulted" containerAuthDataRef="dbAuth" type="javax.sql.DataSource">
+    <connectionManager enableSharingForDirectLookups="false"/>
     <jdbcDriver libraryRef="JDBCLib" javax.sql.DataSource="test.jdbc.heritage.driver.HDDataSource"/>
     <properties databaseName="memory:testdb" createDatabase="create"
                 supportsNetworkTimeout="false" supportsSchema="false" supportsTypeMap="false"/>

--- a/dev/com.ibm.ws.jdbc_fat_heritageinterop/publish/servers/com.ibm.ws.jdbc.heritage/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_heritageinterop/publish/servers/com.ibm.ws.jdbc.heritage/server.xml
@@ -36,8 +36,8 @@
 
   <authData id="dbAuth" user="dbuser" password="{xor}Oz0vKDs=" />
 
-  <dataSource id="DefaultDataSource" containerAuthDataRef="dbAuth" queryTimeout="1m21s" supplementalJDBCTrace="true" type="javax.sql.XADataSource" validationTimeout="18s">
-    <jdbcDriver libraryRef="JDBCLib" javax.sql.XADataSource="test.jdbc.heritage.driver.HDDataSource"/>
+  <dataSource id="DefaultDataSource" containerAuthDataRef="dbAuth" queryTimeout="1m21s" supplementalJDBCTrace="true" validationTimeout="18s">
+    <jdbcDriver libraryRef="JDBCLib" javax.sql.XADataSource="test.jdbc.heritage.driver.HDXADataSource"/>
     <properties databaseName="memory:testdb" createDatabase="create"
                 driverType="fake" longDataCacheSize="4" responseBuffering="maybe"
                 supportsCatalog="false" supportsNetworkTimeout="false" supportsReadOnly="false" supportsSchema="false" supportsTypeMap="false"/>
@@ -50,7 +50,8 @@
     <identifyException as="test.jdbc.heritage.driver.helper.HeritageDBFeatureUnavailableException" errorCode="40960"/>
   </dataSource>
 
-  <dataSource jndiName="jdbc/helperDefaulted" containerAuthDataRef="dbAuth" type="javax.sql.DataSource">
+  <dataSource jndiName="jdbc/helperDefaulted" containerAuthDataRef="dbAuth" connectionSharing="MatchOriginalRequest"
+              type="javax.sql.DataSource">
     <connectionManager enableSharingForDirectLookups="false"/>
     <jdbcDriver libraryRef="JDBCLib" javax.sql.DataSource="test.jdbc.heritage.driver.HDDataSource"/>
     <properties databaseName="memory:testdb" createDatabase="create"
@@ -66,6 +67,13 @@
     <identifyException as="test.jdbc.heritage.driver.helper.HeritageDBFeatureUnavailableException" sqlState="0A00H"/>
     <identifyException as="Unsupported" errorCode="10"/>
     <identifyException as="Unsupported" sqlState="HDISA"/>
+  </dataSource>
+
+  <dataSource jndiName="jdbc/one-phase" containerAuthDataRef="dbAuth" connectionSharing="MatchCurrentState"
+              isolationLevel="TRANSACTION_READ_COMMITTED" type="javax.sql.DataSource">
+    <jdbcDriver libraryRef="JDBCLib" javax.sql.DataSource="test.jdbc.heritage.driver.HDDataSource"/>
+    <properties databaseName="memory:testdb" createDatabase="create"/>
+    <heritageSettings helperClass="com.ibm.websphere.rsadapter.GenericDataStoreHelper" replaceExceptions="false"/>
   </dataSource>
 
   <javaPermission codeBase="${shared.resource.dir}derby/derby.jar" className="java.security.AllPermission"/>

--- a/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-applications/heritageApp/src/test/jdbc/heritage/app/ConnectionRequest.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-applications/heritageApp/src/test/jdbc/heritage/app/ConnectionRequest.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jdbc.heritage.app;
+
+import java.util.Map;
+
+import com.ibm.websphere.rsadapter.JDBCConnectionSpec;
+
+/**
+ * Mock implementation of the legacy JDBCConnectionSpec.
+ */
+@SuppressWarnings("restriction")
+public class ConnectionRequest implements JDBCConnectionSpec {
+    private String catalog;
+    private int holdability;
+    private int isolationLevel;
+    private Boolean isReadOnly;
+    private int networkTimeout;
+    private String password;
+    private String schema;
+    private Map<?, ?> typeMap;
+    private String user;
+
+    @Override
+    public String getCatalog() {
+        return catalog;
+    }
+
+    @Override
+    public int getHoldability() {
+        return holdability;
+    }
+
+    @Override
+    public Boolean isReadOnly() {
+        return isReadOnly;
+    }
+
+    @Override
+    public int getNetworkTimeout() {
+        return networkTimeout;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getSchema() {
+        return schema;
+    }
+
+    @Override
+    public int getTransactionIsolation() {
+        return isolationLevel;
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Map getTypeMap() {
+        return typeMap;
+    }
+
+    @Override
+    public String getUserName() {
+        return user;
+    }
+
+    @Override
+    public void setCatalog(String value) {
+        catalog = value;
+    }
+
+    @Override
+    public void setHoldability(int value) {
+        holdability = value;
+    }
+
+    @Override
+    public void setNetworkTimeout(int value) {
+        networkTimeout = value;
+    }
+
+    @Override
+    public void setPassword(String value) {
+        password = value;
+    }
+
+    @Override
+    public void setReadOnly(Boolean value) {
+        isReadOnly = value;
+    }
+
+    @Override
+    public void setSchema(String value) {
+        schema = value;
+    }
+
+    @Override
+    public void setTransactionIsolation(int value) {
+        isolationLevel = value;
+    }
+
+    @Override
+    public void setTypeMap(@SuppressWarnings("rawtypes") Map value) {
+        typeMap = value;
+    }
+
+    @Override
+    public void setUserName(String value) {
+        user = value;
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-applications/heritageApp/src/test/jdbc/heritage/app/JDBCHeritageTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-applications/heritageApp/src/test/jdbc/heritage/app/JDBCHeritageTestServlet.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -500,6 +501,25 @@ public class JDBCHeritageTestServlet extends FATServlet {
         // Must not reuse the same connection from the connection pool
         try (Connection con = defaultDataSource_unsharable_loosely_coupled.getConnection("user-of-testIsConnectionError", "password-of-user-of-testIsConnectionError")) {
             assertNotSame(connImpl, connImpl(con));
+        }
+    }
+
+    /**
+     * Verifies that the type of sharing indicated by the isShareable legacy operation
+     * is consistent with the resource reference.
+     */
+    @Test
+    public void testIsShareable() throws Exception {
+        Method isShareable;
+
+        try (Connection con = defaultDataSource.getConnection()) {
+            isShareable = con.getClass().getMethod("isShareable");
+
+            assertTrue((Boolean) isShareable.invoke(con));
+        }
+
+        try (Connection con = dsWithHelperDefaulted.getConnection()) {
+            assertFalse((Boolean) isShareable.invoke(con));
         }
     }
 

--- a/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-applications/heritageApp/src/test/jdbc/heritage/app/JDBCHeritageTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-applications/heritageApp/src/test/jdbc/heritage/app/JDBCHeritageTestServlet.java
@@ -47,7 +47,10 @@ import org.junit.Test;
 import com.ibm.websphere.ce.cm.DuplicateKeyException;
 import com.ibm.websphere.ce.cm.ObjectClosedException;
 import com.ibm.websphere.ce.cm.StaleConnectionException;
+import com.ibm.websphere.rsadapter.JDBCConnectionSpec;
+import com.ibm.websphere.rsadapter.WSDataSource;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.app.FATServlet;
 import test.jdbc.heritage.driver.HeritageDBConnection;
 import test.jdbc.heritage.driver.helper.HeritageDBDuplicateKeyException;
@@ -65,6 +68,12 @@ public class JDBCHeritageTestServlet extends FATServlet {
 
     @Resource(name = "java:comp/jdbc/env/unsharable-ds-xa-tightly-coupled", shareable = false)
     private DataSource defaultDataSource_unsharable_tightly_coupled;
+
+    @Resource(lookup = "jdbc/one-phase", shareable = true)
+    private DataSource dsOnePhaseSharable;
+
+    @Resource(lookup = "jdbc/one-phase", shareable = false)
+    private DataSource dsOnePhaseUnsharable;
 
     @Resource(lookup = "jdbc/helperDefaulted", shareable = false)
     private DataSource dsWithHelperDefaulted;
@@ -524,6 +533,20 @@ public class JDBCHeritageTestServlet extends FATServlet {
     }
 
     /**
+     * Verifies that the isXADataSource legacy operation returns the correct value
+     * based on the dataSource configuration.
+     */
+    @Test
+    public void testIsXADataSource() throws Exception {
+        assertTrue(((WSDataSource) defaultDataSource).isXADataSource());
+        assertTrue(((WSDataSource) defaultDataSource_unsharable_loosely_coupled).isXADataSource());
+        assertTrue(((WSDataSource) defaultDataSource_unsharable_tightly_coupled).isXADataSource());
+        assertFalse(((WSDataSource) dsOnePhaseSharable).isXADataSource());
+        assertFalse(((WSDataSource) dsOnePhaseUnsharable).isXADataSource());
+        assertFalse(((WSDataSource) dsWithHelperDefaulted).isXADataSource());
+    }
+
+    /**
      * Verifies that API classes can be loaded from the mock heritage API bundle fragment.
      */
     @Test
@@ -576,6 +599,59 @@ public class JDBCHeritageTestServlet extends FATServlet {
 
             // user-defined exception indicates stale:
             assertTrue(con.isClosed());
+        }
+    }
+
+    /**
+     * Verify that WSDataSource.getConnection(conspec) can be used to match and share a connection
+     * based on its isolation level.
+     */
+    @AllowedFFDC({
+                   "java.lang.IllegalStateException", // test attempts to enlist multiple one-phase resources to prove that sharing does not occur
+                   "java.sql.SQLException", // test attempts to enlist multiple one-phase resources to prove that sharing does not occur
+                   "javax.resource.ResourceException" // test attempts to enlist multiple one-phase resources to prove that sharing does not occur
+    })
+    @SuppressWarnings("restriction")
+    @Test
+    public void testMatchCurrentIsolationLevel() throws Exception {
+        tx.begin();
+        try (Connection con1 = dsOnePhaseSharable.getConnection()) {
+            // normal connection request defaults to isolationLevel from the dataSource,
+            assertEquals(Connection.TRANSACTION_READ_COMMITTED, con1.getTransactionIsolation());
+
+            con1.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
+            con1.createStatement().executeUpdate("INSERT INTO MYTABLE VALUES (13, 'testMatchCurrentIsolationLevel')");
+
+            // connection can be shared based on its current state,
+            WSDataSource wsds = (WSDataSource) dsOnePhaseSharable;
+            JDBCConnectionSpec req2 = new ConnectionRequest();
+            req2.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
+            Connection con2 = wsds.getConnection(req2);
+            assertEquals(Connection.TRANSACTION_SERIALIZABLE, con2.getTransactionIsolation());
+            int numUpdates = con2.createStatement().executeUpdate("UPDATE MYTABLE SET STRVAL='XIII' where ID=13");
+            assertEquals(1, numUpdates);
+
+            // connection cannot be shared based on a non-matching request
+            JDBCConnectionSpec req3 = new ConnectionRequest();
+            req3.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
+            Connection con3 = wsds.getConnection(req3);
+            try {
+                con3.createStatement().executeUpdate("INSERT INTO MYTABLE VALUES (14, 'testMatchCurrentIsolationLevel')");
+                fail("3rd connection request should not share and thus be unable to enlist in second transactional resource.");
+            } catch (SQLException x) {
+                boolean multiple1PCResources = false;
+                for (Throwable cause = x.getCause(); cause != null && !multiple1PCResources; cause = cause.getCause())
+                    multiple1PCResources |= cause instanceof IllegalStateException;
+                if (multiple1PCResources) // expected
+                    tx.setRollbackOnly();
+                else
+                    throw x;
+            }
+        } finally {
+            if (tx.getStatus() == Status.STATUS_ACTIVE)
+                tx.commit();
+            else
+                tx.rollback();
         }
     }
 

--- a/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-applications/heritageApp/src/test/jdbc/heritage/app/JDBCHeritageTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-applications/heritageApp/src/test/jdbc/heritage/app/JDBCHeritageTestServlet.java
@@ -20,6 +20,8 @@ import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -32,9 +34,14 @@ import java.sql.SQLException;
 import java.sql.SQLRecoverableException;
 import java.sql.SQLTransactionRollbackException;
 import java.sql.Statement;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.Executor;
 
 import javax.annotation.Resource;
+import javax.annotation.Resource.AuthenticationType;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -57,7 +64,7 @@ import test.jdbc.heritage.driver.helper.HeritageDBDuplicateKeyException;
 import test.jdbc.heritage.driver.helper.HeritageDBFeatureUnavailableException;
 import test.jdbc.heritage.driver.helper.HeritageDBStaleConnectionException;
 
-@SuppressWarnings("serial")
+@SuppressWarnings({ "serial", "restriction" })
 @WebServlet(urlPatterns = "/JDBCHeritageTestServlet")
 public class JDBCHeritageTestServlet extends FATServlet {
     @Resource
@@ -71,6 +78,9 @@ public class JDBCHeritageTestServlet extends FATServlet {
 
     @Resource(lookup = "jdbc/one-phase", shareable = true)
     private DataSource dsOnePhaseSharable;
+
+    @Resource(lookup = "jdbc/one-phase", shareable = true, authenticationType = AuthenticationType.APPLICATION)
+    private DataSource dsOnePhaseSharableWithAppAuth;
 
     @Resource(lookup = "jdbc/one-phase", shareable = false)
     private DataSource dsOnePhaseUnsharable;
@@ -98,6 +108,7 @@ public class JDBCHeritageTestServlet extends FATServlet {
                 // probably didn't exist
             }
             stmt.execute("CREATE TABLE MYTABLE (ID INT NOT NULL PRIMARY KEY, STRVAL VARCHAR(40))");
+            stmt.executeUpdate("INSERT INTO MYTABLE VALUES (0, 'zero')");
         } catch (SQLException x) {
             throw new ServletException(x);
         }
@@ -604,6 +615,96 @@ public class JDBCHeritageTestServlet extends FATServlet {
 
     /**
      * Verify that WSDataSource.getConnection(conspec) can be used to match and share a connection
+     * based on its catalog attribute.
+     */
+    @Test
+    public void testMatchCurrentCatalog() throws Exception {
+        WSDataSource wsds = (WSDataSource) dsOnePhaseSharable;
+
+        try (Connection con1 = wsds.getConnection()) {
+            con1.setAutoCommit(false);
+            con1.setCatalog("CATALOG-17");
+            con1.createStatement().executeUpdate("INSERT INTO MYTABLE VALUES (17, 'testMatchCurrentCatalog')");
+        }
+
+        // connection is not shared with a non-matching request
+        JDBCConnectionSpec req2 = new ConnectionRequest();
+        req2.setCatalog("CATALOG-18");
+        try (Connection con2 = wsds.getConnection(req2)) {
+            assertEquals("CATALOG-18", con2.getCatalog());
+            con2.setAutoCommit(false);
+            con2.createStatement().executeUpdate("INSERT INTO MYTABLE VALUES (18, 'testMatchCurrentCatalog')");
+            con2.rollback();
+        }
+
+        // connection can be shared based on its current state,
+        JDBCConnectionSpec req3 = new ConnectionRequest();
+        req3.setCatalog("CATALOG-17");
+        try (Connection con3 = wsds.getConnection(req3)) {
+            assertEquals("CATALOG-17", con3.getCatalog());
+            con3.commit();
+        }
+
+        // verify that only the first update was committed, whereas the second rolled back,
+        tx.begin();
+        try (Connection con4 = wsds.getConnection(new ConnectionRequest())) {
+            ResultSet result = con4.createStatement().executeQuery("SELECT ID FROM MYTABLE WHERE STRVAL='testMatchCurrentCatalog'");
+            assertTrue(result.next());
+            assertEquals(17, result.getInt(1));
+            assertFalse(result.next());
+        } finally {
+            tx.commit();
+        }
+    }
+
+    /**
+     * Verify that WSDataSource.getConnection(conspec) can be used to match and share a connection
+     * based on its cursor holdability attribute.
+     */
+    @Test
+    public void testMatchCurrentHoldability() throws Exception {
+        WSDataSource wsds = (WSDataSource) dsOnePhaseSharable;
+
+        try (Connection con1 = wsds.getConnection()) {
+            con1.setAutoCommit(false);
+            con1.setHoldability(ResultSet.CLOSE_CURSORS_AT_COMMIT);
+            con1.createStatement().executeUpdate("INSERT INTO MYTABLE VALUES (21, 'testMatchCurrentHoldability')");
+        }
+
+        // connection is not shared with a non-matching request
+        JDBCConnectionSpec req2 = new ConnectionRequest();
+        req2.setHoldability(ResultSet.HOLD_CURSORS_OVER_COMMIT);
+        try (Connection con2 = wsds.getConnection(req2)) {
+            assertEquals(ResultSet.HOLD_CURSORS_OVER_COMMIT, con2.getHoldability());
+            con2.setAutoCommit(false);
+            con2.createStatement().executeUpdate("INSERT INTO MYTABLE VALUES (22, 'testMatchCurrentHoldability')");
+            con2.rollback();
+        }
+
+        // connection can be shared based on its current state,
+        JDBCConnectionSpec req3 = new ConnectionRequest();
+        req3.setHoldability(ResultSet.CLOSE_CURSORS_AT_COMMIT);
+        try (Connection con3 = wsds.getConnection(req3)) {
+            assertEquals(ResultSet.CLOSE_CURSORS_AT_COMMIT, con3.getHoldability());
+            ResultSet result = con3.createStatement().executeQuery("SELECT STRVAL FROM MYTABLE WHERE ID=21");
+            con3.commit();
+            assertTrue(result.isClosed());
+        }
+
+        // verify that only the first update was committed, whereas the second rolled back,
+        tx.begin();
+        try (Connection con4 = wsds.getConnection(new ConnectionRequest())) {
+            ResultSet result = con4.createStatement().executeQuery("SELECT ID FROM MYTABLE WHERE STRVAL='testMatchCurrentHoldability'");
+            assertTrue(result.next());
+            assertEquals(21, result.getInt(1));
+            assertFalse(result.next());
+        } finally {
+            tx.commit();
+        }
+    }
+
+    /**
+     * Verify that WSDataSource.getConnection(conspec) can be used to match and share a connection
      * based on its isolation level.
      */
     @AllowedFFDC({
@@ -611,7 +712,6 @@ public class JDBCHeritageTestServlet extends FATServlet {
                    "java.sql.SQLException", // test attempts to enlist multiple one-phase resources to prove that sharing does not occur
                    "javax.resource.ResourceException" // test attempts to enlist multiple one-phase resources to prove that sharing does not occur
     })
-    @SuppressWarnings("restriction")
     @Test
     public void testMatchCurrentIsolationLevel() throws Exception {
         tx.begin();
@@ -652,6 +752,233 @@ public class JDBCHeritageTestServlet extends FATServlet {
                 tx.commit();
             else
                 tx.rollback();
+        }
+    }
+
+    /**
+     * Verify that WSDataSource.getConnection(conspec) can be used to match and share a connection
+     * based on its network timeout.
+     */
+    @AllowedFFDC({
+                   "java.lang.IllegalStateException", // test attempts to enlist multiple one-phase resources to prove that sharing does not occur
+                   "java.sql.SQLException", // test attempts to enlist multiple one-phase resources to prove that sharing does not occur
+                   "javax.resource.ResourceException" // test attempts to enlist multiple one-phase resources to prove that sharing does not occur
+    })
+    @Test
+    public void testMatchCurrentNetworkTimeout() throws Exception {
+        tx.begin();
+        try (Connection con1 = dsOnePhaseSharable.getConnection()) {
+            int originalNetworkTimeout = con1.getNetworkTimeout();
+            int newNetworkTimeout = originalNetworkTimeout + 30000;
+            Executor sameThreadExecutor = r -> r.run();
+
+            con1.setNetworkTimeout(sameThreadExecutor, newNetworkTimeout);
+            con1.createStatement().executeUpdate("INSERT INTO MYTABLE VALUES (15, 'testMatchCurrentNetworkTimeout')");
+
+            // connection can be shared based on its current state,
+            WSDataSource wsds = (WSDataSource) dsOnePhaseSharable;
+            JDBCConnectionSpec req2 = new ConnectionRequest();
+            req2.setNetworkTimeout(newNetworkTimeout);
+            Connection con2 = wsds.getConnection(req2);
+            assertEquals(newNetworkTimeout, con2.getNetworkTimeout());
+            int numUpdates = con2.createStatement().executeUpdate("UPDATE MYTABLE SET STRVAL='XV' where ID=15");
+            assertEquals(1, numUpdates);
+
+            // connection cannot be shared based on a non-matching request
+            JDBCConnectionSpec req3 = new ConnectionRequest();
+            req3.setNetworkTimeout(originalNetworkTimeout + 40000);
+            try (Connection con3 = wsds.getConnection(req3)) {
+                con3.createStatement().executeUpdate("INSERT INTO MYTABLE VALUES (16, 'testMatchCurrentNetworkTimeout')");
+                fail("3rd connection request should not share and thus be unable to enlist in second transactional resource.");
+            } catch (SQLException x) {
+                boolean multiple1PCResources = false;
+                for (Throwable cause = x.getCause(); cause != null && !multiple1PCResources; cause = cause.getCause())
+                    multiple1PCResources |= cause instanceof IllegalStateException;
+                if (multiple1PCResources) // expected
+                    tx.setRollbackOnly();
+                else
+                    throw x;
+            }
+        } finally {
+            if (tx.getStatus() == Status.STATUS_ACTIVE)
+                tx.commit();
+            else
+                tx.rollback();
+        }
+    }
+
+    /**
+     * Verify that WSDataSource.getConnection(conspec) can be used to match and share a connection
+     * based on its read only attribute.
+     */
+    @Test
+    public void testMatchCurrentReadOnly() throws Exception {
+        tx.begin();
+        try (Connection con1 = dsOnePhaseSharable.getConnection()) {
+
+            assertFalse(con1.isReadOnly());
+            con1.setReadOnly(true);
+
+            // connection can be shared based on its current state,
+            WSDataSource wsds = (WSDataSource) dsOnePhaseSharable;
+            JDBCConnectionSpec req2 = new ConnectionRequest();
+            req2.setReadOnly(true);
+            Connection con2 = wsds.getConnection(req2);
+            assertTrue(con2.isReadOnly());
+            ResultSet result = con2.createStatement().executeQuery("SELECT STRVAL FROM MYTABLE WHERE ID=0");
+            assertTrue(result.next());
+            assertEquals("zero", result.getString(1));
+        } finally {
+            tx.commit();
+        }
+    }
+
+    /**
+     * Verify that WSDataSource.getConnection(conspec) can be used to match and share a connection
+     * based on its schema attribute.
+     */
+    @Test
+    public void testMatchCurrentSchema() throws Exception {
+        WSDataSource wsds = (WSDataSource) dsOnePhaseSharable;
+
+        try (Connection con1 = wsds.getConnection()) {
+            con1.setAutoCommit(false);
+            con1.setSchema("APP");
+            con1.createStatement().executeUpdate("INSERT INTO DBUSER.MYTABLE VALUES (23, 'testMatchCurrentSchema')");
+        }
+
+        // connection is not shared with a non-matching request
+        JDBCConnectionSpec req2 = new ConnectionRequest();
+        req2.setSchema("DBUSER");
+        try (Connection con2 = wsds.getConnection(req2)) {
+            assertEquals("DBUSER", con2.getSchema());
+            con2.setAutoCommit(false);
+            con2.createStatement().executeUpdate("INSERT INTO DBUSER.MYTABLE VALUES (24, 'testMatchCurrentSchema')");
+            con2.rollback();
+        }
+
+        // connection can be shared based on its current state,
+        JDBCConnectionSpec req3 = new ConnectionRequest();
+        req3.setSchema("APP");
+        try (Connection con3 = wsds.getConnection(req3)) {
+            assertEquals("APP", con3.getSchema());
+            con3.commit();
+        }
+
+        // verify that only the first update was committed, whereas the second rolled back,
+        tx.begin();
+        try (Connection con4 = wsds.getConnection(new ConnectionRequest())) {
+            ResultSet result = con4.createStatement().executeQuery("SELECT ID FROM DBUSER.MYTABLE WHERE STRVAL='testMatchCurrentSchema'");
+            assertTrue(result.next());
+            assertEquals(23, result.getInt(1));
+            assertFalse(result.next());
+        } finally {
+            tx.commit();
+        }
+    }
+
+    /**
+     * Verify that WSDataSource.getConnection(conspec) can be used to match and share a connection
+     * based on its typeMap attribute.
+     */
+    @Test
+    public void testMatchCurrentTypeMap() throws Exception {
+        WSDataSource wsds = (WSDataSource) dsOnePhaseSharable;
+
+        Map<String, Class<?>> typeMap = new LinkedHashMap<String, Class<?>>();
+        typeMap.put("BIGINT", BigInteger.class);
+        typeMap.put("BIGD", BigDecimal.class);
+
+        Map<String, Class<?>> matchingTypeMap = new TreeMap<String, Class<?>>();
+        matchingTypeMap.put("BIGD", BigDecimal.class);
+        matchingTypeMap.put("BIGINT", BigInteger.class);
+
+        Map<String, Class<?>> nonMatchingTypeMap = new LinkedHashMap<String, Class<?>>();
+        nonMatchingTypeMap.put("BIGINT", BigInteger.class);
+        nonMatchingTypeMap.put("BIGD", Number.class);
+
+        try (Connection con1 = wsds.getConnection()) {
+            con1.setAutoCommit(false);
+            con1.setTypeMap(typeMap);
+            con1.createStatement().executeUpdate("INSERT INTO MYTABLE VALUES (19, 'testMatchCurrentTypeMap')");
+        }
+
+        // connection is not shared with a non-matching request
+        JDBCConnectionSpec req2 = new ConnectionRequest();
+        req2.setTypeMap(nonMatchingTypeMap);
+        try (Connection con2 = wsds.getConnection(req2)) {
+            assertEquals(nonMatchingTypeMap, con2.getTypeMap());
+            con2.setAutoCommit(false);
+            con2.createStatement().executeUpdate("INSERT INTO MYTABLE VALUES (20, 'testMatchCurrentTypeMap')");
+            con2.rollback();
+        }
+
+        // connection can be shared based on its current state,
+        JDBCConnectionSpec req3 = new ConnectionRequest();
+        req3.setTypeMap(matchingTypeMap);
+        try (Connection con3 = wsds.getConnection(req3)) {
+            assertEquals(matchingTypeMap, con3.getTypeMap());
+            con3.commit();
+        }
+
+        // verify that only the first update was committed, whereas the second rolled back,
+        tx.begin();
+        try (Connection con4 = wsds.getConnection(new ConnectionRequest())) {
+            ResultSet result = con4.createStatement().executeQuery("SELECT ID FROM MYTABLE WHERE STRVAL='testMatchCurrentTypeMap'");
+            assertTrue(result.next());
+            assertEquals(19, result.getInt(1));
+            assertFalse(result.next());
+        } finally {
+            tx.commit();
+        }
+    }
+
+    /**
+     * Verify that WSDataSource.getConnection(conspec) can be used to match and share a connection
+     * based on its user name attribute.
+     */
+    @Test
+    public void testMatchCurrentUser() throws Exception {
+        WSDataSource wsds = (WSDataSource) dsOnePhaseSharableWithAppAuth;
+
+        JDBCConnectionSpec req1 = new ConnectionRequest();
+        req1.setUserName("dbuser");
+        req1.setPassword("dbpwd");
+        try (Connection con1 = wsds.getConnection(req1)) {
+            con1.setAutoCommit(false);
+            assertEquals("dbuser", con1.getMetaData().getUserName().toLowerCase());
+            con1.createStatement().executeUpdate("INSERT INTO DBUSER.MYTABLE VALUES (25, 'testMatchCurrentUser')");
+        }
+
+        // connection is not shared with a non-matching request
+        JDBCConnectionSpec req2 = new ConnectionRequest();
+        req2.setUserName("otheruser");
+        req2.setPassword("dbpwd");
+        try (Connection con2 = wsds.getConnection(req2)) {
+            assertEquals("otheruser", con2.getMetaData().getUserName().toLowerCase());
+            con2.setAutoCommit(false);
+            con2.createStatement().executeUpdate("INSERT INTO DBUSER.MYTABLE VALUES (26, 'testMatchCurrentUser')");
+            con2.rollback();
+        }
+
+        // connection can be shared based on its current state,
+        JDBCConnectionSpec req3 = new ConnectionRequest();
+        req3.setUserName("dbuser");
+        req3.setPassword("dbpwd");
+        try (Connection con3 = wsds.getConnection(req3)) {
+            assertEquals("dbuser", con3.getMetaData().getUserName().toLowerCase());
+            con3.commit();
+        }
+
+        // verify that only the first update was committed, whereas the second rolled back,
+        tx.begin();
+        try (Connection con4 = wsds.getConnection(req2)) {
+            ResultSet result = con4.createStatement().executeQuery("SELECT ID FROM DBUSER.MYTABLE WHERE STRVAL='testMatchCurrentUser'");
+            assertTrue(result.next());
+            assertEquals(25, result.getInt(1));
+            assertFalse(result.next());
+        } finally {
+            tx.commit();
         }
     }
 

--- a/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HDDataSource.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HDDataSource.java
@@ -14,10 +14,8 @@ import java.sql.Connection;
 import java.sql.SQLException;
 
 import javax.sql.DataSource;
-import javax.sql.XAConnection;
-import javax.sql.XADataSource;
 
-public class HDDataSource extends org.apache.derby.jdbc.EmbeddedDataSource implements XADataSource, DataSource {
+public class HDDataSource extends org.apache.derby.jdbc.EmbeddedDataSource implements DataSource {
     private static final long serialVersionUID = 1L;
 
     String driverType;
@@ -36,16 +34,6 @@ public class HDDataSource extends org.apache.derby.jdbc.EmbeddedDataSource imple
 
     @Override
     public Connection getConnection(String username, String password) throws SQLException {
-        return new HDConnection(this, super.getConnection(username, password));
-    }
-
-    @Override
-    public XAConnection getXAConnection() throws SQLException {
-        return new HDConnection(this, super.getConnection());
-    }
-
-    @Override
-    public XAConnection getXAConnection(String username, String password) throws SQLException {
         return new HDConnection(this, super.getConnection(username, password));
     }
 

--- a/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HDXADataSource.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-applications/heritageDriver/src/test/jdbc/heritage/driver/HDXADataSource.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jdbc.heritage.driver;
+
+import java.sql.SQLException;
+
+import javax.sql.XAConnection;
+import javax.sql.XADataSource;
+
+public class HDXADataSource extends HDDataSource implements XADataSource {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public XAConnection getXAConnection() throws SQLException {
+        return new HDConnection(this, super.getConnection());
+    }
+
+    @Override
+    public XAConnection getXAConnection(String username, String password) throws SQLException {
+        return new HDConnection(this, super.getConnection(username, password));
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-applications/heritageDriver/src/test/jdbc/heritage/driver/helper/HDDataStoreHelper.java
+++ b/dev/com.ibm.ws.jdbc_fat_heritageinterop/test-applications/heritageDriver/src/test/jdbc/heritage/driver/helper/HDDataStoreHelper.java
@@ -41,6 +41,7 @@ import com.ibm.websphere.ce.cm.StaleStatementException;
 
 import test.jdbc.heritage.driver.HDConnection;
 import test.jdbc.heritage.driver.HDDataSource;
+import test.jdbc.heritage.driver.HDXADataSource;
 import test.jdbc.heritage.driver.HeritageDBConnection;
 import test.jdbc.heritage.driver.HeritageDBDoesNotImplementItException;
 
@@ -79,7 +80,8 @@ public class HDDataStoreHelper {
             throw new UnsupportedOperationException("This DataStoreHelper only works with fake JDBC drivers, not " + driverType);
 
         String dataSourceClassName = props.getProperty("dataSourceClass");
-        if (!HDDataSource.class.getName().equals(dataSourceClassName))
+        if (!HDDataSource.class.getName().equals(dataSourceClassName)
+            && !HDXADataSource.class.getName().equals(dataSourceClassName))
             throw new UnsupportedOperationException("This DataStoreHelper is incapable of supporting data source class " + dataSourceClassName);
 
         int longDataCacheSize = Integer.parseInt(props.getProperty("longDataCacheSize"));


### PR DESCRIPTION
Tests of connectionSharing=MatchCurrentState on the various connection attributes that can be requested via the legacy WSConnectionSpec.