### PR TITLE
Add runtime update trace to help debug server quiesce issue

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent_fat_auto_pollinterval/publish/servers/com.ibm.ws.concurrent.persistent.fat.autonomicalpolling1serv/bootstrap.properties
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_auto_pollinterval/publish/servers/com.ibm.ws.concurrent.persistent.fat.autonomicalpolling1serv/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020,2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 
-com.ibm.ws.logging.trace.specification=*=info=enabled:persistentExecutor=all:logservice=all
+com.ibm.ws.logging.trace.specification=*=info=enabled:persistentExecutor=all:logservice=all:com.ibm.ws.runtime.update.*=all
 com.ibm.ws.logging.max.file.size=0
 
 ds.loglevel=debug 


### PR DESCRIPTION
Add trace that will capture the stacks of threads on server quiesce to aid in debugging an issue where some quiesce threads do not complete.