### PR TITLE
Enable extra logging for testcontainers

### DIFF
--- a/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/ContainersTest.java
+++ b/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/ContainersTest.java
@@ -51,12 +51,14 @@ public class ContainersTest extends FATServletClient {
     public static final String POSTGRES_PASSWORD = "test";
     public static final int POSTGRE_PORT = 5432;
 
-    /*
+    /**
      * When using a generic container you will need to provide all the information needed
      * to run that container. This is equivalent of constructing a docker run command.
+     * <br>
      *
      * This is annotated as a ClassRule which will call start/stop on the container automatically
      *
+     * <pre>
      * ~~Common settings~~
      * Constructor: accepts image name in form user/container:version
      * - withExposedPorts: what ports does that container use that need to be exposed
@@ -65,6 +67,7 @@ public class ContainersTest extends FATServletClient {
      * - withLogConsumer: redirect stout/sterr from container to a log consumer
      * Use the SimpleLogConsumer from fattest.simplicity to redirect those logs to output.txt
      * - waitingFor: defines a wait strategy to know when container has started
+     * </pre>
      *
      * NOTE: the testcontainers project has a pre-configured PostgreSQLContainer class that could
      * have been used here. This is just an example of how to setup a GenericContainer.

--- a/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/DatabaseRotationTest.java
+++ b/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/DatabaseRotationTest.java
@@ -31,7 +31,7 @@ import web.dbrotation.DbRotationServlet;
  * Example test class showing how to setup a test class that can
  * be run against any of our supported databases.
  *
- * This workload is commonly refered to as "Database Rotation", but
+ * This workload is commonly referred to as "Database Rotation", but
  * it should be noted that the rotation workflow happens as part of our
  * SOE testing and not within the test infrastructure itself.
  */
@@ -44,13 +44,15 @@ public class DatabaseRotationTest {
     @TestServlet(servlet = DbRotationServlet.class, contextRoot = APP_NAME)
     public static LibertyServer server;
 
-    /*
+    /**
      * Here we are using a child class of GenericContainer called JdbcDatabaseContainer.
      * This class has extra workflows specific to database containers.
+     * <br>
      *
      * The DatabaseContainerFactory is from fattest.simplicity and will setup and return
      * a container based on the fat.bucket.db.type property. This can be set either on the
-     * commandline when doing ./gradlew <project>:buildandrun or on a build system.
+     * commandline when doing ./gradlew \<project\>:buildandrun or on a build system.
+     * <br>
      *
      * This is how our SOE builds run against each database.
      */

--- a/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/DockerfileTest.java
+++ b/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/DockerfileTest.java
@@ -57,14 +57,19 @@ public class DockerfileTest {
      * </pre>
      *
      * Doing this will result in a warning being logged:
+     *
+     * <pre>
      * W WARNING: Cannot use private registry for programmatically built image testcontainers/[image-sha]:latest.
      * Consider using a pre-built image instead.
+     * </pre>
      *
      * This warning is thrown to alert the developer that we CANNOT use our Artifactory image cache.
      * This could result in hitting our docker pull limits and introduce intermittent failures.
+     * <br>
      *
      * Instead, it is best practice to build and push your docker image to docker hub, and reference that instead.
      * You can still keep the Dockerfile and any related files in source control under publish/files.
+     * <br>
      *
      * In this case I pushed my custom image to my personal DockerHub repo under kyleaure/postgres-test-table:1.0
      * You will notice that everything else is configured the same as in the regular ContainersTest test class.

--- a/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/FATSuite.java
+++ b/dev/build.example.testcontainers_fat/fat/src/com/ibm/ws/testcontainers/example/FATSuite.java
@@ -14,7 +14,10 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+import org.slf4j.LoggerFactory;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import componenttest.containers.ExternalTestServiceDockerClientStrategy;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
@@ -30,33 +33,50 @@ import componenttest.rules.repeater.RepeatTests;
  */
 public class FATSuite {
 
-    /*
-     * TestContainers uses a properties file located at ~/.testcontainers.properties
-     * This method call clears and set's the values in this property file.
-     *
-     * Unless otherwise specified TestContainers will attempt to run against a local
-     * docker instance, and pull from DockerHub. If you set the property:
-     * -Dfat.test.use.remote.docker=true
-     * We will change the properties below. This only works if you are on the IBM network.
-     *
-     * We use two properties in this file:
-     * 1. docker.client.strategy:
-     * Default: org.testcontainers.dockerclient.UnixSocketClientProviderStrategy
-     * Custom: componenttest.containers.ExternalTestServiceDockerClientStrategy
-     * Purpose: This is the strategy TestContainers uses to locate and
-     * run against a docker instance.
-     * 2. image.substitutor:
-     * Default: [none]
-     * Custom: componenttest.containers.ArtifactoryImageNameSubstitutor
-     * Purpose: This defines a strategy for substituting image names.
-     * This is so that we can use a private docker repository to cache docker images
-     * to avoid the docker pull limits.
-     * If a TestContainer uses foo/bar:1.0 it will get changed to
-     * wasliberty-docker-remote.artifactory.swg-devops.com/foo/bar:1.0
-     */
     static {
+        /*
+         * By default the testcontainers component and dependencies will log at the following levels:
+         * - org.testcontainers: INFO
+         * - com.github.dockerjava: WARN
+         * - OTHER: ERROR
+         *
+         * You can overwrite these default configurations programmatically here.
+         * This can help in debugging build errors related to testcontaienrs and docker-java.
+         * However, this is not required for successful use of testcontainers.
+         */
+        Logger root = (Logger) LoggerFactory.getLogger("org.testcontainers");
+        root.setLevel(Level.ALL);
+
+        /*
+         * Testcontainers uses a properties file located at ~/.testcontainers.properties
+         * This method call clears and set's the values in this property file.
+         *
+         * Unless otherwise specified testcontaienrs will attempt to run against a local
+         * docker instance, and pull from DockerHub.
+         *
+         * If you set the property: -Dfat.test.use.remote.docker=true
+         * This only works if you are on the IBM network.
+         *
+         * We will change the properties below.
+         * 1. docker.client.strategy:
+         * Default: [Depends on local OS]
+         * Custom : componenttest.containers.ExternalTestServiceDockerClientStrategy
+         * Purpose: This is the strategy testcontaienrs uses to locate and run against a docker instance.
+         *
+         * 2. image.substitutor:
+         * Default: [none]
+         * Custom : componenttest.containers.ArtifactoryImageNameSubstitutor
+         * Purpose: This defines a strategy for substituting image names.
+         * This is so that we can use a private docker repository to cache docker images
+         * to avoid the docker pull limits.
+         * Example: foo/bar:1.0 it will get changed to wasliberty-docker-remote.artifactory.swg-devops.com/foo/bar:1.0
+         */
         ExternalTestServiceDockerClientStrategy.setupTestcontainers();
     }
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.NO_REPLACEMENT().fullFATOnly())
+                    .andWith(FeatureReplacementAction.EE9_FEATURES());
 
     /*
      * If you want to use the same container for the entire test suite you can
@@ -67,9 +87,5 @@ public class FATSuite {
      */
 //    @ClassRule
 //    public static PostgreSQLContainer container = new PostgreSQLContainer("postgres:9.6.12");
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.NO_REPLACEMENT().fullFATOnly())
-                    .andWith(FeatureReplacementAction.EE9_FEATURES());
 
 }

--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -32,6 +32,16 @@
       <version>3.3.0</version>
     </dependency>
     <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.3</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <version>1.2.3</version>
+    </dependency>
+    <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
       <version>1.72</version>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -2,6 +2,8 @@ biz.aQute.bnd:biz.aQute.bnd.annotation:5.3.0
 biz.aQute.bnd:biz.aQute.bnd.transform:5.3.0
 biz.aQute.bnd:biz.aQute.bnd:5.3.0
 cglib:cglib-nodep:3.3.0
+ch.qos.logback:logback-classic:1.2.3
+ch.qos.logback:logback-core:1.2.3
 com.beust:jcommander:1.72
 com.cloudant:cloudant-client:2.16.0
 com.cloudant:cloudant-client:2.8.0

--- a/dev/io.openliberty.org.testcontainers/bnd.bnd
+++ b/dev/io.openliberty.org.testcontainers/bnd.bnd
@@ -20,17 +20,20 @@ Bundle-Description: FAT Testcontainer Bundle; version=${bVersion}
 # binary files instead of class files. This is expected and necessary
 
 Export-Package: \
+	ch.qos.logback.classic.*;version="1.2.3",\
+	ch.qos.logback.core.*;version="1.2.3",\
 	com.github.*;version="3.2.8",\
 	com.sun.jna.*;version="5.8.0",\
 	org.apache.commons.*;version="1.20",\
 	org.testcontainers.*;version="1.15.3";-split-package:=merge-last,\
 	org.rnorth.*;version="1.0.8",\
-	org.slf4j.*;version="1.7.30"
+	org.slf4j.*;version="1.7.30";-split-package:=merge-last
 
 #Ensure that /META-INF/service folder from testcontainers core project is included in bundle.
 # This will ensure that the other docker container strategies are accessible at runtime.	
 Include-Resource: \
-	@${repo;org.testcontainers:testcontainers;1.15.3;EXACT}!/META-INF/**
+	@${repo;org.testcontainers:testcontainers;1.15.3;EXACT}!/META-INF/**,\
+	resources/logback-test.xml
 
 #Ensure that a stub project is created in CL
 generate.replacement: true
@@ -59,4 +62,6 @@ generate.replacement: true
 	org.rnorth.visible-assertions:visible-assertions;version=2.1.2,\
 	org.slf4j:slf4j-api;version=1.7.30,\
 	org.slf4j:slf4j-simple;version=1.7.30,\
-	net.java.dev.jna:jna;version=5.8.0
+	net.java.dev.jna:jna;version=5.8.0,\
+	ch.qos.logback:logback-classic;version=1.2.3,\
+	ch.qos.logback:logback-core;version=1.2.3

--- a/dev/io.openliberty.org.testcontainers/resources/logback-test.xml
+++ b/dev/io.openliberty.org.testcontainers/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+	This is the default logging configuration for packages:
+		- org.testcontainers.*		Default Level: INFO
+		- com.github.dockerjava.*	Default Level: WARN
+ -->
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+</configuration>


### PR DESCRIPTION
Create a method to expand the logging done by testcontainers to achieve better debug messages when resolving build / test errors.
