### PR TITLE
Move MicroProfile 4.1 to GA

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -440,6 +440,7 @@ if (isAutomatedBuild && !isIFIXBuild) {
         dependsOn parent.subprojects.assemble
         dependsOn ':com.ibm.websphere.appserver.features:publishFeatureResources'
         withFeatures this.&microProfile4Features
+        packageServerConflict = true
         outputTo packageDir
         doLast {
             copy {

--- a/dev/build.image/profiles/javaee8/features.xml
+++ b/dev/build.image/profiles/javaee8/features.xml
@@ -19,3 +19,4 @@
 <feature>microProfile-3.2</feature>
 <feature>microProfile-3.3</feature>
 <feature>microProfile-4.0</feature>
+<feature>microProfile-4.1</feature>

--- a/dev/build.image/profiles/microProfile4/features.xml
+++ b/dev/build.image/profiles/microProfile4/features.xml
@@ -1,1 +1,2 @@
 <feature>microProfile-4.0</feature>
+<feature>microProfile-4.1</feature>

--- a/dev/build.image/profiles/webProfile8/features.xml
+++ b/dev/build.image/profiles/webProfile8/features.xml
@@ -16,3 +16,4 @@
 <feature>microProfile-3.2</feature>
 <feature>microProfile-3.3</feature>
 <feature>microProfile-4.0</feature>
+<feature>microProfile-4.1</feature>

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.health-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.org.eclipse.microprofile.health-3.1.feature
@@ -3,6 +3,6 @@ symbolicName=com.ibm.websphere.appserver.org.eclipse.microprofile.health-3.1
 singleton=true
 -features=io.openliberty.mpCompatible-4.0
 -bundles=io.openliberty.org.eclipse.microprofile.health.3.1; location:="dev/api/stable/,lib/"; mavenCoordinates="org.eclipse.microprofile.health:microprofile-health-api:3.1"
-kind=beta
+kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-4.1/com.ibm.websphere.appserver.microProfile-4.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/microProfile-4.1/com.ibm.websphere.appserver.microProfile-4.1.feature
@@ -22,5 +22,5 @@ Subsystem-Name: MicroProfile 4.1
   com.ibm.websphere.appserver.mpOpenAPI-2.0, \
   com.ibm.websphere.appserver.mpOpenTracing-2.0, \
   com.ibm.websphere.appserver.mpRestClient-2.0
-kind=beta
+kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpHealth-3.1/com.ibm.websphere.appserver.mpHealth-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpHealth-3.1/com.ibm.websphere.appserver.mpHealth-3.1.feature
@@ -20,6 +20,6 @@ Subsystem-Name: MicroProfile Health 3.1
 -bundles=com.ibm.websphere.jsonsupport, \
  io.openliberty.microprofile.health.3.1.internal; apiJar=false; location:="lib/", \
  com.ibm.ws.org.joda.time.1.6.2
-kind=beta
+kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.ws.kernel.boot/publish/templates/servers/microProfile4/server.xml
+++ b/dev/com.ibm.ws.kernel.boot/publish/templates/servers/microProfile4/server.xml
@@ -3,7 +3,7 @@
 
     <!-- Enable features -->
     <featureManager>
-        <feature>microProfile-4.0</feature>
+        <feature>microProfile-4.1</feature>
     </featureManager>
 
     <!-- To access this server from a remote client add a host attribute to the following element, e.g. host="*" -->

--- a/dev/io.openliberty.opentracing.2.x_fat/fat/src/io/openliberty/opentracing/internal/test/FATSuite.java
+++ b/dev/io.openliberty.opentracing.2.x_fat/fat/src/io/openliberty/opentracing/internal/test/FATSuite.java
@@ -30,9 +30,8 @@ import componenttest.topology.impl.LibertyServerFactory;
     TestSpanUtils.class,
     FATOpentracing.class,
     FATOpentracingHelloWorld.class,
-    FATMPOpenTracing.class
-// Comment out this test class until microprofile-4.0 is available
-//    MicroProfile40NoTracer.class  
+    FATMPOpenTracing.class,
+    MicroProfile40NoTracer.class  
     
 })
 public class FATSuite implements FATOpentracingConstants {


### PR DESCRIPTION
Move MicroProfile 4.1 and MP Health 3.1 to GA
Include MicroProfile 4.1 in appropriate OL GA packages
Re-instate an open tracing test that was incorrectly commented out

#build