### PR TITLE
spnego fat: allow timeout warning in shutdown messages

### DIFF
--- a/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/BasicAuthTest.java
+++ b/dev/com.ibm.ws.security.spnego_fat/fat/src/com/ibm/ws/security/spnego/fat/BasicAuthTest.java
@@ -30,8 +30,8 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.websphere.simplicity.config.Spnego;
 import com.ibm.websphere.simplicity.log.Log;
-import com.ibm.ws.security.spnego.fat.config.ApacheKDCforSPNEGO;
 import com.ibm.ws.security.spnego.fat.config.ApacheKDCCommonTest;
+import com.ibm.ws.security.spnego.fat.config.ApacheKDCforSPNEGO;
 import com.ibm.ws.security.spnego.fat.config.CommonTest;
 import com.ibm.ws.security.spnego.fat.config.InitClass;
 import com.ibm.ws.security.spnego.fat.config.Krb5Helper;
@@ -87,7 +87,7 @@ public class BasicAuthTest extends ApacheKDCCommonTest {
                                         SPNEGOConstants.USE_COMMON_KEYTAB,
                                         SPNEGOConstants.START_SERVER);
 
-        testHelper.addShutdownMessages("CWWKS9127W", "CWWKS4317E", "CWWKS4308E", "CWWKS4309E", "CWWKS4318E", "CWWKG0083W", "CWWKS4313E", "CWWKS4312E");
+        testHelper.addShutdownMessages("CWWKS9127W", "CWWKS4317E", "CWWKS4308E", "CWWKS4309E", "CWWKS4318E", "CWWKG0083W", "CWWKS4313E", "CWWKS4312E", "CWWKG0027W");
     }
 
     @Before


### PR DESCRIPTION
Fix for: [RTC 285086](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=285086)

Message to allow:
```
W CWWKG0027W: Timeout while updating server configuration.
```
**Problem**: The warning occurred from build machine running very slow, despite this all of the tests were still able to run and pass. Afterwords the fat threw a failure because it did not expect the timeout warning. 

**Solution**: Allow the timeout warning by adding it to the server shutdown messages list.