### PR TITLE
Add wait for SSL Port restart to restore and reconfig methods in LibertyServer

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/MessageConstants.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/MessageConstants.java
@@ -16,14 +16,17 @@ public class MessageConstants {
     public static final String CWWKG0032W_CONFIG_INVALID_VALUE = "CWWKG0032W";
     public static final String CWWKG0083W_CONFIG_INVALID_VALUE_USING_DEFAULT = "CWWKG0083W";
     public static final String CWWKO0219I_SSL_CHANNEL_READY = ".*CWWKO0219I.*defaultHttpEndpoint-ssl.*";
-    public static final String CWWKS0008I_SECURITY_SERVICE_READY = "CWWKS0008I" ;
-    public static final String CWWKS4105I_LTPA_CONFIG_READY = "CWWKS4105I" ;
+    public static final String CWWKS0008I_SECURITY_SERVICE_READY = "CWWKS0008I";
+    public static final String CWWKS4105I_LTPA_CONFIG_READY = "CWWKS4105I";
     public static final String CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR = "CWWKG0014E";
-    
+
     public static final String CWWKE1102W_QUIESCE_WARNING = "CWWKE1102W";
     public static final String CWWKE1106W_QUIESCE_LISTENERS_NOT_COMPLETE = "CWWKE1106W";
     public static final String CWWKE1107W_QUIESCE_WAITING_ON_THREAD = "CWWKE1107W";
     public static final String CWWKG0014E_XML_PARSER_ERROR = "CWWKG0014E";
     public static final String CWWKO0221E_PORT_IN_USE = "CWWKO0221E";
     public static final String CWWKO0227E_EXECUTOR_SERVICE_MISSING = "CWWKO0227E";
+
+    public static final String SSL_NOT_RESTARTED_PROPERLY = "SSL may not have started properly";
+
 }

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/servers/ServerTracker.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/servers/ServerTracker.java
@@ -55,7 +55,7 @@ public class ServerTracker {
         // ignore shutdown timing issues
         server.addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
         // ignore potential timing issue with SSL port restart - if the port was ready when tests need it, that's good enough
-        server.addIgnoredErrors(Arrays.asList("SSL may not have started properly"));
+        server.addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
 
     }
 

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/servers/ServerTracker.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/servers/ServerTracker.java
@@ -54,6 +54,8 @@ public class ServerTracker {
         server.addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
         // ignore shutdown timing issues
         server.addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
+        // ignore potential timing issue with SSL port restart - if the port was ready when tests need it, that's good enough
+        server.addIgnoredErrors(Arrays.asList("SSL may not have started properly"));
 
     }
 

--- a/dev/com.ibm.ws.security.fat.common/test/com/ibm/ws/security/fat/common/servers/ServerTrackerTest.java
+++ b/dev/com.ibm.ws.security.fat.common/test/com/ibm/ws/security/fat/common/servers/ServerTrackerTest.java
@@ -106,6 +106,7 @@ public class ServerTrackerTest extends CommonTestClass {
                     one(server1).addInstalledAppForValidation(Constants.APP_TESTMARKER);
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
                 }
             });
 
@@ -133,6 +134,7 @@ public class ServerTrackerTest extends CommonTestClass {
                     exactly(2).of(server1).addInstalledAppForValidation(Constants.APP_TESTMARKER);
                     exactly(2).of(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     exactly(2).of(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
+                    exactly(2).of(server1).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
                 }
             });
 
@@ -161,12 +163,15 @@ public class ServerTrackerTest extends CommonTestClass {
                     one(server1).addInstalledAppForValidation(Constants.APP_TESTMARKER);
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
                     one(server2).addInstalledAppForValidation(Constants.APP_TESTMARKER);
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
+                    one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
                     one(server3).addInstalledAppForValidation(Constants.APP_TESTMARKER);
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
+                    one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
                 }
             });
 
@@ -232,7 +237,8 @@ public class ServerTrackerTest extends CommonTestClass {
                     one(server1).addInstalledAppForValidation(Constants.APP_TESTMARKER);
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
-               }
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
+                }
             });
 
             tracker.addServer(server1);
@@ -264,7 +270,8 @@ public class ServerTrackerTest extends CommonTestClass {
                     one(server1).addInstalledAppForValidation(Constants.APP_TESTMARKER);
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
-               }
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
+                }
             });
 
             tracker.addServer(server1);
@@ -301,12 +308,15 @@ public class ServerTrackerTest extends CommonTestClass {
                     one(server1).addInstalledAppForValidation(Constants.APP_TESTMARKER);
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
                     one(server2).addInstalledAppForValidation(Constants.APP_TESTMARKER);
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
+                    one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
                     one(server3).addInstalledAppForValidation(Constants.APP_TESTMARKER);
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
+                    one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
                 }
             });
 
@@ -343,12 +353,15 @@ public class ServerTrackerTest extends CommonTestClass {
                     one(server1).addInstalledAppForValidation(Constants.APP_TESTMARKER);
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
                     one(server2).addInstalledAppForValidation(Constants.APP_TESTMARKER);
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
+                    one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
                     one(server3).addInstalledAppForValidation(Constants.APP_TESTMARKER);
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
+                    one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
                 }
             });
 


### PR DESCRIPTION
The restart of the SSL port is an async process that it sometimes occurring after the config complete message is logged.
Test cases wait for he update complete message as well as app restart messages.  But, it's hard to add a check for ssl restart to individual test cases.  Many of our test reconfigure, but whether ssl is restarted will depend on what was configured before the reconfig was requested.  That previous config will depend on what test case just completed and we do not control the order of the test cases.
So, I've added some code that will search for the ssl stop message for a "short" period of time.   If it finds it, it'll wait for the start message (and will wait for a longer period of time)
Hopefully, this will resolve most of the connection refused and "SSL Peer shut down incorrectly" failures that we see...