### PR TITLE
Add wait in EJB BadApp FAT for Windows

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/BadApplicationTests.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/BadApplicationTests.java
@@ -195,11 +195,13 @@ public class BadApplicationTests extends AbstractTest {
         server.setMarkToEndOfLog();
         server.saveServerConfiguration();
         server.setServerConfigurationFile("ExtendsThrowable" + eeVersion + ".xml");
+        server.waitForStringInLogUsingMark("CWWKG0016I", 240 * 1000); // Starting server configuration update.
         server.waitForConfigUpdateInLogUsingMark(installedApps);
         assertNotNull(server.waitForStringInLogUsingMark("CNTR5107E"));
         assertNotNull(server.waitForStringInLogUsingMark("CWWKZ0106E"));
         server.setMarkToEndOfLog();
         server.restoreServerConfiguration();
+        server.waitForStringInLogUsingMark("CWWKG0016I", 240 * 1000); // Starting server configuration update.
         server.waitForConfigUpdateInLogUsingMark(installedApps);
     }
 


### PR DESCRIPTION
Some windows systems are slow to react to config updates, so add an
extra wait for beginning of config update.

