### PR TITLE
Fix Key/Trust store type in config

### DIFF
--- a/dev/com.ibm.ws.security.oauth_fat/publish/files/serversettings/goodSSLSettings.xml
+++ b/dev/com.ibm.ws.security.oauth_fat/publish/files/serversettings/goodSSLSettings.xml
@@ -19,12 +19,12 @@
 	<keyStore
 		id="myKeyStore"
 		password="Liberty"
-		type="jks"
+		type="pkcs12"
 		location="${server.config.dir}/oauthTestKeyStore.p12" />
 	<keyStore
 		id="myTrustStore"
 		password="Liberty"
-		type="jks"
+		type="pkcs12"
 		location="${server.config.dir}/oauthTestTrustStore.p12" />
 
 </server>        


### PR DESCRIPTION
Added a default key and trust store a while back to prevent an intermittent issue with creating the default keystore.
The new keystores are p12 type files, but, the config set:
type="jks"
and should have set:
type="pkcs12"
doh...
Things work fine with Java 11 and above, but, Java 8 can't handle it.
Java 8 gives a message indicating that the password was invalid in some cases, and the format was invalid in other cases.
Updating the type fixes the issue...