### PR TITLE
Only run jaxrs-2.0 FAT bucket if Java level is less than 16

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -70,6 +70,7 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.JavaInfo;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -128,7 +129,7 @@ import componenttest.rules.repeater.RepeatTests;
 })
 public class FATSuite {
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification()
+    public static RepeatTests r = RepeatTests.withoutModification().onlyIf(() -> JavaInfo.JAVA_VERSION < 16)
                     .andWith(FeatureReplacementAction.EE8_FEATURES().withID("JAXRS-2.1"))
                     .andWith(new JakartaEE9Action().alwaysAddFeature("jsonb-2.0"));
 }

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/RepeatTests.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/RepeatTests.java
@@ -12,6 +12,7 @@ package componenttest.rules.repeater;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 import org.junit.rules.ExternalResource;
 import org.junit.runner.Description;
@@ -74,6 +75,18 @@ public class RepeatTests extends ExternalResource {
      */
     public RepeatTests andWith(RepeatTestAction action) {
         actions.add(action);
+        return this;
+    }
+
+    /**
+     * Removes an iteration of test execution of the previous <code>and*</code> call if the passed-in supplier
+     * returns false. If true or if no test executions have been added, this method will have no effect.
+     */
+    public RepeatTests onlyIf(Supplier<Boolean> check) {
+        int size = actions.size();
+        if (size > 0 && !check.get()) {
+            actions.remove(size - 1);
+        }
         return this;
     }
 


### PR DESCRIPTION
Fixes #17616 - users should note that if they are using Java 16, they should either use JAX-RS 2.1 or they will need to add the `--add-opens` JVM switch as documented in the issue.