### PR TITLE
remove obsolete shutdown callback method

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/PolicyExecutor.java
@@ -285,16 +285,6 @@ public interface PolicyExecutor extends ExecutorService {
      */
     void registerShutdownCallback(Consumer<Set<Object>> callback);
 
-    // TODO remove once consuming code is switched over to above
-    /**
-     * Registers a one-time callback to be invoked inline when the
-     * policy executor shuts down. This method is intended for optional use
-     * on a newly created policy executor instance.
-     *
-     * @param callback the callback, or null to unregister.
-     */
-    void registerShutdownCallback(Runnable callback);
-
     /**
      * Applies when using the <code>execute</code> or <code>submit</code> methods. Indicates whether or not to run the task on the
      * caller's thread when the queue is full and the <code>maxWaitForEnqueue</code> has been exceeded.

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/PolicyExecutorImpl.java
@@ -1126,17 +1126,6 @@ public class PolicyExecutorImpl implements PolicyExecutor {
             throw new IllegalStateException(cbShutdown + " is already registered");
     }
 
-    // TODO remove once consuming code is switched over to above
-    @Override
-    public void registerShutdownCallback(final Runnable callback) {
-        cbShutdown.set(new Consumer<Set<Object>>() {
-            @Override
-            public void accept(Set<Object> runningTasks) {
-                callback.run();
-            }
-        });
-    }
-
     @Override
     public PolicyExecutor runIfQueueFull(boolean runIfFull) {
         if (state.get() != State.ACTIVE)


### PR DESCRIPTION
Now that the consuming code has been updated, we can remove the obsolete method signature for registering a shutdown callback.