### PR TITLE
Fix maven coordinate changes from #17710

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2029,12 +2029,12 @@
     <dependency>
       <groupId>org.eclipse.persistence</groupId>
       <artifactId>org.eclipse.persistence.asm</artifactId>
-      <version>2.7.9</version>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.persistence</groupId>
       <artifactId>org.eclipse.persistence.asm</artifactId>
-      <version>3.0.0</version>
+      <version>9.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.persistence</groupId>
@@ -2059,12 +2059,12 @@
     <dependency>
       <groupId>org.eclipse.persistence</groupId>
       <artifactId>org.eclipse.persistence.jpa.modelgen.processor</artifactId>
-      <version>3.0.0</version>
+      <version>2.7.9</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.persistence</groupId>
-      <artifactId>org.eclipse.persistence.jpa.modelgen</artifactId>
-      <version>2.7.9</version>
+      <artifactId>org.eclipse.persistence.jpa.modelgen.processor</artifactId>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.persistence</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -401,14 +401,14 @@ org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.3.1
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:1.4.0
 org.eclipse.microprofile.rest.client:microprofile-rest-client-api:2.0
 org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.9
-org.eclipse.persistence:org.eclipse.persistence.asm:2.7.9
 org.eclipse.persistence:org.eclipse.persistence.asm:3.0.0
+org.eclipse.persistence:org.eclipse.persistence.asm:9.1.0
 org.eclipse.persistence:org.eclipse.persistence.core:2.7.9
 org.eclipse.persistence:org.eclipse.persistence.core:3.0.0
 org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:2.7.9
 org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:3.0.0
+org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor:2.7.9
 org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor:3.0.0
-org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen:2.7.9
 org.eclipse.persistence:org.eclipse.persistence.jpa:2.7.9
 org.eclipse.persistence:org.eclipse.persistence.jpa:3.0.0
 org.eclipse.transformer:org.eclipse.transformer.cli:0.2.0

--- a/dev/com.ibm.websphere.appserver.thirdparty.eclipselink.2.7/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.thirdparty.eclipselink.2.7/bnd.bnd
@@ -16,6 +16,7 @@ eclVersion=2.7.9
 eclHash=2c549e2
 eclFullVersion=${eclVersion}
 eclPackageVersion=2.0.16
+asmFullVersion=9.1.0
 
 Bundle-SymbolicName: com.ibm.websphere.appserver.thirdparty.eclipselink.2.7
 Bundle-Description: EclipseLink JPA
@@ -35,7 +36,7 @@ Export-Package: \
             org.eclipse.persistence.internal.jpa.config.*;version="${eclPackageVersion}", \
             org.eclipse.persistence.internal.jpa.metadata.graphs;version="${eclPackageVersion}", \
             org.eclipse.persistence.internal.jpa.metadata.sop;version="${eclPackageVersion}", \
-            org.eclipse.persistence.internal.libraries.asm*;version="${eclPackageVersion}", \
+            org.eclipse.persistence.internal.libraries.asm*;version="${asmFullVersion}", \
             org.eclipse.persistence.internal.libraries.antlr.runtime*;version="${eclPackageVersion}", \
             org.eclipse.persistence.jpa.jpql*;version="${eclPackageVersion}", \
             org.eclipse.persistence.*;version="${eclVersion}"
@@ -110,11 +111,11 @@ Private-Package: com.ibm.ws.eclipselink.osgi
 
 Include-Resource: \
   @${repo;org.eclipse.persistence:org.eclipse.persistence.antlr;${eclFullVersion};EXACT}!/!META-INF/maven/*,\
-  @${repo;org.eclipse.persistence:org.eclipse.persistence.asm;${eclFullVersion};EXACT}!/!META-INF/maven/*,\
+  @${repo;org.eclipse.persistence:org.eclipse.persistence.asm;${asmFullVersion};EXACT}!/!META-INF/maven/*,\
   @${repo;org.eclipse.persistence:org.eclipse.persistence.core;${eclFullVersion};EXACT}!/!META-INF/maven/*,\
   @${repo;org.eclipse.persistence:org.eclipse.persistence.jpa;${eclFullVersion};EXACT}!/!META-INF/maven/*,\
   @${repo;org.eclipse.persistence:org.eclipse.persistence.jpa.jpql;${eclFullVersion};EXACT}!/!META-INF/maven/*,\
-  @${repo;org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen;${eclFullVersion};EXACT}!/!META-INF/maven/*,\
+  @${repo;org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor;${eclFullVersion};EXACT}!/!META-INF/maven/*,\
   org/eclipse/persistence/internal/helper=${bin}/org/eclipse/persistence/internal/helper
 
 


### PR DESCRIPTION
Need to modify some of the changes from #17710.  First, since the level of ASM did not change, the coordinate needs to be org.eclipse.persistence:org.eclipse.persistence:asm:9.1.0 (see eclipselink dev mailing list snippet below).  The second, is that "org.eclipse.persistence.jpa.modelgen:2.7.9" does not exist on Maven Central, but  "org.eclipse.persistence.jpa.modelgen.processor:2.7.9" does.

Eclipselink dev-mailing list snippet regarding the subject:
```
Lukas Jungmann via eclipse.org 
Jul 21, 2021, 12:54 PM (19 hours ago)
 to eclipselink-dev

On 7/21/21 6:37 PM, Jody Grassel wrote:
> I was checking maven central, and noticed there were no resources for
> the maven coordinate 
> "org.eclipse.persistence:org.eclipse.persistence.asm:2.7.9" -- is this
> an omission?

No, it is intention. eclipselink 2.7.9 uses
org.eclipse.persistence:org.eclipse.persistence.asm:9.1.0 - same version
as master and/or 3.0.2.

thanks,
--lukas
```
