### PR TITLE
Fix JPA relationship test breaks introduced by 17420

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXmany/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXmany/tests/AbstractFATSuite.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.tests.spec10.relationships.manyXmany.tests;
+
+import org.junit.ClassRule;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+
+import componenttest.containers.ExternalTestServiceDockerClientStrategy;
+import componenttest.topology.database.container.DatabaseContainerFactory;
+
+/**
+ *
+ */
+public class AbstractFATSuite {
+    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+
+    //Required to ensure we calculate the correct strategy each run even when
+    //switching between local and remote docker hosts.
+    static {
+        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
+    }
+
+    @ClassRule
+    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+}

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXmany/tests/Relationships_ManyXMany_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXmany/tests/Relationships_ManyXMany_EJB.java
@@ -39,7 +39,6 @@ import com.ibm.ws.jpa.fvt.relationships.manyXmany.testlogic.tests.ejb.TestManyXM
 import com.ibm.ws.jpa.fvt.relationships.manyXmany.testlogic.tests.ejb.TestManyXManyUnidirectional_EJB_SFEX_Servlet;
 import com.ibm.ws.jpa.fvt.relationships.manyXmany.testlogic.tests.ejb.TestManyXManyUnidirectional_EJB_SF_Servlet;
 import com.ibm.ws.jpa.fvt.relationships.manyXmany.testlogic.tests.ejb.TestManyXManyUnidirectional_EJB_SL_Servlet;
-import com.ibm.ws.jpa.tests.spec10.relationships.manyXmany.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -88,11 +87,11 @@ public class Relationships_ManyXMany_EJB extends JPAFATServletClient {
     })
     public static LibertyServer server;
 
-    public static final JdbcDatabaseContainer<?> testContainer = FATSuite.testContainer;
+    public static final JdbcDatabaseContainer<?> testContainer = AbstractFATSuite.testContainer;
 
     @BeforeClass
     public static void setUp() throws Exception {
-        PrivHelper.generateCustomPolicy(server, FATSuite.JAXB_PERMS);
+        PrivHelper.generateCustomPolicy(server, AbstractFATSuite.JAXB_PERMS);
         bannerStart(Relationships_ManyXMany_EJB.class);
         timestart = System.currentTimeMillis();
 

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXmany/tests/Relationships_ManyXMany_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXmany/tests/Relationships_ManyXMany_Web.java
@@ -31,7 +31,6 @@ import com.ibm.ws.jpa.fvt.relationships.manyXmany.testlogic.tests.web.TestManyXM
 import com.ibm.ws.jpa.fvt.relationships.manyXmany.testlogic.tests.web.TestManyXManyCollectionTypeServlet;
 import com.ibm.ws.jpa.fvt.relationships.manyXmany.testlogic.tests.web.TestManyXManyCompoundPKServlet;
 import com.ibm.ws.jpa.fvt.relationships.manyXmany.testlogic.tests.web.TestManyXManyUnidirectionalServlet;
-import com.ibm.ws.jpa.tests.spec10.relationships.manyXmany.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -72,11 +71,11 @@ public class Relationships_ManyXMany_Web extends JPAFATServletClient {
     })
     public static LibertyServer server;
 
-    public static final JdbcDatabaseContainer<?> testContainer = FATSuite.testContainer;
+    public static final JdbcDatabaseContainer<?> testContainer = AbstractFATSuite.testContainer;
 
     @BeforeClass
     public static void setUp() throws Exception {
-        PrivHelper.generateCustomPolicy(server, FATSuite.JAXB_PERMS);
+        PrivHelper.generateCustomPolicy(server, AbstractFATSuite.JAXB_PERMS);
         bannerStart(Relationships_ManyXMany_Web.class);
         timestart = System.currentTimeMillis();
 

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXmany/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXmany/FATSuite.java
@@ -15,14 +15,12 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
+import com.ibm.ws.jpa.tests.spec10.relationships.manyXmany.tests.AbstractFATSuite;
 import com.ibm.ws.jpa.tests.spec10.relationships.manyXmany.tests.Relationships_ManyXMany_EJB;
 import com.ibm.ws.jpa.tests.spec10.relationships.manyXmany.tests.Relationships_ManyXMany_Web;
 
-import componenttest.containers.ExternalTestServiceDockerClientStrategy;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.database.container.DatabaseContainerFactory;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -30,20 +28,7 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 Relationships_ManyXMany_EJB.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
-public class FATSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
-                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
-
-    //Required to ensure we calculate the correct strategy each run even when
-    //switching between local and remote docker hosts.
-    static {
-        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
-    }
-
-    @ClassRule
-    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
-
+public class FATSuite extends AbstractFATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests.with(new RepeatWithJPA20());
 

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXmany/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXmany/FATSuite.java
@@ -15,15 +15,13 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
+import com.ibm.ws.jpa.tests.spec10.relationships.manyXmany.tests.AbstractFATSuite;
 import com.ibm.ws.jpa.tests.spec10.relationships.manyXmany.tests.Relationships_ManyXMany_EJB;
 import com.ibm.ws.jpa.tests.spec10.relationships.manyXmany.tests.Relationships_ManyXMany_Web;
 
-import componenttest.containers.ExternalTestServiceDockerClientStrategy;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.database.container.DatabaseContainerFactory;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -31,19 +29,7 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 Relationships_ManyXMany_EJB.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
-public class FATSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
-                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
-
-    //Required to ensure we calculate the correct strategy each run even when
-    //switching between local and remote docker hosts.
-    static {
-        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
-    }
-
-    @ClassRule
-    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+public class FATSuite extends AbstractFATSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES());

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXmany/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXmany/FATSuite.java
@@ -15,15 +15,13 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
+import com.ibm.ws.jpa.tests.spec10.relationships.manyXmany.tests.AbstractFATSuite;
 import com.ibm.ws.jpa.tests.spec10.relationships.manyXmany.tests.Relationships_ManyXMany_EJB;
 import com.ibm.ws.jpa.tests.spec10.relationships.manyXmany.tests.Relationships_ManyXMany_Web;
 
-import componenttest.containers.ExternalTestServiceDockerClientStrategy;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.database.container.DatabaseContainerFactory;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -31,19 +29,7 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 Relationships_ManyXMany_EJB.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
-public class FATSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
-                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
-
-    //Required to ensure we calculate the correct strategy each run even when
-    //switching between local and remote docker hosts.
-    static {
-        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
-    }
-
-    @ClassRule
-    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+public class FATSuite extends AbstractFATSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE8_FEATURES());

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXmany/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXmany/FATSuite.java
@@ -15,15 +15,13 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
+import com.ibm.ws.jpa.tests.spec10.relationships.manyXmany.tests.AbstractFATSuite;
 import com.ibm.ws.jpa.tests.spec10.relationships.manyXmany.tests.Relationships_ManyXMany_EJB;
 import com.ibm.ws.jpa.tests.spec10.relationships.manyXmany.tests.Relationships_ManyXMany_Web;
 
-import componenttest.containers.ExternalTestServiceDockerClientStrategy;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.database.container.DatabaseContainerFactory;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -31,20 +29,7 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 Relationships_ManyXMany_EJB.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
-public class FATSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
-                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
-
-    //Required to ensure we calculate the correct strategy each run even when
-    //switching between local and remote docker hosts.
-    static {
-        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
-    }
-
-    @ClassRule
-    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
-
+public class FATSuite extends AbstractFATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE9_FEATURES());
 

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXone/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXone/tests/AbstractFATSuite.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.tests.spec10.relationships.manyXone.tests;
+
+import org.junit.ClassRule;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+
+import componenttest.containers.ExternalTestServiceDockerClientStrategy;
+import componenttest.topology.database.container.DatabaseContainerFactory;
+
+/**
+ *
+ */
+public class AbstractFATSuite {
+    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+
+    //Required to ensure we calculate the correct strategy each run even when
+    //switching between local and remote docker hosts.
+    static {
+        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
+    }
+
+    @ClassRule
+    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+}

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXone/tests/Relationships_ManyXOne_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXone/tests/Relationships_ManyXOne_EJB.java
@@ -36,7 +36,6 @@ import com.ibm.ws.jpa.fvt.relationships.manyXone.tests.ejb.TestManyXOneCompoundP
 import com.ibm.ws.jpa.fvt.relationships.manyXone.tests.ejb.TestManyXOneUnidirectional_EJB_SFEX_Servlet;
 import com.ibm.ws.jpa.fvt.relationships.manyXone.tests.ejb.TestManyXOneUnidirectional_EJB_SF_Servlet;
 import com.ibm.ws.jpa.fvt.relationships.manyXone.tests.ejb.TestManyXOneUnidirectional_EJB_SL_Servlet;
-import com.ibm.ws.jpa.tests.spec10.relationships.manyXone.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -82,11 +81,11 @@ public class Relationships_ManyXOne_EJB extends JPAFATServletClient {
     })
     public static LibertyServer server;
 
-    public static final JdbcDatabaseContainer<?> testContainer = FATSuite.testContainer;
+    public static final JdbcDatabaseContainer<?> testContainer = AbstractFATSuite.testContainer;
 
     @BeforeClass
     public static void setUp() throws Exception {
-        PrivHelper.generateCustomPolicy(server, FATSuite.JAXB_PERMS);
+        PrivHelper.generateCustomPolicy(server, AbstractFATSuite.JAXB_PERMS);
         bannerStart(Relationships_ManyXOne_EJB.class);
         timestart = System.currentTimeMillis();
 

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXone/tests/Relationships_ManyXOne_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXone/tests/Relationships_ManyXOne_Web.java
@@ -30,7 +30,6 @@ import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.ws.jpa.fvt.relationships.manyXone.tests.web.TestManyXOneBidirectionalServlet;
 import com.ibm.ws.jpa.fvt.relationships.manyXone.tests.web.TestManyXOneCompoundPKServlet;
 import com.ibm.ws.jpa.fvt.relationships.manyXone.tests.web.TestManyXOneUnidirectionalServlet;
-import com.ibm.ws.jpa.tests.spec10.relationships.manyXone.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -70,11 +69,11 @@ public class Relationships_ManyXOne_Web extends JPAFATServletClient {
     })
     public static LibertyServer server;
 
-    public static final JdbcDatabaseContainer<?> testContainer = FATSuite.testContainer;
+    public static final JdbcDatabaseContainer<?> testContainer = AbstractFATSuite.testContainer;
 
     @BeforeClass
     public static void setUp() throws Exception {
-        PrivHelper.generateCustomPolicy(server, FATSuite.JAXB_PERMS);
+        PrivHelper.generateCustomPolicy(server, AbstractFATSuite.JAXB_PERMS);
         bannerStart(Relationships_ManyXOne_Web.class);
         timestart = System.currentTimeMillis();
 

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXone/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXone/FATSuite.java
@@ -15,14 +15,12 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
+import com.ibm.ws.jpa.tests.spec10.relationships.manyXone.tests.AbstractFATSuite;
 import com.ibm.ws.jpa.tests.spec10.relationships.manyXone.tests.Relationships_ManyXOne_EJB;
 import com.ibm.ws.jpa.tests.spec10.relationships.manyXone.tests.Relationships_ManyXOne_Web;
 
-import componenttest.containers.ExternalTestServiceDockerClientStrategy;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.database.container.DatabaseContainerFactory;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -30,19 +28,7 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 Relationships_ManyXOne_EJB.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
-public class FATSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
-                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
-
-    //Required to ensure we calculate the correct strategy each run even when
-    //switching between local and remote docker hosts.
-    static {
-        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
-    }
-
-    @ClassRule
-    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+public class FATSuite extends AbstractFATSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.with(new RepeatWithJPA20());

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXone/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXone/FATSuite.java
@@ -15,15 +15,13 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
+import com.ibm.ws.jpa.tests.spec10.relationships.manyXone.tests.AbstractFATSuite;
 import com.ibm.ws.jpa.tests.spec10.relationships.manyXone.tests.Relationships_ManyXOne_EJB;
 import com.ibm.ws.jpa.tests.spec10.relationships.manyXone.tests.Relationships_ManyXOne_Web;
 
-import componenttest.containers.ExternalTestServiceDockerClientStrategy;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.database.container.DatabaseContainerFactory;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -31,19 +29,7 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 Relationships_ManyXOne_EJB.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
-public class FATSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
-                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
-
-    //Required to ensure we calculate the correct strategy each run even when
-    //switching between local and remote docker hosts.
-    static {
-        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
-    }
-
-    @ClassRule
-    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+public class FATSuite extends AbstractFATSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES());

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXone/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXone/FATSuite.java
@@ -15,15 +15,13 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
+import com.ibm.ws.jpa.tests.spec10.relationships.manyXone.tests.AbstractFATSuite;
 import com.ibm.ws.jpa.tests.spec10.relationships.manyXone.tests.Relationships_ManyXOne_EJB;
 import com.ibm.ws.jpa.tests.spec10.relationships.manyXone.tests.Relationships_ManyXOne_Web;
 
-import componenttest.containers.ExternalTestServiceDockerClientStrategy;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.database.container.DatabaseContainerFactory;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -31,19 +29,7 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 Relationships_ManyXOne_EJB.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
-public class FATSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
-                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
-
-    //Required to ensure we calculate the correct strategy each run even when
-    //switching between local and remote docker hosts.
-    static {
-        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
-    }
-
-    @ClassRule
-    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+public class FATSuite extends AbstractFATSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE8_FEATURES());

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXone/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXone/FATSuite.java
@@ -15,15 +15,13 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
+import com.ibm.ws.jpa.tests.spec10.relationships.manyXone.tests.AbstractFATSuite;
 import com.ibm.ws.jpa.tests.spec10.relationships.manyXone.tests.Relationships_ManyXOne_EJB;
 import com.ibm.ws.jpa.tests.spec10.relationships.manyXone.tests.Relationships_ManyXOne_Web;
 
-import componenttest.containers.ExternalTestServiceDockerClientStrategy;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.database.container.DatabaseContainerFactory;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -31,19 +29,7 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 Relationships_ManyXOne_EJB.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
-public class FATSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
-                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
-
-    //Required to ensure we calculate the correct strategy each run even when
-    //switching between local and remote docker hosts.
-    static {
-        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
-    }
-
-    @ClassRule
-    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+public class FATSuite extends AbstractFATSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE9_FEATURES());

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXmany/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXmany/tests/AbstractFATSuite.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.tests;
+
+import org.junit.ClassRule;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+
+import componenttest.containers.ExternalTestServiceDockerClientStrategy;
+import componenttest.topology.database.container.DatabaseContainerFactory;
+
+/**
+ *
+ */
+public class AbstractFATSuite {
+    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+
+    //Required to ensure we calculate the correct strategy each run even when
+    //switching between local and remote docker hosts.
+    static {
+        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
+    }
+
+    @ClassRule
+    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+}

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXmany/tests/Relationships_OneXMany_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXmany/tests/Relationships_OneXMany_EJB.java
@@ -36,7 +36,6 @@ import com.ibm.ws.jpa.fvt.relationships.oneXmany.tests.ejb.TestOneXManyCompoundP
 import com.ibm.ws.jpa.fvt.relationships.oneXmany.tests.ejb.TestOneXManyUnidirectional_EJB_SFEX_Servlet;
 import com.ibm.ws.jpa.fvt.relationships.oneXmany.tests.ejb.TestOneXManyUnidirectional_EJB_SF_Servlet;
 import com.ibm.ws.jpa.fvt.relationships.oneXmany.tests.ejb.TestOneXManyUnidirectional_EJB_SL_Servlet;
-import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -82,11 +81,11 @@ public class Relationships_OneXMany_EJB extends JPAFATServletClient {
     })
     public static LibertyServer server;
 
-    public static final JdbcDatabaseContainer<?> testContainer = FATSuite.testContainer;
+    public static final JdbcDatabaseContainer<?> testContainer = AbstractFATSuite.testContainer;
 
     @BeforeClass
     public static void setUp() throws Exception {
-        PrivHelper.generateCustomPolicy(server, FATSuite.JAXB_PERMS);
+        PrivHelper.generateCustomPolicy(server, AbstractFATSuite.JAXB_PERMS);
         bannerStart(Relationships_OneXMany_EJB.class);
         timestart = System.currentTimeMillis();
 

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXmany/tests/Relationships_OneXMany_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXmany/tests/Relationships_OneXMany_Web.java
@@ -30,7 +30,6 @@ import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.ws.jpa.fvt.relationships.oneXmany.tests.web.TestOneXManyCollectionTypeServlet;
 import com.ibm.ws.jpa.fvt.relationships.oneXmany.tests.web.TestOneXManyCompoundPKServlet;
 import com.ibm.ws.jpa.fvt.relationships.oneXmany.tests.web.TestOneXManyUnidirectionalServlet;
-import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -70,11 +69,11 @@ public class Relationships_OneXMany_Web extends JPAFATServletClient {
     })
     public static LibertyServer server;
 
-    public static final JdbcDatabaseContainer<?> testContainer = FATSuite.testContainer;
+    public static final JdbcDatabaseContainer<?> testContainer = AbstractFATSuite.testContainer;
 
     @BeforeClass
     public static void setUp() throws Exception {
-        PrivHelper.generateCustomPolicy(server, FATSuite.JAXB_PERMS);
+        PrivHelper.generateCustomPolicy(server, AbstractFATSuite.JAXB_PERMS);
         bannerStart(Relationships_OneXMany_Web.class);
         timestart = System.currentTimeMillis();
 

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXmany/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXmany/FATSuite.java
@@ -15,14 +15,12 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
+import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.tests.AbstractFATSuite;
 import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.tests.Relationships_OneXMany_EJB;
 import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.tests.Relationships_OneXMany_Web;
 
-import componenttest.containers.ExternalTestServiceDockerClientStrategy;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.database.container.DatabaseContainerFactory;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -30,19 +28,7 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 Relationships_OneXMany_EJB.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
-public class FATSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
-                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
-
-    //Required to ensure we calculate the correct strategy each run even when
-    //switching between local and remote docker hosts.
-    static {
-        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
-    }
-
-    @ClassRule
-    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+public class FATSuite extends AbstractFATSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.with(new RepeatWithJPA20());

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXmany/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXmany/FATSuite.java
@@ -15,15 +15,13 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
+import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.tests.AbstractFATSuite;
 import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.tests.Relationships_OneXMany_EJB;
 import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.tests.Relationships_OneXMany_Web;
 
-import componenttest.containers.ExternalTestServiceDockerClientStrategy;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.database.container.DatabaseContainerFactory;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -31,19 +29,7 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 Relationships_OneXMany_EJB.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
-public class FATSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
-                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
-
-    //Required to ensure we calculate the correct strategy each run even when
-    //switching between local and remote docker hosts.
-    static {
-        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
-    }
-
-    @ClassRule
-    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+public class FATSuite extends AbstractFATSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES());

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXmany/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXmany/FATSuite.java
@@ -15,15 +15,13 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
+import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.tests.AbstractFATSuite;
 import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.tests.Relationships_OneXMany_EJB;
 import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.tests.Relationships_OneXMany_Web;
 
-import componenttest.containers.ExternalTestServiceDockerClientStrategy;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.database.container.DatabaseContainerFactory;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -31,19 +29,7 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 Relationships_OneXMany_EJB.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
-public class FATSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
-                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
-
-    //Required to ensure we calculate the correct strategy each run even when
-    //switching between local and remote docker hosts.
-    static {
-        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
-    }
-
-    @ClassRule
-    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+public class FATSuite extends AbstractFATSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE8_FEATURES());

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXmany/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXmany/FATSuite.java
@@ -15,15 +15,13 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
+import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.tests.AbstractFATSuite;
 import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.tests.Relationships_OneXMany_EJB;
 import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.tests.Relationships_OneXMany_Web;
 
-import componenttest.containers.ExternalTestServiceDockerClientStrategy;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.database.container.DatabaseContainerFactory;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -31,19 +29,7 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 Relationships_OneXMany_EJB.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
-public class FATSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
-                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
-
-    //Required to ensure we calculate the correct strategy each run even when
-    //switching between local and remote docker hosts.
-    static {
-        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
-    }
-
-    @ClassRule
-    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+public class FATSuite extends AbstractFATSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE9_FEATURES());

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXone/tests/AbstractFATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXone/tests/AbstractFATSuite.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.tests.spec10.relationships.oneXone.tests;
+
+import org.junit.ClassRule;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+
+import componenttest.containers.ExternalTestServiceDockerClientStrategy;
+import componenttest.topology.database.container.DatabaseContainerFactory;
+
+/**
+ *
+ */
+public class AbstractFATSuite {
+    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
+                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
+                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
+
+    //Required to ensure we calculate the correct strategy each run even when
+    //switching between local and remote docker hosts.
+    static {
+        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
+    }
+
+    @ClassRule
+    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+}

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXone/tests/Relationships_OneXOne_EJB.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXone/tests/Relationships_OneXOne_EJB.java
@@ -39,7 +39,6 @@ import com.ibm.ws.jpa.fvt.relationships.oneXone.tests.ejb.TestOneXOnePKJoin_EJB_
 import com.ibm.ws.jpa.fvt.relationships.oneXone.tests.ejb.TestOneXOneUnidirectional_EJB_SFEX_Servlet;
 import com.ibm.ws.jpa.fvt.relationships.oneXone.tests.ejb.TestOneXOneUnidirectional_EJB_SF_Servlet;
 import com.ibm.ws.jpa.fvt.relationships.oneXone.tests.ejb.TestOneXOneUnidirectional_EJB_SL_Servlet;
-import com.ibm.ws.jpa.tests.spec10.relationships.oneXone.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -91,11 +90,11 @@ public class Relationships_OneXOne_EJB extends JPAFATServletClient {
     })
     public static LibertyServer server;
 
-    public static final JdbcDatabaseContainer<?> testContainer = FATSuite.testContainer;
+    public static final JdbcDatabaseContainer<?> testContainer = AbstractFATSuite.testContainer;
 
     @BeforeClass
     public static void setUp() throws Exception {
-        PrivHelper.generateCustomPolicy(server, FATSuite.JAXB_PERMS);
+        PrivHelper.generateCustomPolicy(server, AbstractFATSuite.JAXB_PERMS);
         bannerStart(Relationships_OneXOne_EJB.class);
         timestart = System.currentTimeMillis();
 

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXone/tests/Relationships_OneXOne_Web.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXone/tests/Relationships_OneXOne_Web.java
@@ -31,7 +31,6 @@ import com.ibm.ws.jpa.fvt.relationships.oneXone.tests.web.TestOneXOneBidirection
 import com.ibm.ws.jpa.fvt.relationships.oneXone.tests.web.TestOneXOneCompoundPKServlet;
 import com.ibm.ws.jpa.fvt.relationships.oneXone.tests.web.TestOneXOnePKJoinServlet;
 import com.ibm.ws.jpa.fvt.relationships.oneXone.tests.web.TestOneXOneUnidirectionalServlet;
-import com.ibm.ws.jpa.tests.spec10.relationships.oneXone.FATSuite;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -72,11 +71,11 @@ public class Relationships_OneXOne_Web extends JPAFATServletClient {
     })
     public static LibertyServer server;
 
-    public static final JdbcDatabaseContainer<?> testContainer = FATSuite.testContainer;
+    public static final JdbcDatabaseContainer<?> testContainer = AbstractFATSuite.testContainer;
 
     @BeforeClass
     public static void setUp() throws Exception {
-        PrivHelper.generateCustomPolicy(server, FATSuite.JAXB_PERMS);
+        PrivHelper.generateCustomPolicy(server, AbstractFATSuite.JAXB_PERMS);
         bannerStart(Relationships_OneXOne_Web.class);
         timestart = System.currentTimeMillis();
 

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXone/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXone/FATSuite.java
@@ -15,14 +15,12 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
+import com.ibm.ws.jpa.tests.spec10.relationships.oneXone.tests.AbstractFATSuite;
 import com.ibm.ws.jpa.tests.spec10.relationships.oneXone.tests.Relationships_OneXOne_EJB;
 import com.ibm.ws.jpa.tests.spec10.relationships.oneXone.tests.Relationships_OneXOne_Web;
 
-import componenttest.containers.ExternalTestServiceDockerClientStrategy;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.database.container.DatabaseContainerFactory;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -30,19 +28,7 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 Relationships_OneXOne_Web.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
-public class FATSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
-                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
-
-    //Required to ensure we calculate the correct strategy each run even when
-    //switching between local and remote docker hosts.
-    static {
-        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
-    }
-
-    @ClassRule
-    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+public class FATSuite extends AbstractFATSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.with(new RepeatWithJPA20());

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXone/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.1_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXone/FATSuite.java
@@ -15,15 +15,13 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
+import com.ibm.ws.jpa.tests.spec10.relationships.oneXone.tests.AbstractFATSuite;
 import com.ibm.ws.jpa.tests.spec10.relationships.oneXone.tests.Relationships_OneXOne_EJB;
 import com.ibm.ws.jpa.tests.spec10.relationships.oneXone.tests.Relationships_OneXOne_Web;
 
-import componenttest.containers.ExternalTestServiceDockerClientStrategy;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.database.container.DatabaseContainerFactory;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -31,19 +29,7 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 Relationships_OneXOne_Web.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
-public class FATSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
-                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
-
-    //Required to ensure we calculate the correct strategy each run even when
-    //switching between local and remote docker hosts.
-    static {
-        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
-    }
-
-    @ClassRule
-    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+public class FATSuite extends AbstractFATSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES());

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXone/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.2_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXone/FATSuite.java
@@ -15,15 +15,13 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
+import com.ibm.ws.jpa.tests.spec10.relationships.oneXone.tests.AbstractFATSuite;
 import com.ibm.ws.jpa.tests.spec10.relationships.oneXone.tests.Relationships_OneXOne_EJB;
 import com.ibm.ws.jpa.tests.spec10.relationships.oneXone.tests.Relationships_OneXOne_Web;
 
-import componenttest.containers.ExternalTestServiceDockerClientStrategy;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.database.container.DatabaseContainerFactory;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -31,19 +29,7 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 Relationships_OneXOne_Web.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
-public class FATSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
-                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
-
-    //Required to ensure we calculate the correct strategy each run even when
-    //switching between local and remote docker hosts.
-    static {
-        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
-    }
-
-    @ClassRule
-    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+public class FATSuite extends AbstractFATSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE8_FEATURES());

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXone/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_3.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXone/FATSuite.java
@@ -15,15 +15,13 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 
+import com.ibm.ws.jpa.tests.spec10.relationships.oneXone.tests.AbstractFATSuite;
 import com.ibm.ws.jpa.tests.spec10.relationships.oneXone.tests.Relationships_OneXOne_EJB;
 import com.ibm.ws.jpa.tests.spec10.relationships.oneXone.tests.Relationships_OneXOne_Web;
 
-import componenttest.containers.ExternalTestServiceDockerClientStrategy;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.database.container.DatabaseContainerFactory;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -31,19 +29,7 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 Relationships_OneXOne_Web.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
-public class FATSuite {
-    public final static String[] JAXB_PERMS = { "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind.v2.runtime.reflect\";",
-                                                "permission java.lang.RuntimePermission \"accessClassInPackage.com.sun.xml.internal.bind\";",
-                                                "permission java.lang.RuntimePermission \"accessDeclaredMembers\";" };
-
-    //Required to ensure we calculate the correct strategy each run even when
-    //switching between local and remote docker hosts.
-    static {
-        ExternalTestServiceDockerClientStrategy.setupTestcontainers();
-    }
-
-    @ClassRule
-    public static JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+public class FATSuite extends AbstractFATSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE9_FEATURES());


### PR DESCRIPTION
Last minute changes in #17420 which didn't get tested against another build will cause failures in the JPA relationship buckets.  Fixing the issue.