### PR TITLE
Revert "Create the lock base on hashtable in subject instead of authentication data"

### DIFF
--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/AuthenticationServiceImpl.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/AuthenticationServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2021 IBM Corporation and others.
+ * Copyright (c) 2012, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -199,15 +199,13 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     /** {@inheritDoc} */
     @Override
     public Subject authenticate(String jaasEntryName, AuthenticationData authenticationData, Subject subject) throws AuthenticationException {
-        AuthenticationData hashtableAuthData = getHashtable(subject);
-        ReentrantLock currentLock = obtainCurrentLock(authenticationData, hashtableAuthData);
-
+        ReentrantLock currentLock = optionallyObtainLockedLock(authenticationData);
         try {
             // If basic auth login to a different realm, then create a basic auth subject
             if (isBasicAuthLogin(authenticationData)) {
                 return createBasicAuthSubject(authenticationData, subject);
             } else {
-                Subject authenticatedSubject = findSubjectInAuthCache(authenticationData, subject, hashtableAuthData);
+                Subject authenticatedSubject = findSubjectInAuthCache(authenticationData, subject);
                 if (authenticatedSubject == null) {
                     authenticatedSubject = performJAASLogin(jaasEntryName, authenticationData, subject);
                     insertSubjectInAuthCache(authenticationData, authenticatedSubject);
@@ -218,23 +216,6 @@ public class AuthenticationServiceImpl implements AuthenticationService {
             releaseLock(authenticationData, currentLock);
             CertificateLoginModule.collectiveCertificate.set(false);
         }
-    }
-
-    /**
-     * If we have hashtableAuthData from the subject, then use the hashtableAuthData to lock it.
-     * Otherwise, will use the regular authenticationData to lock it.
-     *
-     * @param authenticationData
-     * @param hashtableAuthData
-     * @return
-     */
-    private ReentrantLock obtainCurrentLock(AuthenticationData authenticationData, AuthenticationData hashtableAuthData) {
-        ReentrantLock currentLock;
-        if (!hashtableAuthData.isEmpty())
-            currentLock = optionallyObtainLockedLock(hashtableAuthData);
-        else
-            currentLock = optionallyObtainLockedLock(authenticationData);
-        return currentLock;
     }
 
     private boolean isBasicAuthLogin(AuthenticationData authenticationData) {
@@ -279,15 +260,14 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         } catch (Exception e) {
             throw new AuthenticationException(e.getMessage());
         }
-        AuthenticationData hashtableAuthData = getHashtable(subject);
-        ReentrantLock currentLock = obtainCurrentLock(authenticationData, hashtableAuthData);
 
+        ReentrantLock currentLock = optionallyObtainLockedLock(authenticationData);
         try {
             // If basic auth login to a different realm, then create a basic auth subject
             if (isBasicAuthLogin(authenticationData)) {
                 return createBasicAuthSubject(authenticationData, subject);
             } else {
-                Subject authenticatedSubject = findSubjectInAuthCache(authenticationData, subject, hashtableAuthData);
+                Subject authenticatedSubject = findSubjectInAuthCache(authenticationData, subject);
                 if (authenticatedSubject == null) {
                     authenticatedSubject = performJAASLogin(jaasEntryName, callbackHandler, subject);
                     insertSubjectInAuthCache(authenticationData, authenticatedSubject);
@@ -335,8 +315,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         authenticationGuard.relinquishAccess(authenticationData, currentLock);
     }
 
-    private Subject findSubjectInAuthCache(AuthenticationData authenticationData, Subject partialSubject,
-                                           AuthenticationData hashtableAuthData) throws AuthenticationException {
+    private Subject findSubjectInAuthCache(AuthenticationData authenticationData, Subject partialSubject) throws AuthenticationException {
         Subject subject = null;
         AuthCacheService authCacheService = getAuthCacheService();
         if (authCacheService != null && authenticationData != null) {
@@ -363,7 +342,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
                         if (userid != null && password != null) {
                             subject = findSubjectByUseridAndPassword(authCacheService, userid, password);
                         } else if (partialSubject != null) {
-                            subject = findSubjectBySubjectHashtable(authCacheService, partialSubject, hashtableAuthData);
+                            subject = findSubjectBySubjectHashtable(authCacheService, partialSubject);
                         }
                     }
                 }
@@ -428,63 +407,35 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         return authCacheService.getSubject(BasicAuthCacheKeyProvider.createLookupKey(getRealm(), userid, password));
     }
 
-/*
- * We only create cache key (CustomCacheKeyProvider.java) for hashtable login so there is no need to
- * get the lookup key for userId/pwd and userId only cases.
- */
-    private Subject findSubjectBySubjectHashtable(AuthCacheService authCacheService, Subject partialSubject, AuthenticationData hashtableAuthData) {
+    private Subject findSubjectBySubjectHashtable(AuthCacheService authCacheService, Subject partialSubject) {
         Subject subject = null;
-        if (hashtableAuthData.isEmpty())
-            return subject;
-
-        String customCacheKey = (String) hashtableAuthData.get(AttributeNameConstants.WSCREDENTIAL_CACHE_KEY);
-        if (customCacheKey != null) {
-            subject = authCacheService.getSubject(customCacheKey);
-        }
-        //We do not create look up key for hashtable userid/pwd or userid only
-        String userid = (String) hashtableAuthData.get(AttributeNameConstants.WSCREDENTIAL_USERID);
-        String password = (String) hashtableAuthData.get(AttributeNameConstants.WSCREDENTIAL_PASSWORD);
-
-        String lookupKey;
-        if (password != null) {
-            lookupKey = BasicAuthCacheKeyProvider.createLookupKey(getRealm(), userid, password);
-        } else {
-            lookupKey = BasicAuthCacheKeyProvider.createLookupKey(getRealm(), userid);
-        }
-        subject = authCacheService.getSubject(lookupKey);
-
-        return subject;
-    }
-
-    private AuthenticationData getHashtable(Subject partialSubject) {
-        AuthenticationData authData = new WSAuthenticationData();
-
         SubjectHelper subjectHelper = new SubjectHelper();
         Hashtable<String, ?> hashtable = subjectHelper.getHashtableFromSubject(partialSubject, new String[] { AttributeNameConstants.WSCREDENTIAL_CACHE_KEY });
         if (hashtable != null) {
             String customCacheKey = (String) hashtable.get(AttributeNameConstants.WSCREDENTIAL_CACHE_KEY);
             Boolean internalCachekeyAssertion = (Boolean) hashtable.get(AuthenticationConstants.INTERNAL_ASSERTION_KEY);
+
             if (customCacheKey != null && internalCachekeyAssertion != null && internalCachekeyAssertion.equals(Boolean.TRUE)) {
-                authData.set(AttributeNameConstants.WSCREDENTIAL_CACHE_KEY, customCacheKey);
+                subject = authCacheService.getSubject(customCacheKey);
+                return subject;
             }
         }
-
         hashtable = subjectHelper.getHashtableFromSubject(partialSubject, new String[] { AttributeNameConstants.WSCREDENTIAL_USERID,
                                                                                          AttributeNameConstants.WSCREDENTIAL_PASSWORD });
         if (hashtable != null) {
-            Boolean internalCachekeyAssertion = (Boolean) hashtable.get(AuthenticationConstants.INTERNAL_ASSERTION_KEY);
             String userid = (String) hashtable.get(AttributeNameConstants.WSCREDENTIAL_USERID);
             String password = (String) hashtable.get(AttributeNameConstants.WSCREDENTIAL_PASSWORD);
-            if (userid != null & password != null) {
-                authData.set(AttributeNameConstants.WSCREDENTIAL_USERID, userid);
-                authData.set(AttributeNameConstants.WSCREDENTIAL_PASSWORD, password);
 
-            } else if (userid != null && internalCachekeyAssertion != null && internalCachekeyAssertion.equals(Boolean.TRUE)) {
-                authData.set(AttributeNameConstants.WSCREDENTIAL_USERID, userid); //Allow to login with user ID only
+            String lookupKey;
+            if (password != null) {
+                lookupKey = BasicAuthCacheKeyProvider.createLookupKey(getRealm(), userid, password);
+            } else {
+                lookupKey = BasicAuthCacheKeyProvider.createLookupKey(getRealm(), userid);
             }
+            subject = authCacheService.getSubject(lookupKey);
         }
 
-        return authData;
+        return subject;
     }
 
     @Sensitive

--- a/dev/com.ibm.ws.security.authentication/src/com/ibm/ws/security/authentication/AuthenticationConstants.java
+++ b/dev/com.ibm.ws.security.authentication/src/com/ibm/ws/security/authentication/AuthenticationConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 IBM Corporation and others.
+ * Copyright (c) 2011, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -34,7 +34,7 @@ public interface AuthenticationConstants {
     /**
      * This key maps to a boolean property in a Subject's private credentials
      * hashtable. When the property is true, the authentication service will
-     * authenticate a user with only the username supplied or cache key.
+     * authenticate a user with only the username supplied.
      */
     String INTERNAL_ASSERTION_KEY = "com.ibm.ws.authentication.internal.assertion";
 

--- a/dev/com.ibm.ws.security.authentication/src/com/ibm/ws/security/authentication/AuthenticationData.java
+++ b/dev/com.ibm.ws.security.authentication/src/com/ibm/ws/security/authentication/AuthenticationData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 IBM Corporation and others.
+ * Copyright (c) 2011 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -92,9 +92,4 @@ public interface AuthenticationData {
      */
     @Sensitive
     public Object get(String key);
-
-    /**
-     * Empty authentication data.
-     */
-    public boolean isEmpty();
 }

--- a/dev/com.ibm.ws.security.authentication/src/com/ibm/ws/security/authentication/WSAuthenticationData.java
+++ b/dev/com.ibm.ws.security.authentication/src/com/ibm/ws/security/authentication/WSAuthenticationData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 IBM Corporation and others.
+ * Copyright (c) 2011 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -110,10 +110,5 @@ public class WSAuthenticationData implements AuthenticationData {
             hash = credentialsMap.hashCode();
         }
         return hash;
-    }
-
-    @Override
-    public boolean isEmpty() {
-        return credentialsMap.isEmpty();
     }
 }


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#17147

This caused a hard break in the LAOS continuous build https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=284673

This failure can also be seen in the last personal build before delivery.
We have no looked in to how this changed caused this, but are reasonably certain that it did.