### PR TITLE
Issue #13717: EE 9 EJB Remote FAT

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/build.gradle
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -54,6 +54,16 @@ task addEJBTools {
 task addEnterpriseBeansTools {
   dependsOn ':io.openliberty.ejbcontainer.jakarta.fat_tools:release'
   doLast {
+    copy {
+      from configurations.enterpriseBeansTools
+      into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteServer/lib/global"
+      rename 'io.openliberty.ejbcontainer.jakarta.fat_tools-(.*).jar', 'io.openliberty.ejbcontainer.jakarta.fat_tools.jar'
+    }
+    copy {
+      from configurations.enterpriseBeansTools
+      into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteServerClient/lib/global"
+      rename 'io.openliberty.ejbcontainer.jakarta.fat_tools-(.*).jar', 'io.openliberty.ejbcontainer.jakarta.fat_tools.jar'
+    }
     copy {
       from configurations.enterpriseBeansTools
       into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteSessionServer/lib/global"

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/RemoteTests.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/RemoteTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 IBM Corporation and others.
+ * Copyright (c) 2015, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.websphere.simplicity.config.EJBAsynchronousElement;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.ws.ejbcontainer.remote.ejb3session.sl.ann.web.AdvBasicCMTStatelessRemoteServlet;
@@ -120,7 +121,7 @@ public class RemoteTests extends AbstractTest {
     }
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.ejbcontainer.remote.fat.RemoteServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.remote.fat.RemoteServer"));
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.ejbcontainer.remote.fat.RemoteServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.remote.fat.RemoteServer")).andWith(FeatureReplacementAction.EE9_FEATURES().forServers("com.ibm.ws.ejbcontainer.remote.fat.RemoteServer"));
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -132,13 +133,13 @@ public class RemoteTests extends AbstractTest {
         EnterpriseArchive InitTxRecoveryLogApp = ShrinkWrap.create(EnterpriseArchive.class, "InitTxRecoveryLogApp.ear");
         InitTxRecoveryLogApp.addAsModule(InitTxRecoveryLogEJBJar);
 
-        ShrinkHelper.exportDropinAppToServer(server, InitTxRecoveryLogApp);
+        ShrinkHelper.exportDropinAppToServer(server, InitTxRecoveryLogApp, DeployOptions.SERVER_ONLY);
 
         //#################### BasicRemote.war
         WebArchive BasicRemoteWeb = ShrinkHelper.buildDefaultApp("BasicRemote.war", "com.ibm.ws.ejbcontainer.remote.fat.basic.");
         BasicRemoteWeb = (WebArchive) ShrinkHelper.addDirectory(BasicRemoteWeb, "test-applications/BasicRemote.war/resources");
 
-        ShrinkHelper.exportDropinAppToServer(server, BasicRemoteWeb);
+        ShrinkHelper.exportDropinAppToServer(server, BasicRemoteWeb, DeployOptions.SERVER_ONLY);
 
         //#################### CrossAppRemoteClient.war
         JavaArchive CrossAppRemoteSharedJar = ShrinkHelper.buildJavaArchive("CrossAppRemoteShared.jar", "com.ibm.ws.ejbcontainer.remote.fat.crossapp.shared.");
@@ -146,13 +147,13 @@ public class RemoteTests extends AbstractTest {
         CrossAppRemoteClient.addAsLibrary(CrossAppRemoteSharedJar);
         CrossAppRemoteClient = (WebArchive) ShrinkHelper.addDirectory(CrossAppRemoteClient, "test-applications/CrossAppRemoteClient.war/resources");
 
-        ShrinkHelper.exportDropinAppToServer(server, CrossAppRemoteClient);
+        ShrinkHelper.exportDropinAppToServer(server, CrossAppRemoteClient, DeployOptions.SERVER_ONLY);
 
         //#################### CrossAppRemoteEJB.war
         WebArchive CrossAppRemoteEJB = ShrinkHelper.buildDefaultApp("CrossAppRemoteEJB.war", "com.ibm.ws.ejbcontainer.remote.fat.crossapp.ejb.");
         CrossAppRemoteEJB.addAsLibrary(CrossAppRemoteSharedJar);
 
-        ShrinkHelper.exportDropinAppToServer(server, CrossAppRemoteEJB);
+        ShrinkHelper.exportDropinAppToServer(server, CrossAppRemoteEJB, DeployOptions.SERVER_ONLY);
 
         //#################### EJBHome2xTest.ear
         JavaArchive EJBHome2xTestEJB = ShrinkHelper.buildJavaArchive("EJBHome2xTestEJB.jar", "com.ibm.ws.ejbcontainer.remote.fat.home2x.ejb.");
@@ -163,13 +164,13 @@ public class RemoteTests extends AbstractTest {
         EJBHome2xTest.addAsModule(EJBHome2xTestEJB).addAsModule(EJBHome2xTestWeb);
         EJBHome2xTest = (EnterpriseArchive) ShrinkHelper.addDirectory(EJBHome2xTest, "test-applications/EJBHome2xTest.ear/resources");
 
-        ShrinkHelper.exportDropinAppToServer(server, EJBHome2xTest);
+        ShrinkHelper.exportDropinAppToServer(server, EJBHome2xTest, DeployOptions.SERVER_ONLY);
 
         //#################### EJBHomeTest.war
         WebArchive EJBHomeTest = ShrinkHelper.buildDefaultApp("EJBHomeTest.war", "com.ibm.ws.ejbcontainer.remote.fat.home.");
         EJBHomeTest = (WebArchive) ShrinkHelper.addDirectory(EJBHomeTest, "test-applications/EJBHomeTest.war/resources");
 
-        ShrinkHelper.exportDropinAppToServer(server, EJBHomeTest);
+        ShrinkHelper.exportDropinAppToServer(server, EJBHomeTest, DeployOptions.SERVER_ONLY);
 
         //#################### JitDeployApp
         JavaArchive JitDeployEJBJar = ShrinkHelper.buildJavaArchive("JitDeployEJB.jar", "com.ibm.ws.ejbcontainer.remote.misc.jitdeploy.ejb.");
@@ -179,13 +180,13 @@ public class RemoteTests extends AbstractTest {
         JitDeployApp.addAsModule(JitDeployEJBJar).addAsModule(JitDeployWeb);
         JitDeployApp = (EnterpriseArchive) ShrinkHelper.addDirectory(JitDeployApp, "test-applications/JitDeployApp.ear/resources");
 
-        ShrinkHelper.exportDropinAppToServer(server, JitDeployApp);
+        ShrinkHelper.exportDropinAppToServer(server, JitDeployApp, DeployOptions.SERVER_ONLY);
 
         //#################### RemoteTx.war
         WebArchive RemoteTx = ShrinkHelper.buildDefaultApp("RemoteTx.war", "com.ibm.ws.ejbcontainer.remote.fat.tx.");
         RemoteTx = (WebArchive) ShrinkHelper.addDirectory(RemoteTx, "test-applications/RemoteTx.war/resources");
 
-        ShrinkHelper.exportDropinAppToServer(server, RemoteTx);
+        ShrinkHelper.exportDropinAppToServer(server, RemoteTx, DeployOptions.SERVER_ONLY);
 
         //#################### SingletonApp.ear
         JavaArchive SingletonAnnEJBJar = ShrinkHelper.buildJavaArchive("SingletonAnnEJB.jar", "com.ibm.ws.ejbcontainer.remote.singleton.ann.ejb.",
@@ -199,7 +200,7 @@ public class RemoteTests extends AbstractTest {
         SingletonApp.addAsModule(SingletonAnnEJBJar).addAsModule(SingletonMixEJBJar).addAsModule(SingletonWeb);
         SingletonApp = (EnterpriseArchive) ShrinkHelper.addDirectory(SingletonApp, "test-applications/SingletonApp.ear/resources");
 
-        ShrinkHelper.exportDropinAppToServer(server, SingletonApp);
+        ShrinkHelper.exportDropinAppToServer(server, SingletonApp, DeployOptions.SERVER_ONLY);
 
         //#################### StatelessAnnTestApp
         JavaArchive StatelessAnnEJBJar = ShrinkHelper.buildJavaArchive("StatelessAnnEJB.jar", "com.ibm.ws.ejbcontainer.remote.ejb3session.sl.ann.ejb.");
@@ -209,7 +210,7 @@ public class RemoteTests extends AbstractTest {
         StatelessAnnApp.addAsModule(StatelessAnnEJBJar).addAsModule(StatelessAnnWeb);
         StatelessAnnApp = (EnterpriseArchive) ShrinkHelper.addDirectory(StatelessAnnApp, "test-applications/StatelessAnnTest.ear/resources");
 
-        ShrinkHelper.exportDropinAppToServer(server, StatelessAnnApp);
+        ShrinkHelper.exportDropinAppToServer(server, StatelessAnnApp, DeployOptions.SERVER_ONLY);
 
         //#################### StatelessMixTestApp
         JavaArchive StatelessMixASMDescEJBJar = ShrinkHelper.buildJavaArchive("StatelessMixASMDescEJB.jar", "com.ibm.ws.ejbcontainer.remote.ejb3session.sl.mix.asmdesc.");
@@ -224,7 +225,7 @@ public class RemoteTests extends AbstractTest {
         StatelessMixApp.addAsLibrary(StatelessMixIntfJar);
         StatelessMixApp = (EnterpriseArchive) ShrinkHelper.addDirectory(StatelessMixApp, "test-applications/StatelessMixTest.ear/resources");
 
-        ShrinkHelper.exportDropinAppToServer(server, StatelessMixApp);
+        ShrinkHelper.exportDropinAppToServer(server, StatelessMixApp, DeployOptions.SERVER_ONLY);
 
         // Finally, start server
         server.startServer();

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/Server2ServerTests.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/Server2ServerTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 import com.ibm.ws.ejbcontainer.remote.client.web.RemoteTxAttrServlet;
 
 import componenttest.annotation.Server;
@@ -51,7 +52,8 @@ public class Server2ServerTests extends AbstractTest {
     @ClassRule
     public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.remote.fat.RemoteServerClient",
                                                                                                                     "com.ibm.ws.ejbcontainer.remote.fat.RemoteServer")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.remote.fat.RemoteServerClient",
-                                                                                                                                                                                                                                   "com.ibm.ws.ejbcontainer.remote.fat.RemoteServer"));
+                                                                                                                                                                                                                                   "com.ibm.ws.ejbcontainer.remote.fat.RemoteServer")).andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.remote.fat.RemoteServerClient",
+                                                                                                                                                                                                                                                                                                                                                                "com.ibm.ws.ejbcontainer.remote.fat.RemoteServer"));
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -63,8 +65,8 @@ public class Server2ServerTests extends AbstractTest {
         EnterpriseArchive InitTxRecoveryLogApp = ShrinkWrap.create(EnterpriseArchive.class, "InitTxRecoveryLogApp.ear");
         InitTxRecoveryLogApp.addAsModule(InitTxRecoveryLogEJBJar);
 
-        ShrinkHelper.exportDropinAppToServer(clientServer, InitTxRecoveryLogApp);
-        ShrinkHelper.exportDropinAppToServer(remoteServer, InitTxRecoveryLogApp);
+        ShrinkHelper.exportDropinAppToServer(clientServer, InitTxRecoveryLogApp, DeployOptions.SERVER_ONLY);
+        ShrinkHelper.exportDropinAppToServer(remoteServer, InitTxRecoveryLogApp, DeployOptions.SERVER_ONLY);
 
         //#################### RemoteClientApp
         JavaArchive RemoteServerSharedJar = ShrinkHelper.buildJavaArchive("RemoteServerShared.jar", "com.ibm.ws.ejbcontainer.remote.server.shared.", "test.");
@@ -75,7 +77,7 @@ public class Server2ServerTests extends AbstractTest {
         RemoteClientApp.addAsModule(RemoteClientWeb);
         RemoteClientApp = (EnterpriseArchive) ShrinkHelper.addDirectory(RemoteClientApp, "test-applications/RemoteClientApp.ear/resources");
 
-        ShrinkHelper.exportDropinAppToServer(clientServer, RemoteClientApp);
+        ShrinkHelper.exportDropinAppToServer(clientServer, RemoteClientApp, DeployOptions.SERVER_ONLY);
 
         //#################### RemoteServerApp
         JavaArchive RemoteServerEJBJar = ShrinkHelper.buildJavaArchive("RemoteServerEJB.jar", "com.ibm.ws.ejbcontainer.remote.server.ejb.");
@@ -84,7 +86,7 @@ public class Server2ServerTests extends AbstractTest {
         RemoteServerApp.addAsLibraries(RemoteServerSharedJar).addAsModule(RemoteServerEJBJar);
         RemoteServerApp = (EnterpriseArchive) ShrinkHelper.addDirectory(RemoteServerApp, "test-applications/RemoteServerApp.ear/resources");
 
-        ShrinkHelper.exportDropinAppToServer(remoteServer, RemoteServerApp);
+        ShrinkHelper.exportDropinAppToServer(remoteServer, RemoteServerApp, DeployOptions.SERVER_ONLY);
 
         // Finally, start servers
         remoteServer.startServer();

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/publish/files/ExtendsThrowableEE9.xml
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/publish/files/ExtendsThrowableEE9.xml
@@ -1,0 +1,14 @@
+<server>
+    <featureManager>
+        <feature>servlet-5.0</feature>
+        <feature>enterpriseBeansHome-4.0</feature>
+        <feature>enterpriseBeansRemote-4.0</feature>
+        <feature>componenttest-2.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+
+    <iiopEndpoint id="defaultIiopEndpoint" iiopPort="${bvt.prop.IIOP}" iiopsPort="${bvt.prop.IIOP.secure}"/>
+    
+    <application id="AppExcExtendsThrowableErrBeanApp" name="AppExcExtendsThrowableErrBeanApp" type="ear" location="AppExcExtendsThrowableErrBean.ear"/>
+</server>

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.BadAppServer/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.BadAppServer/server.xml
@@ -4,7 +4,7 @@
         <feature>ejbRemote-3.2</feature>
         <feature>componenttest-1.0</feature>
     </featureManager>
-    
+
     <include location="../fatTestPorts.xml"/>
 
     <iiopEndpoint id="defaultIiopEndpoint" iiopPort="${bvt.prop.IIOP}" iiopsPort="${bvt.prop.IIOP.secure}"/>
@@ -12,5 +12,8 @@
     <!-- Yoko ORB bug; org.apache.yoko.rmispec.util.UtilLoader.loadServiceClass needs doPriv around getClassLoader + others -->	
     <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.net.SocketPermission" name="*" actions="listen,connect,resolve"/>
     <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
-	<javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="*" actions="read,write"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="*" actions="read,write"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.net.SocketPermission" name="*" actions="listen,connect,resolve"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.util.PropertyPermission" name="*" actions="read,write"/>
 </server>

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteServer/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteServer/server.xml
@@ -5,7 +5,7 @@
         <feature>ejbRemote-3.2</feature>
         <feature>componenttest-1.0</feature>
     </featureManager>
-    
+
     <include location="../fatTestPorts.xml"/>
 
     <iiopEndpoint id="defaultIiopEndpoint" iiopPort="${bvt.prop.IIOP}" iiopsPort="${bvt.prop.IIOP.secure}"/>
@@ -13,5 +13,8 @@
     <!-- Yoko ORB bug; org.apache.yoko.rmispec.util.UtilLoader.loadServiceClass needs doPriv around getClassLoader + others -->	
     <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.net.SocketPermission" name="*" actions="listen,connect,resolve"/>
     <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
-	<javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="*" actions="read,write"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="*" actions="read,write"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.net.SocketPermission" name="*" actions="listen,connect,resolve"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.util.PropertyPermission" name="*" actions="read,write"/>
 </server>

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteServerClient/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteServerClient/server.xml
@@ -5,7 +5,7 @@
         <feature>ejbRemote-3.2</feature>
         <feature>componenttest-1.0</feature>
     </featureManager>
-    
+
     <include location="../fatTestCommon.xml"/>
 
     <httpEndpoint id="defaultHttpEndpoint"
@@ -20,5 +20,8 @@
     <!-- Yoko ORB bug; org.apache.yoko.rmispec.util.UtilLoader.loadServiceClass needs doPriv around getClassLoader + others -->	
     <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.net.SocketPermission" name="*" actions="listen,connect,resolve"/>
     <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
-	<javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="*" actions="read,write"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="*" actions="read,write"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.net.SocketPermission" name="*" actions="listen,connect,resolve"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.util.PropertyPermission" name="*" actions="read,write"/>
 </server>

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteSessionServer/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.fat.RemoteSessionServer/server.xml
@@ -5,7 +5,7 @@
         <feature>ejbRemote-3.2</feature>
         <feature>componenttest-1.0</feature>
     </featureManager>
-    
+
     <include location="../fatTestPorts.xml"/>
 
     <iiopEndpoint id="defaultIiopEndpoint" iiopPort="${bvt.prop.IIOP}" iiopsPort="${bvt.prop.IIOP.secure}"/>
@@ -13,8 +13,8 @@
     <!-- Yoko ORB bug; org.apache.yoko.rmispec.util.UtilLoader.loadServiceClass needs doPriv around getClassLoader + others -->	
     <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.net.SocketPermission" name="*" actions="listen,connect,resolve"/>
     <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
-	<javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="*" actions="read,write"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="*" actions="read,write"/>
     <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.net.SocketPermission" name="*" actions="listen,connect,resolve"/>
     <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
-	<javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.util.PropertyPermission" name="*" actions="read,write"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.util.PropertyPermission" name="*" actions="read,write"/>
 </server>

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/BasicRemote.war/src/com/ibm/ws/ejbcontainer/remote/fat/basic/BasicRemoteTestServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/BasicRemote.war/src/com/ibm/ws/ejbcontainer/remote/fat/basic/BasicRemoteTestServlet.java
@@ -36,6 +36,7 @@ import org.omg.CosNaming.NamingContext;
 import org.omg.CosNaming.NamingContextHelper;
 
 import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 @WebServlet("/BasicRemoteTestServlet")
@@ -211,6 +212,8 @@ public class BasicRemoteTestServlet extends FATServlet {
     }
 
     @Test
+    // TODO: Remove Skip when #17742 is fixed
+    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     @ExpectedFFDC({
                     "java.lang.reflect.InvocationTargetException",
                     "com.ibm.ws.ejbcontainer.remote.fat.basic.TestRollbackException",

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/EJBHomeTest.war/src/com/ibm/ws/ejbcontainer/remote/fat/home/EJBHomeTestServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/EJBHomeTest.war/src/com/ibm/ws/ejbcontainer/remote/fat/home/EJBHomeTestServlet.java
@@ -43,6 +43,7 @@ import org.omg.CosNaming.NameComponent;
 import org.omg.CosNaming.NamingContext;
 import org.omg.CosNaming.NamingContextHelper;
 
+import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 @WebServlet("/EJBHomeTestServlet")
@@ -115,6 +116,8 @@ public class EJBHomeTestServlet extends FATServlet {
      * so a tie mismatch will result in an OutOfMemoryError.
      */
     @Test
+    // TODO: Remove Skip when #17757 is fixed
+    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     public void testEJBHomeWriteValueDirect_EJBHomeTest() throws Exception {
         List<?> expected = new ArrayList<Object>(Arrays.asList("a", "b", "c"));
         List<?> actual = stubTestWriteValue((Stub) home.create(), expected);

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/SingletonWeb.war/src/com/ibm/ws/ejbcontainer/remote/singleton/mix/web/PassivationServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/SingletonWeb.war/src/com/ibm/ws/ejbcontainer/remote/singleton/mix/web/PassivationServlet.java
@@ -23,6 +23,7 @@ import com.ibm.ws.ejbcontainer.remote.singleton.mix.shared.MixHelper;
 import com.ibm.ws.ejbcontainer.remote.singleton.mix.shared.StatefulEJBRefLocal;
 import com.ibm.ws.ejbcontainer.remote.singleton.mix.shared.StatefulEJBRefRemote;
 
+import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 /**
@@ -44,6 +45,8 @@ public class PassivationServlet extends FATServlet {
      * Passivate and activate an SFSB with a reference to a singleton bean's business interface
      */
     @Test
+    // TODO: Remove Skip when #17757 is fixed
+    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     public void testMixPassivateSingleton() throws Exception {
         // Create an instance of the bean by looking up the business interface and ensure the bean contains the default state.
         StatefulEJBRefLocal localBean = lookupLocal();

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/StatelessAnnWeb.war/src/com/ibm/ws/ejbcontainer/remote/ejb3session/sl/ann/web/TxAttrComp2Servlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/StatelessAnnWeb.war/src/com/ibm/ws/ejbcontainer/remote/ejb3session/sl/ann/web/TxAttrComp2Servlet.java
@@ -40,6 +40,7 @@ import com.ibm.ws.ejbcontainer.remote.ejb3session.sl.ann.ejb.TxAttrEJBLocal;
 import com.ibm.ws.ejbcontainer.remote.ejb3session.sl.ann.ejb.TxAttrEJBLocalHome;
 
 import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 /**
@@ -326,6 +327,8 @@ public class TxAttrComp2Servlet extends FATServlet {
      * javax.transaction.TransactionRequiredException.
      */
     @Test
+    // TODO: Remove Skip when #17742 is fixed
+    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     @ExpectedFFDC({ "com.ibm.websphere.csi.CSITransactionRequiredException" })
     public void testMandatoryAttribThrowsExcp_TxAttrComp2() throws Exception {
         try {

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/StatelessAnnWeb.war/src/com/ibm/ws/ejbcontainer/remote/ejb3session/sl/ann/web/TxAttrCompView2Servlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/StatelessAnnWeb.war/src/com/ibm/ws/ejbcontainer/remote/ejb3session/sl/ann/web/TxAttrCompView2Servlet.java
@@ -40,6 +40,7 @@ import com.ibm.ws.ejbcontainer.remote.ejb3session.sl.ann.ejb.TxAttrEJBLocal;
 import com.ibm.ws.ejbcontainer.remote.ejb3session.sl.ann.ejb.TxAttrEJBLocalHome;
 
 import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 /**
@@ -322,6 +323,8 @@ public class TxAttrCompView2Servlet extends FATServlet {
      * javax.transaction.TransactionRequiredException.
      */
     @Test
+    // TODO: Remove Skip when #17742 is fixed
+    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     @ExpectedFFDC({ "com.ibm.websphere.csi.CSITransactionRequiredException" })
     public void testMandatoryAttribThrowsExcp_TxAttrCompView2() throws Exception {
         try {


### PR DESCRIPTION
Enable the remaining EJB remote FAT tests to run with Jakarta EE 9 features.

for #13717 