### PR TITLE
add test for unregistered annotation

### DIFF
--- a/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi12/fat/tests/CDI12ExtensionSPITest.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/fat/src/com/ibm/ws/cdi12/fat/tests/CDI12ExtensionSPITest.java
@@ -70,6 +70,7 @@ public class CDI12ExtensionSPITest {
                                       , "Injection of a normal scoped class that was registered via getBeanClasses"
                                       , "An Interceptor registered via getBeanClasses in the SPI intercepted a normal scoped class registered via getBeanClasses"
                                       , "Could not find unregistered bean"
+                                      , "Could not find unregistered BDA bean"
                                       , "An Interceptor registered via getBeanClasses in the SPI intercepted a normal scoped class in the application WAR"
                                       , "A Bean with an annotation registered via getBeanDefiningAnnotationClasses was successfully injected into a different bean with an annotation registered via getBeanDefiningAnnotationClasses"  });
     }

--- a/dev/com.ibm.ws.cdi.extension_fat/test-applications/SPIConstructorException.war/src/com/ibm/ws/cdi/extension/spi/test/constructor/TestServlet.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-applications/SPIConstructorException.war/src/com/ibm/ws/cdi/extension/spi/test/constructor/TestServlet.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 
 import javax.enterprise.inject.UnsatisfiedResolutionException;
+import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -43,7 +44,7 @@ public class TestServlet extends HttpServlet {
         String unregString = "";
 
         try {
-            ExtensionRegisteredBean ub = javax.enterprise.inject.spi.CDI.current().select(ExtensionRegisteredBean.class).get();
+            ExtensionRegisteredBean ub = CDI.current().select(ExtensionRegisteredBean.class).get();
             unregString = "Found unregistered bean";
         } catch (UnsatisfiedResolutionException e) {
             unregString = "Could not find unregistered bean";

--- a/dev/com.ibm.ws.cdi.extension_fat/test-applications/SPIExtension.war/src/com/ibm/ws/cdi/extension/spi/test/app/MisplacedTestServlet.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-applications/SPIExtension.war/src/com/ibm/ws/cdi/extension/spi/test/app/MisplacedTestServlet.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 
 import javax.enterprise.inject.UnsatisfiedResolutionException;
+import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -48,7 +49,7 @@ public class MisplacedTestServlet extends HttpServlet {
         String unregString = "";
         try {
             //This will fail because while the extension will run as expected and add MyExtensionString to the BDA, it will be filtered out later because it cannot be found in the bundle.
-            MyExtensionString ub = javax.enterprise.inject.spi.CDI.current().select(MyExtensionString.class).get();
+            MyExtensionString ub = CDI.current().select(MyExtensionString.class).get();
             unregString = "Bean registered via an extension when both the bean and the extension are in a different bundle to the SPI impl class. This is unexpected";
         } catch (UnsatisfiedResolutionException e) {
             unregString = "Could not find bean registered via an extension when both the bean and the extension are in a different bundle to the SPI impl class";

--- a/dev/com.ibm.ws.cdi.extension_fat/test-applications/SPIExtension.war/src/com/ibm/ws/cdi/extension/spi/test/app/TestServlet.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-applications/SPIExtension.war/src/com/ibm/ws/cdi/extension/spi/test/app/TestServlet.java
@@ -57,12 +57,21 @@ public class TestServlet extends HttpServlet {
             unregString = "Could not find unregistered bean";
         }
 
+        String unregBDAString = "";
+        try {
+            UnregisteredBDABean ub = javax.enterprise.inject.spi.CDI.current().select(UnregisteredBDABean.class).get();
+            unregBDAString = ub.toString();
+        } catch (UnsatisfiedResolutionException e) {
+            unregBDAString = "Could not find unregistered BDA bean";
+        }
+
         PrintWriter pw = response.getWriter();
         pw.println("Test Results:");
         pw.println(extensionString.toString());
         pw.println(beanInjectedString.toString());
         pw.println(classString.toString());
         pw.println(unregString);
+        pw.println(unregBDAString);
         pw.println(appBean.toString());
         pw.println(customBDABean.toString());
 

--- a/dev/com.ibm.ws.cdi.extension_fat/test-applications/SPIExtension.war/src/com/ibm/ws/cdi/extension/spi/test/app/TestServlet.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-applications/SPIExtension.war/src/com/ibm/ws/cdi/extension/spi/test/app/TestServlet.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 
 import javax.enterprise.inject.UnsatisfiedResolutionException;
+import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -51,7 +52,7 @@ public class TestServlet extends HttpServlet {
 
         String unregString = "";
         try {
-            UnregisteredBean ub = javax.enterprise.inject.spi.CDI.current().select(UnregisteredBean.class).get();
+            UnregisteredBean ub = CDI.current().select(UnregisteredBean.class).get();
             unregString = "Found unregistered bean";
         } catch (UnsatisfiedResolutionException e) {
             unregString = "Could not find unregistered bean";
@@ -59,7 +60,7 @@ public class TestServlet extends HttpServlet {
 
         String unregBDAString = "";
         try {
-            UnregisteredBDABean ub = javax.enterprise.inject.spi.CDI.current().select(UnregisteredBDABean.class).get();
+            UnregisteredBDABean ub = CDI.current().select(UnregisteredBDABean.class).get();
             unregBDAString = ub.toString();
         } catch (UnsatisfiedResolutionException e) {
             unregBDAString = "Could not find unregistered BDA bean";

--- a/dev/com.ibm.ws.cdi.extension_fat/test-applications/SPIExtension.war/src/com/ibm/ws/cdi/extension/spi/test/app/UnregisteredBDABean.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-applications/SPIExtension.war/src/com/ibm/ws/cdi/extension/spi/test/app/UnregisteredBDABean.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.extension.spi.test.app;
+
+import javax.inject.Inject;
+
+import com.ibm.ws.cdi.extension.spi.test.bundle.annotations.UnregisteredBDA;
+
+@UnregisteredBDA
+public class UnregisteredBDABean {
+
+    public String toString() {
+        return "A class with a BDA that was not registerd through the SPI somehow got injected";
+    }
+
+}

--- a/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.extension/src/com/ibm/ws/cdi/extension/spi/test/bundle/annotations/UnregisteredBDA.java
+++ b/dev/com.ibm.ws.cdi.extension_fat/test-bundles/cdi.spi.extension/src/com/ibm/ws/cdi/extension/spi/test/bundle/annotations/UnregisteredBDA.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.cdi.extension.spi.test.bundle.annotations;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({ METHOD, TYPE })
+@Retention(RUNTIME)
+public @interface UnregisteredBDA {
+}


### PR DESCRIPTION
This adds another FAT for 15540, verifying that an annotation will not become a BDA even if it's in the same package as a BDA registered through the SPI