### PR TITLE
Criu: rm server exports

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -69,8 +69,6 @@
 #              a z/OS environment.
 #
 ###############################################################################
-export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu
-export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libcriu.so
 SERVER_UNKNOWN_STATUS=5
 
 ##


### PR DESCRIPTION
Remove some temporary exports. They were needed for jigawatts but not openJ9. A simple manual workaround will be needed to continue using jigaWatts:

-- export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu
and
-- add '/usr/lib/x86_64-linux-gnu/libcriu.so' to /etc/ld.so.preload