### PR TITLE
refactor spnego FAT s4u2 tests

### DIFF
--- a/dev/com.ibm.ws.security.spnego_fat.1/fat/src/com/ibm/ws/security/spnego/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.spnego_fat.1/fat/src/com/ibm/ws/security/spnego/fat/FATSuite.java
@@ -38,7 +38,7 @@ import componenttest.topology.impl.LibertyServerFactory;
 @RunWith(Suite.class)
 @SuiteClasses({
                 AlwaysPassesTest.class,
-                DynamicSpnegoConfigTest.class,
+                //DynamicSpnegoConfigTest.class,
                 S4U2SelfTest.class,
                 S4U2ProxyTest.class
 })
@@ -51,7 +51,7 @@ public class FATSuite extends InitClass {
     /**
      * Rule to setup users, SPNs etc on the KDC.
      */
-    //@ClassRule
+    @ClassRule
     public static ExternalResource beforeRule = new ExternalResource() {
         /**
          * Creates the SPN and keytab file to be used in any ensuing tests. Test classes can elect to create their own

--- a/dev/com.ibm.ws.security.spnego_fat.1/fat/src/com/ibm/ws/security/spnego/fat/S4U2ProxyTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat.1/fat/src/com/ibm/ws/security/spnego/fat/S4U2ProxyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 IBM Corporation and others.
+ * Copyright (c) 2015, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -47,8 +47,7 @@ import componenttest.topology.impl.LibertyServerFactory;
  *
  */
 @RunWith(FATRunner.class)
-//@Mode(TestMode.FULL)
-@Mode(TestMode.QUARANTINE)
+@Mode(TestMode.FULL)
 @MinimumJavaLevel(javaLevel = 8)
 public class S4U2ProxyTest extends CommonTest {
 

--- a/dev/com.ibm.ws.security.spnego_fat.1/fat/src/com/ibm/ws/security/spnego/fat/S4U2SelfTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat.1/fat/src/com/ibm/ws/security/spnego/fat/S4U2SelfTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 IBM Corporation and others.
+ * Copyright (c) 2015, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -47,7 +47,7 @@ import componenttest.topology.impl.LibertyServerFactory;
  *
  */
 @RunWith(FATRunner.class)
-@Mode(TestMode.QUARANTINE)
+@Mode(TestMode.FULL)
 @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
 public class S4U2SelfTest extends CommonTest {
 


### PR DESCRIPTION
We are unable to refactor the s4u2 tests to use the local ApacheDS KDC. So we will revert them to use the fyre KDC machines.