### PR TITLE
Add additional timeouts on MongoDB validate for CustomStore

### DIFF
--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/MongoDBUtils.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/MongoDBUtils.java
@@ -273,6 +273,10 @@ public class MongoDBUtils {
         File trustStore = null;
 
         MongoClientOptions.Builder optionsBuilder = new MongoClientOptions.Builder().connectTimeout(30000);
+        optionsBuilder.socketTimeout(10000);
+        optionsBuilder.socketKeepAlive(true);
+        optionsBuilder.maxWaitTime(30000);
+
         try {
             trustStore = File.createTempFile("mongoTrustStore", "jks");
             Map<String, String> serviceProperties = mongoService.getProperties();
@@ -291,7 +295,9 @@ public class MongoDBUtils {
                      "Attempting to contact server " + dbHost + ":" + port + " with password " + (password != null ? "set" : "not set") + " and truststore "
                                         + "not set");
             mongoClient = new MongoClient(new ServerAddress(dbHost, port), credentials, clientOptions);
+            Log.info(thisClass, method, "New client connected");
             mongoClient.getDB(TEST_DATABASE_REMOTE).getCollectionNames();
+            Log.info(thisClass, method, "getDB/getCollectionNames called.");
             dbName = TEST_DATABASE_REMOTE;
             mongoClient.close();
         } catch (Exception e) {

--- a/dev/com.ibm.ws.security.oauth_test.custom_servlets/test-applications/oAuth20MongoSetup/src/web/oAuth20MongoSetup.java
+++ b/dev/com.ibm.ws.security.oauth_test.custom_servlets/test-applications/oAuth20MongoSetup/src/web/oAuth20MongoSetup.java
@@ -258,29 +258,33 @@ public class oAuth20MongoSetup extends HttpServlet {
      *
      */
     private void addEntryMongo(DB ds, String compId, String clientID, String secret, String dispName,
-                               String redirectUri, boolean enabled, JSONObject metaData) {
+                               String redirectUri, boolean enabled, JSONObject metaData) throws Exception {
 
-        System.out.println(CLASS_NAME + "Create on OauthClient: " + clientID + " " + compId);
+        System.out.println(CLASS_NAME + "Creating on OauthClient: " + clientID + " " + compId);
 
-        try {
-            DBCollection col = mongoDB.getCollection(OAUTHCLIENT);
-            BasicDBObject d = new BasicDBObject(CLIENTID, clientID);
+        for (int i = 0; i < 3; i++) {
+            try {
+                DBCollection col = mongoDB.getCollection(OAUTHCLIENT);
+                BasicDBObject d = new BasicDBObject(CLIENTID, clientID);
 
-            d.append(PROVIDERID, compId);
+                d.append(PROVIDERID, compId);
 
-            d.append(CLIENTSECRET, secret);
-            d.append(DISPLAYNAME, dispName);
-            d.append(REDIRECTURI, redirectUri);
-            d.append(ENABLED, enabled);
-            d.append(METADATA, metaData.toString());
+                d.append(CLIENTSECRET, secret);
+                d.append(DISPLAYNAME, dispName);
+                d.append(REDIRECTURI, redirectUri);
+                d.append(ENABLED, enabled);
+                d.append(METADATA, metaData.toString());
 
-            col.insert(d);
+                col.insert(d);
 
-        } catch (Throwable e) {
-            System.out.println("oAuth20MongoSetup Exception trying to add " + clientID);
-            e.printStackTrace();
+                System.out.println(CLASS_NAME + "Created on OauthClient: " + clientID + " " + compId);
+                break;
+            } catch (Throwable e) {
+                System.out.println("oAuth20MongoSetup Exception trying to add " + clientID + ", will try again");
+                e.printStackTrace();
+                Thread.sleep(1000);
+            }
         }
-
     }
 
     /**
@@ -291,21 +295,28 @@ public class oAuth20MongoSetup extends HttpServlet {
     private void queryTableMongo() throws Exception {
         System.out.println("oAuth20MongoSetup queryTable, double check setup on " + mongoDB.getName());
 
-        DBCollection col = mongoDB.getCollection(OAUTHCLIENT);
-        System.out.println("oAuth20MongoSetup Collection " + col.getName());
+        for (int i = 0; i < 3; i++) {
+            try {
+                DBCollection col = mongoDB.getCollection(OAUTHCLIENT);
+                System.out.println("oAuth20MongoSetup Collection " + col.getName());
 
-        DBCursor cursor = col.find();
+                DBCursor cursor = col.find();
 
-        if (cursor != null && cursor.size() > 0) {
-            while (cursor.hasNext()) {
-                DBObject dbo = cursor.next();
-                System.out.println("oAuth20MongoSetup Client " + dbo.get(CLIENTID) + " " + dbo.get(PROVIDERID) + " "
-                                   + dbo.get("_id"));
+                if (cursor != null && cursor.size() > 0) {
+                    while (cursor.hasNext()) {
+                        DBObject dbo = cursor.next();
+                        System.out.println("oAuth20MongoSetup Client " + dbo.get(CLIENTID) + " " + dbo.get(PROVIDERID) + " "
+                                           + dbo.get("_id"));
+                    }
+                } else {
+                    System.out.println("oAuth20MongoSetup Query returned no results");
+                }
+                break;
+            } catch (Exception e) {
+                System.out.println("oAuth20MongoSetup queryTableMongo hit an exception, try again. " + e);
+                Thread.sleep(1000);
             }
-        } else {
-            System.out.println("oAuth20MongoSetup Query returned no results");
         }
-
     }
 
     private String getSecretType(String clientId, String providerId) throws Exception {
@@ -473,12 +484,19 @@ public class oAuth20MongoSetup extends HttpServlet {
      * Create the default table used by the tests.
      *
      */
-    private void createCacheTableMongo(DB ds) {
+    private void createCacheTableMongo(DB ds) throws Exception {
 
-        mongoDB.getCollection(OAUTHCLIENT);
-        mongoDB.getCollection(OAUTHCONSENT);
-        mongoDB.getCollection(OAUTHTOKEN);
-
+        for (int i = 0; i < 3; i++) {
+            try {
+                mongoDB.getCollection(OAUTHCLIENT);
+                mongoDB.getCollection(OAUTHCONSENT);
+                mongoDB.getCollection(OAUTHTOKEN);
+                break;
+            } catch (Exception e) {
+                System.out.println("oAuth20MongoSetup creating tables hit an exception, try again. " + e);
+                Thread.sleep(1000);
+            }
+        }
         System.out.println("oAuth20MongoSetup created tables");
     }
 
@@ -610,7 +628,6 @@ public class oAuth20MongoSetup extends HttpServlet {
             mongoClient = new MongoClient(new ServerAddress(dbHost, Integer.parseInt(dbPort)), null, clientOptions);
             mongoDB = mongoClient.getDB(dbName);
             System.out.println("oAuth20MongoSetup connected to the database");
-
         } catch (UnknownHostException e) {
             System.out.println("oAuth20MongoSetup failed connecting to the database " + e);
             e.printStackTrace();
@@ -642,7 +659,6 @@ public class oAuth20MongoSetup extends HttpServlet {
             mongoClient = new MongoClient(new ServerAddress(dbHost, Integer.parseInt(dbPort)), credentials, clientOptions);
             mongoDB = mongoClient.getDB(dbName);
             System.out.println("oAuth20MongoSetup connected to the database");
-
         } catch (UnknownHostException e) {
             System.out.println("oAuth20MongoSetup failed connecting to the database " + e);
             e.printStackTrace();


### PR DESCRIPTION
Add the same MongoDB option timeouts when we validate the connection on the consul DB server. 

Also add reties on the helper servlet, `oAuth20MongoSetup` when connecting to the DB.

RTC 284816 and 284816