### PR TITLE
Increase timeout by .5 seconds to wait for a thread to unblock

### DIFF
--- a/dev/com.ibm.ws.collector.manager/test/com/ibm/ws/collector/manager/buffer/RingBufferTest.java
+++ b/dev/com.ibm.ws.collector.manager/test/com/ibm/ws/collector/manager/buffer/RingBufferTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,9 +20,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import com.ibm.ws.collector.manager.buffer.BufferManagerImpl;
-import com.ibm.ws.collector.manager.buffer.Event;
 
 import test.common.SharedOutputManager;
 
@@ -377,7 +374,7 @@ public class RingBufferTest {
     public void assertNotBlocked(String message, Thread thread) {
 
         long threadWaitTimeOutInMilliSecs = 10000;
-        long waitTimeInMilliSecs = 1000;
+        long waitTimeInMilliSecs = 1500;
         long timeElapsedInMilliSecs = 0;
 
         System.out.println("Waiting for thread to enter either runnable or terminated state...");


### PR DESCRIPTION
fixes #15733 
#build

Context of the failing test.
- Unit  test for the Buffer class.
- Thread 1 tries to consume an item from the Empty Buffer
- Thread 2 checks that Thread 1 is blocked (waits 4 sec max)
- Thread 2 adds an item to the buffer (allowing  Thread 1 to unblock and consume item)
- Thread 2 checks that Thread is no longer blocked. (waits 1 sec max)|

The failure scenario may be due to Thread 2 being delayed/interrupted by the system  longer than 1 second and is unable to unblock in  time. Can increase the duration for the wait to 1.5 seconds.