### PR TITLE
Sleep for revoke completion on Boulder for Acme

### DIFF
--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeRevocationTest.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/fat/AcmeRevocationTest.java
@@ -161,9 +161,17 @@ public class AcmeRevocationTest {
 			 * status as revoked. Cycle the server and we should now see that
 			 * the certificate is replaced since it was revoked.
 			 */
+			long markStop = System.currentTimeMillis();
 			stopServer();
+			
+			// account for possible time from Boulder: welcome-to-the-purge, purge expected in: 153s
+			long sleepFor = (153 * 1000) - (System.currentTimeMillis() - markStop);
+			if (sleepFor > 0) {
+				Log.info(AcmeSimpleTest.class, methodName, "Before restarting server, sleep for " + sleepFor);
+				Thread.sleep(sleepFor);
+			}
 			server.startServer();
-			server.waitForStringInLog("CWPKI2059I"); // Detected cert revoked!
+			assertNotNull("Did not find revoke in the logs: CWPKI2059I", server.waitForStringInLog("CWPKI2059I")); // Detected cert revoked!
 			AcmeFatUtils.waitForAcmeToCreateCertificate(server);
 			AcmeFatUtils.waitForSslEndpoint(server);
 			Certificate[] certificates2 = AcmeFatUtils.assertAndGetServerCertificate(server, boulder);


### PR DESCRIPTION
It appears that there is some variability on when the revoke is complete on the Boulder server. Add additional time before restarting the server.

RTC 284855