### PR TITLE
Issue 17731: Skip new winJDK level and ignore config update msg ACME FATs

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSimpleTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeSimpleTest.java
@@ -26,6 +26,7 @@ import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -611,6 +612,10 @@ public class AcmeSimpleTest {
 	}
 	
 	protected void stopServer(String ...msgs) throws Exception {
-		AcmeFatUtils.stopServer(server, msgs);
+		String alwaysAdd = "CWWKG0027W"; // update timeouts are okay, sometimes the acme certificate fetch takes longer
+ 		
+ 		List<String> tempList = new ArrayList<String>(Arrays.asList(msgs));
+		tempList.add(alwaysAdd);
+		AcmeFatUtils.stopServer(server, tempList.toArray(new String[tempList.size()]));
 	}
 }

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
@@ -882,7 +882,7 @@ public class AcmeFatUtils {
 		Log.info(AcmeFatUtils.class, methodName,
 				"Checking os.name: " + os + " java.vendor: " + javaVendor + " java.version: " + javaVersion);
 		if (os.startsWith("win") && (javaVendor.contains("openjdk") || javaVendor.contains(("oracle")))
-				&& (javaVersion.equals("11.0.5") || javaVersion.equals("14.0.1") || javaVersion.equals("11")
+				&& (javaVersion.startsWith("11") || javaVersion.equals("14.0.1")
 						|| javaVersion.equals("1.8.0_181") || javaVersion.equals("15") || javaVersion.equals("16"))) {
 			/*
 			 * On Windows with OpenJDK 11.0.5 (and others), we sometimes get an exception


### PR DESCRIPTION
Fixes #17731 

Updated the isWin/OpenJDK check to ignore all JDK 11s, instead of adding a new one (`11.0.11` in this case).

Ignore `CWWKG0027W: Timeout while updating server configuration.` on all `AcmeSimpleTest` runs -- sometimes the fetchCertificate takes longer than the server config update.