### PR TITLE
config: fix getObscuredDefaultValue

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/variables/AbstractLibertyVariable.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/xml/internal/variables/AbstractLibertyVariable.java
@@ -33,7 +33,7 @@ public abstract class AbstractLibertyVariable implements LibertyVariable {
         if (obscuredValuePattern.matcher(value).matches())
             return OBSCURED_VALUE;
 
-        return getValue();
+        return value;
     }
 
     @Override


### PR DESCRIPTION
Previously, if getObscuredDefaultValue decided that the value did not
need to be obscured, it would return the value, rather than the
defaultValue.