### PR TITLE
improve DynamicVirtualHostManager unknown virtual host SRVE9956W warning

### DIFF
--- a/dev/com.ibm.ws.webcontainer/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2020 IBM Corporation and others.
+# Copyright (c) 2017, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -65,12 +65,14 @@ Service-Component: \
      immediate:=true; \
      properties:="service.vendor=IBM,jmx.objectname=WebSphere:name=com.ibm.ws.jmx.mbeans.generatePluginConfig"
      
--dsannotations: com.ibm.ws.webcontainer.osgi.container.config.WebAppConfigurationAdapter,\
- com.ibm.ws.webcontainer.osgi.webapp.WebAppInjectionClassListAdapter,\
+-dsannotations: \
+ com.ibm.ws.webcontainer.osgi.DynamicVirtualHostManager,\
  com.ibm.ws.webcontainer.osgi.WebContainer,\
  com.ibm.ws.webcontainer.osgi.WebContainerListener,\
+ com.ibm.ws.webcontainer.osgi.container.config.WebAppConfigurationAdapter,\
+ com.ibm.ws.webcontainer.osgi.interceptor.RegisterRequestInterceptor,\
  com.ibm.ws.webcontainer.osgi.session.SessionHelper, \
- com.ibm.ws.webcontainer.osgi.interceptor.RegisterRequestInterceptor
+ com.ibm.ws.webcontainer.osgi.webapp.WebAppInjectionClassListAdapter
  
 # For each exported package, create (in that package) a package-info.java
 # file, and place an @version javadoc tag in package-level javadoc. 
@@ -184,6 +186,7 @@ jakartaeeMe: true
 	com.ibm.ws.adaptable.module;version=latest,\
 	com.ibm.ws.container.service;version=latest,\
 	com.ibm.ws.javaee.dd;version=latest,\
+	com.ibm.ws.kernel.feature,\
 	com.ibm.ws.kernel.security.thread,\
 	com.ibm.ws.anno;version=latest,\
 	com.ibm.ws.artifact;version=latest,\

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/DynamicVirtualHostManager.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/DynamicVirtualHostManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2011, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,13 +17,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
+import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.kernel.feature.ServerStarted;
 import com.ibm.ws.webcontainer.osgi.osgi.WebContainerConstants;
 import com.ibm.wsspi.http.VirtualHost;
 import com.ibm.wsspi.kernel.service.location.WsLocationAdmin;
@@ -42,7 +47,8 @@ import com.ibm.wsspi.kernel.service.utils.FrameworkState;
  * When a {@link com.ibm.wsspi.http.VirtualHost} is set, all contexts roots managed by the
  * DynamicVirtualHost will be added to it.
  */
-public class DynamicVirtualHostManager implements Runnable {
+@Component(name = "com.ibm.ws.webcontainer.osgi.DynamicVirtualHostManager", property = { "service.vendor=IBM"})
+public class DynamicVirtualHostManager {
 
     private static final TraceComponent tc = Tr.register(DynamicVirtualHostManager.class, WebContainerConstants.TR_GROUP, WebContainerConstants.NLS_PROPS);
 
@@ -53,8 +59,6 @@ public class DynamicVirtualHostManager implements Runnable {
     private final ConcurrentHashMap<String, VirtualHost> transportMap = new ConcurrentHashMap<String, VirtualHost>();
 
     private volatile WsLocationAdmin locationService = null;
-    
-    private volatile ScheduledExecutorService schedExecutor = null;
 
     private Map<String, Set<String>> pluginCfgVhostUris = null;
     private final static String PLUGIN_CFG = "plugin-cfg.xml";
@@ -70,17 +74,20 @@ public class DynamicVirtualHostManager implements Runnable {
             } catch (IOException e) {
             }
         }
-        
-        // Schedule a task to run after 30 seconds to see if any virtual hosts
-        // that applications reference are missing.. 
-        schedExecutor.schedule(this, 30, TimeUnit.SECONDS);
     }
-    
-    @Override
-    public void run() {
+
+    /**
+     * Invoked once the server is started: log missing vhost warnings
+     *
+     * @param ref reference to the ServerStarted service
+     */
+    @Reference(service = ServerStarted.class,
+               policy = ReferencePolicy.DYNAMIC,
+               cardinality = ReferenceCardinality.OPTIONAL,
+               policyOption = ReferencePolicyOption.GREEDY)
+    protected void setServerStarted(ServiceReference<ServerStarted> ref) {
         List<String> missingHosts = new ArrayList<String>();
 
-        // runnable used for scheduled executor.. 
         for (DynamicVirtualHost host : hostMap.values()) {
             String name = host.getName();
             if ( transportMap.get(name) == null ) {
@@ -108,6 +115,15 @@ public class DynamicVirtualHostManager implements Runnable {
         if ( !missingHosts.isEmpty() && !FrameworkState.isStopping()) {
             Tr.warning(tc, "UNKNOWN_VIRTUAL_HOST", missingHosts);
         }
+    }
+
+    /**
+     * required DS method for unsetting the ServerStarted service
+     *
+     * @param ref reference to the service
+     */
+    protected synchronized void unsetServerStarted(ServiceReference<ServerStarted> ref) {
+        // server is shutting down
     }
 
     /**


### PR DESCRIPTION
for #17693

The current behavior implemented by this PR is an improvement - rather than waiting for a fixed period of 30s to allow vhosts to resolve, it waits until the `ServerStarted` service indicates the server is ready. However the drawback with this approach is that the vhost check is tied to server startup rather than bundle/feature activation (which might happen after server startup). Before settling on this PR's current approach, we should do some investigation to see if there's some other mechanism we can use to listen for feature update completion events.