### PR TITLE
Experimentation with library loading resource adapter classes

### DIFF
--- a/dev/com.ibm.ws.jca_fat_classloading/.classpath
+++ b/dev/com.ibm.ws.jca_fat_classloading/.classpath
@@ -9,5 +9,6 @@
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/fvtweb/src"/>
 	<classpathentry kind="src" path="test-resourceadapters/fvtra/src"/>
+	<classpathentry kind="src" path="test-libraries/testlib/src"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.jca_fat_classloading/bnd.bnd
+++ b/dev/com.ibm.ws.jca_fat_classloading/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020,2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ bVersion=1.0
 src: \
 	fat/src,\
 	test-applications/fvtweb/src,\
+	test-libraries/testlib/src,\
 	test-resourceadapters/fvtra/src
 
 fat.project: true

--- a/dev/com.ibm.ws.jca_fat_classloading/fat/src/com/ibm/ws/jca/fat/classloading/JCAClassLoadingTest.java
+++ b/dev/com.ibm.ws.jca_fat_classloading/fat/src/com/ibm/ws/jca/fat/classloading/JCAClassLoadingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertNotNull;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -60,6 +61,12 @@ public class JCAClassLoadingTest extends FATServletClient {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        JavaArchive testlib = ShrinkWrap //
+                        .create(JavaArchive.class, "testlib.jar") //
+                        .addPackage("com.ibm.ws.jca.fat.classloading.sharedlib");
+
+        ShrinkHelper.exportToServer(server, "libraries", testlib);
+
         WebArchive war = ShrinkHelper.buildDefaultApp(WAR_NAME, "web");
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME + ".ear")
                         .addAsModule(war);
@@ -85,6 +92,13 @@ public class JCAClassLoadingTest extends FATServletClient {
     public void testLoadResourceAdapterClassFromSingleApp() throws Exception {
         restartWithNewConfig(true);
         runTest();
+    }
+
+    @Test
+    public void testResourceAdapterClassesAccessibleToSharedLibrary() throws Exception {
+        restartWithNewConfig(true);
+        runTest(server, WAR_NAME, "testSharedLibraryClassesAccessibleToApplication");
+        runTest(server, WAR_NAME, "testResourceAdapterClassesAccessibleToSharedLibrary");
     }
 
     @Test

--- a/dev/com.ibm.ws.jca_fat_classloading/publish/files/testResourceAdapterClassesAccessibleToSharedLibrary_server.xml
+++ b/dev/com.ibm.ws.jca_fat_classloading/publish/files/testResourceAdapterClassesAccessibleToSharedLibrary_server.xml
@@ -20,12 +20,12 @@
 
     <include optional="true" location="../fatTestPorts.xml"/>
 
-    <library id="testlib">
-      <file name="${server.config.dir}/libraries/testlib.jar"/>
-    </library>
-
     <resourceAdapter id="DummyRA" location="${server.config.dir}connectors/fvtra.rar" autoStart="true">
-      <classloader privateLibraryRef="testlib"/>
+      <classloader>
+        <privateLibrary>
+          <file name="${server.config.dir}/libraries/testlib.jar"/>
+        </privateLibrary>
+      </classloader>
       <properties.DummyRA userName="Mr. Classy Loader" password="secret" />
     </resourceAdapter>
     

--- a/dev/com.ibm.ws.jca_fat_classloading/publish/files/testResourceAdapterClassesAccessibleToSharedLibrary_server.xml
+++ b/dev/com.ibm.ws.jca_fat_classloading/publish/files/testResourceAdapterClassesAccessibleToSharedLibrary_server.xml
@@ -1,0 +1,35 @@
+<!--
+    Copyright (c) 2014, 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+    <featureManager>
+      <feature>connectors-2.0</feature>
+      <feature>jndi-1.0</feature>
+      <feature>localConnector-1.0</feature>
+      <feature>servlet-5.0</feature>
+      <feature>messaging-3.0</feature>
+      <feature>mdb-4.0</feature>
+    </featureManager>
+
+    <include optional="true" location="../fatTestPorts.xml"/>
+
+    <library id="testlib">
+      <file name="${server.config.dir}/libraries/testlib.jar"/>
+    </library>
+
+    <resourceAdapter id="DummyRA" location="${server.config.dir}connectors/fvtra.rar" autoStart="true">
+      <classloader privateLibraryRef="testlib"/>
+      <properties.DummyRA userName="Mr. Classy Loader" password="secret" />
+    </resourceAdapter>
+    
+    <application location="${server.config.dir}apps/ClassLoadingApp.ear"> 
+        <classloader classProviderRef="DummyRA"/>
+    </application>
+</server>

--- a/dev/com.ibm.ws.jca_fat_classloading/test-applications/fvtweb/src/web/ClassLoadingTestServlet.java
+++ b/dev/com.ibm.ws.jca_fat_classloading/test-applications/fvtweb/src/web/ClassLoadingTestServlet.java
@@ -14,6 +14,9 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.lang.reflect.InvocationTargetException;
 
+import com.ibm.ws.jca.fat.classloading.sharedlib.LibraryClassThatDoesNotUseResourceAdapterClasses;
+import com.ibm.ws.jca.fat.classloading.sharedlib.LibraryClassThatUsesResourceAdapterClasses;
+
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
@@ -124,4 +127,24 @@ public class ClassLoadingTestServlet extends HttpServlet {
             System.out.println("Was not able to load third party class, this is correct.");
 
     }
+
+    /**
+     * Verify that resource adapter classes are available to a library that the
+     * resourceAdapter classloader references, which is in turn referenced by the application
+     * classloader via classProviderRef.
+     */
+    public void testResourceAdapterClassesAccessibleToSharedLibrary(HttpServletRequest request, PrintWriter out) throws Exception {
+        LibraryClassThatUsesResourceAdapterClasses libClassInstance = new LibraryClassThatUsesResourceAdapterClasses();
+        libClassInstance.createQueue();
+        libClassInstance.createTopic();
+    }
+
+    /**
+     * Verify that the application can use classes from a shared library.
+     */
+    public void testSharedLibraryClassesAccessibleToApplication(HttpServletRequest request, PrintWriter out) throws Exception {
+        LibraryClassThatDoesNotUseResourceAdapterClasses libClassInstance = new LibraryClassThatDoesNotUseResourceAdapterClasses();
+        libClassInstance.createSomething();
+    }
+
 }

--- a/dev/com.ibm.ws.jca_fat_classloading/test-libraries/testlib/src/com/ibm/ws/jca/fat/classloading/sharedlib/LibraryClassThatDoesNotUseResourceAdapterClasses.java
+++ b/dev/com.ibm.ws.jca_fat_classloading/test-libraries/testlib/src/com/ibm/ws/jca/fat/classloading/sharedlib/LibraryClassThatDoesNotUseResourceAdapterClasses.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jca.fat.classloading.sharedlib;
+
+/**
+ * A shared library class that does not acces any resource adapter classes.
+ */
+public class LibraryClassThatDoesNotUseResourceAdapterClasses {
+    public Object createSomething() {
+        return 2;
+    }
+}

--- a/dev/com.ibm.ws.jca_fat_classloading/test-libraries/testlib/src/com/ibm/ws/jca/fat/classloading/sharedlib/LibraryClassThatUsesResourceAdapterClasses.java
+++ b/dev/com.ibm.ws.jca_fat_classloading/test-libraries/testlib/src/com/ibm/ws/jca/fat/classloading/sharedlib/LibraryClassThatUsesResourceAdapterClasses.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.jca.fat.classloading.sharedlib;
+
+import ra.DummyQueue;
+import ra.DummyTopic;
+
+/**
+ * A shared library class that accesses some resource adapter classes.
+ */
+public class LibraryClassThatUsesResourceAdapterClasses {
+    public Object createQueue() {
+        return new DummyQueue();
+    }
+
+    public Object createTopic() {
+        return new DummyTopic();
+    }
+}


### PR DESCRIPTION
This test case experiments with trying to get a shared library to load classes from a resource adapter by making the shared library part of the resource adapter with the following style of config,

```
<resourceAdapter id="myAdapter" location=...
   <classloader privateLibraryRef="sharedLib"/>
   ...
</resourceAdapter>

<application location=...>
  <classloader classProviderRef="myAdapter"/>
</application>
```