### PR TITLE
fix identifyException to show under dataSource and beta it

### DIFF
--- a/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/metatype/metatype.xml
@@ -82,8 +82,8 @@
   <AD id="enableBranchCouplingExtension"          name="internal"      description="internal use only"  ibmui:group="Advanced" required="false" type="Boolean"/>
   <AD id="enableConnectionCasting"                name="%enblConCast"  description="%enblConCast.desc"  ibmui:group="Advanced" type="Boolean" default="false"/>
   <AD id="heritage"                               name="internal"      description="internal use only"  ibmui:group="Advanced" required="false" type="String"  cardinality="1" ibm:type="pid" ibm:reference="com.ibm.ws.jdbc.dataSource.heritage" ibm:flat="true"/>
-  <AD id="identifyException"                      name="internal"      description="internal use only"  ibmui:group="Advanced" required="false" type="String"  cardinality="1000" ibm:type="pid" ibm:reference="com.ibm.ws.jdbc.dataSource.identifyException" ibm:flat="true"/>
-  <!-- TODO both identifyException and enableBranchCouplingExtension should Beta together. But at GA, remove the latter altogether  -->
+  <AD id="identifyException"                      ibm:beta="true"                                       ibmui:group="Advanced" required="false" type="String"  cardinality="1000" ibm:type="pid" ibm:reference="com.ibm.ws.jdbc.dataSource.identifyException" ibm:flat="true"/>
+  <!-- TODO remove enableBranchCouplingExtension. It is temporarily used internally to switch on code path for a test case -->
   <AD id="onConnect"                              name="%onConnect"    description="%onConnect.desc"    ibmui:group="Advanced" required="false" type="String"  cardinality="1000"/>
   <AD id="queryTimeout"                           name="%qryTimeout"   description="%qryTimeout.desc"   ibmui:group="Advanced" required="false" type="String"  ibm:type="duration(s)"/>
   <AD id="recoveryAuthDataRef"                    name="%recoveryAuth" description="%recoveryAuth.desc" ibmui:group="Advanced" required="false" type="String"  cardinality="1" ibm:type="pid" ibm:reference="com.ibm.ws.security.jca.internal.authdata.config"/>
@@ -108,7 +108,7 @@
   <Object ocdref="com.ibm.ws.jdbc.dataSource.identifyException"/>
  </Designate>
 
- <OCD id="com.ibm.ws.jdbc.dataSource.identifyException" ibm:alias="identifyException" name="%identifyException" description="%identifyException.desc" ibmui:localization="OSGI-INF/l10n/metatype">
+ <OCD id="com.ibm.ws.jdbc.dataSource.identifyException" ibm:beta="true" name="%identifyException" description="%identifyException.desc" ibmui:localization="OSGI-INF/l10n/metatype">
   <AD id="sqlState"  required="false" type="String"  name="%identifyException.sqlState"  description="%identifyException.sqlState.desc"/>
   <AD id="errorCode" required="false" type="Integer" name="%identifyException.errorCode" description="%identifyException.errorCode.desc"/>
   <AD id="as"        required="true"  type="String"  name="%identifyException.as"        description="%identifyException.as.desc"/>

--- a/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/metatype/metatype.xml
@@ -108,7 +108,8 @@
   <Object ocdref="com.ibm.ws.jdbc.dataSource.identifyException"/>
  </Designate>
 
- <OCD id="com.ibm.ws.jdbc.dataSource.identifyException" ibm:beta="true" name="%identifyException" description="%identifyException.desc" ibmui:localization="OSGI-INF/l10n/metatype">
+ <!-- TODO This should not have been externalized as a top level element, where it is unusable. Need to determine if we we are stuck with it. -->
+ <OCD id="com.ibm.ws.jdbc.dataSource.identifyException" ibm:alias="identifyException" name="%identifyException" description="%identifyException.desc" ibmui:localization="OSGI-INF/l10n/metatype">
   <AD id="sqlState"  required="false" type="String"  name="%identifyException.sqlState"  description="%identifyException.sqlState.desc"/>
   <AD id="errorCode" required="false" type="Integer" name="%identifyException.errorCode" description="%identifyException.errorCode.desc"/>
   <AD id="as"        required="true"  type="String"  name="%identifyException.as"        description="%identifyException.as.desc"/>


### PR DESCRIPTION
The identifyException element is missing from the schema under dataSource.
Fix this and then beta identifyException so that users can try it out.