### PR TITLE
Fix SRVE8501E by delaying the start of com.ibm.ws.webcontainer.monitor bundle 

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.webcontainerMonitor-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.webcontainerMonitor-1.0.feature
@@ -5,6 +5,6 @@ IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.monitor-1.0))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(|(osgi.identity=com.ibm.websphere.appserver.servlet-3.0)(osgi.identity=com.ibm.websphere.appserver.servlet-3.1)(osgi.identity=com.ibm.websphere.appserver.servlet-4.0)))"
 IBM-Install-Policy: when-satisfied
--bundles=com.ibm.ws.webcontainer.monitor
+-bundles=com.ibm.ws.webcontainer.monitor; start-phase:=APPLICATION_EARLY
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.servlet5.0-monitor1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/io.openliberty.servlet5.0-monitor1.0.feature
@@ -5,6 +5,6 @@ IBM-Provision-Capability: \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.monitor-1.0))", \
   osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.servlet-5.0))"
 IBM-Install-Policy: when-satisfied
--bundles=com.ibm.ws.webcontainer.monitor.jakarta
+-bundles=com.ibm.ws.webcontainer.monitor.jakarta; start-phase:=APPLICATION_EARLY
 kind=beta
 edition=core

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/FATSuite.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/FATSuite.java
@@ -37,6 +37,7 @@ import com.ibm.ws.fat.wc.tests.WCServletContainerInitializerFilterServletNameMap
 import com.ibm.ws.fat.wc.tests.WCServletPathForDefaultMappingDefault;
 import com.ibm.ws.fat.wc.tests.WCServletPathForDefaultMappingFalse;
 import com.ibm.ws.fat.wc.tests.WCTrailersTest;
+import com.ibm.ws.fat.wc.tests.WCServerMiscTest;
 
 import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
@@ -87,7 +88,8 @@ import componenttest.rules.repeater.RepeatTests;
                 WCSendRedirectRelativeURLTrue.class,
                 WCSendRedirectRelativeURLDefault.class,
                 WC5GetContextPath.class,
-                WCSCIHandlesTypesTest.class
+                WCSCIHandlesTypesTest.class,
+                WCServerMiscTest.class
 })
 
 public class FATSuite {

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCServerMiscTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/fat/src/com/ibm/ws/fat/wc/tests/WCServerMiscTest.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.fat.wc.tests;
+
+import static org.junit.Assert.assertNull;
+
+import java.util.logging.Logger;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.JakartaEE9Action;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ *  Misc Test Class
+ */
+@RunWith(FATRunner.class)
+@SkipForRepeat(SkipForRepeat.EE9_FEATURES) 
+@Mode(TestMode.FULL)
+public class WCServerMiscTest {
+
+    private static final Logger LOG = Logger.getLogger(WCServerMiscTest.class.getName());
+
+    @Server("servlet40_monitor")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        server.startServer(WCServerTest.class.getSimpleName() + ".log");
+    }
+
+    @AfterClass
+    public static void testCleanup() throws Exception {
+        LOG.info("testCleanUp : stop server");
+
+        // Stop the server
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+    /**
+     * Test for "SRVE8501E: The servlet container did not load with an acceptable version." 
+     * Find more at OLGH #17950
+     * Occurs when com.ibm.ws.webcontianer is still activating but getServletContainerSpecLevel() call occurs in addGlobalListener
+       
+     * @throws Exception
+     */
+    @Test
+    public void ensureServletSpecLevelIsLoaded() throws Exception {
+       assertNull("Log should not contain SRVE8501E: The servlet container did not load with an acceptable version.", server.verifyStringNotInLogUsingMark("SRVE8501E.*", 1000));
+    }
+
+}

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet40_monitor/.gitignore
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet40_monitor/.gitignore
@@ -1,0 +1,2 @@
+/apps
+/dropins

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet40_monitor/bootstrap.properties
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet40_monitor/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2021 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+osgi.console=7777
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.webcontainer*=all:com.ibm.wsspi.webcontainer*=all
+com.ibm.ws.classloading.tcclLockWaitTimeMillis=60000

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet40_monitor/server.xml
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat/publish/servers/servlet40_monitor/server.xml
@@ -1,0 +1,33 @@
+<!--
+    Copyright (c) 2021 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Tests for SRVE8501E">
+
+  <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>servlet-4.0</feature>
+        <!--
+            Problematic feature is monitor-1.0, but it's more easily reproducible with mpMetrics-2.3 
+        -->
+        <feature>mpMetrics-2.3</feature> 
+    </featureManager>
+
+    <monitor enableTraditionalPMI="true"/>
+
+    <!-- FAT framework expects to start with the usual port  -->
+    <httpEndpoint id="defaultHttpEndpoint"
+                  host="*"
+                  httpPort="${bvt.prop.HTTP_default}"
+                  httpsPort="${bvt.prop.HTTP_default.secure}">
+        <samesite lax="*"/>
+    </httpEndpoint>
+
+</server>


### PR DESCRIPTION
fix #17950 

Root Cause: `com.ibm.ws.webcontainer.montior`'s WebContainerMonitor class is initialized before `com.ibm.ws.webcontainer` is finished activating 


Current Fix: start-phase:=APPLICATION_EARLY to the com.ibm.ws.webcontainer.monitor bundle so it is loaded later.  This is probably the best (and simplest) option here. 

Other options:

1)  Add` start-phase:=CONTAINER_LATE` to the com.ibm.ws.webcontainer.monitor bundle to have it load later.  -- DID NOT WORK 

2) Check to see if the `javax.servlet.http.HttpSessionIdListener` is on the class path here instead of the servlet spec level check. Reasoning is that `javax.servlet.http.HttpSessionIdListener` is **not** part of servlet 3.0 but is for later versions. 
https://github.com/OpenLiberty/open-liberty/blob/c237b98426d1be2cbff9731d5b0560332d43e33a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/WebContainer.java#L325-L328

3) Create a queue of global listeners and then add them once the setVersion method is called (Previous  Approach) 

4) Refactor the webcontainer code to have the version set through bundle wiring/capability. 