### PR TITLE
Issue 16237: Make EJB 4 RMIC Compatible

### DIFF
--- a/dev/com.ibm.ws.clientcontainer.remote.common/src/com/ibm/ws/clientcontainer/remote/common/ClientEJBFactory.java
+++ b/dev/com.ibm.ws.clientcontainer.remote.common/src/com/ibm/ws/clientcontainer/remote/common/ClientEJBFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -47,6 +47,10 @@ public interface ClientEJBFactory {
      * ensure that stubs for pre-EJB 3 modules are generated with as much
      * compatibility with RMIC as we can. <p>
      *
+     * Starting with Jakarta EE 9 / Enterprise Beans 4.0 all remote bean
+     * interfaces are RMIC compatible so an application at EE 9 or later
+     * should not use this method; UnsupportedOperationException will be thrown.
+     *
      * @param appName name of the client application.
      *
      * @return Set of EJB interface class names that require compatibility with RMIC.
@@ -62,14 +66,14 @@ public interface ClientEJBFactory {
      *
      * All parameters must be non-null. <p>
      *
-     * @param appName name of the application containing the EJB.
-     * @param beanName beanName or ejb-link, including module information.
+     * @param appName       name of the application containing the EJB.
+     * @param beanName      beanName or ejb-link, including module information.
      * @param interfaceName component home or business interface of EJB.
      *
      * @return a reference to the EJB object specified.
      *
      * @exception RemoteException is thrown when the specified EJB cannot
-     *                be found or a failure occurs creating an instance.
+     *                                be found or a failure occurs creating an instance.
      **/
     RemoteObjectInstance create(String appName, String beanName, String interfaceName) throws RemoteException;
 
@@ -82,15 +86,15 @@ public interface ClientEJBFactory {
      *
      * All parameters must be non-null. <p>
      *
-     * @param appName name of the application containing the EJB.
-     * @param moduleName name of the module containing the EJB.
-     * @param beanName name of the specific EJB.
+     * @param appName       name of the application containing the EJB.
+     * @param moduleName    name of the module containing the EJB.
+     * @param beanName      name of the specific EJB.
      * @param interfaceName component home or business interface of EJB.
      *
      * @return a reference to the EJB object specified.
      *
      * @exception RemoteException is thrown when the specified EJB cannot
-     *                be found or a failure occurs creating an instance.
+     *                                be found or a failure occurs creating an instance.
      **/
     RemoteObjectInstance create(String appName, String moduleName, String beanName, String interfaceName) throws RemoteException;
 
@@ -108,14 +112,14 @@ public interface ClientEJBFactory {
      * considered an ambiguous reference, and an EJBException will
      * be thrown. <p>
      *
-     * @param appName name of the application containing the EJB.
-     * @param beanName name of the specific EJB.
+     * @param appName       name of the application containing the EJB.
+     * @param beanName      name of the specific EJB.
      * @param interfaceName component home or business interface of EJB.
      *
      * @return a reference to the EJB object specified.
      *
      * @exception RemoteException is thrown when the specified EJB cannot
-     *                be found or a failure occurs creating an instance.
+     *                                be found or a failure occurs creating an instance.
      **/
     RemoteObjectInstance findByBeanName(String appName, String beanName, String interfaceName) throws RemoteException;
 
@@ -133,13 +137,13 @@ public interface ClientEJBFactory {
      * interface, this is considered an ambiguous reference, and an
      * EJBException will be thrown. <p>
      *
-     * @param appName name of the application containing the EJB.
+     * @param appName       name of the application containing the EJB.
      * @param interfaceName component home or business interface of EJB.
      *
      * @return a reference to the EJB object specified.
      *
      * @exception RemoteException is thrown when the specified EJB cannot
-     *                be found or a failure occurs creating an instance.
+     *                                be found or a failure occurs creating an instance.
      **/
     RemoteObjectInstance findByInterface(String appName, String interfaceName) throws RemoteException;
 }

--- a/dev/com.ibm.ws.clientcontainer.remote.common/src/com/ibm/ws/clientcontainer/remote/common/ClientSupport.java
+++ b/dev/com.ibm.ws.clientcontainer.remote.common/src/com/ibm/ws/clientcontainer/remote/common/ClientSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,11 +30,13 @@ import com.ibm.ws.container.service.naming.RemoteObjectInstance;
 public interface ClientSupport extends Remote {
     public static final String SERVICE_NAME = "ClientSupport";
 
-    RemoteObjectInstance getRemoteObjectInstance(String appName, String moduleName, String compName, String namespaceString, String jndiName) throws NamingException, RemoteException;
+    RemoteObjectInstance getRemoteObjectInstance(String appName, String moduleName, String compName, String namespaceString,
+                                                 String jndiName) throws NamingException, RemoteException;
 
     public boolean hasRemoteObjectWithPrefix(String appName, String moduleName, String compName, String namespaceString, String name) throws NamingException, RemoteException;
 
-    public Collection<? extends NameClassPair> listRemoteInstances(String appName, String moduleName, String compName, String namespaceString, String nameInContext) throws NamingException, RemoteException;
+    public Collection<? extends NameClassPair> listRemoteInstances(String appName, String moduleName, String compName, String namespaceString,
+                                                                   String nameInContext) throws NamingException, RemoteException;
 
     /**
      * Returns a set of Remote EJB interface classes for which the dynamically
@@ -49,6 +51,10 @@ public interface ClientSupport extends Remote {
      * In Liberty profile, there is no separate deploy step, so we need to
      * ensure that stubs for pre-EJB 3 modules are generated with as much
      * compatibility with RMIC as we can. <p>
+     *
+     * Starting with Jakarta EE 9 / Enterprise Beans 4.0 all remote bean
+     * interfaces are RMIC compatible so an application at EE 9 or later
+     * should not use this method; UnsupportedOperationException will be thrown.
      *
      * @param appName name of the client application.
      *
@@ -65,14 +71,14 @@ public interface ClientSupport extends Remote {
      *
      * All parameters must be non-null. <p>
      *
-     * @param appName name of the application containing the EJB.
-     * @param beanName beanName or ejb-link, including module information.
+     * @param appName       name of the application containing the EJB.
+     * @param beanName      beanName or ejb-link, including module information.
      * @param beanInterface component home or business interface of EJB.
      *
      * @return a RemoteObjectInstance containing a reference to the EJB object specified.
      *
      * @exception RemoteException is thrown when the specified EJB cannot
-     *                be found or a failure occurs creating an instance.
+     *                                be found or a failure occurs creating an instance.
      **/
     public RemoteObjectInstance createEJB(String appName, String beanName, String beanInterface) throws NamingException, RemoteException;
 
@@ -85,15 +91,15 @@ public interface ClientSupport extends Remote {
      *
      * All parameters must be non-null. <p>
      *
-     * @param appName name of the application containing the EJB.
-     * @param moduleName name of the module containing the EJB.
-     * @param beanName name of the specific EJB.
+     * @param appName       name of the application containing the EJB.
+     * @param moduleName    name of the module containing the EJB.
+     * @param beanName      name of the specific EJB.
      * @param beanInterface component home or business interface of EJB.
      *
      * @return a RemoteObjectInstance containing a reference to the EJB object specified.
      *
      * @exception RemoteException is thrown when the specified EJB cannot
-     *                be found or a failure occurs creating an instance.
+     *                                be found or a failure occurs creating an instance.
      **/
     public RemoteObjectInstance createEJB(String appName, String moduleName, String beanName, String beanInterface) throws NamingException, RemoteException;
 
@@ -111,14 +117,14 @@ public interface ClientSupport extends Remote {
      * considered an ambiguous reference, and a RemoteException will
      * be thrown. <p>
      *
-     * @param appName name of the application containing the EJB.
-     * @param beanName name of the specific EJB.
+     * @param appName       name of the application containing the EJB.
+     * @param beanName      name of the specific EJB.
      * @param beanInterface component home or business interface of EJB.
      *
      * @return a RemoteObjectInstance containing a reference to the EJB object specified.
      *
      * @exception RemoteException is thrown when the specified EJB cannot
-     *                be found or a failure occurs creating an instance.
+     *                                be found or a failure occurs creating an instance.
      **/
     public RemoteObjectInstance findEJBByBeanName(String appName, String beanName, String beanInterface) throws NamingException, RemoteException;
 
@@ -136,13 +142,13 @@ public interface ClientSupport extends Remote {
      * interface, this is considered an ambiguous reference, and a
      * RemoteException will be thrown. <p>
      *
-     * @param appName name of the application containing the EJB.
+     * @param appName       name of the application containing the EJB.
      * @param beanInterface component home or business interface of EJB.
      *
      * @return a RemoteObjectInstance containing a reference to the EJB object specified.
      *
      * @exception RemoteException is thrown when the specified EJB cannot
-     *                be found or a failure occurs creating an instance.
+     *                                be found or a failure occurs creating an instance.
      **/
     public RemoteObjectInstance findEJBByInterface(String appName, String beanInterface) throws NamingException, RemoteException;
 }

--- a/dev/com.ibm.ws.clientcontainer.remote.server/src/com/ibm/ws/clientcontainer/remote/server/ClientSupportImpl.java
+++ b/dev/com.ibm.ws.clientcontainer.remote.server/src/com/ibm/ws/clientcontainer/remote/server/ClientSupportImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -85,7 +85,8 @@ public class ClientSupportImpl implements ClientSupport {
         }
 
         @Override
-        public void setMetaData(MetaDataSlot slot, Object metadata) {}
+        public void setMetaData(MetaDataSlot slot, Object metadata) {
+        }
 
         @Override
         public Object getMetaData(MetaDataSlot slot) {
@@ -93,7 +94,8 @@ public class ClientSupportImpl implements ClientSupport {
         }
 
         @Override
-        public void release() {}
+        public void release() {
+        }
 
         @Override
         public ModuleMetaData getModuleMetaData() {
@@ -125,7 +127,7 @@ public class ClientSupportImpl implements ClientSupport {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.ws.clientcontainer.remote.common.ClientSupport#getRemoteObjectInstance(java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String)
      */
     @Override
@@ -157,7 +159,7 @@ public class ClientSupportImpl implements ClientSupport {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.ws.clientcontainer.remote.common.ClientSupport#hasRemoteObjectWithPrefix(java.lang.String, java.lang.String, java.lang.String, java.lang.String,
      * java.lang.String)
      */
@@ -184,7 +186,7 @@ public class ClientSupportImpl implements ClientSupport {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.ibm.ws.clientcontainer.remote.common.ClientSupport#listRemoteInstances(java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String)
      */
     @Override
@@ -331,7 +333,7 @@ public class ClientSupportImpl implements ClientSupport {
         if (factory != null) {
             return factory.getRmicCompatibleClasses(appName);
         }
-        throw new RemoteException("ejbRemote feature is not enabled in server process.");
+        throw new RemoteException("Enterprise beans remote feature is not enabled in server process.");
     }
 
     @Override
@@ -340,7 +342,7 @@ public class ClientSupportImpl implements ClientSupport {
         if (factory != null) {
             return factory.create(appName, moduleName, beanName, beanInterface);
         }
-        throw new RemoteException("ejbRemote feature is not enabled in server process.");
+        throw new RemoteException("Enterprise beans remote feature is not enabled in server process.");
     }
 
     @Override
@@ -349,7 +351,7 @@ public class ClientSupportImpl implements ClientSupport {
         if (factory != null) {
             return factory.create(appName, beanName, beanInterface);
         }
-        throw new RemoteException("ejbRemote feature is not enabled in server process.");
+        throw new RemoteException("Enterprise beans remote feature is not enabled in server process.");
     }
 
     @Override
@@ -358,7 +360,7 @@ public class ClientSupportImpl implements ClientSupport {
         if (factory != null) {
             return factory.findByBeanName(appName, beanName, beanInterface);
         }
-        throw new RemoteException("ejbRemote feature is not enabled in server process.");
+        throw new RemoteException("Enterprise beans remote feature is not enabled in server process.");
     }
 
     @Override
@@ -367,7 +369,7 @@ public class ClientSupportImpl implements ClientSupport {
         if (factory != null) {
             return factory.findByInterface(appName, beanInterface);
         }
-        throw new RemoteException("ejbRemote feature is not enabled in server process.");
+        throw new RemoteException("Enterprise beans remote feature is not enabled in server process.");
     }
 
 }

--- a/dev/com.ibm.ws.ejbcontainer.remote.client/src/com/ibm/ws/ejbcontainer/remote/client/internal/ClientEJBStubClassGeneratorImpl.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote.client/src/com/ibm/ws/ejbcontainer/remote/client/internal/ClientEJBStubClassGeneratorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,8 @@ package com.ibm.ws.ejbcontainer.remote.client.internal;
 import java.rmi.RemoteException;
 import java.util.HashSet;
 import java.util.Set;
+
+import javax.ejb.EJBException;
 
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Component;
@@ -38,6 +40,7 @@ public class ClientEJBStubClassGeneratorImpl implements ClassGenerator, Applicat
     private static final TraceComponent tc = Tr.register(ClientEJBStubClassGeneratorImpl.class);
     private static final String ORG_OMG_STUB_PREFIX = "org.omg.stub.";
     private static final int RMIC_COMPATIBLE_ALL = -1;
+    private static final boolean isJakarta = EJBException.class.getCanonicalName().startsWith("jakarta");
 
     /**
      * Client application name.
@@ -47,25 +50,33 @@ public class ClientEJBStubClassGeneratorImpl implements ClassGenerator, Applicat
     /**
      * Indication that an attempt should be made to connect to the server process through
      * the ClientSupport service to obtain the set of RMIC compatible classes.
+     *
+     * Note: not used for Jakarta name space (Enterprise Beans 4.0); always RMIC compatible.
      */
     private boolean attemptConnectionToServer = true;
 
     /**
      * Set of classes that should be generated with maximum RMIC compatibility.
      * This is used to simulate traditional WAS, which would normally run rmic.
+     *
+     * Note: not used for Jakarta name space (Enterprise Beans 4.0); always RMIC compatible.
      */
     private Set<Class<?>> rmicCompatibleClasses;
 
     /**
      * ClientSupportFactory provides a mechanism to connect to a server process
      * and obtain the set of RMIC compatible classes for the application.
+     *
+     * Note: not used for Jakarta name space (Enterprise Beans 4.0); always RMIC compatible.
      */
     private ClientSupportFactory clientSupportFactory;
 
     @Reference(service = LibertyProcess.class, target = "(wlp.process.type=client)")
-    protected void setLibertyProcess(ServiceReference<LibertyProcess> reference) {}
+    protected void setLibertyProcess(ServiceReference<LibertyProcess> reference) {
+    }
 
-    protected void unsetLibertyProcess(ServiceReference<LibertyProcess> reference) {}
+    protected void unsetLibertyProcess(ServiceReference<LibertyProcess> reference) {
+    }
 
     @Reference
     protected void setClientSupportFactory(ClientSupportFactory clientSupportFactory) {
@@ -122,6 +133,11 @@ public class ClientEJBStubClassGeneratorImpl implements ClassGenerator, Applicat
     @FFDCIgnore({ ClassNotFoundException.class, RemoteException.class })
     private synchronized boolean isRMICCompatibleClass(Class<?> c, ClassLoader loader) {
 
+        // Starting with Jakarta EE 9/Enterprise Beans 4.0 RMICCompatible is always used.
+        if (isJakarta) {
+            return true;
+        }
+
         if (attemptConnectionToServer && appName != null) {
 
             // Only attempt to get the set of RMIC compatible classes one time;
@@ -167,13 +183,16 @@ public class ClientEJBStubClassGeneratorImpl implements ClassGenerator, Applicat
 
     @Trivial
     @Override
-    public void applicationStarted(ApplicationInfo appInfo) throws StateChangeException {}
+    public void applicationStarted(ApplicationInfo appInfo) throws StateChangeException {
+    }
 
     @Trivial
     @Override
-    public void applicationStopping(ApplicationInfo appInfo) {}
+    public void applicationStopping(ApplicationInfo appInfo) {
+    }
 
     @Trivial
     @Override
-    public void applicationStopped(ApplicationInfo appInfo) {}
+    public void applicationStopped(ApplicationInfo appInfo) {
+    }
 }

--- a/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/EJBStubClassGenerator.java
+++ b/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/EJBStubClassGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,10 @@ public interface EJBStubClassGenerator {
      * Returns a set of Remote classes for which the dynamically generated
      * stub classes need to be compatible with RMIC generated stubs and ties
      * for the specified application. <p>
+     *
+     * Starting with Jakarta EE 9 / Enterprise Beans 4.0 all remote bean
+     * interfaces are RMIC compatible so an application at EE 9 or later
+     * should not use this method; UnsupportedOperationException will be thrown.
      *
      * @param appName application name
      * @return the RMIC compatible class names; or an empty set if none exist.
@@ -38,7 +42,11 @@ public interface EJBStubClassGenerator {
      * that stubs for pre-EJB 3 modules are generated with as much
      * compatibility with RMIC as we can.
      *
-     * @param loader application classloader for which the RMIC compatible stubs are required
+     * Starting with Jakarta EE 9 / Enterprise Beans 4.0 all remote bean
+     * interfaces are RMIC compatible so an application at EE 9 or later
+     * should not use this method; UnsupportedOperationException will be thrown.
+     *
+     * @param loader                application classloader for which the RMIC compatible stubs are required
      * @param rmicCompatibleClasses the RMIC compatible class names
      */
     void addRMICCompatibleClasses(ClassLoader loader, Set<String> rmicCompatibleClasses);


### PR DESCRIPTION
For Enterprise Beans 4.0 all remote interfaces will use RMIC compatible
stub and tie classes; the setting will not be configurable.

Also, the application client will no longer need to obtain a list
of RMIC compatible interfaces from the server.

fixes #16237 