### PR TITLE
Rename reserved word in ReduceableSemaphore

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ReduceableSemaphore.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ReduceableSemaphore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,8 +18,8 @@ import java.util.concurrent.Semaphore;
 public class ReduceableSemaphore extends Semaphore {
     private static final long serialVersionUID = 1L;
 
-    public ReduceableSemaphore(int permits, boolean fair) {
-        super(permits, fair);
+    public ReduceableSemaphore(int numPermits, boolean fair) {
+        super(numPermits, fair);
     }
 
     @Override // to make visible


### PR DESCRIPTION
Greg pointed out that https://openjdk.java.net/jeps/409 is in Java 17.
It shows "permits" becoming a reserved word, so we will need to rename a variable in ReduceableSemaphore which has that same name so that compilation against Java 17 will be possible.