### PR TITLE
Update to handle JAVA_HOME not being set in client script

### DIFF
--- a/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client
+++ b/dev/com.ibm.ws.appclient.boot.ws-client/publish/bin/client
@@ -424,8 +424,13 @@ clientEnvAndJVMOptions()
     mergeJVMOptions "${WLP_INSTALL_DIR}/etc/client.jvm.options"
   fi
   
-  # If we are running on Java 9, apply Liberty's built-in java 9 options
-  if [ -f "${JAVA_HOME}/lib/modules" ]; then
+  JPMS_MODULE_FILE_LOCATION="${JAVA_HOME}/lib/modules"
+  if [ -z "${JAVA_HOME}" ]; then
+    JPMS_MODULE_FILE_LOCATION=$(dirname $(dirname $(which java)))/lib/modules
+  fi
+
+  # If we are running on Java 9, apply Liberty's built-in java 9 options  
+  if [ -f "${JPMS_MODULE_FILE_LOCATION}" ]; then
     mergeJVMOptions "${WLP_INSTALL_DIR}/lib/platform/java/java9.options"
   fi
 


### PR DESCRIPTION
- When determining if we are using a Java level of 9 or greater, the client script did not handle when JAVA_HOME was not set.
- This is a port of PR #7567 where the same thing was updated for the server script.
