### PR TITLE
Ensure jaxrs-2.0 feature works with JDK 16 OOTB

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/FATSuite.java
@@ -70,7 +70,6 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
-import componenttest.topology.impl.JavaInfo;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -129,7 +128,7 @@ import componenttest.topology.impl.JavaInfo;
 })
 public class FATSuite {
     @ClassRule
-    public static RepeatTests r = RepeatTests.withoutModification().onlyIf(() -> JavaInfo.JAVA_VERSION < 16)
+    public static RepeatTests r = RepeatTests.withoutModification()
                     .andWith(FeatureReplacementAction.EE8_FEATURES().withID("JAXRS-2.1"))
                     .andWith(new JakartaEE9Action().alwaysAddFeature("jsonb-2.0").removeFeature("mpMetrics-2.3"));
 }

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/annotationscan/AnnotationScanTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/annotationscan/AnnotationScanTest.java
@@ -15,8 +15,6 @@ import static com.ibm.ws.jaxrs20.fat.TestUtils.readEntity;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Collections;
-
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.Path;
 import javax.ws.rs.client.Client;
@@ -41,8 +39,6 @@ import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.JakartaEE9Action;
-import componenttest.topology.impl.JavaInfo;
-import componenttest.topology.impl.JavaInfo.Vendor;
 import componenttest.topology.impl.LibertyServer;
 
 @AllowedFFDC({"java.lang.ClassNotFoundException", "java.lang.ClassCastException"})
@@ -64,11 +60,6 @@ public class AnnotationScanTest {
         JavaArchive jar = ShrinkHelper.buildJavaArchive("resourcejar.jar", "com.ibm.ws.jaxrs.fat.resourceinjar");
         app.addAsLibraries(jar);
         ShrinkHelper.exportDropinAppToServer(server, app);
-
-        // Conditionally apply for non-Hotspot JVMs, since Hotspot does not support -Xdump
-        if (JavaInfo.forServer(server).vendor() != Vendor.SUN_ORACLE) {
-            server.setJvmOptions(Collections.singletonList("-Xdump:java+system+snap:events=throw+systhrow,filter=java/lang/reflect/GenericSignatureFormatError"));
-        }
 
         // Make sure we don't fail because we try to start an
         // already started server

--- a/dev/com.ibm.ws.kernel.boot/publish/platform/java/java9.options
+++ b/dev/com.ibm.ws.kernel.boot/publish/platform/java/java9.options
@@ -46,6 +46,6 @@ java.desktop/java.awt.image=ALL-UNNAMED
 # for com.ibm.ws.transport.iiop_fat:testResolvable/testResolvableThatThrows (yoko accessible calls)
 --add-opens
 java.base/java.security=ALL-UNNAMED
-# for java -jar execution on command line (java.net.URLClassLoader)
+# for java -jar execution on command line (java.net.URLClassLoader) and CXF 3.1.X Authenticator support
 --add-opens
 java.base/java.net=ALL-UNNAMED


### PR DESCRIPTION
- re-enables FAT tests for Java 16
- adds comments regarding --adds-open in java9.options file
- removes jvm.option that conflicts with Java 16 in AnnotationScanTest
