### PR TITLE
Added retry for slow request servlet hits for requestTiming FATs

### DIFF
--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/SlowRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/SlowRequestTiming.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -725,6 +725,8 @@ public class SlowRequestTiming {
         //Step 2 - Create 2 requests of 4 seconds each.
         createRequest("?sleepTime=4000");
         createRequest("?sleepTime=4000");
+
+        server.waitForStringInLog("TRAS0112W", 20000);
         int slowCount = fetchNoOfslowRequestWarnings();
 
         assertTrue("No slow warning found for sampleRate 2!", (slowCount > 0));
@@ -736,7 +738,17 @@ public class SlowRequestTiming {
         waitForConfigurationUpdate();
 
         createRequest("?sleepTime=4000");
+
+        server.waitForStringInLog("TRAS0112W", 20000);
         int newslowCount = fetchNoOfslowRequestWarnings();
+
+        //Retry the request again
+        if (newslowCount == 0) {
+            CommonTasks.writeLogMsg(Level.INFO, "$$$$ -----> Retry because no new slow request warning found!");
+            createRequest("?sleepTime=4000");
+            server.waitForStringInLog("TRAS0112W", 20000);
+            newslowCount = fetchNoOfslowRequestWarnings();
+        }
 
         assertTrue("No slow warning found for sampleRate 1!", (newslowCount - slowCount > 0));
 
@@ -753,6 +765,7 @@ public class SlowRequestTiming {
         //Step 2 -Create Request for 11 seconds
         createRequest("?sleepTime=11000");
 
+        server.waitForStringInLog("TRAS0112W", 20000);
         int slowCount = fetchNoOfslowRequestWarnings();
         assertTrue("No slow request warning found..", (slowCount > 0));
 
@@ -765,7 +778,17 @@ public class SlowRequestTiming {
         //Step 3 - Create 2 requests of 4 seconds each and verify that it works like sampleRate 2.
         createRequest("?sleepTime=4000");
         createRequest("?sleepTime=4000");
+        server.waitForStringInLog("TRAS0112W", 20000);
         int currentCount = fetchNoOfslowRequestWarnings() - slowCount;
+
+        //Retry the request again
+        if (currentCount <= 0) {
+            CommonTasks.writeLogMsg(Level.INFO, "$$$$ -----> Retry because no new slow request warning found!");
+            createRequest("?sleepTime=4000");
+            createRequest("?sleepTime=4000");
+            server.waitForStringInLog("TRAS0112W", 20000);
+            currentCount = fetchNoOfslowRequestWarnings() - slowCount;
+        }
 
         assertTrue("No slow warning found for sampleRate 2!", (currentCount > 0));
         CommonTasks.writeLogMsg(Level.INFO, "***** SampleRate Dynamic Enablement works as expected! *****");

--- a/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/TimingRequestTiming.java
+++ b/dev/com.ibm.ws.request.timing_fat/fat/src/com/ibm/ws/request/timing/fat/TimingRequestTiming.java
@@ -130,10 +130,7 @@ public class TimingRequestTiming {
         createRequests(6000, 1);
 
         server.waitForStringInLog("TRAS0112W", 10000);
-        server.waitForStringInLog("TRAS0114W", 10000);
-
         int slow = fetchSlowRequestWarningsCount();
-        int hung = fetchHungRequestWarningsCount();
 
         //Retry the request again
         if (slow == 0) {
@@ -142,6 +139,9 @@ public class TimingRequestTiming {
             server.waitForStringInLogUsingMark("TRAS0112W", 10000);
             slow = fetchSlowRequestWarningsCount();
         }
+
+        server.waitForStringInLog("TRAS0114W", 10000);
+        int hung = fetchHungRequestWarningsCount();
 
         assertTrue("Expected > 0 slow request warning but found : " + slow, (slow > 0));
 
@@ -181,11 +181,19 @@ public class TimingRequestTiming {
 
         createRequests(8000, 1);
 
-        int slow = fetchSlowRequestWarningsCount();
-        int hung = fetchHungRequestWarningsCount();
-
         server.waitForStringInLogUsingMark("TRAS0112W", 10000);
+        int slow = fetchSlowRequestWarningsCount();
+
+        // Retry the request again
+        if (slow == 0) {
+            CommonTasks.writeLogMsg(Level.INFO, "$$$$ -----> Retry because no slow request warning found!");
+            createRequests(8000, 1);
+            server.waitForStringInLogUsingMark("TRAS0112W", 10000);
+            slow = fetchSlowRequestWarningsCount();
+        }
+
         server.waitForStringInLogUsingMark("TRAS0114W", 10000);
+        int hung = fetchHungRequestWarningsCount();
 
         assertTrue("Expected  > 0 slow request warnings but found : " + slow, ((slow - p_slow) > 0));
         assertTrue("Expected 1 or more hung request warning but found : " + hung, (hung > 0));
@@ -197,7 +205,18 @@ public class TimingRequestTiming {
 
         createRequests(12000, 1);
 
+        server.waitForStringInLogUsingMark("TRAS0112W", 10000);
         int n_slow = fetchSlowRequestWarningsCount();
+
+        // Retry the request again
+        if (n_slow == 0) {
+            CommonTasks.writeLogMsg(Level.INFO, "$$$$ -----> Retry because no new_slow request warning found!");
+            createRequests(12000, 1);
+            server.waitForStringInLogUsingMark("TRAS0112W", 10000);
+            n_slow = fetchSlowRequestWarningsCount();
+        }
+
+        server.waitForStringInLogUsingMark("TRAS0114W", 10000);
         int n_hung = fetchHungRequestWarningsCount();
 
         assertTrue("Expected > 0 slow request warning but found : " + n_slow, ((n_slow - slow) > 0));
@@ -313,9 +332,17 @@ public class TimingRequestTiming {
         createRequests(20000, 1);
 
         server.waitForStringInLogUsingMark("TRAS0112W", 10000);
-        server.waitForStringInLogUsingMark("TRAS0114W", 10000);
-
         int slow = fetchSlowRequestWarningsCount();
+
+        // Retry the request again
+        if (slow == 0) {
+            CommonTasks.writeLogMsg(Level.INFO, "$$$$ -----> Retry because no slow request warning found!");
+            createRequests(20000, 1);
+            server.waitForStringInLogUsingMark("TRAS0112W", 10000);
+            slow = fetchSlowRequestWarningsCount();
+        }
+
+        server.waitForStringInLogUsingMark("TRAS0114W", 10000);
         int hung = fetchHungRequestWarningsCount();
 
         assertTrue("Expected > 1 slow request warnings but found : " + slow, (slow > 1));
@@ -346,7 +373,6 @@ public class TimingRequestTiming {
         createRequests(7000, 1);
 
         server.waitForStringInLogUsingMark("TRAS0112W", 10000);
-        server.waitForStringInLogUsingMark("TRAS0114W", 10000);
 
         int slow = fetchSlowRequestWarningsCount();
 
@@ -358,6 +384,7 @@ public class TimingRequestTiming {
             slow = fetchSlowRequestWarningsCount();
         }
 
+        server.waitForStringInLogUsingMark("TRAS0114W", 10000);
         int hung = fetchHungRequestWarningsCount();
 
         assertTrue("Expected > 0 slow request warning but found : " + slow, (slow > 0));
@@ -432,10 +459,16 @@ public class TimingRequestTiming {
         server.waitForStringInLogUsingMark("TRAS0114W", 10000);
 
         int slow = fetchSlowRequestWarningsCount();
-        int hung = fetchHungRequestWarningsCount();
-
         assertTrue("Expected 0 slow request warning but found : " + slow, (slow == 0));
 
+        int hung = fetchHungRequestWarningsCount();
+        // Retry the request again
+        if (hung == 0) {
+            CommonTasks.writeLogMsg(Level.INFO, "$$$$ -----> Retry because no h request warning found!");
+            createRequests(5000, 1);
+            server.waitForStringInLogUsingMark("TRAS0114W", 10000);
+            hung = fetchHungRequestWarningsCount();
+        }
         assertTrue("Expected 1 hung request warning but found : " + hung, (hung > 0));
 
         CommonTasks.writeLogMsg(Level.INFO, "***** timing works - local config disables slow request for value smaller that 1 *****");
@@ -459,7 +492,6 @@ public class TimingRequestTiming {
         createRequests(6000, 1);
 
         server.waitForStringInLogUsingMark("TRAS0112W", 15000);
-        server.waitForStringInLogUsingMark("TRAS0114W", 10000);
 
         int slow = fetchSlowRequestWarningsCount();
 
@@ -470,6 +502,7 @@ public class TimingRequestTiming {
             slow = fetchSlowRequestWarningsCount();
         }
 
+        server.waitForStringInLogUsingMark("TRAS0114W", 10000);
         int hung = fetchHungRequestWarningsCount();
 
         assertTrue("Expected > 1 slow request warnings but found : " + slow, (slow > 1));
@@ -560,8 +593,8 @@ public class TimingRequestTiming {
             server.waitForStringInLog("TRAS0112W", 15000);
             slow = fetchSlowRequestWarningsCount();
         }
-
         int hung = fetchHungRequestWarningsCount();
+
         assertTrue("Expected > 1 slow request warnings but found : " + slow, (slow > 1));
 
         assertTrue("Expected 0 hung request warning but found : " + hung, (hung == 0));
@@ -588,13 +621,22 @@ public class TimingRequestTiming {
         createRequests(9000, 1);
 
         server.waitForStringInLogUsingMark("TRAS0112W", 10000);
-        server.waitForStringInLogUsingMark("TRAS0114W", 10000);
-
         int slow = fetchSlowRequestWarningsCount();
-        int hung = fetchHungRequestWarningsCount();
-        assertTrue("Expected > 0 slow request warnings but found : " + slow, (slow > 0));
 
+        //Retry the request again
+        if (slow == 0) {
+            CommonTasks.writeLogMsg(Level.INFO, "$$$$ -----> Retry because no slow request warning found!");
+            createRequests(9000, 1);
+            server.waitForStringInLogUsingMark("TRAS0112W", 10000);
+            slow = fetchSlowRequestWarningsCount();
+        }
+
+        server.waitForStringInLogUsingMark("TRAS0114W", 10000);
+        int hung = fetchHungRequestWarningsCount();
+
+        assertTrue("Expected > 0 slow request warnings but found : " + slow, (slow > 0));
         assertTrue("Expected 1 hung request warning but found : " + hung, (hung > 0));
+
         server.setMarkToEndOfLog();
 
         CommonTasks.writeLogMsg(Level.INFO, "**** >>>>> UPDATED server configuration thresholds for  <global : defaults ><timing - Slow : 3s , hung : 5s>");

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRate1.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRate1.xml
@@ -26,6 +26,6 @@
 
  	<include location="../fatTestPorts.xml"/>
    
-	<requestTiming sampleRate = "1" slowRequestThreshold="3s" />
+	<requestTiming sampleRate="1" slowRequestThreshold="3s" />
   
 </server>

--- a/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRate2.xml
+++ b/dev/com.ibm.ws.request.timing_fat/publish/files/server_sampleRate2.xml
@@ -26,6 +26,6 @@
 
  	<include location="../fatTestPorts.xml"/>
    
-	<requestTiming sampleRate = "2" slowRequestThreshold="3s" />
+	<requestTiming sampleRate="2" slowRequestThreshold="3s" />
   
 </server>


### PR DESCRIPTION
fixes #17702
fixes #17701
- Added retry functionality for Servlet hits when slow requests are not detected in the requestTiming FAT, due to a timing issue, where the server config and the servlet hit happens simultaneously in SOE builds.