### PR TITLE
Skip test with IBM JAVA 11

### DIFF
--- a/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/HealthCenterTest.java
+++ b/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/HealthCenterTest.java
@@ -35,8 +35,9 @@ public class HealthCenterTest {
     public static void beforeClass() throws Exception {
         server = LibertyServerFactory.getLibertyServer("com.ibm.ws.logging.healthcenter");
         ShrinkHelper.defaultDropinApp(server, "logger-servlet", "com.ibm.ws.logging.fat.logger.servlet");
-
-        Assume.assumeTrue(JavaInfo.forServer(server).vendor().equals(JavaInfo.Vendor.IBM));
+        // IBM JDK supports Health Center except IBM Java 11
+        Assume.assumeTrue((JavaInfo.forServer(server).vendor().equals(JavaInfo.Vendor.IBM)) &&
+                          (JavaInfo.forServer(server).majorVersion() != 11));
 
         if (!server.isStarted())
             server.startServer();


### PR DESCRIPTION
fixes #17646 

IBM JDK 11 doesn't ship Health Center as it is based on Open Source Adopt JDK.