### PR TITLE
Removed the common resource bundle from Export Packages for MPHealth

### DIFF
--- a/dev/com.ibm.ws.microprofile.health.2.0/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.health.2.0/bnd.bnd
@@ -38,11 +38,11 @@ Import-Package: \
   *
 
 Export-Package: \
-	com.ibm.ws.microprofile.health.resources,\
 	com.ibm.ws.microprofile.health.impl,\
 	com.ibm.ws.microprofile.health.spi.impl
 
 Private-Package: \
+	com.ibm.ws.microprofile.health.resources,\
 	com.ibm.ws.microprofile.health.internal,\
 	com.ibm.ws.microprofile.health.services,\
 	com.ibm.ws.microprofile.health.services.impl,\

--- a/dev/com.ibm.ws.microprofile.health/bnd.bnd
+++ b/dev/com.ibm.ws.microprofile.health/bnd.bnd
@@ -38,7 +38,6 @@ Import-Package: \
   *
 
 Export-Package: \
-    com.ibm.ws.microprofile.health.resources; version="1.0", \
     com.ibm.ws.microprofile.health.impl;version=1.0, \
     com.ibm.ws.microprofile.health.spi.impl;version=1.0
 

--- a/dev/io.openliberty.microprofile.health.3.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.health.3.0.internal/bnd.bnd
@@ -33,19 +33,18 @@ WS-TraceGroup: HEALTH
 Import-Package: \
   !com.ibm.ws.microprofile.health.spi.impl, \
   !com.ibm.ws.microprofile.health.impl,\
-  io.openliberty.microprofile.health.resources, \
   javax.enterprise.context.spi; version="[1.1,3)",\
   javax.enterprise.inject.*; version="[1.1,3)",\
   javax.enterprise.util; version="[1.1,3)",\
   *
 
 Export-Package: \
-	io.openliberty.microprofile.health.resources,\
 	io.openliberty.microprofile.health.internal.common,\
 	io.openliberty.microprofile.health30.impl,\
 	io.openliberty.microprofile.health30.spi.impl;version=1.0
 
 Private-Package: \
+	io.openliberty.microprofile.health.resources,\
 	com.ibm.ws.microprofile.health.internal,\
 	com.ibm.ws.microprofile.health.services,\
 	com.ibm.ws.microprofile.health.services.impl,\

--- a/dev/io.openliberty.microprofile.health.3.1.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.health.3.1.internal/bnd.bnd
@@ -33,14 +33,12 @@ WS-TraceGroup: HEALTH
 Import-Package: \
   !com.ibm.ws.microprofile.health.spi.impl, \
   !com.ibm.ws.microprofile.health.impl,\
-  io.openliberty.microprofile.health.resources,\
   javax.enterprise.context.spi; version="[1.1,3)",\
   javax.enterprise.inject.*; version="[1.1,3)",\
   javax.enterprise.util; version="[1.1,3)",\
   *
 
 Export-Package: \
-	io.openliberty.microprofile.health.resources,\
 	io.openliberty.microprofile.health.internal.common,\
 	io.openliberty.microprofile.health30.impl,\
 	io.openliberty.microprofile.health30.internal,\
@@ -48,6 +46,7 @@ Export-Package: \
 	io.openliberty.microprofile.health31.spi.impl;version=1.0
 
 Private-Package: \
+	io.openliberty.microprofile.health.resources,\
 	com.ibm.ws.microprofile.health.internal,\
 	com.ibm.ws.microprofile.health.services,\
 	com.ibm.ws.microprofile.health.services.impl,\

--- a/dev/io.openliberty.microprofile.health.internal.common/bnd.bnd
+++ b/dev/io.openliberty.microprofile.health.internal.common/bnd.bnd
@@ -25,8 +25,7 @@ Import-Package: \
   *
 
 Export-Package: \
-  io.openliberty.microprofile.health.internal.common,\
-  io.openliberty.microprofile.health.resources; version="1.0"
+  io.openliberty.microprofile.health.internal.common
   
 Private-Package: \
   io.openliberty.microprofile.health.resources


### PR DESCRIPTION
fixes #17353
- Removes the NLS resources from Export-Packages from all the bnd files for MP Health and adds it to Private-Packages