### PR TITLE
Avoid ConcurrentModificationException in MP Config

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/sources/SystemConfig14Source.java
+++ b/dev/com.ibm.ws.microprofile.config.1.4/src/com/ibm/ws/microprofile/config14/sources/SystemConfig14Source.java
@@ -49,9 +49,13 @@ public class SystemConfig14Source extends InternalConfigSource implements Extend
     public Map<String, String> getProperties() {
         // Return a copy, removing any entries where either the key or value is not a string
         // This is a bit slow
-        return priv.getProperties().entrySet().stream()
-                        .filter(e -> e.getKey() instanceof String && e.getValue() instanceof String)
-                        .collect(Collectors.toMap(e -> (String) e.getKey(), e -> (String) e.getValue()));
+        // Properties.stringPropertyNames() returns an enumeration over the keys that will not change while we're using it
+        Properties props = priv.getProperties();
+        return props.stringPropertyNames().stream()
+                        .collect(Collectors.toMap(e -> e, e -> props.getProperty(e))) //create a new Map<String, String>
+                        .entrySet().stream()
+                        .filter(e -> e.getValue() != null) //remove the null values
+                        .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
     }
 
     @Override


### PR DESCRIPTION
ConcurrentModificationException seen if system properties are being updated while MP Config is copying them...

```
has thrown an exception java.util.ConcurrentModificationException
    at java.util.Hashtable$Enumerator.next(Hashtable.java:1506)
    at java.util.Iterator.forEachRemaining(Iterator.java:127)
    at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1812)
    at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:523)
    at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:513)
    at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:719)
    at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:245)
    at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:510)
    at com.ibm.ws.microprofile.config14.sources.SystemConfig14Source.getProperties(SystemConfig14Source.java:54)
    at com.ibm.ws.microprofile.config14.sources.SystemConfig14Source.getPropertyNames(SystemConfig14Source.java:59)
    at com.ibm.ws.microprofile.config14.impl.Config14Impl.getPropertyNames(Config14Impl.java:92)
    at com.ibm.ws.microprofile.config14.impl.Config14Impl.getKeySet(Config14Impl.java:105)
    at com.ibm.ws.microprofile.config.impl.AbstractConfig.getPropertyNames(AbstractConfig.java:80)
    at com.ibm.ws.microprofile.config.impl.AbstractConfig.getPropertyNames(AbstractConfig.java:28)
    at com.ibm.ws.microprofile.openapi.ConfigProcessor.retrieveServers(ConfigProcessor.java:183)
    at com.ibm.ws.microprofile.openapi.ConfigProcessor.<init>(ConfigProcessor.java:81)
    at com.ibm.ws.microprofile.openapi.impl.CustomCSSProcessor.activateFileMonitor(CustomCSSProcessor.java:126)
    at com.ibm.ws.microprofile.openapi.impl.CustomCSSProcessor.activate(CustomCSSProcessor.java:103)
```