### PR TITLE
Don't put exception stack in json error objects

### DIFF
--- a/dev/com.ibm.ws.jmx.connector.client.rest/src/com/ibm/ws/jmx/connector/converter/JSONConverter.java
+++ b/dev/com.ibm.ws.jmx.connector.client.rest/src/com/ibm/ws/jmx/connector/converter/JSONConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2017 IBM Corporation and others.
+ * Copyright (c) 2012, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -475,6 +475,8 @@ public class JSONConverter {
     // "stacktrace" is not read by the Java client.
     //    private static final String N_STACKTRACE = "stackTrace";
     private static final byte[] OM_STACKTRACE = { '"', 's', 't', 'a', 'c', 'k', 'T', 'r', 'a', 'c', 'e', '"', ':' };
+    // "error" is not read by the Java client
+    private static final byte[] OM_EXCEPTION_MESSAGE = { '"', 'e', 'r', 'r', 'o', 'r', '"', ':' };
     private static final String N_THROWABLE = "throwable";
     private static final byte[] OM_THROWABLE = { '"', 't', 'h', 'r', 'o', 'w', 'a', 'b', 'l', 'e', '"', ':' };
     private static final String N_TIMESTAMP = "timeStamp";
@@ -1937,7 +1939,7 @@ public class JSONConverter {
      * Encode a Throwable instance as JSON:
      * {
      * "throwable" : Base64,
-     * "stackTrace" : String
+     * "error" : String - the exception message
      * }
      *
      * @param out The stream to write JSON to
@@ -1948,9 +1950,7 @@ public class JSONConverter {
     public void writeThrowable(OutputStream out, Throwable value) throws IOException {
         writeStartObject(out);
         writeSerializedField(out, OM_THROWABLE, value);
-        StringWriter sw = new StringWriter();
-        value.printStackTrace(new PrintWriter(sw));
-        writeStringField(out, OM_STACKTRACE, sw.toString());
+        writeStringField(out, OM_EXCEPTION_MESSAGE, value.getMessage());
         writeEndObject(out);
     }
 

--- a/dev/com.ibm.ws.jmx.connector.client.rest/test/com/ibm/ws/jmx/connector/converter/JSONConverterTest.java
+++ b/dev/com.ibm.ws.jmx.connector.client.rest/test/com/ibm/ws/jmx/connector/converter/JSONConverterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2013 IBM Corporation and others.
+ * Copyright (c) 2012, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -137,6 +137,7 @@ public class JSONConverterTest {
     private static final String N_SIMPLEKEY = "simpleKey";
     private static final String N_SOURCE = "source";
     private static final String N_STACKTRACE = "stackTrace";
+    private static final String N_EXCEPTION_MESSAGE = "error";
     private static final String N_THROWABLE = "throwable";
     private static final String N_TIMESTAMP = "timeStamp";
     private static final String N_TYPE = "type";
@@ -286,7 +287,7 @@ public class JSONConverterTest {
 
     private static final String TEST_ATTRIBUTE_NAME = "attributeName";
 
-    private static final String TEST_THROWABLE_STACK_TRACE = "throwable stack trace";
+    private static final String TEST_THROWABLE_MESSAGE = "throwable error message";
 
     private static final String TEST_INVOCATION_SIGNATURE = "invocation signature";
 
@@ -2942,24 +2943,16 @@ public class JSONConverterTest {
     @Test
     public void testWriteThrowable() {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        OutputStream tempOut = new ByteArrayOutputStream();
         StringBuilder regex = new StringBuilder();
-        StringWriter stackTrace = new StringWriter();
 
-        Throwable throwable = new Throwable(TEST_THROWABLE_STACK_TRACE);
+        Throwable throwable = new Throwable(TEST_THROWABLE_MESSAGE);
         //Setup test parameters
         try {
-
             regex.append(ESCAPE);
             regex.append(OPEN_JSON);
-
             regex.append(encloseString(N_THROWABLE, ".+"));
             regex.append(COMMA);
-
-            throwable.printStackTrace(new PrintWriter(stackTrace));
-            converter.writeString(tempOut, stackTrace.toString());
-
-            regex.append(encloseString(N_STACKTRACE, ".+"));
+            regex.append(encloseString(N_EXCEPTION_MESSAGE, ".+"));
             regex.append(ESCAPE);
             regex.append(CLOSE_JSON);
         } catch (Exception e) {
@@ -2975,7 +2968,7 @@ public class JSONConverterTest {
             JSONArtifact art = JSON.parse(out.toString());
             JSONObject obj = (JSONObject) art;
 
-            assertEquals(obj.get(N_STACKTRACE), stackTrace.toString());
+            assertEquals(obj.get(N_EXCEPTION_MESSAGE), TEST_THROWABLE_MESSAGE);
 
         } catch (Exception e) {
             fail("Exception encoutered " + e);
@@ -2990,7 +2983,7 @@ public class JSONConverterTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         InputStream in;
 
-        Throwable throwable = new Throwable(TEST_THROWABLE_STACK_TRACE);
+        Throwable throwable = new Throwable(TEST_THROWABLE_MESSAGE);
 
         try {
             //setup output stream to get data.


### PR DESCRIPTION
When the JMX REST APIs encounter an error, the caught exception is serialized into
a JSON object which is returned from the API. The stack trace from the exception is
also added to the JSON object as a string field. This is not read by our REST client,
and was flagged as a security concern. Instead, put the exception message in a
string field to provide some human debuggability.



