### PR TITLE
Wait for SSL to be ready after server restart

### DIFF
--- a/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLMessageConstants.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLMessageConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,9 @@
  *******************************************************************************/
 package com.ibm.ws.security.saml20.fat.commonTest;
 
-public class SAMLMessageConstants {
+import com.ibm.ws.security.fat.common.MessageConstants;
+
+public class SAMLMessageConstants extends MessageConstants {
 
     public static final String CWWKS5000I_SAML_CONFIG_PROCESSED = "CWWKS5000I";
     public static final String CWWKS5002I_SAML_SERVICE_ACTIVATED = "CWWKS5002I";

--- a/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/SPInitiated/BasicSolicitedSPInitiatedTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/SPInitiated/BasicSolicitedSPInitiatedTests.java
@@ -75,6 +75,8 @@ public class BasicSolicitedSPInitiatedTests extends BasicSAMLTests {
         // add any additional messages that you want the "start" to wait for
         // we should wait for any providers that this test requires
         extraMsgs = getDefaultSAMLStartMsgs();
+        // make sure that we wait for ssl to be up and ready during the original start and server restarts
+        extraMsgs.add("CWWKO0219I:.*defaultHttpEndpoint-ssl.*");
 
         extraApps.add(SAMLConstants.SAML_CLIENT_APP);
 

--- a/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/SPInitiated/BasicSolicitedSPInitiatedTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/SPInitiated/BasicSolicitedSPInitiatedTests.java
@@ -76,7 +76,7 @@ public class BasicSolicitedSPInitiatedTests extends BasicSAMLTests {
         // we should wait for any providers that this test requires
         extraMsgs = getDefaultSAMLStartMsgs();
         // make sure that we wait for ssl to be up and ready during the original start and server restarts
-        extraMsgs.add("CWWKO0219I:.*defaultHttpEndpoint-ssl.*");
+        extraMsgs.add(SAMLMessageConstants.CWWKO0219I_SSL_CHANNEL_READY);
 
         extraApps.add(SAMLConstants.SAML_CLIENT_APP);
 


### PR DESCRIPTION
Session Affinity tests restart the SP after requesting access.
We've recently hit a case where the restarted server is not quite ready when we make the first request after the restart.
I'm adding a check for the SSL ready message before we assume that the server is up and ready for requests.