### PR TITLE
No obvious cause of of cached streams if junits are executed sequenti…

### DIFF
--- a/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
+++ b/dev/com.ibm.ws.logging/src/com/ibm/ws/logging/internal/impl/BaseTraceService.java
@@ -260,7 +260,7 @@ public class BaseTraceService implements TrService {
      * of system properties we expect (for FFDC and logging).
      *
      * @param config a {@link LogProviderConfigImpl} containing TrService configuration
-     *            from bootstrap properties
+     *                   from bootstrap properties
      */
     @Override
     public void init(LogProviderConfig config) {
@@ -286,10 +286,12 @@ public class BaseTraceService implements TrService {
             }
 
             @Override
-            public void flush() {}
+            public void flush() {
+            }
 
             @Override
-            public void close() {}
+            public void close() {
+            }
         });
     }
 
@@ -306,7 +308,7 @@ public class BaseTraceService implements TrService {
      * so values set there are not unset by metatype defaults.
      *
      * @param config a {@link LogProviderConfigImpl} containing dynamic updates from
-     *            the OSGi managed service.
+     *                   the OSGi managed service.
      */
     @Override
     public synchronized void update(LogProviderConfig config) {
@@ -1058,10 +1060,10 @@ public class BaseTraceService implements TrService {
     /**
      * Publish a trace log record.
      *
-     * @param detailLog the trace writer
+     * @param detailLog           the trace writer
      * @param logRecord
-     * @param id the trace object id
-     * @param formattedMsg the result of {@link BaseTraceFormatter#formatMessage}
+     * @param id                  the trace object id
+     * @param formattedMsg        the result of {@link BaseTraceFormatter#formatMessage}
      * @param formattedVerboseMsg the result of {@link BaseTraceFormatter#formatVerboseMessage}
      */
     protected void publishTraceLogRecord(TraceWriter detailLog, LogRecord logRecord, Object id, String formattedMsg, String formattedVerboseMsg) {
@@ -1208,7 +1210,7 @@ public class BaseTraceService implements TrService {
      * the trace file.
      *
      * @param config a {@link LogProviderConfigImpl} containing TrService configuration
-     *            from bootstrap properties
+     *                   from bootstrap properties
      */
     protected void initializeWriters(LogProviderConfigImpl config) {
         // createFileLog may or may not return the original log holder..
@@ -1352,7 +1354,8 @@ public class BaseTraceService implements TrService {
 
         /** {@inheritDoc} */
         @Override
-        public void close() throws IOException {}
+        public void close() throws IOException {
+        }
 
         /**
          * Only allow "off" as a valid value for toggling system.out
@@ -1658,18 +1661,23 @@ public class BaseTraceService implements TrService {
      * when the special trace components are created.
      */
     protected void restoreSystemStreams() {
-        if (System.out == teeOut)
-            System.setOut(systemOut.getOriginalStream());
-        if (System.err == teeErr)
-            System.setErr(systemErr.getOriginalStream());
+        /*
+         * OL17768 - No obvious cause of OL17768.
+         * Disable this check and "restore"
+         * it regardless to evaluate effects.
+         */
+        //if (System.out == teeOut)
+        System.setOut(systemOut.getOriginalStream());
+        //if (System.err == teeErr)
+        System.setErr(systemErr.getOriginalStream());
     }
 
     /**
      * Write the text to the associated original stream.
      * This is preserved as a subroutine for extension by other delegates (test, JSR47 logging)
      *
-     * @param tc StreamTraceComponent associated with original stream
-     * @param txt pre-formatted or raw message
+     * @param tc        StreamTraceComponent associated with original stream
+     * @param txt       pre-formatted or raw message
      * @param rawStream if true, this is from direct invocation of System.out or System.err
      */
     protected synchronized void writeStreamOutput(SystemLogHolder holder, String txt, boolean rawStream) {


### PR DESCRIPTION
…ally (which they should be). Change is to restore stream to original System.out/err regardless of current stream state

#build 
addresses #17768 