### PR TITLE
Force in Memory LDAP to use specific ports - avoid port conflict

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/Constants.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/Constants.java
@@ -218,4 +218,7 @@ public class Constants {
 
     /* ****************** Misc ****************************** */
     public static final String TEST_CASE = "test_case";
+    public static final int DEFAULT_LDAP_PORT = 9085;
+    public static final int DEFAULT_LDAP_SECURE_PORT = 8995;
+
 }

--- a/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderCommonLDAPFat.java
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderCommonLDAPFat.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import org.junit.AfterClass;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.com.unboundid.InMemoryLDAPServer;
 import com.ibm.ws.security.fat.common.CommonSecurityFat;
+import com.ibm.ws.security.fat.common.Constants;
 import com.ibm.ws.security.fat.common.servers.ServerBootstrapUtils;
 import com.unboundid.ldap.sdk.Entry;
 
@@ -55,7 +56,10 @@ public class JwtBuilderCommonLDAPFat extends CommonSecurityFat {
     }
 
     public static void initLdapServer() throws Exception {
-        ds = new InMemoryLDAPServer(BASE_DN);
+        // Choose a port for LDAP - we ran into an instance where 8020 and 8021 were chosen
+        // This caused problems starting one of the other servers that the tests use
+        //        ds = new InMemoryLDAPServer(BASE_DN);
+        ds = new InMemoryLDAPServer(true, Constants.DEFAULT_LDAP_PORT, Constants.DEFAULT_LDAP_SECURE_PORT, BASE_DN);
 
         /*
          * Add the partition entries.

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/CommonLocalLDAPServerSuite.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/CommonLocalLDAPServerSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -67,7 +67,14 @@ public class CommonLocalLDAPServerSuite {
      */
     @BeforeClass
     public void ldapSetUp() throws Exception {
-        ds = new InMemoryLDAPServer(LDAP_PARTITION_1_DN);
+        ldapSetUp(0); // use the default ports
+    }
+
+    public void ldapSetUp(int instance) throws Exception {
+        // Choose a port for LDAP - we ran into an instance where 8020 and 8021 were chosen
+        // This caused problems starting one of the other servers that the tests use
+        // ds = new InMemoryLDAPServer(LDAP_PARTITION_1_DN);
+        ds = new InMemoryLDAPServer(true, SAMLConstants.DEFAULT_LDAP_PORT + instance, SAMLConstants.DEFAULT_LDAP_SECURE_PORT + instance, LDAP_PARTITION_1_DN);
 
         ldapPort = ds.getLdapPort();
         ldapSSLPort = ds.getLdapsPort();

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLCommonTest.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLCommonTest.java
@@ -289,7 +289,7 @@ public class SAMLCommonTest extends CommonTest {
                 CommonLocalLDAPServerSuite two = new CommonLocalLDAPServerSuite();
                 one.ldapSetUp();
                 ldapRefList.add(one);
-                two.ldapSetUp();
+                two.ldapSetUp(1);
                 ldapRefList.add(two);
                 // we're having an issue with the in memory LDAP server on z/OS, added a method to see if it can accept requests,
                 // if NOT, we'll use a "external" LDAP server (Shibboleth allows for failover to additional LDAP servers, but,


### PR DESCRIPTION
When starting the in-memory LDAP server, specify the ports to use.
We've run into a problem in our test environment where the in memory LDAP is choosing a port that one of the test servers will want to use.  That test server will then have problems and will fail to start.  Have the in memory LDAP start with its own unique ports.

