### PR TITLE
cbhandler for wssec saml fat

### DIFF
--- a/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLCommonTest.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLCommonTest.java
@@ -16,6 +16,8 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+//issue 17687
+import java.util.HashMap;
 
 import javax.net.ssl.TrustManager;
 
@@ -112,6 +114,9 @@ public class SAMLCommonTest extends CommonTest {
     protected static List<CommonLocalLDAPServerSuite> ldapRefList = new ArrayList<CommonLocalLDAPServerSuite>();
     protected static boolean cipherMayExceed128 = false;
     public static boolean usingExternalLDAPServer = false;
+	//issue 17687
+    public static String callbackHandlerWss4j = SAMLConstants.EXAMPLE_CALLBACK_WSS4J;
+    public static String featureWss4j = SAMLConstants.EXAMPLE_CALLBACK_FEATURE_WSS4J;
 
     @Rule
     public final TestName testName = new TestName();
@@ -200,11 +205,30 @@ public class SAMLCommonTest extends CommonTest {
 
     }
 
+    //issue 17687 
     public static SAMLTestServer commonSetUp(String requestedServer,
                                              String serverXML, String testType, String serverType,
                                              List<String> addtlApps, List<String> addtlMessages, Boolean checkForSecuityStart, String callbackHandler,
                                              String feature) throws Exception {
 
+        Map<String, String> cbHandlers = null;
+        if (callbackHandler != null && feature != null) {
+            cbHandlers = new HashMap<String, String>();
+            cbHandlers.put(callbackHandler, feature);
+            cbHandlers.put(callbackHandlerWss4j, featureWss4j);
+        }
+
+        return commonSetUp(requestedServer, serverXML, testType, serverType, addtlApps, addtlMessages, checkForSecuityStart, cbHandlers);
+
+    } //End issue 17687
+	
+    
+    //issue 17687
+    public static SAMLTestServer commonSetUp(String requestedServer,
+                                             String serverXML, String testType, String serverType,
+                                             List<String> addtlApps, List<String> addtlMessages, Boolean checkForSecuityStart, Map<String, String> cbHandlers) throws Exception {
+    //End issue 17687
+		
         String thisMethod = "commonSetUp";
         msgUtils.printMethodName(thisMethod);
 
@@ -239,13 +263,13 @@ public class SAMLCommonTest extends CommonTest {
             // The usable server xml should NOT be the one ending in ".base"
             String usableServerXml = (outputServerXml != null) ? outputServerXml : serverXML;
 
-            if (callbackHandler == null) {
+            //issue 17687
+            if (cbHandlers == null) {
                 aTestServer = new SAMLTestServer(requestedServer, usableServerXml, serverType);
             } else {
-                Log.info(thisClass, "commonSetup", "callbackHandler: " + callbackHandler + " feature: " + feature);
-                aTestServer = new SAMLTestServer(requestedServer, usableServerXml, serverType, callbackHandler, feature);
-            }
-
+                aTestServer = new SAMLTestServer(requestedServer, usableServerXml, serverType, cbHandlers);
+            } //End issue 17687
+			
             aTestServer.removeServerConfigFiles();
             aTestServer.setServerNameAndHostIp();
 

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLConstants.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -552,4 +552,7 @@ public class SAMLConstants extends Constants {
     public static final String SERVLET_40 = "servlet40";
     public static final String EXAMPLE_CALLBACK = "com.ibm.ws.wssecurity.example.cbh_1.0.0";
     public static final String EXAMPLE_CALLBACK_FEATURE = "wsseccbh-1.0";
+	//issue 17687
+    public static final String EXAMPLE_CALLBACK_WSS4J = "com.ibm.ws.wssecurity.example.cbhwss4j";
+    public static final String EXAMPLE_CALLBACK_FEATURE_WSS4J = "wsseccbh-2.0";
 }

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLTestServer.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLTestServer.java
@@ -13,6 +13,8 @@ package com.ibm.ws.security.saml20.fat.commonTest;
 import java.io.FileWriter;
 import java.util.ArrayList;
 import java.util.List;
+//issue 17687
+import java.util.Map;
 
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.security.fat.common.TestServer;
@@ -59,6 +61,23 @@ public class SAMLTestServer extends TestServer {
         setServerType(testServerType);
 
     }
+
+    //issue 17687
+    public SAMLTestServer(String requestedServer, String serverXML, String testServerType, Map<String, String> cbHandlers) {
+        super(requestedServer, serverXML);
+        if (cbHandlers != null) {
+            for (Map.Entry<String, String> cbHandler : cbHandlers.entrySet()) {
+                try {
+                    Log.info(thisClass, "SAMLTestServer", "callbackHandler: " + cbHandler.getKey() + " feature: " + cbHandler.getValue());
+                    installCallbackHandler(cbHandler.getKey(), cbHandler.getValue());
+                } catch (Exception e) {
+                    Log.info(thisClass, "SAMLTestServer constructor with cbHandler map could NOT install the callback handler", e.toString());
+                }
+            }
+        }
+        setServerType(testServerType);
+
+    } //End issue 17687
 
     public SAMLTestServer() {
         super();


### PR DESCRIPTION
Update 3 files in com.ibm.ws.security.saml.sso_fat.common to install callbackhandler via SAMLTestServer instance used in wssecurity saml FAT:

SAMLCommonTest.java
SAMLConstants.java
SAMLTestServer.java