### PR TITLE
Issue #17757: Fix rmicCompatible EJB passivation

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.remote.portable.core/src/com/ibm/ejs/container/SerializedStub.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote.portable.core/src/com/ibm/ejs/container/SerializedStub.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,22 +22,26 @@ import javax.rmi.PortableRemoteObject;
  * of this object. The ORB will reconnect stubs stored in instance fields of
  * this serialized object.
  */
-public class SerializedStub
-                implements Serializable
-{
+public class SerializedStub implements Serializable {
     private static final long serialVersionUID = 3019532699780090519L;
 
     private final Object ivStub;
-    private final Class ivClass;
+    private final Class<?> ivClass;
 
-    SerializedStub(Object stub, Class klass)
-    {
+    SerializedStub(Object stub, Class<?> klass) {
         ivStub = stub;
         ivClass = klass;
     }
 
-    private Object readResolve()
-    {
+    private Object readResolve() {
         return PortableRemoteObject.narrow(ivStub, ivClass);
+    }
+
+    public Object getStub() {
+        return ivStub;
+    }
+
+    public Class<?> getInterfaceClass() {
+        return ivClass;
     }
 }

--- a/dev/com.ibm.ws.ejbcontainer.remote/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.remote/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2020 IBM Corporation and others.
+# Copyright (c) 2017, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -47,6 +47,13 @@ Private-Package: \
   com.ibm.ws.ejbcontainer.remote.internal.ORBObjectFactory, \
   com.ibm.ws.ejbcontainer.remote.internal.ORBObjectFactoryInfo, \
   com.ibm.ws.ejbcontainer.remote.internal.StubObjectResolver
+
+Service-Component: \
+  com.ibm.ws.ejbcontainer.classProvider;\
+    implementation:=com.ibm.ws.serialization.DeserializationClassProvider;\
+    provide:=com.ibm.ws.serialization.DeserializationClassProvider;\
+    properties:="service.vendor=IBM,\
+      classes=com.ibm.ws.ejbcontainer.remote.internal.SerializedStubString"
 
 -buildpath: \
 	com.ibm.ws.org.apache.yoko.corba.spec.1.5;version=latest,\

--- a/dev/com.ibm.ws.ejbcontainer.remote/src/com/ibm/ws/ejbcontainer/remote/internal/SerializedStubString.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote/src/com/ibm/ws/ejbcontainer/remote/internal/SerializedStubString.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.remote.internal;
+
+import java.io.Serializable;
+
+/**
+ * A wrapper for a stub that supports standard serialization.
+ *
+ * When a stub is read using read_value, the ORB will not reconnect the stub.
+ * When rmic compatibility is enabled, stubs for interfaces that are not RMI/IDL
+ * abstract interfaces will extend SerializableStub, which has a writeReplace
+ * method to substitute an instance of SerialiedStub, but that instance will
+ * contain a reference to the original stub which serialization will replace
+ * with a reference back to the same SerializedStub instance. The original stub
+ * is lost.
+ *
+ * The serialization service (via SerializedStubHandler) will compensate by replacing
+ * the SerializedStub with an instance of this class, which holds a reference to the
+ * String representation of the stub rather than the original stub. Then when read
+ * back in the stringified stub will be converted back to the original stub and
+ * narrowed in resolveObject(). The ORB will reconnect the stub.
+ */
+public class SerializedStubString implements Serializable {
+
+    private static final long serialVersionUID = 221516676682695674L;
+
+    private final String stub_string;
+    private final Class<?> remote_interface;
+
+    SerializedStubString(String stub, Class<?> remoteInterface) {
+        stub_string = stub;
+        remote_interface = remoteInterface;
+    }
+
+    String getStub() {
+        return stub_string;
+    }
+
+    Class<?> getInterface() {
+        return remote_interface;
+    }
+}

--- a/dev/com.ibm.ws.ejbcontainer.remote/src/com/ibm/ws/ejbcontainer/remote/internal/StubObjectResolver.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote/src/com/ibm/ws/ejbcontainer/remote/internal/StubObjectResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 IBM Corporation and others.
+ * Copyright (c) 2015, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,8 +12,10 @@ package com.ibm.ws.ejbcontainer.remote.internal;
 
 import java.io.IOException;
 
+import javax.rmi.PortableRemoteObject;
 import javax.rmi.CORBA.Stub;
 
+import org.omg.CORBA.ORB;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -21,12 +23,15 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
+import com.ibm.ejs.container.SerializedStub;
+import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.ws.serialization.DeserializationObjectResolver;
+import com.ibm.ws.serialization.SerializationObjectReplacer;
 import com.ibm.ws.transport.iiop.spi.ClientORBRef;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 
 @Component
-public class StubObjectResolver implements DeserializationObjectResolver {
+public class StubObjectResolver implements SerializationObjectReplacer, DeserializationObjectResolver {
     private static final String REFERENCE_ORB = "orb";
 
     private final AtomicServiceReference<ClientORBRef> orbRef = new AtomicServiceReference<ClientORBRef>(REFERENCE_ORB);
@@ -47,11 +52,46 @@ public class StubObjectResolver implements DeserializationObjectResolver {
     }
 
     @Override
+    public Object replaceObject(@Sensitive Object object) {
+        // -----------------------------------------------------------------------
+        // When rmic compatibility is enabled, stubs for interfaces that are not
+        // RMI/IDL abstract interfaces will extend SerializableStub, which has a
+        // writeReplace method to substitute an instance of SerializedStub.
+        // Unfortunately, SerializedStub holds a reference to the original stub
+        // which serialization will replace with a reference to the same
+        // SerializdStub returned by writeReplace causing a circular reference
+        // that cannot be deserialized.
+        //
+        // To avoid this, the SerializedStub is replaced here with a very similar
+        // SerializedStubString, using the ORB to convert the Stub to a
+        // String that may be serialized, and then the ORB is used again during
+        // resolveObject to convert the String back to the original Stub.
+        // -----------------------------------------------------------------------
+        if (object instanceof SerializedStub) {
+            ORB orb = orbRef.getServiceWithException().getORB();
+            SerializedStub serializedStub = (SerializedStub) object;
+            String stub_string = orb.object_to_string((org.omg.CORBA.Object) serializedStub.getStub());
+            return new SerializedStubString(stub_string, serializedStub.getInterfaceClass());
+        }
+
+        return null;
+    }
+
+    @Override
     public Object resolveObject(Object object) throws IOException {
         if (object instanceof Stub) {
             ((Stub) object).connect(orbRef.getServiceWithException().getORB());
             return object;
         }
+
+        if (object instanceof SerializedStubString) {
+            ORB orb = orbRef.getServiceWithException().getORB();
+            SerializedStubString serializedStub = (SerializedStubString) object;
+            Object stub = orb.string_to_object(serializedStub.getStub());
+            stub = PortableRemoteObject.narrow(stub, serializedStub.getInterface());
+            return stub;
+        }
+
         return null;
     }
 }

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/EJBHomeTest.war/src/com/ibm/ws/ejbcontainer/remote/fat/home/EJBHomeTestServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/EJBHomeTest.war/src/com/ibm/ws/ejbcontainer/remote/fat/home/EJBHomeTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2019 IBM Corporation and others.
+ * Copyright (c) 2014, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -43,13 +43,15 @@ import org.omg.CosNaming.NameComponent;
 import org.omg.CosNaming.NamingContext;
 import org.omg.CosNaming.NamingContextHelper;
 
-import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 @WebServlet("/EJBHomeTestServlet")
 @SuppressWarnings("serial")
 public class EJBHomeTestServlet extends FATServlet {
     private static final Logger logger = Logger.getLogger(EJBHomeTestServlet.class.getName());
+    private static final String rmicCompatibleProperty = System.getProperty("com.ibm.websphere.ejbcontainer.rmicCompatible");
+    private static final boolean rmicCompatible = EJB.class.getName().startsWith("jakarta.")
+                                                  || ("all".equalsIgnoreCase(rmicCompatibleProperty) || "values".equalsIgnoreCase(rmicCompatibleProperty));
 
     @EJB(name = "ejb/home")
     private TestEJBHome home;
@@ -114,10 +116,11 @@ public class EJBHomeTestServlet extends FATServlet {
      * values that should use write_value/read_value. The "WAS EJB 3"
      * marshalling actually uses writeAbstractObject/read_abstract_interface,
      * so a tie mismatch will result in an OutOfMemoryError.
+     * The Enterprise Beans 4.0 marshalling is compatible with RMIC and uses
+     * write_value/read_value so a tie mismatch will result in
+     * CORBA.MARSHAL: Illegal valuetype.
      */
     @Test
-    // TODO: Remove Skip when #17757 is fixed
-    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     public void testEJBHomeWriteValueDirect_EJBHomeTest() throws Exception {
         List<?> expected = new ArrayList<Object>(Arrays.asList("a", "b", "c"));
         List<?> actual = stubTestWriteValue((Stub) home.create(), expected);
@@ -132,11 +135,21 @@ public class EJBHomeTestServlet extends FATServlet {
             try {
                 try {
                     OutputStream out = (OutputStream) stub._request("testWriteValue", true);
-                    // "WAS EJB 3" marshalling using writeAbstractObject...
-                    Util.writeAbstractObject(out, value);
+                    if (rmicCompatible) {
+                        // Enterprise Beans 4.0 (or rmicCompatible) marshalling using write_value..
+                        out.write_value((Serializable) value, List.class);
+                    } else {
+                        // "WAS EJB 3" marshalling using writeAbstractObject...
+                        Util.writeAbstractObject(out, value);
+                    }
                     in = (InputStream) stub._invoke(out);
-                    // ...and read_abstract_interface.
-                    return (List<?>) in.read_abstract_interface(List.class);
+                    if (rmicCompatible) {
+                        // ...and read_value.
+                        return (List<?>) in.read_value(List.class);
+                    } else {
+                        // ...and read_abstract_interface.
+                        return (List<?>) in.read_abstract_interface(List.class);
+                    }
                 } catch (ApplicationException ex) {
                     in = (InputStream) ex.getInputStream();
                     String id = in.read_string();

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/SingletonWeb.war/src/com/ibm/ws/ejbcontainer/remote/singleton/mix/web/PassivationServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/test-applications/SingletonWeb.war/src/com/ibm/ws/ejbcontainer/remote/singleton/mix/web/PassivationServlet.java
@@ -23,7 +23,6 @@ import com.ibm.ws.ejbcontainer.remote.singleton.mix.shared.MixHelper;
 import com.ibm.ws.ejbcontainer.remote.singleton.mix.shared.StatefulEJBRefLocal;
 import com.ibm.ws.ejbcontainer.remote.singleton.mix.shared.StatefulEJBRefRemote;
 
-import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 /**
@@ -45,8 +44,6 @@ public class PassivationServlet extends FATServlet {
      * Passivate and activate an SFSB with a reference to a singleton bean's business interface
      */
     @Test
-    // TODO: Remove Skip when #17757 is fixed
-    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     public void testMixPassivateSingleton() throws Exception {
         // Create an instance of the bean by looking up the business interface and ensure the bean contains the default state.
         StatefulEJBRefLocal localBean = lookupLocal();


### PR DESCRIPTION
During passivation/serialization, use the ORB to convert a SerializedStub to
a SerializedStubString which may be restored during activation/deserialization.

Also fix test to handle rmicCompatible not specified or enabled.

fixes #17757 