### PR TITLE
Issue #13717: EE9 EJB Timer Persistent FAT

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/NoDatasourceTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/NoDatasourceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,14 +20,18 @@ import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
@@ -47,6 +51,9 @@ public class NoDatasourceTest extends FATServletClient {
 
     @Server("com.ibm.ws.ejbcontainer.timer.persistent.fat.NoDatasourceServer")
     public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.timer.persistent.fat.NoDatasourceServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.timer.persistent.fat.NoDatasourceServer")).andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.timer.persistent.fat.NoDatasourceServer"));
 
     @After
     public void cleanUp() throws Exception {
@@ -76,7 +83,7 @@ public class NoDatasourceTest extends FATServletClient {
         WebArchive NoDBNonPersistAutoTimerWeb = ShrinkHelper.buildDefaultApp("NoDBNonPersistAutoTimerWeb.war", "com.ibm.ws.ejbcontainer.timer.nodb.npauto.web.");
         EnterpriseArchive NoDBNonPersistAutoTimerApp = ShrinkWrap.create(EnterpriseArchive.class, "NoDBNonPersistAutoTimerApp.ear");
         NoDBNonPersistAutoTimerApp.addAsModule(NoDBNonPersistAutoTimerEJB).addAsModule(NoDBNonPersistAutoTimerWeb);
-        ShrinkHelper.exportToServer(server, "dropins", NoDBNonPersistAutoTimerApp);
+        ShrinkHelper.exportToServer(server, "dropins", NoDBNonPersistAutoTimerApp, DeployOptions.SERVER_ONLY);
 
         // Wait for the application to start
         assertNotNull("START_NON_PERSIST_AUTO", server.waitForStringInLogUsingMark(START_NON_PERSIST_AUTO));
@@ -108,7 +115,7 @@ public class NoDatasourceTest extends FATServletClient {
         JavaArchive NoDBPersistAutoTimerEJB = ShrinkHelper.buildJavaArchive("NoDBPersistAutoTimerEJB.jar", "com.ibm.ws.ejbcontainer.timer.nodb.pauto.ejb.");
         EnterpriseArchive NoDBPersistAutoTimerApp = ShrinkWrap.create(EnterpriseArchive.class, "NoDBPersistAutoTimerApp.ear");
         NoDBPersistAutoTimerApp.addAsModule(NoDBPersistAutoTimerEJB);
-        ShrinkHelper.exportToServer(server, "dropins", NoDBPersistAutoTimerApp);
+        ShrinkHelper.exportToServer(server, "dropins", NoDBPersistAutoTimerApp, DeployOptions.SERVER_ONLY);
 
         // Verify the application failed to start with correct messages
         assertNotNull(CNTR4020E, server.waitForStringInLogUsingMark(CNTR4020E)); // persistent timers not supported
@@ -143,7 +150,7 @@ public class NoDatasourceTest extends FATServletClient {
         WebArchive NoDBProgrammaticTimerWeb = ShrinkHelper.buildDefaultApp("NoDBProgrammaticTimerWeb.war", "com.ibm.ws.ejbcontainer.timer.nodb.programmatic.web.");
         EnterpriseArchive NoDBProgrammaticTimerApp = ShrinkWrap.create(EnterpriseArchive.class, "NoDBProgrammaticTimerApp.ear");
         NoDBProgrammaticTimerApp.addAsModule(NoDBProgrammaticTimerEJB).addAsModule(NoDBProgrammaticTimerWeb);
-        ShrinkHelper.exportToServer(server, "dropins", NoDBProgrammaticTimerApp);
+        ShrinkHelper.exportToServer(server, "dropins", NoDBProgrammaticTimerApp, DeployOptions.SERVER_ONLY);
 
         // Wait for the application to start
         assertNotNull(START_PROGRAMMATIC_AUTO, server.waitForStringInLogUsingMark(START_PROGRAMMATIC_AUTO));

--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/NoTablesTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/NoTablesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,14 +19,18 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.After;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 
@@ -43,6 +47,9 @@ public class NoTablesTest extends FATServletClient {
 
     @Server("com.ibm.ws.ejbcontainer.timer.persistent.fat.NoTablesServer")
     public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.timer.persistent.fat.NoTablesServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.timer.persistent.fat.NoTablesServer")).andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.timer.persistent.fat.NoTablesServer"));
 
     @After
     public void cleanUp() throws Exception {
@@ -72,7 +79,7 @@ public class NoTablesTest extends FATServletClient {
         JavaArchive NoDBPersistAutoTimerEJB = ShrinkHelper.buildJavaArchive("NoDBPersistAutoTimerEJB.jar", "com.ibm.ws.ejbcontainer.timer.nodb.pauto.ejb.");
         EnterpriseArchive NoDBPersistAutoTimerApp = ShrinkWrap.create(EnterpriseArchive.class, "NoDBPersistAutoTimerApp.ear");
         NoDBPersistAutoTimerApp.addAsModule(NoDBPersistAutoTimerEJB);
-        ShrinkHelper.exportToServer(server, "dropins", NoDBPersistAutoTimerApp);
+        ShrinkHelper.exportToServer(server, "dropins", NoDBPersistAutoTimerApp, DeployOptions.SERVER_ONLY);
 
         // Verify the application failed to start with correct messages
         assertNotNull(CNTR0218E, server.waitForStringInLogUsingMark(CNTR0218E)); // persistent timers not supported

--- a/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/PersistentTimerRestartTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.persistent_fat/fat/src/com/ibm/ws/ejbcontainer/timer/persistent/fat/tests/PersistentTimerRestartTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.websphere.simplicity.config.EJBContainerElement;
 import com.ibm.websphere.simplicity.config.EJBTimerServiceElement;
 import com.ibm.websphere.simplicity.config.PersistentExecutor;
@@ -47,7 +48,7 @@ public class PersistentTimerRestartTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.timer.persistent.fat.PersistentTimerRestartServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.timer.persistent.fat.PersistentTimerRestartServer"));
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.timer.persistent.fat.PersistentTimerRestartServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.timer.persistent.fat.PersistentTimerRestartServer")).andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.timer.persistent.fat.PersistentTimerRestartServer"));
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -59,7 +60,7 @@ public class PersistentTimerRestartTest extends FATServletClient {
         EnterpriseArchive InitTxRecoveryLogApp = ShrinkWrap.create(EnterpriseArchive.class, "InitTxRecoveryLogApp.ear");
         InitTxRecoveryLogApp.addAsModule(InitTxRecoveryLogEJBJar);
 
-        ShrinkHelper.exportDropinAppToServer(server, InitTxRecoveryLogApp);
+        ShrinkHelper.exportDropinAppToServer(server, InitTxRecoveryLogApp, DeployOptions.SERVER_ONLY);
 
         //#################### RestartMissedTimerActionApp.ear
         JavaArchive RestartMissedTimerActionEJB = ShrinkHelper.buildJavaArchive("RestartMissedTimerActionEJB.jar", "com.ibm.ws.ejbcontainer.timer.persistent.restart.missed.ejb.");
@@ -68,7 +69,7 @@ public class PersistentTimerRestartTest extends FATServletClient {
         EnterpriseArchive RestartMissedTimerActionApp = ShrinkWrap.create(EnterpriseArchive.class, "RestartMissedTimerActionApp.ear");
         RestartMissedTimerActionApp.addAsModule(RestartMissedTimerActionEJB).addAsModule(RestartMissedTimerActionWeb);
 
-        ShrinkHelper.exportDropinAppToServer(server, RestartMissedTimerActionApp);
+        ShrinkHelper.exportDropinAppToServer(server, RestartMissedTimerActionApp, DeployOptions.SERVER_ONLY);
     }
 
     @AfterClass


### PR DESCRIPTION
Enable remaining EJB persistent timer FAT to run with Jakarta EE 9 features.

for #13717 