### PR TITLE
disable testPropertyConfigSource

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.1_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -19,7 +19,12 @@
                         // Test unreliable in 1.x TCK due to URL.equals() performing DNS resolution. See: https://github.com/eclipse/microprofile-config/issues/549
                         return false;
                     }
-                    
+                    // org.eclipse.microprofile.config.tck.ConfigProviderTest
+                    if(method.getName().startsWith("testPropertyConfigSource")
+                       ){
+                        // Test unreliable due to ConcurrentModificationExcpetion. Fixed in 2.0 by https://github.com/eclipse/microprofile-config/pull/560
+                        return false;
+                    }
                     // org.eclipse.microprofile.config.tck.ConfigProviderTest
                     String os = System.getProperty("os.name");
                     if (os.contains("Windows") && method.getName().startsWith("testEnvironmentConfigSource")){

--- a/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -24,7 +24,12 @@
                         // Tests unreliable in 1.x TCK due to URL.equals() performing DNS resolution. See: https://github.com/eclipse/microprofile-config/issues/549
                         return false;
                     }
-                    
+                    // org.eclipse.microprofile.config.tck.ConfigProviderTest
+                    if(method.getName().startsWith("testPropertyConfigSource")
+                       ){
+                        // Test unreliable due to ConcurrentModificationExcpetion. Fixed in 2.0 by https://github.com/eclipse/microprofile-config/pull/560
+                        return false;
+                    }
                     // org.eclipse.microprofile.config.tck.ConfigProviderTest
                     String os = System.getProperty("os.name");
                     if (os.contains("Windows") && method.getName().startsWith("testEnvironmentConfigSource")){

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -26,6 +26,12 @@
                     }
                     
                     // org.eclipse.microprofile.config.tck.ConfigProviderTest
+                    if(method.getName().startsWith("testPropertyConfigSource")
+                       ){
+                        // Test unreliable due to ConcurrentModificationExcpetion. Fixed in 2.0 by https://github.com/eclipse/microprofile-config/pull/560
+                        return false;
+                    }
+                    // org.eclipse.microprofile.config.tck.ConfigProviderTest
                     String os = System.getProperty("os.name");
                     if (os.contains("Windows") && method.getName().startsWith("testEnvironmentConfigSource")){
                         // Test unreliable in 1.x TCK on Windows due to inconsistent path variable name. See https://github.com/eclipse/microprofile-config/issues/664

--- a/dev/com.ibm.ws.microprofile.config.1.4_fat_tck/publish/tckRunner/tck/tck-suite.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.4_fat_tck/publish/tckRunner/tck/tck-suite.xml
@@ -25,7 +25,12 @@
                         // Tests unreliable in 1.x TCK due to URL.equals() performing DNS resolution. See: https://github.com/eclipse/microprofile-config/issues/549
                         return false;
                     }
-                    
+                    // org.eclipse.microprofile.config.tck.ConfigProviderTest
+                    if(method.getName().startsWith("testPropertyConfigSource")
+                       ){
+                        // Test unreliable due to ConcurrentModificationExcpetion. Fixed in 2.0 by https://github.com/eclipse/microprofile-config/pull/560
+                        return false;
+                    }
                     // org.eclipse.microprofile.config.tck.ConfigProviderTest
                     String os = System.getProperty("os.name");
                     if (os.contains("Windows") && method.getName().startsWith("testEnvironmentConfigSource")){


### PR DESCRIPTION
In the MP Config 1.x TCKs, `org.eclipse.microprofile.config.tck.ConfigProviderTest.testPropertyConfigSource` is written in such a way that makes a ConcurrentModificationExcpetion possible when iterating over system properties. This was fixed in the MP Config 2.0 TCK by https://github.com/eclipse/microprofile-config/pull/560 but there are no plans to back-port. Therefore we have no choice but to disable the unreliable test.

#build

