### PR TITLE
PR for Issue 17072: Add support for JWT-formatted UserInfo responses

### DIFF
--- a/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JweHelper.java
+++ b/dev/com.ibm.ws.security.jwt/src/com/ibm/ws/security/jwt/utils/JweHelper.java
@@ -98,8 +98,17 @@ public class JweHelper {
         return (keyAlias != null || keyLocation != null);
     }
 
-    @FFDCIgnore({ Exception.class })
     public static String extractJwsFromJweToken(String jweString, JwtConsumerConfig config, MpConfigProperties mpConfigProps) throws InvalidTokenException {
+        String payload = extractPayloadFromJweToken(jweString, config, mpConfigProps);
+        if (!isJws(payload)) {
+            String errorMsg = Tr.formatMessage(tc, "NESTED_JWS_REQUIRED_BUT_NOT_FOUND");
+            throw new InvalidTokenException(errorMsg);
+        }
+        return payload;
+    }
+
+    @FFDCIgnore({ Exception.class })
+    public static String extractPayloadFromJweToken(String jweString, JwtConsumerConfig config, MpConfigProperties mpConfigProps) throws InvalidTokenException {
         JweHelper helper = new JweHelper();
         String payload = null;
         try {
@@ -107,10 +116,6 @@ public class JweHelper {
         } catch (Exception e) {
             String errorMsg = Tr.formatMessage(tc, "ERROR_EXTRACTING_JWS_PAYLOAD_FROM_JWE", new Object[] { config.getId(), e });
             throw new InvalidTokenException(errorMsg, e);
-        }
-        if (!isJws(payload)) {
-            String errorMsg = Tr.formatMessage(tc, "NESTED_JWS_REQUIRED_BUT_NOT_FOUND");
-            throw new InvalidTokenException(errorMsg);
         }
         return payload;
     }

--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/AccessTokenAuthenticator.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/AccessTokenAuthenticator.java
@@ -360,6 +360,7 @@ public class AccessTokenAuthenticator {
         }
         String contentType = getContentType(entity);
         if (contentType == null) {
+            logError(clientConfig, oidcClientRequest, "PROPAGATION_TOKEN_INVALID_VALIDATION_URL", clientConfig.getValidationEndpointUrl());
             return null;
         }
         JSONObject jobj = null;

--- a/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/AccessTokenAuthenticator.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/src/com/ibm/ws/security/openidconnect/client/AccessTokenAuthenticator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 IBM Corporation and others.
+ * Copyright (c) 2016, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,7 +27,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
-import org.apache.http.ParseException;
 import org.apache.http.StatusLine;
 import org.apache.http.util.EntityUtils;
 
@@ -38,6 +37,8 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ssl.JSSEHelper;
 import com.ibm.websphere.ssl.SSLException;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.kernel.productinfo.ProductInfo;
+import com.ibm.ws.security.jwt.utils.JweHelper;
 import com.ibm.ws.security.openidconnect.client.internal.TraceConstants;
 import com.ibm.ws.security.openidconnect.client.jose4j.util.Jose4jUtil;
 import com.ibm.ws.security.openidconnect.clients.common.ClientConstants;
@@ -66,6 +67,8 @@ public class AccessTokenAuthenticator {
     OidcClientUtil oidcClientUtil = new OidcClientUtil();
     SSLSupport sslSupport = null;
     private Jose4jUtil jose4jUtil = null;
+
+    private static boolean issuedBetaMessage = false;
 
     public AccessTokenAuthenticator() {
     }
@@ -271,93 +274,168 @@ public class AccessTokenAuthenticator {
         return sslSocketFactory;
     }
 
-    @FFDCIgnore({ IOException.class })
-    JSONObject handleResponseMap(Map<String, Object> responseMap, OidcClientConfig clientConfig, OidcClientRequest oidcClientRequest) throws ParseException, IOException {
-        String jresponse = null;
-        JSONObject jobj = null, errorjson = null;
+    JSONObject handleResponseMap(Map<String, Object> responseMap, OidcClientConfig clientConfig, OidcClientRequest oidcClientRequest) throws Exception {
+        JSONObject jobj = null;
 
         if (responseMap.get(ClientConstants.RESPONSEMAP_CODE) != null) {
             HttpResponse response = (HttpResponse) responseMap.get(ClientConstants.RESPONSEMAP_CODE);
             if (isErrorResponse(response)) {
-                HttpEntity entity = response.getEntity();
-                if (entity != null) {
-                    jresponse = EntityUtils.toString(entity);
-                    try {
-                        if (jresponse != null) {
-                            if (tc.isDebugEnabled()) {
-                                Tr.debug(tc, "received error from OP =", jresponse);
-                                // Tr.debug(tc, "debugging:" +
-                                // OidcUtil.dumpStackTrace(new Exception(),
-                                // -1));
-                            }
-                            errorjson = JSONObject.parse(jresponse);
-                            logErrorMessage(errorjson, clientConfig, oidcClientRequest);// we
-                                                                                        // are
-                                                                                        // logging
-                                                                                        // error
-                                                                                        // messages
-                                                                                        // here,
-                                                                                        // so
-                                                                                        // we
-                                                                                        // stop
-                                                                                        // the
-                                                                                        // processing
-                                                                                        // here.
-                            return null;
-                        }
-                    } catch (IOException ioe) {
-                        // ignore, we'll continue with logging the error message
-                    }
-                }
-
-                if (jresponse == null || jresponse.isEmpty()) {
-                    // WWW-Authenticate: Bearer error=invalid_token,
-                    // error_description=CWWKS1617E: A userinfo request was made
-                    // with an access token that was not recognized. The request
-                    // URI was /oidc/endpoint/OidcConfigSample/userinfo.
-                    Header header = response.getFirstHeader("WWW-Authenticate");
-                    jresponse = header.getValue();
-                }
-
-                if (jresponse != null) {
-                    if (tc.isDebugEnabled()) {
-                        Tr.debug(tc, "received error from OP and extracted it from the header =", jresponse);
-                        // Tr.debug(tc, "debugging:" +
-                        // OidcUtil.dumpStackTrace(new Exception(), -1));
-                    }
-
-                    if (jresponse.contains(INVALID_TOKEN)) {
-                        logError(clientConfig, oidcClientRequest, "PROPAGATION_TOKEN_NOT_ACTIVE", clientConfig.getValidationMethod(), clientConfig.getValidationEndpointUrl());
-                    }
-                    String originalError = extractErrorDescription(jresponse);
-                    if (originalError != null) {
-                        if (tc.isDebugEnabled()) {
-                            Tr.debug(tc, "the original error from OP =", originalError);
-                        }
-                    }
-                    logError(clientConfig, oidcClientRequest, "OIDC_PROPAGATION_FAIL", originalError, clientConfig.getValidationEndpointUrl());
-                } else {
-                    logError(clientConfig, oidcClientRequest, "OIDC_PROPAGATION_FAIL", "", clientConfig.getValidationEndpointUrl());
-                }
-
-                jobj = null;
+                jobj = extractErrorResponse(clientConfig, oidcClientRequest, response);
             } else {
                 // HTTP 200 response
-                HttpEntity entity = response.getEntity();
-                if (entity != null) {
-                    jresponse = EntityUtils.toString(entity);
-                }
-                try {
-                    jobj = JSONObject.parse(jresponse);
-                } catch (IOException e) {
-                    if (tc.isDebugEnabled()) {
-                        Tr.debug(tc, "the response from OP is not in JSON format = ", jresponse);
-                    }
-                    logError(clientConfig, oidcClientRequest, "PROPAGATION_TOKEN_INVALID_VALIDATION_URL", clientConfig.getValidationEndpointUrl());
-                }
+                jobj = extractSuccessfulResponse(clientConfig, oidcClientRequest, response);
             }
         }
         return jobj;
+    }
+
+    @FFDCIgnore({ IOException.class })
+    JSONObject extractErrorResponse(OidcClientConfig clientConfig, OidcClientRequest oidcClientRequest, HttpResponse response) throws IOException {
+        String jresponse = null;
+        JSONObject jobj = null;
+        JSONObject errorjson = null;
+        HttpEntity entity = response.getEntity();
+        if (entity != null) {
+            jresponse = EntityUtils.toString(entity);
+            try {
+                if (jresponse != null) {
+                    if (tc.isDebugEnabled()) {
+                        Tr.debug(tc, "received error from OP =", jresponse);
+                        // Tr.debug(tc, "debugging:" +
+                        // OidcUtil.dumpStackTrace(new Exception(),
+                        // -1));
+                    }
+                    errorjson = JSONObject.parse(jresponse);
+                    // we are logging error messages here, so we stop the processing here.
+                    logErrorMessage(errorjson, clientConfig, oidcClientRequest);
+                    return null;
+                }
+            } catch (IOException ioe) {
+                // ignore, we'll continue with logging the error message
+            }
+        }
+
+        if (jresponse == null || jresponse.isEmpty()) {
+            // WWW-Authenticate: Bearer error=invalid_token,
+            // error_description=CWWKS1617E: A userinfo request was made
+            // with an access token that was not recognized. The request
+            // URI was /oidc/endpoint/OidcConfigSample/userinfo.
+            Header header = response.getFirstHeader("WWW-Authenticate");
+            jresponse = header.getValue();
+        }
+
+        if (jresponse != null) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "received error from OP and extracted it from the header =", jresponse);
+                // Tr.debug(tc, "debugging:" +
+                // OidcUtil.dumpStackTrace(new Exception(), -1));
+            }
+
+            if (jresponse.contains(INVALID_TOKEN)) {
+                logError(clientConfig, oidcClientRequest, "PROPAGATION_TOKEN_NOT_ACTIVE", clientConfig.getValidationMethod(), clientConfig.getValidationEndpointUrl());
+            }
+            String originalError = extractErrorDescription(jresponse);
+            if (originalError != null) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "the original error from OP =", originalError);
+                }
+            }
+            logError(clientConfig, oidcClientRequest, "OIDC_PROPAGATION_FAIL", originalError, clientConfig.getValidationEndpointUrl());
+        } else {
+            logError(clientConfig, oidcClientRequest, "OIDC_PROPAGATION_FAIL", "", clientConfig.getValidationEndpointUrl());
+        }
+
+        jobj = null;
+        return jobj;
+    }
+
+    JSONObject extractSuccessfulResponse(OidcClientConfig clientConfig, OidcClientRequest oidcClientRequest, HttpResponse response) throws Exception {
+        HttpEntity entity = response.getEntity();
+        String jresponse = null;
+        if (entity != null) {
+            jresponse = EntityUtils.toString(entity);
+        }
+        if (jresponse == null) {
+            return null;
+        }
+        String contentType = getContentType(entity);
+        if (contentType == null) {
+            return null;
+        }
+        JSONObject jobj = null;
+        if (contentType.contains("application/json")) {
+            jobj = extractClaimsFromJsonResponse(jresponse, clientConfig, oidcClientRequest);
+        } else if (contentType.contains("application/jwt") && isRunningBetaMode()) {
+            jobj = extractClaimsFromJwtResponse(jresponse, clientConfig, oidcClientRequest);
+        }
+        return jobj;
+    }
+
+    String getContentType(HttpEntity entity) {
+        Header contentTypeHeader = entity.getContentType();
+        if (contentTypeHeader != null) {
+            return contentTypeHeader.getValue();
+        }
+        return null;
+    }
+
+    @FFDCIgnore({ IOException.class })
+    JSONObject extractClaimsFromJsonResponse(String jresponse, OidcClientConfig clientConfig, OidcClientRequest oidcClientRequest) {
+        JSONObject jobj = null;
+        try {
+            jobj = JSONObject.parse(jresponse);
+        } catch (IOException e) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "the response from OP is not in JSON format = ", jresponse);
+            }
+            logError(clientConfig, oidcClientRequest, "PROPAGATION_TOKEN_INVALID_VALIDATION_URL", clientConfig.getValidationEndpointUrl());
+        }
+        return jobj;
+    }
+
+    JSONObject extractClaimsFromJwtResponse(String responseString, OidcClientConfig clientConfig, OidcClientRequest oidcClientRequest) throws Exception {
+        if (responseString == null || responseString.isEmpty()) {
+            return null;
+        }
+        boolean isJwe = false;
+        if (JweHelper.isJwe(responseString)) {
+            responseString = JweHelper.extractPayloadFromJweToken(responseString, clientConfig, null);
+            isJwe = true;
+        }
+        if (JweHelper.isJws(responseString)) {
+            // TODO - parse differently
+            //            // Option 1
+            //            jose4jUtil.createResultWithJose4JForJwt(responseString, clientConfig, oidcClientRequest);
+            //            // Option 2
+            //            ConsumerUtils consumerUtils = clientConfig.getConsumerUtils();
+            //            if (consumerUtils != null) {
+            //                JwtToken jwtResponse = consumerUtils.parseJwt(responseString, clientConfig);
+            //                if (jwtResponse != null) {
+            //                    Claims claims = jwtResponse.getClaims();
+            //                    if (claims != null) {
+            //                        responseString = claims.toJsonString();
+            //                        return JSONObject.parse(responseString);
+            //                    }
+            //                }
+            //            }
+        } else if (isJwe) {
+            // JWE payloads can be either JWS or raw JSON, so allow falling back to parsing raw JSON in the case of a JWE response
+            return extractClaimsFromJsonResponse(responseString, clientConfig, oidcClientRequest);
+        }
+        return null;
+    }
+
+    boolean isRunningBetaMode() {
+        if (!ProductInfo.getBetaEdition()) {
+            return false;
+        } else {
+            // Running beta exception, issue message if we haven't already issued one for this class
+            if (!issuedBetaMessage) {
+                Tr.info(tc, "BETA: A beta method has been invoked for the class " + this.getClass().getName() + " for the first time.");
+                issuedBetaMessage = !issuedBetaMessage;
+            }
+            return true;
+        }
     }
 
     /**
@@ -521,10 +599,9 @@ public class AccessTokenAuthenticator {
 
     protected ProviderAuthenticationResult getUserInfoFromToken(OidcClientConfig clientConfig, String accessToken, SSLSocketFactory sslSocketFactory, OidcClientRequest oidcClientRequest) {
         ProviderAuthenticationResult oidcResult = new ProviderAuthenticationResult(AuthResult.FAILURE, HttpServletResponse.SC_UNAUTHORIZED);
-        Map<String, Object> responseMap = null;
         JSONObject jobj = null;
         try {
-            responseMap = oidcClientUtil.getUserinfo(clientConfig.getValidationEndpointUrl(), accessToken, sslSocketFactory, clientConfig.isHostNameVerificationEnabled(), clientConfig.getUseSystemPropertiesForHttpClientConnections());
+            Map<String, Object> responseMap = oidcClientUtil.getUserinfo(clientConfig.getValidationEndpointUrl(), accessToken, sslSocketFactory, clientConfig.isHostNameVerificationEnabled(), clientConfig.getUseSystemPropertiesForHttpClientConnections());
 
             jobj = handleResponseMap(responseMap, clientConfig, oidcClientRequest);
             if (jobj != null) {
@@ -544,13 +621,17 @@ public class AccessTokenAuthenticator {
         } catch (Exception e) {
             if (tc.isDebugEnabled()) {
                 Tr.debug(tc, "exception while getting the userInfo =", e.getLocalizedMessage());
-                // Tr.debug(tc, "debugging:" + OidcUtil.dumpStackTrace(new
-                // Exception(), -1));
             }
             logError(clientConfig, oidcClientRequest, "PROPAGATION_TOKEN_INTERNAL_ERR", e.getLocalizedMessage(), clientConfig.getValidationMethod(), clientConfig.getValidationEndpointUrl());
             return oidcResult;
         }
 
+        addUserInfoStringToCustomProperties(oidcResult, jobj);
+
+        return oidcResult;
+    }
+
+    void addUserInfoStringToCustomProperties(ProviderAuthenticationResult oidcResult, JSONObject jobj) {
         // if result was good, put userinfo string on the subject as well.
         try {
             String userInfoStr = jobj == null ? null : jobj.serialize();
@@ -559,40 +640,28 @@ public class AccessTokenAuthenticator {
             }
         } catch (IOException e) {
         } // ffdc
-
-        return oidcResult;
     }
 
-    /**
-     * @param jobj
-     * @param clientConfig
-     * @return
-     */
     private boolean validateUserinfoJsonResponse(JSONObject jobj, OidcClientConfig clientConfig, OidcClientRequest oidcClientRequest) {
-        // TODO Auto-generated method stub
         String err = (String) jobj.get(Constants.ERROR);
         if (err != null) {
             logErrorMessage(jobj, clientConfig, oidcClientRequest);
             return false;
-        } else {
-            String issuer = (String) jobj.get("iss");
-            String issuers = null;
-            if (issuer != null) {
-                if (issuer.isEmpty() ||
-                        ((issuers = getIssuerIdentifier(clientConfig)) == null) ||
-                        notContains(issuers, issuer)) {
-                    logError(clientConfig, oidcClientRequest, "PROPAGATION_TOKEN_ISS_ERROR", issuers, issuer);
-                    return false;
-                }
+        }
+        // TODO - https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse
+        // The sub (subject) Claim MUST always be returned in the UserInfo Response.
+        // The sub Claim in the UserInfo Response MUST be verified to exactly match the sub Claim in the ID Token; if they do not match, the UserInfo Response values MUST NOT be used.
+        // ayoho note: For propagated access tokens, we don't have an ID token - do we just verify that the sub claim is present?
+        // If signed, the UserInfo Response SHOULD contain the Claims iss (issuer) and aud (audience) as members. The iss value SHOULD be the OP's Issuer Identifier URL. The aud value SHOULD be or include the RP's Client ID value.
+        String issuer = (String) jobj.get("iss");
+        String issuers = null;
+        if (issuer != null) {
+            if (issuer.isEmpty() ||
+                    ((issuers = getIssuerIdentifier(clientConfig)) == null) ||
+                    notContains(issuers, issuer)) {
+                logError(clientConfig, oidcClientRequest, "PROPAGATION_TOKEN_ISS_ERROR", issuers, issuer);
+                return false;
             }
-            // TODO
-            // else {
-            // required field
-            // logError(clientConfig,
-            // "PROPAGATION_TOKEN_MISSING_REQUIRED_CLAIM_ERR", "iss",
-            // "iss, iat, exp");
-            // return false;
-            // }
         }
         return true;
     }

--- a/dev/com.ibm.ws.security.openidconnect.client/test/com/ibm/ws/security/openidconnect/client/AccessTokenAuthenticatorTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/test/com/ibm/ws/security/openidconnect/client/AccessTokenAuthenticatorTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corporation and others.
+ * Copyright (c) 2016, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.openidconnect.client;
 
@@ -15,10 +15,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.security.Key;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,13 +31,13 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
-import org.apache.http.ParseException;
 import org.apache.http.StatusLine;
 import org.apache.http.entity.BasicHttpEntity;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JUnit4Mockery;
 import org.jmock.lib.legacy.ClassImposteriser;
+import org.jose4j.jwt.consumer.InvalidJwtException;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -47,11 +49,15 @@ import org.junit.rules.TestRule;
 
 import com.ibm.json.java.JSONObject;
 import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.websphere.security.jwt.InvalidTokenException;
 import com.ibm.websphere.ssl.JSSEHelper;
 import com.ibm.websphere.ssl.SSLConfig;
 import com.ibm.websphere.ssl.SSLConfigChangeListener;
 import com.ibm.websphere.ssl.SSLConfigurationNotAvailableException;
 import com.ibm.websphere.ssl.SSLException;
+import com.ibm.ws.common.internal.encoder.Base64Coder;
+import com.ibm.ws.security.common.crypto.HashUtils;
+import com.ibm.ws.security.jwt.config.ConsumerUtils;
 import com.ibm.ws.security.openidconnect.clients.common.ClientConstants;
 import com.ibm.ws.security.openidconnect.clients.common.MockOidcClientRequest;
 import com.ibm.ws.security.openidconnect.clients.common.OidcClientConfig;
@@ -95,6 +101,7 @@ public class AccessTokenAuthenticatorTest {
     private final HttpResponse httpResponse = mockery.mock(HttpResponse.class, "httpResponse");
     private final StatusLine statusLine = mockery.mock(StatusLine.class, "statusLine");
     private final Header header = mockery.mock(Header.class, "header");
+    private final Key decryptionKey = mockery.mock(Key.class);
     protected final SSLSocketFactory sslSocketFactory = mockery.mock(SSLSocketFactory.class, "sslSocketFactory");
 
     private static final AccessTokenAuthenticatorTest authenticatorTest = new AccessTokenAuthenticatorTest();
@@ -109,7 +116,12 @@ public class AccessTokenAuthenticatorTest {
     private static final String SUPPORTED = "supported";
     private static final String REQUIRED = "required";
 
-    private final AccessTokenAuthenticator tokenAuth = new AccessTokenAuthenticator();
+    private final AccessTokenAuthenticator tokenAuth = new AccessTokenAuthenticator() {
+        @Override
+        boolean isRunningBetaMode() {
+            return true;
+        }
+    };
     private final AccessTokenAuthenticator sslTokenAuth = new FakeAccessTokenAuthenticator(sslSupport);
     private final ReferrerURLCookieHandler referrerURLCookieHandler = new ReferrerURLCookieHandler(webAppSecConfig);
     private final Map<String, Object> respMap = new HashMap<String, Object>();
@@ -250,6 +262,7 @@ public class AccessTokenAuthenticatorTest {
         final InputStream input = new ByteArrayInputStream(getJSONObjectString(true, currentDate, currentDate).getBytes());
         final BasicHttpEntity entity = new BasicHttpEntity();
         entity.setContent(input);
+        entity.setContentType("application/json");
 
         mockery.checking(new Expectations() {
             {
@@ -296,6 +309,7 @@ public class AccessTokenAuthenticatorTest {
         final InputStream input = new ByteArrayInputStream(getJSONObjectString(true, currentDate, currentDate).getBytes());
         final BasicHttpEntity entity = new BasicHttpEntity();
         entity.setContent(input);
+        entity.setContentType("application/json");
 
         mockery.checking(new Expectations() {
             {
@@ -365,6 +379,7 @@ public class AccessTokenAuthenticatorTest {
         final InputStream input = new ByteArrayInputStream(getJSONObjectString(true, currentDate, currentDate, GOOD_ISSUER).getBytes());
         final BasicHttpEntity entity = new BasicHttpEntity();
         entity.setContent(input);
+        entity.setContentType("application/json");
 
         mockery.checking(new Expectations() {
             {
@@ -414,6 +429,7 @@ public class AccessTokenAuthenticatorTest {
         final InputStream input = new ByteArrayInputStream(getJSONObjectString(true, currentDate, currentDate).getBytes());
         final BasicHttpEntity entity = new BasicHttpEntity();
         entity.setContent(input);
+        entity.setContentType("application/json");
 
         mockery.checking(new Expectations() {
             {
@@ -461,6 +477,7 @@ public class AccessTokenAuthenticatorTest {
         final InputStream input = new ByteArrayInputStream(getJSONObjectString(true, currentDate, currentDate, GOOD_ISSUER).getBytes());
         final BasicHttpEntity entity = new BasicHttpEntity();
         entity.setContent(input);
+        entity.setContentType("application/json");
 
         mockery.checking(new Expectations() {
             {
@@ -509,6 +526,7 @@ public class AccessTokenAuthenticatorTest {
         final InputStream input = new ByteArrayInputStream(getJSONObjectString(false, currentDate, currentDate, GOOD_ISSUER).getBytes());
         final BasicHttpEntity entity = new BasicHttpEntity();
         entity.setContent(input);
+        entity.setContentType("application/json");
 
         mockery.checking(new Expectations() {
             {
@@ -883,7 +901,7 @@ public class AccessTokenAuthenticatorTest {
     }
 
     @Test
-    public void testHandleResponseMap() throws ParseException, IOException {
+    public void testHandleResponseMap() throws Exception {
         final InputStream input = new ByteArrayInputStream(new String("").getBytes());
         final BasicHttpEntity entity = new BasicHttpEntity();
         entity.setContent(input);
@@ -926,7 +944,7 @@ public class AccessTokenAuthenticatorTest {
     }
 
     @Test
-    public void testHandleResponseMap_NullHeader() throws ParseException, IOException {
+    public void testHandleResponseMap_NullHeader() throws Exception {
         final InputStream input = new ByteArrayInputStream(new String("").getBytes());
         final BasicHttpEntity entity = new BasicHttpEntity();
         entity.setContent(input);
@@ -960,6 +978,215 @@ public class AccessTokenAuthenticatorTest {
         respMap.put(ClientConstants.RESPONSEMAP_CODE, httpResponse);
         JSONObject jsonObject = tokenAuth.handleResponseMap(respMap, clientConfig, clientRequest);
         assertNull("Expected to receive a null value but was received: " + jsonObject, jsonObject);
+    }
+
+    @Test
+    public void test_extractSuccessfulResponse_responseMissingEntity() throws Exception {
+        mockery.checking(new Expectations() {
+            {
+                one(httpResponse).getEntity();
+                will(returnValue(null));
+            }
+        });
+        JSONObject result = tokenAuth.extractSuccessfulResponse(clientConfig, clientRequest, httpResponse);
+        assertNull("Result should have been null but was " + result + ".", result);
+    }
+
+    @Test
+    public void test_extractSuccessfulResponse_emptyString() throws Exception {
+        final InputStream input = new ByteArrayInputStream(("").getBytes());
+        final BasicHttpEntity entity = new BasicHttpEntity();
+        entity.setContent(input);
+        entity.setContentType("application/json");
+        mockery.checking(new Expectations() {
+            {
+                one(httpResponse).getEntity();
+                will(returnValue(entity));
+                one(clientConfig).getInboundPropagation();
+                will(returnValue(REQUIRED));
+                one(clientRequest).getRsFailMsg();
+                will(returnValue("doesn't matter"));
+            }
+        });
+        JSONObject result = tokenAuth.extractSuccessfulResponse(clientConfig, clientRequest, httpResponse);
+        assertNull("Result should have been null but was " + result + ".", result);
+    }
+
+    @Test
+    public void test_extractSuccessfulResponse_notJson() throws Exception {
+        final InputStream input = new ByteArrayInputStream(("This is not JSON").getBytes());
+        final BasicHttpEntity entity = new BasicHttpEntity();
+        entity.setContent(input);
+        entity.setContentType("text/plain");
+        mockery.checking(new Expectations() {
+            {
+                one(httpResponse).getEntity();
+                will(returnValue(entity));
+            }
+        });
+        JSONObject result = tokenAuth.extractSuccessfulResponse(clientConfig, clientRequest, httpResponse);
+        assertNull("Result should have been null but was " + result + ".", result);
+    }
+
+    @Test
+    public void test_extractSuccessfulResponse_emptyJson() throws Exception {
+        JSONObject responseJson = new JSONObject();
+        final InputStream input = new ByteArrayInputStream(new String(responseJson.toString()).getBytes());
+        final BasicHttpEntity entity = new BasicHttpEntity();
+        entity.setContent(input);
+        entity.setContentType("application/json");
+        mockery.checking(new Expectations() {
+            {
+                one(httpResponse).getEntity();
+                will(returnValue(entity));
+            }
+        });
+        JSONObject result = tokenAuth.extractSuccessfulResponse(clientConfig, clientRequest, httpResponse);
+        assertNotNull("Result should not have been null but was.", result);
+        assertTrue("Result should have been empty, but was " + result + ".", result.isEmpty());
+    }
+
+    @Test
+    public void test_extractSuccessfulResponse_validNonEmptyJson() throws Exception {
+        JSONObject responseJson = new JSONObject();
+        responseJson.put("key1", "value1");
+        responseJson.put("key2", "value2");
+        final InputStream input = new ByteArrayInputStream(new String(responseJson.toString()).getBytes());
+        final BasicHttpEntity entity = new BasicHttpEntity();
+        entity.setContent(input);
+        entity.setContentType("application/json");
+        mockery.checking(new Expectations() {
+            {
+                one(httpResponse).getEntity();
+                will(returnValue(entity));
+            }
+        });
+        JSONObject result = tokenAuth.extractSuccessfulResponse(clientConfig, clientRequest, httpResponse);
+        assertNotNull("Result should not have been null but was.", result);
+        assertEquals("Result did not match the expected value.", responseJson, result);
+    }
+
+    @Test
+    public void test_extractSuccessfulResponse_validNonEmptyJson_contentTypeJwt() throws Exception {
+        JSONObject responseJson = new JSONObject();
+        responseJson.put("key1", "value1");
+        responseJson.put("key2", "value2");
+        final InputStream input = new ByteArrayInputStream(new String(responseJson.toString()).getBytes());
+        final BasicHttpEntity entity = new BasicHttpEntity();
+        entity.setContent(input);
+        entity.setContentType("application/jwt");
+        mockery.checking(new Expectations() {
+            {
+                one(httpResponse).getEntity();
+                will(returnValue(entity));
+            }
+        });
+        JSONObject result = tokenAuth.extractSuccessfulResponse(clientConfig, clientRequest, httpResponse);
+        assertNull("Result should have been null but was " + result + ".", result);
+    }
+
+    //@Test
+    public void test_extractSuccessfulResponse_jws() throws Exception {
+        JSONObject headerJson = new JSONObject();
+        headerJson.put("alg", "HS256");
+        headerJson.put("typ", "JWT");
+        JSONObject payloadJson = new JSONObject();
+        payloadJson.put("iss", GOOD_ISSUER);
+        String jwsHeader = Base64Coder.base64Encode(headerJson.toString());
+        String jwsPayload = Base64Coder.base64Encode(payloadJson.toString());
+        String signature = HashUtils.digest(jwsHeader + "." + jwsPayload);
+        String rawResponse = jwsHeader + "." + jwsPayload + "." + signature;
+        final InputStream input = new ByteArrayInputStream(rawResponse.getBytes());
+        final BasicHttpEntity entity = new BasicHttpEntity();
+        entity.setContent(input);
+        entity.setContentType("application/jwt");
+        ConsumerUtils consumerUtils = new ConsumerUtils(null);
+
+        // TODO - update once parsing JWS tokens is implemented
+        mockery.checking(new Expectations() {
+            {
+                one(httpResponse).getEntity();
+                will(returnValue(entity));
+                one(clientConfig).getConsumerUtils();
+                will(returnValue(consumerUtils));
+                allowing(clientConfig).getKeyManagementKeyAlias();
+                will(returnValue(null));
+                one(clientConfig).getClockSkew();
+                will(returnValue(3000L));
+                one(clientConfig).isValidationRequired();
+                will(returnValue(false));
+                one(clientConfig).getTokenReuse();
+                will(returnValue(false));
+            }
+        });
+        JSONObject result = tokenAuth.extractSuccessfulResponse(clientConfig, clientRequest, httpResponse);
+        assertNotNull("Result should not have been null but was.", result);
+        assertEquals("Result did not match the expected value.", payloadJson, result);
+    }
+
+    @Test
+    public void test_extractClaimsFromJwtResponse_responseStringEmpty() throws Exception {
+        String rawResponse = "";
+
+        JSONObject result = tokenAuth.extractClaimsFromJwtResponse(rawResponse, clientConfig, clientRequest);
+        assertNull("Result should have been null but was " + result + ".", result);
+    }
+
+    //@Test
+    public void test_extractClaimsFromJwtResponse_jwsMalformed() throws Exception {
+        // Create a JWS but mangle the payload string
+        JSONObject headerJson = new JSONObject();
+        headerJson.put("alg", "HS256");
+        headerJson.put("typ", "JWT");
+        JSONObject payloadJson = new JSONObject();
+        payloadJson.put("iss", GOOD_ISSUER);
+        String jwsHeader = Base64Coder.base64Encode(headerJson.toString());
+        String jwsPayload = Base64Coder.base64Encode(payloadJson.toString()) + "_mangled";
+        String signature = HashUtils.digest(jwsHeader + "." + jwsPayload);
+        String rawResponse = jwsHeader + "." + jwsPayload + "." + signature;
+
+        // TODO - update once parsing JWS tokens is implemented
+        mockery.checking(new Expectations() {
+            {
+                //                one(clientConfig).getConsumerUtils();
+                //                will(returnValue(consumerUtils));
+                //                allowing(clientConfig).getKeyManagementKeyAlias();
+                //                will(returnValue(null));
+                //                one(clientConfig).getClockSkew();
+                //                will(returnValue(3000L));
+            }
+        });
+        try {
+            JSONObject result = tokenAuth.extractClaimsFromJwtResponse(rawResponse, clientConfig, clientRequest);
+            fail("Should have thrown an exception, but got " + result + ".");
+        } catch (InvalidJwtException e) {
+            assertTrue("Did not find expected exception and reason string. Exception was " + e, e.toString().contains("Unable to parse"));
+        }
+    }
+
+    @Test
+    public void test_extractClaimsFromJwtResponse_jweMalformed() throws Exception {
+        String rawResponse = "";
+        for (int i = 1; i <= 4; i++) {
+            rawResponse += Base64Coder.base64Encode("part" + i) + ".";
+        }
+        rawResponse += Base64Coder.base64Encode("part" + 5);
+
+        mockery.checking(new Expectations() {
+            {
+                one(clientConfig).getJweDecryptionKey();
+                will(returnValue(decryptionKey));
+                one(clientConfig).getId();
+                will(returnValue("configId"));
+            }
+        });
+        try {
+            JSONObject result = tokenAuth.extractClaimsFromJwtResponse(rawResponse, clientConfig, clientRequest);
+            fail("Should have thrown an exception, but got " + result + ".");
+        } catch (InvalidTokenException e) {
+            String expectedMsg = "CWWKS6056E";
+            assertTrue("Did not see expected " + expectedMsg + " error message in the exception [" + e + "].", e.getMessage().contains(expectedMsg));
+        }
     }
 
     /**


### PR DESCRIPTION
For #17072

**Note: Incomplete support**

Adds some support for parsing UserInfo responses in JWT format, if found. The Content-Type header of the response is checked for `application/json` or `application/jwt` values and parsing is done accordingly. Responses in JWE format can be decrypted, but work still needs to be done to perform the appropriate JWS validation (i.e. checking the claims required/expected by the UserInfo spec).
    
Note that UserInfo responses in JWE format aren't required to contain a nested JWS, so the payload of a JWE could be raw JSON. The updated behavior also takes that into account.