### PR TITLE
Issue #15979: JPA defaultProperties metatype

### DIFF
--- a/dev/com.ibm.ws.jpa.container.core/resources/com/ibm/ws/jpa/jpa.nlsprops
+++ b/dev/com.ibm.ws.jpa.container.core/resources/com/ibm/ws/jpa/jpa.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2006, 2019 IBM Corporation and others.
+# Copyright (c) 2006, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -305,6 +305,12 @@ NOT_COMPLIANT_WITH_JPA21_CWWJP0054E.useraction=Obtain a newer version of the JPA
 ERROR_TRANSFORMING_CLASS_CWWJP0055E=CWWJP0055E: An error occurred while attempting to transform the {0} Java Class.  The following failure detail was gathered: {1}
 ERROR_TRANSFORMING_CLASS_CWWJP0055E.explanation=An unexpected error occurred while transforming the Java class. This error is usually caused by invalid Java bytecode.
 ERROR_TRANSFORMING_CLASS_CWWJP0055E.useraction=The class cache might be corrupted or the application might be packaged incorrectly. First, clear the class cache. If that action does not resolve the problem, then review the application archive for packaging mistakes.
+
+#-------------------------------------------------------------------------------
+# 0=property name, 1=property value
+EMPTY_PROP_NAME_VALUE_CWWJP0056W=CWWJP0056W: A JPA default property configured in the server.xml file contains an empty name or empty value: name = [{0}], value = [{1}]. The property will be ignored.
+EMPTY_PROP_NAME_VALUE_CWWJP0056W.explanation=The name and value attributes for a JPA default property must not be empty.
+EMPTY_PROP_NAME_VALUE_CWWJP0056W.useraction=Change the server configuration to provide a non-empty name and value for the property or remove the property.
 
 #-------------------------------------------------------------------------------
 # Error messages from the JPA Provider below this point

--- a/dev/com.ibm.ws.jpa.container/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.jpa.container/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011 IBM Corporation and others.
+# Copyright (c) 2011, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -32,3 +32,15 @@ excluded.application.desc=An application to be excluded from JPA processing.
 
 ignore.data.source.errors=Ignore data source errors
 ignore.data.source.errors.desc=If true, errors that occur while attempting to lookup a data source that is specified by the jta-data-source or non-jta-data-source elements in the persistence.xml file are reported and ignored, which allows the persistence provider to determine a default data source. If false, the errors are propagated to the persistence provider so that the errors can be diagnosed more easily, but misconfigured applications might not work. By default, this property is true if JPA 2.0 is enabled and false otherwise.
+
+default.properties=Default Persistence Properties
+default.properties.desc=Default integration-level persistence properties for use by the persistence provider when a container managed entity manager factory is created. Specified default persistence properties are included when the PersistenceProvider.createContainerEntityManagerFactory method is called. 
+
+default.properties.property=Name/value Pair Describing A Persistence Property
+default.properties.property.desc=Provides a specific persistence property for creation of all container managed entity manager factories.
+
+default.properties.property.name=Persistence property name
+default.properties.property.name.desc=Provides the name of the integration-level persistence property.
+
+default.properties.property.value=Persistence property value
+default.properties.property.value.desc=Provides the value of the integration-level persistence property.

--- a/dev/com.ibm.ws.jpa.container/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.jpa.container/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011 IBM Corporation and others.
+    Copyright (c) 2011, 2021 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@
  -->
 <metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.1.0"
                    xmlns:ibm="http://www.ibm.com/xmlns/appservers/osgi/metatype/v1.0.0"
+                   xmlns:ibmui="http://www.ibm.com/xmlns/appservers/osgi/metatype/ui/v1.0.0"
                    localization="OSGI-INF/l10n/metatype">
 
   <OCD description="%com.ibm.ws.jpa.container.desc"
@@ -60,10 +61,39 @@
         required="false"
         type="Boolean" />
 
+    <AD name="%default.properties"
+        description="%default.properties.desc"
+        id="defaultProperties"
+        required="false"
+        type="String"
+        ibm:type="pid"
+        ibm:reference="com.ibm.ws.jpacomponent.defaultProperties"
+        ibmui:group="Advanced"
+        ibm:beta="true"
+        ibm:flat="true" />
+
   </OCD>
 
   <Designate pid="com.ibm.ws.jpacomponent">
     <Object ocdref="com.ibm.ws.jpacomponent" />
   </Designate>
+
+  <!-- Default integration-level properties -->
+  <Designate factoryPid="com.ibm.ws.jpacomponent.defaultProperties">
+    <Object ocdref="com.ibm.ws.jpacomponent.defaultProperties" />
+  </Designate>
+
+  <OCD id="com.ibm.ws.jpacomponent.defaultProperties" name="%default.properties" description="%default.properties.desc" ibm:beta="true" >
+    <AD id="property" name="%default.properties.property" ibm:type="pid" ibm:flat="true" ibm:reference="com.ibm.ws.jpacomponent.defaultProperties.property" required="false" type="String" cardinality="2147483647" default="" description="%default.properties.property.desc" ibm:beta="true"/>
+  </OCD>
+
+  <Designate factoryPid="com.ibm.ws.jpacomponent.defaultProperties.property">
+    <Object ocdref="com.ibm.ws.jpacomponent.defaultProperties.property"/>
+  </Designate>
+ 
+  <OCD id="com.ibm.ws.jpacomponent.defaultProperties.property" name="%default.properties.property" description="%default.properties.property.desc" ibm:beta="true" >
+    <AD id="name" required="false" type="String" default="" name="%default.properties.property.name" description="%default.properties.property.name.desc" ibm:beta="true"/>
+    <AD id="value" required="false" type="String" default="" name="%default.properties.property.value" description="%default.properties.property.value.desc" ibm:beta="true"/>
+  </OCD>
 
 </metatype:MetaData>

--- a/dev/com.ibm.ws.jpa.container/src/com/ibm/ws/jpa/container/osgi/internal/JPAComponentImpl.java
+++ b/dev/com.ibm.ws.jpa.container/src/com/ibm/ws/jpa/container/osgi/internal/JPAComponentImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 IBM Corporation and others.
+ * Copyright (c) 2011, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ import static com.ibm.ws.jpa.management.JPAConstants.PERSISTENCE_XML_RESOURCE_NA
 
 import java.io.File;
 import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.AccessController;
@@ -48,6 +49,7 @@ import com.ibm.websphere.csi.J2EEName;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TrConfigurator;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.Transaction.UOWCurrent;
 import com.ibm.ws.container.service.app.deploy.ApplicationClassesContainerInfo;
 import com.ibm.ws.container.service.app.deploy.ApplicationInfo;
@@ -111,8 +113,13 @@ public class JPAComponentImpl extends AbstractJPAComponent implements Applicatio
     private static final String REFERENCE_APP_COORD = "appCoord";
     private static final String REFERENCE_CLASSLOADING_SERVICE = "classLoadingService";
 
+    private static final String DEFAULT_PROPS_PREFIX = "defaultProperties.0.property.";
+    private static final String DEFAULT_PROPS_NAME = ".name";
+    private static final String DEFAULT_PROPS_VALUE = ".value";
+
     private ComponentContext context;
     private Dictionary<String, Object> props;
+    private Map<String, String> defaultProps;
     private boolean server = false;
     private static final Set<String> stuckApps = new ConcurrentSkipListSet<String>();
 
@@ -127,6 +134,7 @@ public class JPAComponentImpl extends AbstractJPAComponent implements Applicatio
     @Activate
     protected void activate(ComponentContext cc) {
         props = cc.getProperties();
+        setDefaultProperties(props);
         jpaRuntime.activate(cc);
         ivTransactionManagerSR.activate(cc);
         ivContextAccessorSR.activate(cc);
@@ -135,6 +143,7 @@ public class JPAComponentImpl extends AbstractJPAComponent implements Applicatio
         propProviderSRs.activate(cc);
         context = cc;
         initialize();
+        dump();
     }
 
     @Deactivate
@@ -188,6 +197,27 @@ public class JPAComponentImpl extends AbstractJPAComponent implements Applicatio
         if (recycleJPAApplications) {
             recycleJPAApplications();
         }
+    }
+
+    private void setDefaultProperties(Dictionary<String, Object> properties) {
+        // Look for default integration-level properties
+        Map<String, String> dProperties = new HashMap<String, String>();
+        int defaultPropertiesIndex = 0;
+        while (defaultPropertiesIndex >= 0) {
+            String name = (String) properties.get(DEFAULT_PROPS_PREFIX + defaultPropertiesIndex + DEFAULT_PROPS_NAME);
+            if (name != null) {
+                String value = (String) properties.get(DEFAULT_PROPS_PREFIX + defaultPropertiesIndex + DEFAULT_PROPS_VALUE);
+                if (name.length() > 0 && value != null && value.length() > 0) {
+                    dProperties.put(name, value);
+                } else {
+                    Tr.warning(tc, "EMPTY_PROP_NAME_VALUE_CWWJP0056W", name, value);
+                }
+                defaultPropertiesIndex++;
+            } else {
+                defaultPropertiesIndex = -1;
+            }
+        }
+        defaultProps = dProperties;
     }
 
     private javax.naming.Reference createReference(boolean ejbInWar, JPAJndiLookupInfo info) {
@@ -799,9 +829,9 @@ public class JPAComponentImpl extends AbstractJPAComponent implements Applicatio
     @Override
     public void destroyThreadContextClassLoader(final ClassLoader tcclassloader) {
         final ClassLoadingService cls = classLoadingService;
-        AccessController.doPrivileged(new PrivilegedAction() {
+        AccessController.doPrivileged(new PrivilegedAction<Void>() {
             @Override
-            public Object run() {
+            public Void run() {
                 cls.destroyThreadContextClassLoader(tcclassloader);
                 return null;
             }
@@ -926,6 +956,26 @@ public class JPAComponentImpl extends AbstractJPAComponent implements Applicatio
         appCoord.recycleApplications(appsToRestart);
     }
 
+    /**
+     * Format a representation of the JPA component state to the trace stream.
+     */
+    @Trivial
+    public void dump() {
+        if (!TraceComponent.isAnyTracingEnabled() || !(tc.isDumpEnabled() || tc.isDebugEnabled())) {
+            return;
+        }
+        try {
+            StringWriter stringWriter = new StringWriter();
+            PrintWriter printWriter = new PrintWriter(stringWriter);
+            printWriter.println();
+            introspect(printWriter);
+            stringWriter.flush();
+            Tr.dump(tc, "-- JPA Component Dump --", stringWriter);
+        } catch (Exception ex) {
+            Tr.debug(tc, "Exception occurred dumping JPA component state : " + ex);
+        }
+    }
+
     /*
      * com.ibm.wsspi.logging.Introspector implementation
      *
@@ -969,6 +1019,14 @@ public class JPAComponentImpl extends AbstractJPAComponent implements Applicatio
                 out.println("  " + key + " = " + o);
             }
 
+        }
+        out.println();
+
+        out.println("Default Properties:");
+        if (defaultProps != null) {
+            for (Map.Entry<String, String> entry : defaultProps.entrySet()) {
+                out.println("  " + entry.getKey() + " = " + entry.getValue());
+            }
         }
         out.println();
 


### PR DESCRIPTION
Prototype of the new "defaultProperties" attribute in the "jpa" container metatype
so that integration-level properties may be specified in server.xml:

    <jpa>
        <defaultProperties>
            <property name="javax.persistence.lock.timeout" value="10000"/>
            <property name="eclipselink.target-database-properties" value="shouldBindLiterals=true"/>
        </defaultProperties>
    </jpa>

for #15979