### PR TITLE
PR for Issue 14575: OAuth client registration check for illegal client ID chars

### DIFF
--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/OidcBaseClientValidator.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/OidcBaseClientValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@ import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -30,6 +32,7 @@ import com.ibm.ws.security.oauth20.error.impl.BrowserAndServerLogMessage;
 import com.ibm.ws.security.oauth20.util.OIDCConstants;
 import com.ibm.ws.security.oauth20.util.OidcOAuth20Util;
 import com.ibm.ws.security.oauth20.web.AbstractOidcEndpointServices;
+import com.ibm.ws.security.oauth20.web.OAuth20RequestFilter;
 import com.ibm.ws.security.oauth20.web.TraceConstants;
 
 /**
@@ -108,14 +111,42 @@ public class OidcBaseClientValidator {
      * check for disallowed characters that could allow javascript to be fed back to ui.
      */
     private void detectIllegalChars() throws OidcServerException {
-        detectIllegalCharacters(client.getClientId());
-        detectIllegalCharacters(client.getClientSecret());
+        detectNonVSCHARCharacters(client.getClientId(), OAuth20Constants.CLIENT_ID);
+        detectNonVSCHARCharacters(client.getClientSecret(), OAuth20Constants.CLIENT_SECRET);
         detectIllegalCharacters(client.getRedirectUris());
         detectIllegalCharacters(client.getClientName());
         detectIllegalCharacters(client.getPostLogoutRedirectUris());
         detectIllegalCharacters(client.getPreAuthorizedScope());
         detectIllegalCharacters(client.getFunctionalUserId());
         detectIllegalCharacters(client.getFunctionalUserGroupIds());
+    }
+
+    void detectNonVSCHARCharacters(String s, String parameterName) throws OidcServerException {
+        if (s == null || s.length() == 0) {
+            return;
+        }
+        String badChars = getIllegalChars(s, OAuth20RequestFilter.REGEX_RANGE_VSCHAR);
+        if (badChars != null && !badChars.isEmpty()) {
+            BrowserAndServerLogMessage errorMsg = new BrowserAndServerLogMessage(tc, "OAUTH_CLIENT_REGISTRATION_ILLEGAL_CHAR", new Object[] { badChars });
+            Tr.error(tc, errorMsg.getServerErrorMessage());
+            throw new OidcServerException(errorMsg, OIDCConstants.ERROR_INVALID_CLIENT_METADATA, HttpServletResponse.SC_BAD_REQUEST);
+        }
+    }
+
+    String getIllegalChars(String input, String regexAllowableChars) {
+        if (input == null || input.length() == 0) {
+            return null;
+        }
+        String badChars = "";
+        for (int i = 0; i < input.length(); i++) {
+            Pattern vscharRegex = Pattern.compile(regexAllowableChars);
+            String currentChar = input.substring(i, i + 1);
+            Matcher matcher = vscharRegex.matcher(currentChar);
+            if (!matcher.matches()) {
+                badChars += currentChar;
+            }
+        }
+        return badChars;
     }
 
     // detect illegal chars
@@ -164,16 +195,16 @@ public class OidcBaseClientValidator {
     public OidcBaseClient validate() throws OidcServerException {
         return validateCommons(false);
     }
-    
+
     public OidcBaseClient validateAndSetDefaultsOnErrors() {
         try {
             return validateCommons(true);
         } catch (OidcServerException e) {
         } //This will not occur
-    
+
         return null; //This will not occur
     }
-    
+
     private OidcBaseClient validateCommons(boolean setDefaultsOnError) throws OidcServerException {
         //application_type - defaults to web if omitted
         try {
@@ -185,7 +216,7 @@ public class OidcBaseClientValidator {
                 throw e;
             }
         }
-    
+
         try {
             validateResponseTypes();
         } catch (OidcServerException e) {
@@ -196,7 +227,7 @@ public class OidcBaseClientValidator {
                 throw e;
             }
         }
-    
+
         Set<String> grantTypes = new HashSet<String>();
         try {
             grantTypes = validateGrantTypes();
@@ -208,7 +239,7 @@ public class OidcBaseClientValidator {
                 throw e;
             }
         }
-    
+
         try {
             //response_types and grant_types need to match
             validateResponseAndGrantMatch(grantTypes);
@@ -221,7 +252,7 @@ public class OidcBaseClientValidator {
                 throw e;
             }
         }
-    
+
         try {
             validateRedirectUris();
         } catch (OidcServerException e) {
@@ -232,7 +263,7 @@ public class OidcBaseClientValidator {
                 throw e;
             }
         }
-    
+
         try {
             //scope (space separated, if omitted can register default scope)
             validateScopes();
@@ -244,7 +275,7 @@ public class OidcBaseClientValidator {
                 throw e;
             }
         }
-    
+
         try {
             validateSujectType();
         } catch (OidcServerException e) {
@@ -255,7 +286,7 @@ public class OidcBaseClientValidator {
                 throw e;
             }
         }
-    
+
         try {
             //token_endpoint_auth_method - if omitted, defaults to client_secret_basic
             validateTokenEndpointAuthMethod();
@@ -267,7 +298,7 @@ public class OidcBaseClientValidator {
                 throw e;
             }
         }
-    
+
         try {
             validatePostLogoutRedirectUris();
         } catch (OidcServerException e) {
@@ -278,7 +309,7 @@ public class OidcBaseClientValidator {
                 throw e;
             }
         }
-    
+
         try {
             validatePreAuthorizedScopes();
         } catch (OidcServerException e) {
@@ -289,7 +320,7 @@ public class OidcBaseClientValidator {
                 throw e;
             }
         }
-    
+
         try {
             validateTrustedUriPrefixes();
         } catch (OidcServerException e) {
@@ -300,7 +331,7 @@ public class OidcBaseClientValidator {
                 throw e;
             }
         }
-    
+
         try {
             validateOutputParameters();
         } catch (OidcServerException e) {
@@ -312,12 +343,12 @@ public class OidcBaseClientValidator {
                 if (this.client.getClientIdIssuedAt() < 0) {
                     this.client.setClientIdIssuedAt(0);
                 }
-    
+
             } else {
                 throw e;
             }
         }
-    
+
         return this.client;
     }
     **/
@@ -525,10 +556,10 @@ public class OidcBaseClientValidator {
             throw new OidcServerException(description, OIDCConstants.ERROR_INVALID_CLIENT_METADATA, HttpServletResponse.SC_BAD_REQUEST);
         } else if (!OidcOAuth20Util.isNullEmpty(client.getPreAuthorizedScope()) && !OidcOAuth20Util.isNullEmpty(client.getScope())) {
             String errorMsg = "The value \"%s\" for the client registration metadata field \"%s\" should also be specified as a value in the client registration metadata field \"scope\".";
-        
+
             String[] scopeArr = client.getScope().split(" ");
             Set<String> scopeSet = getSetFromArr(scopeArr);
-        
+
             String[] preAuthorizedScopeArr = client.getPreAuthorizedScope().split(" ");
             for (String preAuthorizedScope : preAuthorizedScopeArr) {
                 if (!scopeSet.contains(preAuthorizedScope)) {
@@ -536,7 +567,7 @@ public class OidcBaseClientValidator {
                     throw new OidcServerException(description, OIDCConstants.ERROR_INVALID_CLIENT_METADATA, HttpServletResponse.SC_BAD_REQUEST);
                 }
             }
-        
+
         }
         **/
 

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/OidcBaseClientValidator.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/OidcBaseClientValidator.java
@@ -113,6 +113,8 @@ public class OidcBaseClientValidator {
     private void detectIllegalChars() throws OidcServerException {
         detectNonVSCHARCharacters(client.getClientId(), OAuth20Constants.CLIENT_ID);
         detectNonVSCHARCharacters(client.getClientSecret(), OAuth20Constants.CLIENT_SECRET);
+        detectIllegalCharacters(client.getClientId());
+        detectIllegalCharacters(client.getClientSecret());
         detectIllegalCharacters(client.getRedirectUris());
         detectIllegalCharacters(client.getClientName());
         detectIllegalCharacters(client.getPostLogoutRedirectUris());

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/OidcBaseClientValidator.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/plugins/OidcBaseClientValidator.java
@@ -121,7 +121,7 @@ public class OidcBaseClientValidator {
         detectIllegalCharacters(client.getFunctionalUserGroupIds());
     }
 
-    void detectNonVSCHARCharacters(String s, String parameterName) throws OidcServerException {
+    void detectNonVSCHARCharacters(@Sensitive String s, String parameterName) throws OidcServerException {
         if (s == null || s.length() == 0) {
             return;
         }
@@ -133,7 +133,7 @@ public class OidcBaseClientValidator {
         }
     }
 
-    String getIllegalChars(String input, String regexAllowableChars) {
+    String getIllegalChars(@Sensitive String input, String regexAllowableChars) {
         if (input == null || input.length() == 0) {
             return null;
         }

--- a/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/OAuth20RequestFilter.java
+++ b/dev/com.ibm.ws.security.oauth/src/com/ibm/ws/security/oauth20/web/OAuth20RequestFilter.java
@@ -38,7 +38,8 @@ public class OAuth20RequestFilter implements Filter {
     public static final String REGEX_COMPONENT_ID = "/([\\w-]+)/"; // first capture group, /name_of_provider/
 
     // Matches paths such as /registration/* to extract clientId values
-    public static final String REGEX_REGISTRATION = "registration(/[\u0020-\u007E]*)?";
+    public static final String REGEX_RANGE_VSCHAR = "[\u0020-\u007E]";
+    public static final String REGEX_REGISTRATION = "registration(/" + REGEX_RANGE_VSCHAR + "*)?";
     public static final String PATH_PTM = "personalTokenManagement";
     public static final String PATH_UTM = "usersTokenManagement";
     public static final String PATH_CLIENTMGT = "clientManagement";


### PR DESCRIPTION
Resolves #14575

Adds checks to ensure the `client_id` and `client_secret` parameters do not contain characters outside of the `%x20-7E` range, per the OAuth 2.0 spec.