### PR TITLE
Fix liberty_audit not found test

### DIFF
--- a/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashCollectorTest.java
+++ b/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashCollectorTest.java
@@ -62,7 +62,7 @@ public abstract class LogstashCollectorTest {
     public static final String EXIT = "Exit";
     public static final String MESSAGE_PREFIX = "Test Logstash Message";
     public static final String PATH_TO_AUTOFVT_TESTFILES = "lib/LibertyFATTestFiles/";
-    public static final int DEFAULT_TIMEOUT = 30 * 1000; // 30 seconds
+    public static final int DEFAULT_TIMEOUT = 40 * 1000; // 40 seconds
 
     protected abstract LibertyServer getServer();
 

--- a/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
+++ b/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
@@ -84,7 +84,8 @@ public class LogstashSSLTest extends LogstashCollectorTest {
         if (!checkGcSpecialCase()) {
             found_liberty_gc_at_startup = waitForStringInContainerOutput(LIBERTY_GC) != null;
         }
-
+        
+        assertNotNull("The application is not ready", server.waitForStringInLogUsingMark("CWWKT0016I", 10000));
         assertNotNull("Cannot find TRAS0218I from Logstash output", waitForStringInContainerOutput("TRAS0218I"));
         clearContainerOutput();
     }
@@ -235,7 +236,6 @@ public class LogstashSSLTest extends LogstashCollectorTest {
         testName = "testLogstashForAuditEvent";
         setConfig("server_logs_audit.xml");
         clearContainerOutput();
-        assertNotNull("The application is not ready", server.waitForStringInLogUsingMark("CWWKT0016I", 10000));
 
         createTraceEvent(testName);
 

--- a/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
+++ b/dev/com.ibm.ws.logstash.collector_fat/fat/src/com/ibm/ws/logstash/collector/tests/LogstashSSLTest.java
@@ -235,6 +235,7 @@ public class LogstashSSLTest extends LogstashCollectorTest {
         testName = "testLogstashForAuditEvent";
         setConfig("server_logs_audit.xml");
         clearContainerOutput();
+        assertNotNull("The application is not ready", server.waitForStringInLogUsingMark("CWWKT0016I", 10000));
 
         createTraceEvent(testName);
 


### PR DESCRIPTION
fixes: #17135

#build

One failure occurred because the Logstash Application was not ready yet, so a check was added to resolve that issue.
One failure occurred because the audit message being searched for doesn't appear during the 30 second timeout search period (it occurred 2 seconds after), so a 10 second increase was added to the search timeout.
