### PR TITLE
Fix OpenLiberty build issue for JPA 2.0 FAT

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/callback/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/callback/FATSuite.java
@@ -11,26 +11,17 @@
 
 package com.ibm.ws.jpa.tests.spec10.callback;
 
-import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.jpa.tests.spec10.callback.tests.AbstractFATSuite;
-import com.ibm.ws.jpa.tests.spec10.callback.tests.Callback_EJB;
-import com.ibm.ws.jpa.tests.spec10.callback.tests.Callback_Web;
-
-import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                Callback_EJB.class,
-                Callback_Web.class,
+                JPA20Suite.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
 public class FATSuite extends AbstractFATSuite {
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.with(new RepeatWithJPA20());
 
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/callback/JPA20Suite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/callback/JPA20Suite.java
@@ -9,19 +9,27 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpa.tests.spec10.relationships.oneXmany;
+package com.ibm.ws.jpa.tests.spec10.callback;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.tests.AbstractFATSuite;
+import com.ibm.ws.jpa.tests.spec10.callback.tests.AbstractFATSuite;
+import com.ibm.ws.jpa.tests.spec10.callback.tests.Callback_EJB;
+import com.ibm.ws.jpa.tests.spec10.callback.tests.Callback_Web;
+
+import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                JPA20Suite.class,
-                componenttest.custom.junit.runner.AlwaysPassesTest.class
+                Callback_EJB.class,
+                Callback_Web.class
 })
-public class FATSuite extends AbstractFATSuite {
+public class JPA20Suite extends AbstractFATSuite {
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(new RepeatWithJPA20());
 
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entitymanager/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entitymanager/FATSuite.java
@@ -11,26 +11,17 @@
 
 package com.ibm.ws.jpa.tests.spec10.entitymanager;
 
-import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.jpa.tests.spec10.entitymanager.tests.AbstractFATSuite;
-import com.ibm.ws.jpa.tests.spec10.entitymanager.tests.JPA10EntityManager_EJB;
-import com.ibm.ws.jpa.tests.spec10.entitymanager.tests.JPA10EntityManager_Web;
-
-import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                JPA10EntityManager_EJB.class,
-                JPA10EntityManager_Web.class,
+                JPA20Suite.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
 public class FATSuite extends AbstractFATSuite {
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.with(new RepeatWithJPA20());
 
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entitymanager/JPA20Suite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/entitymanager/JPA20Suite.java
@@ -9,19 +9,27 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpa.tests.spec10.relationships.oneXmany;
+package com.ibm.ws.jpa.tests.spec10.entitymanager;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.tests.AbstractFATSuite;
+import com.ibm.ws.jpa.tests.spec10.entitymanager.tests.AbstractFATSuite;
+import com.ibm.ws.jpa.tests.spec10.entitymanager.tests.JPA10EntityManager_EJB;
+import com.ibm.ws.jpa.tests.spec10.entitymanager.tests.JPA10EntityManager_Web;
+
+import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                JPA20Suite.class,
-                componenttest.custom.junit.runner.AlwaysPassesTest.class
+                JPA10EntityManager_EJB.class,
+                JPA10EntityManager_Web.class
 })
-public class FATSuite extends AbstractFATSuite {
+public class JPA20Suite extends AbstractFATSuite {
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(new RepeatWithJPA20());
 
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/inheritance/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/inheritance/FATSuite.java
@@ -11,26 +11,17 @@
 
 package com.ibm.ws.jpa.tests.spec10.inheritance;
 
-import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.jpa.tests.spec10.inheritance.tests.AbstractFATSuite;
-import com.ibm.ws.jpa.tests.spec10.inheritance.tests.Inheritance_EJB;
-import com.ibm.ws.jpa.tests.spec10.inheritance.tests.Inheritance_Web;
-
-import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                Inheritance_EJB.class,
-                Inheritance_Web.class,
+                JPA20Suite.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
 public class FATSuite extends AbstractFATSuite {
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.with(new RepeatWithJPA20());
 
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/inheritance/JPA20Suite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/inheritance/JPA20Suite.java
@@ -9,19 +9,27 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpa.tests.spec10.relationships.oneXmany;
+package com.ibm.ws.jpa.tests.spec10.inheritance;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.tests.AbstractFATSuite;
+import com.ibm.ws.jpa.tests.spec10.inheritance.tests.AbstractFATSuite;
+import com.ibm.ws.jpa.tests.spec10.inheritance.tests.Inheritance_EJB;
+import com.ibm.ws.jpa.tests.spec10.inheritance.tests.Inheritance_Web;
+
+import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                JPA20Suite.class,
-                componenttest.custom.junit.runner.AlwaysPassesTest.class
+                Inheritance_EJB.class,
+                Inheritance_Web.class
 })
-public class FATSuite extends AbstractFATSuite {
+public class JPA20Suite extends AbstractFATSuite {
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(new RepeatWithJPA20());
 
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/FATSuite.java
@@ -11,54 +11,17 @@
 
 package com.ibm.ws.jpa.tests.spec10.query;
 
-import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.jpa.tests.spec10.query.tests.AbstractFATSuite;
-import com.ibm.ws.jpa.tests.spec10.query.tests.TestSVLLoopAnoQuery_Web;
-import com.ibm.ws.jpa.tests.spec10.query.tests.TestSVLLoopXMLQuery_Web;
-import com.ibm.ws.jpa.tests.spec10.query.tests.TestSVLQuery_Bulkupdate_Web;
-import com.ibm.ws.jpa.tests.spec10.query.tests.TestSVLQuery_Web;
-import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH14137_EJB;
-import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH14137_Web;
-import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH17369_EJB;
-import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH17369_Web;
-import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH17373_EJB;
-import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH17373_Web;
-import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH17376_EJB;
-import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH17376_Web;
-import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH17407_EJB;
-import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH17407_Web;
-import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH8014_EJB;
-import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH8014_Web;
-
-import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                TestOLGH8014_EJB.class,
-                TestOLGH8014_Web.class,
-                TestOLGH14137_EJB.class,
-                TestOLGH14137_Web.class,
-                TestOLGH17369_EJB.class,
-                TestOLGH17369_Web.class,
-                TestOLGH17373_EJB.class,
-                TestOLGH17373_Web.class,
-                TestOLGH17376_EJB.class,
-                TestOLGH17376_Web.class,
-                TestOLGH17407_EJB.class,
-                TestOLGH17407_Web.class,
-                TestSVLQuery_Web.class,
-                TestSVLQuery_Bulkupdate_Web.class,
-                TestSVLLoopAnoQuery_Web.class,
-                TestSVLLoopXMLQuery_Web.class,
+                JPA20Suite.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
 public class FATSuite extends AbstractFATSuite {
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.with(new RepeatWithJPA20());
 
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/JPA20Suite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/query/JPA20Suite.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.ibm.ws.jpa.tests.spec10.query;
+
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.ws.jpa.tests.spec10.query.tests.AbstractFATSuite;
+import com.ibm.ws.jpa.tests.spec10.query.tests.TestSVLLoopAnoQuery_Web;
+import com.ibm.ws.jpa.tests.spec10.query.tests.TestSVLLoopXMLQuery_Web;
+import com.ibm.ws.jpa.tests.spec10.query.tests.TestSVLQuery_Bulkupdate_Web;
+import com.ibm.ws.jpa.tests.spec10.query.tests.TestSVLQuery_Web;
+import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH14137_EJB;
+import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH14137_Web;
+import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH17369_EJB;
+import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH17369_Web;
+import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH17373_EJB;
+import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH17373_Web;
+import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH17376_EJB;
+import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH17376_Web;
+import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH17407_EJB;
+import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH17407_Web;
+import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH8014_EJB;
+import com.ibm.ws.jpa.tests.spec10.query.tests.olgh.TestOLGH8014_Web;
+
+import componenttest.rules.repeater.RepeatTests;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+                TestOLGH8014_EJB.class,
+                TestOLGH8014_Web.class,
+                TestOLGH14137_EJB.class,
+                TestOLGH14137_Web.class,
+                TestOLGH17369_EJB.class,
+                TestOLGH17369_Web.class,
+                TestOLGH17373_EJB.class,
+                TestOLGH17373_Web.class,
+                TestOLGH17376_EJB.class,
+                TestOLGH17376_Web.class,
+                TestOLGH17407_EJB.class,
+                TestOLGH17407_Web.class,
+                TestSVLQuery_Web.class,
+                TestSVLQuery_Bulkupdate_Web.class,
+                TestSVLLoopAnoQuery_Web.class,
+                TestSVLLoopXMLQuery_Web.class
+})
+public class JPA20Suite extends AbstractFATSuite {
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(new RepeatWithJPA20());
+
+}

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXmany/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXmany/FATSuite.java
@@ -11,25 +11,17 @@
 
 package com.ibm.ws.jpa.tests.spec10.relationships.manyXmany;
 
-import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.jpa.tests.spec10.relationships.manyXmany.tests.AbstractFATSuite;
-import com.ibm.ws.jpa.tests.spec10.relationships.manyXmany.tests.Relationships_ManyXMany_EJB;
-import com.ibm.ws.jpa.tests.spec10.relationships.manyXmany.tests.Relationships_ManyXMany_Web;
-
-import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                Relationships_ManyXMany_Web.class,
-                Relationships_ManyXMany_EJB.class,
+                JPA20Suite.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
 public class FATSuite extends AbstractFATSuite {
-    @ClassRule
-    public static RepeatTests r = RepeatTests.with(new RepeatWithJPA20());
 
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXmany/JPA20Suite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXmany/JPA20Suite.java
@@ -9,19 +9,27 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpa.tests.spec10.relationships.oneXmany;
+package com.ibm.ws.jpa.tests.spec10.relationships.manyXmany;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.tests.AbstractFATSuite;
+import com.ibm.ws.jpa.tests.spec10.relationships.manyXmany.tests.AbstractFATSuite;
+import com.ibm.ws.jpa.tests.spec10.relationships.manyXmany.tests.Relationships_ManyXMany_EJB;
+import com.ibm.ws.jpa.tests.spec10.relationships.manyXmany.tests.Relationships_ManyXMany_Web;
+
+import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                JPA20Suite.class,
-                componenttest.custom.junit.runner.AlwaysPassesTest.class
+                Relationships_ManyXMany_Web.class,
+                Relationships_ManyXMany_EJB.class
 })
-public class FATSuite extends AbstractFATSuite {
+public class JPA20Suite extends AbstractFATSuite {
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(new RepeatWithJPA20());
 
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXone/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXone/FATSuite.java
@@ -11,26 +11,17 @@
 
 package com.ibm.ws.jpa.tests.spec10.relationships.manyXone;
 
-import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.jpa.tests.spec10.relationships.manyXone.tests.AbstractFATSuite;
-import com.ibm.ws.jpa.tests.spec10.relationships.manyXone.tests.Relationships_ManyXOne_EJB;
-import com.ibm.ws.jpa.tests.spec10.relationships.manyXone.tests.Relationships_ManyXOne_Web;
-
-import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                Relationships_ManyXOne_Web.class,
-                Relationships_ManyXOne_EJB.class,
+                JPA20Suite.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
 public class FATSuite extends AbstractFATSuite {
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.with(new RepeatWithJPA20());
 
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXone/JPA20Suite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/manyXone/JPA20Suite.java
@@ -9,19 +9,27 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpa.tests.spec10.relationships.oneXmany;
+package com.ibm.ws.jpa.tests.spec10.relationships.manyXone;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.tests.AbstractFATSuite;
+import com.ibm.ws.jpa.tests.spec10.relationships.manyXone.tests.AbstractFATSuite;
+import com.ibm.ws.jpa.tests.spec10.relationships.manyXone.tests.Relationships_ManyXOne_EJB;
+import com.ibm.ws.jpa.tests.spec10.relationships.manyXone.tests.Relationships_ManyXOne_Web;
+
+import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                JPA20Suite.class,
-                componenttest.custom.junit.runner.AlwaysPassesTest.class
+                Relationships_ManyXOne_Web.class,
+                Relationships_ManyXOne_EJB.class
 })
-public class FATSuite extends AbstractFATSuite {
+public class JPA20Suite extends AbstractFATSuite {
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(new RepeatWithJPA20());
 
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXmany/JPA20Suite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXmany/JPA20Suite.java
@@ -11,17 +11,25 @@
 
 package com.ibm.ws.jpa.tests.spec10.relationships.oneXmany;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.tests.AbstractFATSuite;
+import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.tests.Relationships_OneXMany_EJB;
+import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.tests.Relationships_OneXMany_Web;
+
+import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                JPA20Suite.class,
-                componenttest.custom.junit.runner.AlwaysPassesTest.class
+                Relationships_OneXMany_Web.class,
+                Relationships_OneXMany_EJB.class
 })
-public class FATSuite extends AbstractFATSuite {
+public class JPA20Suite extends AbstractFATSuite {
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(new RepeatWithJPA20());
 
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXone/FATSuite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXone/FATSuite.java
@@ -11,26 +11,17 @@
 
 package com.ibm.ws.jpa.tests.spec10.relationships.oneXone;
 
-import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.ws.jpa.tests.spec10.relationships.oneXone.tests.AbstractFATSuite;
-import com.ibm.ws.jpa.tests.spec10.relationships.oneXone.tests.Relationships_OneXOne_EJB;
-import com.ibm.ws.jpa.tests.spec10.relationships.oneXone.tests.Relationships_OneXOne_Web;
-
-import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                Relationships_OneXOne_EJB.class,
-                Relationships_OneXOne_Web.class,
+                JPA20Suite.class,
                 componenttest.custom.junit.runner.AlwaysPassesTest.class
 })
 public class FATSuite extends AbstractFATSuite {
-
-    @ClassRule
-    public static RepeatTests r = RepeatTests.with(new RepeatWithJPA20());
 
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXone/JPA20Suite.java
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.0_fat/fat/src/com/ibm/ws/jpa/tests/spec10/relationships/oneXone/JPA20Suite.java
@@ -9,19 +9,27 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-package com.ibm.ws.jpa.tests.spec10.relationships.oneXmany;
+package com.ibm.ws.jpa.tests.spec10.relationships.oneXone;
 
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
-import com.ibm.ws.jpa.tests.spec10.relationships.oneXmany.tests.AbstractFATSuite;
+import com.ibm.ws.jpa.tests.spec10.relationships.oneXone.tests.AbstractFATSuite;
+import com.ibm.ws.jpa.tests.spec10.relationships.oneXone.tests.Relationships_OneXOne_EJB;
+import com.ibm.ws.jpa.tests.spec10.relationships.oneXone.tests.Relationships_OneXOne_Web;
+
+import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                JPA20Suite.class,
-                componenttest.custom.junit.runner.AlwaysPassesTest.class
+                Relationships_OneXOne_EJB.class,
+                Relationships_OneXOne_Web.class
 })
-public class FATSuite extends AbstractFATSuite {
+public class JPA20Suite extends AbstractFATSuite {
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.with(new RepeatWithJPA20());
 
 }


### PR DESCRIPTION
Running the JPA 2.0 FAT locally with only OpenLiberty, I can see that the results indicate no tests returned any results. For gradle, that does not result in test failures or exception, but for internal builds using only OpenLiberty, the JPA 2.0 FAT fails when no jpa-2.0 feature is present and no tests are executed as a result. 

For that reason, this change moves the JPA 2.0 FAT tests into a separate Suite so that the `componenttest.custom.junit.runner.AlwaysPassesTest` can still execute and return a result, allowing the internal builds to not fail. Using this change, I can observe that now at least 1 result is returned for the `componenttest.custom.junit.runner.AlwaysPassesTest` when run locally.

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>