### PR TITLE
Add channel framework trace

### DIFF
--- a/dev/com.ibm.ws.security.saml.sso_fat.2/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.2.missingMetaData/bootstrap.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.2/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.2.missingMetaData/bootstrap.properties
@@ -13,6 +13,7 @@ bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
 org.apache.xml.security.*=all=enabled:\
 com.ibm.ws.security.saml*=all=enabled:\
+com.ibm.ws.channelfw.internal.ChannelFrameworkImpl*=all=enabled:\
 com.ibm.ws.webcontainer.security*=all=enabled
 
 com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.security.saml.sso_fat.2/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.2/bootstrap.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.2/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.2/bootstrap.properties
@@ -13,6 +13,7 @@ bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
 org.apache.xml.security.*=all=enabled:\
 com.ibm.ws.security.saml*=all=enabled:\
+com.ibm.ws.channelfw.internal.ChannelFrameworkImpl*=all=enabled:\
 com.ibm.ws.webcontainer.security*=all=enabled
 
 com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.security.saml.sso_fat.3/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.3/bootstrap.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.3/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.3/bootstrap.properties
@@ -1,8 +1,19 @@
+###############################################################################
+# Copyright (c) 2020, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
 bootstrap.include=../testports.properties
 
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
 org.apache.xml.security.*=all=enabled:\
 com.ibm.ws.security.saml*=all=enabled:\
+com.ibm.ws.channelfw.internal.ChannelFrameworkImpl*=all=enabled:\
 com.ibm.ws.webcontainer.security*=all=enabled
 
 com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.shibboleth/bootstrap.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.shibboleth/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@ bootstrap.include=../testports.properties
 
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
 com.ibm.ws.webcontainer.security*=all=enabled:\
+com.ibm.ws.channelfw.internal.ChannelFrameworkImpl*=all=enabled:\
 com.ibm.ws.security.saml*=all=enabled
 
 com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.security.saml.sso_fat.config.mapToUserRegistry/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.config.mapToUserRegistry/bootstrap.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.config.mapToUserRegistry/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.config.mapToUserRegistry/bootstrap.properties
@@ -1,8 +1,19 @@
+###############################################################################
+# Copyright (c) 2020, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
 bootstrap.include=../testports.properties
 
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
 org.apache.xml.security.*=all=enabled:\
 com.ibm.ws.security.saml*=all=enabled:\
+com.ibm.ws.channelfw.internal.ChannelFrameworkImpl*=all=enabled:\
 com.ibm.ws.webcontainer.security*=all=enabled
 
 com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.security.saml.sso_fat.config/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.config.2/bootstrap.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.config/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.config.2/bootstrap.properties
@@ -1,8 +1,19 @@
+###############################################################################
+# Copyright (c) 2020, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
 bootstrap.include=../testports.properties
 
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
 org.apache.xml.security.*=all=enabled:\
 com.ibm.ws.security.saml*=all=enabled:\
+com.ibm.ws.channelfw.internal.ChannelFrameworkImpl*=all=enabled:\
 com.ibm.ws.webcontainer.security*=all=enabled
 
 com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.security.saml.sso_fat.config/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.config/bootstrap.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.config/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.config/bootstrap.properties
@@ -1,8 +1,19 @@
+###############################################################################
+# Copyright (c) 2020, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
 bootstrap.include=../testports.properties
 
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
 org.apache.xml.security.*=all=enabled:\
 com.ibm.ws.security.saml*=all=enabled:\
+com.ibm.ws.channelfw.internal.ChannelFrameworkImpl*=all=enabled:\
 com.ibm.ws.webcontainer.security*=all=enabled
 
 com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.security.saml.sso_fat.endpoint.samlmetadata/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.endpoint.samlmetadata/bootstrap.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.endpoint.samlmetadata/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.endpoint.samlmetadata/bootstrap.properties
@@ -1,8 +1,19 @@
+###############################################################################
+# Copyright (c) 2020, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
 bootstrap.include=../testports.properties
 
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
 org.apache.xml.security.*=all=enabled:\
 com.ibm.ws.security.saml*=all=enabled:\
+com.ibm.ws.channelfw.internal.ChannelFrameworkImpl*=all=enabled:\
 com.ibm.ws.webcontainer.security*=all=enabled
 
 com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.jaxrs.config.rs/bootstrap.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.jaxrs.config.rs/bootstrap.properties
@@ -1,9 +1,20 @@
+###############################################################################
+# Copyright (c) 2020, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
 bootstrap.include=../testports.properties
 
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
 org.apache.xml.security.*=all=enabled:\
 com.ibm.ws.security.saml*=all=enabled:\
 com.ibm.ws.webcontainer.security*=all=enabled:\
+com.ibm.ws.channelfw.internal.ChannelFrameworkImpl*=all=enabled:\
 com.ibm.ws.jaxrs20.client.*=all
 
 com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.jaxrs.config.sp/bootstrap.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.jaxrs.config.sp/bootstrap.properties
@@ -1,9 +1,20 @@
+###############################################################################
+# Copyright (c) 2020, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
 bootstrap.include=../testports.properties
 
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
 org.apache.xml.security.*=all=enabled:\
 com.ibm.ws.security.saml*=all=enabled:\
 com.ibm.ws.webcontainer.security*=all=enabled:\
+com.ibm.ws.channelfw.internal.ChannelFrameworkImpl*=all=enabled:\
 com.ibm.ws.jaxrs20.client.*=all
 
 com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.jaxrs.merged_sp_rs/bootstrap.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.jaxrs.merged_sp_rs/bootstrap.properties
@@ -1,9 +1,20 @@
+###############################################################################
+# Copyright (c) 2020, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
 bootstrap.include=../testports.properties
 
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
 org.apache.xml.security.*=all=enabled:\
 com.ibm.ws.security.saml*=all=enabled:\
 com.ibm.ws.webcontainer.security*=all=enabled:\
+com.ibm.ws.channelfw.internal.ChannelFrameworkImpl*=all=enabled:\
 com.ibm.ws.jaxrs20.client.*=all
 
 com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.jaxrs.rs/bootstrap.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.jaxrs.rs/bootstrap.properties
@@ -1,9 +1,20 @@
+###############################################################################
+# Copyright (c) 2020, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
 bootstrap.include=../testports.properties
 
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
 org.apache.xml.security.*=all=enabled:\
 com.ibm.ws.security.saml*=all=enabled:\
 com.ibm.ws.webcontainer.security*=all=enabled:\
+com.ibm.ws.channelfw.internal.ChannelFrameworkImpl*=all=enabled:\
 com.ibm.ws.jaxrs20.client.*=all
 
 com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.jaxrs.sp/bootstrap.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat.jaxrs.sp/bootstrap.properties
@@ -1,9 +1,20 @@
+###############################################################################
+# Copyright (c) 2020, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
 bootstrap.include=../testports.properties
 
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
 org.apache.xml.security.*=all=enabled:\
 com.ibm.ws.security.saml*=all=enabled:\
 com.ibm.ws.webcontainer.security*=all=enabled:\
+com.ibm.ws.channelfw.internal.ChannelFrameworkImpl*=all=enabled:\
 com.ibm.ws.jaxrs20.client.*=all
 
 com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout/publish/servers/com.ibm.ws.security.saml.sso_fat.logout.server2/bootstrap.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout/publish/servers/com.ibm.ws.security.saml.sso_fat.logout.server2/bootstrap.properties
@@ -1,9 +1,20 @@
+###############################################################################
+# Copyright (c) 2020, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
 bootstrap.include=../testports.properties
 
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
 org.apache.xml.security.*=all=enabled:\
 com.ibm.ws.security.saml*=all=enabled:\
 com.ibm.ws.webcontainer.security.metadata.*=all=disabled:\
+com.ibm.ws.channelfw.internal.ChannelFrameworkImpl*=all=enabled:\
 com.ibm.ws.webcontainer.security.*=all=enabled
 
 com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout/publish/servers/com.ibm.ws.security.saml.sso_fat.logout/bootstrap.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout/publish/servers/com.ibm.ws.security.saml.sso_fat.logout/bootstrap.properties
@@ -1,9 +1,20 @@
+###############################################################################
+# Copyright (c) 2020, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
 bootstrap.include=../testports.properties
 
 com.ibm.ws.logging.trace.specification=*=info=enabled:\
 org.apache.xml.security.*=all=enabled:\
 com.ibm.ws.security.saml*=all=enabled:\
 com.ibm.ws.webcontainer.security.metadata.*=all=disabled:\
+com.ibm.ws.channelfw.internal.ChannelFrameworkImpl*=all=enabled:\
 com.ibm.ws.webcontainer.security.*=all=enabled
 
 com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.security.saml.sso_fat/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat/bootstrap.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat/publish/servers/com.ibm.ws.security.saml.sso-2.0_fat/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@ bootstrap.include=../testports.properties
 
 com.ibm.ws.logging.trace.specification=\
 org.apache.xml.security.*=all=enabled:\
+com.ibm.ws.channelfw.internal.ChannelFrameworkImpl*=all=enabled:\
 com.ibm.ws.security.saml*=all=enabled
 
 com.ibm.ws.logging.max.file.size=0


### PR DESCRIPTION
Add channel framework trace to help debug:
_`Stack Dump = com.ibm.wsspi.channelfw.exception.InvalidChainNameException: Unable to init unknown chain, CHAIN-defaultHttpEndpoint-ssl`_
probably caused by reconfigs happening too quickly...
