### PR TITLE
Server was unable to obtain an object instance

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/test-applications/testPortComponentRefApplication/src/com/ibm/ws/jaxws/test/pcr/app/ejb/client/HelloClientBean.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/test-applications/testPortComponentRefApplication/src/com/ibm/ws/jaxws/test/pcr/app/ejb/client/HelloClientBean.java
@@ -22,6 +22,9 @@ public class HelloClientBean {
     @WebServiceRef(name = "services/hello", value = HelloService.class)
     Hello hello;
 
+    // Constructor is required to prevent intermittent InvocationTargetException
+    public HelloClientBean()    {}
+
     public String sayHelloWorld() {
         return hello.sayHello("World");
     }


### PR DESCRIPTION
Fixes #17570

Some of instantiation problems occurs due to lack of default constructor. 