### PR TITLE
Issue #13717: EE 9 EJB Legacy FAT

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/bnd.bnd
@@ -35,6 +35,7 @@ fat.project: true
 tested.features: \
 	enterpriseBeansHome-4.0,\
 	enterpriseBeansLite-4.0,\
+	enterpriseBeansRemote-4.0,\
 	servlet-4.0,\
 	servlet-5.0
 

--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/build.gradle
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/build.gradle
@@ -69,6 +69,21 @@ task addEnterpriseBeansTools {
     }
     copy {
       from configurations.enterpriseBeansTools
+      into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.ejbcontainer.legacy.server.notrace/lib/global"
+      rename 'io.openliberty.ejbcontainer.jakarta.fat_tools-(.*).jar', 'io.openliberty.ejbcontainer.jakarta.fat_tools.jar'
+    }
+    copy {
+      from configurations.enterpriseBeansTools
+      into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.ejbcontainer.legacy.server.remote/lib/global"
+      rename 'io.openliberty.ejbcontainer.jakarta.fat_tools-(.*).jar', 'io.openliberty.ejbcontainer.jakarta.fat_tools.jar'
+    }
+    copy {
+      from configurations.enterpriseBeansTools
+      into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.ejbcontainer.legacy.server.remote.noTrace/lib/global"
+      rename 'io.openliberty.ejbcontainer.jakarta.fat_tools-(.*).jar', 'io.openliberty.ejbcontainer.jakarta.fat_tools.jar'
+    }
+    copy {
+      from configurations.enterpriseBeansTools
       into "${buildDir}/autoFVT/publish/servers/com.ibm.ws.ejbcontainer.legacy.server.sll/lib/global"
       rename 'io.openliberty.ejbcontainer.jakarta.fat_tools-(.*).jar', 'io.openliberty.ejbcontainer.jakarta.fat_tools.jar'
     }

--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/fat/src/com/ibm/ws/ejbcontainer/legacy/fat/tests/CacheTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/fat/src/com/ibm/ws/ejbcontainer/legacy/fat/tests/CacheTest.java
@@ -22,6 +22,7 @@ import org.junit.runner.RunWith;
 import com.ibm.ejb2x.base.cache.web.StatefulOnceServlet;
 import com.ibm.ejb2x.base.cache.web.StatefulTranServlet;
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -46,7 +47,7 @@ public class CacheTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.ejbcontainer.legacy.server.notrace")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.legacy.server.notrace"));
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.ejbcontainer.legacy.server.notrace")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.legacy.server.notrace")).andWith(FeatureReplacementAction.EE9_FEATURES().forServers("com.ibm.ws.ejbcontainer.legacy.server.notrace"));
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -65,7 +66,7 @@ public class CacheTest {
         StatefulCacheApp.addAsModules(StatefulCacheEJB, StatefulCacheWeb);
         ShrinkHelper.addDirectory(StatefulCacheApp, "test-applications/StatefulCacheApp.ear/resources");
 
-        ShrinkHelper.exportDropinAppToServer(server, StatefulCacheApp);
+        ShrinkHelper.exportDropinAppToServer(server, StatefulCacheApp, DeployOptions.SERVER_ONLY);
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/fat/src/com/ibm/ws/ejbcontainer/legacy/fat/tests/EJB1XStatefulTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/fat/src/com/ibm/ws/ejbcontainer/legacy/fat/tests/EJB1XStatefulTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2020 IBM Corporation and others.
+ * Copyright (c) 2002, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -40,6 +40,7 @@ import com.ibm.ejb1x.base.spec.slr.web.SLRemoteInterfaceContextServlet;
 import com.ibm.ejb1x.base.spec.slr.web.SLRemoteInterfaceMethodServlet;
 import com.ibm.ejb1x.base.spec.slr.web.SLRemoteInterfaceRemoveServlet;
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -77,7 +78,7 @@ public class EJB1XStatefulTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote"));
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote")).andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote"));
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -98,7 +99,7 @@ public class EJB1XStatefulTest extends FATServletClient {
         EJB1XRemoteSpecApp.addAsModules(EJB1XSFRemoteSpecEJB, EJB1XSLRemoteSpecEJB, EJB1XRemoteSpecWeb);
         ShrinkHelper.addDirectory(EJB1XRemoteSpecApp, "test-applications/EJB1XRemoteSpecApp.ear/resources");
 
-        ShrinkHelper.exportDropinAppToServer(server, EJB1XRemoteSpecApp);
+        ShrinkHelper.exportDropinAppToServer(server, EJB1XRemoteSpecApp, DeployOptions.SERVER_ONLY);
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/fat/src/com/ibm/ws/ejbcontainer/legacy/fat/tests/EJBinWAR2xTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/fat/src/com/ibm/ws/ejbcontainer/legacy/fat/tests/EJBinWAR2xTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2019 IBM Corporation and others.
+ * Copyright (c) 2010, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,7 @@ import org.junit.runner.RunWith;
 import com.ibm.ejb2x.ejbinwar.web.EJB2xTestServlet;
 import com.ibm.ejb2x.ejbinwar.web.InterfaceAndNamespaceTestServlet;
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -40,7 +41,7 @@ public class EJBinWAR2xTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote"));
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote")).andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote"));
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -55,7 +56,7 @@ public class EJBinWAR2xTest extends FATServletClient {
         EJBinWARTestApp.addAsLibrary(EJBinWARIntf);
         ShrinkHelper.addDirectory(EJBinWARTestApp, "test-applications/EJBinWARTestApp.ear/resources");
 
-        ShrinkHelper.exportDropinAppToServer(server, EJBinWARTestApp);
+        ShrinkHelper.exportDropinAppToServer(server, EJBinWARTestApp, DeployOptions.SERVER_ONLY);
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/fat/src/com/ibm/ws/ejbcontainer/legacy/fat/tests/PassivationRegressionTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/fat/src/com/ibm/ws/ejbcontainer/legacy/fat/tests/PassivationRegressionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2019 IBM Corporation and others.
+ * Copyright (c) 2002, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ import org.junit.runner.RunWith;
 
 import com.ibm.ejb2x.base.pitt.web.PassivationRegressionServlet;
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -42,7 +43,7 @@ public class PassivationRegressionTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote"));
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote")).andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote"));
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -59,7 +60,7 @@ public class PassivationRegressionTest extends FATServletClient {
         StatefulPassivationApp.addAsModules(StatefulPassivationEJB, StatefulPassivationWeb);
         ShrinkHelper.addDirectory(StatefulPassivationApp, "test-applications/StatefulPassivationApp.ear/resources");
 
-        ShrinkHelper.exportDropinAppToServer(server, StatefulPassivationApp);
+        ShrinkHelper.exportDropinAppToServer(server, StatefulPassivationApp, DeployOptions.SERVER_ONLY);
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/fat/src/com/ibm/ws/ejbcontainer/legacy/fat/tests/SFLocalTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/fat/src/com/ibm/ws/ejbcontainer/legacy/fat/tests/SFLocalTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2020 IBM Corporation and others.
+ * Copyright (c) 2002, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,6 +30,7 @@ import com.ibm.ejb2x.base.spec.sfl.web.SFLocalInterfaceContextServlet;
 import com.ibm.ejb2x.base.spec.sfl.web.SFLocalInterfaceMethodServlet;
 import com.ibm.ejb2x.base.spec.sfl.web.SFLocalInterfaceRemoveServlet;
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -77,7 +78,7 @@ public class SFLocalTest extends FATServletClient {
         EJB2XLocalSpecApp.addAsModules(EJB2XSFLocalSpecEJB, EJB2XSLLocalSpecEJB, EJB2XLocalSpecWeb);
         //ShrinkHelper.addDirectory(EJB2XLocalSpecApp, "test-applications/EJB2XLocalSpecApp.ear/resources");
 
-        ShrinkHelper.exportDropinAppToServer(server, EJB2XLocalSpecApp);
+        ShrinkHelper.exportDropinAppToServer(server, EJB2XLocalSpecApp, DeployOptions.SERVER_ONLY);
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/fat/src/com/ibm/ws/ejbcontainer/legacy/fat/tests/SFPassivationTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/fat/src/com/ibm/ws/ejbcontainer/legacy/fat/tests/SFPassivationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2019 IBM Corporation and others.
+ * Copyright (c) 2002, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ import org.junit.runner.RunWith;
 
 import com.ibm.ejb2x.base.pitt.web.StatefulPassivationServlet;
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -44,7 +45,7 @@ public class SFPassivationTest {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote.noTrace")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote.noTrace"));
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote.noTrace")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote.noTrace")).andWith(FeatureReplacementAction.EE9_FEATURES().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote.noTrace"));
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -61,7 +62,7 @@ public class SFPassivationTest {
         StatefulPassivationApp.addAsModules(StatefulPassivationEJB, StatefulPassivationWeb);
         ShrinkHelper.addDirectory(StatefulPassivationApp, "test-applications/StatefulPassivationApp.ear/resources");
 
-        ShrinkHelper.exportDropinAppToServer(server, StatefulPassivationApp);
+        ShrinkHelper.exportDropinAppToServer(server, StatefulPassivationApp, DeployOptions.SERVER_ONLY);
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/fat/src/com/ibm/ws/ejbcontainer/legacy/fat/tests/SFRemoteTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/fat/src/com/ibm/ws/ejbcontainer/legacy/fat/tests/SFRemoteTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2019 IBM Corporation and others.
+ * Copyright (c) 2002, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,6 +30,7 @@ import com.ibm.ejb2x.base.spec.sfr.web.SFRemoteInterfaceContextServlet;
 import com.ibm.ejb2x.base.spec.sfr.web.SFRemoteInterfaceMethodServlet;
 import com.ibm.ejb2x.base.spec.sfr.web.SFRemoteInterfaceRemoveServlet;
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -57,7 +58,7 @@ public class SFRemoteTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote"));
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote")).andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote"));
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -77,7 +78,7 @@ public class SFRemoteTest extends FATServletClient {
         EJB2XRemoteSpecApp.addAsModules(EJB2XSFRemoteSpecEJB, EJB2XSLRemoteSpecEJB, EJB2XRemoteSpecWeb);
         ShrinkHelper.addDirectory(EJB2XRemoteSpecApp, "test-applications/EJB2XRemoteSpecApp.ear/resources");
 
-        ShrinkHelper.exportDropinAppToServer(server, EJB2XRemoteSpecApp);
+        ShrinkHelper.exportDropinAppToServer(server, EJB2XRemoteSpecApp, DeployOptions.SERVER_ONLY);
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/fat/src/com/ibm/ws/ejbcontainer/legacy/fat/tests/SLLocalTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/fat/src/com/ibm/ws/ejbcontainer/legacy/fat/tests/SLLocalTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2020 IBM Corporation and others.
+ * Copyright (c) 2002, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,6 +29,7 @@ import com.ibm.ejb2x.base.spec.sll.web.SLLocalInterfaceContextServlet;
 import com.ibm.ejb2x.base.spec.sll.web.SLLocalInterfaceMethodServlet;
 import com.ibm.ejb2x.base.spec.sll.web.SLLocalInterfaceRemoveServlet;
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -76,7 +77,7 @@ public class SLLocalTest extends FATServletClient {
         EJB2XLocalSpecApp.addAsModules(EJB2XSFLocalSpecEJB, EJB2XSLLocalSpecEJB, EJB2XLocalSpecWeb);
         //ShrinkHelper.addDirectory(EJB2XLocalSpecApp, "test-applications/EJB2XLocalSpecApp.ear/resources");
 
-        ShrinkHelper.exportDropinAppToServer(server, EJB2XLocalSpecApp);
+        ShrinkHelper.exportDropinAppToServer(server, EJB2XLocalSpecApp, DeployOptions.SERVER_ONLY);
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/fat/src/com/ibm/ws/ejbcontainer/legacy/fat/tests/SLRemoteTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/fat/src/com/ibm/ws/ejbcontainer/legacy/fat/tests/SLRemoteTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2019 IBM Corporation and others.
+ * Copyright (c) 2002, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,6 +30,7 @@ import com.ibm.ejb2x.base.spec.slr.web.SLRemoteInterfaceContextServlet;
 import com.ibm.ejb2x.base.spec.slr.web.SLRemoteInterfaceMethodServlet;
 import com.ibm.ejb2x.base.spec.slr.web.SLRemoteInterfaceRemoveServlet;
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -57,7 +58,7 @@ public class SLRemoteTest extends FATServletClient {
     public static LibertyServer server;
 
     @ClassRule
-    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote"));
+    public static RepeatTests r = RepeatTests.with(FeatureReplacementAction.EE7_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote")).andWith(FeatureReplacementAction.EE8_FEATURES().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote")).andWith(FeatureReplacementAction.EE9_FEATURES().fullFATOnly().forServers("com.ibm.ws.ejbcontainer.legacy.server.remote"));
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -77,7 +78,7 @@ public class SLRemoteTest extends FATServletClient {
         EJB2XRemoteSpecApp.addAsModules(EJB2XSFRemoteSpecEJB, EJB2XSLRemoteSpecEJB, EJB2XRemoteSpecWeb);
         ShrinkHelper.addDirectory(EJB2XRemoteSpecApp, "test-applications/EJB2XRemoteSpecApp.ear/resources");
 
-        ShrinkHelper.exportDropinAppToServer(server, EJB2XRemoteSpecApp);
+        ShrinkHelper.exportDropinAppToServer(server, EJB2XRemoteSpecApp, DeployOptions.SERVER_ONLY);
 
         server.startServer();
     }

--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/publish/servers/com.ibm.ws.ejbcontainer.legacy.server.notrace/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/publish/servers/com.ibm.ws.ejbcontainer.legacy.server.notrace/server.xml
@@ -8,4 +8,5 @@
     <include location="../fatTestPorts.xml"/>
     
     <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="testLauncher" actions="read"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.util.PropertyPermission" name="testLauncher" actions="read"/>
 </server>

--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/publish/servers/com.ibm.ws.ejbcontainer.legacy.server.remote.noTrace/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/publish/servers/com.ibm.ws.ejbcontainer.legacy.server.remote.noTrace/server.xml
@@ -12,4 +12,8 @@
     <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.net.SocketPermission" name="*" actions="listen,connect,resolve"/>
     <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
     <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="*" actions="read,write"/>
+
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.net.SocketPermission" name="*" actions="listen,connect,resolve"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.util.PropertyPermission" name="*" actions="read,write"/>
 </server>

--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/publish/servers/com.ibm.ws.ejbcontainer.legacy.server.remote/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/publish/servers/com.ibm.ws.ejbcontainer.legacy.server.remote/server.xml
@@ -13,4 +13,10 @@
     <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.net.SocketPermission" name="*" actions="listen,connect,resolve"/>
     <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
     <javaPermission codebase="${server.config.dir}/lib/global/com.ibm.ws.ejbcontainer.fat_tools.jar" className="java.util.PropertyPermission" name="*" actions="read,write"/>
+
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.util.PropertyPermission" name="testLauncher" actions="read"/>
+    <!-- Yoko ORB bug; org.apache.yoko.rmispec.util.UtilLoader.loadServiceClass needs doPriv around getClassLoader + others -->	
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.net.SocketPermission" name="*" actions="listen,connect,resolve"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <javaPermission codebase="${server.config.dir}/lib/global/io.openliberty.ejbcontainer.jakarta.fat_tools.jar" className="java.util.PropertyPermission" name="*" actions="read,write"/>
 </server>

--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/test-applications/EJB1XRemoteSpecWeb.war/src/com/ibm/ejb1x/base/spec/sfr/web/SFRemoteImplContextServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/test-applications/EJB1XRemoteSpecWeb.war/src/com/ibm/ejb1x/base/spec/sfr/web/SFRemoteImplContextServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2020 IBM Corporation and others.
+ * Copyright (c) 2002, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@
 
 package com.ibm.ejb1x.base.spec.sfr.web;
 
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -29,6 +30,7 @@ import com.ibm.ejb1x.base.spec.sfr.ejb.SFRaHome;
 import com.ibm.websphere.ejbcontainer.test.tools.FATHelper;
 
 import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 /**
@@ -164,6 +166,7 @@ public class SFRemoteImplContextServlet extends FATServlet {
      * (ixc04) Test Stateful remote EJBContext.getEnvironment().
      */
     @Test
+    @SkipForRepeat({ EE9_FEATURES })
     public void test1XSFEJBContext_getEnvironment() throws Exception {
         String tempStr = fejb1.context_getEnvironment("value1");
         assertEquals("Get Environment string from context was unexpected value", tempStr, "value of value1");
@@ -174,6 +177,7 @@ public class SFRemoteImplContextServlet extends FATServlet {
      */
     @Test
     @SuppressWarnings("deprecation")
+    @SkipForRepeat({ EE9_FEATURES })
     public void test1XSFEJBContext_getCallerIdentity() throws Exception {
         Object o = fejb1.context_getCallerIdentity();
         if (o instanceof Throwable) {
@@ -213,6 +217,7 @@ public class SFRemoteImplContextServlet extends FATServlet {
      */
     @Test
     @SuppressWarnings("deprecation")
+    @SkipForRepeat({ EE9_FEATURES })
     public void test1XSFEJBContext_isCallerInRole_Identity() throws Exception {
         Object o = fejb1.context_isCallerInRole((java.security.Identity) null);
         if (o instanceof Throwable) {

--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/test-applications/EJB1XRemoteSpecWeb.war/src/com/ibm/ejb1x/base/spec/slr/web/SLRemoteImplContextServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/test-applications/EJB1XRemoteSpecWeb.war/src/com/ibm/ejb1x/base/spec/slr/web/SLRemoteImplContextServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2020 IBM Corporation and others.
+ * Copyright (c) 2002, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@
 
 package com.ibm.ejb1x.base.spec.slr.web;
 
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -29,6 +30,7 @@ import com.ibm.ejb1x.base.spec.slr.ejb.SLRaHome;
 import com.ibm.websphere.ejbcontainer.test.tools.FATHelper;
 
 import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 /**
@@ -164,6 +166,7 @@ public class SLRemoteImplContextServlet extends FATServlet {
      * (ixc04) Test Stateless remote EJBContext.getEnvironment().
      */
     @Test
+    @SkipForRepeat({ EE9_FEATURES })
     public void test1XSLEJBContext_getEnvironment() throws Exception {
         String tempStr = fejb1.context_getEnvironment("value1");
         assertEquals("Get Environment string from context was unexpected value", tempStr, "value of value1");
@@ -174,6 +177,7 @@ public class SLRemoteImplContextServlet extends FATServlet {
      */
     @Test
     @SuppressWarnings("deprecation")
+    @SkipForRepeat({ EE9_FEATURES })
     public void test1XSLEJBContext_getCallerIdentity() throws Exception {
         Object o = fejb1.context_getCallerIdentity();
         if (o instanceof Throwable) {
@@ -213,6 +217,7 @@ public class SLRemoteImplContextServlet extends FATServlet {
      */
     @Test
     @SuppressWarnings("deprecation")
+    @SkipForRepeat({ EE9_FEATURES })
     public void test1XSLEJBContext_isCallerInRole_Identity() throws Exception {
         Object o = fejb1.context_isCallerInRole((java.security.Identity) null);
         if (o instanceof Throwable) {

--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/test-applications/EJB2XRemoteSpecWeb.war/src/com/ibm/ejb2x/base/spec/sfr/web/SFRemoteImplContextServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/test-applications/EJB2XRemoteSpecWeb.war/src/com/ibm/ejb2x/base/spec/sfr/web/SFRemoteImplContextServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2019 IBM Corporation and others.
+ * Copyright (c) 2002, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ejb2x.base.spec.sfr.web;
 
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -28,6 +29,7 @@ import com.ibm.ejb2x.base.spec.sfr.ejb.SFRaHome;
 import com.ibm.websphere.ejbcontainer.test.tools.FATHelper;
 
 import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 /**
@@ -172,6 +174,7 @@ public class SFRemoteImplContextServlet extends FATServlet {
      * (ixc04) Test Stateful remote EJBContext.getEnvironment().
      */
     @Test
+    @SkipForRepeat({ EE9_FEATURES })
     public void testSFRemoteEJBContext_getEnvironment() throws Exception {
         String tempStr = fejb1.context_getEnvironment("value1");
         assertEquals("Get Environment string from context was unexpected value", tempStr, "value of value1");
@@ -182,6 +185,7 @@ public class SFRemoteImplContextServlet extends FATServlet {
      */
     @SuppressWarnings("deprecation")
     @Test
+    @SkipForRepeat({ EE9_FEATURES })
     public void testSFRemoteEJBContext_getCallerIdentity() throws Exception {
         Object o = fejb1.context_getCallerIdentity();
         if (o instanceof Throwable) {
@@ -221,6 +225,7 @@ public class SFRemoteImplContextServlet extends FATServlet {
      */
     @SuppressWarnings("deprecation")
     @Test
+    @SkipForRepeat({ EE9_FEATURES })
     public void testSFRemoteEJBContext_isCallerInRole_Identity() throws Exception {
         Object o = fejb1.context_isCallerInRole((java.security.Identity) null);
         if (o instanceof Throwable) {

--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/test-applications/EJB2XRemoteSpecWeb.war/src/com/ibm/ejb2x/base/spec/slr/web/SLRemoteImplContextServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/test-applications/EJB2XRemoteSpecWeb.war/src/com/ibm/ejb2x/base/spec/slr/web/SLRemoteImplContextServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2002, 2019 IBM Corporation and others.
+ * Copyright (c) 2002, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ejb2x.base.spec.slr.web;
 
+import static componenttest.annotation.SkipForRepeat.EE9_FEATURES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -28,6 +29,7 @@ import com.ibm.ejb2x.base.spec.slr.ejb.SLRaHome;
 import com.ibm.websphere.ejbcontainer.test.tools.FATHelper;
 
 import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 /**
@@ -172,6 +174,7 @@ public class SLRemoteImplContextServlet extends FATServlet {
      * (ixc04) Test Stateless remote EJBContext.getEnvironment().
      */
     @Test
+    @SkipForRepeat({ EE9_FEATURES })
     public void testSLRemoteEJBContext_getEnvironment() throws Exception {
         String tempStr = fejb1.context_getEnvironment("value1");
         assertEquals("Get Environment string from context was unexpected value", tempStr, "value of value1");
@@ -182,6 +185,7 @@ public class SLRemoteImplContextServlet extends FATServlet {
      */
     @SuppressWarnings("deprecation")
     @Test
+    @SkipForRepeat({ EE9_FEATURES })
     public void testSLRemoteEJBContext_getCallerIdentity() throws Exception {
         Object o = fejb1.context_getCallerIdentity();
         if (o instanceof Throwable) {
@@ -221,6 +225,7 @@ public class SLRemoteImplContextServlet extends FATServlet {
      */
     @SuppressWarnings("deprecation")
     @Test
+    @SkipForRepeat({ EE9_FEATURES })
     public void testSLRemoteEJBContext_isCallerInRole_Identity() throws Exception {
         Object o = fejb1.context_isCallerInRole((java.security.Identity) null);
         if (o instanceof Throwable) {

--- a/dev/com.ibm.ws.ejbcontainer.legacy_fat/test-applications/StatefulPassivationWeb.war/src/com/ibm/ejb2x/base/pitt/web/PassivationRegressionServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.legacy_fat/test-applications/StatefulPassivationWeb.war/src/com/ibm/ejb2x/base/pitt/web/PassivationRegressionServlet.java
@@ -46,6 +46,7 @@ import com.ibm.ejb2x.base.pitt.ejb.StatelessSessionHome;
 import com.ibm.websphere.ejbcontainer.test.tools.FATHelper;
 
 import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.app.FATServlet;
 
 /**
@@ -222,6 +223,8 @@ public class PassivationRegressionServlet extends FATServlet {
      * </ul>
      */
     @Test
+    // TODO: Remove Skip when #17742 is fixed
+    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     @ExpectedFFDC({ "org.omg.CORBA.OBJECT_NOT_EXIST", "java.lang.RuntimeException", "com.ibm.websphere.csi.CSITransactionRolledbackException" })
     public void testTXRequiredExceptionCommit() throws Exception {
         CMEntityHome cmHome = FATHelper.lookupRemoteBinding(CMENTITY_HOME, CMEntityHome.class);
@@ -279,6 +282,8 @@ public class PassivationRegressionServlet extends FATServlet {
      * </ul>
      */
     @Test
+    // TODO: Remove Skip when #17742 is fixed
+    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     @ExpectedFFDC({ "org.omg.CORBA.OBJECT_NOT_EXIST", "java.lang.RuntimeException", "com.ibm.websphere.csi.CSITransactionRolledbackException" })
     public void testTXRequiredException() throws Exception {
         CMEntityHome cmHome = FATHelper.lookupRemoteBinding(CMENTITY_HOME, CMEntityHome.class);
@@ -613,6 +618,8 @@ public class PassivationRegressionServlet extends FATServlet {
      * </ul>
      */
     @Test
+    // TODO: Remove Skip when #17742 is fixed
+    @SkipForRepeat(SkipForRepeat.EE9_FEATURES)
     @ExpectedFFDC({ "com.ibm.websphere.csi.CSITransactionRolledbackException" })
     public void testBMTLeftOpenCausesRollback() throws Exception {
         CMEntityHome cmHome = FATHelper.lookupRemoteBinding(CMENTITY_HOME, CMEntityHome.class);


### PR DESCRIPTION
Enable the remaining EJB legacy FAT tests to run with Jakarta EE 9 features.

for #13717 