### PR TITLE
Updates to fix some things from recent FAT changes

### DIFF
--- a/.github/test-categories/JAXWS
+++ b/.github/test-categories/JAXWS
@@ -2,3 +2,4 @@ com.ibm.ws.jaxws.2.2.webcontainer_fat
 com.ibm.ws.jaxws.cdi_fat
 com.ibm.ws.jaxws.clientcontainer_fat
 com.ibm.ws.jaxws.ejb_fat
+com.ibm.ws.jaxws.X.wsat_fat

--- a/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/.classpath
+++ b/dev/com.ibm.ws.jaxrs.2.0.cdi.1.2_fat/.classpath
@@ -13,7 +13,6 @@
 	<classpathentry kind="src" path="test-applications/loadonstartup/src"/>
 	<classpathentry kind="src" path="test-applications/resourceInfoAtStartup/src"/>
 	<classpathentry kind="src" path="test-applications/interceptor/src"/>
-	<classpathentry kind="src" path="test-applications/injectIntoApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/com.ibm.ws.jaxws.X.wsat_fat/.classpath
+++ b/dev/com.ibm.ws.jaxws.X.wsat_fat/.classpath
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="src" path="test-applications/WSATAssertionTest/src"/>
 	<classpathentry kind="src" path="test-applications/policyAttachmentsClient1/src"/>
 	<classpathentry kind="src" path="test-applications/policyAttachmentsClient2/src"/>
-	<classpathentry kind="src" path="test-applications/policyAttachmentsService1/.apt_generated"/>
 	<classpathentry kind="src" path="test-applications/policyAttachmentsService1/src"/>
 	<classpathentry kind="src" path="test-applications/policyAttachmentsService2/src"/>
-	<classpathentry kind="src" path="test-applications/policyAttachmentsService3/.apt_generated"/>
 	<classpathentry kind="src" path="test-applications/policyAttachmentsService3/src"/>
 	<classpathentry kind="src" path="test-applications/simpleTestService/src"/>
-	<classpathentry kind="src" path="/fattest.simplicity"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.jaxws.X.wsat_fat/.project
+++ b/dev/com.ibm.ws.jaxws.X.wsat_fat/.project
@@ -11,13 +11,13 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.wst.common.project.facet.core.builder</name>
+			<name>bndtools.core.bndbuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.wst.common.project.facet.core.nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
 	</natures>
 </projectDescription>

--- a/dev/com.ibm.ws.jaxws.X.wsat_fat/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.jaxws.X.wsat_fat/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.wsat.recovery_fat.multi.1/fat/src/com/ibm/ws/wsat/fat/tests/MultiRecoveryTest.java
+++ b/dev/com.ibm.ws.wsat.recovery_fat.multi.1/fat/src/com/ibm/ws/wsat/fat/tests/MultiRecoveryTest.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.ws.wsat.fat;
+package com.ibm.ws.wsat.fat.tests;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;

--- a/dev/com.ibm.ws.wsat.recovery_fat.multi.1/fat/src/com/ibm/ws/wsat/fat/tests/MultiRecoveryTest1.java
+++ b/dev/com.ibm.ws.wsat.recovery_fat.multi.1/fat/src/com/ibm/ws/wsat/fat/tests/MultiRecoveryTest1.java
@@ -16,8 +16,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.ibm.ws.wsat.fat.MultiRecoveryTest;
-
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;

--- a/dev/com.ibm.ws.wsat.recovery_fat.multi.1/fat/src/com/ibm/ws/wsat/fat/tests/MultiRecoveryTest2.java
+++ b/dev/com.ibm.ws.wsat.recovery_fat.multi.1/fat/src/com/ibm/ws/wsat/fat/tests/MultiRecoveryTest2.java
@@ -16,8 +16,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.ibm.ws.wsat.fat.MultiRecoveryTest;
-
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;

--- a/dev/com.ibm.ws.wsat.recovery_fat.multi.2/.settings/bndtools.core.prefs
+++ b/dev/com.ibm.ws.wsat.recovery_fat.multi.2/.settings/bndtools.core.prefs
@@ -1,0 +1,2 @@
+compileErrorAction=build
+eclipse.preferences.version=1

--- a/dev/com.ibm.ws.wsat.recovery_fat.multi.2/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.wsat.recovery_fat.multi.2/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8


### PR DESCRIPTION
- Update jaxws.X.wsat_fat .classpath and .project to use bnd and remove referencing fattest.simplicity directly
- Remove non existent src directories from jaxrs.2.0.cdi.1.2_fat and jaxws.X.wsat_fat
- Add missing bndtools and eclipse settings from new fats
- Add new FAT to the github actions test categories
- Update the package name for MultiRecoveryTest to be the new one.
