### PR TITLE
Next round of fixes for wsAtomicTransaction for JAXWS 2.3 and 3.0

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.cxf.common-3.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.cxf.common-3.2.feature
@@ -12,7 +12,7 @@ Subsystem-Name: Internal Apache CXF 3.2 Common Feature for JAX-RS and JAX-WS
  com.ibm.ws.org.apache.cxf.cxf.core.3.2, \
  com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2, \
  com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.hc.3.2, \
- com.ibm.ws.org.apache.neethi.3.0.2, \
+ com.ibm.ws.org.apache.neethi.3.1.1, \
  com.ibm.ws.org.apache.ws.xmlschema.core.2.0.3, \
  com.ibm.ws.org.apache.xml.resolver.1.2
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlws.common-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.xmlws.common-3.0.feature
@@ -44,7 +44,7 @@ IBM-API-Package:\
  com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2.jakarta, \
  com.ibm.ws.org.apache.cxf.cxf.tools.common.3.2.jakarta, \
  com.ibm.ws.org.apache.cxf.cxf.tools.validator.3.2.jakarta, \
- com.ibm.ws.org.apache.neethi.3.0.2, \
+ com.ibm.ws.org.apache.neethi.3.1.1, \
  com.ibm.ws.org.apache.ws.xmlschema.core.2.0.3, \
  com.ibm.ws.org.apache.xml.resolver.1.2, \
  com.ibm.websphere.javaee.wsdl4j.1.2; location:="dev/api/spec/,lib/"; mavenCoordinates="wsdl4j:wsdl4j:1.6.3", \

--- a/dev/com.ibm.ws.jaxws.2.3.common/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.2.3.common/bnd.bnd
@@ -211,7 +211,7 @@ instrument.classesExcludes: com/ibm/ws/jaxws/internal/resources/*.class
 	com.ibm.websphere.org.osgi.service.component;version=latest,\
 	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
 	com.ibm.ws.webservices.handler;version=latest,\
-	com.ibm.ws.org.apache.neethi.3.0.2;version=latest,\
+	com.ibm.ws.org.apache.neethi.3.1.1;version=latest,\
 	com.ibm.websphere.appserver.spi.threading;version=latest, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.ws.jaxws.tools.2.2.10, \

--- a/dev/com.ibm.ws.jaxws.2.3.wsat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxws.2.3.wsat/bnd.bnd
@@ -53,7 +53,7 @@ Service-Component: \
 	com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2;version=latest,\
 	com.ibm.websphere.appserver.spi.logging;version=latest,\
 	com.ibm.websphere.appserver.spi.kernel.service;version=latest,\
-	com.ibm.ws.org.apache.neethi.3.0.2;version=latest,\
+	com.ibm.ws.org.apache.neethi.3.1.1;version=latest,\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.websphere.org.osgi.service.component;version=latest, \
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.overrides
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/bnd.overrides
@@ -113,6 +113,7 @@ Import-Package: \
   !com.sun.tools.internal.xjc.api, \
   !com.sun.tools.xjc.api, \
   !com.sun.xml.bind.api, \
+  !org.glassfish.jaxb.runtime.api, \
   !org.apache.karaf.jaas.boot.principal, \
   !sun.misc, \
   !com.ctc.wstx.*, \
@@ -137,6 +138,8 @@ Import-Package: \
 DynamicImport-Package: \
   com.ctc.wstx.*,\
   com.sun.xml.messaging.saaj.*,\
+  com.sun.xml.bind.*,\
+  org.glassfish.jaxb.*,\
   javax.xml.ws,\
   org.apache.cxf.bus,\
   org.apache.cxf.*

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/common/jaxb/JAXBUtils.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/common/jaxb/JAXBUtils.java
@@ -98,6 +98,10 @@ public final class JAXBUtils {
 
     private static final Logger LOG = LogUtils.getL7dLogger(JAXBUtils.class);
 
+    //Liberty change begin
+    private static boolean isEE9OrHigher = JAXBContext.class.getCanonicalName().startsWith("jakarta");
+    //Liberty change end
+
     public enum IdentifierType {
         CLASS,
         INTERFACE,
@@ -634,7 +638,11 @@ public final class JAXBUtils {
             } else if (marshaller.getClass().getName().contains("eclipse")) {
                 marshaller.setProperty("eclipselink.namespace-prefix-mapper",
                                        mapper);
+            //Liberty change begin
+            } else if (marshaller.getClass().getName().startsWith("org.glassfish.")) {
+                marshaller.setProperty("org.glassfish.jaxb.namespacePrefixMapper", mapper);
             }
+           //Liberty change end
         }
         return mapper;
     }
@@ -646,15 +654,20 @@ public final class JAXBUtils {
         try {
             Class<?> cls;
             Class<?> refClass;
-            String pkg = "com.sun.xml.bind.";
-            try {
-                cls = Class.forName("com.sun.xml.bind.api.JAXBRIContext");
-                refClass = Class.forName(pkg + "api.TypeReference");
-            } catch (ClassNotFoundException e) {
-                cls = Class.forName("com.sun.xml.internal.bind.api.JAXBRIContext", true, getXJCClassLoader());
-                pkg = "com.sun.xml.internal.bind.";
-                refClass = Class.forName(pkg + "api.TypeReference", true, getXJCClassLoader());
+            //Liberty change begin
+            if (isEE9OrHigher) {
+                cls = Class.forName("org.glassfish.jaxb.runtime.api.JAXBRIContext");
+                refClass = Class.forName("org.glassfish.jaxb.runtime.api.TypeReference");
+            } else {
+                try {
+                    cls = Class.forName("com.sun.xml.bind.api.JAXBRIContext");
+                    refClass = Class.forName("com.sun.xml.bind.api.TypeReference");
+                } catch (ClassNotFoundException e) {
+                    cls = Class.forName("com.sun.xml.internal.bind.api.JAXBRIContext", true, getXJCClassLoader());
+                    refClass = Class.forName("com.sun.xml.internal.bind.api.TypeReference", true, getXJCClassLoader());
+                }
             }
+            //Liberty change end
             Object ref = refClass.getConstructor(QName.class,
                                                  Type.class,
                                                  anns.getClass()).newInstance(qname, refcls, anns);
@@ -1145,7 +1158,7 @@ public final class JAXBUtils {
             //Liberty change begin
             String propertyName;
             //Jakarta EE 9
-            if (JAXBContext.class.getName().startsWith("jakarta.")) {
+            if (isEE9OrHigher) {
                 propertyName = "org.glassfish.jaxb.marshaller.CharacterEscapeHandler";
             } else {
                 String postFix = getPostfix(marshaller.getClass());
@@ -1179,7 +1192,7 @@ public final class JAXBUtils {
             //Liberty change begin
             String packageName;
             //Jakarta EE 9
-            if (JAXBContext.class.getName().startsWith("jakarta.")) {
+            if (isEE9OrHigher) {
                 packageName = "org.glassfish.jaxb.core.marshaller";
             } else {
                 String postFix = getPostfix(cls);

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/common/spi/NamespaceClassGenerator.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.core.3.2/src/org/apache/cxf/common/spi/NamespaceClassGenerator.java
@@ -1,0 +1,459 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.common.spi;
+
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.common.classloader.ClassLoaderUtils;
+import org.apache.cxf.common.logging.LogUtils;
+import org.apache.cxf.common.util.ASMHelper;
+import org.apache.cxf.common.util.OpcodesProxy;
+
+public class NamespaceClassGenerator extends ClassGeneratorClassLoader implements NamespaceClassCreator {
+
+    private static final Logger LOG = LogUtils.getL7dLogger(ClassGeneratorClassLoader.class);
+    private final ASMHelper helper;
+
+    public NamespaceClassGenerator(Bus bus) {
+        super(bus);
+        helper = bus.getExtension(ASMHelper.class);
+    }
+
+    @Override
+    public synchronized Class<?> createNamespaceWrapperClass(Class<?> mcls, Map<String, String> map) {
+        String postFix = "";
+
+        if (mcls.getName().contains("eclipse")) {
+            return createEclipseNamespaceMapper(mcls, map);
+        } else if (mcls.getName().contains(".internal")) {
+            postFix = "Internal";
+        } else if (mcls.getName().contains("com.sun")) {
+            postFix = "RI";
+        //Liberty change begin
+        } else if (mcls.getName().startsWith("org.glassfish")) {
+            postFix = "Glassfish";
+        }
+        //Liberty change end
+
+        String className = "org.apache.cxf.jaxb.NamespaceMapper";
+        className += postFix;
+        Class<?> cls = findClass(className, NamespaceClassCreator.class);
+        Throwable t = null;
+        if (cls == null) {
+            try {
+                byte[] bts = createNamespaceWrapperInternal(postFix);
+                className = "org.apache.cxf.jaxb.NamespaceMapper" + postFix;
+                return loadClass(className, NamespaceClassCreator.class, bts);
+            } catch (RuntimeException ex) {
+                // continue
+                t = ex;
+            }
+        }
+        if (cls == null
+                && (!mcls.getName().contains(".internal.") && mcls.getName().contains("com.sun"))) {
+            try {
+                cls = ClassLoaderUtils.loadClass("org.apache.cxf.common.jaxb.NamespaceMapper",
+                        NamespaceClassCreator.class);
+            } catch (Throwable ex2) {
+                // ignore
+                t = ex2;
+            }
+        }
+        LOG.log(Level.INFO, "Could not create a NamespaceMapper compatible with Marshaller class " + mcls.getName(), t);
+        return cls;
+    }
+
+    private Class<?> createEclipseNamespaceMapper(Class<?> mcls, Map<String, String> map) {
+        String className = "org.apache.cxf.jaxb.EclipseNamespaceMapper";
+        Class<?> cls = findClass(className, NamespaceClassCreator.class);
+        if (cls != null) {
+            return cls;
+        }
+        byte[] bts = createEclipseNamespaceMapper();
+        //previous code use mcls instead of NamespaceClassGenerator.class
+        return loadClass(className, NamespaceClassCreator.class, bts);
+    }
+
+    /*
+    // This is the "prototype" for the ASM generated class below
+    public static class MapNamespacePrefixMapper2
+        extends org.eclipse.persistence.internal.oxm.record.namespaces.MapNamespacePrefixMapper {
+
+        String[] nsctxt;
+
+        public MapNamespacePrefixMapper2(Map<String, String> foo) {
+            super(foo);
+        }
+        public String[] getPreDeclaredNamespaceUris() {
+            String[] sup = super.getPreDeclaredNamespaceUris();
+            if (nsctxt == null) {
+                return sup;
+            }
+            List<String> s = new ArrayList<>(Arrays.asList(sup));
+            for (int x = 1; x < nsctxt.length; x = x + 2) {
+                s.remove(nsctxt[x]);
+            }
+            return s.toArray(new String[s.size()]);
+        }
+        public void setContextualNamespaceDecls(String[] f) {
+            nsctxt = f;
+        }
+        public String[] getContextualNamespaceDecls() {
+            return nsctxt;
+        }
+    }
+    */
+    //CHECKSTYLE:OFF
+    //bunch of really long ASM based methods that cannot be shortened easily
+    private byte[] createEclipseNamespaceMapper() {
+        OpcodesProxy Opcodes = helper.getOpCodes();
+        String slashedName = "org/apache/cxf/jaxb/EclipseNamespaceMapper";
+        ASMHelper.ClassWriter cw = helper.createClassWriter();
+        if (cw == null) {
+            return null;
+        }
+        String superName = "org/eclipse/persistence/internal/oxm/record/namespaces/MapNamespacePrefixMapper";
+        ASMHelper.FieldVisitor fv;
+        ASMHelper.MethodVisitor mv;
+        cw.visit(Opcodes.V1_6,
+                Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL + Opcodes.ACC_SUPER,
+                slashedName, null,
+                superName, null);
+
+        cw.visitSource("EclipseNamespaceMapper.java", null);
+
+        fv = cw.visitField(Opcodes.ACC_PRIVATE, "nsctxt", "[Ljava/lang/String;", null, null);
+        fv.visitEnd();
+
+
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "(Ljava/util/Map;)V",
+                "(Ljava/util/Map<Ljava/lang/String;Ljava/lang/String;>;)V", null);
+        mv.visitCode();
+        ASMHelper.Label l0 = helper.createLabel();
+        mv.visitLabel(l0);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitVarInsn(Opcodes.ALOAD, 1);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL,
+                superName, "<init>", "(Ljava/util/Map;)V", false);
+        ASMHelper.Label l1 = helper.createLabel();
+        mv.visitLabel(l1);
+        mv.visitInsn(Opcodes.RETURN);
+        ASMHelper.Label l2 = helper.createLabel();
+        mv.visitLabel(l2);
+        mv.visitMaxs(0, 0);
+        mv.visitEnd();
+
+
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "setContextualNamespaceDecls", "([Ljava/lang/String;)V",
+                null, null);
+        mv.visitCode();
+        l0 = helper.createLabel();
+        mv.visitLabel(l0);
+        mv.visitLineNumber(47, l0);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitVarInsn(Opcodes.ALOAD, 1);
+        mv.visitFieldInsn(Opcodes.PUTFIELD, slashedName, "nsctxt", "[Ljava/lang/String;");
+        l1 = helper.createLabel();
+        mv.visitLabel(l1);
+        mv.visitLineNumber(48, l1);
+        mv.visitInsn(Opcodes.RETURN);
+        l2 = helper.createLabel();
+        mv.visitLabel(l2);
+        mv.visitLocalVariable("this", "L" + slashedName + ";", null, l0, l2, 0);
+        mv.visitLocalVariable("contextualNamespaceDecls", "[Ljava/lang/String;", null, l0, l2, 1);
+        mv.visitMaxs(0, 0);
+        mv.visitEnd();
+
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "getContextualNamespaceDecls", "()[Ljava/lang/String;", null, null);
+        mv.visitCode();
+        l0 = helper.createLabel();
+        mv.visitLabel(l0);
+        mv.visitLineNumber(51, l0);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitFieldInsn(Opcodes.GETFIELD, slashedName, "nsctxt", "[Ljava/lang/String;");
+        mv.visitInsn(Opcodes.ARETURN);
+        l1 = helper.createLabel();
+
+        mv.visitLabel(l1);
+        mv.visitLocalVariable("this", "L" + slashedName + ";", null, l0, l1, 0);
+
+        mv.visitMaxs(0, 0);
+        mv.visitEnd();
+
+
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "getPreDeclaredNamespaceUris", "()[Ljava/lang/String;", null, null);
+        mv.visitCode();
+        l0 = helper.createLabel();
+        mv.visitLabel(l0);
+        mv.visitLineNumber(1036, l0);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL,
+                superName,
+                "getPreDeclaredNamespaceUris", "()[Ljava/lang/String;", false);
+        mv.visitVarInsn(Opcodes.ASTORE, 1);
+        l1 = helper.createLabel();
+        mv.visitLabel(l1);
+        mv.visitLineNumber(1037, l1);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitFieldInsn(Opcodes.GETFIELD, slashedName, "nsctxt", "[Ljava/lang/String;");
+        l2 = helper.createLabel();
+        mv.visitJumpInsn(Opcodes.IFNONNULL, l2);
+        ASMHelper.Label l3 = helper.createLabel();
+        mv.visitLabel(l3);
+        mv.visitLineNumber(1038, l3);
+        mv.visitVarInsn(Opcodes.ALOAD, 1);
+        mv.visitInsn(Opcodes.ARETURN);
+        mv.visitLabel(l2);
+        mv.visitLineNumber(1040, l2);
+        mv.visitFrame(Opcodes.F_APPEND, 1, new Object[] {"[Ljava/lang/String;"}, 0, null);
+        mv.visitTypeInsn(Opcodes.NEW, "java/util/ArrayList");
+        mv.visitInsn(Opcodes.DUP);
+        mv.visitVarInsn(Opcodes.ALOAD, 1);
+        mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/util/Arrays", "asList",
+                "([Ljava/lang/Object;)Ljava/util/List;", false);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/util/ArrayList", "<init>",
+                "(Ljava/util/Collection;)V", false);
+        mv.visitVarInsn(Opcodes.ASTORE, 2);
+        ASMHelper.Label l4 = helper.createLabel();
+        mv.visitLabel(l4);
+        mv.visitLineNumber(1041, l4);
+        mv.visitInsn(Opcodes.ICONST_1);
+        mv.visitVarInsn(Opcodes.ISTORE, 3);
+        ASMHelper.Label l5 = helper.createLabel();
+        mv.visitLabel(l5);
+        ASMHelper.Label l6 = helper.createLabel();
+        mv.visitJumpInsn(Opcodes.GOTO, l6);
+        ASMHelper.Label l7 = helper.createLabel();
+        mv.visitLabel(l7);
+        mv.visitLineNumber(1042, l7);
+        mv.visitFrame(Opcodes.F_APPEND, 2, new Object[] {"java/util/List", Opcodes.INTEGER}, 0, null);
+        mv.visitVarInsn(Opcodes.ALOAD, 2);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitFieldInsn(Opcodes.GETFIELD, slashedName, "nsctxt", "[Ljava/lang/String;");
+        mv.visitVarInsn(Opcodes.ILOAD, 3);
+        mv.visitInsn(Opcodes.AALOAD);
+        mv.visitMethodInsn(Opcodes.INVOKEINTERFACE, "java/util/List", "remove", "(Ljava/lang/Object;)Z", true);
+        mv.visitInsn(Opcodes.POP);
+        ASMHelper.Label l8 = helper.createLabel();
+        mv.visitLabel(l8);
+        mv.visitLineNumber(1041, l8);
+        mv.visitIincInsn(3, 2);
+        mv.visitLabel(l6);
+        mv.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
+        mv.visitVarInsn(Opcodes.ILOAD, 3);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitFieldInsn(Opcodes.GETFIELD,
+                slashedName,
+                "nsctxt", "[Ljava/lang/String;");
+        mv.visitInsn(Opcodes.ARRAYLENGTH);
+        mv.visitJumpInsn(Opcodes.IF_ICMPLT, l7);
+        ASMHelper.Label l9 = helper.createLabel();
+        mv.visitLabel(l9);
+        mv.visitLineNumber(1044, l9);
+        mv.visitVarInsn(Opcodes.ALOAD, 2);
+        mv.visitVarInsn(Opcodes.ALOAD, 2);
+        mv.visitMethodInsn(Opcodes.INVOKEINTERFACE, "java/util/List", "size", "()I", true);
+        mv.visitTypeInsn(Opcodes.ANEWARRAY, "java/lang/String");
+        mv.visitMethodInsn(Opcodes.INVOKEINTERFACE, "java/util/List",
+                "toArray", "([Ljava/lang/Object;)[Ljava/lang/Object;", true);
+        mv.visitTypeInsn(Opcodes.CHECKCAST, "[Ljava/lang/String;");
+        mv.visitInsn(Opcodes.ARETURN);
+        ASMHelper.Label l10 = helper.createLabel();
+        mv.visitLabel(l10);
+        mv.visitLocalVariable("this", "L" + slashedName + ";",
+                null, l0, l10, 0);
+        mv.visitLocalVariable("sup", "[Ljava/lang/String;", null, l1, l10, 1);
+        mv.visitLocalVariable("s", "Ljava/util/List;", "Ljava/util/List<Ljava/lang/String;>;", l4, l10, 2);
+        mv.visitLocalVariable("x", "I", null, l5, l9, 3);
+        mv.visitMaxs(0, 0);
+        mv.visitEnd();
+
+        cw.visitEnd();
+
+        byte[] bts = cw.toByteArray();
+        return bts;
+    }
+
+    private byte[] createNamespaceWrapperInternal(String postFix) {
+
+        //Liberty change begin
+        String superName = "Glassfish".equals(postFix) ? 
+                        "org/glassfish/jaxb/runtime/marshaller/NamespacePrefixMapper" : 
+                        ("com/sun/xml/"
+                        + ("RI".equals(postFix) ? "" : "internal/")
+                        + "bind/marshaller/NamespacePrefixMapper");
+        //Liberty change end
+        String postFixedName = "org/apache/cxf/jaxb/NamespaceMapper" + postFix;
+        ASMHelper.ClassWriter cw = helper.createClassWriter();
+        if (cw == null) {
+            return null;
+        }
+        ASMHelper.FieldVisitor fv;
+        ASMHelper.MethodVisitor mv;
+        OpcodesProxy Opcodes= helper.getOpCodes();
+        cw.visit(Opcodes.V1_6,
+                Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL + Opcodes.ACC_SUPER,
+                postFixedName, null,
+                superName, null);
+
+        cw.visitSource("NamespaceMapper.java", null);
+
+        fv = cw.visitField(Opcodes.ACC_PRIVATE + Opcodes.ACC_FINAL,
+                "nspref", "Ljava/util/Map;",
+                "Ljava/util/Map<Ljava/lang/String;Ljava/lang/String;>;", null);
+        fv.visitEnd();
+
+        fv = cw.visitField(Opcodes.ACC_PRIVATE, "nsctxt", "[Ljava/lang/String;", null, null);
+        fv.visitEnd();
+
+        fv = cw.visitField(Opcodes.ACC_PRIVATE + Opcodes.ACC_FINAL + Opcodes.ACC_STATIC,
+                "EMPTY_STRING", "[Ljava/lang/String;", null, null);
+        fv.visitEnd();
+
+        mv = cw.visitMethod(Opcodes.ACC_STATIC, "<clinit>", "()V", null, null);
+        mv.visitCode();
+        ASMHelper.Label l0 = helper.createLabel();
+        mv.visitLabel(l0);
+        mv.visitLineNumber(30, l0);
+        mv.visitInsn(Opcodes.ICONST_0);
+        mv.visitTypeInsn(Opcodes.ANEWARRAY, "java/lang/String");
+        mv.visitFieldInsn(Opcodes.PUTSTATIC, postFixedName, "EMPTY_STRING", "[Ljava/lang/String;");
+        mv.visitInsn(Opcodes.RETURN);
+        mv.visitMaxs(0, 0);
+        mv.visitEnd();
+
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>",
+                "(Ljava/util/Map;)V",
+                "(Ljava/util/Map<Ljava/lang/String;Ljava/lang/String;>;)V", null);
+        mv.visitCode();
+        l0 = helper.createLabel();
+        mv.visitLabel(l0);
+        mv.visitLineNumber(32, l0);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, superName, "<init>", "()V", false);
+        ASMHelper.Label l1 = helper.createLabel();
+        mv.visitLabel(l1);
+        mv.visitLineNumber(29, l1);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitFieldInsn(Opcodes.GETSTATIC, postFixedName, "EMPTY_STRING", "[Ljava/lang/String;");
+        mv.visitFieldInsn(Opcodes.PUTFIELD, postFixedName, "nsctxt", "[Ljava/lang/String;");
+        ASMHelper.Label l2 = helper.createLabel();
+        mv.visitLabel(l2);
+        mv.visitLineNumber(33, l2);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitVarInsn(Opcodes.ALOAD, 1);
+        mv.visitFieldInsn(Opcodes.PUTFIELD, postFixedName, "nspref", "Ljava/util/Map;");
+        ASMHelper.Label l3 = helper.createLabel();
+        mv.visitLabel(l3);
+        mv.visitLineNumber(34, l3);
+        mv.visitInsn(Opcodes.RETURN);
+        ASMHelper.Label l4 = helper.createLabel();
+        mv.visitLabel(l4);
+        mv.visitLocalVariable("this", "L" + postFixedName + ";", null, l0, l4, 0);
+        mv.visitLocalVariable("nspref",
+                "Ljava/util/Map;", "Ljava/util/Map<Ljava/lang/String;Ljava/lang/String;>;",
+                l0, l4, 1);
+        mv.visitMaxs(0, 0);
+        mv.visitEnd();
+
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "getPreferredPrefix",
+                "(Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;",
+                null, null);
+        mv.visitCode();
+        l0 = helper.createLabel();
+        mv.visitLabel(l0);
+        mv.visitLineNumber(39, l0);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitFieldInsn(Opcodes.GETFIELD, postFixedName, "nspref", "Ljava/util/Map;");
+        mv.visitVarInsn(Opcodes.ALOAD, 1);
+        mv.visitMethodInsn(Opcodes.INVOKEINTERFACE, "java/util/Map",
+                "get", "(Ljava/lang/Object;)Ljava/lang/Object;", true);
+        mv.visitTypeInsn(Opcodes.CHECKCAST, "java/lang/String");
+        mv.visitVarInsn(Opcodes.ASTORE, 4);
+        l1 = helper.createLabel();
+        mv.visitLabel(l1);
+        mv.visitLineNumber(40, l1);
+        mv.visitVarInsn(Opcodes.ALOAD, 4);
+        l2 = helper.createLabel();
+        mv.visitJumpInsn(Opcodes.IFNULL, l2);
+        l3 = helper.createLabel();
+        mv.visitLabel(l3);
+        mv.visitLineNumber(41, l3);
+        mv.visitVarInsn(Opcodes.ALOAD, 4);
+        mv.visitInsn(Opcodes.ARETURN);
+        mv.visitLabel(l2);
+        mv.visitLineNumber(43, l2);
+        mv.visitFrame(Opcodes.F_APPEND, 1, new Object[] {"java/lang/String"}, 0, null);
+        mv.visitVarInsn(Opcodes.ALOAD, 2);
+        mv.visitInsn(Opcodes.ARETURN);
+        l4 = helper.createLabel();
+        mv.visitLabel(l4);
+        mv.visitLocalVariable("this", "L" + postFixedName + ";", null, l0, l4, 0);
+        mv.visitLocalVariable("namespaceUri", "Ljava/lang/String;", null, l0, l4, 1);
+        mv.visitLocalVariable("suggestion", "Ljava/lang/String;", null, l0, l4, 2);
+        mv.visitLocalVariable("requirePrefix", "Z", null, l0, l4, 3);
+        mv.visitLocalVariable("prefix", "Ljava/lang/String;", null, l1, l4, 4);
+        mv.visitMaxs(0, 0);
+        mv.visitEnd();
+
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "setContextualNamespaceDecls", "([Ljava/lang/String;)V", null, null);
+        mv.visitCode();
+        l0 = helper.createLabel();
+        mv.visitLabel(l0);
+        mv.visitLineNumber(47, l0);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitVarInsn(Opcodes.ALOAD, 1);
+        mv.visitFieldInsn(Opcodes.PUTFIELD, postFixedName, "nsctxt", "[Ljava/lang/String;");
+        l1 = helper.createLabel();
+        mv.visitLabel(l1);
+        mv.visitLineNumber(48, l1);
+        mv.visitInsn(Opcodes.RETURN);
+        l2 = helper.createLabel();
+        mv.visitLabel(l2);
+        mv.visitLocalVariable("this", "L" + postFixedName + ";", null, l0, l2, 0);
+        mv.visitLocalVariable("contextualNamespaceDecls", "[Ljava/lang/String;", null, l0, l2, 1);
+        mv.visitMaxs(0, 0);
+        mv.visitEnd();
+
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "getContextualNamespaceDecls", "()[Ljava/lang/String;", null, null);
+        mv.visitCode();
+        l0 = helper.createLabel();
+        mv.visitLabel(l0);
+        mv.visitLineNumber(51, l0);
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitFieldInsn(Opcodes.GETFIELD, postFixedName, "nsctxt", "[Ljava/lang/String;");
+        mv.visitInsn(Opcodes.ARETURN);
+        l1 = helper.createLabel();
+
+        mv.visitLabel(l1);
+        mv.visitLocalVariable("this", "L" + postFixedName + ";", null, l0, l1, 0);
+
+        mv.visitMaxs(0, 0);
+        mv.visitEnd();
+
+        cw.visitEnd();
+
+        return cw.toByteArray();
+    }
+    //CHECKSTYLE:ON
+}

--- a/dev/com.ibm.ws.wsat.common.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.wsat.common.3.2/bnd.bnd
@@ -71,7 +71,7 @@ instrument.classesExcludes: com/ibm/ws/wsat/resources/*.class
 	com.ibm.ws.org.apache.cxf.cxf.core.3.2;version=latest,\
 	com.ibm.ws.org.apache.cxf.cxf.rt.frontend.simple.3.2;version=latest,\
 	com.ibm.ws.org.apache.cxf.cxf.rt.ws.policy.3.2;version=latest,\
-	com.ibm.ws.org.apache.neethi.3.0.2;version=latest,\
+	com.ibm.ws.org.apache.neethi.3.1.1;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.ws.transport.http;version=latest,\
 	com.ibm.ws.tx.embeddable;version=latest,\

--- a/dev/com.ibm.ws.wsat.webservice.3.2/bnd.bnd
+++ b/dev/com.ibm.ws.wsat.webservice.3.2/bnd.bnd
@@ -81,7 +81,7 @@ Service-Component: \
 	com.ibm.ws.jaxws.wsat;version=latest,\
 	com.ibm.ws.kernel.service;version=latest,\
 	com.ibm.ws.logging;version=latest,\
-	com.ibm.ws.org.apache.neethi.3.0.2;version=latest,\
+	com.ibm.ws.org.apache.neethi.3.1.1;version=latest,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
 	com.ibm.ws.wsat.common;version=latest,\
 	com.ibm.ws.wsat.webclient;version=latest,\

--- a/dev/com.ibm.ws.wsat_fat.db/fat/src/com/ibm/ws/wsat/fat/tests/AssertionTest.java
+++ b/dev/com.ibm.ws.wsat_fat.db/fat/src/com/ibm/ws/wsat/fat/tests/AssertionTest.java
@@ -28,8 +28,9 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.ExpectedFFDC;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.EE8FeatureReplacementAction;
+import componenttest.rules.repeater.EmptyAction;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 import componenttest.topology.utils.HttpUtils;
@@ -143,9 +144,12 @@ public class AssertionTest extends WSATTest {
 		}
 	}
 
+	// CXF 2.6.2 does some work during Servlet.init that causes FFDC to come out,
+	// but with CXF 3.x, that logic does not happen any longer, so the FFDCs do not come out.
+	// See AbstractHTTPDestination.initConfig to see the difference in behavior.
 	@Test
-	@ExpectedFFDC(value = { "javax.servlet.ServletException", "java.lang.RuntimeException" })
-	@SkipForRepeat({"jaxws-2.3", SkipForRepeat.EE9_FEATURES})
+	@ExpectedFFDC(value = { "javax.servlet.ServletException", "java.lang.RuntimeException" },
+	              repeatAction = {EmptyAction.ID, EE8FeatureReplacementAction.ID})
 	public void testAssertionIgnorable() {
 		// Expect an exception because Atomic Transaction policy assertion
 		// MUST NOT include a wsp:Ignorable attribute with a value of 'true'.

--- a/dev/com.ibm.ws.wsat_fat.db/fat/src/com/ibm/ws/wsat/fat/tests/MultiServerTest.java
+++ b/dev/com.ibm.ws.wsat_fat.db/fat/src/com/ibm/ws/wsat/fat/tests/MultiServerTest.java
@@ -18,8 +18,6 @@ import java.io.BufferedReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-import javax.xml.ws.soap.SOAPFaultException;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -29,7 +27,6 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.ExpectedFFDC;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -113,7 +110,6 @@ public class MultiServerTest extends WSATTest {
 	
 	@Test
   @Mode(TestMode.LITE)
-        @SkipForRepeat({"jaxws-2.3", SkipForRepeat.EE9_FEATURES})
 	public void testOneway() {
 		try {
 			String urlStr = BASE_URL + "/oneway/OnewayClientServlet"
@@ -125,10 +121,12 @@ public class MultiServerTest extends WSATTest {
 			String result = br.readLine();
 			assertNotNull(result);
 			System.out.println("testOneway Result : " + result);
+			// The fault exception can start with jakarta or jaxa depending
+			// on if EE9 or before.
 			assertTrue(
 					"Cannot get expected exception from server",
-					result.contains(SOAPFaultException.class.getName()
-							+ ": WS-AT can not work on ONE-WAY webservice method"));
+					result.contains(".xml.ws.soap.SOAPFaultException:"
+							+ " WS-AT can not work on ONE-WAY webservice method"));
 			// List<String> errors = new ArrayList<String>();
 			// errors.add("WTRN0127E");
 			// server.addIgnoredErrors(errors);

--- a/dev/fattest.simplicity/src/componenttest/custom/junit/runner/FATRunner.java
+++ b/dev/fattest.simplicity/src/componenttest/custom/junit/runner/FATRunner.java
@@ -629,26 +629,28 @@ public class FATRunner extends BlockJUnit4ClassRunner {
 
         ExpectedFFDC ffdc = m.getAnnotation(ExpectedFFDC.class);
         if (ffdc != null) {
+            String[] exceptionClasses = ffdc.value();
             if (JakartaEE9Action.isActive()) {
-                String[] exceptionClasses = ffdc.value();
+                String[] jakarta9ReplacementExceptionClasses = new String[exceptionClasses.length];
+                System.arraycopy(exceptionClasses, 0, jakarta9ReplacementExceptionClasses, 0, exceptionClasses.length);
+                int index = 0;
                 for (String exceptionClass : exceptionClasses) {
                     if (ee9Helper == null) {
                         ee9Helper = new EE9PackageReplacementHelper();
                     }
-                    exceptionClass = ee9Helper.replacePackages(exceptionClass);
-                    annotationListPerClass.add(exceptionClass);
+                    jakarta9ReplacementExceptionClasses[index++] = ee9Helper.replacePackages(exceptionClass);
                 }
-            } else if (RepeatTestFilter.isAnyRepeatActionActive()) {
+                exceptionClasses = jakarta9ReplacementExceptionClasses;
+            }
+            if (RepeatTestFilter.isAnyRepeatActionActive()) {
                 for (String repeatAction : ffdc.repeatAction()) {
                     if (repeatAction.equals(ExpectedFFDC.ALL_REPEAT_ACTIONS) || RepeatTestFilter.isRepeatActionActive(repeatAction)) {
-                        String[] exceptionClasses = ffdc.value();
                         for (String exceptionClass : exceptionClasses) {
                             annotationListPerClass.add(exceptionClass);
                         }
                     }
                 }
             } else {
-                String[] exceptionClasses = ffdc.value();
                 for (String exceptionClass : exceptionClasses) {
                     annotationListPerClass.add(exceptionClass);
                 }

--- a/dev/wlp-jakartaee-transform/rules/jakarta-direct.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-direct.properties
@@ -154,7 +154,7 @@ javax.xml.ws.session.maintain=jakarta.xml.ws.session.maintain
 javax.xml.ws.soap.http.soapaction.use=jakarta.xml.ws.soap.http.soapaction.use
 javax.xml.ws.soap.http.soapaction.uri=jakarta.xml.ws.soap.http.soapaction.uri
 
-com.sun.xml.bind.v2.ContextFactory=org.glassfish.jaxb.runtime.v2.JAXBContextFactory
+com.sun.xml.bind.v2.ContextFactory=org.glassfish.jaxb.runtime.v2.ContextFactory
 com.ibm.xml.xlxp2.jaxb.JAXBContextFactory=org.glassfish.jaxb.runtime.v2.JAXBContextFactory
 
 javax.annotation.security.RolesAllowed=jakarta.annotation.security.RolesAllowed


### PR DESCRIPTION
- Update a couple of CXF classes to handle XML Binding (JAXB) 3.0
- Update AssertionTest to not expect the FFDCs when doing JXWS 2.3 and XMLWS 3.0 because of a change in how CXF initializes
- Update ExpectedFFDC to correctly handle EE9 for the repeatAction value
- Update JAXWS 2.3, XMLWS 3.0 and JAXRS 2.1 to use a newer version of Apache neethi to line up with what is being done with wsSecurity to support JAXWS 2.3 and XMLWS 3.0