### PR TITLE
Cleanup some intermittently failing test cases

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/FATSuite.java
@@ -76,7 +76,7 @@ import componenttest.rules.repeater.RepeatTests;
 })
 public class FATSuite {
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification()
+    public static RepeatTests r = RepeatTests.withoutModificationInFullMode()
     .andWith(FeatureReplacementAction.EE8_FEATURES().withID("JAXRS-2.1"))
     .andWith(new JakartaEE9Action().alwaysAddFeature("jsonb-2.0"));
 }

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/publish/servers/jaxrs21.client.JAXRS21TimeoutClientTest/bootstrap.properties
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/publish/servers/jaxrs21.client.JAXRS21TimeoutClientTest/bootstrap.properties
@@ -1,10 +1,4 @@
 bootstrap.include=../testports.properties
 
-com.ibm.ws.logging.trace.specification=*=info:\
-com.ibm.ws.jaxrs*=all:\
-com.ibm.websphere.jaxrs*=all:\
-org.apache.cxf.*=all:\
-ClassLoadingService=all:\
-RESTfulWS=all:\
-org.jboss.resteasy.*=all
+#com.ibm.ws.logging.trace.specification=*=info:\com.ibm.ws.jaxrs*=all:\com.ibm.websphere.jaxrs*=all:\org.apache.cxf.*=all:\ClassLoadingService=all:\RESTfulWS=all:\org.jboss.resteasy.*=all
 com.ibm.ws.logging.max.file.size=0

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/AsyncMethodTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/AsyncMethodTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,11 +13,8 @@ package com.ibm.ws.microprofile.rest.client.fat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
-import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -27,8 +24,6 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.RepeatTestAction;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -66,7 +61,7 @@ public class AsyncMethodTest extends FATServletClient {
     public static void afterClass() throws Exception {
         try {
             // check for error that occurs if cannot handle CompletionStage<?> generic type in JsonBProvider
-            List<String> jsonbProviderErrors = server.findStringsInLogs("E Problem with reading the data");
+            List<String> jsonbProviderErrors = server.findStringsInLogs("E Problem with reading the data.*CompletionStage");
             assertTrue("Found JsonBProvider errors in log file", 
                        jsonbProviderErrors == null || jsonbProviderErrors.isEmpty());
         } finally {

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/JsonbContextTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/JsonbContextTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,7 +20,6 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/jsonbContextApp/src/mpRestClient12/jsonbContext/JsonbContextTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/test-applications/jsonbContextApp/src/mpRestClient12/jsonbContext/JsonbContextTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,22 +12,17 @@ package mpRestClient12.jsonbContext;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.core.Response;
 
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.junit.Test;
@@ -47,7 +42,7 @@ public class JsonbContextTestServlet extends FATServlet {
 
     @Override
     public void init() throws ServletException {
-        String baseUrlStr = "https://localhost:" + getSysProp("bvt.prop.HTTP_secondary.secure") + "/basicRemoteApp";
+        String baseUrlStr = "http://localhost:" + getSysProp("bvt.prop.HTTP_secondary") + "/basicRemoteApp";
         LOG.info("baseUrl = " + baseUrlStr);
         URL baseUrl;
         try {
@@ -57,7 +52,6 @@ public class JsonbContextTestServlet extends FATServlet {
         }
         builder = RestClientBuilder.newBuilder()
                         .register(JsonbContextResolver.class)
-                        .property("com.ibm.ws.jaxrs.client.ssl.config", "mySSLConfig")
                         .property("com.ibm.ws.jaxrs.client.receive.timeout", "120000")
                         .property("com.ibm.ws.jaxrs.client.connection.timeout", "120000")
                         .baseUrl(baseUrl);
@@ -66,14 +60,9 @@ public class JsonbContextTestServlet extends FATServlet {
     @Test
     public void testSimplePostGetDeleteUsingUserSpecifiedJsonbContext(HttpServletRequest req, HttpServletResponse resp) throws Exception {
         BasicServiceClient client = builder.build(BasicServiceClient.class);
-        try {
-            client.createNewWidget(new Widget("Pencils", 100, 0.2));
-            assertTrue("POSTed widget does not show up in query", client.getWidgetNames().contains("Pencils"));
-            Widget w = client.getWidget("Pencils");
-            assertEquals("Widget returned from GET does not match widget POSTed", "Pencils;100;0.2", w.toString());
-        } finally {
-            //ensure we delete so as to not throw off other tests
-            client.removeWidget("Pencils");
-        }
+        client.createNewWidget(new Widget("Pencils", 100, 0.2));
+        assertTrue("POSTed widget does not show up in query", client.getWidgetNames().contains("Pencils"));
+        Widget w = client.getWidget("Pencils");
+        assertEquals("Widget returned from GET does not match widget POSTed", "Pencils;100;0.2", w.toString());
     }
 }

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/RepeatTests.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/RepeatTests.java
@@ -47,6 +47,13 @@ public class RepeatTests extends ExternalResource {
     }
 
     /**
+     * Adds an iteration of test execution without making any modifications, but only run in FULL mode
+     */
+    public static RepeatTests withoutModificationInFullMode() {
+        return new RepeatTests().andWithoutModificationInFullMode();
+    }
+
+    /**
      * Adds an iteration of test execution, where the action.setup() is called before repeating the tests.
      */
     public static RepeatTests with(RepeatTestAction action) {
@@ -66,6 +73,14 @@ public class RepeatTests extends ExternalResource {
      */
     public RepeatTests andWithoutModification() {
         actions.add(NO_MODIFICATION_ACTION);
+        return this;
+    }
+
+    /**
+     * Adds an iteration of test execution without making any modifications, but run in FULL mode
+     */
+    public RepeatTests andWithoutModificationInFullMode() {
+        actions.add(new EmptyAction().fullFATOnly());
         return this;
     }
 


### PR DESCRIPTION
This PR cleans up some JAX-RS / MP Rest Client test cases - like removing HTTPS when that is not being tested, reducing time spent in tests by using FULL mode, etc.