### PR TITLE
Issue 17404: Add cache to OIDC client inbound propagation processing

### DIFF
--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/structures/CacheEntry.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/structures/CacheEntry.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.common.structures;
+
+public class CacheEntry {
+
+    Object value;
+    long createdAt = 0L;
+
+    public CacheEntry(Object value) {
+        this.value = value;
+        this.createdAt = System.currentTimeMillis();
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public long getCreatedAt() {
+        return createdAt;
+    }
+
+    public boolean isExpired(long timeoutInMilliseconds) {
+        long now = System.currentTimeMillis();
+        if ((now - createdAt) > timeoutInMilliseconds) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        CacheEntry other = (CacheEntry) obj;
+        if (value == null) {
+            if (other.getValue() != null) {
+                return false;
+            }
+        } else if (!value.equals(other.getValue())) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/structures/CommonCache.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/structures/CommonCache.java
@@ -10,9 +10,6 @@
  *******************************************************************************/
 package com.ibm.ws.security.common.structures;
 
-import java.util.Timer;
-import java.util.TimerTask;
-
 import com.ibm.websphere.ras.annotation.Sensitive;
 
 public abstract class CommonCache {
@@ -26,11 +23,6 @@ public abstract class CommonCache {
      * Default cache timeout.
      */
     protected long timeoutInMilliSeconds = 5 * 60 * 1000;
-
-    /**
-     * Timer to schedule the eviction task.
-     */
-    protected Timer timer;
 
     public int size() {
         return this.entryLimit;
@@ -62,30 +54,6 @@ public abstract class CommonCache {
         if (newTimeoutInMillis > 0) {
             this.timeoutInMilliSeconds = newTimeoutInMillis;
         }
-        timer.cancel();
-        scheduleEvictionTask(timeoutInMilliSeconds);
-    }
-
-    protected void scheduleEvictionTask(long timeoutInMilliSeconds) {
-        EvictionTask evictionTask = new EvictionTask();
-        timer = new Timer(true);
-        long period = timeoutInMilliSeconds;
-        long delay = period;
-        timer.schedule(evictionTask, delay, period);
-    }
-
-    /**
-     * Implementation of the eviction strategy.
-     */
-    abstract protected void evictStaleEntries();
-
-    private class EvictionTask extends TimerTask {
-        /** {@inheritDoc} */
-        @Override
-        public void run() {
-            evictStaleEntries();
-        }
-
     }
 
 }

--- a/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/structures/SingleTableCache.java
+++ b/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/structures/SingleTableCache.java
@@ -32,7 +32,7 @@ public class SingleTableCache extends CommonCache {
         }
         lookupTable = Collections.synchronizedMap(new BoundedHashMap(this.entryLimit));
 
-        if (timeoutInMilliSeconds > 0) {
+        if (timeoutInMilliSeconds >= 0) {
             this.timeoutInMilliSeconds = timeoutInMilliSeconds;
         }
     }

--- a/dev/com.ibm.ws.security.common/test/com/ibm/ws/security/common/structures/CacheEntryTest.java
+++ b/dev/com.ibm.ws.security.common/test/com/ibm/ws/security/common/structures/CacheEntryTest.java
@@ -1,0 +1,122 @@
+package com.ibm.ws.security.common.structures;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.ws.security.test.common.CommonTestClass;
+
+import test.common.SharedOutputManager;
+
+public class CacheEntryTest extends CommonTestClass {
+
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("com.ibm.ws.security.common.*=all");
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    @Before
+    public void beforeTest() {
+        System.out.println("Entering test: " + testName.getMethodName());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.out.println("Exiting test: " + testName.getMethodName());
+        outputMgr.resetStreams();
+    }
+
+    @Test
+    public void test_equals_identicalValues() {
+        try {
+            String value = "value";
+            CacheEntry entry1 = new CacheEntry(value);
+            // Ensure the createdAt time for each is different
+            Thread.sleep(100);
+            CacheEntry entry2 = new CacheEntry(value);
+
+            assertTrue("Entry [" + entry1 + "] was not considered equal to [" + entry2 + "].", entry1.equals(entry2));
+            assertTrue("Entry [" + entry2 + "] was not considered equal to [" + entry1 + "].", entry2.equals(entry1));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_equals_differentValues() {
+        try {
+            String value1 = "value1";
+            String value2 = "value2";
+            CacheEntry entry1 = new CacheEntry(value1);
+            CacheEntry entry2 = new CacheEntry(value2);
+
+            assertFalse("Entry [" + entry1 + "] was considered equal to [" + entry2 + "].", entry1.equals(entry2));
+            assertFalse("Entry [" + entry2 + "] was considered equal to [" + entry1 + "].", entry2.equals(entry1));
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_isExpired_timeoutZero() {
+        try {
+            String value = "value";
+            CacheEntry entry = new CacheEntry(value);
+            long timeout = 0;
+
+            Thread.sleep(10);
+
+            boolean result = entry.isExpired(timeout);
+
+            assertTrue("Entry should have been considered expired, but wasn't. Entry created at [" + entry.getCreatedAt() + "]. Current time: [" + System.currentTimeMillis() + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_isExpired_shortTimeout_waitToExpire() {
+        try {
+            String value = "value";
+            CacheEntry entry = new CacheEntry(value);
+            long timeout = 50;
+
+            Thread.sleep(100);
+
+            boolean result = entry.isExpired(timeout);
+
+            assertTrue("Entry should have been considered expired, but wasn't. Entry created at [" + entry.getCreatedAt() + "]. Current time: [" + System.currentTimeMillis() + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
+    public void test_isExpired_longTimeout() {
+        try {
+            String value = "value";
+            CacheEntry entry = new CacheEntry(value);
+            long timeout = 1000 * 60;
+
+            boolean result = entry.isExpired(timeout);
+
+            assertFalse("Entry should not have been considered expired yet, but was. Entry created at [" + entry.getCreatedAt() + "]. Current time: [" + System.currentTimeMillis() + "].", result);
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.security.common/test/com/ibm/ws/security/common/structures/SingleTableCacheTest.java
+++ b/dev/com.ibm.ws.security.common/test/com/ibm/ws/security/common/structures/SingleTableCacheTest.java
@@ -221,7 +221,6 @@ public class SingleTableCacheTest extends CommonTestClass {
     public void test_rescheduleCleanup() {
         try {
             long originalTimeout = 100;
-            long newTimeout = originalTimeout * 3;
             SingleTableCache cache = new SingleTableCache(10, originalTimeout);
 
             String key = "key";
@@ -245,6 +244,7 @@ public class SingleTableCacheTest extends CommonTestClass {
             returnedValue = (String) cache.get(key);
             assertEquals("Returned value did not match the inputted value.", value, returnedValue);
 
+            long newTimeout = originalTimeout * 3;
             cache.rescheduleCleanup(newTimeout);
 
             // Make sure the value remains in the cache even after the reschedule

--- a/dev/com.ibm.ws.security.common/test/com/ibm/ws/security/common/structures/SingleTableCacheTest.java
+++ b/dev/com.ibm.ws.security.common/test/com/ibm/ws/security/common/structures/SingleTableCacheTest.java
@@ -50,11 +50,22 @@ public class SingleTableCacheTest extends CommonTestClass {
     }
 
     @Test
+    public void test_constructor_negativeTimeout() {
+        try {
+            SingleTableCache cache = new SingleTableCache(-5);
+            assertEquals("Cache size did not equal the expected value.", 50000, cache.size());
+            assertEquals("Cache timeout duration did not equal the expected value.", 5 * 60 * 1000, cache.getTimeoutInMilliseconds());
+        } catch (Throwable t) {
+            outputMgr.failWithThrowable(testName.getMethodName(), t);
+        }
+    }
+
+    @Test
     public void test_constructor_zeroTimeout() {
         try {
             SingleTableCache cache = new SingleTableCache(0);
             assertEquals("Cache size did not equal the expected value.", 50000, cache.size());
-            assertEquals("Cache timeout duration did not equal the expected value.", 5 * 60 * 1000, cache.getTimeoutInMilliseconds());
+            assertEquals("Cache timeout duration did not equal the expected value.", 0, cache.getTimeoutInMilliseconds());
         } catch (Throwable t) {
             outputMgr.failWithThrowable(testName.getMethodName(), t);
         }
@@ -65,7 +76,7 @@ public class SingleTableCacheTest extends CommonTestClass {
         try {
             SingleTableCache cache = new SingleTableCache(0, 0);
             assertEquals("Cache size did not equal the expected value.", 50000, cache.size());
-            assertEquals("Cache timeout duration did not equal the expected value.", 5 * 60 * 1000, cache.getTimeoutInMilliseconds());
+            assertEquals("Cache timeout duration did not equal the expected value.", 0, cache.getTimeoutInMilliseconds());
         } catch (Throwable t) {
             outputMgr.failWithThrowable(testName.getMethodName(), t);
         }

--- a/dev/com.ibm.ws.security.jwt/test/com/ibm/ws/security/jwt/internal/ConsumerUtilTest.java
+++ b/dev/com.ibm.ws.security.jwt/test/com/ibm/ws/security/jwt/internal/ConsumerUtilTest.java
@@ -773,11 +773,11 @@ public class ConsumerUtilTest {
             final String tokenString = testName.getMethodName();
             mockery.checking(new Expectations() {
                 {
-                    one(jwtContext).getJwtClaims();
+                    allowing(jwtContext).getJwtClaims();
                     will(returnValue(jwtClaims));
-                    one(jwtClaims).getExpirationTime();
+                    allowing(jwtClaims).getExpirationTime();
                     will(returnValue(createDate(1000 * 60 * 60 * 2)));
-                    one(jwtConfig).getClockSkew();
+                    allowing(jwtConfig).getClockSkew();
                     will(returnValue(3600L));
                 }
             });

--- a/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/JwtConsumerApiConfigTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/JwtConsumerApiConfigTests.java
@@ -29,6 +29,7 @@ import com.ibm.ws.security.fat.common.expectations.Expectations;
 import com.ibm.ws.security.fat.common.expectations.ResponseMessageExpectation;
 import com.ibm.ws.security.fat.common.expectations.ResponseStatusExpectation;
 import com.ibm.ws.security.fat.common.jwt.JWTTokenBuilder;
+import com.ibm.ws.security.fat.common.jwt.JwtConstants;
 import com.ibm.ws.security.fat.common.jwt.PayloadConstants;
 import com.ibm.ws.security.fat.common.jwt.expectations.JwtApiExpectation;
 import com.ibm.ws.security.fat.common.jwt.utils.JwtKeyTools;
@@ -77,6 +78,7 @@ public class JwtConsumerApiConfigTests extends CommonSecurityFat {
         serverTracker.addServer(consumerServer);
         skipRestoreServerTracker.addServer(consumerServer);
         consumerServer.addInstalledAppForValidation(JwtConsumerConstants.JWT_CONSUMER_SERVLET);
+        consumerServer.addInstalledAppForValidation(JwtConstants.JWT_SIMPLE_BUILDER_SERVLET);
         consumerServer.startServerUsingExpandedConfiguration("server_configTests.xml");
         SecurityFatHttpUtils.saveServerPorts(consumerServer, JwtConsumerConstants.BVT_SERVER_1_PORT_NAME_ROOT);
         // one of the JWT Consumer configs has an empty SignatureAlg value which results in a CWWKG0032W warning - mark this as "OK"

--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/l10n/metatype.properties
@@ -261,3 +261,6 @@ clockSkew.desc=Specifies the allowed clock skew in seconds when you validate the
 # Do not translate "Content Encryption Key", "JSON Web Encryption"
 keyManagementKeyAlias=Key management key alias
 keyManagementKeyAlias.desc=Private key alias of the key management key that is used to decrypt the Content Encryption Key of a JSON Web Encryption (JWE) token.
+
+accessTokenCacheTimeout=Access token cache timeout
+accessTokenCacheTimeout.desc=Specifies how long an authenticated subject that is created by using a propagated access token is cached.

--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/metatype/metatype.xml
@@ -147,6 +147,7 @@
          <AD id="requireExpClaimForIntrospection" name="internal" description="internal use only" required="false" type="Boolean" default="true" />
          <AD id="requireIatClaimForIntrospection" name="internal" description="internal use only" required="false" type="Boolean" default="true" />
          <AD id="keyManagementKeyAlias" name="%keyManagementKeyAlias" description="%keyManagementKeyAlias.desc" required="false" type="String" ibm:beta="true" />
+         <AD id="accessTokenCacheTimeout" name="%accessTokenCacheTimeout" description="%accessTokenCacheTimeout.desc" required="false" type="String" default="5m" ibm:type="duration" ibm:beta="true" />
      </OCD>
 
     <Designate factoryPid="com.ibm.ws.security.openidconnect.client.oidcClientConfig">

--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
@@ -169,6 +169,7 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     public static final String CFG_KEY_REQUIRE_EXP_CLAIM = "requireExpClaimForIntrospection";
     public static final String CFG_KEY_REQUIRE_IAT_CLAIM = "requireIatClaimForIntrospection";
     public static final String CFG_KEY_KEY_MANAGEMENT_KEY_ALIAS = "keyManagementKeyAlias";
+    public static final String CFG_KEY_ACCESS_TOKEN_CACHE_TIMEOUT = "accessTokenCacheTimeout";
 
     public static final String OPDISCOVERY_AUTHZ_EP_URL = "authorization_endpoint";
     public static final String OPDISCOVERY_TOKEN_EP_URL = "token_endpoint";
@@ -261,6 +262,7 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     private boolean requireExpClaimForIntrospection = true;
     private boolean requireIatClaimForIntrospection = true;
     private String keyManagementKeyAlias;
+    private long accessTokenCacheTimeout = 1000 * 60 * 5;
 
     private String oidcClientCookieName;
     private boolean authnSessionDisabled;
@@ -289,8 +291,7 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     private final DiscoveryConfigUtils discoveryUtils = new DiscoveryConfigUtils();
     private ConsumerUtils consumerUtils = null;
 
-    long timeoutInMilliseconds = 1000 * 60 * 5;
-    private SingleTableCache cache = new SingleTableCache(500, timeoutInMilliseconds);
+    private SingleTableCache cache = null;
 
     private boolean useSystemPropertiesForHttpClientConnections = false;
     private boolean tokenReuse = false;
@@ -535,6 +536,7 @@ public class OidcClientConfigImpl implements OidcClientConfig {
         requireExpClaimForIntrospection = configUtils.getBooleanConfigAttribute(props, CFG_KEY_REQUIRE_EXP_CLAIM, requireExpClaimForIntrospection);
         requireIatClaimForIntrospection = configUtils.getBooleanConfigAttribute(props, CFG_KEY_REQUIRE_IAT_CLAIM, requireIatClaimForIntrospection);
         keyManagementKeyAlias = configUtils.getConfigAttribute(props, CFG_KEY_KEY_MANAGEMENT_KEY_ALIAS);
+        accessTokenCacheTimeout = configUtils.getLongConfigAttribute(props, CFG_KEY_ACCESS_TOKEN_CACHE_TIMEOUT, accessTokenCacheTimeout);
         // TODO - 3Q16: Check the validationEndpointUrl to make sure it is valid
         // before continuing to process this config
         // checkValidationEndpointUrl();
@@ -546,6 +548,11 @@ public class OidcClientConfigImpl implements OidcClientConfig {
         }
 
         consumerUtils = new ConsumerUtils(keyStoreServiceRef);
+        if (cache == null) {
+            cache = new SingleTableCache(500, accessTokenCacheTimeout);
+        } else {
+            cache.rescheduleCleanup(accessTokenCacheTimeout);
+        }
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "id: " + id);
@@ -1894,6 +1901,11 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     @Override
     public String getKeyManagementKeyAlias() {
         return keyManagementKeyAlias;
+    }
+
+    @Override
+    public long getAccessTokenCacheTimeout() {
+        return accessTokenCacheTimeout;
     }
 
     @Override

--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/internal/OidcClientConfigImpl.java
@@ -65,6 +65,7 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.common.config.CommonConfigUtils;
 import com.ibm.ws.security.common.config.DiscoveryConfigUtils;
 import com.ibm.ws.security.common.jwk.impl.JWKSet;
+import com.ibm.ws.security.common.structures.SingleTableCache;
 import com.ibm.ws.security.jwt.config.ConsumerUtils;
 import com.ibm.ws.security.jwt.utils.JwtUtils;
 import com.ibm.ws.security.openidconnect.clients.common.ClientConstants;
@@ -287,6 +288,9 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     private final ConfigUtils oidcConfigUtils = new ConfigUtils(configAdminRef);
     private final DiscoveryConfigUtils discoveryUtils = new DiscoveryConfigUtils();
     private ConsumerUtils consumerUtils = null;
+
+    long timeoutInMilliseconds = 1000 * 60 * 5;
+    private SingleTableCache cache = new SingleTableCache(500, timeoutInMilliseconds);
 
     private boolean useSystemPropertiesForHttpClientConnections = false;
     private boolean tokenReuse = false;
@@ -1990,6 +1994,11 @@ public class OidcClientConfigImpl implements OidcClientConfig {
     public List<String> getAMRClaim() {
         // TODO Auto-generated method stub
         return null;
+    }
+
+    @Override
+    public SingleTableCache getCache() {
+        return cache;
     }
 
 }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientConfig.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientConfig.java
@@ -85,4 +85,6 @@ public interface OidcClientConfig extends ConvergedClientConfig {
 
     public SingleTableCache getCache();
 
+    public long getAccessTokenCacheTimeout();
+
 }

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientConfig.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/clients/common/OidcClientConfig.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.clients.common;
 
+import com.ibm.ws.security.common.structures.SingleTableCache;
+
 public interface OidcClientConfig extends ConvergedClientConfig {
 
     public static final String ID_TOKEN_ONLY = "ID_TOKEN_ONLY";
@@ -80,5 +82,7 @@ public interface OidcClientConfig extends ConvergedClientConfig {
     public boolean requireExpClaimForIntrospection();
 
     public boolean requireIatClaimForIntrospection();
+
+    public SingleTableCache getCache();
 
 }


### PR DESCRIPTION
For #17404

Uses the [SingleTableCache](https://github.com/OpenLiberty/open-liberty/blob/integration/dev/com.ibm.ws.security.common/src/com/ibm/ws/security/common/structures/SingleTableCache.java) class to cache authentication results for access tokens in the inbound propagation flow.

With these changes:
- Successful authentication results are cached for both opaque and JWT access tokens.
- Authentication results with a status other than `AuthResult.SUCCESS` are **not** cached.
- The created `ProviderAuthenticationResult` object is cached, which stores the built Subject and custom properties (among other things).