### PR TITLE
Add thread-context=true to Servlet API Exports

### DIFF
--- a/dev/io.openliberty.jakarta.servlet.5.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.servlet.5.0/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2021 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -16,10 +16,10 @@ Bundle-SymbolicName: io.openliberty.jakarta.servlet.5.0; singleton:=true
 Bundle-Description: Jakarta Servlet, version 5.0
 
 Export-Package: \
-   	jakarta.servlet;uses:="jakarta.servlet.annotation,jakarta.servlet.descriptor";version="5.0.0",\
-   	jakarta.servlet.annotation;uses:="jakarta.servlet";version="5.0.0",\
-   	jakarta.servlet.descriptor;version="5.0.0",\
-   	jakarta.servlet.http;uses:="jakarta.servlet";version="5.0.0",\
+   	jakarta.servlet;thread-context=true;uses:="jakarta.servlet.annotation,jakarta.servlet.descriptor";version="5.0.0",\
+   	jakarta.servlet.annotation;thread-context=true;uses:="jakarta.servlet";version="5.0.0",\
+   	jakarta.servlet.descriptor;thread-context=true;version="5.0.0",\
+   	jakarta.servlet.http;thread-context=true;uses:="jakarta.servlet";version="5.0.0",\
    	jakarta.servlet.resources;thread-context=true;version="5.0.0"
 
 instrument.disabled: true


### PR DESCRIPTION
fixes #17916

Changed to match servlet 4.0 exports:

https://github.com/OpenLiberty/open-liberty/blob/7476e589299192edfa759d42a85b7425638e0763/dev/com.ibm.websphere.javaee.servlet.4.0/bnd.bnd#L8-L13


It was discovered that the webcachemonitor-1.0 didn't work properly with servlet 5.0 because the jakarta.servlet classes failed to be found for the JSP classloader when retrieving pages from the `com.ibm.ws.dynacache.cachemonitor` bundle.