### PR TITLE
Update repeat actions for com.ibm.ws.wsat_fat.multi

### DIFF
--- a/dev/com.ibm.ws.wsat_fat.multi/fat/src/com/ibm/ws/wsat/fat/FATSuite.java
+++ b/dev/com.ibm.ws.wsat_fat.multi/fat/src/com/ibm/ws/wsat/fat/FATSuite.java
@@ -28,10 +28,12 @@ import com.ibm.ws.wsat.fat.tests.MultiServerTest;
 })
 public class FATSuite {
 
+    // Only run EE9 in lite mode and for now don't run JAXWS 2.3.  If you run all of them
+    // in full fat mode, it blows past the 3 hour limit for full fat mode on some platforms.
     @ClassRule
     public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly())
                     .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly())
-                    .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly()
-                            .removeFeature("jaxws-2.2").alwaysAddFeature("jaxws-2.3").withID("jaxws-2.3"))
-                    .andWith(FeatureReplacementAction.EE9_FEATURES().removeFeature("jaxws-2.3")); 
+/*                    .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly()
+                            .removeFeature("jaxws-2.2").alwaysAddFeature("jaxws-2.3").withID("jaxws-2.3"))*/
+                    .andWith(FeatureReplacementAction.EE9_FEATURES().liteFATOnly()/*.removeFeature("jaxws-2.3")*/); 
 }

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/FeatureReplacementAction.java
@@ -120,6 +120,7 @@ public class FeatureReplacementAction implements RepeatTestAction {
     private final Set<String> addFeatures = new LinkedHashSet<>();
     private final Set<String> alwaysAddFeatures = new HashSet<>();
     private TestMode testRunMode = TestMode.LITE;
+    private boolean liteFATOnly = false;
     private final Set<String> serverConfigPaths = new HashSet<String>();
     private boolean calledForServers = false;
     private boolean calledForServerConfigPaths = false;
@@ -264,6 +265,13 @@ public class FeatureReplacementAction implements RepeatTestAction {
 
     public FeatureReplacementAction fullFATOnly() {
         this.testRunMode = TestMode.FULL;
+        liteFATOnly = false;
+        return this;
+    }
+
+    public FeatureReplacementAction liteFATOnly() {
+        this.testRunMode = TestMode.LITE;
+        liteFATOnly = true;
         return this;
     }
 
@@ -373,6 +381,12 @@ public class FeatureReplacementAction implements RepeatTestAction {
                                      " is not valid for current mode " + TestModeFilter.FRAMEWORK_TEST_MODE);
             return false;
         }
+        if (liteFATOnly && TestModeFilter.FRAMEWORK_TEST_MODE.compareTo(TestMode.LITE) != 0) {
+            Log.info(c, "isEnabled", "Skipping action '" + toString() + "' because the test mode " + testRunMode +
+                                     " is not LITE and the test is marked to run in LITE FAT mode only.");
+            return false;
+        }
+
         return true;
     }
 

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE9Action.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/JakartaEE9Action.java
@@ -131,6 +131,11 @@ public class JakartaEE9Action extends FeatureReplacementAction {
     }
 
     @Override
+    public JakartaEE9Action liteFATOnly() {
+        return (JakartaEE9Action) super.liteFATOnly();
+    }
+
+    @Override
     public JakartaEE9Action withTestMode(TestMode mode) {
         return (JakartaEE9Action) super.withTestMode(mode);
     }


### PR DESCRIPTION
- Update to only run EE7 and EE8 in full fat mode by not running with JAXWS-2.3 since it is just the untranformed version of EE9 and running EE9 in lite mode only so that it doesn't run with full fat.
