### PR TITLE
Apply BZ 65358: Improve EL matching of varargs methods. 

### DIFF
--- a/dev/com.ibm.websphere.javaee.el.3.0/src/javax/el/Util.java
+++ b/dev/com.ibm.websphere.javaee.el.3.0/src/javax/el/Util.java
@@ -269,19 +269,22 @@ class Util {
             int exactMatch = 0;
             int assignableMatch = 0;
             int coercibleMatch = 0;
+            int varArgsMatch = 0;
             boolean noMatch = false;
             for (int i = 0; i < mParamCount; i++) {
                 // Can't be null
                 if (w.isVarArgs() && i == (mParamCount - 1)) {
                     if (i == paramCount || (paramValues != null && paramValues.length == i)) {
-                        // Nothing is passed as varargs
-                        assignableMatch++;
+                        // Var args defined but nothing is passed as varargs
+                        // Use MAX_VALUE so this matches only if nothing else does
+                        varArgsMatch = Integer.MAX_VALUE;
                         break;
                     }
                     Class<?> varType = mParamTypes[i].getComponentType();
                     for (int j = i; j < paramCount; j++) {
                         if (isAssignableFrom(paramTypes[j], varType)) {
                             assignableMatch++;
+                            varArgsMatch++;
                         } else {
                             if (paramValues == null) {
                                 noMatch = true;
@@ -289,6 +292,7 @@ class Util {
                             } else {
                                 if (isCoercibleFrom(paramValues[j], varType)) {
                                     coercibleMatch++;
+                                    varArgsMatch++;
                                 } else {
                                     noMatch = true;
                                     break;
@@ -324,18 +328,17 @@ class Util {
             }
 
             // If a method is found where every parameter matches exactly,
-            // return it
-            if (exactMatch == paramCount) {
+            // and no vars args are present, return it
+            if (exactMatch == paramCount && varArgsMatch == 0) {
                 return w;
             }
 
-            candidates.put(w, new MatchResult(
-                    exactMatch, assignableMatch, coercibleMatch, w.isBridge()));
+            candidates.put(w, new MatchResult(exactMatch, assignableMatch, coercibleMatch, varArgsMatch, w.isBridge()));
         }
 
         // Look for the method that has the highest number of parameters where
         // the type matches exactly
-        MatchResult bestMatch = new MatchResult(0, 0, 0, false);
+        MatchResult bestMatch = new MatchResult(0, 0, 0, 0, false);
         Wrapper<T> match = null;
         boolean multiple = false;
         for (Map.Entry<Wrapper<T>, MatchResult> entry : candidates.entrySet()) {
@@ -757,12 +760,14 @@ class Util {
         private final int exact;
         private final int assignable;
         private final int coercible;
+        private final int varArgs;
         private final boolean bridge;
 
-        public MatchResult(int exact, int assignable, int coercible, boolean bridge) {
+        public MatchResult(int exact, int assignable, int coercible, int varArgs, boolean bridge) {
             this.exact = exact;
             this.assignable = assignable;
             this.coercible = coercible;
+            this.varArgs = varArgs;
             this.bridge = bridge;
         }
 
@@ -778,6 +783,10 @@ class Util {
             return coercible;
         }
 
+        public int getVarArgs() {
+            return varArgs;
+        }
+
         public boolean isBridge() {
             return bridge;
         }
@@ -790,11 +799,15 @@ class Util {
                 if (cmp == 0) {
                     cmp = Integer.compare(this.getCoercible(), o.getCoercible());
                     if (cmp == 0) {
-                        // The nature of bridge methods is such that it actually
-                        // doesn't matter which one we pick as long as we pick
-                        // one. That said, pick the 'right' one (the non-bridge
-                        // one) anyway.
-                        cmp = Boolean.compare(o.isBridge(), this.isBridge());
+                        // Fewer var args matches are better
+                        cmp = Integer.compare(o.getVarArgs(), this.getVarArgs());
+                        if (cmp == 0) {
+                            // The nature of bridge methods is such that it actually
+                            // doesn't matter which one we pick as long as we pick
+                            // one. That said, pick the 'right' one (the non-bridge
+                            // one) anyway.
+                            cmp = Boolean.compare(o.isBridge(), this.isBridge());
+                        }
                     }
                 }
             }
@@ -802,23 +815,26 @@ class Util {
         }
 
         @Override
-        public boolean equals(Object o)
-        {
+        public boolean equals(Object o) {
             return o == this || (null != o &&
                     this.getClass().equals(o.getClass()) &&
                     ((MatchResult)o).getExact() == this.getExact() &&
                     ((MatchResult)o).getAssignable() == this.getAssignable() &&
                     ((MatchResult)o).getCoercible() == this.getCoercible() &&
+                    ((MatchResult)o).getVarArgs() == this.getVarArgs() &&
                     ((MatchResult)o).isBridge() == this.isBridge());
         }
 
         @Override
-        public int hashCode()
-        {
-            return (this.isBridge() ? 1 << 24 : 0) ^
-                    this.getExact() << 16 ^
-                    this.getAssignable() << 8 ^
-                    this.getCoercible();
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + assignable;
+            result = prime * result + (bridge ? 1231 : 1237);
+            result = prime * result + coercible;
+            result = prime * result + exact;
+            result = prime * result + varArgs;
+            return result;
         }
     }
 

--- a/dev/com.ibm.ws.el.3.0_fat/.classpath
+++ b/dev/com.ibm.ws.el.3.0_fat/.classpath
@@ -2,6 +2,7 @@
 <classpath>
     <classpathentry kind="src" path="fat/src"/>
     <classpathentry kind="src" path="test-applications/TestEL3.0.war/src"/>
+    <classpathentry kind="src" path="test-applications/TestVarargsMatching.war/src"/>
     <classpathentry kind="con" path="aQute.bnd.classpath.container"/>
     <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
     <classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.el.3.0_fat/bnd.bnd
+++ b/dev/com.ibm.ws.el.3.0_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2018, 2020 IBM Corporation and others.
+# Copyright (c) 2018, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -13,7 +13,8 @@ bVersion=1.0
 
 src: \
     fat/src,\
-    test-applications/TestEL3.0.war/src
+    test-applications/TestEL3.0.war/src,\
+    test-applications/TestVarargsMatching.war/src
 
 fat.project: true
 

--- a/dev/com.ibm.ws.el.3.0_fat/fat/src/com/ibm/ws/el/fat/FATSuite.java
+++ b/dev/com.ibm.ws.el.3.0_fat/fat/src/com/ibm/ws/el/fat/FATSuite.java
@@ -25,6 +25,7 @@ import com.ibm.ws.el.fat.tests.EL30OperatorPrecedenceTest;
 import com.ibm.ws.el.fat.tests.EL30OperatorsTest;
 import com.ibm.ws.el.fat.tests.EL30ReservedWordsTest;
 import com.ibm.ws.el.fat.tests.EL30StaticFieldsAndMethodsTest;
+import com.ibm.ws.el.fat.tests.EL30VarargsMethodMatchingTest;
 import com.ibm.ws.fat.util.FatLogHandler;
 
 import componenttest.rules.repeater.EmptyAction;
@@ -55,7 +56,8 @@ import componenttest.rules.repeater.RepeatTests;
                 EL30OperatorPrecedenceTest.class,
                 EL22OperatorsTest.class,
                 EL30OperatorsTest.class,
-                EL30MethodExpressionInvocationsTest.class
+                EL30MethodExpressionInvocationsTest.class,
+                EL30VarargsMethodMatchingTest.class
 })
 public class FATSuite {
 

--- a/dev/com.ibm.ws.el.3.0_fat/fat/src/com/ibm/ws/el/fat/tests/EL30VarargsMethodMatchingTest.java
+++ b/dev/com.ibm.ws.el.3.0_fat/fat/src/com/ibm/ws/el/fat/tests/EL30VarargsMethodMatchingTest.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.el.fat.tests;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.el30.fat.varargstest.EL30VarargsMethodMatchingServlet;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+/**
+ * Test EL 3.0 Method Matching when Varargs are used. See BZ 65358 
+ */
+@RunWith(FATRunner.class)
+public class EL30VarargsMethodMatchingTest extends FATServletClient {
+
+    @Server("elServer")
+    @TestServlet(servlet = EL30VarargsMethodMatchingServlet.class, contextRoot = "TestVarargsMatching")
+    public static LibertyServer elServer;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        ShrinkHelper.defaultDropinApp(elServer, "TestVarargsMatching.war", "com.ibm.ws.el30.fat.varargstest");
+
+        elServer.startServer(EL30VarargsMethodMatchingTest.class.getSimpleName() + ".log");
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        // Stop the server
+        if (elServer != null && elServer.isStarted()) {
+            elServer.stopServer();
+        }
+    }
+}

--- a/dev/com.ibm.ws.el.3.0_fat/test-applications/TestVarargsMatching.war/resources/META-INF/permissions.xml
+++ b/dev/com.ibm.ws.el.3.0_fat/test-applications/TestVarargsMatching.war/resources/META-INF/permissions.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+    version="7">
+
+    <permission>  
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>getClassLoader</name>  
+    </permission>
+
+</permissions>

--- a/dev/com.ibm.ws.el.3.0_fat/test-applications/TestVarargsMatching.war/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.el.3.0_fat/test-applications/TestVarargsMatching.war/resources/WEB-INF/web.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<web-app
+    version="3.1"
+    xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+
+  <display-name>TestVarargsMatching</display-name>
+    
+</web-app>

--- a/dev/com.ibm.ws.el.3.0_fat/test-applications/TestVarargsMatching.war/src/com/ibm/ws/el30/fat/varargstest/EL30VarargsMethodMatchingServlet.java
+++ b/dev/com.ibm.ws.el.3.0_fat/test-applications/TestVarargsMatching.war/src/com/ibm/ws/el30/fat/varargstest/EL30VarargsMethodMatchingServlet.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.el30.fat.varargstest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import javax.el.ELProcessor;
+import javax.servlet.annotation.WebServlet;
+
+import org.junit.Test;
+
+import com.ibm.ws.el30.fat.varargstest.EL30VarargsMethodMatchingTestBean;
+
+import componenttest.annotation.SkipForRepeat;
+import componenttest.app.FATServlet;
+
+/**
+ * This servlet tests method matching when varargs are used 
+ */
+@WebServlet("/EL30VarargsMethodMatchingServlet")
+public class EL30VarargsMethodMatchingServlet extends FATServlet {
+
+    private static final long serialVersionUID = 1L;
+    ELProcessor elp;
+
+    /**
+     * Constructor
+     */
+    public EL30VarargsMethodMatchingServlet() {
+        super();
+
+        elp = new ELProcessor();
+
+        // Create an instance of the EL30VarargsMethodMatchingTestBean bean
+        EL30VarargsMethodMatchingTestBean testBean = new EL30VarargsMethodMatchingTestBean();
+
+        // Add the bean to the ELProcessor
+        elp.defineBean("testBean", testBean);
+ 
+
+    }
+
+    @Test
+    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
+    public void testSingleEnum() throws Exception {
+
+        getMethodExpression("testBean.testMethod(testBean.enum1)", "(IEnum enum1)");
+
+    }
+
+    @Test
+    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
+    public void testSingleString() throws Exception {
+
+        getMethodExpression("testBean.testMethod('string1')", "(String param1)");
+
+    }
+
+    @Test
+    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
+    public void testString_VarargsString() throws Exception {
+
+        getMethodExpression("testBean.testMethod('string1','string2','string3')", "(String param1, String... param2)");
+
+    }
+
+    @Test
+    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
+    public void testString_String() throws Exception {
+
+        getMethodExpression("testBean.testMethod('string1','string2')", "(String param1, String param2)");
+
+    }
+
+    @Test
+    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
+    public void testEnum_VarargsEnum() throws Exception {
+        
+        getMethodExpression("testBean.testMethod(testBean.enum1,testBean.enum1,testBean.enum1)", "(IEnum enum1, IEnum... enum2)");
+
+    }
+
+    @Test
+    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
+    public void testString_VarargsEnum() throws Exception {
+        
+        getMethodExpression("testBean.testMethod('string1',testBean.enum1)", "(String param1, IEnum... param2)");
+
+    }
+
+    @Test
+    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
+    public void testVarargsInt() throws Exception {
+        
+        getMethodExpression("testBean.testMethod(testBean.number)", "(int... param1)");
+
+    }
+
+    /**
+     * Helper method to get value using Method Expressions
+     *
+     * @param expression Expression to be evaluated
+     * @return the result of the evaluated expression
+     */
+    private void getMethodExpression(String expression, String expectedResult) throws Exception {
+        String result;
+        Object obj = elp.eval(expression);
+        assertNotNull(obj);
+        result = obj.toString();
+
+        assertEquals("The expression did not evaluate to: " + expectedResult + " but was: " + result, expectedResult, result);
+    }
+
+}

--- a/dev/com.ibm.ws.el.3.0_fat/test-applications/TestVarargsMatching.war/src/com/ibm/ws/el30/fat/varargstest/EL30VarargsMethodMatchingTestBean.java
+++ b/dev/com.ibm.ws.el.3.0_fat/test-applications/TestVarargsMatching.war/src/com/ibm/ws/el30/fat/varargstest/EL30VarargsMethodMatchingTestBean.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.el30.fat.varargstest;
+
+/**
+ *  This bean is used to test which methods definitions are matched
+ */
+public class EL30VarargsMethodMatchingTestBean{
+
+    private static final long serialVersionUID = 1L;
+    
+    public IEnum getEnum1() {
+        return EnumBean.ENUM1;
+    }
+
+    public int getNumber() {
+        return 1;
+    }
+
+    public String testMethod(IEnum enum1) {
+        return "(IEnum enum1)";
+    }
+
+    public String testMethod(String param1) {
+        return "(String param1)";
+    }
+
+    public String testMethod(String param1, String... param2) {
+        return "(String param1, String... param2)";
+    }
+
+    public String testMethod(String param1, String param2) {
+        return "(String param1, String param2)";
+    }
+
+    public String testMethod(String param1, IEnum... param2) {
+        return "(String param1, IEnum... param2)";
+    }
+
+    public String testMethod(IEnum enum1, IEnum... enum2) {
+        return "(IEnum enum1, IEnum... enum2)";
+    }
+
+    public String testMethod(int... param1) {
+        return "(int... param1)";
+    }
+
+}

--- a/dev/com.ibm.ws.el.3.0_fat/test-applications/TestVarargsMatching.war/src/com/ibm/ws/el30/fat/varargstest/EnumBean.java
+++ b/dev/com.ibm.ws.el.3.0_fat/test-applications/TestVarargsMatching.war/src/com/ibm/ws/el30/fat/varargstest/EnumBean.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.el30.fat.varargstest;
+
+public enum EnumBean implements IEnum {
+
+    ENUM1("ENUM1");
+
+	private String message;
+
+	EnumBean(String message) {
+		this.message = message;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+
+}

--- a/dev/com.ibm.ws.el.3.0_fat/test-applications/TestVarargsMatching.war/src/com/ibm/ws/el30/fat/varargstest/IEnum.java
+++ b/dev/com.ibm.ws.el.3.0_fat/test-applications/TestVarargsMatching.war/src/com/ibm/ws/el30/fat/varargstest/IEnum.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.el30.fat.varargstest;
+
+public interface IEnum {
+    String getMessage();
+}

--- a/dev/com.ibm.ws.org.apache.jasper.el/src/org/apache/el/util/ReflectionUtil.java
+++ b/dev/com.ibm.ws.org.apache.jasper.el/src/org/apache/el/util/ReflectionUtil.java
@@ -178,9 +178,27 @@ public class ReflectionUtil {
             int mParamCount = mParamTypes.length;
 
             // Check the number of parameters
-            if (!(paramCount == mParamCount ||
-                    (m.isVarArgs() && paramCount >= mParamCount))) {
+            // Multiple tests to improve readability
+            if (!m.isVarArgs() && paramCount != mParamCount) {
                 // Method has wrong number of parameters
+                continue;
+            }
+            if (m.isVarArgs() && paramCount < mParamCount -1) {
+                // Method has wrong number of parameters
+                continue;
+            }
+            if (m.isVarArgs() && paramCount == mParamCount && paramValues != null &&
+                    paramValues.length > paramCount && !paramTypes[mParamCount -1].isArray()) {
+                // Method arguments don't match
+                continue;
+            }
+            if (m.isVarArgs() && paramCount > mParamCount && paramValues != null &&
+                    paramValues.length != paramCount) {
+                // Might match a different varargs method
+                continue;
+            }
+            if (!m.isVarArgs() && paramValues != null && paramCount != paramValues.length) {
+                // Might match a different varargs method
                 continue;
             }
 
@@ -188,16 +206,22 @@ public class ReflectionUtil {
             int exactMatch = 0;
             int assignableMatch = 0;
             int coercibleMatch = 0;
+            int varArgsMatch = 0;
             boolean noMatch = false;
             for (int i = 0; i < mParamCount; i++) {
                 // Can't be null
-                if (mParamTypes[i].equals(paramTypes[i])) {
-                    exactMatch++;
-                } else if (i == (mParamCount - 1) && m.isVarArgs()) {
+                if (m.isVarArgs() && i == (mParamCount - 1)) {
+                    if (i == paramCount || (paramValues != null && paramValues.length == i)) {
+                        // Var args defined but nothing is passed as varargs
+                        // Use MAX_VALUE so this matches only if nothing else does
+                        varArgsMatch = Integer.MAX_VALUE;
+                        break;
+                    }
                     Class<?> varType = mParamTypes[i].getComponentType();
                     for (int j = i; j < paramCount; j++) {
                         if (isAssignableFrom(paramTypes[j], varType)) {
                             assignableMatch++;
+                            varArgsMatch++;
                         } else {
                             if (paramValues == null) {
                                 noMatch = true;
@@ -205,6 +229,7 @@ public class ReflectionUtil {
                             } else {
                                 if (isCoercibleFrom(ctx, paramValues[j], varType)) {
                                     coercibleMatch++;
+                                    varArgsMatch++;
                                 } else {
                                     noMatch = true;
                                     break;
@@ -215,18 +240,22 @@ public class ReflectionUtil {
                         // lead to a varArgs method matching when the result
                         // should be ambiguous
                     }
-                } else if (isAssignableFrom(paramTypes[i], mParamTypes[i])) {
-                    assignableMatch++;
                 } else {
-                    if (paramValues == null) {
-                        noMatch = true;
-                        break;
+                    if (mParamTypes[i].equals(paramTypes[i])) {
+                        exactMatch++;
+                    } else if (paramTypes[i] != null && isAssignableFrom(paramTypes[i], mParamTypes[i])) {
+                        assignableMatch++;
                     } else {
-                        if (isCoercibleFrom(ctx, paramValues[i], mParamTypes[i])) {
-                            coercibleMatch++;
-                        } else {
+                        if (paramValues == null) {
                             noMatch = true;
                             break;
+                        } else {
+                            if (isCoercibleFrom(ctx, paramValues[i], mParamTypes[i])) {
+                                coercibleMatch++;
+                            } else {
+                                noMatch = true;
+                                break;
+                            }
                         }
                     }
                 }
@@ -236,18 +265,17 @@ public class ReflectionUtil {
             }
 
             // If a method is found where every parameter matches exactly,
-            // return it
-            if (exactMatch == paramCount) {
+            // and no vars args are present, return it
+            if (exactMatch == paramCount && varArgsMatch == 0) {
                 return getMethod(base.getClass(), base, m);
             }
 
-            candidates.put(m, new MatchResult(
-                    exactMatch, assignableMatch, coercibleMatch, m.isBridge()));
+            candidates.put(m, new MatchResult(exactMatch, assignableMatch, coercibleMatch, varArgsMatch, m.isBridge()));
         }
 
         // Look for the method that has the highest number of parameters where
         // the type matches exactly
-        MatchResult bestMatch = new MatchResult(0, 0, 0, false);
+        MatchResult bestMatch = new MatchResult(0, 0, 0, 0, false);
         Method match = null;
         boolean multiple = false;
         for (Map.Entry<Method, MatchResult> entry : candidates.entrySet()) {
@@ -475,12 +503,14 @@ public class ReflectionUtil {
         private final int exact;
         private final int assignable;
         private final int coercible;
+        private final int varArgs;
         private final boolean bridge;
 
-        public MatchResult(int exact, int assignable, int coercible, boolean bridge) {
+        public MatchResult(int exact, int assignable, int coercible, int varArgs, boolean bridge) {
             this.exact = exact;
             this.assignable = assignable;
             this.coercible = coercible;
+            this.varArgs = varArgs;
             this.bridge = bridge;
         }
 
@@ -496,6 +526,10 @@ public class ReflectionUtil {
             return coercible;
         }
 
+        public int getVarArgs() {
+            return varArgs;
+        }
+
         public boolean isBridge() {
             return bridge;
         }
@@ -508,15 +542,42 @@ public class ReflectionUtil {
                 if (cmp == 0) {
                     cmp = Integer.compare(this.getCoercible(), o.getCoercible());
                     if (cmp == 0) {
-                        // The nature of bridge methods is such that it actually
-                        // doesn't matter which one we pick as long as we pick
-                        // one. That said, pick the 'right' one (the non-bridge
-                        // one) anyway.
-                        cmp = Boolean.compare(o.isBridge(), this.isBridge());
+                        // Fewer var args matches are better
+                        cmp = Integer.compare(o.getVarArgs(), this.getVarArgs());
+                        if (cmp == 0) {
+                            // The nature of bridge methods is such that it actually
+                            // doesn't matter which one we pick as long as we pick
+                            // one. That said, pick the 'right' one (the non-bridge
+                            // one) anyway.
+                            cmp = Boolean.compare(o.isBridge(), this.isBridge());
+                        }
                     }
                 }
             }
             return cmp;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o == this || (null != o &&
+                    this.getClass().equals(o.getClass()) &&
+                    ((MatchResult)o).getExact() == this.getExact() &&
+                    ((MatchResult)o).getAssignable() == this.getAssignable() &&
+                    ((MatchResult)o).getCoercible() == this.getCoercible() &&
+                    ((MatchResult)o).getVarArgs() == this.getVarArgs() &&
+                    ((MatchResult)o).isBridge() == this.isBridge());
+        }
+        
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + assignable;
+            result = prime * result + (bridge ? 1231 : 1237);
+            result = prime * result + coercible;
+            result = prime * result + exact;
+            result = prime * result + varArgs;
+            return result;
         }
     }
 


### PR DESCRIPTION
fixes #17444

See the original patch here: https://github.com/apache/tomcat/commit/4f5a35563f83e28aa341f69c9dd7a856a0aed895#

In a nutshell, it keeps track of the varargs when selecting the best method. Method with the fewest varargs would then selected. 

Fix applies to EL-3.0. 

This is also fixed for expressionLanague-4.0 in PR  #17669 (Update EL to 10.0.7)