### PR TITLE
Add wait in EJB automatic timer FAT

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.auto_fat/test-applications/AutoNPTimersEJB.jar/src/com/ibm/ws/ejbcontainer/timer/auto/npTimer/ejb/AutoCreatedTimerDriverBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.auto_fat/test-applications/AutoNPTimersEJB.jar/src/com/ibm/ws/ejbcontainer/timer/auto/npTimer/ejb/AutoCreatedTimerDriverBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2020 IBM Corporation and others.
+ * Copyright (c) 2009, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -101,6 +101,10 @@ public class AutoCreatedTimerDriverBean implements AutoCreatedTimerDriver {
         try {
             svLogger.info("Waiting for timers to expire; or 5 minutes");
             timersExpiredLatch.await(5, TimeUnit.MINUTES);
+            if (timersExpiredLatch.getCount() != 0) {
+                svLogger.info("Waiting for timers to expire 1 extra minute; likely a server pause delayed timers; still waiting on " + timersExpiredLatch.getCount());
+                timersExpiredLatch.await(1, TimeUnit.MINUTES);
+            }
         } catch (InterruptedException ex) {
             ex.printStackTrace();
             throw new EJBException("Unexpected exception waiting.", ex);


### PR DESCRIPTION
 Normal setup during a local full run takes 4 minutes and the test is only waiting 5,
so it seems reasonable to have the test wait another minute.... and to have the additional
minute be a separate wait after the first 5 minute wait.  By adding a second wait for
1 minute, the second wait will occur completely after any server pause, at which time
the timers are likely running rapidly to catchup from the pause... and thus very likely
they will all have caught up by the time the test checks again after a second wait time.

