### PR TITLE
AdminCenter to use encrypted file name to persist toolbox and tool data

### DIFF
--- a/dev/com.ibm.ws.ui/resources/com/ibm/ws/ui/internal/resources/UIMessages.nlsprops
+++ b/dev/com.ibm.ws.ui/resources/com/ibm/ws/ui/internal/resources/UIMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2013 IBM Corporation and others.
+# Copyright (c) 2013, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.ui/resources/com/ibm/ws/ui/internal/resources/UIMessages.nlsprops
+++ b/dev/com.ibm.ws.ui/resources/com/ibm/ws/ui/internal/resources/UIMessages.nlsprops
@@ -309,3 +309,11 @@ UNSUPPORTED_SSL_SOCKET_FACTORY.useraction=Get a JVM that supports Liberty profil
 OSGI_SERVICE_ERROR=CWWKX1066E: The {0} OSGi service is not available.
 OSGI_SERVICE_ERROR.explanation=This internal server error occurred because the specified service is not available.
 OSGI_SERVICE_ERROR.useraction=Restart the server with the clean option.
+
+TOOLBOX_FILE_PROMOTED_TO_ENCODED_NAME=CWWKX1068I: The Admin Center toolbox for user {0} was loaded from the persisted storage using its old file name and has converted to its new file name.
+TOOLBOX_FILE_PROMOTED_TO_ENCODED_NAME.explanation=The product loaded the Admin Center toolbox from persisted storage using its old file name and stored a copy into the new file name. The copy in the new file name will be loaded by subsequent access to persisted storage.
+TOOLBOX_FILE_PROMOTED_TO_ENCODED_NAME.useraction=No action is required.
+
+TOOL_DATA_PROMOTED_TO_ENCODED_NAME=CWWKX1069I: Tool {0} data for user {1} was loaded from the persisted storage using its old file name and has converted to its new file name.
+TOOL_DATA_PROMOTED_TO_ENCODED_NAME.explanation=The product loaded the tool data for the specified user and tool from persisted storage using its old file name and stored a copy into the new file name. The copy in the new file name will be loaded by subsequent access to persisted storage.
+TOOL_DATA_PROMOTED_TO_ENCODED_NAME.useraction=No action is required.

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/pojo/POJOLoaderService.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/pojo/POJOLoaderService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/pojo/POJOLoaderService.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/pojo/POJOLoaderService.java
@@ -316,15 +316,54 @@ public class POJOLoaderService implements ICatalogService, IToolboxService {
     }
 
     /**
-     * Load the Toolbox for the given user from the specified persistence provider.
-     * 
+     * Load the Toolbox for the given user from the specified persistence provider. It would attempt to load first the toolbox
+     * using the encoded file name format. If the file does not exist, then it would attempt to load the toolbox with the unecrypted 
+     * file name. If the file exists, promote the file name to encoded format if converting is flagged.
+     *
+     * @param persist The persistent layer
      * @param userId The userId of the toolbox to load
+     * @param convertToEncodedName Whether to perform promotion of an existing non-encoded file name found in persisted storage to its encoded file name
      * @return Returns a loaded, validated Toolbox instance or {@code null} if the instance was not available (or was invalid)
      */
-    @FFDCIgnore(FileNotFoundException.class)
-    private Toolbox loadToolboxFromPersistence(final IPersistenceProvider persist, final String userId) {
+    private Toolbox loadToolboxFromPersistence(final IPersistenceProvider persist, final String userId, final boolean convertToEncodedName) {
+        Toolbox toolbox = null;
         try {
-            String persistedName = Toolbox.PERSIST_NAME + "-" + userId;
+            toolbox = loadToolboxFromPersistenceUsingName(persist, Toolbox.PERSIST_NAME + "-" + Toolbox.getEncodedUserId(userId), userId);
+            if (toolbox == null) {
+
+                toolbox = loadToolboxFromPersistenceUsingName(persist, Toolbox.PERSIST_NAME + "-" + userId, userId);
+                if (toolbox == null) {
+                    if (tc.isEventEnabled()) {
+                        Tr.event(tc, "The persisted instance is not available. This is an expected code path and is likely fine.\n" +
+                                 "If the file should have been there, we'll see isDefault=true (rather than isDefault=false).\n" +
+                                 "That is the indicator to the client something may be wrong.");
+                    }
+                } else if (convertToEncodedName) {
+                    // save it to the encoded file name
+                    toolbox.storeToolbox();
+                    // delete the non-encoded toolbox json file
+                    persist.delete(Toolbox.PERSIST_NAME + "-" + userId);
+                    Tr.info(tc, "TOOLBOX_FILE_PROMOTED_TO_ENCODED_NAME", userId);
+
+                }
+            }
+        } catch (Throwable th) {
+            toolbox = null;
+        }
+        return toolbox;
+    }
+
+    /**
+     * Load the Toolbox for the given persisted name from the specified persistence provider.
+     *
+     * @param persist The persistent layer
+     * @param persistedName The file name in the persistent layer
+     * @param userId The userId of the toolbox to load
+     * @return Returns a loaded, validated Toolbox instance or {@code null} if the instance was not available
+     */
+    @FFDCIgnore(FileNotFoundException.class)
+    private Toolbox loadToolboxFromPersistenceUsingName(final IPersistenceProvider persist, final String persistedName, final String userId) throws Throwable {
+        try {
             Toolbox toolbox = persist.load(persistedName, Toolbox.class);
             toolbox.setCatalog(getCatalog());
             toolbox.setPersistenceProvider(getPersist());
@@ -332,13 +371,7 @@ public class POJOLoaderService implements ICatalogService, IToolboxService {
             Tr.info(tc, "LOADED_PERSISTED_TOOLBOX", userId);
             return toolbox;
         } catch (FileNotFoundException e) {
-            // This is an expected code path. If the toolbox persisted
-            // data is not there, just use the default instance!
-            if (tc.isEventEnabled()) {
-                Tr.event(tc, "The persisted instance is not available. This is an expected code path and is likely fine.\n" +
-                             "If the file should have been there, we'll see isDefault=true (rather than isDefault=false).\n" +
-                             "That is the indicator to the client something may be wrong.");
-            }
+            // do nothing and let the caller handles it
         } catch (JSONMarshallException e) {
             String msg = e.getMessage();
             if (msg != null && msg.equals("Fatal problems occurred while mapping content")) {
@@ -350,16 +383,19 @@ public class POJOLoaderService implements ICatalogService, IToolboxService {
                 // This is an unexpected code path. We should FFDC here.
                 Tr.error(tc, "UNABLE_TO_LOAD_TOOLBOX_SYNTAX", userId);
             }
+            throw e;
         } catch (IOException e) {
             // A general I/O error occured while accessing the persisted data.
             // This is the unexpected code path. We should FFDC here.
             Tr.error(tc, "UNABLE_TO_LOAD_TOOLBOX_ACCESS", userId);
+            throw e;
         } catch (InvalidPOJOException e) {
             if (tc.isDebugEnabled()) {
                 Tr.debug(tc, "Caught an InvalidPOJOException while trying to load the catalog from persisted storage", e);
             }
             // The persisted Toolbox instance is not valid, use the default instance
             Tr.error(tc, "LOADED_TOOLBOX_NOT_VALID", userId);
+            throw e;
         }
 
         return null;
@@ -371,7 +407,11 @@ public class POJOLoaderService implements ICatalogService, IToolboxService {
      * @return Returns a loaded, validated Catalog instance or {@code null} if the instance was not available (or was invalid).
      */
     private Toolbox loadToolboxFromFile(final String userId) {
-        return loadToolboxFromPersistence(persistenceProviderFile, userId);
+        return loadToolboxFromFile(userId, true);
+    }
+
+    private Toolbox loadToolboxFromFile(final String userId, boolean convertToEncodedName) {
+        return loadToolboxFromPersistence(persistenceProviderFile, userId, convertToEncodedName);
     }
 
     /**
@@ -394,9 +434,11 @@ public class POJOLoaderService implements ICatalogService, IToolboxService {
      * @return Returns a loaded, validated Toolbox instance or the default instance if a persisted copy was not available (or was invalid).
      */
     private Toolbox loadToolboxFromCollective(final String userId) {
-        Toolbox toolbox = loadToolboxFromPersistence(persistenceProviderCollective, userId);
+        Toolbox toolbox = loadToolboxFromPersistence(persistenceProviderCollective, userId, true);
         if (toolbox == null) {
-            toolbox = loadToolboxFromFile(userId);
+            // If the toolbox file is found in the non-encoded file name format in the file presistence layer, no need to convert it as the file
+            // is going to be promoted to collective encoded file name format.
+            toolbox = loadToolboxFromFile(userId, false);
             if (toolbox != null) {
                 Tr.info(tc, "TOOLBOX_FILE_PROMOTED_TO_COLLECTIVE", userId, "FILE", "COLLECTIVE");
             } else {

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/pojo/PlainTextLoaderService.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/pojo/PlainTextLoaderService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/pojo/PlainTextLoaderService.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/pojo/PlainTextLoaderService.java
@@ -12,6 +12,9 @@ package com.ibm.ws.ui.internal.v1.pojo;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -42,6 +45,7 @@ public class PlainTextLoaderService implements IToolDataService {
     // DS dependencies
     private IPersistenceProvider persistenceProviderFile;
     private IPersistenceProvider persistenceProviderCollective;
+    private final Map<String, Object> syncObjects = new HashMap<String, Object>();
 
     /**
      * Only set the FILE persistence provider. This service is required.
@@ -101,82 +105,222 @@ public class PlainTextLoaderService implements IToolDataService {
         }
     }
 
+    /**
+     * Gets the object for the specified tool persisted name to
+     * synchronize read/write/delete of the tool data
+     *
+     * Access to this method is synchronized. Callers should use the returned
+     * object for local synchronization.
+     *
+     * @param encodedPersistedName The tool encoded persisted name to look up or create the synchronization object
+     * @return The object used to do synchormization
+     */
+    private synchronized Object getSyncObject(final String encodedPersistedName) {
+        if (tc.isEntryEnabled()) {
+            Tr.entry(tc, "getSyncObject", "encodedPersistedName=" + encodedPersistedName);
+        }
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "getSyncObject", syncObjects.toString());
+        }
+        Object syncObj = syncObjects.get(encodedPersistedName);
+        if (syncObj == null) {
+            syncObj = new Object();
+            syncObjects.put(encodedPersistedName, syncObj);
+        }
+        if (tc.isEntryEnabled()) {
+            Tr.exit(tc, "getSyncObject", syncObj);
+        }
+        return syncObj;
+    }
+
+    /**
+     * The persisted file name for the tool with user id in it in previous releases is not encrypted because it is sensitive. However, 
+     * encryption is now done on the user id to avoid path traversal attack through the id and to provide an unique string.
+     *
+     * @param toolName The name of the tool
+     * @param userId The user id
+     * @return The encrypted file path to the tool data
+     */
+    private String getEncodedPersistedName(final String toolName, final String userId) {
+        return toolName + "/" + Toolbox.getEncodedUserId(userId);
+    }
+
+     /**
+     * Each tool persists its data in non-encrypted persisted file path in previous releases.
+     *
+     * @param toolName The name of the tool
+     * @param userId The user id
+     * @return The non-encrypted file path to the tool data
+     */
+    private String getNonencodedPersistedName(final String toolName, final String userId) {
+        return toolName + "/" + userId;
+    }
+
+    /**
+     * Return the encrypted and non-encrypted persisted names for the given tool and user id.
+     *
+     * @param toolName The name of the tool
+     * @param userId The user id
+     * @return The tool file paths including both encrypted and non-encrypted json file names
+     */
+    private String[] getPersistedNames(final String toolName, final String userId) {
+        String[] persistedNames = new String[2];
+        persistedNames[0] = getNonencodedPersistedName(toolName, userId);
+        persistedNames[1] = getEncodedPersistedName(toolName, userId);
+
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "getPersistedNames", "non-encoded file name is " + persistedNames[0]);
+            Tr.debug(tc, "getPersistedNames", "encoded file name is " + persistedNames[1]);
+        }
+        return persistedNames;
+    }
+
+    /**
+     * Promote the tool data for the given tool and user from the specified persistence provider to its encrypted persisted name.
+     *
+     * @param persistProvider The persistence layer
+     * @param persistedNames String array containing the non-encrypted and encrypted persisted file paths 
+     * @param userId The user id
+     * @param toolName The name of the tool
+     * @param toolData The tool data to be persisted
+     * @return Returns the tool data, or null if the file is not found, or if IOException is thrown.
+     */
+    private void convertToEncodedPersistedName(final IPersistenceProvider persistProvider, final String[] persistedNames, 
+            final String userId, final String toolName, final String toolData) {
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "convertToEncodedPersistedName", "converting from " + persistedNames[0] + " to " + persistedNames[1]);
+        }
+
+        // delete the tool data in the non-encoded file name
+        deleteToolDataFromPersistence(persistProvider, persistedNames[0], userId, toolName);
+        // create the tool data in the encoded file name
+        if (postAndPutToolDataToPersistence(persistProvider, persistedNames[1], userId, toolName, toolData) != null) {
+            Tr.info(tc, "TOOL_DATA_PROMOTED_TO_ENCODED_NAME", new Object[] {toolName, userId});
+        }
+    }
+
     /** {@inheritDoc} */
     @Override
     public String getToolData(String userId, String toolName) {
-        String persistedName = toolName + "/" + userId;
-        synchronized (persistedName) {
-            if (persistenceProviderCollective != null) {
-                return loadToolDataFromPersistence(persistenceProviderCollective, userId, toolName);
+        if (tc.isEntryEnabled()) {
+            Tr.entry(tc, "getToolData", new Object[] {"userId=" + userId, "toolName=" + toolName});
+        }
 
-            } else {
-                return loadToolDataFromPersistence(persistenceProviderFile, userId, toolName);
+        String[] persistedNames = getPersistedNames(toolName, userId);
+        synchronized(getSyncObject(persistedNames[1])) {
+            final IPersistenceProvider persistenceProvider = getPersist();
+            // if the persisted tool data stored in the encoded file name does not exist, then read the data from the non-ecoded file name.
+            // If the non-ecoded file name does not exist, then it is safe to assume persisted data not available for this tool.
+            // If the non-ecoded file name exists and contains data, change the file name to the encoded name.
+            String toolData = loadToolDataFromPersistence(persistenceProvider, persistedNames[1], userId, toolName);
+            if (toolData == null) {
+                toolData = loadToolDataFromPersistence(persistenceProvider, persistedNames[0], userId, toolName);
+                if (toolData == null) {
+                    if (tc.isEventEnabled()) {
+                        Tr.event(tc, "The persisted tool data is not available. This is an expected code path and is likely fine.\n");
+                    }
+                } else if (!toolData.equals("IOException")) {
+                    convertToEncodedPersistedName(persistenceProvider, persistedNames, userId, toolName, toolData);
+                }
             }
+            if (toolData != null && toolData.equals("IOException")) {
+                // if error other than FileNotFoundException, reset to no toolData before return
+                toolData = null;
+            }
+            if (tc.isEntryEnabled()) {
+                Tr.exit(tc, "getToolData", toolData);
+            }
+            return toolData;
         }
     }
 
     /**
-     * Load the tool data for the given user/tool from the specified persistence provider.
-     * 
-     * @param userId The user id.
+     * Load the tool data for the given persisted file path from the specified persistence provider.
+     *
+     * @param persistProvider The persistence layer
+     * @param persistedName The persisted file path for the tool
+     * @param userId The user id
      * @param toolName the name of the tool
      * @return Returns the tool data, or null if the file is not found, or if IOException is thrown.
      */
     @FFDCIgnore(FileNotFoundException.class)
-    private String loadToolDataFromPersistence(final IPersistenceProvider persist, final String userId, final String toolName) {
+    private String loadToolDataFromPersistence(final IPersistenceProvider persist, final String persistedName, final String userId, final String toolName) {
+        if (tc.isEntryEnabled()) {
+            Tr.entry(tc, "loadToolDataFromPersistence", "persistedName=" + persistedName);
+        }
+        String toolData = null;
+        // synchronized is done by the caller
         try {
-            String persistedName = toolName + "/" + userId;
-            String toolData = persist.loadPlainText(persistedName);
-            Tr.info(tc, "LOADED_PERSISTED_TOOL_DATA", userId, toolName);
-            return toolData;
-        } catch (FileNotFoundException e) {
-            // This is an expected code path. If the user/tool has no data
-            if (tc.isEventEnabled()) {
-                Tr.event(tc, "The persisted tool data is not available. This is an expected code path and is likely fine.\n");
+            if (persist != null) {
+                toolData = persist.loadPlainText(persistedName);
+                Tr.info(tc, "LOADED_PERSISTED_TOOL_DATA", userId, toolName);
             }
+        } catch (FileNotFoundException e) {
+            // do nothing and return null toolData
         } catch (IOException e) {
             // A general I/O error occured while accessing the persisted data.
             // This is the unexpected code path. We should FFDC here.
             Tr.error(tc, "UNABLE_TO_LOAD_TOOL_DATA_ACCESS", userId, toolName);
+            // signal for error and not to continue loading of different file
+            toolData = "IOException";
         }
-        return null;
+        if (tc.isEntryEnabled()) {
+            Tr.exit(tc, "loadToolDataFromPersistence", toolData);
+        }
+        return toolData;
     }
 
     /** {@inheritDoc} */
     @Override
     public boolean deleteToolData(String userId, String toolName) {
-        boolean deletedFromCollective = true;
-        boolean deletedFromFile = true;
-        String persistedName = toolName + "/" + userId;
-        synchronized (persistedName) {
-
-            if (persistenceProviderCollective != null)
-                deletedFromCollective = deleteToolDataFromPersistence(persistenceProviderCollective, userId, toolName);
-
-            if (persistenceProviderFile != null)
-                deletedFromFile = deleteToolDataFromPersistence(persistenceProviderFile, userId, toolName);
+        if (tc.isEntryEnabled()) {
+            Tr.entry(tc, "deleteToolData", new Object[] {"userId=" + userId, "toolName=" + toolName});
         }
-        return deletedFromFile && deletedFromCollective;
+        String[] persistedNames = getPersistedNames(toolName, userId);
+        boolean isDeleted = true;
+        synchronized(getSyncObject(persistedNames[1])) {
+            for (String persistedName : persistedNames) {
+                if (persistenceProviderCollective != null)
+                    isDeleted  = isDeleted && deleteToolDataFromPersistence(persistenceProviderCollective, persistedName, userId, toolName);
 
+                if (persistenceProviderFile != null)
+                    isDeleted = isDeleted && deleteToolDataFromPersistence(persistenceProviderFile, persistedName,  userId, toolName);
+            }
+        }
+        if (tc.isEntryEnabled()) {
+            Tr.exit(tc, "deleteToolData", isDeleted);
+        }
+
+        return isDeleted;
     }
 
     /** {@inheritDoc} */
     @Override
     public String addToolData(String userId, String toolName, String toolData) {
-
-        return postAndPutToolDataToPersistence(getPersist(), userId, toolName, toolData);
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "addToolData", new Object[] {"userId=" + userId, "toolName=" + toolName});
+        }
+        String encodedPersistedName = getEncodedPersistedName(toolName, userId);
+        synchronized(getSyncObject(encodedPersistedName)) {
+            return postAndPutToolDataToPersistence(getPersist(), encodedPersistedName, userId, toolName, toolData);
+        }
     }
 
     /**
-     * Deletes the tool data for the given user/tool from the specified persistence provider.
-     * 
-     * @param userId The user id.
+     * Deletes the tool data for the given persisted file path from the specified persistence provider.
+     *
+     * @param persistProvider The persistence layer
+     * @param persistedName The persisted file path for the tool
+     * @param userId The user id
      * @param toolName the name of the tool
-     * @return Returns <code>true</code> if the tool data is deleted. Otherwise return <code>false</code>.
+     * @return Returns <code>true</code> if the tool data is deleted or does not exist. Otherwise return <code>false</code>.
      */
-    private boolean deleteToolDataFromPersistence(final IPersistenceProvider persist, final String userId, final String toolName) {
+    private boolean deleteToolDataFromPersistence(final IPersistenceProvider persist, final String persistedName, final String userId, final String toolName) {
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "deleteToolDataFromPersistence", "persistedName=" + persistedName);
+        }
+        // synchronized is done by the caller
         try {
-            String persistedName = toolName + "/" + userId;
             boolean ret = true;
             if (persist != null && persist.exists(persistedName))
             {
@@ -192,20 +336,23 @@ public class PlainTextLoaderService implements IToolDataService {
     }
 
     /**
-     * Posts the tool data for the given user/tool to the specified persistence provider.
-     * 
-     * @param userId The userId of the tool data to be saved.
+     * Posts the tool data to the given encrypted persisted name using the specified persistence provider.
+     *
+     * @param persistProvider The persistence layer
+     * @param persistedName The encrypted persisted file path for the tool
+     * @param userId The userId of the tool data to be saved
      * @param toolName the name of the tool
-     * @return Returns tool data string.
+     * @return Returns tool data string, otherwise null if error
      */
-    private String postAndPutToolDataToPersistence(final IPersistenceProvider persist, final String userId, final String toolName,
+    private String postAndPutToolDataToPersistence(final IPersistenceProvider persist, final String persistedName, final String userId, final String toolName,
                                                    final String toolData) {
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "postAndPutToolDataToPersistence", "persistedName=" + persistedName);
+        }
+        // synchronized is done by the caller
         try {
-            String persistedName = toolName + "/" + userId;
-            synchronized (persistedName) {
-                persist.storePlainText(persistedName, toolData);
-                Tr.info(tc, "POSTED_TOOL_DATA", userId, toolName);
-            }
+            persist.storePlainText(persistedName, toolData);
+            Tr.info(tc, "POSTED_TOOL_DATA", userId, toolName);
             return toolData;
         } catch (JSONMarshallException e) {
             // This should not occur. FFDC here.
@@ -219,12 +366,12 @@ public class PlainTextLoaderService implements IToolDataService {
     /** {@inheritDoc} */
     @Override
     public boolean exists(String userId, String toolName) {
-        String persistedName = toolName + "/" + userId;
-        synchronized (persistedName) {
+        String encodedPersistedName = getEncodedPersistedName(toolName, userId);
+        synchronized(getSyncObject(encodedPersistedName)) {
             if (persistenceProviderCollective != null) {
-                return persistenceProviderCollective.exists(persistedName);
+                return persistenceProviderCollective.exists(encodedPersistedName);
             } else {
-                return persistenceProviderFile.exists(persistedName);
+                return persistenceProviderFile.exists(encodedPersistedName);
             }
         }
     }
@@ -233,23 +380,57 @@ public class PlainTextLoaderService implements IToolDataService {
     @Override
     public void promoteIfPossible(String userId, String toolName)
     {
-        String persistedName = toolName + "/" + userId;
-        synchronized (persistedName) {
-            if (persistenceProviderCollective != null) {
-                if (persistenceProviderCollective.exists(persistedName) == false && persistenceProviderFile.exists(persistedName) == true)
-                {
-                    try {
-                        String s = loadToolDataFromPersistence(persistenceProviderFile, userId, toolName);
-                        if (s != null)
-                            persistenceProviderCollective.storePlainText(persistedName, s);
-                    } catch (IOException e)
-                    {
-                        Tr.error(tc, "UNABLE_TO_PROMOTE_TOOL_DATA_CONTENT", userId, toolName);
-                    } catch (JSONMarshallException e) {
-                        Tr.error(tc, "UNABLE_TO_PROMOTE_TOOL_JSON_DATA_CONTENT", e.getMessage());
-                    }
+        if (tc.isEntryEnabled()) {
+            Tr.entry(tc, "promoteIfPossible", new Object[] {"userId=" + userId, "toolName=" + toolName});
+        }
+        // Try promoting the content in the encoded file name from the file persistence layer to collective first. If the file doesn't exist, then
+        // promote the content in the non-encoded file name from the file to collective persistence layer.
+        String[] persistedNames = getPersistedNames(toolName, userId);
+        synchronized(getSyncObject(persistedNames[1])) {
+            if (persistenceProviderCollective != null && persistenceProviderCollective.exists(persistedNames[1]) == false) {
+                if (!promoteIfPossible(persistedNames[1], persistedNames[1], userId, toolName)) {
+                    promoteIfPossible(persistedNames[0], persistedNames[1], userId, toolName);
                 }
             }
         }
+        if (tc.isEntryEnabled()) {
+            Tr.exit(tc, "promoteIfPossible");
+        }
+    }
+
+    /**
+     * Promotes the tool data from file persistence layer to collective if data doesn't exist in collective.
+     *
+     * @param fromPersistedName The presisted file name in the file persistence layer to be prompted
+     * @param toPersistedName The persisted file name to be saved in the collective persistence layer
+     * @param userId The userId of the tool data to be saved
+     * @param toolName the name of the tool
+     * @return Returns tool data string, otherwise null if error
+     */
+    private boolean promoteIfPossible(final String fromPersistedName, final String toPersistedName, final String userId, final String toolName) {
+        if (tc.isEntryEnabled()) {
+            Tr.entry(tc, "promoteIfPossible", new Object[] {"fromPersistedName=" + fromPersistedName, "toPersistedName=" + toPersistedName});
+        }
+        boolean promoted = false;
+        if (persistenceProviderCollective != null) {
+            if (persistenceProviderCollective.exists(fromPersistedName) == false && persistenceProviderFile.exists(fromPersistedName) == true)
+            {
+                try {
+                    String data = loadToolDataFromPersistence(persistenceProviderFile, fromPersistedName, userId, toolName);
+                        if (data != null) {
+                            persistenceProviderCollective.storePlainText(toPersistedName, data);
+                            promoted = true;
+                        }
+                } catch (IOException e) {
+                    Tr.error(tc, "UNABLE_TO_PROMOTE_TOOL_DATA_CONTENT", userId, toolName);
+                } catch (JSONMarshallException e) {
+                    Tr.error(tc, "UNABLE_TO_PROMOTE_TOOL_JSON_DATA_CONTENT", e.getMessage());
+                }
+            }
+        }
+        if (tc.isEntryEnabled()) {
+            Tr.exit(tc, "promoteIfPossible", promoted);
+        }
+        return promoted;
     }
 }

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/pojo/PlainTextLoaderService.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/pojo/PlainTextLoaderService.java
@@ -411,22 +411,22 @@ public class PlainTextLoaderService implements IToolDataService {
             Tr.entry(tc, "promoteIfPossible", new Object[] {"fromPersistedName=" + fromPersistedName, "toPersistedName=" + toPersistedName});
         }
         boolean promoted = false;
-        if (persistenceProviderCollective != null) {
-            if (persistenceProviderCollective.exists(fromPersistedName) == false && persistenceProviderFile.exists(fromPersistedName) == true)
-            {
-                try {
-                    String data = loadToolDataFromPersistence(persistenceProviderFile, fromPersistedName, userId, toolName);
-                    if (data != null && !"IOException".equals(data)) {
-                        persistenceProviderCollective.storePlainText(toPersistedName, data);
-                        promoted = true;
-                    }
-                } catch (IOException e) {
-                    Tr.error(tc, "UNABLE_TO_PROMOTE_TOOL_DATA_CONTENT", userId, toolName);
-                } catch (JSONMarshallException e) {
-                    Tr.error(tc, "UNABLE_TO_PROMOTE_TOOL_JSON_DATA_CONTENT", e.getMessage());
+ 
+        if (persistenceProviderFile.exists(fromPersistedName) == true)
+        {
+            try {
+                String data = loadToolDataFromPersistence(persistenceProviderFile, fromPersistedName, userId, toolName);
+                if (data != null && !"IOException".equals(data)) {
+                    persistenceProviderCollective.storePlainText(toPersistedName, data);
+                    promoted = true;
                 }
+            } catch (IOException e) {
+                Tr.error(tc, "UNABLE_TO_PROMOTE_TOOL_DATA_CONTENT", userId, toolName);
+            } catch (JSONMarshallException e) {
+                Tr.error(tc, "UNABLE_TO_PROMOTE_TOOL_JSON_DATA_CONTENT", e.getMessage());
             }
         }
+
         if (tc.isEntryEnabled()) {
             Tr.exit(tc, "promoteIfPossible", promoted);
         }

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/pojo/Toolbox.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/pojo/Toolbox.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/pojo/Toolbox.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/pojo/Toolbox.java
@@ -19,6 +19,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Base64;
 
 import com.ibm.websphere.jsonsupport.JSONMarshallException;
 import com.ibm.websphere.ras.Tr;
@@ -137,6 +138,18 @@ public class Toolbox implements IToolbox {
     }
 
     /**
+     * The user id in previous releases is not encrypted because it is sensitive.
+     * However, encryption is now done on the user id to avoid path traversal attack through
+     * the id and to provide an unique string.
+     *
+     * @param userId user id
+     * @return The encrypted user id
+     */
+    public static String getEncodedUserId(String userId) {
+        return Base64.getUrlEncoder().encodeToString(userId.getBytes());
+    }
+
+    /**
      * Sets the catalog instance.
      * Must be called if deserialized by Jackson.
      * 
@@ -163,7 +176,7 @@ public class Toolbox implements IToolbox {
     @Trivial
     private synchronized void setOwnerId(final String userId) {
         this.ownerId = userId;
-        this.persistedName = PERSIST_NAME + "-" + userId;
+        this.persistedName = PERSIST_NAME + "-" + getEncodedUserId(userId);
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/pojo/Toolbox.java
+++ b/dev/com.ibm.ws.ui/src/com/ibm/ws/ui/internal/v1/pojo/Toolbox.java
@@ -146,7 +146,11 @@ public class Toolbox implements IToolbox {
      * @return The encrypted user id
      */
     public static String getEncodedUserId(String userId) {
-        return Base64.getUrlEncoder().encodeToString(userId.getBytes());
+        String encodedUserId = userId;
+        if (userId != null) {
+            encodedUserId = Base64.getUrlEncoder().encodeToString(userId.getBytes());
+        }
+        return encodedUserId;
     }
 
     /**


### PR DESCRIPTION
This PR persists the toolbox and tool data in a file name with encrypted user id. If there is existing toolbox or tool data persisted in the old file name, it will migrate the data to the new encrypted file name.

