### PR TITLE
Move com.ibm.ws.jaxws.wsat bundle to wsAtomicTransaction feature

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wsAtomicTransaction1.2.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wsAtomicTransaction1.2.internal.ee-9.0.feature
@@ -6,6 +6,7 @@ visibility = private
   io.openliberty.xmlWS-3.0, \
   com.ibm.websphere.appserver.servlet-5.0
 -bundles=\
+  com.ibm.ws.jaxws.2.3.wsat, \
   com.ibm.ws.wsat.common.3.2.jakarta; start-phase:=CONTAINER_LATE, \
   com.ibm.ws.wsat.cxf.utils.3.2.jakarta, \
   com.ibm.ws.wsat.webclient.3.2.jakarta, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wsAtomicTransaction1.2.internal.jaxws-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wsAtomicTransaction1.2.internal.jaxws-2.2.feature
@@ -6,6 +6,7 @@ WLP-DisableAllFeatures-OnConflict: false
 -features=\
   com.ibm.websphere.appserver.jaxws-2.2
 -bundles=\
+  com.ibm.ws.jaxws.wsat, \
   com.ibm.ws.wsat.common; start-phase:=CONTAINER_LATE, \
   com.ibm.ws.wsat.cxf.utils.2.6.2, \
   com.ibm.ws.wsat.webclient, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wsAtomicTransaction1.2.internal.jaxws-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.wsAtomicTransaction1.2.internal.jaxws-2.3.feature
@@ -5,6 +5,7 @@ visibility = private
 -features=\
   com.ibm.websphere.appserver.jaxws-2.3
 -bundles=\
+  com.ibm.ws.jaxws.2.3.wsat, \
   com.ibm.ws.wsat.common.3.2; start-phase:=CONTAINER_LATE, \
   com.ibm.ws.wsat.cxf.utils.3.2, \
   com.ibm.ws.wsat.webclient.3.2, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jaxws-2.2/com.ibm.websphere.appserver.jaxws-2.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jaxws-2.2/com.ibm.websphere.appserver.jaxws-2.2.feature
@@ -48,7 +48,6 @@ Subsystem-Name: Java Web Services 2.2
  com.ibm.ws.javaee.ddmodel.wsbnd, \
  com.ibm.ws.jaxws.common; start-phase:=CONTAINER_LATE, \
  com.ibm.ws.jaxws.tools.2.2.10, \
- com.ibm.ws.jaxws.wsat, \
  com.ibm.ws.org.apache.cxf.cxf.api.2.6.2, \
  com.ibm.ws.org.apache.cxf.cxf.rt.bindings.soap.2.6.2, \
  com.ibm.ws.org.apache.cxf.cxf.rt.bindings.xml.2.6.2, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jaxws-2.3/com.ibm.websphere.appserver.jaxws-2.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jaxws-2.3/com.ibm.websphere.appserver.jaxws-2.3.feature
@@ -17,7 +17,6 @@ Subsystem-Name: Java Web Services 2.3
   com.ibm.websphere.appserver.globalhandler-1.0
 -bundles=\
  com.ibm.ws.javaee.ddmodel.ws, \
- com.ibm.ws.jaxws.2.3.wsat, \
  com.ibm.ws.jaxws.2.3.common; start-phase:=CONTAINER_LATE, \
  com.ibm.ws.webservices.javaee.common
 kind=noship

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWS-3.0/io.openliberty.xmlWS-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/xmlWS-3.0/io.openliberty.xmlWS-3.0.feature
@@ -18,7 +18,6 @@ IBM-API-Package: \
  com.ibm.ws.jaxws.2.3.common.jakarta;start-phase:=CONTAINER_LATE, \
  com.ibm.ws.jaxws.webcontainer.jakarta, \
  com.ibm.ws.jaxws.2.3.web.jakarta, \
- com.ibm.ws.jaxws.2.3.wsat, \
  com.ibm.ws.webservices.javaee.common.jakarta
 -files=\
  bin/xmlWS/wsgen; ibm.executable:=true; ibm.file.encoding:=ebcdic, \

--- a/dev/com.ibm.ws.wsat_fat.db/fat/src/com/ibm/ws/wsat/fat/tests/DBOptionalTestDisabled.java
+++ b/dev/com.ibm.ws.wsat_fat.db/fat/src/com/ibm/ws/wsat/fat/tests/DBOptionalTestDisabled.java
@@ -20,7 +20,6 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServerFactory;
 
@@ -130,7 +129,6 @@ public class DBOptionalTestDisabled extends DBTestBase {
 	}
 
 	@Test
-    @SkipForRepeat({"jaxws-2.3", SkipForRepeat.EE9_FEATURES})
 	public void testDBDisabled10() {
 		String testURL = "/" + appNameOptional + "/ClientServlet";
 		String wsatURL = CLient_URL + testURL + "?" + server1Name + "p="
@@ -148,7 +146,6 @@ public class DBOptionalTestDisabled extends DBTestBase {
 	}
 
 	@Test
-    @SkipForRepeat({"jaxws-2.3", SkipForRepeat.EE9_FEATURES})
 	public void testDBDisabled12() {
 		String testURL = "/" + appNameOptional + "/ClientServlet";
 		String wsatURL = CLient_URL + testURL + "?" + server1Name + "p="

--- a/dev/com.ibm.ws.wsat_fat.db/fat/src/com/ibm/ws/wsat/fat/tests/DBServiceOptionalTestDisabled.java
+++ b/dev/com.ibm.ws.wsat_fat.db/fat/src/com/ibm/ws/wsat/fat/tests/DBServiceOptionalTestDisabled.java
@@ -20,7 +20,6 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServerFactory;
 
@@ -71,7 +70,6 @@ import componenttest.topology.impl.LibertyServerFactory;
  * 
  */
 @RunWith(FATRunner.class)
-@SkipForRepeat({"jaxws-2.3", SkipForRepeat.EE9_FEATURES})
 public class DBServiceOptionalTestDisabled extends DBTestBase {
 
 	public static String notInstalled = "WS-AT Feature is not installed";


### PR DESCRIPTION
- Move com.ibm.ws.jaxws.wsat and its 2.3 equivalent bundle to the wsAtomicTranaction feature so it is not used when only jaxws is enabled
- Update to remove final SkipForRepeat for wsat tests failing when running with jaxws-2.3 and xmlWS-3.0.