### PR TITLE
allow quiesce warnings during test shutdown

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/servers/ServerTracker.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/servers/ServerTracker.java
@@ -48,6 +48,13 @@ public class ServerTracker {
      */
     public void addServerIgnoreErrorMessages(LibertyServer server) {
 
+        // ignore quiesce issues during server shutdown
+        server.addIgnoredErrors(Arrays.asList(MessageConstants.CWWKE1102W_QUIESCE_WARNING,
+                MessageConstants.CWWKE1106W_QUIESCE_LISTENERS_NOT_COMPLETE,
+                MessageConstants.CWWKE1107W_QUIESCE_WAITING_ON_THREAD));
+        // sometimes a port is in use during startup, but is available when tests run - the tests will have issues if
+        // the port remains blocked and will generate their own errors - ignore this hiccup during the shutdown checks.
+        server.addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0221E_PORT_IN_USE));
         // The code reading the server config sometimes starts before the file is written (it happens rarely)
         // that code will retry and succeed, but the error has already been logged
         // The test framework will still see the error and fail the tests - tell the framework to ignore this error

--- a/dev/com.ibm.ws.security.fat.common/test/com/ibm/ws/security/fat/common/servers/ServerTrackerTest.java
+++ b/dev/com.ibm.ws.security.fat.common/test/com/ibm/ws/security/fat/common/servers/ServerTrackerTest.java
@@ -104,6 +104,8 @@ public class ServerTrackerTest extends CommonTestClass {
             mockery.checking(new Expectations() {
                 {
                     one(server1).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKE1102W_QUIESCE_WARNING, MessageConstants.CWWKE1106W_QUIESCE_LISTENERS_NOT_COMPLETE, MessageConstants.CWWKE1107W_QUIESCE_WAITING_ON_THREAD));
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0221E_PORT_IN_USE));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
@@ -132,6 +134,8 @@ public class ServerTrackerTest extends CommonTestClass {
             mockery.checking(new Expectations() {
                 {
                     exactly(2).of(server1).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    exactly(2).of(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKE1102W_QUIESCE_WARNING, MessageConstants.CWWKE1106W_QUIESCE_LISTENERS_NOT_COMPLETE, MessageConstants.CWWKE1107W_QUIESCE_WAITING_ON_THREAD));
+                    exactly(2).of(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0221E_PORT_IN_USE));
                     exactly(2).of(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     exactly(2).of(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     exactly(2).of(server1).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
@@ -161,14 +165,20 @@ public class ServerTrackerTest extends CommonTestClass {
             mockery.checking(new Expectations() {
                 {
                     one(server1).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKE1102W_QUIESCE_WARNING, MessageConstants.CWWKE1106W_QUIESCE_LISTENERS_NOT_COMPLETE, MessageConstants.CWWKE1107W_QUIESCE_WAITING_ON_THREAD));
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0221E_PORT_IN_USE));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
                     one(server2).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKE1102W_QUIESCE_WARNING, MessageConstants.CWWKE1106W_QUIESCE_LISTENERS_NOT_COMPLETE, MessageConstants.CWWKE1107W_QUIESCE_WAITING_ON_THREAD));
+                    one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0221E_PORT_IN_USE));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
                     one(server3).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKE1102W_QUIESCE_WARNING, MessageConstants.CWWKE1106W_QUIESCE_LISTENERS_NOT_COMPLETE, MessageConstants.CWWKE1107W_QUIESCE_WAITING_ON_THREAD));
+                    one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0221E_PORT_IN_USE));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
@@ -235,6 +245,8 @@ public class ServerTrackerTest extends CommonTestClass {
             mockery.checking(new Expectations() {
                 {
                     one(server1).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKE1102W_QUIESCE_WARNING, MessageConstants.CWWKE1106W_QUIESCE_LISTENERS_NOT_COMPLETE, MessageConstants.CWWKE1107W_QUIESCE_WAITING_ON_THREAD));
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0221E_PORT_IN_USE));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
@@ -268,6 +280,8 @@ public class ServerTrackerTest extends CommonTestClass {
             mockery.checking(new Expectations() {
                 {
                     one(server1).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKE1102W_QUIESCE_WARNING, MessageConstants.CWWKE1106W_QUIESCE_LISTENERS_NOT_COMPLETE, MessageConstants.CWWKE1107W_QUIESCE_WAITING_ON_THREAD));
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0221E_PORT_IN_USE));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
@@ -306,14 +320,20 @@ public class ServerTrackerTest extends CommonTestClass {
             mockery.checking(new Expectations() {
                 {
                     one(server1).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKE1102W_QUIESCE_WARNING, MessageConstants.CWWKE1106W_QUIESCE_LISTENERS_NOT_COMPLETE, MessageConstants.CWWKE1107W_QUIESCE_WAITING_ON_THREAD));
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0221E_PORT_IN_USE));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
                     one(server2).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKE1102W_QUIESCE_WARNING, MessageConstants.CWWKE1106W_QUIESCE_LISTENERS_NOT_COMPLETE, MessageConstants.CWWKE1107W_QUIESCE_WAITING_ON_THREAD));
+                    one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0221E_PORT_IN_USE));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
                     one(server3).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKE1102W_QUIESCE_WARNING, MessageConstants.CWWKE1106W_QUIESCE_LISTENERS_NOT_COMPLETE, MessageConstants.CWWKE1107W_QUIESCE_WAITING_ON_THREAD));
+                    one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0221E_PORT_IN_USE));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
@@ -351,14 +371,20 @@ public class ServerTrackerTest extends CommonTestClass {
             mockery.checking(new Expectations() {
                 {
                     one(server1).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKE1102W_QUIESCE_WARNING, MessageConstants.CWWKE1106W_QUIESCE_LISTENERS_NOT_COMPLETE, MessageConstants.CWWKE1107W_QUIESCE_WAITING_ON_THREAD));
+                    one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0221E_PORT_IN_USE));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server1).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
                     one(server2).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKE1102W_QUIESCE_WARNING, MessageConstants.CWWKE1106W_QUIESCE_LISTENERS_NOT_COMPLETE, MessageConstants.CWWKE1107W_QUIESCE_WAITING_ON_THREAD));
+                    one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0221E_PORT_IN_USE));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server2).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));
                     one(server3).addInstalledAppForValidation(Constants.APP_TESTMARKER);
+                    one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKE1102W_QUIESCE_WARNING, MessageConstants.CWWKE1106W_QUIESCE_LISTENERS_NOT_COMPLETE, MessageConstants.CWWKE1107W_QUIESCE_WAITING_ON_THREAD));
+                    one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0221E_PORT_IN_USE));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKG0014E_CONFIG_PARSER_XML_SYNTAX_ERROR));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.CWWKO0227E_EXECUTOR_SERVICE_MISSING));
                     one(server3).addIgnoredErrors(Arrays.asList(MessageConstants.SSL_NOT_RESTARTED_PROPERLY));


### PR DESCRIPTION
Allow quiesce warning messages during server shutdown in OL security fats (like we do in the CL security fats).