### PR TITLE
mpOpenApi-2.0: ignore non-public properties by default

### DIFF
--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/FATSuite.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/FATSuite.java
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.ibm.ws.microprofile.openapi.fat.annotations.AnnotationProcessingTest;
 import com.ibm.ws.microprofile.openapi.fat.filter.FilterConfigTest;
 import com.ibm.ws.microprofile.openapi.validation.fat.OpenAPIValidationTestFive;
 import com.ibm.ws.microprofile.openapi.validation.fat.OpenAPIValidationTestFour;
@@ -28,6 +29,7 @@ import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
+                AnnotationProcessingTest.class,
                 ApplicationProcessorTest.class,
                 OpenAPIValidationTestOne.class,
                 OpenAPIValidationTestTwo.class,

--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/annotations/AnnotationProcessingTest.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/annotations/AnnotationProcessingTest.java
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.openapi.fat.annotations;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.microprofile.openapi.fat.annotations.NonPublicFieldVisibilityApplication.NonPublicFieldVisibilityDataObject;
+import com.ibm.ws.microprofile.openapi.fat.annotations.PrivateFieldVisibilityApplication.PrivateFieldVisibilityDataObject;
+import com.ibm.ws.microprofile.openapi.fat.utils.OpenAPIConnection;
+import com.ibm.ws.microprofile.openapi.fat.utils.OpenAPITestUtil;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * Annotation processing correctness tests which aren't adequately covered by
+ * the TCK
+ */
+@RunWith(FATRunner.class)
+public class AnnotationProcessingTest {
+
+    @Server("AnnotationProcessingServer")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        server.stopServer();
+    }
+
+    @Test
+    public void testPrivateFieldVisibility() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "testPrivateFieldVisibility.war")
+            .addClass(PrivateFieldVisibilityApplication.class);
+
+        try {
+            ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
+
+            ObjectNode openApi = (ObjectNode) OpenAPITestUtil
+                .readYamlTree(new OpenAPIConnection(server, OpenAPIConnection.OPEN_API_DOCS).download());
+
+            ObjectNode endpointResponse = (ObjectNode) OpenAPITestUtil
+                .readYamlTree(new OpenAPIConnection(server, "/testPrivateFieldVisibility/").download());
+
+            assertDataMatchesSchema(endpointResponse, openApi, PrivateFieldVisibilityDataObject.class.getSimpleName());
+        } finally {
+            server.removeAndStopDropinsApplications("testPrivateFieldVisibility.war");
+        }
+    }
+
+    @Test
+    public void testNonPublicFieldVisibility() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "testNonPublicFieldVisibility.war")
+            .addClass(NonPublicFieldVisibilityApplication.class);
+
+        try {
+            ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
+
+            ObjectNode openApi = (ObjectNode) OpenAPITestUtil
+                .readYamlTree(new OpenAPIConnection(server, OpenAPIConnection.OPEN_API_DOCS).download());
+
+            ObjectNode endpointResponse = (ObjectNode) OpenAPITestUtil
+                .readYamlTree(new OpenAPIConnection(server, "/testNonPublicFieldVisibility/").download());
+
+            assertDataMatchesSchema(endpointResponse, openApi,
+                NonPublicFieldVisibilityDataObject.class.getSimpleName());
+        } finally {
+            server.removeAndStopDropinsApplications("testNonPublicFieldVisibility.war");
+        }
+    }
+
+    /**
+     * Assert that a data object matches an openapi schema
+     * <p>
+     * This is a light check, it only validates that the fields in the data object
+     * match the properties listed in the schema.
+     *
+     * @param data       the data object
+     * @param openApiDoc the OpenAPI document containing the schema
+     * @param schemaName the name of the schema to use
+     */
+    private void assertDataMatchesSchema(
+        JsonNode data,
+        JsonNode openApiDoc,
+        String schemaName) {
+
+        JsonNode schema = openApiDoc.path("components").path("schemas")
+            .path(schemaName);
+
+        if (schema.isMissingNode()) {
+            throw new AssertionError("Expected: schema named " + schemaName + " to exist\n"
+                + "but openApi document was: " + openApiDoc.toPrettyString());
+        }
+
+        Set<String> schemaNames = toSet(schema.path("properties").fieldNames());
+
+        if (!data.isObject()) {
+            throw new AssertionError("Expected: data to be an object\n"
+                + "   but was: " + data.toPrettyString());
+        }
+
+        Set<String> dataNames = toSet(data.fieldNames());
+
+        if (!schemaNames.equals(dataNames)) {
+            throw new AssertionError("The fields in the data object do not match those listed in the schema\n"
+                + "data: " + dataNames + "\n"
+                + "schema: " + schemaNames);
+        }
+    }
+
+    private <T> Set<T> toSet(
+        Iterator<T> i) {
+        Set<T> result = new HashSet<>();
+        while (i.hasNext()) {
+            result.add(i.next());
+        }
+        return result;
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/annotations/NonPublicFieldVisibilityApplication.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/annotations/NonPublicFieldVisibilityApplication.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.openapi.fat.annotations;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+
+@ApplicationPath("/")
+@Path("/")
+public class NonPublicFieldVisibilityApplication extends Application {
+
+    @Produces(MediaType.APPLICATION_JSON)
+    @GET
+    public NonPublicFieldVisibilityDataObject testGet() {
+        return new NonPublicFieldVisibilityDataObject();
+    }
+
+    public static class NonPublicFieldVisibilityDataObject {
+
+        private String privateWithGetters = "value";
+
+        @SuppressWarnings("unused")
+        private final String privateWithoutGetters = "value";
+
+        protected String protectedWithoutGetters = "value";
+
+        String packageScopedWithoutGetters = "value";
+
+        public String publicWithoutGetters = "value";
+
+        public String getPrivateWithGetters() {
+            return privateWithGetters;
+        }
+
+        public void setPrivateWithGetters(
+            String privateWithGetters) {
+            this.privateWithGetters = privateWithGetters;
+        }
+
+        @SuppressWarnings("unused")
+        private String getPrivateGetter() {
+            return "value";
+        }
+
+        public String getPublicGetter() {
+            return "value";
+        }
+
+        protected String getProtectedGetter() {
+            return "value";
+        }
+
+        String getPackageScopedGetter() {
+            return "value";
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/annotations/PrivateFieldVisibilityApplication.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/annotations/PrivateFieldVisibilityApplication.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.microprofile.openapi.fat.annotations;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+
+@ApplicationPath("/")
+@Path("/")
+public class PrivateFieldVisibilityApplication extends Application {
+
+    @Produces(MediaType.APPLICATION_JSON)
+    @GET
+    public PrivateFieldVisibilityDataObject testGet() {
+        return new PrivateFieldVisibilityDataObject();
+    }
+
+    public static class PrivateFieldVisibilityDataObject {
+
+        private String privateWithGetters = "value";
+
+        @SuppressWarnings("unused")
+        private final String privateWithoutGetters = "value";
+
+        public String publicWithoutGetters = "value";
+
+        public String getPrivateWithGetters() {
+            return privateWithGetters;
+        }
+
+        public void setPrivateWithGetters(
+            String privateWithGetters) {
+            this.privateWithGetters = privateWithGetters;
+        }
+
+        @SuppressWarnings("unused")
+        private String getPrivateGetter() {
+            return "value";
+        }
+
+        public String getPublicGetter() {
+            return "value";
+        }
+    }
+
+}

--- a/dev/com.ibm.ws.microprofile.openapi_fat/publish/servers/AnnotationProcessingServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/publish/servers/AnnotationProcessingServer/bootstrap.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2018, 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info=enabled:logservice=all=enabled:mpOpenAPI=debug=enabled

--- a/dev/com.ibm.ws.microprofile.openapi_fat/publish/servers/AnnotationProcessingServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/publish/servers/AnnotationProcessingServer/server.xml
@@ -1,0 +1,22 @@
+<!--
+    Copyright (c) 2018, 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+  <include location="../fatTestPorts.xml"/>
+
+  <featureManager>
+    <feature>componenttest-1.0</feature>
+    <feature>mpOpenAPI-1.0</feature>
+  </featureManager>
+  
+  <keyStore id="defaultKeyStore" password="password" />
+
+</server>

--- a/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/ServerXMLDefaultVariableConfigSource.java
+++ b/dev/io.openliberty.microprofile.config.internal.serverxml/src/io/openliberty/microprofile/config/internal/serverxml/ServerXMLDefaultVariableConfigSource.java
@@ -11,7 +11,6 @@
 package io.openliberty.microprofile.config.internal.serverxml;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import com.ibm.websphere.ras.Tr;
@@ -54,9 +53,13 @@ public class ServerXMLDefaultVariableConfigSource extends ServerXMLVariableConfi
     protected Map<String, String> getServerXMLVariables() {
         ConfigVariables configVariables = getConfigVariables();
         if (configVariables != null) {//configVariables could be null if not inside an OSGi framework (e.g. unit test) or if framework is shutting down
-            // We must request all Liberty variables, rather than all user defined defaults,
-            // since we want to know the default values of any variables which have been overwritten.
-            HashMap<String, String> result = new HashMap<>();
+            // Bit of a workaround:
+            // * getUserDefinedVariableDefaults includes variables defined in
+            //   defaultInstances.xml, but doesn't include variables with a default
+            //   value which has been overridden.
+            // * getAllLibertyVariables doesn't include variables defined in
+            //   defaultInstances.xml.
+            Map<String, String> result = OSGiConfigUtils.getDefaultVariablesFromServerXML(configVariables);
             for (LibertyVariable var : configVariables.getAllLibertyVariables()) {
                 if (var.getDefaultValue() != null) {
                     result.put(var.getName(), var.getDefaultValue());

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/bnd.bnd
@@ -41,7 +41,10 @@ Private-Package: \
 
 Include-Resource: \
     META-INF/services=resources/META-INF/services,\
-    WEB-INF=resources/WEB-INF
+    WEB-INF=resources/WEB-INF,\
+    OSGI-INF/wlp=resources/OSGI-INF/wlp
+
+IBM-Default-Config: OSGI-INF/wlp/defaultInstances.xml
 
 -dsannotations-inherit: true
 -dsannotations: io.openliberty.microprofile.openapi20.ApplicationListener,\

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/resources/OSGI-INF/wlp/defaultInstances.xml
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/resources/OSGI-INF/wlp/defaultInstances.xml
@@ -1,0 +1,14 @@
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+    <!-- Default to hiding non-public fields in schemas -->
+    <variable name="mp.openapi.extensions.smallrye.private-properties.enable" defaultValue="false" />
+</server>

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/test-applications/complete-flow/src/app/web/complete/flow/filter/OASFilterImpl.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/test-applications/complete-flow/src/app/web/complete/flow/filter/OASFilterImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,13 @@ import org.eclipse.microprofile.openapi.models.servers.Server;
 public class OASFilterImpl implements OASFilter {
     @Override
     public Server filterServer(Server server) {
+        // Test using app classloader
+        // (unusual but this case exposed subtle problems with DefaultsConfigSource)
         ConfigProvider.getConfig(this.getClass().getClassLoader()).getValue("myKey1", String.class);
+        
+        // Test using tccl (this is the normal use case)
+        ConfigProvider.getConfig().getValue("myKey1", String.class);
+        
         server.setDescription(server.getDescription() + " + from filter");
         return server;
     }


### PR DESCRIPTION
Fixes #17428

* ~Updates smallrye-open-api to 2.1.7~ (already done elsewhere)
* sets the property to disable non-public properties by default
* adds tests