### PR TITLE
Fix Build Break: 285120 - spnegoFAT jdk check

### DIFF
--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/ApacheKDCforSPNEGO.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/ApacheKDCforSPNEGO.java
@@ -76,6 +76,9 @@ public class ApacheKDCforSPNEGO extends ApacheDSandKDC {
     @BeforeClass
     public static void setup() throws Exception {
 
+        if (!InitClass.RUN_TESTS)
+            return;
+
         WHICH_FAT = "SPNEGO";
 
         bindUserName = "user1";

--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/FATSuite.java
@@ -69,8 +69,7 @@ public class FATSuite extends ApacheKDCforSPNEGO {
             String thisMethod = "before";
             Log.info(c, thisMethod, "Performing the common setup for all test classes");
 
-            if (!isSupportJDK())
-                return;
+            isSupportJDK();
 
             /*
              * String ip = InetAddress.getByName("localhost").getHostAddress();
@@ -108,6 +107,13 @@ public class FATSuite extends ApacheKDCforSPNEGO {
                 runTests = false;
             }
             Log.info(c, thisMethod, "The JDK vendor used is " + javaInfo.vendor() + " and version: " + javaInfo.majorVersion());
+
+            if (!runTests) {
+                Log.info(c, thisMethod, "=== JDK NOT SUPPORTED FOR SPNEGO FAT TESTS ===");
+                Log.info(c, thisMethod, "=== SKIPPING SPNEGO FAT TESTS ===");
+            }
+
+            InitClass.RUN_TESTS = runTests;
             return runTests;
         };
 


### PR DESCRIPTION
Fix for: [RTC 285120](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=285120)

**Problem**: The refactored spnego tests were not being skipped when an incompatible JDK was used, resulting in a test failure.

**Solution**: Correct the skipping logic when isSupportJDK() is called.

Also, added output loggin messages to make it more obvious when an incompatible JDK is used and tests are skipped
```
=== JDK NOT SUPPORTED FOR SPNEGO FAT TESTS ===
=== SKIPPING SPNEGO FAT TESTS ===
```

I used an incompatible JDK locally to verify the skipping logic works as expected