### PR TITLE
jsfContainer MyFaces 2.3-next-* version string support

### DIFF
--- a/dev/com.ibm.ws.jsfContainer/src/com/ibm/ws/jsf/container/application/JSFContainerApplicationFactory.java
+++ b/dev/com.ibm.ws.jsfContainer/src/com/ibm/ws/jsf/container/application/JSFContainerApplicationFactory.java
@@ -146,7 +146,7 @@ public class JSFContainerApplicationFactory extends ApplicationFactory {
     private static boolean isVersionValid(String version) {
         // A simple way of checking that version is within MAJOR.MINOR.*
         String specLevel = JSFContainer.getJSFSpecLevel();
-        return version.equals(specLevel) || version.startsWith(specLevel + ".");
+        return version.equals(specLevel) || version.startsWith(specLevel + ".") || version.startsWith(specLevel + "-");
     }
 
     private IllegalStateException noJsfProviderFound() {


### PR DESCRIPTION
Testing with basic apps shows that MyFaces `2.3-next` works correctly with `jsfContainer-2.3` once the jsfContainer version string check is updated in 1eb8b21867f3557ae92a1c0ce9e6b584396749fe. However in order to test this properly we need to update `com.ibm.ws.jsfContainer_fat_2.3` to test `2.3-next`,  which will include determining which tests in that bucket are actually valid for `2.3-next` (ie. not dependent on JSF managed beans).