### PR TITLE
More restfulWS-3.0 / EE9 SkipForRepeat cleanup

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLProxyAuthTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLProxyAuthTest.java
@@ -132,8 +132,8 @@ public class JAXRSClientSSLProxyAuthTest extends AbstractTest {
         assertTrue(proxy.retrieveLogMessages(request()).contains("received request"));
     }
 
-    @SkipForRepeat(NO_MODIFICATION) // jaxrs-2.0 currently does not implement HTTPS-based proxy authentication
-    @MinimumJavaLevel(javaLevel = 11)
+    @SkipForRepeat({NO_MODIFICATION, // jaxrs-2.0 currently does not implement HTTPS-based proxy authentication
+        "JAXRS-2.1"}) // and jaxrs-2.1 currently fails in certain environments with Java 8 and 16 - TODO investigate
     @Test
     public void testTunnelThroughProxyToHTTPSEndpoint() throws Exception {
         Map<String, String> p = new HashMap<String, String>();

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/bnd.bnd
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/bnd.bnd
@@ -33,7 +33,9 @@ tested.features: \
   appsecurity-3.0,\
   restfulWS-3.0, \
   xmlBinding-3.0, \
-  jsonb-2.0
+  jsonb-2.0, \
+  appsecurity-4.0, \
+  expressionlanguage-4.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.2,\

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21AbstractTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21AbstractTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,9 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import com.ibm.websphere.simplicity.log.Log;
@@ -35,7 +37,7 @@ public class JAXRS21AbstractTest {
 
     protected LibertyServer serverRef;
 
-    protected void runTestOnServer(String target, String testMethod, Map<String, String> params, String expectedResponse) throws ProtocolException, MalformedURLException, IOException {
+    protected void runTestOnServer(String target, String testMethod, Map<String, String> params, String... expectedResponse) throws ProtocolException, MalformedURLException, IOException {
 
         // build basic URI
         StringBuilder sBuilder = new StringBuilder("http://").append(serverRef.getHostname())
@@ -78,7 +80,9 @@ public class JAXRS21AbstractTest {
             Log.info(this.getClass(), testMethod, line);
         }
 
-        assertTrue("Real response is " + firstLine + " and the expected response is " + expectedResponse, firstLine.contains(expectedResponse));
+        List<String> expectedResponseLines = Arrays.asList(expectedResponse);
+        assertTrue("Real response is " + firstLine + " and the expected response is one of " + expectedResponseLines,
+                   expectedResponseLines.stream().anyMatch(firstLine::contains));
 
     }
 }

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientLTPATest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientLTPATest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,12 +26,10 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // Continue to skip this test for EE9 as com.ibm.ws.jaxrs.client.ltpa.handler is not supported
 public class JAXRS21ClientLTPATest extends JAXRS21AbstractTest {
     @Server("jaxrs21.client.JAXRS21ClientLTPATest")
     public static LibertyServer server;

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientSSLProxyAuthTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientSSLProxyAuthTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -45,7 +45,6 @@ import componenttest.topology.impl.LibertyServer;
  * case can check that the password specified in the actual Client APIs are not logged, even when tracing is enabled.
  */
 @RunWith(FATRunner.class)
-@SkipForRepeat("EE9_FEATURES") // Continue to skip this test for EE9 as proxy authority (properties com.ibm.ws.jaxrs.client.proxy.*) is not supported yet
 public class JAXRS21ClientSSLProxyAuthTest extends JAXRS21AbstractTest {
     private final static Class<?> c = JAXRS21ClientSSLProxyAuthTest.class;
 
@@ -193,13 +192,14 @@ public class JAXRS21ClientSSLProxyAuthTest extends JAXRS21AbstractTest {
         p.put("proxyusername", "jaxrsUser");
         p.put("proxypassword", "USE_PASSWORD_FROM_SERVLET");
 
-        this.runTestOnServer(target, "testProxyToHTTP_ClientBuilder", p, "[Proxy Error]:javax.ws.rs.ClientErrorException: HTTP 407 Proxy Authentication Required");
+        this.runTestOnServer(target, "testProxyToHTTP_ClientBuilder", p, "[Proxy Error]:javax.ws.rs.ClientErrorException: HTTP 407 Proxy Authentication Required",
+                                                                         "[Proxy Error]:jakarta.ws.rs.ClientErrorException: HTTP 407 Proxy Authentication Required");
 
         assertEquals("Proxy Password value printed in trace output", 0, server.findStringsInLogsAndTraceUsingMark("myPa\\$\\$word").size());
         server.setMarkToEndOfLog(server.getFileFromLibertyServerRoot("logs/trace.log"));
     }
 
-    // @Test // TODO: Enable after fixing Open-Liberty issue 169
+    @Test
     public void testTunnelThroughProxyToHTTPEndpointTimeout_ClientBuilder() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         p.put("param", "helloRochester");
@@ -210,7 +210,8 @@ public class JAXRS21ClientSSLProxyAuthTest extends JAXRS21AbstractTest {
         p.put("proxypassword", "USE_PASSWORD_FROM_SERVLET");
         p.put("timeout", "100");
 
-        this.runTestOnServer(target, "testProxyToHTTPTimeout_ClientBuilder", p, "[Proxy Error]:javax.ws.rs.ProcessingException: java.net.SocketTimeoutException: ");
+        this.runTestOnServer(target, "testProxyToHTTPTimeout_ClientBuilder", p, "[Proxy Error]:javax.ws.rs.ProcessingException: java.net.SocketTimeoutException: ",
+                                                                                "[Proxy Error]:jakarta.ws.rs.ProcessingException: RESTEASY004655");
 
         assertEquals("Proxy Password value printed in trace output", 0, server.findStringsInLogsAndTraceUsingMark("myPa\\$\\$word").size());
         server.setMarkToEndOfLog(server.getFileFromLibertyServerRoot("logs/trace.log"));
@@ -293,13 +294,15 @@ public class JAXRS21ClientSSLProxyAuthTest extends JAXRS21AbstractTest {
         p.put("proxyusername", "jaxrsUser");
         p.put("proxypassword", "USE_PASSWORD_FROM_SERVLET");
 
-        this.runTestOnServer(target, "testProxyToHTTP_Client", p, "[Proxy Error]:javax.ws.rs.ClientErrorException: HTTP 407 Proxy Authentication Required");
+        this.runTestOnServer(target, "testProxyToHTTP_Client", p, "[Proxy Error]:javax.ws.rs.ClientErrorException: HTTP 407 Proxy Authentication Required",
+                                                                  "[Proxy Error]:jakarta.ws.rs.ClientErrorException: HTTP 407 Proxy Authentication Required");
 
         assertEquals("Proxy Password value printed in trace output", 0, server.findStringsInLogsAndTraceUsingMark("myPa\\$\\$word").size());
         server.setMarkToEndOfLog(server.getFileFromLibertyServerRoot("logs/trace.log"));
     }
 
-    // @Test // TODO: Enable after fixing Open-Liberty issue 169
+    @Test
+    @SkipForRepeat("EE9_FEATURES") // RESTEasy only supports properties set on ClientBuilder
     public void testTunnelThroughProxyToHTTPEndpointTimeout_Client() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         p.put("param", "helloRochester");
@@ -310,7 +313,8 @@ public class JAXRS21ClientSSLProxyAuthTest extends JAXRS21AbstractTest {
         p.put("proxypassword", "USE_PASSWORD_FROM_SERVLET");
         p.put("timeout", "100");
 
-        this.runTestOnServer(target, "testProxyToHTTPTimeout_Client", p, "[Proxy Error]:javax.ws.rs.ProcessingException: java.net.SocketTimeoutException: ");
+        this.runTestOnServer(target, "testProxyToHTTPTimeout_Client", p, "[Proxy Error]:javax.ws.rs.ProcessingException: java.net.SocketTimeoutException: ",
+                                                                         "[Proxy Error]:jakarta.ws.rs.ProcessingException: java.net.SocketTimeoutException: ");
 
         assertEquals("Proxy Password value printed in trace output", 0, server.findStringsInLogsAndTraceUsingMark("myPa\\$\\$word").size());
         server.setMarkToEndOfLog(server.getFileFromLibertyServerRoot("logs/trace.log"));
@@ -393,12 +397,14 @@ public class JAXRS21ClientSSLProxyAuthTest extends JAXRS21AbstractTest {
         p.put("proxyusername", "jaxrsUser");
         p.put("proxypassword", "USE_PASSWORD_FROM_SERVLET");
 
-        this.runTestOnServer(target, "testProxyToHTTP_WebTarget", p, "[Proxy Error]:javax.ws.rs.ClientErrorException: HTTP 407 Proxy Authentication Required");
+        this.runTestOnServer(target, "testProxyToHTTP_WebTarget", p, "[Proxy Error]:javax.ws.rs.ClientErrorException: HTTP 407 Proxy Authentication Required",
+                                                                     "[Proxy Error]:jakarta.ws.rs.ClientErrorException: HTTP 407 Proxy Authentication Required");
 
         assertEquals("Proxy Password value printed in trace output", 0, server.findStringsInLogsAndTraceUsingMark("myPa\\$\\$word").size());
     }
 
-    // @Test // TODO: Enable after fixing Open-Liberty issue 169
+    @Test
+    @SkipForRepeat("EE9_FEATURES") // RESTEasy only supports properties set on ClientBuilder
     public void testTunnelThroughProxyToHTTPEndpointTimeout_WebTarget() throws Exception {
         Map<String, String> p = new HashMap<String, String>();
         p.put("param", "helloRochester");
@@ -409,7 +415,8 @@ public class JAXRS21ClientSSLProxyAuthTest extends JAXRS21AbstractTest {
         p.put("proxypassword", "USE_PASSWORD_FROM_SERVLET");
         p.put("timeout", "100");
 
-        this.runTestOnServer(target, "testProxyToHTTPTimeout_WebTarget", p, "[Proxy Error]:javax.ws.rs.ProcessingException: java.net.SocketTimeoutException: ");
+        this.runTestOnServer(target, "testProxyToHTTPTimeout_WebTarget", p, "[Proxy Error]:javax.ws.rs.ProcessingException: java.net.SocketTimeoutException: ",
+                                                                            "[Proxy Error]:jakarta.ws.rs.ProcessingException: java.net.SocketTimeoutException: ");
 
         assertEquals("Proxy Password value printed in trace output", 0, server.findStringsInLogsAndTraceUsingMark("myPa\\$\\$word").size());
         server.setMarkToEndOfLog(server.getFileFromLibertyServerRoot("logs/trace.log"));
@@ -492,24 +499,8 @@ public class JAXRS21ClientSSLProxyAuthTest extends JAXRS21AbstractTest {
         p.put("proxyusername", "jaxrsUser");
         p.put("proxypassword", "USE_PASSWORD_FROM_SERVLET");
 
-        this.runTestOnServer(target, "testProxyToHTTP_Builder", p, "[Proxy Error]:javax.ws.rs.ClientErrorException: HTTP 407 Proxy Authentication Required");
-
-        assertEquals("Proxy Password value printed in trace output", 0, server.findStringsInLogsAndTraceUsingMark("myPa\\$\\$word").size());
-        server.setMarkToEndOfLog(server.getFileFromLibertyServerRoot("logs/trace.log"));
-    }
-
-    // @Test // TODO: Enable after fixing Open-Liberty issue 169
-    public void testTunnelThroughProxyToHTTPEndpointTimeout_Builder() throws Exception {
-        Map<String, String> p = new HashMap<String, String>();
-        p.put("param", "helloRochester");
-        p.put("proxyhost", "localhost");
-        p.put("proxyport", "" + proxyPort);
-        p.put("proxytype", "HTTP");
-        p.put("proxyusername", "jaxrsUser");
-        p.put("proxypassword", "USE_PASSWORD_FROM_SERVLET");
-        p.put("timeout", "100");
-
-        this.runTestOnServer(target, "testProxyToHTTPTimeout_Builder", p, "[Proxy Error]:javax.ws.rs.ProcessingException: java.net.SocketTimeoutException: ");
+        this.runTestOnServer(target, "testProxyToHTTP_Builder", p, "[Proxy Error]:javax.ws.rs.ClientErrorException: HTTP 407 Proxy Authentication Required",
+                                                                   "[Proxy Error]:jakarta.ws.rs.ClientErrorException: HTTP 407 Proxy Authentication Required");
 
         assertEquals("Proxy Password value printed in trace output", 0, server.findStringsInLogsAndTraceUsingMark("myPa\\$\\$word").size());
         server.setMarkToEndOfLog(server.getFileFromLibertyServerRoot("logs/trace.log"));

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ComplexClientTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ComplexClientTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,6 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 
@@ -71,13 +70,11 @@ public class JAXRS21ComplexClientTest extends JAXRS21AbstractTest {
      */
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
     public void testNew2WebTargetsRequestFilterForRx1() throws Exception {
         this.runTestOnServer(target, "testNew2WebTargetsRequestFilterForRx1", null, "{filter1=GET},{filter1=GET, filter2=*/*}");
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
     public void testNew2WebTargetsRequestFilterForRx2() throws Exception {
         this.runTestOnServer(target, "testNew2WebTargetsRequestFilterForRx2", null, "{filter1=GET},{filter1=GET, filter2=*/*}");
     }
@@ -88,9 +85,9 @@ public class JAXRS21ComplexClientTest extends JAXRS21AbstractTest {
     }
 
     @Test
-    @SkipForRepeat("EE9_FEATURES") // currently broken due to multiple issues
     public void testNew2MixFilterForRx() throws Exception {
-        this.runTestOnServer(target, "testNew2MixFilterForRx", null, "222,{filter1=GET},223,{filter2=null}");
+        this.runTestOnServer(target, "testNew2MixFilterForRx", null, "222,{filter1=GET},223,{filter2=null}",
+                                                                     "222,{filter1=GET},223,{filter2=*/*}");
     }
 
     /**

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/publish/servers/jaxrs21.client.JAXRS21ClientLTPATest/server.xml
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/publish/servers/jaxrs21.client.JAXRS21ClientLTPATest/server.xml
@@ -15,4 +15,6 @@
      
   	<include location="../fatTestPorts.xml"/>
  
+    <javaPermission className="javax.security.auth.AuthPermission" name="wssecurity.getCallerSubject"/>
+    <javaPermission className="javax.security.auth.AuthPermission" name="wssecurity.getRunAsSubject"/>
 </server>

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/test-applications/jaxrs21complexclient/src/com/ibm/ws/jaxrs21/client/JAXRS21ComplexClientTest/client/JAXRS21ClientTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/test-applications/jaxrs21complexclient/src/com/ibm/ws/jaxrs21/client/JAXRS21ComplexClientTest/client/JAXRS21ClientTestServlet.java
@@ -113,7 +113,11 @@ public class JAXRS21ClientTestServlet extends HttpServlet {
 
                 WebTarget t1 = c.target("http://" + serverIP + ":" + serverPort + "/" + moduleName + "/JAXRS21ComplexClientTest/JAXRS21ComplexResource").register(JAXRS21ClientRequestFilter1.class);
                 t1.path("echo1").path("test1").request().get(String.class);
-                String result1 = c.getConfiguration().getProperties().toString();
+                Map<String, Object> props = c.getConfiguration().getProperties();
+                if (!(props instanceof HashMap)) {
+                    props = new HashMap<>(props);
+                }
+                String result1 = props.toString();
                 System.out.println("callable1: result1: " + result1);
 
                 return result1;
@@ -136,7 +140,11 @@ public class JAXRS21ClientTestServlet extends HttpServlet {
 
                 WebTarget t2 = c.target("http://" + serverIP + ":" + serverPort + "/" + moduleName + "/JAXRS21ComplexClientTest/JAXRS21ComplexResource").register(JAXRS21ClientRequestFilter2.class);
                 t2.path("echo2").path("test2").request().get(String.class);
-                String result2 = c.getConfiguration().getProperties().toString();
+                Map<String, Object> props = c.getConfiguration().getProperties();
+                if (!(props instanceof HashMap)) {
+                    props = new HashMap<>(props);
+                }
+                String result2 = props.toString();
                 System.out.println("callable2: result2: " + result2);
 
                 return result2;

--- a/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/client/LibertyClientHttpEngineBuilder43.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common/src/io/openliberty/org/jboss/resteasy/common/client/LibertyClientHttpEngineBuilder43.java
@@ -31,6 +31,8 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient43Engine;
 import org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43;
 
+import com.ibm.websphere.ras.annotation.Sensitive;
+
 /**
  * This is primarily taken from org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43,
  * but modified to include proxy authentication support - changes noted with {@code //Liberty...}
@@ -90,7 +92,8 @@ public class LibertyClientHttpEngineBuilder43 extends ClientHttpEngineBuilder43 
         return httpClientBuilder.build();
     }
 
-    private static String str(Object o) {
+    @Sensitive
+    private static String str(@Sensitive Object o) {
         if (o instanceof String) {
             return (String) o;
         }

--- a/dev/io.openliberty.restfulWS.internal.globalhandler/src/io/openliberty/restfulWS/internal/globalhandler/RESTfulGlobalHandlerMessageContext.java
+++ b/dev/io.openliberty.restfulWS.internal.globalhandler/src/io/openliberty/restfulWS/internal/globalhandler/RESTfulGlobalHandlerMessageContext.java
@@ -21,9 +21,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import com.ibm.websphere.ras.Traceable;
+import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.wsspi.webservices.handler.GlobalHandlerMessageContext;
 import com.ibm.wsspi.webservices.handler.HandlerConstants;
 
+@Trivial
 public class RESTfulGlobalHandlerMessageContext implements GlobalHandlerMessageContext, Traceable {
 
     private final boolean isServerSide;
@@ -74,6 +77,7 @@ public class RESTfulGlobalHandlerMessageContext implements GlobalHandlerMessageC
     }
 
     @Override
+    @Sensitive
     public Object getProperty(String name) {
         return propertyGetter.apply(name);
     }
@@ -136,7 +140,11 @@ public class RESTfulGlobalHandlerMessageContext implements GlobalHandlerMessageC
             Iterator<String> iter = getPropertyNames();
             while (iter.hasNext()) {
                 String name = iter.next();
-                sb.append(LS).append(name).append("=").append(getProperty(name));
+                if (name.toLowerCase().contains("password")) {
+                    sb.append(LS).append(name).append("=").append("*****");
+                } else {
+                    sb.append(LS).append(name).append("=").append(getProperty(name));
+                }
             }
         }
         sb.append("]");


### PR DESCRIPTION
- skips HTTPS proxy tunneling for JAX-RS 2.1
- enables RESTFUL WS 3.0 for several tests
- ensures passwords are not written to log/trace output
- Java 2 security permission for LTPA test