### PR TITLE
update DB2 ssl testing to explictly request TLSv1.2

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_db2/publish/servers/com.ibm.ws.jdbc.fat.db2/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_db2/publish/servers/com.ibm.ws.jdbc.fat.db2/server.xml
@@ -55,7 +55,7 @@
     <properties.db2.jcc
       databaseName="${DB2_DBNAME}" serverName="${DB2_HOSTNAME}" portNumber="${DB2_PORT_SECURE}"
       user="${DB2_USER}" password="${DB2_PASS}"
-      sslConnection="true"/>
+      sslConnection="true" sslVersion="TLSv1.2"/>
   </dataSource>
   
   <dataSource jndiName="jdbc/db2-using-driver">


### PR DESCRIPTION
This test was failing with the following exception when running against IBM JDK 11 on Mac. 
```txt
java.sql.SQLException: Unsupported protocolSSL_TLSv2
	at com.ibm.ws.rsadapter.AdapterUtil.toSQLException(AdapterUtil.java:869)
	at com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource.getConnection(WSJdbcDataSource.java:149)
	at com.ibm.ws.rsadapter.jdbc.WSJdbcDataSource.getConnection(WSJdbcDataSource.java:114)
	at db2.web.DB2TestServlet.testDB2SecureConnection(DB2TestServlet.java:94)
...
Caused by: javax.resource.spi.ResourceAllocationException: Unsupported protocolSSL_TLSv2
	at com.ibm.ejs.j2c.FreePool.createManagedConnectionWithMCWrapper(FreePool.java:1595)
...
Caused by: java.lang.IllegalArgumentException: Unsupported protocolSSL_TLSv2
	at java.base/sun.security.ssl.ProtocolVersion.namesOf(ProtocolVersion.java:292)
	at java.base/sun.security.ssl.SSLSocketImpl.setEnabledProtocols(SSLSocketImpl.java:346)
	at com.ibm.db2.jcc.t4.w.run(w.java:123)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:738)
...
```

Based on the documentation here: https://openliberty.io/docs/21.0.0.6/reference/config/ssl.html
```
The SSL handshake protocol. Protocol values can be found in the documentation for the underlying JRE's Java Secure Socket Extension (JSSE) provider. When using the IBM JRE the default value is SSL_TLSv2 and when using the Oracle JRE the default value is SSL.
```

We can see why the protocol `SSL_TLSv2` was used.  But this should be a supported protocol on the IBM JDK.  
Regardless, this test case is not testing that.  
We are testing to make sure the the driver and database can complete a handshake using TLSv1.2