### PR TITLE
update testcontainer bundle

### DIFF
--- a/.github/test-categories/CLASSLOADING
+++ b/.github/test-categories/CLASSLOADING
@@ -1,0 +1,1 @@
+com.ibm.ws.classloading.bells_fat

--- a/.github/test-categories/JAXWS
+++ b/.github/test-categories/JAXWS
@@ -3,3 +3,4 @@ com.ibm.ws.jaxws.cdi_fat
 com.ibm.ws.jaxws.clientcontainer_fat
 com.ibm.ws.jaxws.ejb_fat
 com.ibm.ws.jaxws.X.wsat_fat
+com.ibm.ws.jaxws.2.2.webcontainer_fat_extended

--- a/dev/build.example.testcontainers_fat/build.gradle
+++ b/dev/build.example.testcontainers_fat/build.gradle
@@ -8,17 +8,14 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
- apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
- 
- // Add budle io.openliberty.org.testcontainers to list of required
- // libraries.  This bundle is needed both for compile time and runtime.
- dependencies {
-  requiredLibs project(':io.openliberty.org.testcontainers')
- }
+
+ // Copy bundle io.openliberty.org.testcontainers to AutoFVT/lib/
+ // This bundle is required both at compiletime and runtime.
+  addRequiredLibraries.dependsOn copyTestContainers
  
  // If you are preforming database testing use the copyJdbcDrivers
  // task to copy the common JDBC drivers into the
  // publish/shared/resources/jdbc directory 
  addRequiredLibraries.dependsOn copyJdbcDrivers
- 
+
  addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/com.ibm.ws.cloudant_fat/build.gradle
+++ b/dev/com.ibm.ws.cloudant_fat/build.gradle
@@ -19,7 +19,6 @@ dependencies {
            project(':io.openliberty.org.apache.commons.codec'),
            project(':com.ibm.ws.org.apache.commons.io'),
            'com.google.code.gson:gson:2.2.4'
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task copyCloudant(type: Copy) {
@@ -29,3 +28,4 @@ task copyCloudant(type: Copy) {
 }
 
 addRequiredLibraries.dependsOn copyCloudant
+addRequiredLibraries.dependsOn copyTestContainers

--- a/dev/com.ibm.ws.concurrent.persistent_fat/build.gradle
+++ b/dev/com.ibm.ws.concurrent.persistent_fat/build.gradle
@@ -8,11 +8,6 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-
- dependencies {
-  requiredLibs project(':io.openliberty.org.testcontainers')
- }
- 
 task copyFeatureBundle(type: Copy) {
   from buildDir
   into new File(autoFvtDir, 'lib/LibertyFATTestFiles/bundles')
@@ -26,4 +21,5 @@ autoFVT {
 addRequiredLibraries {
 	dependsOn copyJdbcDrivers
 	dependsOn addJakartaTransformer
+	dependsOn copyTestContainers
 }

--- a/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/build.gradle
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_demo_timers/build.gradle
@@ -8,10 +8,6 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-
- dependencies {
-  requiredLibs project(':io.openliberty.org.testcontainers')
- }
-
+addRequiredLibraries.dependsOn copyTestContainers
 addRequiredLibraries.dependsOn copyJdbcDrivers
 

--- a/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/build.gradle
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_failovertimers/build.gradle
@@ -11,10 +11,10 @@
 
 dependencies {
   requiredLibs 'org.apache.derby:derbynet:10.11.1.1'
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 addRequiredLibraries {
 	dependsOn addJakartaTransformer
 	dependsOn copyJdbcDrivers
+	dependsOn copyTestContainers
 }

--- a/dev/com.ibm.ws.concurrent.persistent_fat_locking/build.gradle
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_locking/build.gradle
@@ -9,9 +9,6 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
- dependencies {
-  requiredLibs project(':io.openliberty.org.testcontainers')
- }
- 
+addRequiredLibraries.dependsOn copyTestContainers 
 addRequiredLibraries.dependsOn copyJdbcDrivers
 

--- a/dev/com.ibm.ws.concurrent.persistent_fat_multiple/build.gradle
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_multiple/build.gradle
@@ -8,10 +8,6 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-
- dependencies {
-  requiredLibs project(':io.openliberty.org.testcontainers')
- }
- 
+addRequiredLibraries.dependsOn copyTestContainers
 addRequiredLibraries.dependsOn copyJdbcDrivers
 

--- a/dev/com.ibm.ws.concurrent.persistent_fat_timers/build.gradle
+++ b/dev/com.ibm.ws.concurrent.persistent_fat_timers/build.gradle
@@ -8,9 +8,5 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-
- dependencies {
-  requiredLibs project(':io.openliberty.org.testcontainers')
- }
- 
+addRequiredLibraries.dependsOn copyTestContainers
 addRequiredLibraries.dependsOn copyJdbcDrivers

--- a/dev/com.ibm.ws.couchdb_fat/build.gradle
+++ b/dev/com.ibm.ws.couchdb_fat/build.gradle
@@ -24,7 +24,6 @@ dependencies {
           'org.slf4j:slf4j-api:1.7.7',
           'org.slf4j:slf4j-jdk14:1.7.7'
           
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task copyCouchDB(type: Copy) {
@@ -34,3 +33,4 @@ task copyCouchDB(type: Copy) {
 }
 
  addRequiredLibraries.dependsOn copyCouchDB
+ addRequiredLibraries.dependsOn copyTestContainers

--- a/dev/com.ibm.ws.jdbc_fat/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   db2 'com.ibm.db2:jcc:11.1.4.4'
   derbyClient 'org.apache.derby:derbyclient:10.11.1.1'
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
  
 //Anonymous drivers
@@ -55,4 +54,5 @@ task copyDB2(type: Copy) {
   dependsOn copyAutomaticDerby
   dependsOn copyDB2
   dependsOn copyJdbcDrivers
+  dependsOn copyTestContainers
 }

--- a/dev/com.ibm.ws.jdbc_fat_db2/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_db2/build.gradle
@@ -15,7 +15,6 @@ configurations {
 }
 
 dependencies {
-  requiredLibs project(':io.openliberty.org.testcontainers')
   db2 'com.ibm.db2:jcc:11.1.4.4'
 }
 
@@ -26,6 +25,7 @@ task copyDB2(type: Copy) {
 }
 
 addRequiredLibraries.dependsOn copyDB2
+addRequiredLibraries.dependsOn copyTestContainers
 
 // This is the equivalent ant code that needs to be invoked in order to transform the SQLJProcedure.sqlj
 // file into a .java file. Since the SQLJ customizer code library is not publicly available, and the

--- a/dev/com.ibm.ws.jdbc_fat_krb5/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_krb5/build.gradle
@@ -8,13 +8,9 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
-
-dependencies {
-  requiredLibs project(':io.openliberty.org.testcontainers')
-}
 
 addRequiredLibraries {
   dependsOn copyJdbcDrivers
   dependsOn addJakartaTransformer
+  dependsOn copyTestContainers
 }

--- a/dev/com.ibm.ws.jdbc_fat_oracle/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_oracle/build.gradle
@@ -19,7 +19,6 @@ configurations {
 }
 
 dependencies {
-  requiredLibs project(':io.openliberty.org.testcontainers')
   oracle        "com.oracle.database.jdbc.debug:ojdbc8_g:${oracleVersion}"
   oraclessl     "com.oracle.database.jdbc.debug:ojdbc8_g:${oracleVersion}",
                	"com.oracle.database.security:oraclepki:${oracleVersion}",
@@ -64,4 +63,5 @@ addRequiredLibraries {
   dependsOn copySharedUCP
   dependsOn copyAnonymousOracle
   dependsOn copySharedOracleSSL
+  dependsOn copyTestContainers
 }

--- a/dev/com.ibm.ws.jdbc_fat_postgresql/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_postgresql/build.gradle
@@ -15,7 +15,6 @@ configurations {
 }
 
 dependencies {
-  requiredLibs project(':io.openliberty.org.testcontainers')
   postgres 'org.postgresql:postgresql:42.2.5'
 }
 
@@ -35,3 +34,4 @@ task copyAnonymousPostgres(type: Copy) {
 
 addRequiredLibraries.dependsOn copySharedPostgres
 addRequiredLibraries.dependsOn copyAnonymousPostgres
+addRequiredLibraries.dependsOn copyTestContainers

--- a/dev/com.ibm.ws.jdbc_fat_sqlserver/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_sqlserver/build.gradle
@@ -15,7 +15,6 @@ configurations {
 }
 
 dependencies {
-  requiredLibs project(':io.openliberty.org.testcontainers')
   sqlserver 'com.microsoft.sqlserver:mssql-jdbc:9.2.1.jre8'
 }
 
@@ -35,3 +34,4 @@ task copySharedSQLServer(type: Copy) {
 
 addRequiredLibraries.dependsOn copySharedSQLServer
 addRequiredLibraries.dependsOn copySharedSqlServerAnon
+addRequiredLibraries.dependsOn copyTestContainers

--- a/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_2.0_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.callback")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_2.1_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_2.1_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.callback")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_2.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_2.2_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.callback")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_3.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.callback_jpa_3.0_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.callback")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.embeddable_fat/build.gradle
@@ -15,7 +15,6 @@ configurations {
 
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -30,4 +29,5 @@ addRequiredLibraries {
   dependsOn copyJdbcDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
+  dependsOn copyTestContainers
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_2.0_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.entitymanager")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_2.1_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_2.1_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.entitymanager")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_2.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_2.2_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.entitymanager")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_3.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.entitymanager_jpa_3.0_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.entitymanager")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_2.0_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.inheritance")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_2.1_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_2.1_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.inheritance")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_2.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_2.2_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.inheritance")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_3.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.inheritance_jpa_3.0_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.inheritance")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.defaultPersistenceUnit_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.defaultPersistenceUnit_fat/build.gradle
@@ -28,8 +28,6 @@ dependencies {
   hibernateJPA22 'org.hibernate.common:hibernate-commons-annotations:5.1.0.Final'
   
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
-  
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addhibernateJPA22(type: Copy) {
@@ -59,4 +57,5 @@ addRequiredLibraries {
   dependsOn addhibernateJPA22
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
+  dependsOn copyTestContainers
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.dfi_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.dfi_fat/build.gradle
@@ -29,7 +29,6 @@ dependencies {
   
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.injection.common")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addhibernateJPA22(type: Copy) {
@@ -93,6 +92,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.dmi_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.dmi_fat/build.gradle
@@ -29,7 +29,6 @@ dependencies {
   
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.injection.common")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addhibernateJPA22(type: Copy) {
@@ -93,6 +92,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.ejbinwar_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.ejbinwar_fat/build.gradle
@@ -28,7 +28,6 @@ dependencies {
   hibernateJPA22 'org.hibernate.common:hibernate-commons-annotations:5.1.0.Final'
   
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addhibernateJPA22(type: Copy) {
@@ -58,4 +57,5 @@ addRequiredLibraries {
   dependsOn addhibernateJPA22
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
+  dependsOn copyTestContainers
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.jndi_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.jndi_fat/build.gradle
@@ -29,7 +29,6 @@ dependencies {
   
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.injection.common")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addhibernateJPA22(type: Copy) {
@@ -93,6 +92,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.injection.mdb_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.injection.mdb_fat/build.gradle
@@ -29,7 +29,6 @@ dependencies {
   
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.injection.common")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addhibernateJPA22(type: Copy) {
@@ -93,6 +92,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.issues_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.issues_fat/build.gradle
@@ -15,7 +15,6 @@ configurations {
 
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -30,4 +29,5 @@ addRequiredLibraries {
   dependsOn copyJdbcDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
+  dependsOn copyTestContainers
 }

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.0_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.query")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.1_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.1_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.query")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_2.2_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.query")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.query_jpa_3.0_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.query")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.0_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.manyXmany")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.1_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.1_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.manyXmany")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_2.2_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.manyXmany")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_3.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXmany_jpa_3.0_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.manyXmany")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.0_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.manyXone")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.1_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.1_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.manyXone")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_2.2_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.manyXone")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_3.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.manyXone_jpa_3.0_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.manyXone")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.0_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.oneXmany")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.1_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.1_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.oneXmany")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_2.2_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.oneXmany")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_3.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXmany_jpa_3.0_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.oneXmany")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.0_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.oneXone")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.1_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.1_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.oneXone")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_2.2_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.oneXone")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_3.0_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec10.relationships.oneXone_jpa_3.0_fat/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
   requiredLibs project(":com.ibm.ws.jpa.tests.spec10.relationships.oneXone")
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -61,6 +60,7 @@ addRequiredLibraries {
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
   dependsOn copyFAT
+  dependsOn copyTestContainers
 }
 
 jar {

--- a/dev/com.ibm.ws.jpa.tests.spec20.lock_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.spec20.lock_fat/build.gradle
@@ -15,7 +15,6 @@ configurations {
 
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -30,4 +29,5 @@ addRequiredLibraries {
     dependsOn copyJdbcDrivers
     dependsOn addJakartaTransformer
     dependsOn addJPAFATTools
+    dependsOn copyTestContainers
 }

--- a/dev/com.ibm.ws.jpa_eclipselink_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa_eclipselink_fat/build.gradle
@@ -15,7 +15,6 @@ configurations {
 
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -30,4 +29,5 @@ addRequiredLibraries {
   dependsOn copyJdbcDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
+  dependsOn copyTestContainers
 }

--- a/dev/com.ibm.ws.jpa_ol_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa_ol_fat/build.gradle
@@ -15,7 +15,6 @@ configurations {
 
 dependencies {
   jpaFatTools project(':com.ibm.ws.jpa_testframework')
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task addJPAFATTools (type: Copy) {
@@ -30,4 +29,5 @@ addRequiredLibraries {
   dependsOn copyJdbcDrivers
   dependsOn addJakartaTransformer
   dependsOn addJPAFATTools
+  dependsOn copyTestContainers
 }

--- a/dev/com.ibm.ws.logstash.collector_fat/build.gradle
+++ b/dev/com.ibm.ws.logstash.collector_fat/build.gradle
@@ -10,6 +10,7 @@
  *******************************************************************************/
 
 dependencies {
-  requiredLibs 'org.json:json:20080701' 
-  requiredLibs project(':io.openliberty.org.testcontainers')
+  requiredLibs 'org.json:json:20080701'
 } 
+
+addRequiredLibraries.dependsOn copyTestContainers

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat/build.gradle
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat/build.gradle
@@ -23,7 +23,6 @@ dependencies {
   kafkaClient 'org.xerial.snappy:snappy-java:1.1.7.2'
   kafkaClient 'org.slf4j:slf4j-api:1.7.7'
   kafkaClient 'org.slf4j:slf4j-jdk14:1.7.7'
-  requiredLibs project(':io.openliberty.org.testcontainers')
   requiredLibs 'org.testng:testng:6.14.3'
   requiredLibs project(':com.ibm.websphere.org.reactivestreams.reactive-streams.1.0')
   requiredLibs project(':com.ibm.ws.microprofile.reactive.messaging.kafka')
@@ -41,3 +40,4 @@ task addKafkaClientLibs (type: Copy) {
 }
 
 zipAutoFVT.dependsOn addKafkaClientLibs
+addRequiredLibraries.dependsOn copyTestContainers

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/build.gradle
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     kafkaClient 'org.xerial.snappy:snappy-java:1.1.7.2'
     kafkaClient 'org.slf4j:slf4j-api:1.7.7'
     kafkaClient 'org.slf4j:slf4j-jdk14:1.7.7'
-    requiredLibs project(':io.openliberty.org.testcontainers')
     requiredLibs 'org.testng:testng:6.14.3'
     requiredLibs 'org.reactivestreams:reactive-streams-tck:1.0.3'
     requiredLibs project(':com.ibm.websphere.org.reactivestreams.reactive-streams.1.0')
@@ -30,3 +29,4 @@ task addKafkaClientLibs (type: Copy) {
 }
 
 zipAutoFVT.dependsOn addKafkaClientLibs
+addRequiredLibraries.dependsOn copyTestContainers

--- a/dev/com.ibm.ws.rest.handler.validator.cloudant_fat/build.gradle
+++ b/dev/com.ibm.ws.rest.handler.validator.cloudant_fat/build.gradle
@@ -22,7 +22,6 @@ dependencies {
                           'com.cloudant:cloudant-http:2.8.0'
       cloudantCommonDeps  project(':com.ibm.ws.org.apache.commons.io'),
       					  'com.google.code.gson:gson:2.8.0'
-      requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 task copyCloudant(type: Copy) {
@@ -40,5 +39,5 @@ task copyCloudantOld(type: Copy) {
 }
 addRequiredLibraries.dependsOn copyCloudant
 addRequiredLibraries.dependsOn copyCloudantOld
-
+addRequiredLibraries.dependsOn copyTestContainers
 addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/com.ibm.ws.security.acme_fat/build.gradle
+++ b/dev/com.ibm.ws.security.acme_fat/build.gradle
@@ -20,8 +20,7 @@ dependencies {
                'org.shredzone.acme4j:acme4j-client:2.7',
                'org.shredzone.acme4j:acme4j-utils:2.7',
                project(':com.ibm.ws.security.acme'),
-               project(':com.ibm.ws.crypto.certificateutil'),
-               project(':io.openliberty.org.testcontainers')
+               project(':com.ibm.ws.crypto.certificateutil')
                
   runPebble    project(':io.openliberty.org.apache.commons.logging')
                
@@ -30,6 +29,7 @@ dependencies {
 }
 
 addRequiredLibraries.dependsOn addJakartaTransformer
+addRequiredLibraries.dependsOn copyTestContainers
 
 autoFVT.doLast {
   /*

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/build.gradle
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/build.gradle
@@ -12,15 +12,11 @@
 configurations {
   //Transitive dependancies that aren't required. Excluding isn't necessary with Artifactory,
   //but would be beneficial with a mavenCentral cache.
-  infinispanClient {
-      transitive = false
-  }
-
+  infinispanClient { transitive = false; }
 }
 
 // Define G:A:V coordinates of each dependency
 dependencies {
-requiredLibs project(':io.openliberty.org.testcontainers')
 infinispanClient 'com.github.ben-manes.caffeine:caffeine:2.8.0',
                  'org.infinispan:infinispan-client-hotrod:10.0.0.Final',
                  'org.infinispan:infinispan-commons:10.0.0.Final',
@@ -48,4 +44,5 @@ addRequiredLibraries {
   dependsOn addDerby
   dependsOn addInfinispanClientLibs
   dependsOn addJakartaTransformer
+  dependsOn copyTestContainers
 }

--- a/dev/com.ibm.ws.transaction.DB2HADB_fat/build.gradle
+++ b/dev/com.ibm.ws.transaction.DB2HADB_fat/build.gradle
@@ -13,8 +13,7 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.DerbyHADB_fat"),
-               project(':io.openliberty.org.apache.commons.logging'),
-               project(':io.openliberty.org.testcontainers')
+               project(':io.openliberty.org.apache.commons.logging')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -72,6 +71,7 @@ addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
 addRequiredLibraries.dependsOn copyTxJdbcDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
+addRequiredLibraries.dependsOn copyTestContainers
 
 clean.doLast {
   if (file('test-applications').exists()){

--- a/dev/com.ibm.ws.transaction.DerbyHADB_fat/build.gradle
+++ b/dev/com.ibm.ws.transaction.DerbyHADB_fat/build.gradle
@@ -12,8 +12,7 @@
 // Define G:A:V coordinates of each dependency
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
-               project(':io.openliberty.org.apache.commons.logging'),
-               project(':io.openliberty.org.testcontainers')
+               project(':io.openliberty.org.apache.commons.logging')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -36,6 +35,7 @@ autoFVT.dependsOn copyFeatureBundle
 addRequiredLibraries.dependsOn copyJdbcDrivers
 addRequiredLibraries.dependsOn copyTxJdbcDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
+addRequiredLibraries.dependsOn copyTestContainers
 
 clean.doLast {
   if (file('build').exists()){

--- a/dev/com.ibm.ws.transaction.OracleHADB_fat/build.gradle
+++ b/dev/com.ibm.ws.transaction.OracleHADB_fat/build.gradle
@@ -13,8 +13,7 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.DerbyHADB_fat"),
-               project(':io.openliberty.org.apache.commons.logging'),
-               project(':io.openliberty.org.testcontainers')
+               project(':io.openliberty.org.apache.commons.logging')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -72,6 +71,7 @@ addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
 addRequiredLibraries.dependsOn copyTxJdbcDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
+addRequiredLibraries.dependsOn copyTestContainers
 
 clean.doLast {
   if (file('test-applications').exists()){

--- a/dev/com.ibm.ws.transaction.PostgresqlHADB_fat/build.gradle
+++ b/dev/com.ibm.ws.transaction.PostgresqlHADB_fat/build.gradle
@@ -13,8 +13,7 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.DerbyHADB_fat"),
-               project(':io.openliberty.org.apache.commons.logging'),
-               project(':io.openliberty.org.testcontainers')
+               project(':io.openliberty.org.apache.commons.logging')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -72,6 +71,7 @@ addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
 addRequiredLibraries.dependsOn copyTxJdbcDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
+addRequiredLibraries.dependsOn copyTestContainers
 
 clean.doLast {
   if (file('test-applications').exists()){

--- a/dev/com.ibm.ws.transaction.SQLServerHADB_fat/build.gradle
+++ b/dev/com.ibm.ws.transaction.SQLServerHADB_fat/build.gradle
@@ -13,8 +13,7 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.DerbyHADB_fat"),
-               project(':io.openliberty.org.apache.commons.logging'),
-               project(':io.openliberty.org.testcontainers')
+               project(':io.openliberty.org.apache.commons.logging')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -72,6 +71,7 @@ addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
 addRequiredLibraries.dependsOn copyTxJdbcDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
+addRequiredLibraries.dependsOn copyTestContainers
 
 clean.doLast {
   if (file('test-applications').exists()){

--- a/dev/com.ibm.ws.transaction.cloud_fat.base/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloud_fat.base/build.gradle
@@ -12,7 +12,6 @@
 // Define G:A:V coordinates of each dependency
 dependencies {
   requiredLibs project(':io.openliberty.org.apache.commons.logging')
-  requiredLibs project(':io.openliberty.org.testcontainers')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -26,3 +25,4 @@ task addDerbyToSharedDir(type: Copy) {
 addRequiredLibraries.dependsOn addDerbyToSharedDir
 addRequiredLibraries.dependsOn copyJdbcDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
+addRequiredLibraries.dependsOn copyTestContainers

--- a/dev/com.ibm.ws.transaction.cloud_fat.db2.1/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloud_fat.db2.1/build.gradle
@@ -13,8 +13,7 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.cloud_fat.base"),
-               project(':io.openliberty.org.apache.commons.logging'),
-               project(':io.openliberty.org.testcontainers')
+               project(':io.openliberty.org.apache.commons.logging')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -57,6 +56,7 @@ addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
+addRequiredLibraries.dependsOn copyTestContainers
 
 jar {
   dependsOn copyCommonFiles

--- a/dev/com.ibm.ws.transaction.cloud_fat.db2.2/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloud_fat.db2.2/build.gradle
@@ -13,8 +13,7 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.cloud_fat.base"),
-               project(':io.openliberty.org.apache.commons.logging'),
-               project(':io.openliberty.org.testcontainers')
+               project(':io.openliberty.org.apache.commons.logging')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -57,6 +56,7 @@ addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
+addRequiredLibraries.dependsOn copyTestContainers
 
 jar {
   dependsOn copyCommonFiles

--- a/dev/com.ibm.ws.transaction.cloud_fat.derby.1/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloud_fat.derby.1/build.gradle
@@ -13,8 +13,7 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.cloud_fat.base"),
-               project(':io.openliberty.org.apache.commons.logging'),
-               project(':io.openliberty.org.testcontainers')
+               project(':io.openliberty.org.apache.commons.logging')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -57,6 +56,7 @@ addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
+addRequiredLibraries.dependsOn copyTestContainers
 
 jar {
   dependsOn copyCommonFiles

--- a/dev/com.ibm.ws.transaction.cloud_fat.derby.2/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloud_fat.derby.2/build.gradle
@@ -13,8 +13,7 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.cloud_fat.base"),
-               project(':io.openliberty.org.apache.commons.logging'),
-               project(':io.openliberty.org.testcontainers')
+               project(':io.openliberty.org.apache.commons.logging')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -57,6 +56,7 @@ addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
+addRequiredLibraries.dependsOn copyTestContainers
 
 jar {
   dependsOn copyCommonFiles

--- a/dev/com.ibm.ws.transaction.cloud_fat.oracle.1/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloud_fat.oracle.1/build.gradle
@@ -13,8 +13,7 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.cloud_fat.base"),
-               project(':io.openliberty.org.apache.commons.logging'),
-               project(':io.openliberty.org.testcontainers')
+               project(':io.openliberty.org.apache.commons.logging')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -57,6 +56,7 @@ addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
+addRequiredLibraries.dependsOn copyTestContainers
 
 jar {
   dependsOn copyCommonFiles

--- a/dev/com.ibm.ws.transaction.cloud_fat.oracle.2/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloud_fat.oracle.2/build.gradle
@@ -13,8 +13,7 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.cloud_fat.base"),
-               project(':io.openliberty.org.apache.commons.logging'),
-               project(':io.openliberty.org.testcontainers')
+               project(':io.openliberty.org.apache.commons.logging')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -57,6 +56,7 @@ addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
+addRequiredLibraries.dependsOn copyTestContainers
 
 jar {
   dependsOn copyCommonFiles

--- a/dev/com.ibm.ws.transaction.cloud_fat.postgresql.1/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloud_fat.postgresql.1/build.gradle
@@ -12,8 +12,7 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.cloud_fat.base"),
-               project(':io.openliberty.org.apache.commons.logging'),
-               project(':io.openliberty.org.testcontainers')
+               project(':io.openliberty.org.apache.commons.logging')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -56,6 +55,7 @@ addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
+addRequiredLibraries.dependsOn copyTestContainers
 
 jar {
   dependsOn copyCommonFiles

--- a/dev/com.ibm.ws.transaction.cloud_fat.postgresql.2/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloud_fat.postgresql.2/build.gradle
@@ -12,8 +12,7 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.cloud_fat.base"),
-               project(':io.openliberty.org.apache.commons.logging'),
-               project(':io.openliberty.org.testcontainers')
+               project(':io.openliberty.org.apache.commons.logging')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -56,6 +55,7 @@ addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
+addRequiredLibraries.dependsOn copyTestContainers
 
 jar {
   dependsOn copyCommonFiles

--- a/dev/com.ibm.ws.transaction.cloud_fat.sqlserver.1/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloud_fat.sqlserver.1/build.gradle
@@ -13,8 +13,7 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.cloud_fat.base"),
-               project(':io.openliberty.org.apache.commons.logging'),
-               project(':io.openliberty.org.testcontainers')
+               project(':io.openliberty.org.apache.commons.logging')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -57,6 +56,7 @@ addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
+addRequiredLibraries.dependsOn copyTestContainers
 
 jar {
   dependsOn copyCommonFiles

--- a/dev/com.ibm.ws.transaction.cloud_fat.sqlserver.2/build.gradle
+++ b/dev/com.ibm.ws.transaction.cloud_fat.sqlserver.2/build.gradle
@@ -13,8 +13,7 @@
 dependencies {
   requiredLibs project(":com.ibm.ws.tx.embeddable"),
                project(":com.ibm.ws.transaction.cloud_fat.base"),
-               project(':io.openliberty.org.apache.commons.logging'),
-               project(':io.openliberty.org.testcontainers')
+               project(':io.openliberty.org.apache.commons.logging')
 }
 
 File sharedDir = new File(autoFvtDir, 'publish/shared/resources')
@@ -57,6 +56,7 @@ addRequiredLibraries.dependsOn copyFAT
 addRequiredLibraries.dependsOn copyCommonFiles
 addRequiredLibraries.dependsOn copyJdbcDrivers
 addRequiredLibraries.dependsOn addJakartaTransformer
+addRequiredLibraries.dependsOn copyTestContainers
 
 jar {
   dependsOn copyCommonFiles

--- a/dev/com.ibm.ws.transaction.db_fat/build.gradle
+++ b/dev/com.ibm.ws.transaction.db_fat/build.gradle
@@ -15,7 +15,6 @@ configurations {
 }
 
 dependencies {
-  requiredLibs project(':io.openliberty.org.testcontainers')
   postgres 'org.postgresql:postgresql:42.2.5'
 }
 
@@ -35,3 +34,4 @@ task copyAnonymousPostgres(type: Copy) {
 
 addRequiredLibraries.dependsOn copySharedPostgres
 addRequiredLibraries.dependsOn copyAnonymousPostgres
+addRequiredLibraries.dependsOn copyTestContainers

--- a/dev/io.openliberty.org.testcontainers/bnd.bnd
+++ b/dev/io.openliberty.org.testcontainers/bnd.bnd
@@ -27,7 +27,12 @@ Export-Package: \
 	org.rnorth.*;version="1.0.8",\
 	org.slf4j.*;version="1.7.30"
 
-test.project: true
+#Ensure that /META-INF/service folder from testcontainers core project is included in bundle.
+# This will ensure that the other docker container strategies are accessible at runtime.	
+Include-Resource: \
+	@${repo;org.testcontainers:testcontainers;1.15.3;EXACT}!/META-INF/**
+
+#Ensure that a stub project is created in CL
 generate.replacement: true
 
 #Notice: com.github.docker-java:docker-java-api has a runtime dependency on 
@@ -36,8 +41,6 @@ generate.replacement: true
 # Currently, the version included in each FAT is 2.11.2. If Testcontainers ever depends on a version of
 # jackson-annotations that is not backwards compatible with 2.11.2 then we will need to upgrade 
 # the version we include in FATs by updating /cnf/build.gradle configurations binaries.
-
-
 -buildpath: \
 	com.github.docker-java:docker-java-api;version=3.2.8,\
 	com.github.docker-java:docker-java-transport;version=3.2.8,\

--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -41,6 +41,7 @@ task cleanBeforeRun(type: Delete) {
 configurations {
   requiredLibs
   jdbcDrivers { transitive = false; }
+  testcontainers { transitive = false; }
   derby
   jakartaTransformer
 }
@@ -61,6 +62,8 @@ dependencies {
        'org.slf4j:slf4j-api:1.7.26',
        'org.eclipse.transformer:org.eclipse.transformer:0.2.0',
        'org.eclipse.transformer:org.eclipse.transformer.cli:0.2.0'
+       
+  testcontainers project(':io.openliberty.org.testcontainers')
 
 }
 
@@ -72,7 +75,6 @@ task addRequiredLibraries(type: Copy) {
 
 task addJakartaTransformerRules(type: Copy) {
   mustRunAfter jar
-
   from project(':wlp-jakartaee-transform').file('rules')
   include 'jakarta*.properties'
   into new File(autoFvtDir, 'autoFVT-templates')
@@ -81,8 +83,13 @@ task addJakartaTransformerRules(type: Copy) {
 task addJakartaTransformer(type: Copy) {
   mustRunAfter jar
   dependsOn addJakartaTransformerRules
-
   from configurations.jakartaTransformer
+  into new File(autoFvtDir, 'lib')
+}
+
+task copyTestContainers(type: Copy) {
+  mustRunAfter jar
+  from configurations.testcontainers
   into new File(autoFvtDir, 'lib')
 }
 


### PR DESCRIPTION
Ensure that `META-INF/services` are copied from testcontainers-core project into the shared `io.openliberty.org.testcontainers` bundle.  This will ensure that all docker client services are registered and available. 

Switch back to using a custom gradle task to include runtime dependency on the `io.openliberty.org.testcontainers` project.  When using the `requiredLibs` configuration gradle would copy the project jar and also all of the dependencies meaning that most dependencies were being loaded twice at runtime. This should improve memory and performance. 

