### PR TITLE
PR for Issue 17653: Update OIDC UserInfo processing to handle JWS responses

### DIFF
--- a/dev/com.ibm.ws.security.openidconnect.client/resources/com/ibm/ws/security/openidconnect/client/internal/resources/OidcClientMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/com/ibm/ws/security/openidconnect/client/internal/resources/OidcClientMessages.nlsprops
@@ -289,8 +289,8 @@ OIDC_CLIENT_BAD_REQUEST_MALFORMED_URL_IN_COOKIE.explanation=A request was receiv
 OIDC_CLIENT_BAD_REQUEST_MALFORMED_URL_IN_COOKIE.useraction=Verify the OpenID Connect provider and client configurations. The malformed cookie can be caused by cookie modification at the user agent with a host name that differs from the host name of the redirect that is registered with the provider. If the host name is expected, then add it to the wasReqURLRedirectDomainNames attribute of the webAppSecurity element in server.xml.
 
 # 0=OIDC client config ID, 1=Error/exception message
-OIDC_CLIENT_ERROR_EXTRACTING_JWT_CLAIMS_FROM_WEB_RESPONSE=CWWKS1533E: The OpenID Connect client [{0}] cannot extract the JSON Web Token (JWT) claims from the web response. {1}
-OIDC_CLIENT_ERROR_EXTRACTING_JWT_CLAIMS_FROM_WEB_RESPONSE.explanation=The web response is expected to be a JWT in either JSON Web Encryption (JWE) or JSON Web Signature (JWS) format. The response might be malformed, or the OpenID Connect client encountered another error processing the response.
+OIDC_CLIENT_ERROR_EXTRACTING_JWT_CLAIMS_FROM_WEB_RESPONSE=CWWKS1533E: The {0} OpenID Connect client cannot extract the JSON Web Token (JWT) claims from the web response. {1}
+OIDC_CLIENT_ERROR_EXTRACTING_JWT_CLAIMS_FROM_WEB_RESPONSE.explanation=The web response must be a JWT in either JSON Web Encryption (JWE) or JSON Web Signature (JWS) format. The response might be malformed, or the OpenID Connect client encountered another error processing the response.
 OIDC_CLIENT_ERROR_EXTRACTING_JWT_CLAIMS_FROM_WEB_RESPONSE.useraction=See the error in the message for more information. Verify that the response is in JWT format.
 
 # STOP HERE, OIDC SERVER HAS RESERVED 1600 - 1649

--- a/dev/com.ibm.ws.security.openidconnect.client/resources/com/ibm/ws/security/openidconnect/client/internal/resources/OidcClientMessages.nlsprops
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/com/ibm/ws/security/openidconnect/client/internal/resources/OidcClientMessages.nlsprops
@@ -288,4 +288,9 @@ OIDC_CLIENT_BAD_REQUEST_MALFORMED_URL_IN_COOKIE=CWWKS1532E: A request to [{0}] i
 OIDC_CLIENT_BAD_REQUEST_MALFORMED_URL_IN_COOKIE.explanation=A request was received that includes a malformed cookie.
 OIDC_CLIENT_BAD_REQUEST_MALFORMED_URL_IN_COOKIE.useraction=Verify the OpenID Connect provider and client configurations. The malformed cookie can be caused by cookie modification at the user agent with a host name that differs from the host name of the redirect that is registered with the provider. If the host name is expected, then add it to the wasReqURLRedirectDomainNames attribute of the webAppSecurity element in server.xml.
 
+# 0=OIDC client config ID, 1=Error/exception message
+OIDC_CLIENT_ERROR_EXTRACTING_JWT_CLAIMS_FROM_WEB_RESPONSE=CWWKS1533E: The OpenID Connect client [{0}] cannot extract the JSON Web Token (JWT) claims from the web response. {1}
+OIDC_CLIENT_ERROR_EXTRACTING_JWT_CLAIMS_FROM_WEB_RESPONSE.explanation=The web response is expected to be a JWT in either JSON Web Encryption (JWE) or JSON Web Signature (JWS) format. The response might be malformed, or the OpenID Connect client encountered another error processing the response.
+OIDC_CLIENT_ERROR_EXTRACTING_JWT_CLAIMS_FROM_WEB_RESPONSE.useraction=See the error in the message for more information. Verify that the response is in JWT format.
+
 # STOP HERE, OIDC SERVER HAS RESERVED 1600 - 1649

--- a/dev/com.ibm.ws.security.openidconnect.client/test/com/ibm/ws/security/openidconnect/client/AccessTokenAuthenticatorTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/test/com/ibm/ws/security/openidconnect/client/AccessTokenAuthenticatorTest.java
@@ -24,6 +24,7 @@ import java.security.Key;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
@@ -38,7 +39,6 @@ import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JUnit4Mockery;
 import org.jmock.lib.legacy.ClassImposteriser;
-import org.jose4j.jwt.consumer.InvalidJwtException;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -50,21 +50,19 @@ import org.junit.rules.TestRule;
 
 import com.ibm.json.java.JSONObject;
 import com.ibm.websphere.ras.annotation.Sensitive;
-import com.ibm.websphere.security.jwt.InvalidTokenException;
 import com.ibm.websphere.ssl.JSSEHelper;
 import com.ibm.websphere.ssl.SSLConfig;
 import com.ibm.websphere.ssl.SSLConfigChangeListener;
 import com.ibm.websphere.ssl.SSLConfigurationNotAvailableException;
 import com.ibm.websphere.ssl.SSLException;
 import com.ibm.ws.common.internal.encoder.Base64Coder;
-import com.ibm.ws.security.common.crypto.HashUtils;
-import com.ibm.ws.security.jwt.config.ConsumerUtils;
 import com.ibm.ws.security.openidconnect.clients.common.ClientConstants;
 import com.ibm.ws.security.openidconnect.clients.common.MockOidcClientRequest;
 import com.ibm.ws.security.openidconnect.clients.common.OidcClientConfig;
 import com.ibm.ws.security.openidconnect.clients.common.OidcClientRequest;
 import com.ibm.ws.security.openidconnect.clients.common.OidcClientUtil;
 import com.ibm.ws.security.openidconnect.common.Constants;
+import com.ibm.ws.security.test.common.CommonTestClass;
 import com.ibm.ws.ssl.JSSEProviderFactory;
 import com.ibm.ws.webcontainer.security.AuthResult;
 import com.ibm.ws.webcontainer.security.ProviderAuthenticationResult;
@@ -78,7 +76,7 @@ import com.ibm.wsspi.ssl.SSLSupport;
 
 import test.common.SharedOutputManager;
 
-public class AccessTokenAuthenticatorTest {
+public class AccessTokenAuthenticatorTest extends CommonTestClass {
 
     private static SharedOutputManager outputMgr = SharedOutputManager.getInstance();
     @Rule
@@ -1111,45 +1109,6 @@ public class AccessTokenAuthenticatorTest {
         assertNull("Result should have been null but was " + result + ".", result);
     }
 
-    //@Test
-    public void test_extractSuccessfulResponse_jws() throws Exception {
-        JSONObject headerJson = new JSONObject();
-        headerJson.put("alg", "HS256");
-        headerJson.put("typ", "JWT");
-        JSONObject payloadJson = new JSONObject();
-        payloadJson.put("iss", GOOD_ISSUER);
-        String jwsHeader = Base64Coder.base64Encode(headerJson.toString());
-        String jwsPayload = Base64Coder.base64Encode(payloadJson.toString());
-        String signature = HashUtils.digest(jwsHeader + "." + jwsPayload);
-        String rawResponse = jwsHeader + "." + jwsPayload + "." + signature;
-        final InputStream input = new ByteArrayInputStream(rawResponse.getBytes());
-        final BasicHttpEntity entity = new BasicHttpEntity();
-        entity.setContent(input);
-        entity.setContentType("application/jwt");
-        ConsumerUtils consumerUtils = new ConsumerUtils(null);
-
-        // TODO - update once parsing JWS tokens is implemented
-        mockery.checking(new Expectations() {
-            {
-                one(httpResponse).getEntity();
-                will(returnValue(entity));
-                one(clientConfig).getConsumerUtils();
-                will(returnValue(consumerUtils));
-                allowing(clientConfig).getKeyManagementKeyAlias();
-                will(returnValue(null));
-                one(clientConfig).getClockSkew();
-                will(returnValue(3000L));
-                one(clientConfig).isValidationRequired();
-                will(returnValue(false));
-                one(clientConfig).getTokenReuse();
-                will(returnValue(false));
-            }
-        });
-        JSONObject result = tokenAuth.extractSuccessfulResponse(clientConfig, clientRequest, httpResponse);
-        assertNotNull("Result should not have been null but was.", result);
-        assertEquals("Result did not match the expected value.", payloadJson, result);
-    }
-
     @Test
     public void test_extractClaimsFromJwtResponse_responseStringEmpty() throws Exception {
         String rawResponse = "";
@@ -1158,35 +1117,28 @@ public class AccessTokenAuthenticatorTest {
         assertNull("Result should have been null but was " + result + ".", result);
     }
 
-    //@Test
-    public void test_extractClaimsFromJwtResponse_jwsMalformed() throws Exception {
-        // Create a JWS but mangle the payload string
-        JSONObject headerJson = new JSONObject();
-        headerJson.put("alg", "HS256");
-        headerJson.put("typ", "JWT");
-        JSONObject payloadJson = new JSONObject();
-        payloadJson.put("iss", GOOD_ISSUER);
-        String jwsHeader = Base64Coder.base64Encode(headerJson.toString());
-        String jwsPayload = Base64Coder.base64Encode(payloadJson.toString()) + "_mangled";
-        String signature = HashUtils.digest(jwsHeader + "." + jwsPayload);
-        String rawResponse = jwsHeader + "." + jwsPayload + "." + signature;
+    @Test
+    public void test_extractClaimsFromJwtResponse_notJwt() throws Exception {
+        String rawResponse = "This is not in JWT format";
 
-        // TODO - update once parsing JWS tokens is implemented
+        JSONObject result = tokenAuth.extractClaimsFromJwtResponse(rawResponse, clientConfig, clientRequest);
+        assertNull("Result should have been null but was " + result + ".", result);
+    }
+
+    @Test
+    public void test_extractClaimsFromJwtResponse_jwsMalformed() throws Exception {
+        String rawResponse = "aaa.bbb.ccc";
         mockery.checking(new Expectations() {
             {
-                //                one(clientConfig).getConsumerUtils();
-                //                will(returnValue(consumerUtils));
-                //                allowing(clientConfig).getKeyManagementKeyAlias();
-                //                will(returnValue(null));
-                //                one(clientConfig).getClockSkew();
-                //                will(returnValue(3000L));
+                one(clientConfig).getId();
+                will(returnValue("configId"));
             }
         });
         try {
             JSONObject result = tokenAuth.extractClaimsFromJwtResponse(rawResponse, clientConfig, clientRequest);
             fail("Should have thrown an exception, but got " + result + ".");
-        } catch (InvalidJwtException e) {
-            assertTrue("Did not find expected exception and reason string. Exception was " + e, e.toString().contains("Unable to parse"));
+        } catch (Exception e) {
+            verifyException(e, "CWWKS1533E" + ".+" + Pattern.quote("org.jose4j.jwt.consumer.InvalidJwtException"));
         }
     }
 
@@ -1202,16 +1154,15 @@ public class AccessTokenAuthenticatorTest {
             {
                 one(clientConfig).getJweDecryptionKey();
                 will(returnValue(decryptionKey));
-                one(clientConfig).getId();
+                allowing(clientConfig).getId();
                 will(returnValue("configId"));
             }
         });
         try {
             JSONObject result = tokenAuth.extractClaimsFromJwtResponse(rawResponse, clientConfig, clientRequest);
             fail("Should have thrown an exception, but got " + result + ".");
-        } catch (InvalidTokenException e) {
-            String expectedMsg = "CWWKS6056E";
-            assertTrue("Did not see expected " + expectedMsg + " error message in the exception [" + e + "].", e.getMessage().contains(expectedMsg));
+        } catch (Exception e) {
+            verifyException(e, "CWWKS1533E" + ".+" + "CWWKS6056E");
         }
     }
 

--- a/dev/com.ibm.ws.security.openidconnect.client/test/com/ibm/ws/security/openidconnect/client/jose4j/util/EcJwkTest.java
+++ b/dev/com.ibm.ws.security.openidconnect.client/test/com/ibm/ws/security/openidconnect/client/jose4j/util/EcJwkTest.java
@@ -188,7 +188,7 @@ public class EcJwkTest {
         String methodName = "testCreateMicproProfileFormatJWT";
         try {
             String jwtStr = jwtCreaterEC(true);
-            JwtContext jwtContext = Jose4jUtil.parseJwtWithoutValidation(jwtStr, oidcClientConfig);
+            JwtContext jwtContext = Jose4jUtil.parseJwtWithoutValidation(jwtStr);
             assertNotNull("The jwtContext is expect to have an instance but it returns null", jwtContext);
             JwtClaims jwtClaims = jwtContext.getJwtClaims();
             assertNotNull("The jwtClaims is expected to an instance but it return null", jwtClaims);
@@ -263,7 +263,7 @@ public class EcJwkTest {
         }
         Jose4jUtil jose4jUtil = new Jose4jUtil(null);
         try {
-            JwtContext jwtContext = Jose4jUtil.parseJwtWithoutValidation(jwtString, oidcClientConfig);
+            JwtContext jwtContext = Jose4jUtil.parseJwtWithoutValidation(jwtString);
             assertNotNull("The jwtContext is expect to have an instance but it returns null", jwtContext);
             jose4jUtil = createJwkRetrieverConstructorExpectations();
             JwtClaims jwtClaims = jose4jUtil.parseJwtWithValidation(oidcClientConfig, jwtString, jwtContext, oidcClientRequest);
@@ -358,7 +358,7 @@ public class EcJwkTest {
         }
         Jose4jUtil jose4jUtil = new Jose4jUtil(null);
         try {
-            JwtContext jwtContext = Jose4jUtil.parseJwtWithoutValidation(badJwtString, oidcClientConfig);
+            JwtContext jwtContext = Jose4jUtil.parseJwtWithoutValidation(badJwtString);
             assertNotNull("The jwtContext is expect to have an instance but it returns null", jwtContext);
             jose4jUtil = createJwkRetrieverConstructorExpectations();
             JwtClaims jwtClaims = jose4jUtil.parseJwtWithValidation(oidcClientConfig, badJwtString, jwtContext, oidcClientRequest);
@@ -562,7 +562,7 @@ public class EcJwkTest {
         }
         Jose4jUtil jose4jUtil = new Jose4jUtil(null);
         try {
-            JwtContext jwtContext = Jose4jUtil.parseJwtWithoutValidation(rsJwtString, oidcClientConfig);
+            JwtContext jwtContext = Jose4jUtil.parseJwtWithoutValidation(rsJwtString);
             assertNotNull("The jwtContext is expect to have an instance but it returns null", jwtContext);
             jose4jUtil = createJwkRetrieverConstructorExpectations();
             JwtClaims jwtClaims = jose4jUtil.parseJwtWithValidation(oidcClientConfig, rsJwtString, jwtContext, oidcClientRequest);

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
@@ -104,7 +104,7 @@ public class Jose4jUtil {
                 tokenStr = JweHelper.extractJwsFromJweToken(tokenStr, clientConfig, null);
             }
 
-            JwtContext jwtContext = parseJwtWithoutValidation(tokenStr, clientConfig);
+            JwtContext jwtContext = parseJwtWithoutValidation(tokenStr);
             JwtClaims jwtClaims = parseJwtWithValidation(clientConfig, tokenStr, jwtContext, oidcClientRequest);
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "post jwtClaims: " + jwtClaims + " firstPass jwtClaims=" + jwtContext.getJwtClaims());
@@ -218,7 +218,7 @@ public class Jose4jUtil {
     }
 
     //Just parse without validation for now
-    protected static JwtContext parseJwtWithoutValidation(String jwtString, ConvergedClientConfig clientConfig) throws Exception {
+    public static JwtContext parseJwtWithoutValidation(String jwtString) throws Exception {
         JwtConsumer firstPassJwtConsumer = new JwtConsumerBuilder()
                 .setSkipAllValidators()
                 .setDisableRequireSignature()
@@ -229,42 +229,14 @@ public class Jose4jUtil {
     }
 
     @FFDCIgnore({ Exception.class })
-    protected JwtClaims parseJwtWithValidation(ConvergedClientConfig clientConfig,
+    public JwtClaims parseJwtWithValidation(ConvergedClientConfig clientConfig,
             String jwtString,
             JwtContext jwtContext,
             OidcClientRequest oidcClientRequest) throws JWTTokenValidationFailedException, IllegalStateException, Exception {
         try {
-            List<JsonWebStructure> jsonStructures = jwtContext.getJoseObjects();
-            if (jsonStructures == null || jsonStructures.isEmpty()) {
-                throw new Exception("Invalid JsonWebStructure");
-            }
-            JsonWebStructure jsonStruct = jsonStructures.get(0);
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "JsonWebStructure class: " + jsonStruct.getClass().getName() + " data:" + jsonStruct);
-                if (jsonStruct instanceof JsonWebSignature) {
-                    JsonWebSignature signature = (JsonWebSignature) jsonStruct;
-                    Tr.debug(tc, "JsonWebSignature alg: " + signature.getAlgorithmHeaderValue() + " 3rd:'" + signature.getEncodedSignature() + "'");
-                }
-            }
+            JsonWebStructure jsonStruct = getJsonWebStructureFromJwtContext(jwtContext);
 
-            String kid = jsonStruct.getKeyIdHeaderValue();
-            String x5t = jsonStruct.getX509CertSha1ThumbprintHeaderValue();
-            Key key = null;
-            Exception caughtException = null;
-            try {
-                key = getVerifyKey(clientConfig, kid, x5t);
-            } catch (Exception e) {
-                caughtException = e;
-            }
-
-            if (key == null && !SIGNATURE_ALG_NONE.equals(clientConfig.getSignatureAlgorithm())) {
-                Object[] objs = new Object[] { clientConfig.getSignatureAlgorithm(), "" };
-                if (caughtException != null) {
-                    objs = new Object[] { clientConfig.getSignatureAlgorithm(), caughtException.getLocalizedMessage() };
-                }
-                oidcClientRequest.setRsFailMsg(OidcClientRequest.NO_KEY, Tr.formatMessage(tc, "OIDC_CLIENT_NO_VERIFYING_KEY", objs));
-                throw oidcClientRequest.error(true, tc, "OIDC_CLIENT_NO_VERIFYING_KEY", objs);
-            }
+            Key key = getSignatureVerificationKeyFromJsonWebStructure(jsonStruct, clientConfig, oidcClientRequest);
 
             Jose4jValidator validator = new Jose4jValidator(key,
                     clientConfig.getClockSkewInSeconds(),
@@ -280,6 +252,43 @@ public class Jose4jUtil {
             }
             throw e;
         }
+    }
+
+    public JsonWebStructure getJsonWebStructureFromJwtContext(JwtContext jwtContext) throws Exception {
+        List<JsonWebStructure> jsonStructures = jwtContext.getJoseObjects();
+        if (jsonStructures == null || jsonStructures.isEmpty()) {
+            throw new Exception("Invalid JsonWebStructure");
+        }
+        JsonWebStructure jsonStruct = jsonStructures.get(0);
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "JsonWebStructure class: " + jsonStruct.getClass().getName() + " data:" + jsonStruct);
+            if (jsonStruct instanceof JsonWebSignature) {
+                JsonWebSignature signature = (JsonWebSignature) jsonStruct;
+                Tr.debug(tc, "JsonWebSignature alg: " + signature.getAlgorithmHeaderValue() + " 3rd:'" + signature.getEncodedSignature() + "'");
+            }
+        }
+        return jsonStruct;
+    }
+
+    public Key getSignatureVerificationKeyFromJsonWebStructure(JsonWebStructure jsonStruct, ConvergedClientConfig clientConfig, OidcClientRequest oidcClientRequest) throws JWTTokenValidationFailedException {
+        String kid = jsonStruct.getKeyIdHeaderValue();
+        String x5t = jsonStruct.getX509CertSha1ThumbprintHeaderValue();
+        Key key = null;
+        Exception caughtException = null;
+        try {
+            key = getVerifyKey(clientConfig, kid, x5t);
+        } catch (Exception e) {
+            caughtException = e;
+        }
+        if (key == null && !SIGNATURE_ALG_NONE.equals(clientConfig.getSignatureAlgorithm())) {
+            Object[] objs = new Object[] { clientConfig.getSignatureAlgorithm(), "" };
+            if (caughtException != null) {
+                objs = new Object[] { clientConfig.getSignatureAlgorithm(), caughtException.getLocalizedMessage() };
+            }
+            oidcClientRequest.setRsFailMsg(OidcClientRequest.NO_KEY, Tr.formatMessage(tc, "OIDC_CLIENT_NO_VERIFYING_KEY", objs));
+            throw oidcClientRequest.error(true, tc, "OIDC_CLIENT_NO_VERIFYING_KEY", objs);
+        }
+        return key;
     }
 
     protected Key getVerifyKey(ConvergedClientConfig clientConfig, String kid, String x5t) throws Exception {
@@ -350,7 +359,7 @@ public class Jose4jUtil {
             if (JweHelper.isJwe(jwtString) && isRunningBetaMode()) {
                 jwtString = JweHelper.extractJwsFromJweToken(jwtString, clientConfig, null);
             }
-            JwtContext jwtContext = parseJwtWithoutValidation(jwtString, clientConfig);
+            JwtContext jwtContext = parseJwtWithoutValidation(jwtString);
             JwtClaims jwtClaims = parseJwtWithValidation(clientConfig, jwtString, jwtContext, oidcClientRequest);
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "jwtClaims: " + jwtClaims);

--- a/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
+++ b/dev/com.ibm.ws.security.openidconnect.clients.common/src/com/ibm/ws/security/openidconnect/client/jose4j/util/Jose4jUtil.java
@@ -270,6 +270,7 @@ public class Jose4jUtil {
         return jsonStruct;
     }
 
+    @FFDCIgnore({ Exception.class })
     public Key getSignatureVerificationKeyFromJsonWebStructure(JsonWebStructure jsonStruct, ConvergedClientConfig clientConfig, OidcClientRequest oidcClientRequest) throws JWTTokenValidationFailedException {
         String kid = jsonStruct.getKeyIdHeaderValue();
         String x5t = jsonStruct.getX509CertSha1ThumbprintHeaderValue();


### PR DESCRIPTION
For #17653

- Refactors the `Jose4jUtil` class a bit to clean up the `parseJwtWithValidation()` method.
- Adds a `validateJwsSignature()` method to the `Jose4jValidator` class for validating just a JWS token's signature.
- Updates the `AccessTokenAuthenticator` class to parse JWS tokens, validate their signature, and extract the claims to be verified