### PR TITLE
Defect 983910 fix SpringBoot ConfigActuatorXMLOverrideTests20

### DIFF
--- a/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/AbstractSpringTests.java
+++ b/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/AbstractSpringTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -172,6 +172,15 @@ public abstract class AbstractSpringTests {
         return true;
     }
 
+    public List<String> getExpectedWebApplicationEndpoints() {
+        String testMethodName = testName.getMethodName();
+        List<String> expectedEndpoints = new ArrayList<String>();
+        if (testMethodName != null && testMethodName.contains(DEFAULT_HOST_WITH_APP_PORT)) {
+            expectedEndpoints.add("default_host");
+        }
+        return expectedEndpoints;
+    }
+
     public void modifyAppConfiguration(SpringBootApplication appConfig) {
         // do nothing by default
     }
@@ -256,14 +265,13 @@ public abstract class AbstractSpringTests {
                 assertNotNull("The application was not installed", server
                                 .waitForStringInLog("CWWKZ0001I:.*"));
                 if (expectWebApplication()) {
-                    String testMethodName = testName.getMethodName();
-                    if (testMethodName != null && testMethodName.contains(DEFAULT_HOST_WITH_APP_PORT)) {
-                        assertNotNull("The endpoint not available on default_host", server
-                                        .waitForStringInLog("CWWKT0016I:.*\\bdefault_host\\b.*"));
-                    } else {
+                    List<String> expectedEndpoints = getExpectedWebApplicationEndpoints();
+                    for (String ep : getExpectedWebApplicationEndpoints())
+                        assertNotNull("The endpoint \"" + ep + "\" is not available", server
+                                        .waitForStringInLog("CWWKT0016I:.*\\b" + ep + "\\b.*"));
+                    if (expectedEndpoints.isEmpty())
                         assertNotNull("The endpoint is not available", server
                                         .waitForStringInLog("CWWKT0016I:.*"));
-                    }
                 }
             }
         }

--- a/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/ConfigActuatorXMLOverrideTests20.java
+++ b/dev/com.ibm.ws.springboot.support_fat/fat/src/com/ibm/ws/springboot/support/fat/ConfigActuatorXMLOverrideTests20.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2021 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.ws.springboot.support.fat;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -142,6 +143,18 @@ public class ConfigActuatorXMLOverrideTests20 extends AbstractSpringTests {
             actuatorEndpoint.setHttpPort(Integer.toString(OVERRIDE_ACTUATOR_PORT));
             actuatorEndpoint.setId("actuator");
         }
+    }
+
+    @Override
+    public List<String> getExpectedWebApplicationEndpoints() {
+        String methodName = testName.getMethodName();
+        List<String> expectedEndpoints = new ArrayList<String>(super.getExpectedWebApplicationEndpoints());
+        if (methodName != null) {
+            if (methodName.equals(DEFAULT_MAIN_CONFIG_ACTUATOR)) {
+                expectedEndpoints.add("springBootVirtualHost-8096");
+            }
+        }
+        return expectedEndpoints;
     }
 
     @Override


### PR DESCRIPTION
Test `ConfigActuatorXMLOverrideTests20.useDefaultHostForMainConfigActuatorPorts()` of the SpringBoot support FAT can request the `actuator/health:8096` URL before the corresponding application endpoint is available.  These changes enable a general solution by augmenting the `AbstractSpringTest.configureServer()` abstraction to expect specific endpoints become available before test execution; and, they solve the specific problem by expecting endpoint`springBootVirtualHost-8096` becomes available before executing test `useDefaultHostForMainConfigActuatorPorts()`.  
