### PR TITLE
Make gRPC Features Servlet 5.0 Compatible

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpc1.0.internal.ee-8.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpc1.0.internal.ee-8.0.feature
@@ -3,9 +3,7 @@ symbolicName=io.openliberty.grpc1.0.internal.ee-8.0
 singleton=true
 Subsystem-Name: gRPC internal 1.0
 -features=\
-  com.ibm.websphere.appserver.servlet-4.0, \ 
-  com.ibm.websphere.appserver.javax.annotation-1.3; ibm.tolerates:="1.2", \
-  com.ibm.websphere.appserver.anno-1.0
+  com.ibm.websphere.appserver.servlet-4.0
 -bundles=\
   io.openliberty.grpc.1.0.internal.common, \
   io.openliberty.io.grpc.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="io.grpc:grpc-api:1.38.1", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpc1.0.internal.ee-8.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpc1.0.internal.ee-8.0.feature
@@ -1,0 +1,16 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.grpc1.0.internal.ee-8.0
+singleton=true
+Subsystem-Name: gRPC internal 1.0
+-features=\
+  com.ibm.websphere.appserver.servlet-4.0, \ 
+  com.ibm.websphere.appserver.javax.annotation-1.3; ibm.tolerates:="1.2", \
+  com.ibm.websphere.appserver.anno-1.0
+-bundles=\
+  io.openliberty.grpc.1.0.internal.common, \
+  io.openliberty.io.grpc.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="io.grpc:grpc-api:1.38.1", \
+  io.openliberty.grpc.1.0.internal, \
+  com.ibm.ws.security.authorization.util
+kind=ga
+edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpc1.0.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpc1.0.internal.ee-9.0.feature
@@ -3,9 +3,7 @@ symbolicName=io.openliberty.grpc1.0.internal.ee-9.0
 singleton=true
 Subsystem-Name: Jakarta gRPC internal 1.0
 -features=\
-  com.ibm.websphere.appserver.servlet-5.0, \ 
-  io.openliberty.jakarta.annotation-2.0, \
-  com.ibm.websphere.appserver.anno-2.0
+  com.ibm.websphere.appserver.servlet-5.0
 -bundles=\
   io.openliberty.grpc.1.0.internal.common.jakarta, \
   io.openliberty.io.grpc.1.0.jakarta; location:="dev/api/stable/,lib/"; mavenCoordinates="io.grpc:grpc-api:1.38.1", \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpc1.0.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpc1.0.internal.ee-9.0.feature
@@ -1,0 +1,16 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.grpc1.0.internal.ee-9.0
+singleton=true
+Subsystem-Name: Jakarta gRPC internal 1.0
+-features=\
+  com.ibm.websphere.appserver.servlet-5.0, \ 
+  io.openliberty.jakarta.annotation-2.0, \
+  com.ibm.websphere.appserver.anno-2.0
+-bundles=\
+  io.openliberty.grpc.1.0.internal.common.jakarta, \
+  io.openliberty.io.grpc.1.0.jakarta; location:="dev/api/stable/,lib/"; mavenCoordinates="io.grpc:grpc-api:1.38.1", \
+  io.openliberty.grpc.1.0.internal.jakarta, \
+  com.ibm.ws.security.authorization.util.jakarta
+kind=beta
+edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpcClient1.0.internal.ee-8.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpcClient1.0.internal.ee-8.0.feature
@@ -5,14 +5,12 @@ singleton=true
 Subsystem-Version: 1.0.0
 Subsystem-Name: gRPC Client 1.0
 -features=\
-  com.ibm.websphere.appserver.servlet-4.0, \ 
-  com.ibm.websphere.appserver.javax.annotation-1.3; ibm.tolerates:="1.2", \
-  com.ibm.websphere.appserver.anno-1.0
+  com.ibm.websphere.appserver.servlet-4.0
 -bundles=\
+  io.openliberty.grpc.1.0.internal.common, \
   io.openliberty.grpc.1.0.internal.client, \
-  io.openliberty.grpc.client.1.0.thirdparty; location:="dev/api/third-party/,lib/", \
   io.openliberty.io.grpc.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="io.grpc:grpc-api:1.38.1", \
-  io.openliberty.grpc.1.0.internal.common
+  io.openliberty.grpc.client.1.0.thirdparty; location:="dev/api/third-party/,lib/"
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpcClient1.0.internal.ee-8.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpcClient1.0.internal.ee-8.0.feature
@@ -1,0 +1,18 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.grpcClient1.0.internal.ee-8.0
+visibility=private
+singleton=true
+Subsystem-Version: 1.0.0
+Subsystem-Name: gRPC Client 1.0
+-features=\
+  com.ibm.websphere.appserver.servlet-4.0, \ 
+  com.ibm.websphere.appserver.javax.annotation-1.3; ibm.tolerates:="1.2", \
+  com.ibm.websphere.appserver.anno-1.0
+-bundles=\
+  io.openliberty.grpc.1.0.internal.client, \
+  io.openliberty.grpc.client.1.0.thirdparty; location:="dev/api/third-party/,lib/", \
+  io.openliberty.io.grpc.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="io.grpc:grpc-api:1.38.1", \
+  io.openliberty.grpc.1.0.internal.common
+kind=ga
+edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpcClient1.0.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpcClient1.0.internal.ee-9.0.feature
@@ -1,0 +1,18 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.grpcClient1.0.internal.ee-9.0
+visibility=private
+singleton=true
+Subsystem-Version: 1.0.0
+Subsystem-Name: Jakarta gRPC Client 1.0
+-features=\
+  com.ibm.websphere.appserver.servlet-5.0, \ 
+  io.openliberty.jakarta.annotation-2.0, \
+  com.ibm.websphere.appserver.anno-2.0
+-bundles=\
+  io.openliberty.grpc.1.0.internal.client.jakarta, \
+  io.openliberty.grpc.client.1.0.thirdparty.jakarta; location:="dev/api/third-party/,lib/", \
+  io.openliberty.io.grpc.1.0.jakarta; location:="dev/api/stable/,lib/"; mavenCoordinates="io.grpc:grpc-api:1.38.1", \
+  io.openliberty.grpc.1.0.internal.common.jakarta
+kind=beta
+edition=core
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpcClient1.0.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.grpcClient1.0.internal.ee-9.0.feature
@@ -5,14 +5,12 @@ singleton=true
 Subsystem-Version: 1.0.0
 Subsystem-Name: Jakarta gRPC Client 1.0
 -features=\
-  com.ibm.websphere.appserver.servlet-5.0, \ 
-  io.openliberty.jakarta.annotation-2.0, \
-  com.ibm.websphere.appserver.anno-2.0
+  com.ibm.websphere.appserver.servlet-5.0
 -bundles=\
+  io.openliberty.grpc.1.0.internal.common.jakarta, \
   io.openliberty.grpc.1.0.internal.client.jakarta, \
-  io.openliberty.grpc.client.1.0.thirdparty.jakarta; location:="dev/api/third-party/,lib/", \
   io.openliberty.io.grpc.1.0.jakarta; location:="dev/api/stable/,lib/"; mavenCoordinates="io.grpc:grpc-api:1.38.1", \
-  io.openliberty.grpc.1.0.internal.common.jakarta
+  io.openliberty.grpc.client.1.0.thirdparty.jakarta; location:="dev/api/third-party/,lib/"
 kind=beta
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.grpc-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.grpc-1.0.feature
@@ -11,14 +11,9 @@ IBM-API-Package: \
   io.grpc.stub.annotations;  type="internal", \
   io.grpc.internal; type="internal"
 Subsystem-Name: gRPC internal 1.0
--bundles=\
-  io.openliberty.grpc.1.0.internal.common, \
-  io.openliberty.io.grpc.1.0; location:="dev/api/stable/,lib/"; mavenCoordinates="io.grpc:grpc-api:1.38.1"
 -features=com.ibm.websphere.appserver.appmanager-1.0, \
   com.ibm.websphere.appserver.containerServices-1.0, \
-  com.ibm.websphere.appserver.javax.annotation-1.3; ibm.tolerates:="1.2", \
   com.ibm.websphere.appserver.classloading-1.0, \
-  com.ibm.websphere.appserver.anno-1.0, \
   com.ibm.websphere.appserver.artifact-1.0, \
   com.ibm.websphere.appserver.httptransport-1.0
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/grpc-1.0/io.openliberty.grpc-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/grpc-1.0/io.openliberty.grpc-1.0.feature
@@ -10,8 +10,9 @@ IBM-ShortName: grpc-1.0
 Subsystem-Version: 1.0.0
 Subsystem-Name: gRPC 1.0
 -features=\
-  io.openliberty.internal.grpc-1.0, \ 
-  io.openliberty.grpc1.0.internal.ee-8.0; ibm.tolerates:="9.0"
+  com.ibm.websphere.appserver.servlet-4.0; ibm.tolerates:="5.0", \
+  io.openliberty.grpc1.0.internal.ee-8.0; ibm.tolerates:="9.0", \
+  io.openliberty.internal.grpc-1.0
 -files=dev/api/ibm/javadoc/io.openliberty.grpc.1.0_1.0-javadoc.zip
 -jars=\
   io.openliberty.grpc.1.0; location:="dev/api/ibm/,lib/"

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/grpc-1.0/io.openliberty.grpc-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/grpc-1.0/io.openliberty.grpc-1.0.feature
@@ -9,14 +9,12 @@ IBM-API-Package: \
 IBM-ShortName: grpc-1.0
 Subsystem-Version: 1.0.0
 Subsystem-Name: gRPC 1.0
--bundles=\
-  io.openliberty.grpc.1.0.internal,\
-  com.ibm.ws.security.authorization.util
--features=com.ibm.websphere.appserver.servlet-4.0, \
-  io.openliberty.internal.grpc-1.0
+-features=\
+  io.openliberty.internal.grpc-1.0, \ 
+  io.openliberty.grpc1.0.internal.ee-8.0; ibm.tolerates:="9.0"
+-files=dev/api/ibm/javadoc/io.openliberty.grpc.1.0_1.0-javadoc.zip
 -jars=\
   io.openliberty.grpc.1.0; location:="dev/api/ibm/,lib/"
--files=dev/api/ibm/javadoc/io.openliberty.grpc.1.0_1.0-javadoc.zip
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/grpcClient-1.0/io.openliberty.grpcClient-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/grpcClient-1.0/io.openliberty.grpcClient-1.0.feature
@@ -11,7 +11,8 @@ IBM-API-Package: \
 IBM-ShortName: grpcClient-1.0
 Subsystem-Version: 1.0.0
 Subsystem-Name: gRPC Client 1.0
--features=\
+-features= \
+  com.ibm.websphere.appserver.servlet-4.0; ibm.tolerates:="5.0", \
   io.openliberty.grpcClient1.0.internal.ee-8.0; ibm.tolerates:="9.0", \
   com.ibm.websphere.appserver.internal.slf4j-1.7.7, \
   io.openliberty.internal.grpc-1.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/grpcClient-1.0/io.openliberty.grpcClient-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/grpcClient-1.0/io.openliberty.grpcClient-1.0.feature
@@ -11,12 +11,11 @@ IBM-API-Package: \
 IBM-ShortName: grpcClient-1.0
 Subsystem-Version: 1.0.0
 Subsystem-Name: gRPC Client 1.0
--features=com.ibm.websphere.appserver.servlet-4.0, \
+-features=\
+  io.openliberty.grpcClient1.0.internal.ee-8.0; ibm.tolerates:="9.0", \
   com.ibm.websphere.appserver.internal.slf4j-1.7.7, \
   io.openliberty.internal.grpc-1.0
 -bundles=\
-  io.openliberty.grpc.1.0.internal.client, \
-  io.openliberty.grpc.client.1.0.thirdparty; location:="dev/api/third-party/,lib/", \
   io.openliberty.org.apache.commons.logging
 kind=ga
 edition=core

--- a/dev/com.ibm.ws.grpc_fat/bnd.bnd
+++ b/dev/com.ibm.ws.grpc_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.grpc_fat/bnd.bnd
+++ b/dev/com.ibm.ws.grpc_fat/bnd.bnd
@@ -29,7 +29,12 @@ fat.minimum.java.level: 1.8
 
 # Define additional tested features that are NOT present in any XML files in this bucket.
 tested.features:\
-    servlet-4.0,jaxrs-2.1
+    servlet-4.0,\
+	jaxrs-2.1,\
+	servlet-5.0,\
+	appsecurity-4.0,\
+	expressionlanguage-4.0,\
+	cdi-3.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.servlet.4.0;version=latest,\

--- a/dev/com.ibm.ws.grpc_fat/build.gradle
+++ b/dev/com.ibm.ws.grpc_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.grpc_fat/build.gradle
+++ b/dev/com.ibm.ws.grpc_fat/build.gradle
@@ -202,3 +202,5 @@ assemble.doLast {
           into "generated-src"
     }
 }
+
+addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/ClientConfigTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/ClientConfigTests.java
@@ -109,6 +109,11 @@ public class ClientConfigTests extends FATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         Exception excep = null;
+        
+        LOG.info("ClientConfigTests : tearDown() : serverConfigurationFile set to null");
+        // Setting serverConfigurationFile to null forces a server.xml update (when GrpcTestUtils.setServerConfiguration() is first called) on the repeat run
+        // If not set to null, test failures may occur (since the incorrect server.xml could be used)
+        serverConfigurationFile = null;
 
         try {
             stopClientServer();
@@ -135,6 +140,7 @@ public class ClientConfigTests extends FATServletClient {
 
     private static void stopClientServer() throws Exception {
         if (GrpcClientOnly != null && GrpcClientOnly.isStarted()) {
+            
             /*
              * CWWKG0083W: expected by testInvalidMaxInboundMessageSize due to invalid message size config
              * CWWKG0076W: expected when a previous config is still in use because an invalid config was rejected

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/FATSuite.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/FATSuite.java
@@ -10,9 +10,15 @@
  *******************************************************************************/
 package com.ibm.ws.fat.grpc;
 
+import org.junit.ClassRule;
+
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+
+import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -38,5 +44,9 @@ import org.junit.runners.Suite.SuiteClasses;
 public class FATSuite {
 
     private static final Class<?> c = FATSuite.class;
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.withoutModification()
+                    .andWith(FeatureReplacementAction.EE9_FEATURES().removeFeature("servlet-4.0").alwaysAddFeature("servlet-5.0").fullFATOnly());
 
 }

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/FATSuite.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/FATSuite.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/FATSuite.java
@@ -47,6 +47,6 @@ public class FATSuite {
 
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(FeatureReplacementAction.EE9_FEATURES().removeFeature("servlet-4.0").alwaysAddFeature("servlet-5.0").fullFATOnly());
+                    .andWith(FeatureReplacementAction.EE9_FEATURES().removeFeature("servlet-4.0").alwaysAddFeature("servlet-5.0"));
 
 }

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/GrpcMetricsTest.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/GrpcMetricsTest.java
@@ -36,10 +36,12 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
+@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @RunWith(FATRunner.class)
 public class GrpcMetricsTest extends FATServletClient {
 

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldCDITests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldCDITests.java
@@ -29,9 +29,11 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
+@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @RunWith(FATRunner.class)
 public class HelloWorldCDITests extends HelloWorldBasicTest {
 

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldCDITests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldCDITests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldTest.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldTest.java
@@ -26,9 +26,11 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
+@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @RunWith(FATRunner.class)
 public class HelloWorldTest extends HelloWorldBasicTest {
 

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldTest.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/ServiceSupportTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/ServiceSupportTests.java
@@ -110,8 +110,9 @@ public class ServiceSupportTests extends FATServletClient {
         assertTrue("Expected the grpc feature 'grpc-1.0' to be enabled but was not: " + features,
                    features.contains("grpc-1.0"));
 
+        // Ignore case for EE9 RepeatAction
         assertTrue("Expected the grpc feature 'grpcClient-1.0' to be enabled but was not: " + features,
-                   features.contains("grpcClient-1.0"));
+                   features.contains("grpcClient-1.0") || features.contains("grpcclient-1.0")); 
 
     }
 

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreConsumerServletClientTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreConsumerServletClientTests.java
@@ -29,6 +29,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -39,6 +40,7 @@ import componenttest.topology.utils.FATServletClient;
  * @author anupag
  *
  */
+@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class StoreConsumerServletClientTests extends FATServletClient {

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreConsumerServletClientTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreConsumerServletClientTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreProducerServletClientTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreProducerServletClientTests.java
@@ -27,6 +27,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
@@ -37,6 +38,7 @@ import componenttest.topology.utils.FATServletClient;
  * @author anupag
  *
  */
+@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @RunWith(FATRunner.class)
 @Mode(TestMode.FULL)
 public class StoreProducerServletClientTests extends FATServletClient {

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreProducerServletClientTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreProducerServletClientTests.java
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreServicesRESTClientTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreServicesRESTClientTests.java
@@ -27,6 +27,7 @@ import com.ibm.testapp.g3store.restProducer.client.ProducerEndpointFATServlet;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -36,6 +37,7 @@ import componenttest.topology.utils.FATServletClient;
  * @author anupag
  *
  */
+@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @RunWith(FATRunner.class)
 public class StoreServicesRESTClientTests extends FATServletClient {
 

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreServicesRESTClientTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreServicesRESTClientTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreServicesSecurityTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreServicesSecurityTests.java
@@ -19,6 +19,7 @@ import com.ibm.testapp.g3store.restConsumer.client.ConsumerEndpointJWTCookieFATS
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -28,6 +29,7 @@ import componenttest.topology.utils.FATServletClient;
  *
  */
 
+@SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 @RunWith(FATRunner.class)
 public class StoreServicesSecurityTests extends FATServletClient {
 

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreServicesSecurityTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreServicesSecurityTests.java
@@ -1,6 +1,13 @@
-/**
+/*******************************************************************************
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  *
- */
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package com.ibm.ws.fat.grpc;
 
 import static org.junit.Assert.assertNotNull;

--- a/dev/com.ibm.ws.security.authorization.util/bnd.bnd
+++ b/dev/com.ibm.ws.security.authorization.util/bnd.bnd
@@ -16,6 +16,8 @@ Bundle-Description: Security Authorization Utility for Liberty components, versi
 Bundle-SymbolicName: com.ibm.ws.security.authorization.util
 Bundle-ActivationPolicy: lazy
 
+jakartaeeMe: true
+
 WS-TraceGroup: \
   Authorization
 

--- a/dev/com.ibm.ws.security.authorization.util/bnd.bnd
+++ b/dev/com.ibm.ws.security.authorization.util/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/io.openliberty.grpc.1.0.internal.client/bnd.bnd
+++ b/dev/io.openliberty.grpc.1.0.internal.client/bnd.bnd
@@ -16,6 +16,8 @@ Bundle-Name: gRPC Client
 Bundle-SymbolicName: io.openliberty.grpc.1.0.internal.client
 Bundle-Description: Liberty gRPC Client, version ${bVersion}
 
+jakartaeeMe: true
+
 Import-Package: \
   !com.google.protobuf.nano,\
   !com.google.code.gson,\

--- a/dev/io.openliberty.grpc.1.0.internal.common/bnd.bnd
+++ b/dev/io.openliberty.grpc.1.0.internal.common/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/io.openliberty.grpc.1.0.internal.common/bnd.bnd
+++ b/dev/io.openliberty.grpc.1.0.internal.common/bnd.bnd
@@ -16,6 +16,8 @@ Bundle-Name: gRPC Common Components
 Bundle-SymbolicName: io.openliberty.grpc.1.0.internal.common
 Bundle-Description: gRPC Common Components, version ${bVersion}
 
+jakartaeeMe: true
+
 # Using version=! in order to not have a version attached to the import for packages that were removed
 # from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
 # packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.

--- a/dev/io.openliberty.grpc.1.0.internal/bnd.bnd
+++ b/dev/io.openliberty.grpc.1.0.internal/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/io.openliberty.grpc.1.0.internal/bnd.bnd
+++ b/dev/io.openliberty.grpc.1.0.internal/bnd.bnd
@@ -16,6 +16,8 @@ Bundle-Name: Liberty gRPC
 Bundle-SymbolicName: io.openliberty.grpc.1.0.internal
 Bundle-Description: Libery gRPC, version ${bVersion}
 
+jakartaeeMe: true
+
 -dsannotations: \
   io.openliberty.grpc.internal.servlet.GrpcServerComponent,\
   io.openliberty.grpc.internal.config.GrpcServiceConfigImpl

--- a/dev/io.openliberty.grpc.1.0/bnd.bnd
+++ b/dev/io.openliberty.grpc.1.0/bnd.bnd
@@ -15,6 +15,8 @@ Bundle-Name: Open Liberty gRPC API
 Bundle-Description: Open Liberty gRPC API, version ${bVersion}
 Bundle-SymbolicName: io.openliberty.grpc.1.0
 
+jakartaeeMe: true
+
 Import-Package: \
   io.grpc, \
   io.openliberty.grpc.annotation

--- a/dev/io.openliberty.grpc.1.0/bnd.bnd
+++ b/dev/io.openliberty.grpc.1.0/bnd.bnd
@@ -15,8 +15,6 @@ Bundle-Name: Open Liberty gRPC API
 Bundle-Description: Open Liberty gRPC API, version ${bVersion}
 Bundle-SymbolicName: io.openliberty.grpc.1.0
 
-jakartaeeMe: true
-
 Import-Package: \
   io.grpc, \
   io.openliberty.grpc.annotation

--- a/dev/io.openliberty.grpc.client.1.0.thirdparty/bnd.bnd
+++ b/dev/io.openliberty.grpc.client.1.0.thirdparty/bnd.bnd
@@ -17,6 +17,8 @@ Bundle-Name: Open Liberty gRPC Client Third Party API
 Bundle-SymbolicName: io.openliberty.grpc.client.1.0.thirdparty
 Bundle-Description: Open Liberty gRPC Client Third Party API
 
+jakartaeeMe: true
+
 # Using version=! in order to not have a version attached to the import for packages that were removed
 # from Java after Java 8.  Doing this keeps the import like before Java 11 support. It will get the 
 # packages from Java when using Java 8 or earlier and from the new shipped bundles for Java 9 and later.

--- a/dev/io.openliberty.grpc.client.1.0.thirdparty/bnd.bnd
+++ b/dev/io.openliberty.grpc.client.1.0.thirdparty/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/io.openliberty.io.grpc.1.0/bnd.bnd
+++ b/dev/io.openliberty.io.grpc.1.0/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/dev/io.openliberty.io.grpc.1.0/bnd.bnd
+++ b/dev/io.openliberty.io.grpc.1.0/bnd.bnd
@@ -15,6 +15,8 @@ grpcVersion=1.38.1
 
 Bundle-SymbolicName: io.openliberty.io.grpc.1.0; singleton:=true
 
+jakartaeeMe: true
+
 Import-Package: \
   *
 

--- a/dev/wlp-jakartaee-transform/rules/jakarta-xml-master.properties
+++ b/dev/wlp-jakartaee-transform/rules/jakarta-xml-master.properties
@@ -88,3 +88,6 @@ validatorCustomLoginModuleServer.xml=jakarta-metatype.properties
 
 #webCache
 com.ibm.ws.cache.servlet.xml=jakarta-xml-servletContainerInitializer.properties
+
+#grpc
+io.openliberty.grpc.internal.servlet.GrpcServerComponent.xml=jakarta-xml-servletContainerInitializer.properties


### PR DESCRIPTION
Fixes #16647 

Makes grpc-1.0 and grpcClient-1.0 servlet-5.0 compatible.

The bundle transformations where straightforward, but the feature files were a bit more complicated. 

The following bundles are transformed: 

- io.openliberty.grpc.1.0.internal.common
- io.openliberty.io.grpc.1.0
- io.openliberty.grpc.1.0.internal
- com.ibm.ws.security.authorization.util
- io.openliberty.grpc.1.0.internal.client
- io.openliberty.grpc.client.1.0.thirdparty

Only one rule was added to handle the servletContainerInitializer.

The following private feature are created: 
- io.openliberty.grpc1.0.internal.ee-8.0.feature
- io.openliberty.grpc1.0.internal.ee-9.0.feature 
- io.openliberty.grpcClient1.0.internal.ee-8.0.feature 
- io.openliberty.grpcClient1.0.internal.ee-9.0.feature

Each of the the features above depends on the appropriate servlet levels. As for the the public features, they tolerate ee-8.0 and ee-9.0.  For example, grpcClient-1.0 has `io.openliberty.grpcClient1.0.internal.ee-8.0; ibm.tolerates:="9.0", \`.

`io.openliberty.internal.grpc-1.0` contains shared bundles/features between the public grpc-1.0 and grpcClient-1.0 features. 

Lastly, only a subset of tests have been enabled for EE9 since many of the tests rely on the `mpMetrics-2.3` (which is not yet  updated for Jakarta but should be later this year).

Lite Mode --  Regular tests + some EE9 tests
Full Mode -- Run all the tests (minus the skips ones). 

. 